### PR TITLE
workflows/autolabel: remove missing license label

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -40,10 +40,6 @@ jobs:
                     "label": "legacy",
                     "path": "Formula/.+@.+"
                 }, {
-                    "label": "missing license",
-                    "path": "Formula/.+",
-                    "missing_content": "\n  license .+\n"
-                }, {
                     "label": "go",
                     "path": "Formula/.+",
                     "content": "depends_on \"go(?:@[0-9.]+)?\""


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

We decided in https://github.com/Homebrew/homebrew-core/issues/58225#issuecomment-669245181 that we should put a hold on adding licenses to existing formulae until all of the license details are worked out.

The autolabel for missing licenses should be removed until we are ready.

CC: @MikeMcQuaid @SMillerDev