### PR TITLE
libsoxr: add a patch to fix on Apple Silicon

### DIFF
--- a/Formula/libsoxr.rb
+++ b/Formula/libsoxr.rb
@@ -20,6 +20,14 @@ class Libsoxr < Formula
 
   depends_on "cmake" => :build
 
+  # Fixes the build on 64-bit ARM macOS; the __arm__ define used in the
+  # code isn't defined on 64-bit Apple Silicon.
+  # Upstream pull request: https://sourceforge.net/p/soxr/code/merge-requests/5/
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/76868b36263be42440501d3692fd3a258f507d82/libsoxr/arm64_defines.patch"
+    sha256 "9df5737a21b9ce70cc136c302e195fad9f9f6c14418566ad021f14bb34bb022c"
+  end
+
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes issues reported here: https://github.com/Homebrew/brew/issues/7857

I've tested and confirmed it now builds and passes on Apple Silicon.