### PR TITLE
boost@*: disable old versioned formulae

### DIFF
--- a/Formula/boost@1.55.rb
+++ b/Formula/boost@1.55.rb
@@ -17,6 +17,8 @@ class BoostAT155 < Formula
 
   keg_only :versioned_formula
 
+  disable! because: :versioned_formula
+
   # Patches boost::atomic for LLVM 3.4 as it is used on OS X 10.9 with Xcode 5.1
   # https://github.com/Homebrew/homebrew/issues/27396
   # https://github.com/Homebrew/homebrew/pull/27436

--- a/Formula/boost@1.57.rb
+++ b/Formula/boost@1.57.rb
@@ -17,6 +17,8 @@ class BoostAT157 < Formula
 
   keg_only :versioned_formula
 
+  disable! because: :versioned_formula
+
   # Fix build on Xcode 11.4
   patch do
     url "https://github.com/boostorg/build/commit/b3a59d265929a213f02a451bb63cea75d668a4d9.patch?full_index=1"

--- a/Formula/boost@1.59.rb
+++ b/Formula/boost@1.59.rb
@@ -17,6 +17,8 @@ class BoostAT159 < Formula
 
   keg_only :versioned_formula
 
+  disable! because: :versioned_formula
+
   # Fixed compilation of operator<< into a record ostream, when
   # the operator right hand argument is not directly supported by
   # formatting_ostream. Fixed https://svn.boost.org/trac/boost/ticket/11549

--- a/Formula/boost@1.60.rb
+++ b/Formula/boost@1.60.rb
@@ -17,6 +17,8 @@ class BoostAT160 < Formula
 
   keg_only :versioned_formula
 
+  disable! because: :versioned_formula
+
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----