### PR TITLE
duck: remove java dependency

### DIFF
--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -5,6 +5,7 @@ class Duck < Formula
   url "https://dist.duck.sh/duck-src-7.5.2.33336.tar.gz"
   sha256 "f084aca8b58069ccfeb62752f47daeff80f54991478189b274c06c7cfe0fa338"
   license "GPL-3.0-only"
+  revision 1
   head "https://svn.cyberduck.io/trunk/"
 
   bottle do
@@ -15,7 +16,6 @@ class Duck < Formula
   end
 
   depends_on "ant" => :build
-  depends_on java: ["1.8", :build]
   depends_on "maven" => :build
   depends_on xcode: :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Seems like Java is only needed as a build dependency.