### PR TITLE
workflows/autolabel: label deprecated licenses

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -44,6 +44,10 @@ jobs:
                     "path": "Formula/.+",
                     "missing_content": "\n  license .+\n"
                 }, {
+                    "label": "deprecated license",
+                    "path": "Formula/.+",
+                    "content": "license .*\"(GPL|LGPL|AGPL|GFDL)-\d\.\d\+?\".*"
+                }, {
                     "label": "go",
                     "path": "Formula/.+",
                     "content": "depends_on \"go(?:@[0-9.]+)?\""


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Now that https://github.com/Homebrew/brew/pull/8201 has been merged, we don't want deprecated license identifiers, but there are still ~1700 formulae that have a deprecated identifier. `brew audit --strict` will now complain about deprecated licenses, but CI won't check for it because we don't want to block PRs just for license issues.

I think adding a `deprecated license` label will be a good compromise here. It makes sure that the contributor and maintainers are notified that the formula uses a deprecated license, but it also doesn't require the license to be fixed before the PR is merged.

This will catch `GPL`, `LGPL`, `AGPL` and `GFDL` licenses that follow the format: `GPL-1.0` with an optional `+` at the end.

The only deprecated license that doesn't fit this pattern is [`wxmac`](https://github.com/Homebrew/homebrew-core/blob/7309ae3024f988cbab142a459b3f355b2d99051c/Formula/wxmac.rb#L6) which uses the deprecated `wxWindows` license identifier.

Regex reference: https://regex101.com/r/8RVMoG/1