### PR TITLE
snort: add license

### DIFF
--- a/Formula/snort.rb
+++ b/Formula/snort.rb
@@ -4,6 +4,7 @@ class Snort < Formula
   url "https://www.snort.org/downloads/snort/snort-2.9.16.1.tar.gz"
   mirror "https://fossies.org/linux/misc/snort-2.9.16.1.tar.gz"
   sha256 "e3ac45a1a3cc2c997d52d19cd92f1adf5641c3a919387adab47a4d13a9dc9f8e"
+  license "GPL-2.0-only"
 
   bottle do
     cellar :any


### PR DESCRIPTION
relates to #59340

---

> This program is free software; you can redistribute it and/or modify
> it under the terms of the GNU General Public License as published by
> the Free Software Foundation; either version 2 of the License, or
> (at your option) any later version.

In the `COPYING` file of the artifact.

cc @Rylan12 @dawidd6