### PR TITLE
abyss: add livecheck

### DIFF
--- a/Formula/abyss.rb
+++ b/Formula/abyss.rb
@@ -6,6 +6,11 @@ class Abyss < Formula
   license "GPL-3.0"
   revision 1
 
+  livecheck do
+    url "https://github.com/bcgsc/abyss/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     cellar :any
     sha256 "0fa7a8feaadb399933d3322c5df54136f47681481a26ec68ad535ff13cbd1f81" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The default check for `abyss` was checking the Git tags and reporting an old version as newest (`2014-submission` instead of `2.2.4`). The GitHub repository has a "latest" release, so we should be checking that anyway but doing so also resolves this issue in the process.

Before:

```
abyss : 2.2.4 ==> 2014-submission
```

After:

```
abyss : 2.2.4 ==> 2.2.4
```