### PR TITLE
eksctl: fix description

### DIFF
--- a/Formula/eksctl.rb
+++ b/Formula/eksctl.rb
@@ -1,5 +1,5 @@
 class Eksctl < Formula
-  desc "The official CLI for Amazon EKS"
+  desc "The official CLI for Amazon EKS (formula not officially supported by Weaveworks)"
   homepage "https://eksctl.io"
   url "https://github.com/weaveworks/eksctl.git",
       tag:      "0.26.0",


### PR DESCRIPTION
This formula is not updated by the eksctl maintainers team (Weaveworks). The official formula lives in the [weaveworks tap](https://github.com/weaveworks/homebrew-tap/blob/master/Formula/eksctl.rb) and it is updated with every new release.

cc @michaelbeaumont @cPu1

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
