### PR TITLE
ghc: update cabal-install version for head build

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -24,8 +24,8 @@ class Ghc < Formula
     depends_on "libtool" => :build
 
     resource "cabal" do
-      url "https://hackage.haskell.org/package/cabal-install-3.0.0.0/cabal-install-3.0.0.0.tar.gz"
-      sha256 "a432a7853afe96c0fd80f434bd80274601331d8c46b628cd19a0d8e96212aaf1"
+      url "https://hackage.haskell.org/package/cabal-install-3.2.0.0/cabal-install-3.2.0.0.tar.gz"
+      sha256 "a0555e895aaf17ca08453fde8b19af96725da8398e027aa43a49c1658a600cb0"
     end
   end
 


### PR DESCRIPTION
update `cabal-install` (which aligns with cabal-install formula) version for `ghc` head build.