### PR TITLE
emscripten: adjust test

### DIFF
--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -103,7 +103,6 @@ class Emscripten < Formula
   end
 
   test do
-    system bin/"emcc"
-    assert_predicate testpath/".emscripten", :exist?, "Failed to create sample config"
+    system "#{bin}/emcc", "--version"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request simplifies the `test` method to work after the `.emscripten` file has been created. By default `brew test emscripten` will fail if there is an existing emscripten installation.

<details>
  <summary>Test output</summary>
==> Testing emscripten
==> /usr/local/Cellar/emscripten/1.40.1/bin/emcc
Last 15 lines from /Users/dave/Library/Logs/Homebrew/emscripten/test.01.emcc:
2020-08-29 23:49:54 +0200

/usr/local/Cellar/emscripten/1.40.1/bin/emcc

cache:INFO: generating system asset: is_vanilla.txt... (this will be cached in "/private/tmp/emscripten-test-20200829-98966-cq8p92/.emscripten_cache/is_vanilla.txt" for subsequent builds)
cache:INFO:  - ok
shared:INFO: (Emscripten: Running sanity checks)
emcc: warning: the fastomp compiler is deprecated.  Please switch to the upstream llvm backend as soon as possible and open issues if you have trouble doing so [-Wfastcomp]
emcc: error: no input files
Error: emscripten: failed
An exception occurred within a child process:
  BuildError: Failed executing: /usr/local/Cellar/emscripten/1.40.1/bin/emcc
/usr/local/Homebrew/Library/Homebrew/formula.rb:2037:in `block in system'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1975:in `open'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1975:in `system'
/Users/dave/homebrew-core/Formula/emscripten.rb:107:in `block in <class:Emscripten>'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1846:in `block (3 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/utils.rb:492:in `with_env'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1845:in `block (2 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/formula.rb:910:in `with_logging'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1844:in `block in run_test'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:57:in `block in run'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:57:in `chdir'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:57:in `run'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2086:in `mktemp'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1838:in `run_test'
/usr/local/Homebrew/Library/Homebrew/test.rb:37:in `block in <main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/usr/local/Homebrew/Library/Homebrew/test.rb:36:in `<main>'
</details>