### PR TITLE
formula*: use http for livecheck when needed to avoid redirect

### DIFF
--- a/Formula/a52dec.rb
+++ b/Formula/a52dec.rb
@@ -6,7 +6,8 @@ class A52dec < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://liba52.sourceforge.io/downloads.html"
+    # Use http because https will be redirected to http
+    url "http://liba52.sourceforge.io/downloads.html"
     strategy :page_match
     regex(/href=.*?a52dec[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end

--- a/Formula/abook.rb
+++ b/Formula/abook.rb
@@ -7,7 +7,8 @@ class Abook < Formula
   head "https://git.code.sf.net/p/abook/git.git"
 
   livecheck do
-    url :homepage
+    # Use http because https will be redirected to http
+    url "http://abook.sourceforge.io/"
     strategy :page_match
     regex(/href=.*?abook[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end

--- a/Formula/bbftp-client.rb
+++ b/Formula/bbftp-client.rb
@@ -7,7 +7,8 @@ class BbftpClient < Formula
   revision 3
 
   livecheck do
-    url "https://software.in2p3.fr/bbftp/download.html"
+    # Use http because https will be redirected to http
+    url "http://software.in2p3.fr/bbftp/download.html"
     regex(/href=.*?bbftp-client[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/bcrypt.rb
+++ b/Formula/bcrypt.rb
@@ -5,7 +5,8 @@ class Bcrypt < Formula
   sha256 "b9c1a7c0996a305465135b90123b0c63adbb5fa7c47a24b3f347deb2696d417d"
 
   livecheck do
-    url :homepage
+    # Use http because https will be redirected to http
+    url "http://bcrypt.sourceforge.io/"
     strategy :page_match
     regex(/href=.*?bcrypt[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end

--- a/Formula/isl.rb
+++ b/Formula/isl.rb
@@ -13,7 +13,8 @@ class Isl < Formula
   license "MIT"
 
   livecheck do
-    url :homepage
+    # Use http because https will be redirected to http
+    url "http://isl.gforge.inria.fr/"
     regex(/href=.*?isl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- N/A ~[ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- N/A ~[ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

These livecheck URLs uses `https` scheme, but actually they just redirect to `http` scheme location.
As redirect is forbidden in livecheck, I replaced them. 