### PR TITLE
syncthing: pass app version when building

### DIFF
--- a/Formula/syncthing.rb
+++ b/Formula/syncthing.rb
@@ -4,6 +4,7 @@ class Syncthing < Formula
   url "https://github.com/syncthing/syncthing/archive/v1.9.0.tar.gz"
   sha256 "ca66e0929428db2ed9476ff8ef4d46b06c5221a5aa24db504cdb2cd1aebe5ac6"
   license "MPL-2.0"
+  revision 1
   head "https://github.com/syncthing/syncthing.git"
 
   livecheck do
@@ -22,7 +23,7 @@ class Syncthing < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "run", "build.go", "--no-upgrade", "tar"
+    system "go", "run", "build.go", "--version", "v#{version}", "--no-upgrade", "tar"
     bin.install "syncthing"
 
     man1.install Dir["man/*.1"]
@@ -65,6 +66,7 @@ class Syncthing < Formula
   end
 
   test do
+    assert_match "syncthing v#{version} ", shell_output("#{bin}/syncthing --version")
     system bin/"syncthing", "-generate", "./"
   end
 end


### PR DESCRIPTION
This should display version instead of "unknown-dev":

```
➔ syncthing --version
syncthing unknown-dev "Fermium Flea" (go1.15.1 darwin-amd64) brew@Catalina 2020-09-08 08:53:29 UTC [noupgrade]
```

This is according to their documentation:
- https://docs.syncthing.net/dev/building.html#building-without-git

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
