### PR TITLE
graphviz: Suppress various unwanted dependencies

### DIFF
--- a/Formula/graphviz.rb
+++ b/Formula/graphviz.rb
@@ -41,6 +41,10 @@ class Graphviz < Formula
       --disable-swig
       --with-quartz
       --without-freetype2
+      --without-gdk
+      --without-gdk-pixbuf
+      --without-gtk
+      --without-rsvg
       --without-qt
       --without-x
       --with-gts


### PR DESCRIPTION
GTK+, the GDK libraries, and librsvg aren't listed
as dependencies, so they should not be used.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Spinning this off from https://github.com/Homebrew/linuxbrew-core/pull/20812 , per https://github.com/Homebrew/linuxbrew-core/pull/20812#discussion_r469724797

I was admittedly not able to reproduce the issue - GTK+ and friends not being listed as dependencies, yet getting partially included in the build and then failing to find header files - on macOS. Nevertheless, this is arguably gives greater control over the desired build result.