### PR TITLE
automake: include more up-to-date config files

### DIFF
--- a/Formula/automake.rb
+++ b/Formula/automake.rb
@@ -4,7 +4,8 @@ class Automake < Formula
   url "https://ftp.gnu.org/gnu/automake/automake-1.16.2.tar.xz"
   mirror "https://ftpmirror.gnu.org/automake/automake-1.16.2.tar.xz"
   sha256 "ccc459de3d710e066ab9e12d2f119bd164a08c9341ca24ba22c9adaa179eedd0"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -15,8 +16,19 @@ class Automake < Formula
 
   depends_on "autoconf"
 
+  # Download more up-to-date config scripts.
+  resource "config" do
+    url "https://git.savannah.gnu.org/cgit/config.git/snapshot/config-0b5188819ba6091770064adf26360b204113317e.tar.gz"
+    sha256 "3dfb73df7d073129350b6896d62cabb6a70f479d3951f00144b408ba087bdbe8"
+    version "2020-08-17"
+  end
+
   def install
     ENV["PERL"] = "/usr/bin/perl"
+
+    resource("config").stage do
+      cp Dir["config.*"], buildpath/"lib"
+    end
 
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In particular, this makes automake use and output config.guess/config.sub files that work on Apple Silicon. Apple Silicon support was added to the config files last month while the ones bundled with automake 1.16.2 are dated 2020-01-01.
