### PR TITLE
prest: update checksum

### DIFF
--- a/Formula/prest.rb
+++ b/Formula/prest.rb
@@ -2,8 +2,9 @@ class Prest < Formula
   desc "Serve a RESTful API from any PostgreSQL database"
   homepage "https://github.com/prest/prest"
   url "https://github.com/prest/prest/archive/v1.0.3.tar.gz"
-  sha256 "bab9c2ebf3507c9724818474e597cbe4925932edcc242ed6e833c403c57a4b7b"
+  sha256 "b5a7f0badc4af936a6269730ec5af7872638207e2e93c02f7d81344f0f2527d4"
   license "MIT"
+  revision 1
   head "https://github.com/prest/prest.git"
 
   bottle do


### PR DESCRIPTION
```
==> brew install --verbose --build-bottle prest
==> FAILED
==> Downloading https://github.com/prest/prest/archive/v1.0.3.tar.gz
Error: SHA256 mismatch
Expected: bab9c2ebf3507c9724818474e597cbe4925932edcc242ed6e833c403c57a4b7b
  Actual: b5a7f0badc4af936a6269730ec5af7872638207e2e93c02f7d81344f0f2527d4
 Archive: /github/home/.cache/Homebrew/downloads/52da879cd63824a84807fbcf9a6ec17a16a4bc4319d46a4db2d694d5165df5dd--prest-1.0.3.tar.gz
To retry an incomplete download, remove the file above.
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
