### PR TITLE
choose-gui 1.2.1

### DIFF
--- a/Formula/choose-gui.rb
+++ b/Formula/choose-gui.rb
@@ -1,8 +1,8 @@
 class ChooseGui < Formula
   desc "Fuzzy matcher that uses std{in,out} and a native GUI"
   homepage "https://github.com/chipsenkbeil/choose"
-  url "https://github.com/chipsenkbeil/choose/archive/1.1.tar.gz"
-  sha256 "cd921cfa6a7b7e976716c33dd8c800a06f41e88e12e385cd7b1ad5edc63578f2"
+  url "https://github.com/chipsenkbeil/choose/archive/1.2.1.tar.gz"
+  sha256 "cab6083be6429e9c67bd0026aedf8bd76675a2dea045d235a973fb61b106aeaf"
   license "MIT"
 
   bottle do
@@ -19,7 +19,8 @@ class ChooseGui < Formula
   conflicts_with "choose-rust", because: "both install a `choose` binary"
 
   def install
-    xcodebuild "SDKROOT=", "SYMROOT=build"
+    xcodebuild "SDKROOT=", "SYMROOT=build", "clean"
+    xcodebuild "SDKROOT=", "SYMROOT=build", "-configuration", "Release", "build"
     bin.install "build/Release/choose"
   end
 


### PR DESCRIPTION
Updates choose-gui to 1.2.1, which fixes an illegal instruction error, and adjusts installation method to support release build as default changed to debug in version 1.2.1

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----