### PR TITLE
server-go 1.1.59 (new formula)

### DIFF
--- a/Formula/server-go.rb
+++ b/Formula/server-go.rb
@@ -1,0 +1,51 @@
+class ServerGo < Formula
+  desc "Server for OpenIoTHub"
+  homepage "https://github.com/OpenIoTHub/server-go"
+  url "https://github.com/OpenIoTHub/server-go.git",
+      tag:      "v1.1.59",
+      revision: "53d0a8d6fbf982a20651d0c420eca3b1f1e95523"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    (etc/"server-go").mkpath
+    system "go", "build", "-mod=vendor", "-ldflags",
+             "-s -w -X main.version=#{version} -X main.commit=#{stable.specs[:revision]} -X main.builtBy=homebrew",
+             *std_go_args
+    etc.install "server-go.yaml" => "server-go/server-go.yaml"
+  end
+
+  plist_options manual: "server-go -c #{HOMEBREW_PREFIX}/etc/server-go/server-go.yaml"
+
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>KeepAlive</key>
+          <true/>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{opt_bin}/server-go</string>
+            <string>-c</string>
+            <string>#{etc}/server-go/server-go.yaml</string>
+          </array>
+          <key>StandardErrorPath</key>
+          <string>#{var}/log/server-go.log</string>
+          <key>StandardOutPath</key>
+          <string>#{var}/log/server-go.log</string>
+        </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/server-go -v 2>&1")
+    assert_match "config created", shell_output("#{bin}/server-go init --config=server.yml 2>&1")
+    assert_predicate testpath/"server.yml", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[OpenIoTHub](https://github.com/OpenIoTHub) contain [server](https://github.com/OpenIoTHub/server-go), [gateway](https://github.com/OpenIoTHub/gateway-go) and [app for mobile](https://github.com/OpenIoTHub/OpenIoTHub) ([iOS APP](https://apps.apple.com/cn/app/云易连/id1501554327) ), OpenIoTHub is best way access your remote network service and IoT Device.
This is OpenIoTHub [server](https://github.com/OpenIoTHub/server-go) :)
refs [gateway-go Formula](https://github.com/Homebrew/homebrew-core/pull/57948)