### PR TITLE
formulae*: depend on linux-only dependencies

### DIFF
--- a/Formula/sn0int.rb
+++ b/Formula/sn0int.rb
@@ -3,7 +3,7 @@ class Sn0int < Formula
   homepage "https://github.com/kpcyrd/sn0int"
   url "https://github.com/kpcyrd/sn0int/archive/v0.19.1.tar.gz"
   sha256 "4720736805bec49102f0622ba6b68cc63da0a023a029687140d5b4d2a4d637dc"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     cellar :any
@@ -18,6 +18,10 @@ class Sn0int < Formula
   depends_on "libsodium"
 
   uses_from_macos "sqlite"
+
+  on_linux do
+    depends_on "libseccomp"
+  end
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/sniffglue.rb
+++ b/Formula/sniffglue.rb
@@ -3,7 +3,7 @@ class Sniffglue < Formula
   homepage "https://github.com/kpcyrd/sniffglue"
   url "https://github.com/kpcyrd/sniffglue/archive/v0.11.1.tar.gz"
   sha256 "f3d4a42ee12113ef82a8033bb0d64359af5425c821407a7469e99c7a5af3186d"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     cellar :any_skip_relocation
@@ -15,6 +15,10 @@ class Sniffglue < Formula
   depends_on "rust" => :build
 
   uses_from_macos "libpcap"
+
+  on_linux do
+    depends_on "libseccomp"
+  end
 
   resource "testdata" do
     url "https://github.com/kpcyrd/sniffglue/raw/163ca299bab711fb0082de216d07d7089c176de6/pcaps/SkypeIRC.pcap"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
