### PR TITLE
imlib2: revert "remove X11 dependency"

### DIFF
--- a/Formula/imlib2.rb
+++ b/Formula/imlib2.rb
@@ -4,7 +4,7 @@ class Imlib2 < Formula
   url "https://downloads.sourceforge.net/project/enlightenment/imlib2-src/1.7.0/imlib2-1.7.0.tar.bz2"
   sha256 "1976ca3db48cbae79cd0fc737dabe39cc81494fc2560e1d22821e7dc9c22b37d"
   license "Imlib2"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "72866470ea175cfa01858f670fbdc8a19afeda10b2541c9cdf79b08d8f3bb08a" => :catalina
@@ -18,6 +18,7 @@ class Imlib2 < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
+  depends_on :x11
 
   def install
     args = %W[
@@ -25,7 +26,6 @@ class Imlib2 < Formula
       --prefix=#{prefix}
       --enable-amd64=no
       --without-id3
-      --without-x
     ]
 
     system "./configure", *args


### PR DESCRIPTION
This reverts #59688, since other formulae depend on certain X11-only functions in imlib2.

Fixed #60009.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
