### PR TITLE
hamlib: add head, update release location/website

### DIFF
--- a/Formula/hamlib.rb
+++ b/Formula/hamlib.rb
@@ -1,8 +1,10 @@
 class Hamlib < Formula
   desc "Ham radio control libraries"
-  homepage "https://hamlib.sourceforge.io/"
-  url "https://src.fedoraproject.org/repo/pkgs/hamlib/hamlib-3.3.tar.gz/sha512/4cf6c94d0238c8a13aed09413b3f4a027c8ded07f8840cdb2b9d38b39b6395a4a88a8105257015345f6de0658ab8c60292d11a9de3e16a493e153637af630a80/hamlib-3.3.tar.gz"
+  homepage "http://www.hamlib.org/"
+  url "https://github.com/Hamlib/Hamlib/releases/download/3.3/hamlib-3.3.tar.gz"
   sha256 "c90b53949c767f049733b442cd6e0a48648b55d99d4df5ef3f852d985f45e880"
+  license "LGPL-2.1-or-later"
+  head "https://github.com/hamlib/hamlib.git"
 
   bottle do
     cellar :any
@@ -12,11 +14,14 @@ class Hamlib < Formula
     sha256 "eb3ce94a8e752ab792dd306221b74d0a254695d64bd818fbb841ef068b6b7600" => :sierra
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "pkg-config" => :build
   depends_on "libtool"
   depends_on "libusb-compat"
 
   def install
+    system "./bootstrap" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds option to build hamlib from HEAD, and updates website and release locations.

The Hamlib 3.x release series is frozen for recently added radio models, so until then, this is the only way to get support for additional models that have been supported since then.

EDIT: Also adds license information for hamlib since this was autotagged by @BrewTestBot. 