### PR TITLE
mmctl: release retag

### DIFF
--- a/Formula/mmctl.rb
+++ b/Formula/mmctl.rb
@@ -3,8 +3,9 @@ class Mmctl < Formula
   homepage "https://github.com/mattermost/mmctl"
   url "https://github.com/mattermost/mmctl.git",
       tag:      "v5.26.0",
-      revision: "a8957423bc2b38519b49e8ee54f729fb8c3f1965"
+      revision: "1dc9cda2e80757ff8fc694f32efc7ea76e327635"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/mattermost/mmctl.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Before tag `v5.26.0` pointed to https://github.com/mattermost/mmctl/commits/a8957423bc2b38519b49e8ee54f729fb8c3f1965
Now it points to https://github.com/mattermost/mmctl/commits/1dc9cda2e80757ff8fc694f32efc7ea76e327635

There is exactly one commit difference between them: https://github.com/mattermost/mmctl/commit/1dc9cda2e80757ff8fc694f32efc7ea76e327635 (https://github.com/mattermost/mmctl/pull/189)
