### PR TITLE
apache-drill: update livecheck

### DIFF
--- a/Formula/apache-drill.rb
+++ b/Formula/apache-drill.rb
@@ -8,7 +8,7 @@ class ApacheDrill < Formula
 
   livecheck do
     url "https://drill.apache.org/download/"
-    regex(/Drill v?(\d+(?:\.\d+)+) was released/i)
+    /href=.*?apache-drill[._-]v?(\d+(?:\.\d+)+)\.t/i
   end
 
   bottle :unneeded

--- a/Formula/apache-drill.rb
+++ b/Formula/apache-drill.rb
@@ -7,7 +7,8 @@ class ApacheDrill < Formula
   license "Apache-2.0"
 
   livecheck do
-    url :stable
+    url "https://drill.apache.org/download/"
+    regex(/Drill v?(\d+(?:\.\d+)+) was released/i)
   end
 
   bottle :unneeded


### PR DESCRIPTION
Currently, the `brew livecheck` checks against Apache ftp server, but it is not an accurate tracking for the release.

This PR is to update the tracking to check against the homepage. 

---

relates to #60732 