### PR TITLE
idnits: update license

### DIFF
--- a/Formula/idnits.rb
+++ b/Formula/idnits.rb
@@ -3,6 +3,7 @@ class Idnits < Formula
   homepage "https://tools.ietf.org/tools/idnits/"
   url "https://tools.ietf.org/tools/idnits/idnits-2.16.05.tgz"
   sha256 "9f30827e0cf7cf02245e248266ece9557886d33ec7a90cc704b450e70f2cead5"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add `GPL-2.0-or-later` license to `idnits`

`copyright` file:

```
idnits is Copyright 2002-2007 Henrik Levkowetz

idnits can be downloaded from html://tools.ietf.org/tools/idnits/

License:
    
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2 of the License, or
    (at your option) any later version.
    
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
    
    You should have received a copy of the GNU General Public License
    along with this program; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
    
    On Debian systems, the complete text of the GNU General
    Public License can be found in '/usr/share/common-licenses/GPL'.
```