### PR TITLE
earthly 0.3.8

### DIFF
--- a/Formula/earthly.rb
+++ b/Formula/earthly.rb
@@ -1,8 +1,8 @@
 class Earthly < Formula
   desc "Build automation tool for the post-container era"
   homepage "https://earthly.dev/"
-  url "https://github.com/earthly/earthly/archive/v0.3.7.tar.gz"
-  sha256 "f8e9e9afb466e9fe6525f867c8825eb1fa1c6614e60004dd88e1bd542cf6a8ff"
+  url "https://github.com/earthly/earthly/archive/v0.3.8.tar.gz"
+  sha256 "29437680c22ba68028df5200cb0582b61bc02a3fe0a83cc9e1df54405b013268"
   license "MPL-2.0"
   head "https://github.com/earthly/earthly.git"
 
@@ -17,7 +17,7 @@ class Earthly < Formula
 
   def install
     ldflags = "-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} -X" \
-              " main.GitSha=de7bfb10fcb6dc26b74aa2a76bc021773f8c9069 "
+              " main.GitSha=4c01bae32ab1ecea65910e06f20d30c30923e225 "
     tags = "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork"
     system "go", "build",
         "-tags", tags,


### PR DESCRIPTION
-------------

#### Debug data

PR generated by the [Earthly build](https://github.com/earthly/earthly/blob/master/release/Earthfile) (target +release-homebrew)

* `RELEASE_TAG=v0.3.8`

* `GIT_USERNAME=alexcb`

* `NEW_URL=https://github.com/earthly/earthly/archive/v0.3.8.tar.gz`

* `NEW_SHA256=d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed`

* `TAGS=dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork`

* `LDFLAGS=-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} -X main.GitSha=4c01bae32ab1ecea65910e06f20d30c30923e225 `

* `LDFLAGS1=-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} -X`

* `LDFLAGS2= main.GitSha=4c01bae32ab1ecea65910e06f20d30c30923e225 `