### PR TITLE
halide 10.0.0 (new formula)

### DIFF
--- a/Formula/halide.rb
+++ b/Formula/halide.rb
@@ -1,0 +1,28 @@
+class Halide < Formula
+  desc "Language for fast, portable data-parallel computation"
+  homepage "https://halide-lang.org"
+  url "https://github.com/halide/Halide/archive/v10.0.0.tar.gz"
+  sha256 "23808f8e9746aea25349a16da92e89ae320990df3c315c309789fb209ee40f20"
+  license "MIT"
+
+  depends_on "cmake" => :build
+  depends_on "jpeg"
+  depends_on "libomp"
+  depends_on "libpng"
+  depends_on "llvm"
+  depends_on "python@3.8"
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    cp share/"tutorial/lesson_01_basics.cpp", testpath
+    system ENV.cxx, "-std=c++11", "lesson_01_basics.cpp", "-L#{lib}", "-lHalide", "-o", "test"
+    assert_match "Success!", shell_output("./test")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Notes
- Requires LLVM 9+ (fails with `uses_from_macos` suggested by `--new-formula` audit)
- The [license file](https://github.com/halide/Halide/blob/v10.0.0/LICENSE.txt) lists two additional licenses (one for `apps/bgu` and another for `apps/support/cmdline.h`) but neither are installed with `make install`. We could delete these files if that's a good practice, or use `license all_of: [...]`.