### PR TITLE
oxipng: apply upstream fixes for ARM

### DIFF
--- a/Formula/oxipng.rb
+++ b/Formula/oxipng.rb
@@ -14,7 +14,19 @@ class Oxipng < Formula
 
   depends_on "rust" => :build
 
+  # Allows one of the dependencies to work on ARM at runtime.
+  # Will be in the next release.
+  # https://github.com/shssoichiro/oxipng/issues/276
+  patch do
+    url "https://github.com/shssoichiro/oxipng/commit/1d05a8a2241fdbd7697d1ba9207347f33611470f.patch?full_index=1"
+    sha256 "4533e32102ef5632b56c8e7843a14ead7b783b93bb8b44383e633b580da22555"
+  end
+
   def install
+    # Ensures that we're using up-to-date copies of these dependencies
+    # that will support ARM Macs.
+    system "cargo", "update", "--package", "cc", "--package", "libc" if Hardware::CPU.arm?
+
     system "cargo", "install", *std_cargo_args
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This applies an upstream fix that ensures that the `cloudflare-zlib` dependency builds with ARM support enabled. Without this, `oxipng` will panic at runtime on ARM CPUs. This affects non-macOS ARM too. It also updates the `libc` and `cc` dependencies so that we have versions that are aware of Apple Silicon definitions.

The build currently fails inside Homebrew but succeeds outside of it, so I think we're doing something in the environment that's having unexpected effects - hence the draft status. Logs here: https://gist.github.com/mistydemeo/367b5ba8cd31c5e883782fde6aba384f

```
  error occurred: Command "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=aarch64-apple-darwin" "-I" "libdeflate/" "-I" "libdeflate/lib/" "-I" "libdeflate/common/" "-o" "/private/tmp/oxipng-20200804-65394-d5xg2d/oxipng-3.0.1/target/release/build/libdeflate-sys-4d326400cdda2edb/out/lib/libdeflate/lib/aligned_malloc.o" "-c" "libdeflate/lib/aligned_malloc.c" with args "clang" did not execute successfully (status code exit code: 1).


warning: build failed, waiting for other jobs to finish...
The following warnings were emitted during compilation:

warning: error: unknown target triple 'unknown-apple-macosx11.0.0', please use -triple or -arch
```