### PR TITLE
apache-arrow: enable Gandiva

### DIFF
--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -16,6 +16,7 @@ class ApacheArrow < Formula
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
+  depends_on "llvm"  => :build
   depends_on "brotli"
   depends_on "glog"
   depends_on "grpc"
@@ -29,10 +30,20 @@ class ApacheArrow < Formula
   depends_on "thrift"
   depends_on "zstd"
 
+  # Fix to not install jemalloc in parallel
+  # https://github.com/apache/arrow/pull/7995
+  patch do
+    url "https://github.com/apache/arrow/commit/ae60bad1c2e28bd67cdaeaa05f35096ae193e43a.patch?full_index=1"
+    sha256 "7a793ca3c98a803c652757faa802667e6d19dbc436cedb942c76346771c9e16f"
+  end
+
   def install
     ENV.cxx11
+    # link against system libc++ instead of llvm provided libc++
+    ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
     args = %W[
       -DARROW_FLIGHT=ON
+      -DARROW_GANDIVA=ON
       -DARROW_JEMALLOC=ON
       -DARROW_ORC=ON
       -DARROW_PARQUET=ON


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Thanks for a great tool!

This PR turns -DARROW_GANDIVA flag on.
We tried to enable ganvida with this PR(https://github.com/Homebrew/homebrew-core/pull/58581), but it failed, so let's fix it and enable it.

The problem is the part that declares llvm as a build dependency.
When we compile with llvm, we are linking against the libc++ that comes with llvm.
So thereby llvm is a runtime dependency, actually.

I changed to force using system libc++ like v8 does(https://github.com/Homebrew/homebrew-core/blob/master/Formula/v8.rb#L101-L102), instead of using llvm libc++.
