### PR TITLE
re2c: disable

### DIFF
--- a/Formula/re2c.rb
+++ b/Formula/re2c.rb
@@ -3,14 +3,15 @@ class Re2c < Formula
   homepage "https://re2c.org"
   url "https://github.com/skvadrik/re2c/releases/download/2.0.1/re2c-2.0.1.tar.xz"
   sha256 "aef8b50bb75905b2d55a7236380c0efdc756fa077fe16d808aaacbb10fb53531"
-  # re2c is in the public domain
-  license "Unlicense"
 
   bottle do
     sha256 "617a92159d2aefb4b454b81496c5c8615f27a303249c11f5ac40f887ee8ca392" => :catalina
     sha256 "d9ae7d2af374b4c57e106685b19998216265d651e8e270af822531f47c3ae44a" => :mojave
     sha256 "69d41987ea6a3250d7f4d5ff559013b20e055c99fb892cf24a14b131724515e5" => :high_sierra
   end
+
+  # Does not have a valid open-source license
+  disable!
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Remove the `Unlicense` license from `re2c`. It is [in the public domain](https://github.com/skvadrik/re2c/blob/master/LICENSE), not under the `Unlicense` license.

Disable re2c because it does not have an SPDX or OSI-approved license.

Similar to #59058.