### PR TITLE
transcrypt 2.1.0

### DIFF
--- a/Formula/transcrypt.rb
+++ b/Formula/transcrypt.rb
@@ -1,8 +1,8 @@
 class Transcrypt < Formula
   desc "Configure transparent encryption of files in a Git repo"
   homepage "https://github.com/elasticdog/transcrypt"
-  url "https://github.com/elasticdog/transcrypt/archive/v2.0.0.tar.gz"
-  sha256 "12b891bcee50c71f5ee00c3c3e992c591ad6146ece3d3c5efa065d966a010d65"
+  url "https://github.com/elasticdog/transcrypt/archive/v2.1.0.tar.gz"
+  sha256 "0075a25f7fb48ddfcfb33dd834a5f12fe0644ed4fb5ab0a5f2f7dca06e9ed48c"
   license "MIT"
   head "https://github.com/elasticdog/transcrypt.git"
 
@@ -20,7 +20,7 @@ class Transcrypt < Formula
     system bin/"transcrypt", "--password", "guest", "--yes"
 
     (testpath/".gitattributes").atomic_write <<~EOS
-      sensitive_file  filter=crypt diff=crypt
+      sensitive_file  filter=crypt diff=crypt merge=crypt
     EOS
     (testpath/"sensitive_file").write "secrets"
     system "git", "add", ".gitattributes", "sensitive_file"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Upgrade transcrypt to released version 2.1.0: https://github.com/elasticdog/transcrypt/releases/tag/v2.1.0

Required a minor tweak to tests to add the new `merge=crypt` attribute now added by default to *.gitattributes* file on init.