### PR TITLE
wownero: conflicts_with "miniupnpc"

### DIFF
--- a/Formula/wownero.rb
+++ b/Formula/wownero.rb
@@ -24,6 +24,8 @@ class Wownero < Formula
   depends_on "unbound"
   depends_on "zeromq"
 
+  conflicts_with "miniupnpc", because: "wownero ships its own copy of miniupnpc"
+
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add a `conflicts_with` directive to indicate that both this formula and `miniupnpc` install a `libminiupnpc.a` library.

This currently blocks CI on PR #59257. To get this out of the way quickly, use `conflicts_with` for now instead of making `miniupnpc` a dependency of `wownero`.
