### PR TITLE
shelltestrunner: deprecate cabal v1 installation

### DIFF
--- a/Formula/shelltestrunner.rb
+++ b/Formula/shelltestrunner.rb
@@ -1,13 +1,10 @@
-require "language/haskell"
-
 class Shelltestrunner < Formula
-  include Language::Haskell::Cabal
-
   desc "Portable command-line tool for testing command-line programs"
   homepage "https://github.com/simonmichael/shelltestrunner"
   url "https://hackage.haskell.org/package/shelltestrunner-1.9/shelltestrunner-1.9.tar.gz"
   sha256 "cbc4358d447e32babe4572cda0d530c648cc4c67805f9f88002999c717feb3a8"
   license "GPL-3.0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -21,7 +18,8 @@ class Shelltestrunner < Formula
   depends_on "ghc@8.8" => :build
 
   def install
-    install_cabal_package using: ["happy"]
+    system "cabal", "v2-update"
+    system "cabal", "v2-install", *std_cabal_v2_args
   end
 
   test do


### PR DESCRIPTION
- deprecate cabal v1 installation 
- relates to #55253