### PR TITLE
libosinfo: fix pci.ids resource to a stable url

### DIFF
--- a/Formula/libosinfo.rb
+++ b/Formula/libosinfo.rb
@@ -23,8 +23,8 @@ class Libosinfo < Formula
   depends_on "libxml2"
 
   resource "pci.ids" do
-    url "https://pci-ids.ucw.cz/v2.2/pci.ids.gz"
-    sha256 "09dc9980728dfeb123884ecedf51311f6441ffa8c5fa246e4cbea571ceae41b7"
+    url "https://deb.debian.org/debian/pool/main/p/pci.ids/pci.ids_0.0~2020.07.21.orig.tar.xz"
+    sha256 "b520bcc27da6a65b91abefd424b278823586dd116d0570a0670033e7011d5f50"
   end
 
   resource "usb.ids" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----