### PR TITLE
caddy: stop using xcaddy --with flag to build

### DIFF
--- a/Formula/caddy.rb
+++ b/Formula/caddy.rb
@@ -24,9 +24,7 @@ class Caddy < Formula
     revision = build.head? ? version.commit : "v#{version}"
 
     resource("xcaddy").stage do
-      system "go", "run", "cmd/xcaddy/main.go", "build", revision,
-                                                "--with", "github.com/caddyserver/caddy/v#{version.major}=#{buildpath}",
-                                                "--output", bin/"caddy"
+      system "go", "run", "cmd/xcaddy/main.go", "build", revision, "--output", bin/"caddy"
     end
   end
 
@@ -48,7 +46,6 @@ class Caddy < Formula
             <string>run</string>
             <string>--config</string>
             <string>#{etc}/Caddyfile</string>
-            <string>--resume</string>
           </array>
           <key>RunAtLoad</key>
           <true/>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #61621 - addresses the panic by moving away from the bad invocation of `xcaddy`, and using it correctly instead.

Now the resulting version number is correct:

```console
$ caddy version
v2.2.0 h1:sMUFqTbVIRlmA8NkFnNt9l7s0e+0gw+7GPIrhty905A=
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>