### PR TITLE
wiimms-szs-tools (new formula)

### DIFF
--- a/Formula/wiimms-szs-tools.rb
+++ b/Formula/wiimms-szs-tools.rb
@@ -1,0 +1,33 @@
+# Documentation: https://docs.brew.sh/Formula-Cookbook
+#                https://rubydoc.brew.sh/Formula
+
+class WiimmsSzsTools < Formula
+  desc "Wiimms SZS Toolset is a set of command line tools to manipulate SZS, U8, WBZ, WU8, PACK, BRRES, BREFF, BREFT, BMG, KCL, KMP, MDL, PAT, TEX, TPL, BTI, main.dol and StaticR.rel files of Mario Kart Wii."
+  homepage "https://szs.wiimm.de/"
+  license "GPL-2.0-only"
+  url "https://download.wiimm.de/source/wiimms-szs-tools/wiimms-szs-tools.source-2.19a.txz"
+
+  depends_on "libpng" => :build
+  uses_from_macos "ncurses"
+
+  head do
+    url "https://github.com/Wiimm/wiimms-szs-tools.git"
+  end
+
+  def install
+    cd "project" do
+      system_command "/usr/bin/sed",
+                     args: [
+                       "-i", ".bak",
+                       "-e", "s|INSTALL_PATH=.*|INSTALL_PATH=#{prefix}|g",
+                       "setup.sh"
+                     ]
+      system "make"
+      system "/bin/sh", "install.sh", "--no-sudo" 
+    end
+  end
+
+  test do
+    system "wszst", "TEST"
+  end
+end

--- a/Formula/wiimms-szs-tools.rb
+++ b/Formula/wiimms-szs-tools.rb
@@ -4,7 +4,7 @@
 class WiimmsSzsTools < Formula
   desc "Wiimms SZS Toolset is a set of command line tools to manipulate SZS, U8, WBZ, WU8, PACK, BRRES, BREFF, BREFT, BMG, KCL, KMP, MDL, PAT, TEX, TPL, BTI, main.dol and StaticR.rel files of Mario Kart Wii."
   homepage "https://szs.wiimm.de/"
-  license "GPL-2.0-only"
+  license "GPL-2.0-or-later"
   url "https://download.wiimm.de/source/wiimms-szs-tools/wiimms-szs-tools.source-2.19a.txz"
 
   depends_on "libpng" => :build

--- a/Formula/wiimms-szs-tools.rb
+++ b/Formula/wiimms-szs-tools.rb
@@ -25,6 +25,9 @@ class WiimmsSzsTools < Formula
   end
 
   test do
-    system "wszst", "TEST"
+    system "mkdir", "test_dir"
+    system "wszst", "CREATE", "test_dir"
+    system "rmdir", "test_dir"
+    system "rm", "test_dir.szs"
   end
 end

--- a/Formula/wiimms-szs-tools.rb
+++ b/Formula/wiimms-szs-tools.rb
@@ -1,6 +1,7 @@
 class WiimmsSzsTools < Formula
   desc "Wiimms SZS Toolset is a set of command-line tools to manipulate Wii files"
   homepage "https://szs.wiimm.de/"
+  sha256 "db8b73e41c2bc80e71f6a8fc95513f9a4424800e55dbcfcf1ea4f103b6c61265"
   url "https://download.wiimm.de/source/wiimms-szs-tools/wiimms-szs-tools.source-2.19a.txz"
   license "GPL-2.0-or-later"
 

--- a/Formula/wiimms-szs-tools.rb
+++ b/Formula/wiimms-szs-tools.rb
@@ -7,7 +7,6 @@ class WiimmsSzsTools < Formula
   head do
     url "https://github.com/Wiimm/wiimms-szs-tools.git"
   end
-  
   depends_on "libpng" => :build
   uses_from_macos "ncurses"
 
@@ -20,7 +19,7 @@ class WiimmsSzsTools < Formula
                        "setup.sh"
                      ]
       system "make"
-      system "/bin/sh", "install.sh", "--no-sudo" 
+      system "/bin/sh", "install.sh", "--no-sudo"
     end
   end
 

--- a/Formula/wiimms-szs-tools.rb
+++ b/Formula/wiimms-szs-tools.rb
@@ -1,11 +1,8 @@
-# Documentation: https://docs.brew.sh/Formula-Cookbook
-#                https://rubydoc.brew.sh/Formula
-
 class WiimmsSzsTools < Formula
-  desc "Wiimms SZS Toolset is a set of command line tools to manipulate SZS, U8, WBZ, WU8, PACK, BRRES, BREFF, BREFT, BMG, KCL, KMP, MDL, PAT, TEX, TPL, BTI, main.dol and StaticR.rel files of Mario Kart Wii."
+  desc "Wiimms SZS Toolset is a set of command-line tools to manipulate files of Mario Kart Wii"
   homepage "https://szs.wiimm.de/"
-  license "GPL-2.0-or-later"
   url "https://download.wiimm.de/source/wiimms-szs-tools/wiimms-szs-tools.source-2.19a.txz"
+  license "GPL-2.0-or-later"
 
   depends_on "libpng" => :build
   uses_from_macos "ncurses"

--- a/Formula/wiimms-szs-tools.rb
+++ b/Formula/wiimms-szs-tools.rb
@@ -1,15 +1,15 @@
 class WiimmsSzsTools < Formula
-  desc "Wiimms SZS Toolset is a set of command-line tools to manipulate files of Mario Kart Wii"
+  desc "Wiimms SZS Toolset is a set of command-line tools to manipulate Wii files"
   homepage "https://szs.wiimm.de/"
   url "https://download.wiimm.de/source/wiimms-szs-tools/wiimms-szs-tools.source-2.19a.txz"
   license "GPL-2.0-or-later"
 
-  depends_on "libpng" => :build
-  uses_from_macos "ncurses"
-
   head do
     url "https://github.com/Wiimm/wiimms-szs-tools.git"
   end
+  
+  depends_on "libpng" => :build
+  uses_from_macos "ncurses"
 
   def install
     cd "project" do


### PR DESCRIPTION
Wiimms SZS Tools is a library to read/write from a lot of file formats used especially in Wii games, especially Mario Kart Wii.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? **(yes, but one exception)**

-----

The only problem that brew audit returns is something out of my control - it says that the GitHub repository is not popular enough.

I will however say that the GitHub repository is new. Wiimms SZS Tools has been around for years and is a popular and very-well-made tool used in the Wii game modding community. The source code was originally in a SVN repository, then as source tarballs on his site, then made into a GitHub repository so he can use a buildbot to compile the app as the developer who made these tools doesn't have access to a Mac.

I hope that the formula can be added, because I worked hard on creating my first formula and I've wanted this tool to be a package installable with brew for a long time.