### PR TITLE
colordiff: remove conflicts_with cdiff

### DIFF
--- a/Formula/colordiff.rb
+++ b/Formula/colordiff.rb
@@ -20,8 +20,6 @@ class Colordiff < Formula
 
   depends_on "coreutils" => :build # GNU install
 
-  conflicts_with "cdiff", because: "both install `cdiff` binaries"
-
   def install
     man1.mkpath
     system "make", "INSTALL=ginstall",

--- a/Formula/colordiff.rb
+++ b/Formula/colordiff.rb
@@ -4,7 +4,7 @@ class Colordiff < Formula
   url "https://www.colordiff.org/colordiff-1.0.19.tar.gz"
   mirror "https://dl.bintray.com/homebrew/mirror/colordiff-1.0.19.tar.gz"
   sha256 "46e8c14d87f6c4b77a273cdd97020fda88d5b2be42cf015d5d84aca3dfff3b19"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [N/A] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [N/A] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The conflict is no longer exists because `cdiff` has been renamed to `ydiff`