### PR TITLE
cowsay: Don't install offensive ASCII art

### DIFF
--- a/Formula/cowsay.rb
+++ b/Formula/cowsay.rb
@@ -5,6 +5,7 @@ class Cowsay < Formula
   url "https://github.com/tnalpgge/rank-amateur-cowsay/archive/cowsay-3.04.tar.gz"
   sha256 "d8b871332cfc1f0b6c16832ecca413ca0ac14d58626491a6733829e3d655878b"
   license "GPL-3.0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -18,6 +19,12 @@ class Cowsay < Formula
   end
 
   def install
+    # Remove offensive content
+    %w[cows/sodomized.cow cows/telebears.cow].each do |file|
+      rm file
+      inreplace "Files.base", file, ""
+    end
+
     system "/bin/sh", "install.sh", prefix
     mv prefix/"man", share
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- These violate our Code of Conduct.
- Fixes https://github.com/Homebrew/brew/issues/8810.
- I had to remove the files entirely, as well from `make`'s input, otherwise they still appeared in `cowsay -l` even if they were inaccessible.

