### PR TITLE
boost: fix arm64 build

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -31,6 +31,13 @@ class Boost < Formula
     directory "tools/build"
   end
 
+  # Fix build on 64-bit arm
+  patch do
+    url "https://github.com/boostorg/build/commit/456be0b7ecca065fbccf380c2f51e0985e608ba0.patch?full_index=1"
+    sha256 "e7a78145452fc145ea5d6e5f61e72df7dcab3a6eebb2cade6b4cfae815687f3a"
+    directory "tools/build"
+  end
+
   def install
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|


### PR DESCRIPTION
Patch Boost build system, so that it does inject '-arch arm64' instead
of '-arch arm'. This patch is already submitted to Boost: https://github.com/boostorg/build/pull/642
This fixes the boost problem mentioned here: https://github.com/Homebrew/brew/issues/7857

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
