### PR TITLE
Haskell formula license update

### DIFF
--- a/Formula/allureofthestars.rb
+++ b/Formula/allureofthestars.rb
@@ -7,7 +7,7 @@ class Allureofthestars < Formula
   homepage "https://www.allureofthestars.com/"
   url "https://hackage.haskell.org/package/Allure-0.9.5.0/Allure-0.9.5.0.tar.gz"
   sha256 "8180fe070633bfa5515de8f7443421044e7ad4ee050f0a92c048cec5f2c88132"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   head "https://github.com/AllureOfTheStars/Allure.git"
 
   bottle do

--- a/Formula/dhall.rb
+++ b/Formula/dhall.rb
@@ -3,6 +3,7 @@ class Dhall < Formula
   homepage "https://dhall-lang.org/"
   url "https://hackage.haskell.org/package/dhall-1.34.0/dhall-1.34.0.tar.gz"
   sha256 "0dbc61611d465f744aec13fd3114a9d75bbaa434f1aaa3de7e49c385d9fe1b67"
+  license "BSD-3-Clause"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -3,6 +3,7 @@ class GitAnnex < Formula
   homepage "https://git-annex.branchable.com/"
   url "https://hackage.haskell.org/package/git-annex-8.20200720.1/git-annex-8.20200720.1.tar.gz"
   sha256 "d6252697151ab01cc8f7a492dc5eb4b4e773c0d48771df360c82a7cca7a39c3c"
+  license "AGPL-3.0-or-later"
   revision 1
   head "git://git-annex.branchable.com/"
 

--- a/Formula/hledger.rb
+++ b/Formula/hledger.rb
@@ -3,7 +3,7 @@ class Hledger < Formula
   homepage "https://hledger.org/"
   url "https://hackage.haskell.org/package/hledger-1.18.1/hledger-1.18.1.tar.gz"
   sha256 "0c88c9a1896a6c431854c76229f0fe8d9bc59b6560829a4af1b8fcbad85486fa"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/hopenpgp-tools.rb
+++ b/Formula/hopenpgp-tools.rb
@@ -7,8 +7,9 @@ class HopenpgpTools < Formula
   homepage "https://hackage.haskell.org/package/hopenpgp-tools"
   url "https://hackage.haskell.org/package/hopenpgp-tools-0.23.1/hopenpgp-tools-0.23.1.tar.gz"
   sha256 "b28ac66343a0bf78b3bfb22cc87f85355909fcd49d9ba5ad43e5a0c38e8b014b"
+  license "AGPL-3.0-only"
   revision 1
-  head "https://salsa.debian.org/clint/hOpenPGP.git"
+  head "https://salsa.debian.org/clint/hopenpgp-tools.git"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/pandoc-crossref.rb
+++ b/Formula/pandoc-crossref.rb
@@ -3,7 +3,7 @@ class PandocCrossref < Formula
   homepage "https://github.com/lierdakil/pandoc-crossref"
   url "https://hackage.haskell.org/package/pandoc-crossref-0.3.7.0/pandoc-crossref-0.3.7.0.tar.gz"
   sha256 "467d2470fa66885179284e54d8757ae1a9b442b6ff8af33bd177870f285b85d7"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -3,7 +3,7 @@ class Pandoc < Formula
   homepage "https://pandoc.org/"
   url "https://hackage.haskell.org/package/pandoc-2.10.1/pandoc-2.10.1.tar.gz"
   sha256 "938a4c9b0a7ed3de886c73af4052913b0ac9e4aa12b435bd2afd09670bd3229a"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/jgm/pandoc.git"
 
   bottle do

--- a/Formula/shelltestrunner.rb
+++ b/Formula/shelltestrunner.rb
@@ -3,7 +3,7 @@ class Shelltestrunner < Formula
   homepage "https://github.com/simonmichael/shelltestrunner"
   url "https://hackage.haskell.org/package/shelltestrunner-1.9/shelltestrunner-1.9.tar.gz"
   sha256 "cbc4358d447e32babe4572cda0d530c648cc4c67805f9f88002999c717feb3a8"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/texmath.rb
+++ b/Formula/texmath.rb
@@ -7,7 +7,7 @@ class Texmath < Formula
   homepage "https://johnmacfarlane.net/texmath.html"
   url "https://hackage.haskell.org/package/texmath-0.12.0.2/texmath-0.12.0.2.tar.gz"
   sha256 "2fec285a2266e56bba17914c122045f31b38de3efcd202dcf32a4f8b830bd184"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Update haskell formulae licenses.

cc @Rylan12 @jonchang 

---

Except `shelltestrunner`, which has license display issue on the `hackage.haskell.org` site, I adopted all the other licenses directly from `haskell.org` 

For `shelltestrunner`, the license should be `GPL-3.0-or-later`, [license ref](https://hackage.haskell.org/package/shelltestrunner-1.9/src/LICENSE)