### PR TITLE
archi-steam-farm: add livecheck

### DIFF
--- a/Formula/archi-steam-farm.rb
+++ b/Formula/archi-steam-farm.rb
@@ -5,6 +5,11 @@ class ArchiSteamFarm < Formula
   sha256 "1a9f50c3cf2eb00e5148bc21a209b0c7c275b6c36c8cae8b4d9b2469bee7ff33"
   license "Apache-2.0"
 
+  livecheck do
+    url "https://github.com/JustArchi/ArchiSteamFarm/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle :unneeded
 
   depends_on "mono"


### PR DESCRIPTION
The default check for `archi-steam-farm` was checking the Git tags and reporting a pre-release version as newest (`4.3.0.3` instead of `4.2.4.0`). The GitHub repository has a "latest" release, so we should be checking that anyway but doing so also resolves this issue in the process.