### PR TITLE
evince reenable Postscript backend

### DIFF
--- a/Formula/evince.rb
+++ b/Formula/evince.rb
@@ -4,6 +4,7 @@ class Evince < Formula
   url "https://download.gnome.org/sources/evince/3.38/evince-3.38.0.tar.xz"
   sha256 "26df897a417545b476d2606b14731122e84278ae994bd64ea535449c3cf01948"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -45,6 +46,7 @@ class Evince < Formula
       -Dbrowser_plugin=false
       -Dgspell=enabled
       -Ddbus=false
+      -Dps=enabled
     ]
 
     mkdir "build" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Re-enable Postscript support for evince per https://github.com/Homebrew/discussions/discussions/6.