### PR TITLE
abcl: depend on openjdk

### DIFF
--- a/Formula/abcl.rb
+++ b/Formula/abcl.rb
@@ -3,6 +3,10 @@ class Abcl < Formula
   homepage "https://abcl.org/"
   url "https://abcl.org/releases/1.7.1/abcl-src-1.7.1.tar.gz"
   sha256 "d51014b2be6ecb5bcaaacda0adf4607a995dd4b6e9e509c8a1f5a998b7649227"
+  license "GPL-2.0-or-later" => {
+    with: "Classpath-exception-2.0",
+  }
+  revision 1
   head "https://abcl.org/svn/trunk/abcl/", using: :svn
 
   bottle do
@@ -13,18 +17,19 @@ class Abcl < Formula
   end
 
   depends_on "ant"
-  depends_on java: "1.8"
+  depends_on "openjdk"
   depends_on "rlwrap"
 
   def install
-    ENV["JAVA_HOME"] = Language::Java.java_home("1.8")
+    ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
 
+    system "ant", "abcl.properties.autoconfigure.openjdk.14"
     system "ant"
 
     libexec.install "dist/abcl.jar", "dist/abcl-contrib.jar"
     (bin/"abcl").write_env_script "rlwrap",
-                                  "java -cp #{libexec}/abcl.jar:\"$CLASSPATH\" org.armedbear.lisp.Main \"$@\"",
-                                  Language::Java.overridable_java_home_env("1.8")
+                                  "java -cp #{libexec}/abcl.jar:\"$CLASSPATH\" org.armedbear.lisp.Main",
+                                  Language::Java.overridable_java_home_env
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
License is currently missing. The website states
> The use of Armed Bear Common Lisp (ABCL) is covered by the GNU General Public License with Classpath exception, meaning that you can use ABCL in your application without the requirement to open the sources to your application.

Not sure how to convey this correctly with SPDX identifiers (I only see GPL-2.0 with Classpath, and even that is deprecated).