### PR TITLE
berglas: 0.5.3 repack

### DIFF
--- a/Formula/berglas.rb
+++ b/Formula/berglas.rb
@@ -2,8 +2,9 @@ class Berglas < Formula
   desc "Tool for managing secrets on Google Cloud"
   homepage "https://github.com/GoogleCloudPlatform/berglas"
   url "https://github.com/GoogleCloudPlatform/berglas/archive/v0.5.3.tar.gz"
-  sha256 "d85cf4b049346b8e643f0870c37c4ea7dee147f10c7f001c828071c13df2fa70"
+  sha256 "cc4608a63813ae8322b21219723bab37edd91a8fcd7ce9810876f4d688eaa1dc"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -15,7 +16,7 @@ class Berglas < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-mod=vendor", *std_go_args
+    system "go", "build", *std_go_args
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

found from https://github.com/Homebrew/homebrew-core/pull/59242

it seems the formula was updated to version `0.5.3` on Jun 29th 2020 https://github.com/Homebrew/homebrew-core/pull/57120

However, the upstream tags `0.5.3` on Jul 2nd 2020 https://github.com/GoogleCloudPlatform/berglas/releases/tag/v0.5.3

I assume this is a repack issue, but I could not find any statement from upstream
