### PR TITLE
maven: provide head location

### DIFF
--- a/Formula/maven.rb
+++ b/Formula/maven.rb
@@ -21,7 +21,7 @@ class Maven < Formula
     end
 
     def find_latest
-      jenkins_base_url = "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven/job/master/"
+      jenkins_base_url = "https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven/job/master"
 
       download_json("#{jenkins_base_url}/api/json")["builds"].each do |build|
         build_details = download_json("#{jenkins_base_url}/#{build["number"]}/api/json")


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request provides the HEAD version of Maven. It does so by inspecting Jenkins, our build server, and fetching the built package from the last succesful build.

There's a couple of things I'm unsure of, and where I'm seeking your advice:

* the formula has some audit errors (they were there before I started), I'm not sure if/how I could resolve them
* I'm not really happy with the code block. I had to do a lot of reformatting before it fitted into 10 lines, but ideally I'd write it a bit more verbose so it would be more clear. I don't know how to extract those methods out of the `Formula` class, though.
* In general, I'm not sure it's supposed to be done this way.

Any help or guidance would be appreciated!