### PR TITLE
zbar 0.23.1 (new upstream)

### DIFF
--- a/Formula/zbar.rb
+++ b/Formula/zbar.rb
@@ -1,36 +1,25 @@
 class Zbar < Formula
   desc "Suite of barcodes-reading tools"
-  homepage "https://zbar.sourceforge.io"
+  homepage "https://github.com/mchehab/zbar"
+  url "https://github.com/mchehab/zbar/archive/0.23.1.tar.gz"
+  sha256 "297439f8859089d2248f55ab95b2a90bba35687975365385c87364c77fdb19f3"
+  license "LGPL-2.1-only"
   revision 10
-
-  stable do
-    url "https://downloads.sourceforge.net/project/zbar/zbar/0.10/zbar-0.10.tar.bz2"
-    sha256 "234efb39dbbe5cef4189cc76f37afbe3cfcfb45ae52493bfe8e191318bdbadc6"
-
-    # Fix JPEG handling using patch from
-    # https://sourceforge.net/p/zbar/discussion/664596/thread/58b8d79b#8f67
-    # already applied upstream but not present in the 0.10 release
-    patch :DATA
-  end
+  head "https://github.com/mchehab/zbar.git"
 
   bottle do
     cellar :any
-    sha256 "c67f6e8064b2c29e707529c211d90499452391ab05739da4774d922f643dd1a3" => :catalina
-    sha256 "17da6d6bbc5072ee46a84b3fed3259afcdc96eabb50988363aa1c13d6437ec4d" => :mojave
-    sha256 "fdba8cdcefcf962f2da1d475bd6556d3bdc3b0f644e3684a0a46efb1dd778fe2" => :high_sierra
+    sha256 "43b41e062704914a007017d7d35dfb518f6c04141a52eb2c146a5e908a75334c" => :high_sierra
+    sha256 "64d9816afc8e6fd898c402f152a9847b4e265da078cf27fa6b1fb289ec3d963c" => :sierra
+    sha256 "8a6c2c77063e98986a8b6d6a5eb19333cd39efccb03af08493d6b5e8a60d57b7" => :el_capitan
   end
 
-  head do
-    url "https://github.com/ZBar/ZBar.git"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "gettext" => :build
-    depends_on "libtool" => :build
-    depends_on "xmlto" => :build
-  end
-
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "gettext" => :build
+  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "xmlto" => :build
   depends_on "freetype"
   depends_on "imagemagick"
   depends_on "jpeg"
@@ -38,26 +27,8 @@ class Zbar < Formula
   depends_on "ufraw"
   depends_on "xz"
 
-  on_linux do
-    # Avoid function naming conflict
-    patch do
-      url "https://salsa.debian.org/debian/zbar/raw/debian/0.10+doc-11/debian/patches/0005-src-Replace-dprintf-macro-with-zbar_dprintf-to-avoid.patch"
-      sha256 "e9a1aab8150f244c7b092a03f16ad8997b26575149b7c86ea8b453199e8916d0"
-    end
-  end
-
   def install
-    if build.head?
-      inreplace "configure.ac", "-Werror", ""
-      gettext = Formula["gettext"]
-      system "autoreconf", "-fvi", "-I", "#{gettext.opt_share}/aclocal"
-    end
-
-    # ImageMagick 7 compatibility
-    # Reported 20 Jun 2016 https://sourceforge.net/p/zbar/support-requests/156/
-    inreplace ["configure", "zbarimg/zbarimg.c"],
-      "wand/MagickWand.h",
-      "ImageMagick-7/MagickWand/MagickWand.h"
+    system "autoreconf", "-fvi"
 
     args = %W[
       --disable-dependency-tracking
@@ -77,27 +48,3 @@ class Zbar < Formula
     system bin/"zbarimg", "-h"
   end
 end
-
-__END__
-diff --git a/zbar/jpeg.c b/zbar/jpeg.c
-index fb566f4..d1c1fb2 100644
---- a/zbar/jpeg.c
-+++ b/zbar/jpeg.c
-@@ -79,8 +79,15 @@ int fill_input_buffer (j_decompress_ptr cinfo)
- void skip_input_data (j_decompress_ptr cinfo,
-                       long num_bytes)
- {
--    cinfo->src->next_input_byte = NULL;
--    cinfo->src->bytes_in_buffer = 0;
-+    if (num_bytes > 0) {
-+        if (num_bytes < cinfo->src->bytes_in_buffer) {
-+            cinfo->src->next_input_byte += num_bytes;
-+            cinfo->src->bytes_in_buffer -= num_bytes;
-+        }
-+        else {
-+            fill_input_buffer(cinfo);
-+        }
-+    }
- }
- 
- void term_source (j_decompress_ptr cinfo)


### PR DESCRIPTION
This updates zbar along with a new upstream repository. It has been actively maintained for a few years.

It seems the major Linux distros now refer to this fork, too:

* Debian: https://salsa.debian.org/debian/zbar
* Fedora: https://www.spinics.net/lists/fedora-package-announce/msg248310.html

The previous maintainer remains inactive and the SourceForge project has been untouched since https://github.com/Homebrew/homebrew-core/pull/31203 was raised to switch upstreams in 2018.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
