### PR TITLE
rclone: Add cmount build tag

### DIFF
--- a/Formula/rclone.rb
+++ b/Formula/rclone.rb
@@ -16,7 +16,7 @@ class Rclone < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args
+    system "go", "build", "-tags", "cmount", *std_go_args
     man1.install "rclone.1"
     system bin/"rclone", "genautocomplete", "bash", "rclone.bash"
     system bin/"rclone", "genautocomplete", "zsh", "_rclone"


### PR DESCRIPTION
Signed-off-by: Anagh Kumar Baranwal <6824881+darthShadow@users.noreply.github.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Reference: https://github.com/rclone/rclone/issues/4393

With 1.53, rclone has added the `cmount` build tag to include the `cmount` command. With 1.54, this will replace the `mount` command.
