### PR TITLE
libvidstab: fix on Apple Silicon

### DIFF
--- a/Formula/libvidstab.rb
+++ b/Formula/libvidstab.rb
@@ -17,6 +17,16 @@ class Libvidstab < Formula
 
   depends_on "cmake" => :build
 
+  # A bug in the FindSSE CMake script means that, if a variable is defined
+  # as an empty string without quoting, it doesn't get passed to a function
+  # and CMake throws an error. This only occurs on ARM, because the
+  # sysctl value being checked is always a non-empty string on Intel.
+  # Upstream PR: https://github.com/georgmartius/vid.stab/pull/93
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/5bf1a0e0cfe666ee410305cece9c9c755641bfdf/libvidstab/fix_cmake_quoting.patch"
+    sha256 "45c16a2b64ba67f7ca5335c2f602d8d5186c29b38188b3cc7aff5df60aecaf60"
+  end
+
   def install
     system "cmake", ".", "-DUSE_OMP=OFF", *std_cmake_args
     system "make", "install"

--- a/Formula/libvidstab.rb
+++ b/Formula/libvidstab.rb
@@ -3,7 +3,7 @@ class Libvidstab < Formula
   homepage "http://public.hronopik.de/vid.stab/"
   url "https://github.com/georgmartius/vid.stab/archive/v1.1.0.tar.gz"
   sha256 "14d2a053e56edad4f397be0cb3ef8eb1ec3150404ce99a426c4eb641861dc0bb"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

What looked like an error due to SSE not being available was actually a CMake quoting bug masked by something else. llibvidstab's call to a function includes a variable which can be an empty string, and if that's not quoted, CMake fails to see that that parameter was passed. Hence, we get this error about calling a function with too few parameters:

```
CMake Error at CMakeModules/FindSSE.cmake:47 (STRING):
  STRING sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
Call Stack (most recent call first):
  CMakeLists.txt:8 (include)
```

Quoting the parameter so it's passed as an empty string to CMake fixes this, and libvidstab builds fine after that. SSE is an optional feature.

cc @claui 