### PR TITLE
restic 0.10.0

### DIFF
--- a/Formula/restic.rb
+++ b/Formula/restic.rb
@@ -1,8 +1,8 @@
 class Restic < Formula
   desc "Fast, efficient and secure backup program"
   homepage "https://restic.github.io/"
-  url "https://github.com/restic/restic/archive/v0.9.6.tar.gz"
-  sha256 "1cc8655fa99f06e787871a9f8b5ceec283c856fa341a5b38824a0ca89420b0fe"
+  url "https://github.com/restic/restic/archive/v0.10.0.tar.gz"
+  sha256 "067fbc0cf0eee4afdc361e12bd03b266e80e85a726647e53709854ec142dd94e"
   license "BSD-2-Clause"
   head "https://github.com/restic/restic.git"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 23,683,545 bytes
- formula fetch time: 2.2 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.