### PR TITLE
patchelf: update license

### DIFF
--- a/Formula/patchelf.rb
+++ b/Formula/patchelf.rb
@@ -3,7 +3,7 @@ class Patchelf < Formula
   homepage "https://github.com/NixOS/patchelf"
   url "https://github.com/NixOS/patchelf/archive/0.11.tar.gz"
   sha256 "e9dc4dbed842e475176ef60531c2805ed37a71c34cc6dc5d1b9ad68d889aeb6b"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/NixOS/patchelf"
 
   bottle do


### PR DESCRIPTION
license ref, https://github.com/NixOS/patchelf#license

finally using the license header ref in the right way.