### PR TITLE
scamper: update license

### DIFF
--- a/Formula/scamper.rb
+++ b/Formula/scamper.rb
@@ -3,7 +3,7 @@ class Scamper < Formula
   homepage "https://www.caida.org/tools/measurement/scamper/"
   url "https://www.caida.org/tools/measurement/scamper/code/scamper-cvs-20200923.tar.gz"
   sha256 "dc9988d9a696152b5066f9d52dfc24cb898275b5c22a9f420cb901115901c324"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url "https://www.caida.org/tools/measurement/scamper/code/?C=M&O=D"


### PR DESCRIPTION
follow up of #61614

```
/*
 * scamper.h
 *
 * $Id: scamper.h,v 1.66.2.1 2020/09/23 02:45:41 mjl Exp $
 *
 * Copyright (C) 2003-2006 Matthew Luckie
 * Copyright (C) 2006-2011 The University of Waikato
 * Copyright (C) 2015-2020 Matthew Luckie
 * Author: Matthew Luckie
 *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, version 2.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
 *
 * You should have received a copy of the GNU General Public License
 * along with this program; if not, write to the Free Software
 * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *
 */
```