### PR TITLE
patchelf: typo fix, add .git to head url

### DIFF
--- a/Formula/patchelf.rb
+++ b/Formula/patchelf.rb
@@ -4,7 +4,7 @@ class Patchelf < Formula
   url "https://github.com/NixOS/patchelf/archive/0.11.tar.gz"
   sha256 "e9dc4dbed842e475176ef60531c2805ed37a71c34cc6dc5d1b9ad68d889aeb6b"
   license "GPL-3.0-or-later"
-  head "https://github.com/NixOS/patchelf"
+  head "https://github.com/NixOS/patchelf.git"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The url in this PR(https://github.com/Homebrew/homebrew-core/pull/59686) 
missed '.git' at the end of url.
