### PR TITLE
platformio 5.0.1

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -3,8 +3,8 @@ class Platformio < Formula
 
   desc "Professional collaborative platform for embedded development"
   homepage "https://platformio.org/"
-  url "https://files.pythonhosted.org/packages/81/8a/b4d17041361063dd1e5c0150c6552f0724ff8ce2601eeb1b0f8d2e7f7669/platformio-5.0.0.tar.gz"
-  sha256 "8aef5bb4aeb6dba49f893bbcaf481e09bf08e47791b5dc546ba3f1127671bf31"
+  url "https://files.pythonhosted.org/packages/38/6e/81a76ed61366ae04c2090ddac25e43c503f216912d582e81279e724ed0ff/platformio-5.0.1.tar.gz"
+  sha256 "0251dd03d31c7ec89d30e5da582b7cad0f4332d9ec20648b672f26c623f885fc"
   license "Apache-2.0"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

# Release Notes

- Added support for "owner" requirement when declaring ``dependencies`` using [library.json](https://docs.platformio.org/page/librarymanager/config.html#dependencies)
- Fixed an issue when using a custom git/ssh package with [platform_packages](https://docs.platformio.org/page/projectconf/section_env_platform.html#platform-packages) option ([issue #3624](https://github.com/platformio/platformio-core/issues/3624))
- Fixed an issue with "ImportError: cannot import name '_get_backend' from 'cryptography.hazmat.backends'" when using [Remote Development](https://docs.platformio.org/page/plus/pio-remote.html) on RaspberryPi device ([issue #3652](https://github.com/platformio/platformio-core/issues/3652))
- Fixed an issue when [pio package unpublish](https://docs.platformio.org/page/core/userguide/package/cmd_unpublish.html) command crashes ([issue #3660](https://github.com/platformio/platformio-core/issues/3660))
- Fixed an issue when the package manager tries to install a built-in library from the registry ([issue #3662](https://github.com/platformio/platformio-core/issues/3662))
- Fixed an issue with incorrect value for C++ language standard in IDE projects when an in-progress language standard is used ([issue #3653](https://github.com/platformio/platformio-core/issues/3653))
- Fixed an issue with "Invalid simple block (semantic_version)" from library dependency that refs to an external source (repository, ZIP/Tar archives) ([issue #3658](https://github.com/platformio/platformio-core/issues/3658))
- Fixed an issue when can not remove update or remove external dev-platform using PlatformIO Home ([issue #3663](https://github.com/platformio/platformio-core/issues/3663))
