### PR TITLE
gnu-sed: add gsed alias

### DIFF
--- a/Aliases/gsed
+++ b/Aliases/gsed
@@ -1,0 +1,1 @@
+../Formula/gnu-sed.rb


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Motivation: The binary installed by the `gnu-sed` formula [is named `gsed`](https://github.com/Homebrew/homebrew-core/blob/master@%7B2020-08-17%7D/Formula/gnu-sed.rb#L39).