### PR TITLE
formulae: add licenses for various formulae

### DIFF
--- a/Formula/exiftool.rb
+++ b/Formula/exiftool.rb
@@ -5,6 +5,7 @@ class Exiftool < Formula
   # https://exiftool.org/history.html
   url "https://exiftool.org/Image-ExifTool-12.00.tar.gz"
   sha256 "d0792cc94ab58a8b3d81b18ccdb8b43848c8fb901b5b7caecdcb68689c6c855a"
+  license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
 
   livecheck do
     url "https://exiftool.org/history.html"

--- a/Formula/less.rb
+++ b/Formula/less.rb
@@ -3,6 +3,7 @@ class Less < Formula
   homepage "http://www.greenwoodsoftware.com/less/index.html"
   url "http://www.greenwoodsoftware.com/less/less-551.tar.gz"
   sha256 "ff165275859381a63f19135a8f1f6c5a194d53ec3187f94121ecd8ef0795fe3d"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -3,7 +3,7 @@ class Perl < Formula
   homepage "https://www.perl.org/"
   url "https://www.cpan.org/src/5.0/perl-5.32.0.tar.xz"
   sha256 "6f436b447cf56d22464f980fac1916e707a040e96d52172984c5d184c09b859b"
-  license "Artistic-1.0-Perl"
+  license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   head "https://github.com/perl/perl5.git", branch: "blead"
 
   livecheck do

--- a/Formula/speex.rb
+++ b/Formula/speex.rb
@@ -3,6 +3,7 @@ class Speex < Formula
   homepage "https://speex.org/"
   url "https://downloads.xiph.org/releases/speex/speex-1.2.0.tar.gz"
   sha256 "eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094"
+  license "BSD-3-Clause"
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/speex/?C=M&O=D"

--- a/Formula/telnet.rb
+++ b/Formula/telnet.rb
@@ -3,6 +3,7 @@ class Telnet < Formula
   homepage "https://opensource.apple.com/"
   url "https://opensource.apple.com/tarballs/remote_cmds/remote_cmds-63.tar.gz"
   sha256 "13858ef1018f41b93026302840e832c2b65289242225c5a19ce5e26f84607f15"
+  license all_of: ["BSD-4-Clause-UC", "APSL-1.0"]
 
   livecheck do
     url "https://opensource.apple.com/tarballs/remote_cmds/"

--- a/Formula/telnetd.rb
+++ b/Formula/telnetd.rb
@@ -3,6 +3,7 @@ class Telnetd < Formula
   homepage "https://opensource.apple.com/"
   url "https://opensource.apple.com/tarballs/remote_cmds/remote_cmds-63.tar.gz"
   sha256 "13858ef1018f41b93026302840e832c2b65289242225c5a19ce5e26f84607f15"
+  license all_of: ["BSD-4-Clause-UC", "BSD-3-Clause"]
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/utf8proc.rb
+++ b/Formula/utf8proc.rb
@@ -3,6 +3,7 @@ class Utf8proc < Formula
   homepage "https://juliastrings.github.io/utf8proc/"
   url "https://github.com/JuliaStrings/utf8proc/archive/v2.5.0.tar.gz"
   sha256 "d4e8dfc898cfd062493cb7f42d95d70ccdd3a4cd4d90bec0c71b47cca688f1be"
+  license all_of: ["MIT", "Unicode-DFS-2015"]
 
   bottle do
     cellar :any

--- a/Formula/wget.rb
+++ b/Formula/wget.rb
@@ -3,6 +3,7 @@ class Wget < Formula
   homepage "https://www.gnu.org/software/wget/"
   url "https://ftp.gnu.org/gnu/wget/wget-1.20.3.tar.gz"
   sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+  license "GPL-3.0-or-later"
   revision 2
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adding my contribution to #58225. 🙂 Included in this PR: `wget`, `exiftools`, `less`, `speex`, `telnet(d)` and `utf8proc`. Please see the individual commit messages for details on how these expressions were derived.

(As a side note, I gained a new appreciation for clear licensing terms. These licenses have been quite cumbersome to determine, as the extended commit messages attest.)

Also, `brew audit --strict` doesn't seem to recognize SPDX expressions. I hope that's OK, as the discussion in #59582 seemed to indicate a general agreement to support them.