### PR TITLE
gcc: enable jit support

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -5,6 +5,7 @@ class Gcc < Formula
   mirror "https://ftpmirror.gnu.org/gcc/gcc-10.2.0/gcc-10.2.0.tar.xz"
   sha256 "b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c"
   license "GPL-3.0"
+  revision 1
   head "https://gcc.gnu.org/git/gcc.git"
 
   bottle do
@@ -46,7 +47,7 @@ class Gcc < Formula
     #  - Ada, which requires a pre-existing GCC Ada compiler to bootstrap
     #  - Go, currently not supported on macOS
     #  - BRIG
-    languages = %w[c c++ objc obj-c++ fortran]
+    languages = %w[c c++ objc obj-c++ fortran jit]
 
     osmajor = `uname -r`.split(".").first
     pkgversion = "Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip
@@ -66,6 +67,7 @@ class Gcc < Formula
       --with-system-zlib
       --with-pkgversion=#{pkgversion}
       --with-bugurl=https://github.com/Homebrew/homebrew-core/issues
+      --enable-host-shared
     ]
 
     # Xcode 10 dropped 32-bit support


### PR DESCRIPTION
Hello,

It would be super nice to have `gcc` compiled with `jit` support. I am not sure about implications for other users, but from what I've read around, should be safe. Would be glad for any feedback.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

```
λ brew audit --strict Formula/gcc.rb
gcc:
  * Formula has other versions so create an alias named gcc@10.2.
Error: 1 problem in 1 formula detected
```

Not sure what to do about it. And doesn't seem to be related to my changes.

-----