### PR TITLE
s3ql: temp deprecate due to fuse3 API issue

### DIFF
--- a/Formula/s3ql.rb
+++ b/Formula/s3ql.rb
@@ -15,6 +15,10 @@ class S3ql < Formula
     sha256 "4d5df651fa2f880a5341b3945ca29190fe798cfddc0f80973b4c6bd0ea31753f" => :high_sierra
   end
 
+  # disable due to osxfuse API is with fuse2
+  # logged an issue, https://github.com/s3ql/s3ql/issues/192
+  disable!
+
   depends_on "pkg-config" => :build
   depends_on "openssl@1.1"
   depends_on :osxfuse

--- a/Formula/s3ql.rb
+++ b/Formula/s3ql.rb
@@ -17,7 +17,7 @@ class S3ql < Formula
 
   # disable due to osxfuse API is with fuse2
   # logged an issue, https://github.com/s3ql/s3ql/issues/192
-  disable!
+  deprecate!
 
   depends_on "pkg-config" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
disable the formula due to fuse API issue.

---

previous upgrade attempts, #53065 (v3.4.0), #59294 (v3.5.0)
logged an issue in the upstream repo, s3ql/s3ql#192