### PR TITLE
yuicompressor: add openjdk as dependency

### DIFF
--- a/Formula/yuicompressor.rb
+++ b/Formula/yuicompressor.rb
@@ -3,8 +3,8 @@ class Yuicompressor < Formula
   homepage "https://yui.github.io/yuicompressor/"
   url "https://github.com/yui/yuicompressor/releases/download/v2.4.8/yuicompressor-2.4.8.zip"
   sha256 "3243fd79cb68cc61a5278a8ff67a0ad6a2d825c36464594b66900ad8426a6a6e"
-  revision 1
   license "BSD-3-Clause"
+  revision 1
 
   bottle :unneeded
 

--- a/Formula/yuicompressor.rb
+++ b/Formula/yuicompressor.rb
@@ -3,6 +3,8 @@ class Yuicompressor < Formula
   homepage "https://yui.github.io/yuicompressor/"
   url "https://github.com/yui/yuicompressor/releases/download/v2.4.8/yuicompressor-2.4.8.zip"
   sha256 "3243fd79cb68cc61a5278a8ff67a0ad6a2d825c36464594b66900ad8426a6a6e"
+  revision 1
+  license "BSD-3-Clause"
 
   bottle :unneeded
 

--- a/Formula/yuicompressor.rb
+++ b/Formula/yuicompressor.rb
@@ -6,6 +6,8 @@ class Yuicompressor < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     libexec.install "yuicompressor-#{version}.jar"
     bin.write_jar_script libexec/"yuicompressor-#{version}.jar", "yuicompressor"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`yuicompressor` requires Java [as described here](https://yui.github.io/yuicompressor/),
but current Formulae does not specify `openjdk` as dependency.

Also, current Formulae makes `brew test yuicompressor` fail.

This PR adds `openjdk` as a dependency of `yuicompressor`.
