### PR TITLE
duti: disable

### DIFF
--- a/Formula/duti.rb
+++ b/Formula/duti.rb
@@ -3,7 +3,6 @@ class Duti < Formula
   homepage "https://github.com/moretension/duti/"
   url "https://github.com/moretension/duti/archive/duti-1.5.4.tar.gz"
   sha256 "3f8f599899a0c3b85549190417e4433502f97e332ce96cd8fa95c0a9adbe56de"
-  license "Unlicense"
   revision 1
   head "https://github.com/moretension/duti.git"
 
@@ -13,6 +12,9 @@ class Duti < Formula
     sha256 "ffb23db168b014703e505ef2d76d7bc431efd5d4d1244833d9b2ddf5723133a6" => :mojave
     sha256 "e495d02894655b516f79fa10671f5d768cae04c5b73c1aa077f8b0c573584cbf" => :high_sierra
   end
+
+  # Does not have a valid open-source license
+  disable!
 
   depends_on "autoconf" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Remove the `Unlicense` license from `duti`. It is [in the public domain](https://github.com/moretension/duti/blob/master/COPYRIGHT), not under the `Unlicense` license.

Disable `duti` because it does not have an SPDX or OSI-approved license.