### PR TITLE
cmockery: revert incorrect license update

### DIFF
--- a/Formula/cmockery.rb
+++ b/Formula/cmockery.rb
@@ -3,7 +3,7 @@ class Cmockery < Formula
   homepage "https://github.com/google/cmockery"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/cmockery/cmockery-0.1.2.tar.gz"
   sha256 "b9e04bfbeb45ceee9b6107aa5db671c53683a992082ed2828295e83dc84a8486"
-  license "Apache-2.0"
+  license "BSD-3-Clause"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This reverts commit c2f4f9edcfadd8bc4b5d57e24032eeb5e31c4fa0.

See https://github.com/Homebrew/homebrew-core/pull/59728#issuecomment-674609197. The master branch for `cmockery` on GitHub lists the `Apache-2.0` license but the version that is distributed ships with `BSD-3-Clause`.