### PR TITLE
workflows: add `bottle unneeded` label for Linux formulae

### DIFF
--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -23,7 +23,7 @@ jobs:
                 }, {
                     "label": "bottle unneeded",
                     "path": "Formula/.+",
-                    "content": "\n  bottle :unneeded\n"
+                    "content": "\n  (bottle :unneeded|depends_on :linux)\n"
                 }, {
                     "label": "formula deprecated",
                     "path": "Formula/.+",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`homebrew-core` currently isn't building bottles for Linux formulae (This happens in `linuxbrew-core`)

Related: Homebrew/homebrew-core#61203