### PR TITLE
clojure 1.10.1.561

### DIFF
--- a/Formula/clojure.rb
+++ b/Formula/clojure.rb
@@ -1,8 +1,8 @@
 class Clojure < Formula
   desc "The Clojure Programming Language"
   homepage "https://clojure.org"
-  url "https://download.clojure.org/install/clojure-tools-1.10.1.645.tar.gz"
-  sha256 "c96976b91c2297601ea13d60a1d317adb0e3556fbf5e25891729698aac4acafc"
+  url "https://download.clojure.org/install/clojure-tools-1.10.1.561.tar.gz"
+  sha256 "46c193d09f8fce9c0e5e530c2463586cec9717593cdee2f57199d278ed104e2d"
   license "EPL-1.0"
 
   bottle :unneeded

--- a/Formula/clojure.rb
+++ b/Formula/clojure.rb
@@ -4,6 +4,7 @@ class Clojure < Formula
   url "https://download.clojure.org/install/clojure-tools-1.10.1.561.tar.gz"
   sha256 "46c193d09f8fce9c0e5e530c2463586cec9717593cdee2f57199d278ed104e2d"
   license "EPL-1.0"
+  version_scheme 1
 
   bottle :unneeded
 


### PR DESCRIPTION
The Clojure team releases new versions of the clj tools frequently (sometimes several times a day) to the official Clojure tap https://github.com/clojure/homebrew-tools as @ formulas. Much less frequently, we mark a release as "stable" and the stable version can always be found at https://github.com/clojure/homebrew-tools/blob/master/Formula/clojure.rb (installed with `brew install clojure/tools/clojure`).

The clojure formula here has been updated several times recently to newer prerelease development versions which are buggy or have as yet unannounced changes. We are now fielding regular support questions related to these prerelease versions because these versions of the tool are not ready for widespread use yet. This PR sets the clojure version backwards to the current stable version.

Is there a better way to stop this from happening in the future? Is there some way to notify users in the formula description etc that this is not the official Clojure formula supported by the Clojure team? Would it make sense to remove the formula and have a message that pointed people to the official Clojure tap instead?


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
