### PR TITLE
workflows/tests: don't always run full CI on PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
 
   tests:
     needs: tap_syntax
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && ! contains(github.event.pull_request.labels.*.name, 'CI-syntax-only')
     strategy:
       matrix:
         version: [10.15, 10.14, 10.13]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This will allow a user to include the string "(syntax only)" in the PR title so that full CI doesn't run. Other options include a different string in the PR title or requiring a magic string in the PR body (`github.event.pull_request.body`). The magic string could also be part of the PR template and if a user checks/unchecks a box, then only the syntax checks would be run.

Motivated by bulk license updates or updates that otherwise won't change the formula but we still want to check the syntax and not manually have to stop CI.