### PR TITLE
caddy: add resume flag

### DIFF
--- a/Formula/caddy.rb
+++ b/Formula/caddy.rb
@@ -50,6 +50,7 @@ class Caddy < Formula
             <string>run</string>
             <string>--config</string>
             <string>#{etc}/Caddyfile</string>
+            <string>--resume</string>
           </array>
           <key>RunAtLoad</key>
           <true/>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I've been caught off guard when restarting and seeing all my rules in the API vanishing, this adds the `--resume` flag to the plist config so that any restarts will resume whatever configuration you had been using.