### PR TITLE
fix nushell HEAD builds

### DIFF
--- a/Formula/nushell.rb
+++ b/Formula/nushell.rb
@@ -4,7 +4,7 @@ class Nushell < Formula
   url "https://github.com/nushell/nushell/archive/0.19.0.tar.gz"
   sha256 "18aefc280a51b2202daca4c5c27aa166f5c0049ebef16d9206fdd88616e8b2a0"
   license "MIT"
-  head "https://github.com/nushell/nushell.git"
+  head "https://github.com/nushell/nushell.git", branch: "main"
 
   bottle do
     cellar :any


### PR DESCRIPTION
nushell's HEAD now uses the `main` branch

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
