### PR TITLE
sponge 0.63 (new formula)

### DIFF
--- a/Formula/sponge.rb
+++ b/Formula/sponge.rb
@@ -1,0 +1,19 @@
+class Sponge < Formula
+  desc "Soak up standard input and write to a file"
+  homepage "https://joeyh.name/code/moreutils/"
+  url "https://git.joeyh.name/index.cgi/moreutils.git/snapshot/moreutils-0.63.tar.gz"
+  sha256 "4fc86d56a8a276a0cec71cdabda5ccca50c7a44a2a1ccd888476741d1ce6831d"
+  license "GPL-2.0-only"
+
+  def install
+    system "make", "sponge"
+    bin.install "sponge"
+  end
+
+  test do
+    file = testpath/"sponge-test.txt"
+    file.write("c\nb\na\n")
+    system "sort #{file} | #{bin/"sponge"} #{file}"
+    assert_equal "a\nb\nc\n", File.read(file)
+  end
+end


### PR DESCRIPTION
sponge is part of moreutils, which is already present in Homebrew.
However, sponge by itself is quite simple and has no dependencies
outside of the C standard library, and is a very useful utility on its
own. moreutils additionally conflicts with a few other common packages
(parallel being the most obvious) and requires a specific tap to exclude
those from install.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
