### PR TITLE
appledoc: add livecheck

### DIFF
--- a/Formula/appledoc.rb
+++ b/Formula/appledoc.rb
@@ -6,6 +6,11 @@ class Appledoc < Formula
   license "Apache-2.0"
   head "https://github.com/tomaz/appledoc.git"
 
+  livecheck do
+    url "https://github.com/tomaz/appledoc/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     rebuild 1
     sha256 "35ced2445cb6f9744a2b8ef09d1f5d504aefe4995a8463639bf4fa8b5271e5f8" => :catalina


### PR DESCRIPTION
The default check for `appledoc` was checking the Git tags and reporting a pre-release version as newest (`3.0exp1` instead of `2.2.1`). The GitHub repository has a "latest" release, so we should be checking that anyway but doing so also resolves this issue in the process.