### PR TITLE
imlib2: remove X11 dependency

### DIFF
--- a/Formula/imlib2.rb
+++ b/Formula/imlib2.rb
@@ -4,6 +4,7 @@ class Imlib2 < Formula
   url "https://downloads.sourceforge.net/project/enlightenment/imlib2-src/1.7.0/imlib2-1.7.0.tar.bz2"
   sha256 "1976ca3db48cbae79cd0fc737dabe39cc81494fc2560e1d22821e7dc9c22b37d"
   license "Imlib2"
+  revision 1
 
   bottle do
     sha256 "460c1523b721a0a2d14d46ea95a4fb7a07ca6b177a4e7d0b0d54d00801bb289e" => :catalina
@@ -17,7 +18,6 @@ class Imlib2 < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on :x11
 
   def install
     args = %W[
@@ -25,6 +25,7 @@ class Imlib2 < Formula
       --prefix=#{prefix}
       --enable-amd64=no
       --without-id3
+      --without-x
     ]
 
     system "./configure", *args


### PR DESCRIPTION
In support of https://discourse.brew.sh/t/error-updating-imlib2/8561

Sidenote: Leaving `--enable-amd64=no` in place, because building without it throws a ton of "unknown directive" errors in assembly code.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
