### PR TITLE
workflows: use pull_request_target event for PR labelling

### DIFF
--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -1,14 +1,9 @@
-name: Label pull requests
+name: Label pull request
 
-on:
-  workflow_dispatch:
-  schedule:
-    # Once every 30 minutes
-    - cron: '*/30 * * * *'
+on: pull_request_target
 
 jobs:
-  autolabel:
-    if: github.repository == 'Homebrew/homebrew-core'
+  label:
     runs-on: ubuntu-latest
     steps:
       - name: Label


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Should be merged in sync with: https://github.com/Homebrew/actions/pull/67