### PR TITLE
usb.ids 2020.06.22 (new formula)

### DIFF
--- a/Formula/libgusb.rb
+++ b/Formula/libgusb.rb
@@ -3,9 +3,21 @@ class Libgusb < Formula
 
   desc "GObject wrappers for libusb1"
   homepage "https://github.com/hughsie/libgusb"
-  url "https://people.freedesktop.org/~hughsient/releases/libgusb-0.3.5.tar.xz"
-  sha256 "5b2a00c6997cc4b0133c5a5748a2e616e9e7504626922105b62aadced78e65df"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only"
+  revision 1
+  head "https://github.com/hughsie/libgusb.git"
+
+  stable do
+    url "https://people.freedesktop.org/~hughsient/releases/libgusb-0.3.5.tar.xz"
+    sha256 "5b2a00c6997cc4b0133c5a5748a2e616e9e7504626922105b62aadced78e65df"
+
+    # Patch accepted upstream to allow for building without meson-internal
+    # Remove on next release
+    patch do
+      url "https://github.com/hughsie/libgusb/commit/b2ca7ebb887ff10314a5a000e7d21e33fd4ffc2f.patch?full_index=1"
+      sha256 "a068b0f66079897866d2b9280b3679f58c040989f74ee8d8bd70b0f8e977ec37"
+    end
+  end
 
   bottle do
     sha256 "e9080684116b2b6e4c78c1c1be5e8e210fab77b6f6b3d659cae1a9ad0c630bbb" => :catalina
@@ -21,27 +33,13 @@ class Libgusb < Formula
   depends_on "vala" => :build
   depends_on "glib"
   depends_on "libusb"
-
-  # The original usb.ids file can be found at http://www.linux-usb.org/usb.ids
-  # It is updated over time and its checksum changes, we maintain a copy
-  resource "usb.ids" do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/4235be3ce12f415f75869349af9a4198543f167a/simple-scan/usb.ids"
-    sha256 "ceceb3759e48eaf47451d7bca81ef4174fced1d4300f9ed33e2b53ee23160c6b"
-  end
-
-  # Patch accepted upstream to allow for building without meson-internal
-  # Remove on next release
-  patch do
-    url "https://github.com/hughsie/libgusb/commit/b2ca7ebb887ff10314a5a000e7d21e33fd4ffc2f.patch?full_index=1"
-    sha256 "a068b0f66079897866d2b9280b3679f58c040989f74ee8d8bd70b0f8e977ec37"
-  end
+  depends_on "usb.ids"
 
   def install
     rewrite_shebang detected_python_shebang, "contrib/generate-version-script.py"
-    (share/"hwdata/").install resource("usb.ids")
 
     mkdir "build" do
-      system "meson", *std_meson_args, "-Ddocs=false", "-Dusb_ids=#{share}/hwdata/usb.ids", ".."
+      system "meson", *std_meson_args, "-Ddocs=false", "-Dusb_ids=#{Formula["usb.ids"].opt_share}/misc/usb.ids", ".."
       system "ninja"
       system "ninja", "install"
     end

--- a/Formula/libosinfo.rb
+++ b/Formula/libosinfo.rb
@@ -3,8 +3,8 @@ class Libosinfo < Formula
   homepage "https://libosinfo.org/"
   url "https://releases.pagure.org/libosinfo/libosinfo-1.8.0.tar.xz"
   sha256 "49ff32be0d209f6c99480e28b94340ac3dd0158322ae4303adfbdfe973a108a5"
-  license "GPL-2.0"
-  revision 2
+  license "LGPL-2.0-or-later"
+  revision 3
 
   bottle do
     sha256 "1f37bf2e3ff5b94f183416806b0cd5ea8c21cf1de87d28bf1e84ae9d4d298d04" => :catalina
@@ -21,26 +21,21 @@ class Libosinfo < Formula
   depends_on "glib"
   depends_on "libsoup"
   depends_on "libxml2"
+  depends_on "usb.ids"
 
   resource "pci.ids" do
-    url "https://pci-ids.ucw.cz/v2.2/pci.ids.gz"
-    sha256 "09dc9980728dfeb123884ecedf51311f6441ffa8c5fa246e4cbea571ceae41b7"
-  end
-
-  resource "usb.ids" do
-    url "https://deb.debian.org/debian/pool/main/u/usb.ids/usb.ids_2020.06.22.orig.tar.xz"
-    sha256 "d55befb3b8bdb5db799fb8894c4e27ef909b2975c062fa6437297902213456a7"
+    url "https://raw.githubusercontent.com/pciutils/pciids/791050fc4eca1e19db3a985a284081f9038c21aa/pci.ids"
+    sha256 "587aa462719ffa840254e88b7b79fb499da2c3af227496a45d7e8b7c87f790f6"
   end
 
   def install
     (share/"misc").install resource("pci.ids")
-    (share/"misc").install resource("usb.ids")
 
     mkdir "build" do
       flags = %W[
         -Denable-gtk-doc=false
         -Dwith-pci-ids-path=#{share/"misc/pci.ids"}
-        -Dwith-usb-ids-path=#{share/"misc/usb.ids"}
+        -Dwith-usb-ids-path=#{Formula["usb.ids"].opt_share/"misc/usb.ids"}
         -Dsysconfdir=#{etc}
       ]
       system "meson", *std_meson_args, *flags, ".."

--- a/Formula/usb.ids.rb
+++ b/Formula/usb.ids.rb
@@ -1,0 +1,15 @@
+class UsbIds < Formula
+  desc "Repository of vendor, device, subsystem and device class IDs used in USB devices"
+  homepage "http://www.linux-usb.org/usb-ids.html"
+  url "https://deb.debian.org/debian/pool/main/u/usb.ids/usb.ids_2020.06.22.orig.tar.xz"
+  sha256 "d55befb3b8bdb5db799fb8894c4e27ef909b2975c062fa6437297902213456a7"
+  license ["GPL-2.0-or-later", "BSD-3-Clause"]
+
+  def install
+    (share/"misc").install "usb.ids"
+  end
+
+  test do
+    assert_match "Version: #{version}", File.read(share/"misc/usb.ids", encoding: "ISO-8859-1")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Track Debian's release of `usb.ids` rather than including as a resource. The main benefit is that this allows version tracking of `usb.ids` on [Repology](https://repology.org/project/usb.ids), while previously it would just only get updated when individual formulae get updated.

In addition, this fixes some other small issues:
- Update LGPL SPDX identifiers in `libgusb` and `libosinfo`
- Add `head` block for `libgusb` and wrap patch in `stable do` block
- Use mirrored, versioned copy of `pci.ids` in `libosinfo` because the previous (canonical) link is updated in-place on a regular basis, resulting in checksum mismatch.