### PR TITLE
Ant: use Ivy 2.5.0 as specified in libraries.properties

### DIFF
--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -5,7 +5,6 @@ class Ant < Formula
   mirror "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.tar.xz"
   sha256 "8be685aacf2bfe8515a1249fbebb0ccd861dfe05ee2c027c89fd7912c1ce2c2a"
   license "Apache-2.0"
-  revision 1
   head "https://git-wip-us.apache.org/repos/asf/ant.git"
 
   livecheck do
@@ -17,9 +16,9 @@ class Ant < Formula
   depends_on "openjdk"
 
   resource "ivy" do
-    url "https://www.apache.org/dyn/closer.lua?path=ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
-    mirror "https://archive.apache.org/dist/ant/ivy/2.4.0/apache-ivy-2.4.0-bin.tar.gz"
-    sha256 "7a3d13a80b69d71608191463dfc2a74fff8ef638ce0208e70d54d28ba9785ee9"
+    url "https://www.apache.org/dyn/closer.lua?path=ant/ivy/2.5.0/apache-ivy-2.5.0-bin.tar.gz"
+    mirror "https://archive.apache.org/dist/ant/ivy/2.5.0/apache-ivy-2.5.0-bin.tar.gz"
+    sha256 "3855a5769b5dbeafa9fb6a00f130467fd0f89da684a0b33a91e3dc5dae2715c7"
   end
 
   resource "bcel" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Ivy 2.5.0 resolves numerous bugs and adds new features.