### PR TITLE
workflows/autolabel: add `resource updates needed`

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -44,6 +44,10 @@ jobs:
                     "path": "Formula/.+",
                     "missing_content": "\n  license .+\n"
                 }, {
+                    "label": "resource updates needed",
+                    "path": "Formula/.+",
+                    "content": "\n +resource .+\n"
+                }, {
                     "label": "go",
                     "path": "Formula/.+",
                     "content": "depends_on \"go(?:@[0-9.]+)?\""


### PR DESCRIPTION
<!--

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

-->

- This adds `resource updates needed` to any formulae that have `resource`s
- (Checks for one or more spaces instead of just two spaces to account for e.g. `on_linux` `resource` blocks)
- Similar to #58852; should this be an automatic check by GitHub or a manual check by maintainers?
  - Could this be a new label separate from `resource updates needed`?