### PR TITLE
Run brew test-bot fontconfig

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -5,6 +5,7 @@ on:
       - "Formula/alsa-lib.rb"
       - "Formula/ladspa-sdk.rb"
       - "Formula/libseccomp.rb"
+      - "Formula/fontconfig.rb"
 jobs:
   tests_linux:
     runs-on: ubuntu-latest

--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -4,6 +4,7 @@ class Fontconfig < Formula
   url "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.13.1.tar.bz2"
   sha256 "f655dd2a986d7aa97e052261b36aa67b0a64989496361eca8d604e6414006741"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
Just testing whether brew test-bot fontconfig passes on ubuntu (since brew test-bot fails on ubuntu for ffmpeg on the fontconfig post-install step: https://github.com/ddelange/homebrew-brewformulae/pull/2/checks?check_run_id=1166214508#step:4:1531)

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
