### PR TITLE
disable!, deprecate!: add reason symbols

### DIFF
--- a/Formula/acmetool.rb
+++ b/Formula/acmetool.rb
@@ -15,7 +15,7 @@ class Acmetool < Formula
   end
 
   # See: https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430
-  deprecate! date: "2020-06-01", because: "is deprecated upstream"
+  deprecate! date: "2020-06-01", because: :deprecated_upstream
 
   depends_on "go" => :build
   uses_from_macos "libpcap"

--- a/Formula/apollo.rb
+++ b/Formula/apollo.rb
@@ -30,7 +30,7 @@ class Apollo < Formula
   end
 
   # https://github.com/apache/activemq-apollo/commit/049d68bf3f94cdf62ded5426d3cad4ef3e3c56ca
-  deprecate! date: "2019-03-11", because: "is deprecated upstream"
+  deprecate! date: "2019-03-11", because: :deprecated_upstream
 
   def install
     prefix.install_metafiles

--- a/Formula/archey.rb
+++ b/Formula/archey.rb
@@ -23,7 +23,7 @@ class Archey < Formula
 
   bottle :unneeded
 
-  deprecate! date: "2017-04-28", because: "has an archived upstream repository"
+  deprecate! date: "2017-04-28", because: :repo_archived
 
   def install
     bin.install "bin/archey"

--- a/Formula/aurora-cli.rb
+++ b/Formula/aurora-cli.rb
@@ -19,7 +19,9 @@ class AuroraCli < Formula
 
   depends_on "python@3.7"
 
-  disable! because: "does not build on Catalina, moved to the Apache Attic"
+  # Does not build on Catalina
+  # Has been moved to the Apache Attic: https://github.com/apache/attic-aurora
+  disable! because: :does_not_build
 
   def install
     # No pants yet for Mojave, so we force High Sierra binaries there

--- a/Formula/bwctl.rb
+++ b/Formula/bwctl.rb
@@ -15,7 +15,7 @@ class Bwctl < Formula
 
   # https://software.internet2.edu/bwctl/
   # The use of BWCTL became deprecated with the release of pScheduler in perfSONAR 4.0 in April, 2017.
-  deprecate! date: "2017-04-01", because: "is deprecated upstream"
+  deprecate! date: "2017-04-01", because: :deprecated_upstream
 
   depends_on "i2util" => :build
 

--- a/Formula/ccze.rb
+++ b/Formula/ccze.rb
@@ -15,7 +15,7 @@ class Ccze < Formula
   end
 
   # query via the last repo status change `https://api.github.com/repos/madhouse/ccze`
-  deprecate! date: "2020-05-24", because: "has an archived upstream repository"
+  deprecate! date: "2020-05-24", because: :repo_archived
 
   depends_on "pcre"
 

--- a/Formula/cvsps.rb
+++ b/Formula/cvsps.rb
@@ -14,7 +14,7 @@ class Cvsps < Formula
 
   # http://www.catb.org/~esr/cvsps/
   # Deprecation warning: this code has been end-of-lifed by its maintainer. Use cvs-fast-export instead.
-  deprecate! date: "2013-12-11", because: "is deprecated upstream"
+  deprecate! date: "2013-12-11", because: :deprecated_upstream
 
   depends_on "asciidoc"
   depends_on "docbook"

--- a/Formula/erlang@20.rb
+++ b/Formula/erlang@20.rb
@@ -19,7 +19,7 @@ class ErlangAT20 < Formula
   end
 
   # Deprecated with OTP-23 release (https://erlang.org/pipermail/erlang-questions/2020-July/099747.html)
-  deprecate! date: "2020-05-13", because: "is not supported upstream"
+  deprecate! date: "2020-05-13", because: :unsupported
 
   keg_only :versioned_formula
 

--- a/Formula/fceux.rb
+++ b/Formula/fceux.rb
@@ -22,7 +22,8 @@ class Fceux < Formula
   depends_on "gtk+3"
   depends_on "sdl"
 
-  disable! because: "does not build: some build scripts rely on Python 2 syntax"
+  # Does not build: some build scripts rely on Python 2 syntax
+  disable! because: :does_not_build
 
   # Fix "error: ordered comparison between pointer and zero"
   if DevelopmentTools.clang_build_version >= 900

--- a/Formula/git-hooks.rb
+++ b/Formula/git-hooks.rb
@@ -9,7 +9,7 @@ class GitHooks < Formula
   # have moved to an alternative location. There is a rewrite in Go by a
   # different author which someone may want to work into a new formula as a
   # replacement: https://github.com/git-hooks/git-hooks
-  deprecate! because: "has a deleted upstream repository"
+  deprecate! because: :repo_removed
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/go@1.10.rb
+++ b/Formula/go@1.10.rb
@@ -15,7 +15,7 @@ class GoAT110 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2019-02-25", because: "is not supported upstream"
+  deprecate! date: "2019-02-25", because: :unsupported
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",

--- a/Formula/go@1.11.rb
+++ b/Formula/go@1.11.rb
@@ -15,7 +15,7 @@ class GoAT111 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2019-09-03", because: "is not supported upstream"
+  deprecate! date: "2019-09-03", because: :unsupported
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",

--- a/Formula/go@1.12.rb
+++ b/Formula/go@1.12.rb
@@ -15,7 +15,7 @@ class GoAT112 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-02-25", because: "is not supported upstream"
+  deprecate! date: "2020-02-25", because: :unsupported
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",

--- a/Formula/go@1.13.rb
+++ b/Formula/go@1.13.rb
@@ -15,7 +15,7 @@ class GoAT113 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-08-11", because: "is not supported upstream"
+  deprecate! date: "2020-08-11", because: :unsupported
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",

--- a/Formula/go@1.9.rb
+++ b/Formula/go@1.9.rb
@@ -15,7 +15,7 @@ class GoAT19 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2018-08-04", because: "is not supported upstream"
+  deprecate! date: "2018-08-04", because: :unsupported
 
   resource "gotools" do
     url "https://go.googlesource.com/tools.git",

--- a/Formula/gobby.rb
+++ b/Formula/gobby.rb
@@ -25,7 +25,7 @@ class Gobby < Formula
   depends_on "libxml++"
 
   # open issue since 2017-04-23, https://github.com/gobby/gobby/issues/143
-  disable! because: "does not build, no releases or maintenance since 2018-08-26"
+  disable! date: "2018-08-26", because: :unmaintained
 
   # Necessary to remove mandatory gtk-mac-integration
   # it's badly broken as it depends on an ancient version of ige-mac-integration

--- a/Formula/godep.rb
+++ b/Formula/godep.rb
@@ -14,7 +14,7 @@ class Godep < Formula
     sha256 "86892d7dd9770920ee08c761a722f85a9354f9813e0119e8fc2f67e8fff0b79b" => :high_sierra
   end
 
-  deprecate! date: "2018-01-26", because: "has an archived upstream repository"
+  deprecate! date: "2018-01-26", because: :repo_archived
 
   depends_on "go"
 

--- a/Formula/gradio.rb
+++ b/Formula/gradio.rb
@@ -12,7 +12,7 @@ class Gradio < Formula
     sha256 "772bc7cd809b085f9eaf2419ae9ddae50e80cbaaace480fe1f3d23c26bd8f164" => :high_sierra
   end
 
-  deprecate! date: "2019-11-16", because: "has an archived upstream repository"
+  deprecate! date: "2019-11-16", because: :repo_archived
 
   depends_on "meson" => :build
   depends_on "ninja" => :build

--- a/Formula/guile@2.rb
+++ b/Formula/guile@2.rb
@@ -13,7 +13,7 @@ class GuileAT2 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! because: "is a versioned formula"
+  deprecate! because: :versioned_formula
 
   depends_on "gnu-sed" => :build
   depends_on "bdw-gc"

--- a/Formula/homesick-completion.rb
+++ b/Formula/homesick-completion.rb
@@ -7,7 +7,7 @@ class HomesickCompletion < Formula
 
   bottle :unneeded
 
-  deprecate! because: "has an archived upstream repository"
+  deprecate! because: :repo_archived
 
   def install
     bash_completion.install "homesick"

--- a/Formula/liblas.rb
+++ b/Formula/liblas.rb
@@ -7,7 +7,7 @@ class Liblas < Formula
   revision 3
   head "https://github.com/libLAS/libLAS.git"
 
-  deprecate! date: "2018-01-01", because: "is not supported upstream"
+  deprecate! date: "2018-01-01", because: :unsupported
 
   bottle do
     sha256 "c63d0d75db5b8e129c13add1de8fe94b2a38d5c15d101b62d6a7f59b796f53a3" => :catalina

--- a/Formula/libpqxx@6.rb
+++ b/Formula/libpqxx@6.rb
@@ -14,7 +14,7 @@ class LibpqxxAT6 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! because: "is a versioned formula"
+  deprecate! because: :versioned_formula
 
   depends_on "pkg-config" => :build
   depends_on "python@3.8" => :build

--- a/Formula/now-cli.rb
+++ b/Formula/now-cli.rb
@@ -21,7 +21,7 @@ class NowCli < Formula
 
   depends_on "node"
 
-  disable! date: "2021-01-31", because: "is not receiving updates upstream"
+  disable! date: "2021-01-31", because: :unmaintained
 
   def install
     rm Dir["dist/{*.exe,xsel}"]

--- a/Formula/ooniprobe.rb
+++ b/Formula/ooniprobe.rb
@@ -21,7 +21,7 @@ class Ooniprobe < Formula
 
   # Unmaintained. Last PyPI release on 2018-02-18
   # Use https://github.com/ooni/probe-cli instead
-  deprecate! date: "2018-02-18", because: "is not supported upstream"
+  deprecate! date: "2018-02-18", because: :unsupported
 
   depends_on "geoip"
   depends_on "libdnet"

--- a/Formula/opencv@2.rb
+++ b/Formula/opencv@2.rb
@@ -18,7 +18,7 @@ class OpencvAT2 < Formula
   end
 
   # https://www.slideshare.net/EugeneKhvedchenya/opencv-30-latest-news-and-the-roadmap
-  deprecate! date: "2015-02-01", because: "is not supported upstream"
+  deprecate! date: "2015-02-01", because: :unsupported
 
   keg_only :versioned_formula
 

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -15,7 +15,7 @@ class PhpAT72 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-11-30", because: "is a versioned formula"
+  deprecate! date: "2020-11-30", because: :versioned_formula
 
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build

--- a/Formula/php@7.3.rb
+++ b/Formula/php@7.3.rb
@@ -15,7 +15,7 @@ class PhpAT73 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2021-12-06", because: "is a versioned formula"
+  deprecate! date: "2021-12-06", because: :versioned_formula
 
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build

--- a/Formula/polipo.rb
+++ b/Formula/polipo.rb
@@ -15,7 +15,7 @@ class Polipo < Formula
   end
 
   # https://github.com/jech/polipo/commit/4d42ca1b5849518762d110f34b6ce2e03d6df9ec
-  deprecate! date: "2016-11-06", because: "is not supported upstream"
+  deprecate! date: "2016-11-06", because: :unsupported
 
   def install
     cache_root = (var + "cache/polipo")

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -14,7 +14,7 @@ class PostgresqlAT94 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-02-13", because: "is a versioned formula"
+  deprecate! date: "2020-02-13", because: :versioned_formula
 
   depends_on "openssl@1.1"
   depends_on "readline"

--- a/Formula/premake.rb
+++ b/Formula/premake.rb
@@ -16,7 +16,7 @@ class Premake < Formula
   end
 
   # See: https://groups.google.com/g/premake-development/c/i1uA1Wk6zYM/m/kbp9q4Awu70J
-  deprecate! date: "2015-05-28", because: "is not supported upstream"
+  deprecate! date: "2015-05-28", because: :unsupported
 
   def install
     if build.head?

--- a/Formula/procyon-decompiler.rb
+++ b/Formula/procyon-decompiler.rb
@@ -13,7 +13,7 @@ class ProcyonDecompiler < Formula
 
   depends_on "openjdk"
 
-  disable! because: "has a removed upstream bitbucket repository"
+  disable! because: :repo_removed
 
   def install
     libexec.install "procyon-decompiler-#{version}.jar"

--- a/Formula/protobuf-swift.rb
+++ b/Formula/protobuf-swift.rb
@@ -14,7 +14,7 @@ class ProtobufSwift < Formula
   end
 
   # https://github.com/Homebrew/homebrew-core/pull/54471#issuecomment-627430555
-  disable! because: "does not build, unmaintained"
+  disable! because: :unmaintained
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/protobuf@3.7.rb
+++ b/Formula/protobuf@3.7.rb
@@ -17,7 +17,7 @@ class ProtobufAT37 < Formula
   keg_only :versioned_formula
 
   # https://github.com/Homebrew/homebrew-core/pull/54471#issuecomment-627430555
-  disable! because: "does not build, unmaintained"
+  disable! because: :unmaintained
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/redis@3.2.rb
+++ b/Formula/redis@3.2.rb
@@ -14,7 +14,7 @@ class RedisAT32 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! because: "is a versioned formula"
+  deprecate! because: :versioned_formula
 
   def install
     system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}"

--- a/Formula/redis@4.0.rb
+++ b/Formula/redis@4.0.rb
@@ -15,7 +15,7 @@ class RedisAT40 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! because: "is a versioned formula"
+  deprecate! because: :versioned_formula
 
   def install
     system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}"

--- a/Formula/rtv.rb
+++ b/Formula/rtv.rb
@@ -16,7 +16,7 @@ class Rtv < Formula
     sha256 "2510e9e484f8eeff62d204b4ae4c21c1cacce11fba156eeb42d3450789b90452" => :high_sierra
   end
 
-  deprecate! date: "2019-06-02", because: "has an archived upstream repository"
+  deprecate! date: "2019-06-02", because: :repo_archived
 
   depends_on "python@3.8"
 

--- a/Formula/s3ql.rb
+++ b/Formula/s3ql.rb
@@ -18,7 +18,7 @@ class S3ql < Formula
 
   # disable due to osxfuse API is with fuse2
   # logged an issue, https://github.com/s3ql/s3ql/issues/192
-  deprecate! because: "does not build"
+  deprecate! because: :does_not_build
 
   depends_on "pkg-config" => :build
   depends_on "openssl@1.1"

--- a/Formula/semtag.rb
+++ b/Formula/semtag.rb
@@ -7,7 +7,7 @@ class Semtag < Formula
   bottle :unneeded
 
   # https://github.com/pnikosis/semtag/issues/15
-  disable! because: "has no license"
+  disable! because: :no_license
 
   def install
     bin.install "semtag"

--- a/Formula/sonar-completion.rb
+++ b/Formula/sonar-completion.rb
@@ -9,7 +9,7 @@ class SonarCompletion < Formula
   bottle :unneeded
 
   # https://github.com/a1dutch/sonarqube-bash-completion/issues/1
-  disable! because: "has no license"
+  disable! because: :no_license
 
   def install
     bash_completion.install "etc/bash_completion.d/sonar"

--- a/Formula/stlviewer.rb
+++ b/Formula/stlviewer.rb
@@ -16,7 +16,7 @@ class Stlviewer < Formula
   end
 
   # https://github.com/vishpat/stlviewer/issues/8
-  disable! because: "has no license"
+  disable! because: :no_license
 
   def install
     system "./compile.py"

--- a/Formula/terraform-provisioner-ansible.rb
+++ b/Formula/terraform-provisioner-ansible.rb
@@ -18,7 +18,7 @@ class TerraformProvisionerAnsible < Formula
   end
 
   # https://github.com/jonmorehouse/terraform-provisioner-ansible/issues/41
-  disable! because: "has no license"
+  disable! because: :no_license
 
   depends_on "go" => :build
   depends_on "terraform"

--- a/Formula/tj.rb
+++ b/Formula/tj.rb
@@ -14,7 +14,7 @@ class Tj < Formula
   end
 
   # https://github.com/sgreben/tj/issues/5
-  disable! because: "has no license"
+  disable! because: :no_license
 
   depends_on "go" => :build
 

--- a/Formula/vsts-cli.rb
+++ b/Formula/vsts-cli.rb
@@ -19,7 +19,7 @@ class VstsCli < Formula
   end
 
   # https://github.com/Azure/azure-devops-cli-extension/pull/219#issuecomment-456404611
-  deprecate! date: "2019-01-22", because: "is not supported upstream"
+  deprecate! date: "2019-01-22", because: :unsupported
 
   depends_on "python@3.8"
 

--- a/Formula/zinc.rb
+++ b/Formula/zinc.rb
@@ -6,7 +6,7 @@ class Zinc < Formula
 
   bottle :unneeded
 
-  deprecate! because: "has an archived upstream repository"
+  deprecate! because: :repo_archived
 
   def install
     rm_f Dir["bin/ng/{linux,win}*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The (hopefully) final part in the `disable!` and `deprecate!` reason saga...

Now that https://github.com/Homebrew/brew/pull/8530/ is merged and tagged we can switch most reasons to using the symbol variant. There are still 6 formulae in homebrew-core that I decided shouldn't use the symbol notation as their reason is more unique.

CC: @MikeMcQuaid to make sure this is what you were anticipating with these changes.