### PR TITLE
ocamlsdl: disable

### DIFF
--- a/Formula/ocamlsdl.rb
+++ b/Formula/ocamlsdl.rb
@@ -3,11 +3,14 @@ class Ocamlsdl < Formula
   homepage "https://ocamlsdl.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ocamlsdl/OCamlSDL/ocamlsdl-0.9.1/ocamlsdl-0.9.1.tar.gz"
   sha256 "abfb295b263dc11e97fffdd88ea1a28b46df8cc2b196777093e4fe7f509e4f8f"
-  revision 14
+  license "LGPL-2.1-or-later"
+  revision 13
 
   livecheck do
     url :stable
   end
+
+  disable! because: :unmaintained
 
   bottle do
     cellar :any


### PR DESCRIPTION
No updates since 2012, and it fails to compile with safe-strings support
needed since ocaml 4.10.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Closes #60741.