### PR TITLE
formulae: fix incorrect license

### DIFF
--- a/Formula/duti.rb
+++ b/Formula/duti.rb
@@ -3,7 +3,6 @@ class Duti < Formula
   homepage "https://github.com/moretension/duti/"
   url "https://github.com/moretension/duti/archive/duti-1.5.4.tar.gz"
   sha256 "3f8f599899a0c3b85549190417e4433502f97e332ce96cd8fa95c0a9adbe56de"
-  license "Unlicense"
   revision 1
   head "https://github.com/moretension/duti.git"
 

--- a/Formula/fmdiff.rb
+++ b/Formula/fmdiff.rb
@@ -3,7 +3,6 @@ class Fmdiff < Formula
   homepage "https://www.defraine.net/~brunod/fmdiff/"
   url "https://github.com/brunodefraine/fmscripts/archive/20150915.tar.gz"
   sha256 "45ead0c972aa8ff5b3f9cf1bcefbc069931fd8218b2e28ff76958437a3fabf96"
-  license "Unlicense"
   head "https://github.com/brunodefraine/fmscripts.git"
 
   bottle do

--- a/Formula/rbenv-gemset.rb
+++ b/Formula/rbenv-gemset.rb
@@ -6,10 +6,6 @@ class RbenvGemset < Formula
   revision 1
   head "https://github.com/jf/rbenv-gemset.git"
 
-  # Does not have a valid license
-  # https://github.com/jf/rbenv-gemset/issues/93
-  disable!
-
   bottle :unneeded
 
   depends_on "rbenv"

--- a/Formula/re2c.rb
+++ b/Formula/re2c.rb
@@ -4,7 +4,6 @@ class Re2c < Formula
   url "https://github.com/skvadrik/re2c/releases/download/2.0.1/re2c-2.0.1.tar.xz"
   sha256 "aef8b50bb75905b2d55a7236380c0efdc756fa077fe16d808aaacbb10fb53531"
   # re2c is in the public domain
-  license "Unlicense"
 
   bottle do
     sha256 "617a92159d2aefb4b454b81496c5c8615f27a303249c11f5ac40f887ee8ca392" => :catalina


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

These formulae are in the public domain, not `unlicense`. c.f. https://github.com/Homebrew/homebrew-core/issues/58225