### PR TITLE
libgr: build using cmake

### DIFF
--- a/Formula/libgr.rb
+++ b/Formula/libgr.rb
@@ -11,19 +11,22 @@ class Libgr < Formula
     sha256 "beaa733249692d24749156ad652ac3a3144cbd4e571e639c2088bb6331b1598b" => :high_sierra
   end
 
+  depends_on "cmake" => :build
   depends_on xcode: :build
   depends_on "cairo"
   depends_on "glfw"
   depends_on "libtiff"
+  depends_on "qhull"
   depends_on "qt"
   depends_on "zeromq"
 
   def install
-    # TODO: Remove this when released archive includes
-    # the fix of https://github.com/sciapp/gr/pull/101 .
-    ENV.deparallelize
-    system "make", "GRDIR=#{prefix}"
-    system "make", "GRDIR=#{prefix}", "install"
+    mkdir "build"
+    cd "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#60710
> Can we remove the `ENV.deparallelize`?
> 
> https://github.com/Homebrew/homebrew-core/blob/00d35e6cf4195faded4eec2627244419f4ca92c3/Formula/libgr.rb#L22-L24
> 
> I think the change is present in the latest tag: [ref](https://github.com/sciapp/gr/blob/90ee73c741271d964f241f098b0dd3ba18eae271/lib/gks/plugin/Makefile#L154)


