### PR TITLE
miniupnpc: conflicts_with "wownero"

### DIFF
--- a/Formula/miniupnpc.rb
+++ b/Formula/miniupnpc.rb
@@ -20,6 +20,8 @@ class Miniupnpc < Formula
     sha256 "b65b947374b703c4473c6f4daa74090181c7372e4b2d663a05890f988605eab9" => :el_capitan
   end
 
+  conflicts_with "wownero", because: "wownero ships its own copy of miniupnpc"
+
   def install
     system "make", "INSTALLPREFIX=#{prefix}", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add a `conflicts_with` directive to indicate that the [newly-added](https://github.com/Homebrew/homebrew-core/pull/59687) `wownero` formula also installs a `libminiupnpc.a` library.

This currently blocks CI on PR #59257. To get this out of the way quickly, use `conflicts_with` for now instead of making `miniupnpc` a dependency of `wownero`.
