### PR TITLE
kustomize: Fix the version string (x.y.z -> kustomize/vx.y.z)

### DIFF
--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -23,10 +23,11 @@ class Kustomize < Formula
 
   def install
     revision = Utils.safe_popen_read("git", "rev-parse", "HEAD").strip
+    tag = Utils.safe_popen_read("git", "tag", "--contains", "HEAD").strip
 
     cd "kustomize" do
       ldflags = %W[
-        -s -X sigs.k8s.io/kustomize/api/provenance.version=kustomize/v#{version}
+        -s -X sigs.k8s.io/kustomize/api/provenance.version=#{tag}
         -X sigs.k8s.io/kustomize/api/provenance.gitCommit=#{revision}
         -X sigs.k8s.io/kustomize/api/provenance.buildDate=#{Time.now.iso8601}
       ]

--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -26,7 +26,7 @@ class Kustomize < Formula
 
     cd "kustomize" do
       ldflags = %W[
-        -s -X sigs.k8s.io/kustomize/api/provenance.version=#{version}
+        -s -X sigs.k8s.io/kustomize/api/provenance.version=kustomize/v#{version}
         -X sigs.k8s.io/kustomize/api/provenance.gitCommit=#{revision}
         -X sigs.k8s.io/kustomize/api/provenance.buildDate=#{Time.now.iso8601}
       ]
@@ -35,7 +35,7 @@ class Kustomize < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/kustomize version")
+    assert_match "kustomize/v#{version.to_s}", shell_output("#{bin}/kustomize version")
 
     (testpath/"kustomization.yaml").write <<~EOS
       resources:

--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -35,7 +35,7 @@ class Kustomize < Formula
   end
 
   test do
-    assert_match "kustomize/v#{version.to_s}", shell_output("#{bin}/kustomize version")
+    assert_match "kustomize/v#{version}", shell_output("#{bin}/kustomize version")
 
     (testpath/"kustomization.yaml").write <<~EOS
       resources:


### PR DESCRIPTION
kustomize: Fix the version string (x.y.z -> kustomize/vx.y.z)

The official binary will print an actual tag

```
$ kustomize version
{Version:kustomize/v3.8.1
```

while the current binary built by Homebrew just prints `{Version:3.8.1}`.
This PR will ensure that `kustomize version` command from the Homebrew binary
uses the same format string.

Explanation
===========

The official kustomize binary is built by (google) cloud build tools.
The build configuration is found at
https://github.com/kubernetes-sigs/kustomize/blob/ba0f583ee5cc47ca436df1910e467613c5e04980/releasing/cloudbuild.sh#L91

This template {.Version} actually uses any current tag (e.g, kustomize/v3.8.2)
https://github.com/kubernetes-sigs/kustomize/blob/ba0f583ee5cc47ca436df1910e467613c5e04980/releasing/cloudbuild.sh#L5

The build tool (goreleaser) is happy to use this non-sematic version
as a specific option is used, as seen in
https://github.com/kubernetes-sigs/kustomize/blob/ba0f583ee5cc47ca436df1910e467613c5e04980/releasing/cloudbuild.sh#L124

In short, the official build flag is, e.g,

    -X sigs.k8s.io/kustomize/api/provenance.version=kustomize/v3.8.2

not

    -X sigs.k8s.io/kustomize/api/provenance.version=3.8.2


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
