### PR TITLE
Use OpenBLAS instead of Accelerate on Armadillo

### DIFF
--- a/Formula/armadillo.rb
+++ b/Formula/armadillo.rb
@@ -15,8 +15,8 @@ class Armadillo < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "arpack"
-  depends_on "openblas"
   depends_on "hdf5"
+  depends_on "openblas"
   depends_on "superlu"
   depends_on "szip"
 

--- a/Formula/armadillo.rb
+++ b/Formula/armadillo.rb
@@ -14,10 +14,10 @@ class Armadillo < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "openblas"
   depends_on "arpack"
-  depends_on "superlu"
+  depends_on "openblas"
   depends_on "hdf5"
+  depends_on "superlu"
   depends_on "szip"
 
   def install

--- a/Formula/armadillo.rb
+++ b/Formula/armadillo.rb
@@ -14,14 +14,16 @@ class Armadillo < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "openblas"
   depends_on "arpack"
+  depends_on "superlu"
   depends_on "hdf5"
   depends_on "szip"
 
   def install
     ENV.prepend "CXXFLAGS", "-DH5_USE_110_API -DH5Ovisit_vers=1"
 
-    system "cmake", ".", "-DDETECT_HDF5=ON", *std_cmake_args
+    system "cmake", ".", "-DDETECT_HDF5=ON", "-DALLOW_OPENBLAS_MACOS=ON", *std_cmake_args
     system "make", "install"
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Homebrew's ARPACK is compiled with OpenBLAS, but by default Armadillo is linked against the Accelerate framework on MacOS. This leads to uncaught runtime issues when using ARPACK-based routines in Armadillo.

Additionally Armadillo uses SuperLU to solve sparse systems and extend sparse diagonalization routines, so it should be added as a dependency. Homebrew's SuperLU is compiled with OpenBLAS as well.

Related: https://gitlab.com/conradsnicta/armadillo-code/-/issues/162