### PR TITLE
workflows/tests: post comment on failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,6 +141,13 @@ jobs:
         run: |
           if grep -q 'Error: [[:digit:]]* failed steps!' */steps_output.txt; then
             echo "::set-output name=tests-failed::true"
+            if grep -q 'brew install' */steps_output.txt; then
+              echo "::set-output name=build-failure::true"
+            elif grep -q 'brew test' */steps_output.txt; then
+              echo "::set-output name=test-failure::true"
+            elif grep -q 'brew audit' */steps_output.txt; then
+              echo "::set-output name=audit-failure::true"
+            fi
           fi
 
       - name: Post comment on failure
@@ -158,3 +165,24 @@ jobs:
           token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
           pr: ${{github.event.pull_request.number}}
           message: 'tests failed'
+
+      - name: Label build failure
+        if: steps.check-failures.outputs.build-failure
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          labels: 'build failure'
+
+      - name: Label test failure
+        if: steps.check-failures.outputs.test-failure
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          labels: 'test failure'
+
+      - name: Label audit failure
+        if: steps.check-failures.outputs.audit-failure
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          labels: 'audit failure'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,13 @@ jobs:
           cd bottles
           brew test-bot --only-formulae
 
+      - name: Upload brew test-bot --only-formulae output
+        if: always()
+        uses: actions/upload-artifact@main
+        with:
+          name: steps output (${{ matrix.version }})
+          path: bottles/steps_output.txt
+
       - name: Output brew test-bot --only-formulae failures
         if: always()
         run: |
@@ -112,3 +119,42 @@ jobs:
       - name: Post Cleanup
         if: always()
         run: rm -rvf bottles
+
+  comment:
+    needs: tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download logs and brew test-bot --only-formulae output
+        uses: actions/download-artifact@v2
+
+      - name: Delete brew test-bot --only-formulae output
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            steps output (10.15)
+            steps output (10.14)
+            steps output (10.13)
+
+      - name: Check for failures
+        id: check-failures
+        run: |
+          if grep -q 'Error: [[:digit:]]* failed steps!' */steps_output.txt; then
+            echo "::set-output name=tests-failed::true"
+          fi
+
+      - name: Post comment on failure
+        if: steps.check-failures.outputs.tests-failed
+        uses: Homebrew/actions/post-comment@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          issue: ${{github.event.pull_request.number}}
+          body: ':warning: Tests [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}).'
+
+      - name: Dismiss approvals on failure
+        if: steps.check-failures.outputs.tests-failed
+        uses: Homebrew/actions/dismiss-approvals@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          pr: ${{github.event.pull_request.number}}
+          message: 'tests failed'


### PR DESCRIPTION
<!-- - [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
-->

Steps:

1. Upload `brew test-bot --only-formulae` output
2. Wait for `tests` workflow to finish
3. Download all artifacts (logs and `brew test-bot --only-formulae` output)
    - (Note: currently uses [`geekyeggo/delete-artifact`](https://github.com/geekyeggo/delete-artifact))
4. Delete `brew test-bot --only-formulae` artifacts
5. Use `grep` to check for any occurrences of `Error: [[:digit:]]* failed steps!` in `*/steps_output.txt`
6. If a match is found, post comment and dismiss any approvals
7. If `steps_output.txt` contains `brew install`/`brew test`/`brew audit`, add the respective label
    - (Currently uses [`actions-ecosystem/action-add-labels`](https://github.com/actions-ecosystem/action-add-labels))

Example comment:

> :warning: Tests [failed](https://github.com/Homebrew/homebrew-core/actions/runs/1).