### PR TITLE
terraform: switch to go@1.14 (from go@1.13)

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -4,6 +4,7 @@ class Terraform < Formula
   url "https://github.com/hashicorp/terraform/archive/v0.13.0.tar.gz"
   sha256 "b531255bd4e1dbbc7fc5e01729b77f8781cc0f369833d01211048f0667e56cee"
   license "MPL-2.0"
+  revision 1
   head "https://github.com/hashicorp/terraform.git"
 
   bottle do
@@ -13,7 +14,7 @@ class Terraform < Formula
     sha256 "4ff5b12ae74bad7014c5b3d516535d12f34af1a9af000b0a2353fb9ed6b7cb23" => :high_sierra
   end
 
-  depends_on "go@1.13" => :build
+  depends_on "go@1.14" => :build
 
   conflicts_with "tfenv", because: "tfenv symlinks terraform binaries"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
terraform 0.13.0 supports go@1.14: https://github.com/hashicorp/terraform/blob/v0.13.0/go.mod#L156
and doesn't support go 1.15 yet https://github.com/hashicorp/terraform/issues/25553