### PR TITLE
freeling, dynet, eigen, foma: conflicts_with + licenses

### DIFF
--- a/Formula/dynet.rb
+++ b/Formula/dynet.rb
@@ -15,6 +15,8 @@ class Dynet < Formula
   depends_on "cmake" => :build
   depends_on "eigen"
 
+  conflicts_with "freeling", because: "freeling ships its own copy of dynet"
+
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args,

--- a/Formula/eigen.rb
+++ b/Formula/eigen.rb
@@ -3,6 +3,7 @@ class Eigen < Formula
   homepage "https://eigen.tuxfamily.org/"
   url "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2"
   sha256 "685adf14bd8e9c015b78097c1dc22f2f01343756f196acdc76a678e1ae352e11"
+  license "MPL-2.0"
   head "https://gitlab.com/libeigen/eigen"
 
   bottle do
@@ -14,6 +15,8 @@ class Eigen < Formula
   end
 
   depends_on "cmake" => :build
+
+  conflicts_with "freeling", because: "freeling ships its own copy of eigen"
 
   def install
     mkdir "eigen-build" do

--- a/Formula/foma.rb
+++ b/Formula/foma.rb
@@ -3,7 +3,7 @@ class Foma < Formula
   homepage "https://code.google.com/p/foma/"
   url "https://bitbucket.org/mhulden/foma/downloads/foma-0.9.18.tar.gz"
   sha256 "cb380f43e86fc7b3d4e43186db3e7cff8f2417e18ea69cc991e466a3907d8cbd"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     cellar :any
@@ -21,6 +21,8 @@ class Foma < Formula
   on_linux do
     depends_on "readline"
   end
+
+  conflicts_with "freeling", because: "freeling ships its own copy of foma"
 
   def install
     system "make"

--- a/Formula/freeling.rb
+++ b/Formula/freeling.rb
@@ -3,7 +3,7 @@ class Freeling < Formula
   homepage "http://nlp.lsi.upc.edu/freeling/"
   url "https://github.com/TALP-UPC/FreeLing/releases/download/4.2/FreeLing-src-4.2.tar.gz"
   sha256 "ef0eac3c82b1d1eb6b87094043c744f6517b3bd639415040eaa6e1e6b298d425"
-  license "AGPL-3.0"
+  license "AGPL-3.0-only"
 
   bottle do
     sha256 "22ee0da143b9d7f402e36992a215891898c9cd9dc0caef7671126b841eca0402" => :catalina
@@ -15,6 +15,9 @@ class Freeling < Formula
   depends_on "boost"
   depends_on "icu4c"
 
+  conflicts_with "dynet", because: "freeling ships its own copy of dynet"
+  conflicts_with "eigen", because: "freeling ships its own copy of eigen"
+  conflicts_with "foma", because: "freeling ships its own copy of foma"
   conflicts_with "hunspell", because: "both install 'analyze' binary"
 
   def install


### PR DESCRIPTION
`freeling` installs its own copies of the other formulae, due to internal patches and concerns about usability: https://github.com/TALP-UPC/FreeLing/issues/90#issuecomment-609680540

Also added `license` for `eigen` and fixed it for `foma` and `freeling`.

In support of https://github.com/Homebrew/homebrew-core/issues/59707

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
