### PR TITLE
diskonaut 0.9.0 (new formula)

### DIFF
--- a/Formula/diskonaut.rb
+++ b/Formula/diskonaut.rb
@@ -1,0 +1,18 @@
+class Diskonaut < Formula
+  desc "Terminal visual disk space navigator"
+  homepage "https://github.com/imsnif/diskonaut"
+  url "https://github.com/imsnif/diskonaut/archive/0.9.0.tar.gz"
+  sha256 "93564a195a62796f95eacc154ad10df8f1050c8a0b2e2e22a0612228c930c1f5"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    output = shell_output "#{bin}/diskonaut", 2
+    assert_match output, "Error:\ Failed\ to\ get\ stdout:\ are\ you\ trying\ to\ pipe\ 'diskonaut'\?\n"
+  end
+end


### PR DESCRIPTION
Diskonaut is a relatively new visual disk space navigator for the terminal. It's gaining in popularity, has some loyal users, contributors and even a couple of blog posts.

Full disclosure: I am the original author and maintainer. I'm opening this myself because not being on brew is a barrier for a lot of mac users.

I hope I did the right thing with the formula test (running the full test suite with `cargo test` will probably be quite long, right?)
Please let me know if you'd like me to change anything.

Thanks!

- [ x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
