### PR TITLE
postgis: add license

### DIFF
--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -3,6 +3,7 @@ class Postgis < Formula
   homepage "https://postgis.net/"
   url "https://download.osgeo.org/postgis/source/postgis-3.0.2.tar.gz"
   sha256 "a3a1641dfd73c83924088a185bdb8b35567b3d1dc8d0887f9e4b492e228ab2ca"
+  license "GPL-2.0-or-later"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- followup PR of #59756
- license header ref in official website, https://postgis.net/ (thanks @Rylan12 )

> License
> PostGIS is released under the GNU General Public License (GPLv2 or later). Refer to License FAQ for more information. PostGIS is developed by a group of contributors led by a Project Steering Committee.