### PR TITLE
stockfish: add Apple Silicon support and AVX2 detection

### DIFF
--- a/Formula/stockfish.rb
+++ b/Formula/stockfish.rb
@@ -14,8 +14,14 @@ class Stockfish < Formula
   end
 
   def install
-    arch = if MacOS.version.requires_popcnt?
-      "x86-64-modern"
+    arch = if Hardware::CPU.type == :arm
+      "apple-silicon"
+    elsif Hardware::CPU.avx2?
+      "x86-64-avx2"
+    elsif Hardware::CPU.sse4_2?
+      "x86-64-sse41-popcnt"
+    elsif Hardware::CPU.ssse3?
+      "x86-64-ssse3"
     else
       "x86-64"
     end
@@ -25,6 +31,6 @@ class Stockfish < Formula
   end
 
   test do
-    system "#{bin}/stockfish", "go", "depth", "20"
+    system "#{bin}/stockfish", "bench"
   end
 end


### PR DESCRIPTION
stockfish: add Apple Silicon support and AVX2 detection

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

One question I'm less clear about: Will Homebrew build separate bottles for e.g. Apple Silicon and all the other processor types, and serve the correct version based on the client `Hardware::CPU`?