### PR TITLE
tektoncd-cli: 0.11.0 repack

### DIFF
--- a/Formula/tektoncd-cli.rb
+++ b/Formula/tektoncd-cli.rb
@@ -2,8 +2,9 @@ class TektoncdCli < Formula
   desc "CLI for interacting with TektonCD"
   homepage "https://github.com/tektoncd/cli"
   url "https://github.com/tektoncd/cli/archive/v0.11.0.tar.gz"
-  sha256 "3573fd6908d2c36b112ae0ee9c82d31ff7a325779c7779f0611518c6742fed07"
+  sha256 "cce12b9674e9e4891b870be24fd46d0877fb15ce23a790c90d68a5d7817e151b"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----


found from #59242

it seems the formula was updated to version 0.11.0 on July 24th 2020 https://github.com/Homebrew/homebrew-core/pull/58564

However, the upstream tags 0.11.0 on July 24th 2020 https://github.com/tektoncd/cli/releases/tag/v0.11.0 comes with a different checksum

I assume this is a repack issue, but I could not find any statement from upstream