### PR TITLE
Add re2 as dependency to grpc

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -29,6 +29,7 @@ class Grpc < Formula
   depends_on "gflags"
   depends_on "openssl@1.1"
   depends_on "protobuf"
+  depends_on "re2"
 
   def install
     mkdir "cmake/build" do
@@ -40,6 +41,7 @@ class Grpc < Formula
         -DgRPC_ABSL_PROVIDER=package
         -DgRPC_CARES_PROVIDER=package
         -DgRPC_PROTOBUF_PROVIDER=package
+        -DgRPC_RE2_PROVIDER=package
         -DgRPC_SSL_PROVIDER=package
         -DgRPC_ZLIB_PROVIDER=package
       ] + std_cmake_args


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

On Apache Arrow's CI, we've experienced a failure since the grpc 1.31.1 update landed an hour or so ago. See https://github.com/apache/arrow/pull/8136/checks?check_run_id=1087052173#step:4:442 for an example. It appears that in grpc's new dependency management setup, it's building/vendoring `re2`, which causes a conflict when we install `re2` ourselves. This PR tries to get `grpc` to use Homebrew's `re2` to resolve the conflict. cc @pitrou
