### PR TITLE
borgbackup: change osxfuse to build-time dependency

### DIFF
--- a/Formula/borgbackup.rb
+++ b/Formula/borgbackup.rb
@@ -14,11 +14,11 @@ class Borgbackup < Formula
     sha256 "6bc8fd5091f705e9843a77d3f87cd7b722b84243a68e99d8d15d8f8ae20d0b03" => :high_sierra
   end
 
+  depends_on osxfuse: :build
   depends_on "pkg-config" => :build
   depends_on "libb2"
   depends_on "lz4"
   depends_on "openssl@1.1"
-  depends_on :osxfuse
   depends_on "python@3.8"
   depends_on "zstd"
 
@@ -29,6 +29,13 @@ class Borgbackup < Formula
 
   def install
     virtualenv_install_with_resources
+  end
+
+  def caveats
+    <<~EOS
+      To use `borg mount`, install osxfuse with Homebrew Cask:
+        brew cask install osxfuse
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Some users don't want to have a kernel extension/osxfuse to be installed automatically. See discussion in https://github.com/Homebrew/homebrew-core/pull/60266