### PR TITLE
git-annex: readd S3 support.

### DIFF
--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -4,7 +4,7 @@ class GitAnnex < Formula
   url "https://hackage.haskell.org/package/git-annex-8.20200810/git-annex-8.20200810.tar.gz"
   sha256 "e631c9d52e440f80e9d305c95a078dcae71f200125bca91e49d5b8e2d864c6f3"
   license all_of: ["AGPL-3.0-or-later", "BSD-2-Clause", "BSD-3-Clause",
-                   "GPL-2.0-only", "GPL-3.0-or-later", "icon-license", "MIT"]
+                   "GPL-2.0-only", "GPL-3.0-or-later", "MIT"]
   revision 1
   head "git://git-annex.branchable.com/"
 

--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -3,6 +3,7 @@ class GitAnnex < Formula
   homepage "https://git-annex.branchable.com/"
   url "https://hackage.haskell.org/package/git-annex-8.20200810/git-annex-8.20200810.tar.gz"
   sha256 "e631c9d52e440f80e9d305c95a078dcae71f200125bca91e49d5b8e2d864c6f3"
+  revision 1
   head "git://git-annex.branchable.com/"
 
   livecheck do
@@ -25,7 +26,8 @@ class GitAnnex < Formula
 
   def install
     system "cabal", "v2-update"
-    system "cabal", "v2-install", *std_cabal_v2_args
+    system "cabal", "v2-install", *std_cabal_v2_args,
+                    "--flags=+S3"
     bin.install_symlink "git-annex" => "git-annex-shell"
   end
 

--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -3,6 +3,8 @@ class GitAnnex < Formula
   homepage "https://git-annex.branchable.com/"
   url "https://hackage.haskell.org/package/git-annex-8.20200810/git-annex-8.20200810.tar.gz"
   sha256 "e631c9d52e440f80e9d305c95a078dcae71f200125bca91e49d5b8e2d864c6f3"
+  license all_of: ["AGPL-3.0-or-later", "BSD-2-Clause", "BSD-3-Clause",
+                   "GPL-2.0-only", "GPL-3.0-or-later", "icon-license", "MIT"]
   revision 1
   head "git://git-annex.branchable.com/"
 

--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -70,6 +70,11 @@ class GitAnnex < Formula
     system "git", "commit", "-a", "-m", "Initial Commit"
     assert File.symlink?("Hello.txt")
 
+    # make sure the various remotes were built
+    assert_match shell_output("git annex version | grep 'remote types:'").chomp,
+                 "remote types: git gcrypt p2p S3 bup directory rsync web bittorrent " \
+                 "webdav adb tahoe glacier ddar git-lfs hook external"
+
     # The steps below are necessary to ensure the directory cleanly deletes.
     # git-annex guards files in a way that isn't entirely friendly of automatically
     # wiping temporary directories in the way `brew test` does at end of execution.


### PR DESCRIPTION
Fixes #60505

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This readds the package settings lost in https://github.com/Homebrew/homebrew-core/pull/59330/.

I didn't readd the `using: ["alex", "happy", "c2hs"],` part because I couldn't figure out how; it means, "build this package with these tools". It sounds like something that cabal v2 already specifies implicitly? I'm not really sure. Anyway the package builds and works for me without them.