### PR TITLE
ios-deploy 1.11.1

### DIFF
--- a/Formula/ios-deploy.rb
+++ b/Formula/ios-deploy.rb
@@ -1,9 +1,9 @@
 class IosDeploy < Formula
   desc "Install and debug iPhone apps from the command-line"
   homepage "https://github.com/ios-control/ios-deploy"
-  url "https://github.com/ios-control/ios-deploy/archive/1.11.0.tar.gz"
-  sha256 "714f0391bd5b5909f666cf9f11a85316ba8c4dfe48b6415e3c5990039b9b7c65"
-  license "GPL-3.0"
+  url "https://github.com/ios-control/ios-deploy/archive/1.11.1.tar.gz"
+  sha256 "638c90ae7ec71bc89ed0f2e9a464b9db8f2b312a20802c782873f82675d41048"
+  # license all_of: ["GPL-3.0-or-later", "BSD-3-Clause"], waiting for next brew release
   head "https://github.com/ios-control/ios-deploy.git"
 
   bottle do


### PR DESCRIPTION
Manually created because of getting error when running locally.

```
brew bump-formula-pr --url="https://github.com/ios-control/ios-deploy/archive/1.11.1.tar.gz" ios-deploy
```
gives the error
```
Error: You need to bump this formula manually since the new URL
and old URL are both:
  https://github.com/ios-control/ios-deploy/archive/1.11.1.tar.gz
```