### PR TITLE
ninja: remove re2c dependency

### DIFF
--- a/Formula/ninja.rb
+++ b/Formula/ninja.rb
@@ -20,7 +20,6 @@ class Ninja < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "re2c"
 
   # from https://github.com/ninja-build/ninja/pull/1836, remove in next release
   patch do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The `re2c` dependency is only needed if a developer is modifying either of the .in.cc files within ninja. All commits that have changed one of those files also commit the corresponding .cc file, so re2c is not needed for building, even from HEAD.