### PR TITLE
Bump samtools and htslib 1.11

### DIFF
--- a/Formula/htslib.rb
+++ b/Formula/htslib.rb
@@ -1,10 +1,9 @@
 class Htslib < Formula
   desc "C library for high-throughput sequencing data formats"
   homepage "https://www.htslib.org/"
-  url "https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2"
-  sha256 "e3b543de2f71723830a1e0472cf5489ec27d0fbeb46b1103e14a11b7177d1939"
+  url "https://github.com/samtools/htslib/releases/download/1.11/htslib-1.11.tar.bz2"
+  sha256 "cffadd9baa6fce27b8fe0b01a462b489f06a5433dfe92121f667f40f632538d7"
   license "MIT"
-  revision 1
 
   livecheck do
     url "https://github.com/samtools/htslib/releases/latest"

--- a/Formula/htslib.rb
+++ b/Formula/htslib.rb
@@ -23,14 +23,6 @@ class Htslib < Formula
   uses_from_macos "curl"
   uses_from_macos "zlib"
 
-  # patch to allow htslib to work with newer libcurls that are packaged by homebrew
-  # see https://github.com/samtools/htslib/pull/1105
-  # this patch should be deleted on next release of htslib
-  patch do
-    url "https://github.com/samtools/htslib/commit/c7c7fb56dba6f81a56a5ec5ea20b8ad81ce62a43.patch?full_index=1"
-    sha256 "2d0244d066c07774ab6e372d0bfdd259fd7f64a918eb9595eae6c201e66db594"
-  end
-
   def install
     system "./configure", "--prefix=#{prefix}", "--enable-libcurl"
     system "make", "install"

--- a/Formula/samtools.rb
+++ b/Formula/samtools.rb
@@ -1,8 +1,8 @@
 class Samtools < Formula
   desc "Tools for manipulating next-generation sequencing data"
   homepage "https://www.htslib.org/"
-  url "https://github.com/samtools/samtools/releases/download/1.10/samtools-1.10.tar.bz2"
-  sha256 "7b9ec5f05d61ec17bd9a82927e45d8ef37f813f79eb03fe06c88377f1bd03585"
+  url "https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2"
+  sha256 "e283cebd6c1c49f0cf8a3ca4fa56e1d651496b4d2e42f80ab75991a9ece4e5b6"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Samtools and htslib are related packages and so they are bumped together, although it is possible the code would function with individual bumps