### PR TITLE
use openjdk 11 for sonarqube-lts

### DIFF
--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -58,7 +58,7 @@ class SonarqubeLts < Formula
 
     begin
       pid = fork do
-        exec bin/"sonar", "start"
+        exec bin/"sonar", "console"
       end
 
       puts "pid: #{pid}"

--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -3,6 +3,7 @@ class SonarqubeLts < Formula
   homepage "https://www.sonarqube.org/"
   url "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.9.4.zip"
   sha256 "67fd0e9b2f4a1cf481ac9c5487173e4b1aa05381e6219428f53de510c8f2289d"
+  license "LGPL-3.0-or-later"
 
   # The regex below should only match the LTS release archive on the Sonarqube
   # downloads page. This is necessary because the usual index page for releases

--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -14,7 +14,7 @@ class SonarqubeLts < Formula
 
   bottle :unneeded
 
-  depends_on "openjdk"
+  depends_on "openjdk@11"
 
   conflicts_with "sonarqube", because: "both install the same binaries"
 
@@ -25,7 +25,7 @@ class SonarqubeLts < Formula
     libexec.install Dir["*"]
 
     (bin/"sonar").write_env_script libexec/"bin/macosx-universal-64/sonar.sh",
-      JAVA_HOME: Formula["openjdk"].opt_prefix
+      JAVA_HOME: Formula["openjdk@11"].opt_prefix
   end
 
   plist_options manual: "sonar console"

--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -62,14 +62,7 @@ class SonarqubeLts < Formula
       end
 
       puts "pid: #{pid}"
-
-      seconds = 0
-      loop do
-        status = shell_output("#{bin}/sonar status")
-        break if status.match?("is running") || (seconds += 5) > 60
-
-        sleep 5
-      end
+      sleep 60
 
       assert_match "pong", shell_output("curl -s http://127.0.0.1:9000/api/system/ping")
     ensure

--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -25,6 +25,7 @@ class SonarqubeLts < Formula
 
     libexec.install Dir["*"]
 
+    inreplace "#{libexec}/conf/wrapper.conf", "wrapper.java.command=java", "wrapper.java.command=#{Formula["openjdk@11"].opt_bin}/java"
     (bin/"sonar").write_env_script libexec/"bin/macosx-universal-64/sonar.sh",
       JAVA_HOME: Formula["openjdk@11"].opt_prefix
   end

--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -25,7 +25,8 @@ class SonarqubeLts < Formula
 
     libexec.install Dir["*"]
 
-    inreplace "#{libexec}/conf/wrapper.conf", "wrapper.java.command=java", "wrapper.java.command=#{Formula["openjdk@11"].opt_bin}/java"
+    inreplace "#{libexec}/conf/wrapper.conf", "wrapper.java.command=java",
+      "wrapper.java.command=#{Formula["openjdk@11"].opt_bin}/java"
     (bin/"sonar").write_env_script libexec/"bin/macosx-universal-64/sonar.sh",
       JAVA_HOME: Formula["openjdk@11"].opt_prefix
   end
@@ -65,7 +66,8 @@ class SonarqubeLts < Formula
       seconds = 0
       loop do
         status = shell_output("#{bin}/sonar status")
-        break if (status.match? 'is running' || (seconds += 5) > 60)
+        break if status.match?("is running") || (seconds += 5) > 60
+
         sleep 5
       end
 

--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -53,5 +53,26 @@ class SonarqubeLts < Formula
 
   test do
     assert_match "SonarQube", shell_output("#{bin}/sonar status", 1)
+
+    begin
+      pid = fork do
+        exec bin/"sonar", "start"
+      end
+
+      puts "pid: #{pid}"
+      sleep 45
+
+      # loop do
+      #   status = shell_output("#{bin}/sonar status")
+      #   break if status.match? 'is running'
+      #   sleep 5
+      # end
+
+      assert_match "pong", shell_output("curl -s http://127.0.0.1:9000/api/system/ping")
+    ensure
+      # Process.kill("TERM", pid)
+      # Process.wait(pid)
+      system bin/"sonar", "stop"
+    end
   end
 end

--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -60,13 +60,13 @@ class SonarqubeLts < Formula
       end
 
       puts "pid: #{pid}"
-      sleep 45
 
-      # loop do
-      #   status = shell_output("#{bin}/sonar status")
-      #   break if status.match? 'is running'
-      #   sleep 5
-      # end
+      seconds = 0
+      loop do
+        status = shell_output("#{bin}/sonar status")
+        break if (status.match? 'is running' || (seconds += 5) > 60)
+        sleep 5
+      end
 
       assert_match "pong", shell_output("curl -s http://127.0.0.1:9000/api/system/ping")
     ensure

--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -12,7 +12,7 @@ class Sonarqube < Formula
 
   bottle :unneeded
 
-  depends_on "openjdk"
+  depends_on "openjdk@11"
 
   conflicts_with "sonarqube-lts", because: "both install the same binaries"
 
@@ -23,7 +23,7 @@ class Sonarqube < Formula
     libexec.install Dir["*"]
 
     (bin/"sonar").write_env_script libexec/"bin/macosx-universal-64/sonar.sh",
-      JAVA_HOME: Formula["openjdk"].opt_prefix
+      JAVA_HOME: Formula["openjdk@11"].opt_prefix
   end
 
   plist_options manual: "sonar console"


### PR DESCRIPTION
SonarQube 7.9+ requires java 11, while currently openjdk is java 14, which is not compatible.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

### Edit

See [Release 7.9 LTS Upgrade Notes][1]:
> **Java 11 Required**
The SonarQube server now requires Java 11. Analyses may continue to use Java 8 if necessary.

[1]: https://github.com/SonarSource/sonarqube/blob/4b24dd9c4060ef27950440249b1a279b02e9405b/server/sonar-docs/src/pages/setup/upgrade-notes.md