### PR TITLE
hadolint: depends_on ghc for build

### DIFF
--- a/Formula/hadolint.rb
+++ b/Formula/hadolint.rb
@@ -13,6 +13,7 @@ class Hadolint < Formula
     sha256 "9c8ea84c521ab94e4f78d73b67593738760cb437e6e050e0e6f81be62c944440" => :high_sierra
   end
 
+  depends_on "ghc" => :build
   depends_on "haskell-stack" => :build
 
   uses_from_macos "xz"


### PR DESCRIPTION
Right now if `stack` cannot find `ghc` installation in the path, it would download the `ghc`. 
In this case, `stack` would download 8.8.3. 

Explicitly specifying the `ghc` build dependency to avoid the ghc download.
Also, it would be useful for the `ghc` upgrade cross-check moving forward.