### PR TITLE
ladspa-sdk 1.15 (new formula)

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "Formula/alsa-lib.rb"
+      - "Formula/ladspa-sdk.rb"
       - "Formula/libseccomp.rb"
 jobs:
   tests_linux:

--- a/Formula/ladspa-sdk.rb
+++ b/Formula/ladspa-sdk.rb
@@ -1,0 +1,46 @@
+class LadspaSdk < Formula
+  desc "Linux Audio Developer's Simple Plugin"
+  homepage "https://ladspa.org"
+  url "https://www.ladspa.org/download/ladspa_sdk_1.15.tgz"
+  sha256 "4229959b09d20c88c8c86f4aa76427843011705df22d9c28b38359fd1829fded"
+  license "LGPL-2.1-only"
+
+  depends_on :linux
+
+  def install
+    args = %W[
+      INSTALL_PLUGINS_DIR=#{lib}/ladspa
+      INSTALL_INCLUDE_DIR=#{include}
+      INSTALL_BINARY_DIR=#{bin}
+    ]
+    cd "src" do
+      system "make", "install", *args
+    end
+    bin.env_script_all_files libexec/"bin", LADSPA_PATH: opt_lib/"ladspa"
+  end
+
+  test do
+    output = shell_output("#{bin}/listplugins")
+    assert_match "Mono Amplifier", output
+    assert_match "Simple Delay Line", output
+    assert_match "Simple Low Pass Filter", output
+    assert_match "Simple High Pass Filter", output
+    assert_match "Sine Oscillator", output
+    assert_match "Stereo Amplifier", output
+    assert_match "White Noise Source", output
+
+    expected_output = <<~EOS
+      Plugin Name: "Mono Amplifier"
+      Plugin Label: "amp_mono"
+      Plugin Unique ID: 1048
+      Maker: "Richard Furse (LADSPA example plugins)"
+      Copyright: "None"
+      Must Run Real-Time: No
+      Has activate() Function: No
+      Has deactivate() Function: No
+      Has run_adding() Function: No
+      Environment: Normal or Hard Real-Time
+    EOS
+    assert_match expected_output, shell_output("#{bin}/analyseplugin amp")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Linuxbrew formula: https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/ladspa-sdk.rb

License header ref:

```
/* ladspa.h

   Linux Audio Developer's Simple Plugin API Version 1.1[LGPL].
   Copyright (C) 2000-2002 Richard W.E. Furse, Paul Barton-Davis,
   Stefan Westerfeld.
   
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public License
   as published by the Free Software Foundation; either version 2.1 of
   the License, or (at your option) any later version.
   
   This library is distributed in the hope that it will be useful, but
   WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
   Lesser General Public License for more details.
   
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
   USA. */
```