### PR TITLE
Remove osxfuse dependency from borgbackup

### DIFF
--- a/Formula/borgbackup.rb
+++ b/Formula/borgbackup.rb
@@ -18,7 +18,6 @@ class Borgbackup < Formula
   depends_on "libb2"
   depends_on "lz4"
   depends_on "openssl@1.1"
-  depends_on :osxfuse
   depends_on "python@3.8"
   depends_on "zstd"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `osxfuse` dependency is only required to run the `borg mount` command, which many people don't use, but it installs a kernel extension that may be unwanted/unnecessary. Previously, when `borgbackup` was a Cask, `osxfuse` wasn't installed. See https://github.com/Homebrew/homebrew-core/pull/59717#issuecomment-678620041.

This PR currently does _not_ pass tests or install properly with `--build-from-source`, I think it has something to do with the `llfuse` "resource", this is some of the error output:

```
  Found link https://files.pythonhosted.org/packages/5a/4a/39400ff9b36e719bdf8f31c99fe1fa7842a42fa77432e584f707a5080063/pip-20.2.2-py2.py3-none-any.whl#sha256=5244e51494f5d1dfbb89da492d4250cb07f9246644736d10ed6c45deb1a48500 (from https://pypi.org/simple/pip/) (requires-python:>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*), version: 20.2.2
  Found link https://files.pythonhosted.org/packages/73/8e/7774190ac616c69194688ffce7c1b2a097749792fea42e390e7ddfdef8bc/pip-20.2.2.tar.gz#sha256=58a3b0b55ee2278104165c7ee7bc8e2db6f635067f3c66cf637113ec5aa71584 (from https://pypi.org/simple/pip/) (requires-python:>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*), version: 20.2.2
Given no hashes to check 145 links for project 'pip': discarding no candidates
```

When I comment out the `resource "llfuse" do` block, everything seems to work fine. I'm not sure what `llfuse` does and [the PyPI page for it](https://pypi.org/project/llfuse/) indicates that it's no longer maintained. Is it necessary?

Would very much appreciate any help or comments from @m3nu @rfrancoise @ThomasWaldmann or others. Thanks!