### PR TITLE
sdl: Added Mojave patches to stable builds

### DIFF
--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -1,7 +1,8 @@
 class Sdl < Formula
   desc "Low-level access to audio, keyboard, mouse, joystick and graphics"
   homepage "https://www.libsdl.org/"
-  revision 1
+  license "LGPL-2.1-only"
+  revision 2
 
   stable do
     url "https://www.libsdl.org/release/SDL-1.2.15.tar.gz"
@@ -24,6 +25,14 @@ class Sdl < Formula
       patch do
         url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=3721"
         sha256 "954875a277d9246bcc444b4e067e75c29b7d3f3d2ace5318a6aab7d7a502f740"
+      end
+    end
+
+    # Fix display issues on 10.14+, https://bugzilla.libsdl.org/show_bug.cgi?id=4788
+    if MacOS.version >= :mojave
+      patch do
+        url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=4288"
+        sha256 "5a89ddce5deaf72348792d33e12b5f66d0dab4f9747718bb5021d3067bdab283"
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds the patches referenced in https://bugzilla.libsdl.org/show_bug.cgi?id=4788 to builds from the last stable source archive (1.2.15), resolving video issues with Mojave and above.