### PR TITLE
cddlib: update license

### DIFF
--- a/Formula/cddlib.rb
+++ b/Formula/cddlib.rb
@@ -3,7 +3,7 @@ class Cddlib < Formula
   homepage "https://www.inf.ethz.ch/personal/fukudak/cdd_home/"
   url "https://github.com/cddlib/cddlib/releases/download/0.94l/cddlib-0.94l.tar.gz"
   sha256 "1ef6b1ee44509a26d480cda699ca1a9a38ecc9a2aba5092dbd7390ca285769e0"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   version_scheme 1
 
   bottle do


### PR DESCRIPTION
follow up of #61609

```
/* cddlib.c: cdd library  (library version of cdd)
   written by Komei Fukuda, fukuda@math.ethz.ch
   Version 0.94i, March 9, 2018
   Standard ftp site: ftp.ifor.math.ethz.ch, Directory: pub/fukuda/cdd
*/

/* cdd : C-Implementation of the double description method for
   computing all vertices and extreme rays of the polyhedron 
   P= {x :  b - A x >= 0}.
   Please read COPYING (GNU General Public Licence) and
   the manual cddlibman.tex for detail.
*/

/*  This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2 of the License, or
    (at your option) any later version.

    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.

    You should have received a copy of the GNU General Public License
    along with this program; if not, write to the Free Software
    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
*/

/* The first version C0.21 was created on November 10,1993 
   with Dave Gillespie's p2c translator 
   from the Pascal program pdd.p written by Komei Fukuda. 
*/
```