### PR TITLE
Update incorrect licenses

### DIFF
--- a/Formula/cmockery.rb
+++ b/Formula/cmockery.rb
@@ -3,7 +3,7 @@ class Cmockery < Formula
   homepage "https://github.com/google/cmockery"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/cmockery/cmockery-0.1.2.tar.gz"
   sha256 "b9e04bfbeb45ceee9b6107aa5db671c53683a992082ed2828295e83dc84a8486"
-  license "BSD-3-Clause"
+  license "Apache-2.0"
 
   bottle do
     cellar :any

--- a/Formula/libjwt.rb
+++ b/Formula/libjwt.rb
@@ -3,7 +3,7 @@ class Libjwt < Formula
   homepage "https://github.com/benmcollins/libjwt"
   url "https://github.com/benmcollins/libjwt/archive/v1.12.0.tar.gz"
   sha256 "eaf5d8b31d867c02dde767efa2cf494840885a415a3c9a62680bf870a4511bee"
-  license "LGPL-3.0"
+  license "MPL-2.0"
 
   bottle do
     cellar :any

--- a/Formula/tcping.rb
+++ b/Formula/tcping.rb
@@ -3,7 +3,7 @@ class Tcping < Formula
   homepage "https://github.com/mkirchner/tcping"
   url "https://github.com/mkirchner/tcping/archive/1.3.6.tar.gz"
   sha256 "a731f0e48ff931d7b2a0e896e4db40867043740fe901dd225780f2164fdbdcf3"
-  license "LGPL-3.0"
+  license "MIT"
   head "https://github.com/mkirchner/tcping.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
cmockery: listed as `BSD-3-Clause`, should be `Apache-2.0`: https://github.com/google/cmockery/blob/master/LICENSE.txt

libjwt: listed as `LGPL-3.0`, should be `MPL-2.0`: https://github.com/benmcollins/libjwt/blob/master/LICENSE, https://github.com/benmcollins/libjwt/issues/130, 

tcping: listed as `LGPL-3.0`, should be `MIT`:  https://github.com/mkirchner/tcping/blob/master/LICENSE, https://github.com/mkirchner/tcping/commit/fb488396016f86b01187b2f77411457bdec864fa