### PR TITLE
sdl_mixer: Added patch to fix compilation on Xcode 12

### DIFF
--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -3,6 +3,7 @@ class SdlMixer < Formula
   homepage "https://www.libsdl.org/projects/SDL_mixer/"
   url "https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-1.2.12.tar.gz"
   sha256 "1644308279a975799049e4826af2cfc787cad2abb11aa14562e402521f86992a"
+  license "Zlib"
   revision 3
 
   livecheck do
@@ -29,6 +30,12 @@ class SdlMixer < Formula
   resource "playwave" do
     url "https://hg.libsdl.org/SDL_mixer/raw-file/a4e9c53d9c30/playwave.c"
     sha256 "92f686d313f603f3b58431ec1a3a6bf29a36e5f792fb78417ac3d5d5a72b76c9"
+  end
+
+  # Fix compilation in clang 12.0.0 https://bugzilla.libsdl.org/show_bug.cgi?id=5296
+  patch do
+    url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=4468"
+    sha256 "84851e0265e9674f544428aa2e82617e8a925a576d736ec33e09ea337fe7823c"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I noticed while manually building SDL_mixer on clang 12.0.0 that there's an include missing in mixer.c which causes it to fail to build.  For whatever reason, it doesn't seem to fail when building with Homebrew, but I figured this would be prudent to submit just in case.