### PR TITLE
cdktf remove depenecy on terraform

### DIFF
--- a/Formula/cdktf.rb
+++ b/Formula/cdktf.rb
@@ -15,6 +15,7 @@ class Cdktf < Formula
   end
 
   depends_on "node"
+  depends_on "tfenv"
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)

--- a/Formula/cdktf.rb
+++ b/Formula/cdktf.rb
@@ -15,7 +15,6 @@ class Cdktf < Formula
   end
 
   depends_on "node"
-  depends_on "terraform"
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)


### PR DESCRIPTION
I use tfenv to manage multiple installations/versions of terraform.
And I'd like to use homebrew to install cdktf, but it has a hard
depenecy on terraform. This PR removes that depenency.

I think it would be better to have some sort of optional or
recommended depency on terraform or tfenv, but I don't see a way
to do that with homebrew - please correct me if I'm wrong.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
