### PR TITLE
cbc 2.10.5 (new formula)

### DIFF
--- a/Formula/cbc.rb
+++ b/Formula/cbc.rb
@@ -1,0 +1,46 @@
+class Cbc < Formula
+  desc "Mixed integer linear programming solver"
+  homepage "https://github.com/coin-or/Cbc"
+  url "https://github.com/coin-or/Cbc/archive/releases/2.10.5.tar.gz"
+  sha256 "cc44c1950ff4615e7791d7e03ea34318ca001d3cac6dc3f7f5ee392459ce6719"
+  # update to EPL-2.0 on next release
+  license "EPL-1.0"
+
+  depends_on "pkg-config" => :build
+  depends_on "cgl"
+  depends_on "clp"
+  depends_on "coinutils"
+  depends_on "osi"
+
+  def install
+    # Work around - same as clp formula
+    # Error 1: "mkdir: #{include}/cbc/coin: File exists."
+    mkdir include/"cbc/coin"
+
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--includedir=#{include}/cbc"
+    system "make"
+    system "make", "install"
+    pkgshare.install "Cbc/examples"
+  end
+
+  test do
+    cp_r pkgshare/"examples/.", testpath
+    system ENV.cxx, "-std=c++11", "sudoku.cpp",
+                    "-L#{lib}", "-lCbc",
+                    "-L#{Formula["cgl"].opt_lib}", "-lCgl",
+                    "-L#{Formula["clp"].opt_lib}", "-lClp", "-lOsiClp",
+                    "-L#{Formula["coinutils"].opt_lib}", "-lCoinUtils",
+                    "-L#{Formula["osi"].opt_lib}", "-lOsi",
+                    "-I#{include}/cbc/coin",
+                    "-I#{Formula["cgl"].opt_include}/cgl/coin",
+                    "-I#{Formula["clp"].opt_include}/clp/coin",
+                    "-I#{Formula["coinutils"].opt_include}/coinutils/coin",
+                    "-I#{Formula["osi"].opt_include}/osi/coin",
+                    "-o", "sudoku"
+    assert_match "solution is valid", shell_output("./sudoku")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Mixed integer programming solver

Notes:
- The latest release is licensed under EPL-1.0 (https://github.com/coin-or/Cbc/blob/releases/2.10.5/Cbc/LICENSE). The next release will likely be licensed under EPL-2.0 (https://github.com/coin-or/Cbc/commit/cc4122790c55a516c106d3813f743acf176d8803).