### PR TITLE
Standardize SourceForge stable URL format

### DIFF
--- a/Formula/aalib.rb
+++ b/Formula/aalib.rb
@@ -1,7 +1,7 @@
 class Aalib < Formula
   desc "Portable ASCII art graphics library"
   homepage "https://aa-project.sourceforge.io/aalib/"
-  url "https://downloads.sourceforge.net/aa-project/aalib-1.4rc5.tar.gz"
+  url "https://downloads.sourceforge.net/project/aa-project/aa-lib/1.4rc5/aalib-1.4rc5.tar.gz"
   sha256 "fbddda9230cf6ee2a4f5706b4b11e2190ae45f5eda1f0409dc4f99b35e0a70ee"
   revision 1
 

--- a/Formula/aften.rb
+++ b/Formula/aften.rb
@@ -1,7 +1,7 @@
 class Aften < Formula
   desc "Audio encoder which generates ATSC A/52 compressed audio streams"
   homepage "https://aften.sourceforge.io/"
-  url "https://downloads.sourceforge.net/aften/aften-0.0.8.tar.bz2"
+  url "https://downloads.sourceforge.net/project/aften/aften/0.0.8/aften-0.0.8.tar.bz2"
   sha256 "87cc847233bb92fbd5bed49e2cdd6932bb58504aeaefbfd20ecfbeb9532f0c0a"
   license "LGPL-2.1"
 

--- a/Formula/apng2gif.rb
+++ b/Formula/apng2gif.rb
@@ -1,7 +1,7 @@
 class Apng2gif < Formula
   desc "Convert APNG animations into animated GIF format"
   homepage "https://apng2gif.sourceforge.io/"
-  url "https://downloads.sourceforge.net/apng2gif/apng2gif-1.8-src.zip"
+  url "https://downloads.sourceforge.net/project/apng2gif/1.8/apng2gif-1.8-src.zip"
   sha256 "9a07e386017dc696573cd7bc7b46b2575c06da0bc68c3c4f1c24a4b39cdedd4d"
 
   bottle do

--- a/Formula/aview.rb
+++ b/Formula/aview.rb
@@ -1,7 +1,7 @@
 class Aview < Formula
   desc "ASCII-art image browser and animation viewer"
   homepage "https://aa-project.sourceforge.io/"
-  url "https://downloads.sourceforge.net/aa-project/aview-1.3.0rc1.tar.gz"
+  url "https://downloads.sourceforge.net/project/aa-project/aview/1.3.0rc1/aview-1.3.0rc1.tar.gz"
   sha256 "42d61c4194e8b9b69a881fdde698c83cb27d7eda59e08b300e73aaa34474ec99"
   license "GPL-2.0"
 

--- a/Formula/base91.rb
+++ b/Formula/base91.rb
@@ -1,7 +1,7 @@
 class Base91 < Formula
   desc "Utility to encode and decode base91 files"
   homepage "https://base91.sourceforge.io"
-  url "https://downloads.sourceforge.net/base91/base91-0.6.0.tar.gz"
+  url "https://downloads.sourceforge.net/project/base91/basE91/0.6.0/base91-0.6.0.tar.gz"
   sha256 "02cfae7322c1f865ca6ce8f2e0bb8d38c8513e76aed67bf1c94eab1343c6c651"
   license "BSD-3-Clause"
 

--- a/Formula/bvi.rb
+++ b/Formula/bvi.rb
@@ -1,7 +1,7 @@
 class Bvi < Formula
   desc "Vi-like binary file (hex) editor"
   homepage "https://bvi.sourceforge.io"
-  url "https://downloads.sourceforge.net/bvi/bvi-1.4.1.src.tar.gz"
+  url "https://downloads.sourceforge.net/project/bvi/bvi/1.4.1/bvi-1.4.1.src.tar.gz"
   sha256 "3035255ca79e0464567d255baa5544f7794e2b7eb791dcc60cc339cf1aa01e28"
   license "GPL-3.0"
 

--- a/Formula/ctags.rb
+++ b/Formula/ctags.rb
@@ -4,7 +4,7 @@ class Ctags < Formula
   revision 1
 
   stable do
-    url "https://downloads.sourceforge.net/ctags/ctags-5.8.tar.gz"
+    url "https://downloads.sourceforge.net/project/ctags/ctags/5.8/ctags-5.8.tar.gz"
     sha256 "0e44b45dcabe969e0bbbb11e30c246f81abe5d32012db37395eb57d66e9e99c7"
 
     # also fixes https://sourceforge.net/p/ctags/bugs/312/

--- a/Formula/docbook2x.rb
+++ b/Formula/docbook2x.rb
@@ -1,7 +1,7 @@
 class Docbook2x < Formula
   desc "Convert DocBook to UNIX manpages and GNU TeXinfo"
   homepage "https://docbook2x.sourceforge.io/"
-  url "https://downloads.sourceforge.net/docbook2x/docbook2X-0.8.8.tar.gz"
+  url "https://downloads.sourceforge.net/project/docbook2x/docbook2x/0.8.8/docbook2X-0.8.8.tar.gz"
   sha256 "4077757d367a9d1b1427e8d5dfc3c49d993e90deabc6df23d05cfe9cd2fcdc45"
 
   bottle do

--- a/Formula/docx2txt.rb
+++ b/Formula/docx2txt.rb
@@ -1,7 +1,7 @@
 class Docx2txt < Formula
   desc "Converts Microsoft Office docx documents to equivalent text documents"
   homepage "https://docx2txt.sourceforge.io/"
-  url "https://downloads.sourceforge.net/docx2txt/docx2txt-1.4.tgz"
+  url "https://downloads.sourceforge.net/project/docx2txt/docx2txt/v1.4/docx2txt-1.4.tgz"
   sha256 "b297752910a404c1435e703d5aedb4571222bd759fa316c86ad8c8bbe58c6d1b"
   license "GPL-3.0"
 

--- a/Formula/doublecpp.rb
+++ b/Formula/doublecpp.rb
@@ -1,7 +1,7 @@
 class Doublecpp < Formula
   desc "Double dispatch in C++"
   homepage "https://doublecpp.sourceforge.io/"
-  url "https://downloads.sourceforge.net/doublecpp/doublecpp-0.6.3.tar.gz"
+  url "https://downloads.sourceforge.net/project/doublecpp/doublecpp/0.6.3/doublecpp-0.6.3.tar.gz"
   sha256 "232f8bf0d73795558f746c2e77f6d7cb54e1066cbc3ea7698c4fba80983423af"
   license "GPL-2.0"
 

--- a/Formula/dvdbackup.rb
+++ b/Formula/dvdbackup.rb
@@ -1,7 +1,7 @@
 class Dvdbackup < Formula
   desc "Rip DVD's from the command-line"
   homepage "https://dvdbackup.sourceforge.io"
-  url "https://downloads.sourceforge.net/dvdbackup/dvdbackup-0.4.2.tar.gz"
+  url "https://downloads.sourceforge.net/project/dvdbackup/dvdbackup/dvdbackup-0.4.2/dvdbackup-0.4.2.tar.gz"
   sha256 "0a37c31cc6f2d3c146ec57064bda8a06cf5f2ec90455366cb250506bab964550"
   revision 2
 

--- a/Formula/gauche.rb
+++ b/Formula/gauche.rb
@@ -1,7 +1,7 @@
 class Gauche < Formula
   desc "R7RS Scheme implementation, developed to be a handy script interpreter"
   homepage "https://practical-scheme.net/gauche/"
-  url "https://downloads.sourceforge.net/gauche/Gauche/Gauche-0.9.9.tgz"
+  url "https://downloads.sourceforge.net/project/gauche/Gauche/Gauche-0.9.9.tgz"
   sha256 "4ca9325322a7efadb9680d156eb7b53521321c9ca4955c4cbe738bc2e1d7f7fb"
 
   bottle do

--- a/Formula/gptsync.rb
+++ b/Formula/gptsync.rb
@@ -1,7 +1,7 @@
 class Gptsync < Formula
   desc "GPT and MBR partition tables synchronization tool"
   homepage "https://refit.sourceforge.io/"
-  url "https://downloads.sourceforge.net/refit/refit-src-0.14.tar.gz"
+  url "https://downloads.sourceforge.net/project/refit/rEFIt/0.14/refit-src-0.14.tar.gz"
   sha256 "c4b0803683c9f8a1de0b9f65d2b5a25a69100dcc608d58dca1611a8134cde081"
 
   bottle do

--- a/Formula/harbour.rb
+++ b/Formula/harbour.rb
@@ -8,7 +8,7 @@ class Harbour < Formula
   # deleted sometime after Harbour 3.0.0 release.
   stable do
     patch :DATA
-    url "https://downloads.sourceforge.net/harbour-project/source/3.0.0/harbour-3.0.0.tar.bz2"
+    url "https://downloads.sourceforge.net/project/harbour-project/source/3.0.0/harbour-3.0.0.tar.bz2"
     sha256 "4e99c0c96c681b40c7e586be18523e33db24baea68eb4e394989a3b7a6b5eaad"
   end
 

--- a/Formula/libcddb.rb
+++ b/Formula/libcddb.rb
@@ -1,7 +1,7 @@
 class Libcddb < Formula
   desc "CDDB server access library"
   homepage "https://libcddb.sourceforge.io/"
-  url "https://downloads.sourceforge.net/libcddb/libcddb-1.3.2.tar.bz2"
+  url "https://downloads.sourceforge.net/project/libcddb/libcddb/1.3.2/libcddb-1.3.2.tar.bz2"
   sha256 "35ce0ee1741ea38def304ddfe84a958901413aa829698357f0bee5bb8f0a223b"
   revision 4
 

--- a/Formula/libdv.rb
+++ b/Formula/libdv.rb
@@ -1,7 +1,7 @@
 class Libdv < Formula
   desc "Codec for DV video encoding format"
   homepage "https://libdv.sourceforge.io"
-  url "https://downloads.sourceforge.net/libdv/libdv-1.0.0.tar.gz"
+  url "https://downloads.sourceforge.net/project/libdv/libdv/1.0.0/libdv-1.0.0.tar.gz"
   sha256 "a305734033a9c25541a59e8dd1c254409953269ea7c710c39e540bd8853389ba"
 
   bottle do

--- a/Formula/libmodplug.rb
+++ b/Formula/libmodplug.rb
@@ -1,7 +1,7 @@
 class Libmodplug < Formula
   desc "Library from the Modplug-XMMS project"
   homepage "https://modplug-xmms.sourceforge.io/"
-  url "https://downloads.sourceforge.net/modplug-xmms/libmodplug/0.8.9.0/libmodplug-0.8.9.0.tar.gz"
+  url "https://downloads.sourceforge.net/project/modplug-xmms/libmodplug/0.8.9.0/libmodplug-0.8.9.0.tar.gz"
   sha256 "457ca5a6c179656d66c01505c0d95fafaead4329b9dbaa0f997d00a3508ad9de"
 
   bottle do

--- a/Formula/libpng.rb
+++ b/Formula/libpng.rb
@@ -1,7 +1,7 @@
 class Libpng < Formula
   desc "Library for manipulating PNG images"
   homepage "http://www.libpng.org/pub/png/libpng.html"
-  url "https://downloads.sourceforge.net/libpng/libpng-1.6.37.tar.xz"
+  url "https://downloads.sourceforge.net/project/libpng/libpng16/1.6.37/libpng-1.6.37.tar.xz"
   mirror "https://sourceforge.mirrorservice.org/l/li/libpng/libpng16/1.6.37/libpng-1.6.37.tar.xz"
   sha256 "505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca"
   license "libpng-2.0"

--- a/Formula/lxsplit.rb
+++ b/Formula/lxsplit.rb
@@ -1,7 +1,7 @@
 class Lxsplit < Formula
   desc "Tool for splitting or joining files"
   homepage "https://lxsplit.sourceforge.io/"
-  url "https://downloads.sourceforge.net/lxsplit/lxsplit-0.2.4.tar.gz"
+  url "https://downloads.sourceforge.net/project/lxsplit/lxsplit/0.2.4/lxsplit-0.2.4.tar.gz"
   sha256 "858fa939803b2eba97ccc5ec57011c4f4b613ff299abbdc51e2f921016845056"
   license "GPL-2.0"
 

--- a/Formula/mergelog.rb
+++ b/Formula/mergelog.rb
@@ -1,7 +1,7 @@
 class Mergelog < Formula
   desc "Merges httpd logs from web servers behind round-robin DNS"
   homepage "https://mergelog.sourceforge.io/"
-  url "https://downloads.sourceforge.net/mergelog/mergelog-4.5.tar.gz"
+  url "https://downloads.sourceforge.net/project/mergelog/mergelog/4.5/mergelog-4.5.tar.gz"
   sha256 "fd97c5b9ae88fbbf57d3be8d81c479e0df081ed9c4a0ada48b1ab8248a82676d"
   license "GPL-2.0"
 

--- a/Formula/mp3val.rb
+++ b/Formula/mp3val.rb
@@ -1,7 +1,7 @@
 class Mp3val < Formula
   desc "Program for MPEG audio stream validation"
   homepage "https://mp3val.sourceforge.io/"
-  url "https://downloads.sourceforge.net/mp3val/mp3val-0.1.8-src.tar.gz"
+  url "https://downloads.sourceforge.net/project/mp3val/mp3val/mp3val%200.1.8/mp3val-0.1.8-src.tar.gz"
   sha256 "95a16efe3c352bb31d23d68ee5cb8bb8ebd9868d3dcf0d84c96864f80c31c39f"
   license "GPL-2.0"
 

--- a/Formula/msdl.rb
+++ b/Formula/msdl.rb
@@ -1,7 +1,7 @@
 class Msdl < Formula
   desc "Downloader for various streaming protocols"
   homepage "https://msdl.sourceforge.io"
-  url "https://downloads.sourceforge.net/msdl/msdl-1.2.7-r2.tar.gz"
+  url "https://downloads.sourceforge.net/project/msdl/msdl/msdl-1.2.7-r2/msdl-1.2.7-r2.tar.gz"
   version "1.2.7-r2"
   sha256 "0297e87bafcab885491b44f71476f5d5bfc648557e7d4ef36961d44dd430a3a1"
   license "GPL-3.0"

--- a/Formula/opencore-amr.rb
+++ b/Formula/opencore-amr.rb
@@ -1,7 +1,7 @@
 class OpencoreAmr < Formula
   desc "Audio codecs extracted from Android open source project"
   homepage "https://opencore-amr.sourceforge.io/"
-  url "https://downloads.sourceforge.net/opencore-amr/opencore-amr-0.1.5.tar.gz"
+  url "https://downloads.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-0.1.5.tar.gz"
   sha256 "2c006cb9d5f651bfb5e60156dbff6af3c9d35c7bbcc9015308c0aff1e14cd341"
   license "Apache-2.0"
 

--- a/Formula/podofo.rb
+++ b/Formula/podofo.rb
@@ -1,7 +1,7 @@
 class Podofo < Formula
   desc "Library to work with the PDF file format"
   homepage "https://podofo.sourceforge.io"
-  url "https://downloads.sourceforge.net/podofo/podofo-0.9.6.tar.gz"
+  url "https://downloads.sourceforge.net/project/podofo/podofo/0.9.6/podofo-0.9.6.tar.gz"
   sha256 "e9163650955ab8e4b9532e7aa43b841bac45701f7b0f9b793a98c8ca3ef14072"
   revision 2
 

--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -1,7 +1,7 @@
 class Qjackctl < Formula
   desc "Simple Qt application to control the JACK sound server daemon"
   homepage "https://qjackctl.sourceforge.io/"
-  url "https://downloads.sourceforge.net/qjackctl/qjackctl-0.6.3.tar.gz"
+  url "https://downloads.sourceforge.net/project/qjackctl/qjackctl/0.6.3/qjackctl-0.6.3.tar.gz"
   sha256 "9db46376cfacb2e2ee051312245f5f7c383c9f5a958c0e3d661b9bd2a9246b7d"
   license "GPL-2.0"
   head "https://git.code.sf.net/p/qjackctl/code.git"

--- a/Formula/qrupdate.rb
+++ b/Formula/qrupdate.rb
@@ -1,7 +1,7 @@
 class Qrupdate < Formula
   desc "Fast updates of QR and Cholesky decompositions"
   homepage "https://sourceforge.net/projects/qrupdate/"
-  url "https://downloads.sourceforge.net/qrupdate/qrupdate-1.1.2.tar.gz"
+  url "https://downloads.sourceforge.net/project/qrupdate/qrupdate/1.2/qrupdate-1.1.2.tar.gz"
   sha256 "e2a1c711dc8ebc418e21195833814cb2f84b878b90a2774365f0166402308e08"
   revision 13
 

--- a/Formula/ttf2pt1.rb
+++ b/Formula/ttf2pt1.rb
@@ -1,7 +1,7 @@
 class Ttf2pt1 < Formula
   desc "True Type Font to Postscript Type 1 converter"
   homepage "https://ttf2pt1.sourceforge.io/"
-  url "https://downloads.sourceforge.net/ttf2pt1/ttf2pt1-3.4.4.tgz"
+  url "https://downloads.sourceforge.net/project/ttf2pt1/ttf2pt1/3.4.4/ttf2pt1-3.4.4.tgz"
   sha256 "ae926288be910073883b5c8a3b8fc168fde52b91199fdf13e92d72328945e1d0"
 
   bottle do

--- a/Formula/two-lame.rb
+++ b/Formula/two-lame.rb
@@ -1,7 +1,7 @@
 class TwoLame < Formula
   desc "Optimized MPEG Audio Layer 2 (MP2) encoder"
   homepage "https://www.twolame.org/"
-  url "https://downloads.sourceforge.net/twolame/0.4.0/twolame-0.4.0.tar.gz"
+  url "https://downloads.sourceforge.net/project/twolame/twolame/0.4.0/twolame-0.4.0.tar.gz"
   sha256 "cc35424f6019a88c6f52570b63e1baf50f62963a3eac52a03a800bb070d7c87d"
   license "LGPL-2.1"
 

--- a/Formula/ucon64.rb
+++ b/Formula/ucon64.rb
@@ -1,7 +1,7 @@
 class Ucon64 < Formula
   desc "ROM backup tool and emulator's Swiss Army knife program"
   homepage "https://ucon64.sourceforge.io/"
-  url "https://downloads.sourceforge.net/ucon64/ucon64-2.2.0-src.tar.gz"
+  url "https://downloads.sourceforge.net/project/ucon64/ucon64/ucon64-2.2.0/ucon64-2.2.0-src.tar.gz"
   sha256 "5727e0be9ee878bba84d204135a7ca25662db6b56fee6895301e50c1bdda70af"
   license "GPL-2.0"
   head "https://svn.code.sf.net/p/ucon64/svn/trunk/ucon64"

--- a/Formula/udis86.rb
+++ b/Formula/udis86.rb
@@ -1,7 +1,7 @@
 class Udis86 < Formula
   desc "Minimalistic disassembler library for x86"
   homepage "https://udis86.sourceforge.io"
-  url "https://downloads.sourceforge.net/udis86/udis86-1.7.2.tar.gz"
+  url "https://downloads.sourceforge.net/project/udis86/udis86/1.7/udis86-1.7.2.tar.gz"
   sha256 "9c52ac626ac6f531e1d6828feaad7e797d0f3cce1e9f34ad4e84627022b3c2f4"
 
   bottle do

--- a/Formula/w-calc.rb
+++ b/Formula/w-calc.rb
@@ -1,7 +1,7 @@
 class WCalc < Formula
   desc "Very capable calculator"
   homepage "https://w-calc.sourceforge.io/"
-  url "https://downloads.sourceforge.net/w-calc/wcalc-2.5.tar.bz2"
+  url "https://downloads.sourceforge.net/project/w-calc/Wcalc/2.5/wcalc-2.5.tar.bz2"
   sha256 "0e2c17c20f935328dcdc6cb4c06250a6732f9ee78adf7a55c01133960d6d28ee"
   revision 1
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Most of the `stable` URLs that use a `https://downloads.sourceforge.net` URL start with `https://downloads.sourceforge.net/project/`. However, there are around 30 that use a format like `https://downloads.sourceforge.net/aa-project/aalib-1.4rc5.tar.gz` which redirects to the `/project/` URL (e.g., `https://downloads.sourceforge.net/project/aa-project/aa-lib/1.4rc5/aalib-1.4rc5.tar.gz`) before redirecting again to a mirror.

This updates these URLs to use the appropriate `/project/` URL to avoid the first (non-mirror) redirection. For what it's worth, the only other `stable` SourceForge URL that doesn't use `https://downloads.sourceforge.net/project/` is `abook` (`http://abook.sourceforge.net/devel/abook-0.6.1.tar.gz`), since it's using a development version that isn't found in the SourceForge project files.

---

I've squashed this into one commit since this PR will simply be squash-and-merge'd.

Since these URL changes are using the same archive files (i.e., same location, same checksum, etc.), I'm going to cancel CI after tap_syntax completes. I've installed all of these from source locally and run `brew audit --strict --online` and `brew test` on each and the only failures are as follows.

## Audit failures

```
gauche:
  * C: 17: col 5: Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
gptsync:
  * C: 1: col 1: A `test do` test block should be added
libdv:
  * C: 1: col 1: A `test do` test block should be added
lxsplit:
  * C: 1: col 1: A `test do` test block should be added
msdl:
  * C: 1: col 1: A `test do` test block should be added
opencore-amr:
  * C: 1: col 1: A `test do` test block should be added
ttf2pt1:
  * C: 1: col 1: A `test do` test block should be added
Error: 7 problems in 7 formulae detected
```

## Test failures

The following `qrupdate` test failure occurs with the bottle as well, so it's not related to the `stable` URL update.

```
==> Testing qrupdate
==> gfortran -o test /usr/local/Cellar/qrupdate/1.1.2_13/share/qrupdate/tch1dn.f
==> ./test
Error: qrupdate: failed
An exception occurred within a child process:
  Test::Unit::AssertionFailedError: </PASSED\ \ \ 4\ \ \ \ \ FAILED\ \ \ 0/> was expected to be =~
<"\n" +
" testing Cholesky rank-1 downdate routines.\n" +
" All residual errors are expected to be small.\n" +
"\n" +
" sch1dn test:\n" +
"      residual error =              0.476837158203E-05       PASS\n" +
" dch1dn test:\n" +
"      residual error =              0.106581410364E-13       PASS\n" +
" cch1dn test:\n" +
"      residual error =              0.114611921163E-04       PASS\n" +
" zch1dn test:\n" +
"      residual error =              0.497379915032E-13       FAIL\n" +
"----------------------------------------------------------------------\n" +
" total:     PASSED   3     FAILED   1\n" +
"\n">.
```