### PR TITLE
clojure: add license

### DIFF
--- a/Formula/clojure.rb
+++ b/Formula/clojure.rb
@@ -3,6 +3,7 @@ class Clojure < Formula
   homepage "https://clojure.org"
   url "https://download.clojure.org/install/clojure-tools-1.10.1.636.tar.gz"
   sha256 "f3a962954a6e45b0f35e2f61c8c10e93dbff469766a57d3cbeb667cb0ea7b2ea"
+  license "EPL-1.0"
 
   bottle :unneeded
 


### PR DESCRIPTION
follow up of #59312 
license reference, `https://github.com/clojure/clojure#readme`

```
 *   Clojure
 *   Copyright (c) Rich Hickey. All rights reserved.
 *   The use and distribution terms for this software are covered by the
 *   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
 *   which can be found in the file epl-v10.html at the root of this distribution.
 *   By using this software in any fashion, you are agreeing to be bound by
 * 	 the terms of this license.
 *   You must not remove this notice, or any other, from this software.
```