### PR TITLE
lbzip2: fix crash on macOS >= 10.13

### DIFF
--- a/Formula/lbzip2.rb
+++ b/Formula/lbzip2.rb
@@ -5,6 +5,7 @@ class Lbzip2 < Formula
   mirror "https://fossies.org/linux/privat/lbzip2-2.5.tar.bz2"
   sha256 "eec4ff08376090494fa3710649b73e5412c3687b4b9b758c93f73aa7be27555b"
   license "GPL-3.0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -15,6 +16,12 @@ class Lbzip2 < Formula
     sha256 "91c1fb0593205365ff4ada30a34fe7f3afcb1c4e684a3bf239e9168d9fdfc4f7" => :el_capitan
     sha256 "983c8fe1c23dbfdb73d9e7320e776521c4998169a2d17cd1c6f3035674d8a147" => :yosemite
     sha256 "7e521c70fadae71ad2e7807cc844183c05751e4a2433d9f1210069fb2a34333e" => :mavericks
+  end
+
+  # Fix crash on macOS >= 10.13.
+  patch :p0 do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/6b276429dbe68323349e1eda09b7e5d5a1082671/lbzip2/gnulib-vasnprintf-port-to-macOS-10-13.diff"
+    sha256 "5b931e071e511a9c56e529278c249d7b2c82bbc3deda3dd9b739b3bd67d3d969"
   end
 
   def install


### PR DESCRIPTION
The current lbzip2 formula is broken since 2018 and crashes on macOS due to it using an incompatible (embedded) version of gnulib.

logological has kindly provided a fork with an updated version of gnulib that works again on recent macOS versions.

Upstream seems unmaintained, thus switching to the fork is probably the most reasonable way forward.

Details are in https://github.com/kjn/lbzip2/issues/20.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
