### PR TITLE
caddy: use source downloaded by brew

### DIFF
--- a/Formula/caddy.rb
+++ b/Formula/caddy.rb
@@ -25,7 +25,9 @@ class Caddy < Formula
     revision = build.head? ? version.commit : "v#{version}"
 
     resource("xcaddy").stage do
-      system "go", "run", "cmd/xcaddy/main.go", "build", revision, "--output", bin/"caddy"
+      system "go", "run", "cmd/xcaddy/main.go", "build", revision,
+                                                "--with", "github.com/caddyserver/caddy/v2=#{buildpath}",
+                                                "--output", bin/"caddy"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

We use `xcaddy` tool to build `caddy`. 
By default `xcaddy` downloads `caddy` source itself (by doing `go get ...`) and uses it for building. i.e. it ignores source code downloaded by homebrew (and checksum provided by the formula).

This PR forces `xcaddy` to use downloaded by homebrew source code.