### PR TITLE
dotnet 3.1.108 (new formula)

### DIFF
--- a/Formula/dotnet.rb
+++ b/Formula/dotnet.rb
@@ -1,0 +1,77 @@
+class Dotnet < Formula
+  desc ".NET Core"
+  homepage "https://dotnet.microsoft.com/"
+  url "https://github.com/dotnet/source-build.git",
+      tag:      "v3.1.108-SDK",
+      revision: "05a0c8f6b13fcbec4b441c977b639b75e8a74f67"
+  license "MIT"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on xcode: :build
+  depends_on "curl"
+  depends_on "icu4c"
+  depends_on "openssl"
+
+  # Patch of https://github.com/dotnet/source-build/pull/1789 which will be
+  # released with tag 3.1.110 in November 2020.
+  resource "0005-Fix-bad-configure-tests.patch" do
+    url "https://raw.githubusercontent.com/dotnet/source-build/17c6409189ed29f0fac2e8f4b1c30d882e6756b5/patches/coreclr/0005-Fix-bad-configure-tests.patch"
+    sha256 "57b83f9445d59137bdcc31c2a64d413bae23e80dc18f6fbcd8ceaac1d8b6754b"
+  end
+
+  def install
+    resource("0005-Fix-bad-configure-tests.patch").stage buildpath/"patches/coreclr"
+
+    # Arguments needed to not artificially time-limit downloads from Azure.
+    # See the following GitHub issue comment for details:
+    # https://github.com/dotnet/source-build/issues/1596#issuecomment-670995776
+    system "./build.sh", "/p:DownloadSourceBuildReferencePackagesTimeoutSeconds=N/A",
+                         "/p:DownloadSourceBuiltArtifactsTimeoutSeconds=N/A"
+
+    libexec.mkpath
+    tarball = Dir["artifacts/*/Release/dotnet-sdk-#{version}-*.tar.gz"].first
+    system "tar", "-xzf", tarball, "--directory", libexec
+    doc.install Dir[libexec/"*.txt"]
+    (bin/"dotnet").write_env_script libexec/"dotnet", DOTNET_ROOT: libexec
+  end
+
+  test do
+    target_framework = "netcoreapp3.1"
+    (testpath/"test.cs").write <<~EOS
+      using System;
+
+      namespace Homebrew
+      {
+        public class Dotnet
+        {
+          public static void Main(string[] args)
+          {
+            var joined = String.Join(",", args);
+            Console.WriteLine(joined);
+          }
+        }
+      }
+    EOS
+    (testpath/"test.csproj").write <<~EOS
+      <Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <OutputType>Exe</OutputType>
+          <TargetFrameworks>#{target_framework}</TargetFrameworks>
+          <PlatformTarget>AnyCPU</PlatformTarget>
+          <RootNamespace>Homebrew</RootNamespace>
+          <PackageId>Homebrew.Dotnet</PackageId>
+          <Title>Homebrew.Dotnet</Title>
+          <Product>$(AssemblyName)</Product>
+          <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+        </PropertyGroup>
+        <ItemGroup>
+          <Compile Include="test.cs" />
+        </ItemGroup>
+      </Project>
+    EOS
+    system bin/"dotnet", "build", "--framework", target_framework, "--output", testpath, testpath/"test.csproj"
+    assert_equal "#{testpath}/test.dll,a,b,c\n",
+                 shell_output("#{bin}/dotnet run --framework #{target_framework} #{testpath}/test.dll a b c")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Thanks to all the valuable feedback given in #53092 and with dotnet/source-build#1685 resolved,  `dotnet` finally builds successfully on macOS and this formula should be ready to go.

Supersedes #3691 and fixes dotnet/sdk#4600.