### PR TITLE
rakuo-star: depend on readline

### DIFF
--- a/Formula/rakudo-star.rb
+++ b/Formula/rakudo-star.rb
@@ -1,5 +1,5 @@
 class RakudoStar < Formula
-  desc "Perl 6 compiler"
+  desc "Rakudo compiler and commonly used packages"
   homepage "https://rakudo.org/"
   url "https://rakudo.org/dl/star/rakudo-star-2020.01.tar.gz"
   sha256 "f1696577670d4ff5b464e572b1b0b8c390e6571e1fb8471cbf369fa39712c668"
@@ -16,6 +16,7 @@ class RakudoStar < Formula
   depends_on "icu4c"
   depends_on "libffi"
   depends_on "pcre"
+  depends_on "readline"
 
   conflicts_with "moarvm", "nqp", because: "rakudo-star currently ships with moarvm and nqp included"
   conflicts_with "parrot"


### PR DESCRIPTION
It's necessary because macOS ships with libedit, rather than libreadline and they are not drop in replacements. The raku REPL needs libreadline.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
