### PR TITLE
couchdb: add caveats for 3.x: requires pw before startup

### DIFF
--- a/Formula/couchdb.rb
+++ b/Formula/couchdb.rb
@@ -58,6 +58,13 @@ class Couchdb < Formula
       If you want to migrate your data from 1.x to 2.x then follow this guide:
       https://docs.couchdb.org/en/stable/install/upgrading.html
 
+      If you are new to CouchDB 3.x, it now requires an admin password set before it can start up.
+      Add this to your #{prefix}/etc/local.ini before starting CouchDB:
+
+      ```
+      [admins]
+      admin = youradminpassword
+      ```
     EOS
   end
 

--- a/Formula/couchdb.rb
+++ b/Formula/couchdb.rb
@@ -58,13 +58,10 @@ class Couchdb < Formula
       If you want to migrate your data from 1.x to 2.x then follow this guide:
       https://docs.couchdb.org/en/stable/install/upgrading.html
 
-      If you are new to CouchDB 3.x, it now requires an admin password set before it can start up.
-      Add this to your #{prefix}/etc/local.ini before starting CouchDB:
-
-      ```
-      [admins]
-      admin = youradminpassword
-      ```
+      CouchDB 3.x requires a set admin password set before startup.
+      Add one to your #{etc}/local.ini before starting CouchDB e.g.:
+        [admins]
+        admin = youradminpassword
     EOS
   end
 

--- a/Formula/couchdb.rb
+++ b/Formula/couchdb.rb
@@ -51,13 +51,6 @@ class Couchdb < Formula
 
   def caveats
     <<~EOS
-      If your upgrade from version 1.7.2_1 then your old database path is "/usr/local/var/lib/couchdb".
-
-      The database path of this installation: #{var}/couchdb/data".
-
-      If you want to migrate your data from 1.x to 2.x then follow this guide:
-      https://docs.couchdb.org/en/stable/install/upgrading.html
-
       CouchDB 3.x requires a set admin password set before startup.
       Add one to your #{etc}/local.ini before starting CouchDB e.g.:
         [admins]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?

  - `brew style` fails for pre-existing issues that are outside of my comfort zone to fix

- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?

  - No, but for an unrelated reason, as it failed before as well.

- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  - `brew style` fails for pre-existing issues that are outside of my comfort zone to fix

-----

Without this, folks will follow the instructions printed and find CouchDB not actually running:

https://mobile.twitter.com/mountain_ghosts/status/1303095943680667648

The fix is explained here: https://mobile.twitter.com/janl/status/1303236775431876608

(I’m one of the authors of CouchDB and I made this particular change in 3.x: https://github.com/apache/couchdb/pull/2389) 
