### PR TITLE
parallel: update livecheck url and regex

### DIFF
--- a/Formula/parallel.rb
+++ b/Formula/parallel.rb
@@ -11,8 +11,8 @@ class Parallel < Formula
   head "https://git.savannah.gnu.org/git/parallel.git"
 
   livecheck do
-    url "https://savannah.gnu.org/projects/parallel/"
-    regex(/GNU Parallel v?(\d+).*released \[stable\]/i)
+    url :homepage
+    regex(/GNU Parallel v?(\d{6,8}).*? released \[stable\]/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a follow-up to #61063, fixing some of the issues present in that PR that weren't identified before being merged. Namely:

* Use `url :homepage` instead of a string literal that duplicates the `homepage` URL.
* Use `(\d{6,8})` when matching a date-based version like `20200913`.
* Make "optionally match anything" (`.*`) non-greedy (`.*?`), when possible.