### PR TITLE
duck 7.5.1

### DIFF
--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -2,8 +2,8 @@ class Duck < Formula
   desc "Command-line interface for Cyberduck (a multi-protocol file transfer tool)"
   homepage "https://duck.sh/"
   # check the changelog for the latest stable version: https://cyberduck.io/changelog/
-  url "https://dist.duck.sh/duck-src-7.4.1.33065.tar.gz"
-  sha256 "b535188cf37946c350f090aa493d5240ee1ef2b077d673613cd5655c337ef912"
+  url "https://dist.duck.sh/duck-src-7.5.1.33324.tar.gz"
+  sha256 "62d16c99392b886fb63b50d0d35b1d7477cca1fae67437b82bfbf8ac66ab5ff8"
   license "GPL-3.0"
   head "https://svn.cyberduck.io/trunk/"
 

--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -4,7 +4,7 @@ class Duck < Formula
   # check the changelog for the latest stable version: https://cyberduck.io/changelog/
   url "https://dist.duck.sh/duck-src-7.5.1.33324.tar.gz"
   sha256 "62d16c99392b886fb63b50d0d35b1d7477cca1fae67437b82bfbf8ac66ab5ff8"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
   head "https://svn.cyberduck.io/trunk/"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

It builds but prints the notorious `Failed changing dylib ID` warning. I suppose we will have to add the `OTHER_LDFLAGS=-headerpad_max_install_names` flag for building this framework.

- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Don't know what to do about this error.
```
  * Formula duck contains deprecated SPDX licenses: ["GPL-3.0"].
```
