### PR TITLE
openrtsp: license update

### DIFF
--- a/Formula/openrtsp.rb
+++ b/Formula/openrtsp.rb
@@ -5,7 +5,7 @@ class Openrtsp < Formula
   mirror "https://download.videolan.org/pub/videolan/testing/contrib/live555/live.2020.08.12.tar.gz"
   # Keep a mirror as upstream tarballs are removed after each version
   sha256 "6380e357076b172c757beccf7f2cc270a7ed3551748d839e2492ea0132062ff6"
-  license "GPL-3.0"
+  license "LGPL-3.0-or-later"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- relates to #59926

Even though, I did find two licenses got referenced in the codebase (GPL-3.0 and LGPL-3.0), but it looks like only LGPL-3.0 is actually in use.

license header ref:

```
/**********
This library is free software; you can redistribute it and/or modify it under
the terms of the GNU Lesser General Public License as published by the
Free Software Foundation; either version 3 of the License, or (at your
option) any later version. (See <http://www.gnu.org/copyleft/lesser.html>.)

This library is distributed in the hope that it will be useful, but WITHOUT
ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
more details.

You should have received a copy of the GNU Lesser General Public License
along with this library; if not, write to the Free Software Foundation, Inc.,
51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
**********/
// Copyright (c) 1996-2020, Live Networks, Inc.  All rights reserved
// LIVE555 Proxy Server
// main program
```
