### PR TITLE
Added FLAC music support to sdl_mixer formula

### DIFF
--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -3,7 +3,8 @@ class SdlMixer < Formula
   homepage "https://www.libsdl.org/projects/SDL_mixer/"
   url "https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-1.2.12.tar.gz"
   sha256 "1644308279a975799049e4826af2cfc787cad2abb11aa14562e402521f86992a"
-  revision 3
+  license "Zlib"
+  revision 4
 
   livecheck do
     url "https://www.libsdl.org/projects/SDL_mixer/release/"
@@ -20,6 +21,7 @@ class SdlMixer < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "flac"
   depends_on "libmikmod"
   depends_on "libogg"
   depends_on "libvorbis"
@@ -38,6 +40,7 @@ class SdlMixer < Formula
       --prefix=#{prefix}
       --disable-dependency-tracking
       --enable-music-ogg
+      --enable-music-flac
       --disable-music-ogg-shared
       --disable-music-mod-shared
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I noticed when playing Descent via the D1X-Rebirth sourceport that my FLAC music files weren't playing.  It turns out that the cause is because my copy of SDL_mixer (from Homebrew) wasn't built with FLAC support, so this adds that.