### PR TITLE
caddy chart-testing git-town k3d traefik: unhardcode module version

### DIFF
--- a/Formula/caddy.rb
+++ b/Formula/caddy.rb
@@ -27,7 +27,7 @@ class Caddy < Formula
 
     resource("xcaddy").stage do
       system "go", "run", "cmd/xcaddy/main.go", "build", revision,
-                                                "--with", "github.com/caddyserver/caddy/v2=#{buildpath}",
+                                                "--with", "github.com/caddyserver/caddy/v#{version.major}=#{buildpath}",
                                                 "--output", bin/"caddy"
     end
   end
@@ -84,5 +84,7 @@ class Caddy < Formula
     assert_match "\":#{port2}\"",
       shell_output("curl -s http://127.0.0.1:#{port1}/config/apps/http/servers/srv0/listen/0")
     assert_match "Hello, Caddy!", shell_output("curl -s http://127.0.0.1:#{port2}")
+
+    assert_match version.to_s, shell_output("#{bin}/caddy version")
   end
 end

--- a/Formula/chart-testing.rb
+++ b/Formula/chart-testing.rb
@@ -20,9 +20,9 @@ class ChartTesting < Formula
   def install
     commit = Utils.safe_popen_read("git", "rev-parse", "HEAD").chomp
     ldflags = %W[
-      -X github.com/helm/chart-testing/v3/ct/cmd.Version=#{version}
-      -X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=#{commit}
-      -X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=#{Date.today}
+      -X github.com/helm/chart-testing/v#{version.major}/ct/cmd.Version=#{version}
+      -X github.com/helm/chart-testing/v#{version.major}/ct/cmd.GitCommit=#{commit}
+      -X github.com/helm/chart-testing/v#{version.major}/ct/cmd.BuildDate=#{Date.today}
     ].join(" ")
     system "go", "build", *std_go_args, "-ldflags", ldflags, "-o", bin/"ct", "./ct/main.go"
     etc.install "etc" => "ct"
@@ -30,6 +30,7 @@ class ChartTesting < Formula
 
   test do
     assert_match "Lint and test", shell_output("#{bin}/ct --help")
+    assert_match /Version:\s+#{version}/, shell_output("#{bin}/ct version")
 
     # Lint an empty Helm chart that we create with `helm create`
     system "helm", "create", "testchart"

--- a/Formula/git-town.rb
+++ b/Formula/git-town.rb
@@ -17,11 +17,13 @@ class GitTown < Formula
 
   def install
     system "go", "build", *std_go_args, "-ldflags",
-           "-X github.com/git-town/git-town/src/cmd.version=v7.4.0 "\
-           "-X github.com/git-town/git-town/src/cmd.buildDate=2020/07/05"
+           "-X github.com/git-town/git-town/src/cmd.version=v#{version} "\
+           "-X github.com/git-town/git-town/src/cmd.buildDate=#{Time.new.strftime("%Y/%m/%d")}"
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/git-town version")
+
     system "git", "init"
     touch "testing.txt"
     system "git", "add", "testing.txt"

--- a/Formula/k3d.rb
+++ b/Formula/k3d.rb
@@ -22,8 +22,8 @@ class K3d < Formula
   def install
     system "go", "build",
            "-mod", "vendor",
-           "-ldflags", "-s -w -X github.com/rancher/k3d/v3/version.Version=v#{version}"\
-           " -X github.com/rancher/k3d/v3/version.K3sVersion=latest",
+           "-ldflags", "-s -w -X github.com/rancher/k3d/v#{version.major}/version.Version=v#{version}"\
+           " -X github.com/rancher/k3d/v#{version.major}/version.K3sVersion=latest",
            "-trimpath", "-o", bin/"k3d"
 
     # Install bash completion
@@ -33,8 +33,6 @@ class K3d < Formula
     # Install zsh completion
     output = Utils.safe_popen_read("#{bin}/k3d", "completion", "zsh")
     (zsh_completion/"_k3d").write output
-
-    prefix.install_metafiles
   end
 
   test do

--- a/Formula/traefik.rb
+++ b/Formula/traefik.rb
@@ -19,9 +19,8 @@ class Traefik < Formula
   def install
     system "go", "generate"
     system "go", "build",
-      "-ldflags", "-s -w -X github.com/containous/traefik/v2/pkg/version.Version=#{version}",
+      "-ldflags", "-s -w -X github.com/containous/traefik/v#{version.major}/pkg/version.Version=#{version}",
       "-trimpath", "-o", bin/"traefik", "./cmd/traefik"
-    prefix.install_metafiles
   end
 
   plist_options manual: "traefik"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR unhardcodes go module version when we set it in ldflags.

This should help us to prevent things like https://github.com/Homebrew/homebrew-core/pull/60477 to happen
