### PR TITLE
Fix livecheck regex and urls

### DIFF
--- a/Formula/flowgrind.rb
+++ b/Formula/flowgrind.rb
@@ -7,7 +7,7 @@ class Flowgrind < Formula
 
   livecheck do
     url :stable
-    regex(%r{<div class="version">\s*Latest version is flowgrind[._-]v?(\d+(?:\.\d+)+)\s*</div>})
+    regex(%r{<div class="version">\s*Latest version is flowgrind[._-]v?(\d+(?:\.\d+)+)\s*</div>}i)
   end
 
   bottle do

--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -7,7 +7,7 @@ class Gtkx3 < Formula
 
   livecheck do
     url :stable
-    regex(/gtk\+[._-](3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/)
+    regex(/gtk\+[._-](3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 
   bottle do

--- a/Formula/patchelf.rb
+++ b/Formula/patchelf.rb
@@ -7,7 +7,7 @@ class Patchelf < Formula
   head "https://github.com/NixOS/patchelf.git"
 
   livecheck do
-    url "https://github.com/NixOS/patchelf.git"
+    url :head
   end
 
   bottle do

--- a/Formula/ragel.rb
+++ b/Formula/ragel.rb
@@ -5,10 +5,8 @@ class Ragel < Formula
   sha256 "5f156edb65d20b856d638dd9ee2dfb43285914d9aa2b6ec779dac0270cd56c3f"
   license "GPL-2.0"
 
-  # TODO: Return to using `url :homepage` once the SSL certificate verification
-  # issue is resolved on the upstream server.
   livecheck do
-    url "https://www.colm.net/open-source/ragel/"
+    url :homepage
     regex(/Stable.*?href=.*?ragel[._-]v?(\d+(?:\.\d+)+)\.t/im)
   end
 

--- a/Formula/tnftp.rb
+++ b/Formula/tnftp.rb
@@ -5,7 +5,7 @@ class Tnftp < Formula
   sha256 "ba4a92b693d04179664524eef0801c8eed4447941c9855f377f98f119f221c03"
 
   livecheck do
-    url "https://ftp.netbsd.org/pub/NetBSD/misc/tnftp/"
+    url :homepage
     regex(/href=.*?tnftp[._-]v?(\d+)\.t/i)
   end
 

--- a/Formula/tnftpd.rb
+++ b/Formula/tnftpd.rb
@@ -5,7 +5,7 @@ class Tnftpd < Formula
   sha256 "92de915e1b4b7e4bd403daac5d89ce67fa73e49e8dda18e230fa86ee98e26ab7"
 
   livecheck do
-    url "https://ftp.netbsd.org/pub/NetBSD/misc/tnftp/"
+    url :homepage
     regex(/href=.*?tnftpd[._-]v?(\d+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR fixes style issues with livecheck blocks in some formulae:
* Regexes must be case-insensitive (unless sensitivity required).
* Formula URLs must be referenced using `:head`, `:stable` or `:homepage`.

Most of these livechecks work, except `ragel`, which should be rectified soon as discussed in https://github.com/Homebrew/homebrew-core/pull/60334#issuecomment-688311925.

Referencing the Homebrew/brew livecheck RuboCops and audit PR: Homebrew/brew#8643.