### PR TITLE
devspace: build binary with version and githash info

### DIFF
--- a/Formula/devspace.rb
+++ b/Formula/devspace.rb
@@ -17,7 +17,8 @@ class Devspace < Formula
   depends_on "kubernetes-cli"
 
   def install
-    system "go", "build", *std_go_args
+    system "go", "build", "-ldflags",
+    "-s -w -X main.commitHash=#{stable.specs[:revision]} -X main.version=#{stable.specs[:tag]}", *std_go_args
   end
 
   test do


### PR DESCRIPTION
This adds the version and git commit hash information to the built binary. This fixes a problem with the `devspace --version` being broken. I obtained the correct arguments from @LukasGentele at devspace.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
