### PR TITLE
dovecot: add license

### DIFF
--- a/Formula/dovecot.rb
+++ b/Formula/dovecot.rb
@@ -3,6 +3,7 @@ class Dovecot < Formula
   homepage "https://dovecot.org/"
   url "https://dovecot.org/releases/2.3/dovecot-2.3.10.1.tar.gz"
   sha256 "6642e62f23b1b23cfac235007ca6e21cb67460cca834689fad450724456eb10c"
+  license "LGPL-2.1-or-later"
 
   bottle do
     sha256 "e8d7b6bf587b5673826b467c3a30b148a191ed94246797609fcdad42e3ad40e4" => :catalina


### PR DESCRIPTION
license PR for #59626


```
See AUTHORS file for list of copyright holders.

Everything in src/lib/, src/auth/, src/lib-sql/ and src/lib-ntlm/ is under
MIT license (see COPYING.MIT) unless otherwise mentioned at the beginning
of the file.

Everything else is LGPLv2.1 (see COPYING.LGPL) unless otherwise mentioned
at the beginning of the file.

Current exceptions are:

src/lib/md5.c : Public Domain

src/lib/sha1.c and sha2.c: BSD-3-Clause

src/lib/UnicodeData.txt: Unicode-DFS-2015

```