### PR TITLE
mtr 0.94

### DIFF
--- a/Formula/mtr.rb
+++ b/Formula/mtr.rb
@@ -1,10 +1,9 @@
 class Mtr < Formula
   desc "'traceroute' and 'ping' in a single tool"
   homepage "https://www.bitwizard.nl/mtr/"
-  url "https://github.com/traviscross/mtr/archive/v0.93.tar.gz"
-  sha256 "3a1ab330104ddee3135af3cfa567b9608001c5deecbf200c08b545ed6d7a4c8f"
+  url "https://github.com/traviscross/mtr/archive/v0.94.tar.gz"
+  sha256 "ea036fdd45da488c241603f6ea59a06bbcfe6c26177ebd34fff54336a44494b8"
   license "GPL-2.0"
-  revision 1
   head "https://github.com/traviscross/mtr.git"
 
   bottle do
@@ -19,12 +18,6 @@ class Mtr < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
-
-  # Pull request submitted upstream as https://github.com/traviscross/mtr/pull/315
-  patch do
-    url "https://github.com/traviscross/mtr/commit/a60f1085287fa8f7634ff0bef88568296a8660e5.patch?full_index=1"
-    sha256 "c67b455198d4ad8269de56464366ed2bbbc5b363ceda0285ee84be40e4893668"
-  end
 
   def install
     # Fix UNKNOWN version reported by `mtr --version`.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Removed patch as the [PR](https://github.com/traviscross/mtr/pull/315) has been merged upstream and landed in the new version.