### PR TITLE
go*: don't depend on macOS and don't set GOOS env

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -29,8 +29,6 @@ class Go < Formula
     end
   end
 
-  depends_on macos: :sierra
-
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do
     on_macos do
@@ -50,7 +48,6 @@ class Go < Formula
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
-      ENV["GOOS"]         = "darwin"
       system "./make.bash", "--no-clean"
     end
 

--- a/Formula/go@1.10.rb
+++ b/Formula/go@1.10.rb
@@ -49,7 +49,6 @@ class GoAT110 < Formula
 
     cd "go/src" do
       ENV["GOROOT_FINAL"] = libexec
-      ENV["GOOS"]         = "darwin"
       system "./make.bash", "--no-clean"
     end
 

--- a/Formula/go@1.11.rb
+++ b/Formula/go@1.11.rb
@@ -41,7 +41,6 @@ class GoAT111 < Formula
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
-      ENV["GOOS"]         = "darwin"
       system "./make.bash", "--no-clean"
     end
 

--- a/Formula/go@1.12.rb
+++ b/Formula/go@1.12.rb
@@ -41,7 +41,6 @@ class GoAT112 < Formula
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
-      ENV["GOOS"]         = "darwin"
       system "./make.bash", "--no-clean"
     end
 

--- a/Formula/go@1.13.rb
+++ b/Formula/go@1.13.rb
@@ -17,8 +17,6 @@ class GoAT113 < Formula
 
   deprecate! date: "2020-08-11"
 
-  depends_on macos: :el_capitan
-
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",
         branch: "release-branch.go1.13"
@@ -43,7 +41,6 @@ class GoAT113 < Formula
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
-      ENV["GOOS"]         = "darwin"
       system "./make.bash", "--no-clean"
     end
 

--- a/Formula/go@1.14.rb
+++ b/Formula/go@1.14.rb
@@ -14,8 +14,6 @@ class GoAT114 < Formula
 
   keg_only :versioned_formula
 
-  depends_on macos: :el_capitan
-
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",
         branch: "release-branch.go1.14"
@@ -40,7 +38,6 @@ class GoAT114 < Formula
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
-      ENV["GOOS"] = "darwin"
       system "./make.bash", "--no-clean"
     end
 

--- a/Formula/go@1.9.rb
+++ b/Formula/go@1.9.rb
@@ -56,7 +56,6 @@ class GoAT19 < Formula
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
-      ENV["GOOS"]         = "darwin"
       system "./make.bash", "--no-clean"
     end
 


### PR DESCRIPTION
Not setting GOOS env variable allows us to use this formula on Linux
without modifications. Those changes should not affect the build as GOOS is determined automatically.

We are supporting `:high_sierra` and up, so I think it is okay to delete references to `:el_capitan` and `:sierra`.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
