### PR TITLE
gnutls: build Guile bindings

### DIFF
--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -4,7 +4,8 @@ class Gnutls < Formula
   url "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.14.tar.xz"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/gnutls/v3.6/gnutls-3.6.14.tar.xz"
   sha256 "5630751adec7025b8ef955af4d141d00d252a985769f51b4059e5affa3d39d63"
-  license "LGPL-2.1"
+  # license "LGPL-2.1-or-later AND GPL-3.0-only" - review syntax after resolving https://github.com/Homebrew/brew/pull/8260
+  license "GPL-3.0-only"
 
   bottle do
     sha256 "ed76b5d22e195a797c2d01ab2f4a8e769a023b056b17e86f11cb6b9af200babe" => :catalina
@@ -16,6 +17,7 @@ class Gnutls < Formula
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
   depends_on "gmp"
+  depends_on "guile"
   depends_on "libidn2"
   depends_on "libtasn1"
   depends_on "libunistring"
@@ -35,7 +37,9 @@ class Gnutls < Formula
       --prefix=#{prefix}
       --sysconfdir=#{etc}
       --with-default-trust-store-file=#{pkgetc}/cert.pem
-      --disable-guile
+      --with-guile-site-dir=#{share}/guile/site/3.0
+      --with-guile-site-ccache-dir=#{lib}/guile/3.0/site-ccache
+      --with-guile-extension-dir=#{lib}/guile/3.0/extensions
       --disable-heartbeat-support
       --with-p11-kit
     ]
@@ -74,7 +78,29 @@ class Gnutls < Formula
     (pkgetc/"cert.pem").atomic_write(valid_certs.join("\n"))
   end
 
+  def caveats
+    <<~EOS
+      If you are going to use the Guile bindings you will need to add the following
+      to your .bashrc or equivalent in order for Guile to find the TLS certificates
+      database:
+        export GUILE_TLS_CERTIFICATE_DIRECTORY=/usr/local/etc/gnutls/
+    EOS
+  end
+
   test do
     system bin/"gnutls-cli", "--version"
+
+    gnutls = testpath/"gnutls.scm"
+    gnutls.write <<~EOS
+      (use-modules (gnutls))
+      (gnutls-version)
+    EOS
+
+    ENV["GUILE_AUTO_COMPILE"] = "0"
+    ENV["GUILE_LOAD_PATH"] = HOMEBREW_PREFIX/"share/guile/site/3.0"
+    ENV["GUILE_LOAD_COMPILED_PATH"] = HOMEBREW_PREFIX/"lib/guile/3.0/site-ccache"
+    ENV["GUILE_SYSTEM_EXTENSIONS_PATH"] = HOMEBREW_PREFIX/"lib/guile/3.0/extensions"
+
+    system "guile", gnutls
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This takes a different approach than #59481 by simply building Guile bindings by default when installing `gnutls`. However, that means that `guile` is now required.

```
❯ brew audit --strict gnutls
gnutls:
  * Formula gnutls contains deprecated SPDX licenses: ["LGPL-2.1"].
```