### PR TITLE
lame: update stable url format, add license

### DIFF
--- a/Formula/lame.rb
+++ b/Formula/lame.rb
@@ -1,8 +1,9 @@
 class Lame < Formula
   desc "High quality MPEG Audio Layer III (MP3) encoder"
   homepage "https://lame.sourceforge.io/"
-  url "https://downloads.sourceforge.net/sourceforge/lame/lame-3.100.tar.gz"
+  url "https://downloads.sourceforge.net/project/lame/lame/3.100/lame-3.100.tar.gz"
   sha256 "ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e"
+  license "LGPL-2.0"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `stable` URL for `lame` is using a format that isn't compatible with `brew livecheck`'s `Sourceforge` strategy. This appears to be the only SourceForge URL that uses this different format. The others use a URL starting with `https://downloads.sourceforge.net/project/` instead of `https://downloads.sourceforge.net/sourceforge/`.

This updates the stable URL to bring it in line with the other SourceForge URLs, while also making it compatible with `livecheck`'s `Sourceforge` strategy.