### PR TITLE
icu4c 67.1 (make C++14 compatible)

### DIFF
--- a/Formula/icu4c.rb
+++ b/Formula/icu4c.rb
@@ -20,6 +20,8 @@ class Icu4c < Formula
 
   keg_only :provided_by_macos, "macOS provides libicucore.dylib (but nothing else)"
 
+  # fix C++14 compatibility of U_ASSERT macro.
+  # Remove with next release (ICU 68).
   patch :p2 do
     url "https://github.com/unicode-org/icu/commit/715d254a02b0b22681cb6f861b0921ae668fa7d6.patch?full_index=1"
     sha256 "a87e1b9626ec5803b1220489c0d6cc544a5f293f1c5280e3b27871780c4ecde8"

--- a/Formula/icu4c.rb
+++ b/Formula/icu4c.rb
@@ -20,6 +20,11 @@ class Icu4c < Formula
 
   keg_only :provided_by_macos, "macOS provides libicucore.dylib (but nothing else)"
 
+  patch :p2 do
+    url "https://github.com/unicode-org/icu/commit/715d254a02b0b22681cb6f861b0921ae668fa7d6.patch?full_index=1"
+    sha256 "a87e1b9626ec5803b1220489c0d6cc544a5f293f1c5280e3b27871780c4ecde8"
+  end
+
   def install
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
This simple cherry-picked upstream patch is needed for building with Xcode 9 on macOS Sierra.

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
