### PR TITLE
Adding Tcl-Tk Dependency to R Formula

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -97,8 +97,10 @@ class R < Formula
     assert_equal "[1] 2", shell_output("#{bin}/Rscript -e 'print(1+1)'").chomp
     assert_equal ".dylib", shell_output("#{bin}/R CMD config DYLIB_EXT").chomp
 
-    system bin/"Rscript", "-e", "install.packages('statcheck', '.', 'https://cloud.r-project.org')"
-    assert_equal "[1] TRUE", shell_output("#{bin}/Rscript -e 'print(\"statcheck\" %in% rownames(installed.packages()))'").chomp
+    system bin/"Rscript", "-e", "install.packages('statcheck', '.', \
+      'https://cloud.r-project.org')"
+    assert_equal "[1] TRUE", shell_output("#{bin}/Rscript -e \
+      'print(\"statcheck\" %in% rownames(installed.packages()))'").chomp
 
     system bin/"Rscript", "-e", "install.packages('gss', '.', 'https://cloud.r-project.org')"
     assert_predicate testpath/"gss/libs/gss.so", :exist?,

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -97,6 +97,9 @@ class R < Formula
     assert_equal "[1] 2", shell_output("#{bin}/Rscript -e 'print(1+1)'").chomp
     assert_equal ".dylib", shell_output("#{bin}/R CMD config DYLIB_EXT").chomp
 
+    system bin/"Rscript", "-e", "install.packages('statcheck', '.', 'https://cloud.r-project.org')"
+    assert_equal "[1] TRUE", shell_output("#{bin}/Rscript -e 'print(\"statcheck\" %in% rownames(installed.packages()))'").chomp
+
     system bin/"Rscript", "-e", "install.packages('gss', '.', 'https://cloud.r-project.org')"
     assert_predicate testpath/"gss/libs/gss.so", :exist?,
                      "Failed to install gss package"

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -20,8 +20,8 @@ class R < Formula
   depends_on "openblas"
   depends_on "pcre2"
   depends_on "readline"
-  depends_on "xz"
   depends_on "tcl-tk"
+  depends_on "xz"
 
   # needed to preserve executable permissions on files without shebangs
   skip_clean "lib/R/bin", "lib/R/doc"

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -4,7 +4,7 @@ class R < Formula
   url "https://cran.r-project.org/src/base/R-4/R-4.0.2.tar.gz"
   sha256 "d3bceab364da0876625e4097808b42512395fdf41292f4915ab1fd257c1bbe75"
   license "GPL-2.0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "4d2073c7d93e1117cc35fcc375f6eb112f16c311cc4400d703a805d57f0de71a" => :catalina
@@ -21,6 +21,7 @@ class R < Formula
   depends_on "pcre2"
   depends_on "readline"
   depends_on "xz"
+  depends_on "tcl-tk"
 
   # needed to preserve executable permissions on files without shebangs
   skip_clean "lib/R/bin", "lib/R/doc"
@@ -36,7 +37,9 @@ class R < Formula
       "--prefix=#{prefix}",
       "--enable-memory-profiling",
       "--without-cairo",
-      "--without-tcltk",
+      "--with-tcltk=-L#{Formula["tcl-tk"].opt_lib}",
+      "--with-tcl-config=#{Formula["tcl-tk"].opt_lib}/tclConfig.sh",
+      "--with-tk-config=#{Formula["tcl-tk"].opt_lib}/tkConfig.sh",
       "--without-x",
       "--with-aqua",
       "--with-lapack",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is an attempt to address this [issue](https://discourse.brew.sh/t/r-and-tcl-tk-support/8477). As discussed, R heavily depends on Tcl-Tk and often users got into a trouble after installing R via Brew and possibly opt-in to install the binary from R website. In my tests, this will solve this issue, and some other Tcl-Tk related issues. 

As [discussed](https://discourse.brew.sh/t/r-and-tcl-tk-support/8477/7?u=amirmasoudabdol), this might have some implication when it comes to R and X11 interaction. I personally not quite sure, and open to suggestion if the build fails or you see any issue with this.

Thanks,
Amir.