### PR TITLE
yasm: fix test for macOS 11.0

### DIFF
--- a/Formula/yasm.rb
+++ b/Formula/yasm.rb
@@ -55,7 +55,7 @@ class Yasm < Formula
       .len:   equ     $ - msg
     EOS
     system "#{bin}/yasm", "-f", "macho64", "test.asm"
-    system "/usr/bin/ld", "-macosx_version_min", "10.7.0", "-lSystem", "-o", "test", "test.o"
+    system "/usr/bin/ld", "-macosx_version_min", "10.8.0", "-static", "-o", "test", "test.o"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Remove the `-lSystem` argument, which no longer works on 11.0

- Add `-static` in order to allow `start` as the entry point

- Bump `macosx_version_min` to get rid of the warning

Without these changes, `brew test yasm` would fail with the following messages:

```
ld: warning: building for macOS 10.7.0 is deprecated
ld: library not found for -lSystem
```
