### PR TITLE
shtools 4.7 (new formula)

### DIFF
--- a/Formula/shtools.rb
+++ b/Formula/shtools.rb
@@ -1,0 +1,36 @@
+class Shtools < Formula
+  desc "Spherical Harmonic Tools"
+  homepage "https://shtools.github.io/SHTOOLS/"
+  url "https://github.com/SHTOOLS/SHTOOLS/archive/v4.7.1.tar.gz"
+  sha256 "6ed2130eed7b741df3b19052b29b3324601403581c7b9afb015e0370e299a2bd"
+  license "BSD-3-Clause"
+  head "https://github.com/SHTOOLS/homebrew-shtools.git"
+
+  depends_on "fftw"
+  depends_on "gcc"
+
+  def install
+    system "make", "fortran"
+    system "make", "fortran-mp"
+
+    pkgshare.install "examples/fortran/", "examples/ExampleDataFiles/"
+
+    lib.install "lib/libSHTOOLS.a", "lib/libSHTOOLS-mp.a"
+    include.install "include/fftw3.mod", "include/planetsconstants.mod", "include/shtools.mod", "include/ftypes.mod"
+    share.install "man"
+  end
+
+  test do
+    cp_r pkgshare, testpath
+    system "make", "-C", "shtools/fortran",
+                   "run-fortran-tests-no-timing",
+                   "F95=gfortran",
+                   "F95FLAGS=-m64 -fPIC -O3 -std=gnu -ffast-math",
+                   "MODFLAG=-I#{HOMEBREW_PREFIX}/include",
+                   "LIBPATH=#{HOMEBREW_PREFIX}/lib",
+                   "LIBNAME=SHTOOLS",
+                   "FFTW=-L #{HOMEBREW_PREFIX}/lib -lfftw3 -lm",
+                   "LAPACK=-framework accelerate",
+                   "BLAS="
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
shtools is a Fortran 95 based library that is used for performing spherical harmonic transforms and related operations. It is the underlying motor of the python-based project pyshtools. More info can be found here: https://shtools.github.io/SHTOOLS/