### PR TITLE
whois: make keg_only

### DIFF
--- a/Formula/whois.rb
+++ b/Formula/whois.rb
@@ -3,7 +3,7 @@ class Whois < Formula
   homepage "https://packages.debian.org/sid/whois"
   url "https://deb.debian.org/debian/pool/main/w/whois/whois_5.5.6.tar.xz"
   sha256 "cba1e9000c60950f46a96ba23e8eea8aee240a2b8560e63a6bfb33f9034af14e"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/rfc1036/whois.git"
 
   bottle do

--- a/Formula/whois.rb
+++ b/Formula/whois.rb
@@ -13,6 +13,8 @@ class Whois < Formula
     sha256 "79bc883f7bbf41fe2e28eb1edb319fa6f62a2dde5ca1308d653f160f1ecc0e25" => :high_sierra
   end
 
+  keg_only :provided_by_macos
+
   depends_on "pkg-config" => :build
   depends_on "libidn2"
 
@@ -23,13 +25,6 @@ class Whois < Formula
     bin.install "whois"
     man1.install "whois.1"
     man5.install "whois.conf.5"
-  end
-
-  def caveats
-    <<~EOS
-      Debian whois has been installed as `whois` and may shadow the
-      system binary of the same name.
-    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR makes `whois` keg-only formula and removes caveats which suggest the exact reason to make it keg-only.
Also, the license updated to `GPL-2.0-or-later`:

```
/*
 * Copyright (C) 1999-2019 Marco d'Itri <md@linux.it>.
 *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or
 * (at your option) any later version.
 */
```

https://github.com/rfc1036/whois/blob/v5.5.6/whois.c#L1-L8