### PR TITLE
sbt@0.13: Fix lookup of Java home

### DIFF
--- a/Formula/sbt@0.13.rb
+++ b/Formula/sbt@0.13.rb
@@ -22,7 +22,7 @@ class SbtAT013 < Formula
 
     (bin/"sbt").write <<~EOS
       #!/bin/sh
-      export JAVA_HOME=$(#{Language::Java.java_home_cmd("1.8")})
+      export JAVA_HOME="#{Language::Java.java_home("1.8")}"
       if [ -f "$HOME/.sbtconfig" ]; then
         echo "Use of ~/.sbtconfig is deprecated, please migrate global settings to #{etc}/sbtopts" >&2
         . "$HOME/.sbtconfig"

--- a/Formula/sbt@0.13.rb
+++ b/Formula/sbt@0.13.rb
@@ -22,7 +22,7 @@ class SbtAT013 < Formula
 
     (bin/"sbt").write <<~EOS
       #!/bin/sh
-      export JAVA_HOME="#{Language::Java.java_home("1.8")}"
+      export JAVA_HOME="#{Language::Java.overridable_java_home_env("1.8")[:JAVA_HOME]}"
       if [ -f "$HOME/.sbtconfig" ]; then
         echo "Use of ~/.sbtconfig is deprecated, please migrate global settings to #{etc}/sbtopts" >&2
         . "$HOME/.sbtconfig"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The current formula fails to install with:

```
Error: An exception occurred within a child process:
  MethodDeprecatedError: Calling Language::Java.java_home_cmd is disabled! Use Language::Java.java_home or Language::Java.overridable_java_home_env instead.
Please report this issue to the homebrew/core tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/sbt@0.13.rb:25
```

This PR fixes this problem by replacing the deprecated `java_home_cmd` with `overridable_java_home_env`.