### PR TITLE
lfe: fix sha mismatch

### DIFF
--- a/Formula/lfe.rb
+++ b/Formula/lfe.rb
@@ -2,7 +2,7 @@ class Lfe < Formula
   desc "Concurrent Lisp for the Erlang VM"
   homepage "https://lfe.io/"
   url "https://github.com/rvirding/lfe/archive/v1.3.tar.gz"
-  sha256 "1946c0df595ae49ac33fe583f359812dec6349da6acf43c1458534de3267036b"
+  sha256 "04634f2c700ecedb55f4369962837792669e6be809dba90d81974198fc2b7b72"
   license "Apache-2.0"
   head "https://github.com/rvirding/lfe.git", branch: "develop"
 


### PR DESCRIPTION
Upstream rebased for administrative reasons (https://groups.google.com/g/lisp-flavoured-erlang/c/9gCdP7agNm0/m/fnQZIRjMAgAJ), but confirmed no actual content was changed (https://github.com/rvirding/lfe/issues/404), so no revision bump.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
