### PR TITLE
Remove license arrays

### DIFF
--- a/Formula/acpica.rb
+++ b/Formula/acpica.rb
@@ -3,7 +3,7 @@ class Acpica < Formula
   homepage "https://www.acpica.org/"
   url "https://acpica.org/sites/acpica/files/acpica-unix-20200717.tar.gz"
   sha256 "cb99903ef240732f395af40c23b9b19c7899033f48840743544eebb6da72a828"
-  license ["Intel-ACPI", "GPL-2.0-only", "BSD-3-Clause"]
+  # license any_of: ["Intel-ACPI", "GPL-2.0-only", "BSD-3-Clause"] - pending next Homebrew/brew release
   head "https://github.com/acpica/acpica.git"
 
   bottle do

--- a/Formula/gnumeric.rb
+++ b/Formula/gnumeric.rb
@@ -3,7 +3,7 @@ class Gnumeric < Formula
   homepage "https://projects.gnome.org/gnumeric/"
   url "https://download.gnome.org/sources/gnumeric/1.12/gnumeric-1.12.48.tar.xz"
   sha256 "57cce33a41d34db81292e9eebae8b5046f30e5d919d848256fbb75bfc132a590"
-  license ["GPL-3.0-only", "GPL-2.0-only"]
+  # license any_of: ["GPL-3.0-only", "GPL-2.0-only"] - pending next Homebrew/brew release
 
   bottle do
     sha256 "d9edd4ae0d044bfe837cc94adfb5f2cc812ae5706b0e7f8a96a0c7b2f9dae63b" => :catalina

--- a/Formula/goffice.rb
+++ b/Formula/goffice.rb
@@ -3,7 +3,7 @@ class Goffice < Formula
   homepage "https://developer.gnome.org/goffice/"
   url "https://download.gnome.org/sources/goffice/0.10/goffice-0.10.48.tar.xz"
   sha256 "a439162fa26a0e58117e07b82b37000a7f421088ad379eb1f6a1cdee101ecefc"
-  license ["GPL-3.0-only", "GPL-2.0-only"]
+  # license any_of: ["GPL-3.0-only", "GPL-2.0-only"] - pending next Homebrew/brew release
 
   bottle do
     sha256 "3e05167a37c42bfa01acf4be7055a52e3c2a03c990536ae5562b2c0aa4812e42" => :catalina

--- a/Formula/libfabric.rb
+++ b/Formula/libfabric.rb
@@ -3,7 +3,7 @@ class Libfabric < Formula
   homepage "https://ofiwg.github.io/libfabric/"
   url "https://github.com/ofiwg/libfabric/releases/download/v1.11.0/libfabric-1.11.0.tar.bz2"
   sha256 "9938abf628e7ea8dcf60a94a4b62d499fbc0dbc6733478b6db2e6a373c80d58f"
-  license ["BSD-2-Clause", "GPL-2.0-only"]
+  # license any_of: ["BSD-2-Clause", "GPL-2.0-only"] - pending next Homebrew/brew release
   head "https://github.com/ofiwg/libfabric.git"
 
   bottle do

--- a/Formula/oci-cli.rb
+++ b/Formula/oci-cli.rb
@@ -5,7 +5,7 @@ class OciCli < Formula
   homepage "https://docs.cloud.oracle.com/iaas/Content/API/Concepts/cliconcepts.htm"
   url "https://github.com/oracle/oci-cli/archive/v2.12.8.tar.gz"
   sha256 "c15832ecf35222650183ec239d2664f776c7f5d830e4dc280569f6cc2f332ed7"
-  license ["UPL-1.0", "Apache-2.0"]
+  # license any_of: ["UPL-1.0", "Apache-2.0"] - pending next Homebrew/brew release
   head "https://github.com/oracle/oci-cli.git"
 
   bottle do

--- a/Formula/sheldon.rb
+++ b/Formula/sheldon.rb
@@ -3,7 +3,7 @@ class Sheldon < Formula
   homepage "https://rossmacarthur.github.io/sheldon"
   url "https://github.com/rossmacarthur/sheldon/archive/0.5.4.tar.gz"
   sha256 "2707f05f59ce3df7e572f8a098d6f0d675b0b351695d04ba8d159d5a7eee8562"
-  license ["Apache-2.0", "MIT"]
+  # license any_of: ["Apache-2.0", "MIT"] - pending next Homebrew/brew release
   head "https://github.com/rossmacarthur/sheldon.git"
 
   bottle do

--- a/Formula/sip.rb
+++ b/Formula/sip.rb
@@ -3,7 +3,7 @@ class Sip < Formula
   homepage "https://www.riverbankcomputing.com/software/sip/intro"
   url "https://www.riverbankcomputing.com/static/Downloads/sip/4.19.24/sip-4.19.24.tar.gz"
   sha256 "edcd3790bb01938191eef0f6117de0bf56d1136626c0ddb678f3a558d62e41e5"
-  license ["GPL-2.0-only", "GPL-3.0-only"]
+  # license any_of: ["GPL-2.0-only", "GPL-3.0-only"] - pending next Homebrew/brew release
   head "https://www.riverbankcomputing.com/hg/sip", using: :hg
 
   bottle do

--- a/Formula/usb.ids.rb
+++ b/Formula/usb.ids.rb
@@ -3,7 +3,7 @@ class UsbIds < Formula
   homepage "http://www.linux-usb.org/usb-ids.html"
   url "https://deb.debian.org/debian/pool/main/u/usb.ids/usb.ids_2020.06.22.orig.tar.xz"
   sha256 "d55befb3b8bdb5db799fb8894c4e27ef909b2975c062fa6437297902213456a7"
-  license ["GPL-2.0-or-later", "BSD-3-Clause"]
+  # license any_of: ["GPL-2.0-or-later", "BSD-3-Clause"] - pending next Homebrew/brew release
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/verilator.rb
+++ b/Formula/verilator.rb
@@ -3,7 +3,7 @@ class Verilator < Formula
   homepage "https://www.veripool.org/wiki/verilator"
   url "https://www.veripool.org/ftp/verilator-4.040.tgz"
   sha256 "6e1574924083922a4eb80ff22eedc866f4ce54e5fd6a34101b6af7aa29e5c0e3"
-  license ["LGPL-3.0-only", "Artistic-2.0"]
+  # license any_of: ["LGPL-3.0-only", "Artistic-2.0"] - pending next Homebrew/brew release
 
   bottle do
     sha256 "f4f7abca35a5479c05aecdab7cd1a0e693a1e6a731663c175ade7b61dc017d10" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Temporarily remove license arrays. These are being deprecated in favor of `license any_of: [...]` in https://github.com/Homebrew/brew/pull/8411.

These can be re-added after the next Homebrew/brew release.

(Marking as `do not merge` until I get some feedback on https://github.com/Homebrew/brew/pull/8411 to make sure this is the direction we want to go).