### PR TITLE
Update the Watchman package to v2020.08.31.00

### DIFF
--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -2,13 +2,7 @@ class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
   license "Apache-2.0"
-  revision 4
   head "https://github.com/facebook/watchman.git"
-
-  stable do
-    url "https://github.com/facebook/watchman/archive/v2020.08.31.00.tar.gz"
-    sha256 "4579d17fb109a4dabb6b3ef73b44ac506e80d81b57925c6a9d80d37ed931e54e"
-  end
 
   livecheck do
     url :head

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -2,8 +2,8 @@ class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
   url "https://github.com/facebook/watchman/archive/v2020.08.31.00.tar.gz"
-  license "Apache-2.0"
   version "2020.08.31.00"
+  license "Apache-2.0"
 
   livecheck do
     url "https://github.com/facebook/watchman/releases/latest"

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -6,14 +6,8 @@ class Watchman < Formula
   head "https://github.com/facebook/watchman.git"
 
   stable do
-    url "https://github.com/facebook/watchman/archive/v4.9.0.tar.gz"
-    sha256 "1f6402dc70b1d056fffc3748f2fdcecff730d8843bb6936de395b3443ce05322"
-
-    # Upstream commit from 1 Sep 2017: "Have bin scripts use iter() method for python3"
-    patch do
-      url "https://github.com/facebook/watchman/commit/17958f7d.diff?full_index=1"
-      sha256 "edad4971fceed2aecfa2b9c3e8e22c455bfa073732a3a0c77b030e506ee860af"
-    end
+    url "https://github.com/facebook/watchman/archive/v2020.08.31.00.tar.gz"
+    sha256 "4579d17fb109a4dabb6b3ef73b44ac506e80d81b57925c6a9d80d37ed931e54e"
   end
  
   livecheck do

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -2,8 +2,9 @@ class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
   license "Apache-2.0"
-  head "https://github.com/facebook/watchman.git"
-
+  url "https://github.com/facebook/watchman.git"
+  version "v2020.08.31.00"
+  
   livecheck do
     url :head
     regex(/^v?(\d+(?:\.\d+){,4})$/i)

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -15,12 +15,10 @@ class Watchman < Formula
       sha256 "edad4971fceed2aecfa2b9c3e8e22c455bfa073732a3a0c77b030e506ee860af"
     end
   end
-
-  # The Git repo contains a few tags like `2020.05.18.00`, so we have to
-  # restrict matching to versions with two to three parts (e.g., 1.2, 1.2.3).
+ 
   livecheck do
     url :head
-    regex(/^v?(\d+(?:\.\d+){,2})$/i)
+    regex(/^v?(\d+(?:\.\d+){,4})$/i)
   end
 
   bottle do

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -9,7 +9,7 @@ class Watchman < Formula
     url "https://github.com/facebook/watchman/archive/v2020.08.31.00.tar.gz"
     sha256 "4579d17fb109a4dabb6b3ef73b44ac506e80d81b57925c6a9d80d37ed931e54e"
   end
- 
+
   livecheck do
     url :head
     regex(/^v?(\d+(?:\.\d+){,4})$/i)

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -2,7 +2,6 @@ class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
   url "https://github.com/facebook/watchman/archive/v2020.08.31.00.tar.gz"
-  version "2020.08.31.00"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -1,13 +1,13 @@
 class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
+  url "https://github.com/facebook/watchman/archive/v2020.08.31.00.tar.gz"
   license "Apache-2.0"
-  url "https://github.com/facebook/watchman.git"
-  version "v2020.08.31.00"
-  
+  version "2020.08.31.00"
+
   livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+){,4})$/i)
+    url "https://github.com/facebook/watchman/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Watchman has moved to a date-based release format with the latest version being `v2020.08.31.00`. This PR relaxes the livecheck (?) regex to accommodate for these tags.