### PR TITLE
zinc: deprecate due to archived status

### DIFF
--- a/Formula/zinc.rb
+++ b/Formula/zinc.rb
@@ -6,6 +6,8 @@ class Zinc < Formula
 
   bottle :unneeded
 
+  deprecate!
+
   def install
     rm_f Dir["bin/ng/{linux,win}*"]
     libexec.install Dir["*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The GitHub repository is now archived: https://github.com/typesafehub/zinc.
