### PR TITLE
Use `version.major` for GCC version suffix

### DIFF
--- a/Formula/augustus.rb
+++ b/Formula/augustus.rb
@@ -40,7 +40,7 @@ class Augustus < Formula
     # to upstream in 2016 (see https://github.com/nextgenusfs/funannotate/issues/3).
     # See also https://github.com/Gaius-Augustus/Augustus/issues/64
     cd "src" do
-      with_env("HOMEBREW_CC" => Formula["gcc"].opt_bin/"gcc-#{Formula["gcc"].linked_version.to_s.slice(/\d+/)}") do
+      with_env("HOMEBREW_CC" => Formula["gcc"].opt_bin/"gcc-#{Formula["gcc"].installed_version.major}") do
         system "make"
       end
     end

--- a/Formula/dynare.rb
+++ b/Formula/dynare.rb
@@ -63,7 +63,7 @@ class Dynare < Formula
                           "--disable-doc"
     # Octave hardcodes its paths which causes problems on GCC minor version bumps
     gcc = Formula["gcc"]
-    flibs = "-L#{gcc.lib/"gcc"/gcc.version_suffix} -lgfortran -lquadmath -lm"
+    flibs = "-L#{gcc.lib/"gcc"/gcc.installed_version.major} -lgfortran -lquadmath -lm"
     system "make", "install", "FLIBS=#{flibs}"
   end
 

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -34,7 +34,7 @@ class Gcc < Formula
     if build.head?
       "HEAD"
     else
-      version.to_s.slice(/\d+/)
+      version.major.to_s
     end
   end
 

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -86,7 +86,7 @@ class GccAT49 < Formula
     # Build dependencies in-tree, to avoid having versioned formulas
     resources.each { |r| r.stage(buildpath/r.name) }
 
-    version_suffix = version.to_s.slice(/\d\.\d/)
+    version_suffix = version.major_minor.to_s
 
     args = [
       "--build=x86_64-apple-darwin#{osmajor}",
@@ -162,7 +162,7 @@ class GccAT49 < Formula
         return 0;
       }
     EOS
-    system bin/"gcc-4.9", "-o", "hello-c", "hello-c.c"
+    system bin/"gcc-#{version.major_minor}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
   end
 end

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -75,7 +75,7 @@ class GccAT5 < Formula
     # C, C++, ObjC and Fortran compilers are always built
     languages = %w[c c++ fortran objc obj-c++]
 
-    version_suffix = version.to_s.slice(/\d/)
+    version_suffix = version.major.to_s
 
     # Even when suffixes are appended, the info pages conflict when
     # install-info is run so pretend we have an outdated makeinfo
@@ -153,7 +153,7 @@ class GccAT5 < Formula
         return 0;
       }
     EOS
-    system bin/"gcc-5", "-o", "hello-c", "hello-c.c"
+    system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
   end
 end

--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -44,7 +44,7 @@ class GccAT6 < Formula
     # C, C++, ObjC, Fortran compilers are always built
     languages = %w[c c++ objc obj-c++ fortran]
 
-    version_suffix = version.to_s.slice(/\d/)
+    version_suffix = version.major.to_s
 
     # Even when suffixes are appended, the info pages conflict when
     # install-info is run so pretend we have an outdated makeinfo
@@ -124,7 +124,7 @@ class GccAT6 < Formula
         return 0;
       }
     EOS
-    system "#{bin}/gcc-6", "-o", "hello-c", "hello-c.c"
+    system "#{bin}/gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 
     (testpath/"hello-cc.cc").write <<~EOS
@@ -135,7 +135,7 @@ class GccAT6 < Formula
         return 0;
       }
     EOS
-    system "#{bin}/g++-6", "-o", "hello-cc", "hello-cc.cc"
+    system "#{bin}/g++-#{version.major}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", `./hello-cc`
 
     fixture = <<~EOS
@@ -150,7 +150,7 @@ class GccAT6 < Formula
       end
     EOS
     (testpath/"in.f90").write(fixture)
-    system "#{bin}/gfortran-6", "-o", "test", "in.f90"
+    system "#{bin}/gfortran-#{version.major}", "-o", "test", "in.f90"
     assert_equal "done", `./test`.strip
   end
 end

--- a/Formula/gcc@7.rb
+++ b/Formula/gcc@7.rb
@@ -31,7 +31,7 @@ class GccAT7 < Formula
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
 
-    version_suffix = version.to_s.slice(/\d/)
+    version_suffix = version.major.to_s
 
     # Even when suffixes are appended, the info pages conflict when
     # install-info is run so pretend we have an outdated makeinfo
@@ -112,7 +112,7 @@ class GccAT7 < Formula
         return 0;
       }
     EOS
-    system "#{bin}/gcc-7", "-o", "hello-c", "hello-c.c"
+    system "#{bin}/gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 
     (testpath/"hello-cc.cc").write <<~EOS
@@ -123,7 +123,7 @@ class GccAT7 < Formula
         return 0;
       }
     EOS
-    system "#{bin}/g++-7", "-o", "hello-cc", "hello-cc.cc"
+    system "#{bin}/g++-#{version.major}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", `./hello-cc`
 
     (testpath/"test.f90").write <<~EOS
@@ -137,7 +137,7 @@ class GccAT7 < Formula
       write(*,"(A)") "Done"
       end
     EOS
-    system "#{bin}/gfortran-7", "-o", "test", "test.f90"
+    system "#{bin}/gfortran-#{version.major}", "-o", "test", "test.f90"
     assert_equal "Done\n", `./test`
   end
 end

--- a/Formula/gcc@8.rb
+++ b/Formula/gcc@8.rb
@@ -31,7 +31,7 @@ class GccAT8 < Formula
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
 
-    version_suffix = version.to_s.slice(/\d/)
+    version_suffix = version.major.to_s
 
     # Even when suffixes are appended, the info pages conflict when
     # install-info is run so pretend we have an outdated makeinfo
@@ -115,7 +115,7 @@ class GccAT8 < Formula
         return 0;
       }
     EOS
-    system "#{bin}/gcc-8", "-o", "hello-c", "hello-c.c"
+    system "#{bin}/gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 
     (testpath/"hello-cc.cc").write <<~EOS
@@ -126,7 +126,7 @@ class GccAT8 < Formula
         return 0;
       }
     EOS
-    system "#{bin}/g++-8", "-o", "hello-cc", "hello-cc.cc"
+    system "#{bin}/g++-#{version.major}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", `./hello-cc`
 
     (testpath/"test.f90").write <<~EOS
@@ -140,7 +140,7 @@ class GccAT8 < Formula
       write(*,"(A)") "Done"
       end
     EOS
-    system "#{bin}/gfortran-8", "-o", "test", "test.f90"
+    system "#{bin}/gfortran-#{version.major}", "-o", "test", "test.f90"
     assert_equal "Done\n", `./test`
   end
 end

--- a/Formula/gcc@9.rb
+++ b/Formula/gcc@9.rb
@@ -32,6 +32,8 @@ class GccAT9 < Formula
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
 
+    version_suffix = version.major.to_s
+
     # Even when suffixes are appended, the info pages conflict when
     # install-info is run so pretend we have an outdated makeinfo
     # to prevent their build.
@@ -49,11 +51,11 @@ class GccAT9 < Formula
     args = %W[
       --build=x86_64-apple-darwin#{osmajor}
       --prefix=#{prefix}
-      --libdir=#{lib}/gcc/9
+      --libdir=#{lib}/gcc/#{version_suffix}
       --disable-nls
       --enable-checking=release
       --enable-languages=#{languages.join(",")}
-      --program-suffix=-9
+      --program-suffix=-#{version_suffix}
       --with-gmp=#{Formula["gmp"].opt_prefix}
       --with-mpfr=#{Formula["mpfr"].opt_prefix}
       --with-mpc=#{Formula["libmpc"].opt_prefix}
@@ -78,7 +80,7 @@ class GccAT9 < Formula
 
     # Ensure correct install names when linking against libgcc_s;
     # see discussion in https://github.com/Homebrew/legacy-homebrew/pull/34303
-    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/9"
+    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
 
     mkdir "build" do
       system "../configure", *args
@@ -93,7 +95,7 @@ class GccAT9 < Formula
     # Handle conflicts between GCC formulae and avoid interfering
     # with system compilers.
     # Rename man7.
-    Dir.glob(man7/"*.7") { |file| add_suffix file, "9" }
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
     # Even when we disable building info pages some are still installed.
     info.rmtree
   end
@@ -114,7 +116,7 @@ class GccAT9 < Formula
         return 0;
       }
     EOS
-    system "#{bin}/gcc-9", "-o", "hello-c", "hello-c.c"
+    system "#{bin}/gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 
     (testpath/"hello-cc.cc").write <<~EOS
@@ -125,7 +127,7 @@ class GccAT9 < Formula
         return 0;
       }
     EOS
-    system "#{bin}/g++-9", "-o", "hello-cc", "hello-cc.cc"
+    system "#{bin}/g++-#{version.major}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", `./hello-cc`
 
     (testpath/"test.f90").write <<~EOS
@@ -139,7 +141,7 @@ class GccAT9 < Formula
       write(*,"(A)") "Done"
       end
     EOS
-    system "#{bin}/gfortran-9", "-o", "test", "test.f90"
+    system "#{bin}/gfortran-#{version.major}", "-o", "test", "test.f90"
     assert_equal "Done\n", `./test`
   end
 end

--- a/Formula/gromacs.rb
+++ b/Formula/gromacs.rb
@@ -25,8 +25,8 @@ class Gromacs < Formula
                                                              "/usr/bin/ld"
 
     args = std_cmake_args + %W[
-      -DCMAKE_C_COMPILER=gcc-#{Formula["gcc"].version_suffix}
-      -DCMAKE_CXX_COMPILER=g++-#{Formula["gcc"].version_suffix}
+      -DCMAKE_C_COMPILER=gcc-#{Formula["gcc"].installed_version.major}
+      -DCMAKE_CXX_COMPILER=g++-#{Formula["gcc"].installed_version.major}
     ]
 
     mkdir "build" do

--- a/Formula/imake.rb
+++ b/Formula/imake.rb
@@ -29,7 +29,7 @@ class Imake < Formula
     ENV.deparallelize
 
     # imake runtime is broken when used with clang's cpp
-    cpp_program = Formula["gcc"].opt_bin/"cpp-#{Formula["gcc"].version_suffix}"
+    cpp_program = Formula["gcc"].opt_bin/"cpp-#{Formula["gcc"].installed_version.major}"
     inreplace "imakemdep.h", /::CPPCMD::/, cpp_program
     inreplace "imake.man", /__cpp__/, cpp_program
 
@@ -52,7 +52,7 @@ class Imake < Formula
   test do
     # Use pipe_output because the return code is unimportant here.
     output = pipe_output("#{bin}/imake -v -s/dev/null -f/dev/null -T/dev/null 2>&1")
-    gcc_major_ver = Formula["gcc"].version_suffix
+    gcc_major_ver = Formula["gcc"].installed_version.major
     assert_match "#{Formula["gcc"].opt_bin}/cpp-#{gcc_major_ver}", output
   end
 end

--- a/Formula/kahip.rb
+++ b/Formula/kahip.rb
@@ -17,8 +17,8 @@ class Kahip < Formula
   depends_on "open-mpi"
 
   def install
-    ENV["CC"] = Formula["gcc"].opt_bin/"gcc-#{Formula["gcc"].version_suffix}"
-    ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{Formula["gcc"].version_suffix}"
+    ENV["CC"] = Formula["gcc"].opt_bin/"gcc-#{Formula["gcc"].installed_version.major}"
+    ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{Formula["gcc"].installed_version.major}"
     mkdir "build" do
       system "cmake", *std_cmake_args, ".."
       system "make", "install"

--- a/Formula/lcov.rb
+++ b/Formula/lcov.rb
@@ -55,8 +55,8 @@ class Lcov < Formula
   end
 
   test do
-    gcc = Formula["gcc"].opt_bin/"gcc-#{Formula["gcc"].version_suffix}"
-    gcov = Formula["gcc"].opt_bin/"gcov-#{Formula["gcc"].version_suffix}"
+    gcc = Formula["gcc"].opt_bin/"gcc-#{Formula["gcc"].installed_version.major}"
+    gcov = Formula["gcc"].opt_bin/"gcov-#{Formula["gcc"].installed_version.major}"
 
     (testpath/"hello.c").write <<~EOS
       #include <stdio.h>

--- a/Formula/pipgrip.rb
+++ b/Formula/pipgrip.rb
@@ -53,7 +53,7 @@ class Pipgrip < Formula
     venv.pip_install buildpath
 
     gcc_path = Formula["gcc"].opt_bin
-    gcc_version = Formula["gcc"].version.to_s.split(".").first
+    gcc_version = Formula["gcc"].installed_version.major
     (bin/"pipgrip").write_env_script(libexec/"bin/pipgrip",
                                      { CC: gcc_path/"gcc-#{gcc_version}", CXX: gcc_path/"g++-#{gcc_version}" })
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

~~Requires Homebrew/brew#8183~~
~~Now waiting for new `brew` version > 2.4.11~~
Can be merged as of version 2.4.12

Related:
- #58520, #58522, #58524, #58525, #58526, #58527 - replace private method call
- #58558 - Fix `version_suffix`
- #58973 - Get GCC version with public method

cc @gromgit