### PR TITLE
little-cms2: update comment about releases

### DIFF
--- a/Formula/little-cms2.rb
+++ b/Formula/little-cms2.rb
@@ -1,7 +1,8 @@
 class LittleCms2 < Formula
   desc "Color management engine supporting ICC profiles"
   homepage "http://www.littlecms.com/"
-  # Ensure release is announced on http://www.littlecms.com/download.html
+  # Ensure release is announced at http://www.littlecms.com/categories/releases/
+  # (or http://www.littlecms.com/blog/)
   url "https://downloads.sourceforge.net/project/lcms/lcms/2.11/lcms2-2.11.tar.gz"
   sha256 "dc49b9c8e4d7cdff376040571a722902b682a795bf92985a85b48854c270772e"
   license "MIT"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `little-cms2` formula currently contains a comment above the stable `url` saying, "Ensure release is announced on http://www.littlecms.com/download.html".

The first-party website has been redesigned and unfortunately there's no longer a "Download" page to check. Instead, our only option seems to be checking the posts in the blog "Releases" category.

This updates the comment accordingly to reference the new location to check.