### PR TITLE
embulk: remove disabled `java_home_cmd`

### DIFF
--- a/Formula/embulk.rb
+++ b/Formula/embulk.rb
@@ -6,6 +6,8 @@ class Embulk < Formula
   # In your production, keep using v0.9.*.
   url "https://bintray.com/artifact/download/embulk/maven/embulk-0.9.23.jar"
   sha256 "153977fad482bf52100dd96f47e897c87b48de4fb13bccd6b3101475d3a5ebb9"
+  license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://github.com/embulk/embulk.git"
@@ -21,7 +23,7 @@ class Embulk < Formula
     libexec.install "embulk-#{version}.jar" => "embulk.jar"
     (bin/"embulk").write <<~EOS
       #!/bin/bash
-      export JAVA_HOME=$(#{Language::Java.java_home_cmd("1.8")})
+      export JAVA_HOME="#{Language::Java.overridable_java_home_env("1.8")[:JAVA_HOME]}"
       exec /bin/bash "#{libexec}/embulk.jar" "$@"
     EOS
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
