### PR TITLE
symbolize 1.0 (new formula)

### DIFF
--- a/Formula/symbolize.rb
+++ b/Formula/symbolize.rb
@@ -1,0 +1,19 @@
+class Symbolize < Formula
+  desc "Use this with ex. Dropbox to keep your config files synced between devices"
+  homepage "https://github.com/SlimG/symbolize"
+  url "https://github.com/SlimG/symbolize/archive/v1.0.tar.gz"
+  sha256 "ea8a84745984e806b6dc2d07204ec01fb993aeb56f6fae21985c5900dbb5be37"
+  license "Apache-2.0"
+
+  def install
+    cp "symbolize", prefix/"symbolize"
+    ln_s prefix/"symbolize", HOMEBREW_PREFIX/"bin/symbolize"
+  end
+
+  test do
+    mkdir(testpath/"config")
+    touch(testpath/"testfile")
+    system "symbolize", testpath/"testfile", testpath/"config"
+    assert_predicate(testpath/"config/testfile", :exist?)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Use this with ex. [Dropbox](https://www.dropbox.com) to keep your configuration files synced between your workstations using symbolic links

I was inspired by [Ira](https://github.com/lra)'s [mackup](https://github.com/lra/mackup), but I needed to have some configuration files shared between all my computers (ex. ~/.vimrc), and some available in Dropbox under their own hostname folders for backup-purpose (ex. ~/.ssh).