### PR TITLE
gnunet: update license

### DIFF
--- a/Formula/gnunet.rb
+++ b/Formula/gnunet.rb
@@ -4,7 +4,7 @@ class Gnunet < Formula
   url "https://ftp.gnu.org/gnu/gnunet/gnunet-0.13.2.tar.gz"
   mirror "https://ftpmirror.gnu.org/gnunet/gnunet-0.13.2.tar.gz"
   sha256 "b615702e701b4569663767a9da72f33c9778bc853b20d1c811b25ec8fb328a2c"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- follow up of #59683
- license reference

```
  If you develop a new program, and you want it to be of the greatest
possible use to the public, the best way to achieve this is to make it
free software which everyone can redistribute and change under these terms.

  To do so, attach the following notices to the program.  It is safest
to attach them to the start of each source file to most effectively
state the exclusion of warranty; and each file should have at least
the "copyright" line and a pointer to where the full notice is found.

    <one line to give the program's name and a brief idea of what it does.>
    Copyright (C) <year>  <name of author>

    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU Affero General Public License as published
    by the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.

    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU Affero General Public License for more details.

    You should have received a copy of the GNU Affero General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
```