### PR TITLE
lst v1.1.7 (new formula)

### DIFF
--- a/Formula/lst.rb
+++ b/Formula/lst.rb
@@ -1,0 +1,25 @@
+class Lst < Formula
+  desc "Save snippets of information quickly through the command line"
+  homepage "https://liszt.readthedocs.io"
+  url "https://github.com/scamacho23/homebrew-liszt/archive/v1.1.7.tar.gz"
+  sha256 "01b9256151079f4c3727a5ce7b179a9ad7733180d966a112bcbeac6321805aea"
+  license "GNU GPL-3.0"
+  version "1.1.7"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make"
+    bin.install "lst"
+  end
+ 
+  test do
+    system "lst " "-ch " "default"
+    expected = <<~EOS
+      default
+    EOS
+ 
+    assert_match expected, shell_output("#{bin}/lst -n")
+  end
+end

--- a/Formula/lst.rb
+++ b/Formula/lst.rb
@@ -1,10 +1,9 @@
 class Lst < Formula
-  desc "Save snippets of information quickly through the command line"
+  desc "Save snippets of information quickly through the command-line"
   homepage "https://liszt.readthedocs.io"
   url "https://github.com/scamacho23/homebrew-liszt/archive/v1.1.7.tar.gz"
   sha256 "01b9256151079f4c3727a5ce7b179a9ad7733180d966a112bcbeac6321805aea"
-  license "GNU GPL-3.0"
-  version "1.1.7"
+  license "GPL-3.0-only"
 
   depends_on "cmake" => :build
 
@@ -13,13 +12,12 @@ class Lst < Formula
     system "make"
     bin.install "lst"
   end
- 
+
   test do
-    system "lst " "-ch " "default"
+    system "lst", "-ch", "default"
     expected = <<~EOS
       default
     EOS
- 
     assert_match expected, shell_output("#{bin}/lst -n")
   end
 end


### PR DESCRIPTION
Add a new formula to the homebrew core. Liszt is a command-line
note taker where you enter a series of arguments and Liszt saves
them as 'memories'. Memories can be compiled in 'notes', which can
be viewed by changing between notes and listing their memories.
Other command line note takers rely on VIM or other text-based
editors to function. The idea behind Liszt is speed, so memories
are effectively static: they cannot be edited once saved (they
can be removed, moved, copied, etc., but cannot be edited in place).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
