### PR TITLE
Use `OS.kernel_version`

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -48,11 +48,10 @@ class Gcc < Formula
     #  - BRIG
     languages = %w[c c++ objc obj-c++ fortran]
 
-    osmajor = `uname -r`.split(".").first
     pkgversion = "Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip
 
     args = %W[
-      --build=x86_64-apple-darwin#{osmajor}
+      --build=x86_64-apple-darwin#{OS.kernel_version.major}
       --prefix=#{prefix}
       --libdir=#{lib}/gcc/#{version_suffix}
       --disable-nls

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -1,8 +1,4 @@
 class GccAT49 < Formula
-  def osmajor
-    `uname -r`.chomp
-  end
-
   desc "The GNU Compiler Collection"
   homepage "https://gcc.gnu.org/"
   url "https://ftp.gnu.org/gnu/gcc/gcc-4.9.4/gcc-4.9.4.tar.bz2"
@@ -89,7 +85,7 @@ class GccAT49 < Formula
     version_suffix = version.to_s.slice(/\d\.\d/)
 
     args = [
-      "--build=x86_64-apple-darwin#{osmajor}",
+      "--build=x86_64-apple-darwin#{OS.kernel_version}",
       "--prefix=#{prefix}",
       "--libdir=#{lib}/gcc/#{version_suffix}",
       "--enable-languages=c,c++,fortran,objc,obj-c++",

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -1,8 +1,4 @@
 class GccAT5 < Formula
-  def osmajor
-    `uname -r`.chomp
-  end
-
   desc "The GNU Compiler Collection"
   homepage "https://gcc.gnu.org/"
   url "https://ftp.gnu.org/gnu/gcc/gcc-5.5.0/gcc-5.5.0.tar.xz"
@@ -83,7 +79,7 @@ class GccAT5 < Formula
     ENV["gcc_cv_prog_makeinfo_modern"] = "no"
 
     args = [
-      "--build=x86_64-apple-darwin#{osmajor}",
+      "--build=x86_64-apple-darwin#{OS.kernel_version}",
       "--prefix=#{prefix}",
       "--libdir=#{lib}/gcc/#{version_suffix}",
       "--enable-languages=#{languages.join(",")}",

--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -51,10 +51,8 @@ class GccAT6 < Formula
     # to prevent their build.
     ENV["gcc_cv_prog_makeinfo_modern"] = "no"
 
-    osmajor = `uname -r`.chomp
-
     args = [
-      "--build=x86_64-apple-darwin#{osmajor}",
+      "--build=x86_64-apple-darwin#{OS.kernel_version}",
       "--prefix=#{prefix}",
       "--libdir=#{lib}/gcc/#{version_suffix}",
       "--enable-languages=#{languages.join(",")}",

--- a/Formula/gcc@7.rb
+++ b/Formula/gcc@7.rb
@@ -44,10 +44,8 @@ class GccAT7 < Formula
     #  - BRIG
     languages = %w[c c++ objc obj-c++ fortran]
 
-    osmajor = `uname -r`.chomp
-
     args = [
-      "--build=x86_64-apple-darwin#{osmajor}",
+      "--build=x86_64-apple-darwin#{OS.kernel_version}",
       "--prefix=#{prefix}",
       "--libdir=#{lib}/gcc/#{version_suffix}",
       "--enable-languages=#{languages.join(",")}",

--- a/Formula/gcc@8.rb
+++ b/Formula/gcc@8.rb
@@ -44,11 +44,10 @@ class GccAT8 < Formula
     #  - BRIG
     languages = %w[c c++ objc obj-c++ fortran]
 
-    osmajor = `uname -r`.split(".").first
     pkgversion = "Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip
 
     args = %W[
-      --build=x86_64-apple-darwin#{osmajor}
+      --build=x86_64-apple-darwin#{OS.kernel_version.major}
       --prefix=#{prefix}
       --libdir=#{lib}/gcc/#{version_suffix}
       --disable-nls

--- a/Formula/gcc@9.rb
+++ b/Formula/gcc@9.rb
@@ -43,11 +43,10 @@ class GccAT9 < Formula
     #  - BRIG
     languages = %w[c c++ objc obj-c++ fortran]
 
-    osmajor = `uname -r`.split(".").first
     pkgversion = "Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip
 
     args = %W[
-      --build=x86_64-apple-darwin#{osmajor}
+      --build=x86_64-apple-darwin#{OS.kernel_version.major}
       --prefix=#{prefix}
       --libdir=#{lib}/gcc/9
       --disable-nls

--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -71,7 +71,7 @@ class Ghc < Formula
     # is mandatory or else you'll get "illegal text relocs" errors.
     resource("gmp").stage do
       system "./configure", "--prefix=#{gmp}", "--with-pic", "--disable-shared",
-                            "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"
+                            "--build=#{Hardware.oldest_cpu}-apple-darwin#{OS.kernel_version.major}"
       system "make"
       system "make", "install"
     end

--- a/Formula/ghc@8.6.rb
+++ b/Formula/ghc@8.6.rb
@@ -59,7 +59,7 @@ class GhcAT86 < Formula
     # is mandatory or else you'll get "illegal text relocs" errors.
     resource("gmp").stage do
       system "./configure", "--prefix=#{gmp}", "--with-pic", "--disable-shared",
-                            "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"
+                            "--build=#{Hardware.oldest_cpu}-apple-darwin#{OS.kernel_version.major}"
       system "make"
       system "make", "install"
     end

--- a/Formula/ghc@8.8.rb
+++ b/Formula/ghc@8.8.rb
@@ -54,7 +54,7 @@ class GhcAT88 < Formula
     # is mandatory or else you'll get "illegal text relocs" errors.
     resource("gmp").stage do
       system "./configure", "--prefix=#{gmp}", "--with-pic", "--disable-shared",
-                            "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"
+                            "--build=#{Hardware.oldest_cpu}-apple-darwin#{OS.kernel_version.major}"
       system "make"
       system "make", "install"
     end

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -38,10 +38,10 @@ class Gmp < Formula
     args = %W[--prefix=#{prefix} --enable-cxx --with-pic]
 
     if Hardware::CPU.arm?
-      args << "--build=aarch64-apple-darwin#{`uname -r`.to_i}"
+      args << "--build=aarch64-apple-darwin#{OS.kernel_version.major}"
       system "autoreconf", "-fiv"
     else
-      args << "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"
+      args << "--build=#{Hardware.oldest_cpu}-apple-darwin#{OS.kernel_version.major}"
     end
     system "./configure", *args
     system "make"

--- a/Formula/libde265.rb
+++ b/Formula/libde265.rb
@@ -14,7 +14,7 @@ class Libde265 < Formula
 
   def install
     extra_args = []
-    extra_args << "--build=aarch64-apple-darwin#{`uname -r`.chomp}" if Hardware::CPU.arm?
+    extra_args << "--build=aarch64-apple-darwin#{OS.kernel_version}" if Hardware::CPU.arm?
 
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -27,7 +27,7 @@ class Libffi < Formula
     # This can be removed in the future when libffi properly detects the CPU on ARM.
     # https://github.com/libffi/libffi/issues/571#issuecomment-655223391
     extra_args = []
-    extra_args << "--build=aarch64-apple-darwin#{`uname -r`.chomp}" if Hardware::CPU.arm?
+    extra_args << "--build=aarch64-apple-darwin#{OS.kernel_version}" if Hardware::CPU.arm?
 
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/mpir.rb
+++ b/Formula/mpir.rb
@@ -18,7 +18,7 @@ class Mpir < Formula
 
   def install
     args = %W[--disable-silent-rules --prefix=#{prefix} --enable-cxx]
-    args << "--build=#{Hardware.oldest_cpu}-apple-darwin#{`uname -r`.to_i}"
+    args << "--build=#{Hardware.oldest_cpu}-apple-darwin#{OS.kernel_version.major}"
     system "./configure", *args
     system "make", "install"
   end

--- a/Formula/nettle.rb
+++ b/Formula/nettle.rb
@@ -29,7 +29,7 @@ class Nettle < Formula
     end
 
     args = []
-    args << "--build=aarch64-apple-darwin#{`uname -r`.chomp}" if Hardware::CPU.arm?
+    args << "--build=aarch64-apple-darwin#{OS.kernel_version}" if Hardware::CPU.arm?
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/pjproject.rb
+++ b/Formula/pjproject.rb
@@ -24,8 +24,7 @@ class Pjproject < Formula
     system "make", "install"
 
     arch = Utils.safe_popen_read("uname", "-m").chomp
-    rel = Utils.safe_popen_read("uname", "-r").chomp
-    bin.install "pjsip-apps/bin/pjsua-#{arch}-apple-darwin#{rel}" => "pjsua"
+    bin.install "pjsip-apps/bin/pjsua-#{arch}-apple-darwin#{OS.kernel_version}" => "pjsua"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

~~Requires next `brew` release after 2.4.12~~ (Depends on Homebrew/brew#8381)
Can be merged as of `brew` version 2.4.13

`brew irb`:

```
irb> "#{`uname -r`.to_i}"
=> "19"
irb> "#{OS.kernel_version.major}"
=> "19"
irb> "#{`uname -r`.chomp}"
=> "19.6.0"
irb> "#{OS.kernel_version}"
=> "19.6.0"
irb> Utils.safe_popen_read("uname", "-r").chomp
=> "19.6.0"
```