### PR TITLE
grpc: Use cmake for build and bump to 1.31.1

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -2,8 +2,8 @@ class Grpc < Formula
   desc "Next generation open source RPC library and framework"
   homepage "https://grpc.io/"
   url "https://github.com/grpc/grpc.git",
-    tag:      "v1.31.0",
-    revision: "56ad644c329d90c0742a02462b2bd365ff759158",
+    tag:      "v1.31.1",
+    revision: "7d7e4567625db7cfebf8969a225948097a3f9f89",
     shallow:  false
   license "Apache-2.0"
   head "https://github.com/grpc/grpc.git"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Reboots #59195 with bump to 1.31.1 and build system fixes to use cmake.