### PR TITLE
sheldon 0.5.3 (new formula)

### DIFF
--- a/Formula/sheldon.rb
+++ b/Formula/sheldon.rb
@@ -1,0 +1,22 @@
+class Sheldon < Formula
+  desc "Fast, configurable, shell plugin manager"
+  homepage "https://rossmacarthur.github.io/sheldon"
+  url "https://github.com/rossmacarthur/sheldon/archive/0.5.3.tar.gz"
+  sha256 "e471dd1ce97587b373313e2cd463a145db0f72573a22aae5a605f3b676258164"
+  # license ["Apache-2.0", "MIT"] - pending https://github.com/Homebrew/brew/pull/7953
+  license "Apache-2.0"
+  head "https://github.com/rossmacarthur/sheldon.git"
+
+  depends_on "rust" => :build
+  depends_on "openssl@1.1"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    touch testpath/"plugins.toml"
+    system "#{bin}/sheldon", "--home", testpath, "--root", testpath, "lock"
+    assert_predicate testpath/"plugins.lock", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds a new formula for [sheldon](https://github.com/rossmacarthur/sheldon) a command-line shell plugin manager. This should be easily bottle-able as well.
