### PR TITLE
sile 0.10.11

### DIFF
--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -1,8 +1,8 @@
 class Sile < Formula
   desc "Modern typesetting system inspired by TeX"
   homepage "https://www.sile-typesetter.org"
-  url "https://github.com/sile-typesetter/sile/releases/download/v0.10.10/sile-0.10.10.tar.xz"
-  sha256 "efc0be18118e20fa5cbde330850b3f65d0835c05a75ad45d4ee85f8ff8f6fe54"
+  url "https://github.com/sile-typesetter/sile/releases/download/v0.10.11/sile-0.10.11.tar.xz"
+  sha256 "acbc94db894bbcdd1bbcf94e1aa506b0bcb8bffc1f2b96c0c345321c85ff8a30"
   license "MIT"
   head "https://github.com/sile-typesetter/sile.git", shallow: false
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a blind update, if anybody can confirm from a mac that this works that would be great. CI results should be pretty definitive though.

No dependency changes upstream this time, but v0.10.11 will now work with Penlight versions newer than 1.8.0. Although there is a newer release I'm saving the actual bumping of Penlight until upstream SILE specifically calls for it (currently being tested).