### PR TITLE
perl-build: update license

### DIFF
--- a/Formula/perl-build.rb
+++ b/Formula/perl-build.rb
@@ -3,8 +3,7 @@ class PerlBuild < Formula
   homepage "https://github.com/tokuhirom/Perl-Build"
   url "https://github.com/tokuhirom/Perl-Build/archive/1.30.tar.gz"
   sha256 "30585889bf7ba9979233d30cfd32686790833f0317ce8d796878dca996fab9bb"
-  # license ["Artistic-1.0", "GPL-1.0"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "Artistic-1.0"
+  license any_of: ["Artistic-1.0", "GPL-1.0-or-later"]
   head "https://github.com/tokuhirom/perl-build.git"
 
   bottle do


### PR DESCRIPTION
relates to #60076

license ref in `LICENSE` file
```
This software is copyright (c) 2013 by Tokuhiro Matsuno E<lt>tokuhirom AAJKLFJEF@ GMAIL COME<gt>.

This is free software; you can redistribute it and/or modify it under
the same terms as the Perl 5 programming language system itself.

Terms of the Perl programming language system itself

a) the GNU General Public License as published by the Free
   Software Foundation; either version 1, or (at your option) any
   later version, or
b) the "Artistic License"
```