### PR TITLE
fmdiff: disable

### DIFF
--- a/Formula/fmdiff.rb
+++ b/Formula/fmdiff.rb
@@ -17,6 +17,9 @@ class Fmdiff < Formula
     sha256 "59d9c9d8a8759531a2f715619cfb2bce404fc7378235cf416ea5a426eb8d967f" => :yosemite
   end
 
+  # Does not have a valid open-source license
+  disable!
+
   # Needs FileMerge.app, which is part of Xcode.
   depends_on :xcode
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Remove the `Unlicense` license from `fmdiff`. It is [in the public domain](https://github.com/brunodefraine/fmscripts/blob/master/LICENSE.txt), not under the `Unlicense` license.

Disable `fmdiff` because it does not have an SPDX or OSI-approved license.