### PR TITLE
neovim 0.4.4

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -1,8 +1,8 @@
 class Neovim < Formula
   desc "Ambitious Vim-fork focused on extensibility and agility"
   homepage "https://neovim.io/"
-  url "https://github.com/neovim/neovim/archive/v0.4.3.tar.gz"
-  sha256 "91a0b5d32204a821bf414690e6b48cf69224d1961d37158c2b383f6a6cf854d2"
+  url "https://github.com/neovim/neovim/archive/v0.4.4.tar.gz"
+  sha256 "2f76aac59363677f37592e853ab2c06151cca8830d4b3fe4675b4a52d41fc42c"
   license "Apache-2.0"
 
   bottle do
@@ -27,9 +27,12 @@ class Neovim < Formula
   depends_on "msgpack"
   depends_on "unibilium"
 
+  # Keep resources updated according to:
+  # https://github.com/neovim/neovim/blob/v#{version}/third-party/CMakeLists.txt
+
   resource "mpack" do
-    url "https://github.com/libmpack/libmpack-lua/releases/download/1.0.7/libmpack-lua-1.0.7.tar.gz"
-    sha256 "68565484a3441d316bd51bed1cacd542b7f84b1ecfd37a8bd18dd0f1a20887e8"
+    url "https://github.com/libmpack/libmpack-lua/releases/download/1.0.8/libmpack-lua-1.0.8.tar.gz"
+    sha256 "ed6b1b4bbdb56f26241397c1e168a6b1672f284989303b150f7ea8d39d1bc9e9"
   end
 
   resource "lpeg" do
@@ -61,9 +64,14 @@ class Neovim < Formula
     ENV.prepend_path "LUA_CPATH", "#{buildpath}/deps-build/lib/lua/5.1/?.so"
     lua_path = "--lua-dir=#{Formula["luajit"].opt_prefix}"
 
+    cmake_compiler_args = %w[
+      -DCMAKE_C_COMPILER=/usr/bin/clang
+      -DCMAKE_CXX_COMPILER=/usr/bin/clang++
+    ]
+
     cd "deps-build" do
       %w[
-        mpack/mpack-1.0.7-0.rockspec
+        mpack/mpack-1.0.8-0.rockspec
         lpeg/lpeg-1.0.2-1.src.rock
         inspect/inspect-3.1.1-0.src.rock
       ].each do |rock|
@@ -79,6 +87,7 @@ class Neovim < Formula
 
       cd "build/src/luv" do
         cmake_args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] }
+        cmake_args += cmake_compiler_args
         cmake_args += %W[
           -DCMAKE_INSTALL_PREFIX=#{buildpath}/deps-build
           -DLUA_BUILD_TYPE=System
@@ -94,6 +103,7 @@ class Neovim < Formula
 
     mkdir "build" do
       cmake_args = std_cmake_args
+      cmake_args += cmake_compiler_args
       cmake_args += %W[
         -DLIBLUV_INCLUDE_DIR=#{buildpath}/deps-build/include
         -DLIBLUV_LIBRARY=#{buildpath}/deps-build/lib/libluv.a


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?

-----

`brew audit --strict` warns, but that was present in 0.4.3 as well:
```
neovim:
  * Files were found with references to the Homebrew shims directory.
    The offending files are:
      bin/nvim
```

Manual update since `brew bump-formula-pr` throws "clone_url not found" error for me.
While here, also updates some build dependencies, `luv` only up to 1.34.1-1 since later releases won't build. Would need to be investigated further and build process probably adjusted.