### PR TITLE
tests.yml: remove redundant 'name's

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: brew install-bundler-gems
 
-    - name: Run brew test-bot --only-tap-syntax
-      run: brew test-bot --only-tap-syntax
+    - run: brew test-bot --only-tap-syntax
 
   tests:
     needs: tap_syntax
@@ -50,11 +49,9 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Run brew test-bot --only-cleanup-before
-        run: brew test-bot --only-cleanup-before
+      - run: brew test-bot --only-cleanup-before
 
-      - name: Run brew test-bot --only-setup
-        run: brew test-bot --only-setup
+      - run: brew test-bot --only-setup
 
       - name: Run brew test-bot --only-formulae
         run: |
@@ -97,9 +94,8 @@ jobs:
           name: bottles
           path: bottles
 
-      - name: Run brew test-bot --only-cleanup-after
+      - run: brew test-bot --only-cleanup-after
         if: always()
-        run: brew test-bot --only-cleanup-after
 
       - name: Post Cleanup
         if: always()


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [N/A] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [N/A] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [N/A] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?


When 'name' is not provided, GitHub actions step automatically get
"Run <comand>" name so we don't need to set that.