### PR TITLE
gnutls-guile 3.6.14 (new formula)

### DIFF
--- a/Formula/gnutls-guile.rb
+++ b/Formula/gnutls-guile.rb
@@ -1,0 +1,70 @@
+class GnutlsGuile < Formula
+  desc "Guile bindings for the GNU Transport Layer Security (TLS) Library"
+  homepage "https://gnutls.org/"
+  url "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.14.tar.xz"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnutls/v3.6/gnutls-3.6.14.tar.xz"
+  sha256 "5630751adec7025b8ef955af4d141d00d252a985769f51b4059e5affa3d39d63"
+  license "LGPL-2.1"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "gnutls"
+  depends_on "guile"
+
+  on_linux do
+    depends_on "autogen" => :build
+  end
+
+  def install
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --disable-static
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}
+      --with-default-trust-store-file=#{pkgetc}/cert.pem
+      --with-guile-site-dir=#{share}/guile/site/3.0
+      --with-guile-site-ccache-dir=#{lib}/guile/3.0/site-ccache
+      --with-guile-extension-dir=#{lib}/guile/3.0/extensions
+      --disable-heartbeat-support
+      --with-p11-kit
+    ]
+
+    # Work around a gnulib issue with macOS Catalina
+    args << "gl_cv_func_ftello_works=yes"
+
+    system "./configure", *args
+    # Adding LDFLAGS= to allow the build on Catalina 10.15.4
+    # See https://gitlab.com/gnutls/gnutls/-/issues/966
+    system "make", "LDFLAGS="
+
+    chdir "guile" do
+      system "make", "install"
+    end
+  end
+
+  def caveats
+    <<~EOS
+      Remember to add the following to your .bashrc or equivalent in order to use this module:
+        export GUILE_LOAD_PATH="#{HOMEBREW_PREFIX}/share/guile/site/3.0"
+        export GUILE_LOAD_COMPILED_PATH="#{HOMEBREW_PREFIX}/lib/guile/3.0/site-ccache"
+        export GUILE_SYSTEM_EXTENSIONS_PATH="#{HOMEBREW_PREFIX}/lib/guile/3.0/extensions"
+    EOS
+  end
+
+  test do
+    gnutls = testpath/"gnutls.scm"
+    gnutls.write <<~EOS
+      (use-modules (gnutls))
+      (gnutls-version)
+    EOS
+
+    ENV["GUILE_AUTO_COMPILE"] = "0"
+    ENV["GUILE_LOAD_PATH"] = HOMEBREW_PREFIX/"share/guile/site/3.0"
+    ENV["GUILE_LOAD_COMPILED_PATH"] = HOMEBREW_PREFIX/"lib/guile/3.0/site-ccache"
+    ENV["GUILE_SYSTEM_EXTENSIONS_PATH"] = HOMEBREW_PREFIX/"lib/guile/3.0/extensions"
+
+    system "guile", gnutls
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula builds `gnutls` library again in order to build the bindings, however it only installs the bindings. By only installing the bindings we have the following issue, however the compiled library is actually not needed since the `gnutls` one will be used. I'm not sure how to do this well without creating this new formula, unless we enable Guile in the `gnutls` formula, but I feel it's better to have a `gnutls-guile` one.

```
❯ brew audit --strict gnutls-guile
Broken dependencies:
  /usr/local/Cellar/gnutls-guile/3.6.14/lib/libgnutls.30.dylib (gnutls-guile)
No broken library linkage detected
gnutls-guile:
  * Formula gnutls-guile contains deprecated SPDX licenses: ["LGPL-2.1"].
  * gnutls-guile has broken dynamic library links:

Error: 2 problems in 1 formula detected
```

