### PR TITLE
gnuradio: add icon theme for gnuradio-companion

### DIFF
--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -18,6 +18,7 @@ class Gnuradio < Formula
   depends_on "doxygen" => :build
   depends_on "pkg-config" => :build
   depends_on "swig" => :build
+  depends_on "adwaita-icon-theme"
   depends_on "boost"
   depends_on "fftw"
   depends_on "gmp"

--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -6,6 +6,7 @@ class Gnuradio < Formula
   url "https://github.com/gnuradio/gnuradio/releases/download/v3.8.2.0/gnuradio-3.8.2.0.tar.gz"
   sha256 "3e293541a9ac8d78660762bae8b80c0f6195b3494e1c50c01a9fd79cc60bb624"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/gnuradio/gnuradio.git"
 
   bottle do


### PR DESCRIPTION
A freshly installed GNU Radio Compaion starts up without icons at toolbars and other locations. See https://github.com/gnuradio/gnuradio/issues/3124.

Automatically installing `adwaita-icon-theme` will give GNU Radio Companion a working GUI right from the start.
 
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?



