### PR TITLE
gnutls: avoid gnutls.scm recompilation

### DIFF
--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -77,6 +77,10 @@ class Gnutls < Formula
 
     pkgetc.mkpath
     (pkgetc/"cert.pem").atomic_write(valid_certs.join("\n"))
+
+    # Touch gnutls.go to avoid Guile recompilation.
+    # See https://github.com/Homebrew/homebrew-core/pull/60307#discussion_r478917491
+    touch "#{lib}/guile/3.0/site-ccache/gnutls.go"
   end
 
   def caveats


### PR DESCRIPTION
This fixes an issue where loading the (gnutls) module in Guile would cause a
recompilation of one file.

The reason is because `gnutls.scm` is auto-generated when building and points
to a Cellar directory. When bottles are built all text fails containing
Homebrew paths will be replaced by placeholders. When installing the bottle
those placeholders will be replaced.

The solution is to recompile the affected file.

See https://github.com/Homebrew/homebrew-core/issues/60279

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
