### PR TITLE
supervisor: fix conf filename

### DIFF
--- a/Formula/supervisor.rb
+++ b/Formula/supervisor.rb
@@ -26,15 +26,22 @@ class Supervisor < Formula
 
     virtualenv_install_with_resources
 
-    etc.install buildpath/"supervisor/skel/sample.conf" => "supervisord.ini"
+    etc.install buildpath/"supervisor/skel/sample.conf" => "supervisord.conf"
   end
 
   def post_install
     (var/"run").mkpath
     (var/"log").mkpath
+    conf_warn = <<~EOS
+      The default location for supervisor's config file is now:
+        #{etc}/supervisord.conf
+      Please move your config file to this location and restart supervisor.
+    EOS
+    old_conf = etc/"supervisord.ini"
+    opoo conf_warn if old_conf.exist?
   end
 
-  plist_options manual: "supervisord -c #{HOMEBREW_PREFIX}/etc/supervisord.ini"
+  plist_options manual: "supervisord"
 
   def plist
     <<~EOS
@@ -53,7 +60,7 @@ class Supervisor < Formula
           <array>
             <string>#{opt_bin}/supervisord</string>
             <string>-c</string>
-            <string>#{etc}/supervisord.ini</string>
+            <string>#{etc}/supervisord.conf</string>
             <string>--nodaemon</string>
           </array>
         </dict>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR moves the `supervisor` config file to `/usr/local/etc/supervisor.conf`, which is the first place that `supervisord` looks for it according to the [config docs](http://supervisord.org/configuration.html#configuration-file) (`../etc/supervisor.conf` relative to the executable). This eliminates the need for the `-c` flag in all instructions, though the plist file still uses it because it invokes `#{opt_bin}/supervisord` instead, thus failing the config file location algorithm.

I've tested it locally, and both `supervisord` and `supervisorctl` find the config file just fine without additional arguments, so this should address https://discourse.brew.sh/t/supervisor-issues-install-fine-cant-run/8504.

However, this likely constitutes a breaking change for all users who've configured and gotten used to the old path (`/usr/local/etc/supervisor.ini`). @Homebrew/core, does anyone have prior experience dealing with this, and what would be the recommended course of action to resolve this?