### PR TITLE
workflows/autolabel: don't label as python if just build dependency

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -78,7 +78,7 @@ jobs:
                 }, {
                     "label": "python",
                     "path": "Formula/.+",
-                    "content": "(?:depends_on|uses_from_macos) \"python@?.+"
+                    "content": "(?:depends_on|uses_from_macos) \"python@?(?:(?!:build).)+\n"
                 }, {
                     "label": "ruby",
                     "path": "Formula/.+",


### PR DESCRIPTION
<!--

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

-->

- This skips adding the `python` label if the formula only depends on Python for build
- Example match: https://regex101.com/r/EsOQbo (might take a few seconds to load properly)
- `(?!:build)` - negative lookahead for `:build`
- Question: Should this be done for other dependencies (e.g. `ruby`) as well?
<!--
- Possible alternative:

```
"content": "(?:depends_on|uses_from_macos) \"python@?.+",
"missing_content": "(?:depends_on|uses_from_macos) \"python@?.+:build.*\n"
```
-->