### PR TITLE
zsh-syntax-highlighting: Loosen dependency on zsh

### DIFF
--- a/Formula/zsh-syntax-highlighting.rb
+++ b/Formula/zsh-syntax-highlighting.rb
@@ -14,7 +14,7 @@ class ZshSyntaxHighlighting < Formula
     sha256 "6b7d4cdc41b56c842a4b76f9901d922d1f39bd638e94249881078a873de8970b" => :high_sierra
   end
 
-  uses_from_macos "zsh" => :build
+  uses_from_macos "zsh" => [:build, :test]
 
   def install
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/zsh-syntax-highlighting.rb
+++ b/Formula/zsh-syntax-highlighting.rb
@@ -14,7 +14,7 @@ class ZshSyntaxHighlighting < Formula
     sha256 "6b7d4cdc41b56c842a4b76f9901d922d1f39bd638e94249881078a873de8970b" => :high_sierra
   end
 
-  uses_from_macos "zsh"
+  uses_from_macos "zsh" => :build
 
   def install
     system "make", "install", "PREFIX=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This removes the hard dependency on `zsh`, which is only used during the build. Other similar packages such as `zsh-history-substring-search` and `zsh-completions` do not depend on `zsh` either.