### PR TITLE
Remove livecheck blocks for deprecated formulae

### DIFF
--- a/Formula/akka.rb
+++ b/Formula/akka.rb
@@ -6,11 +6,6 @@ class Akka < Formula
   license "Apache-2.0"
   revision 1
 
-  livecheck do
-    url "https://github.com/akka/akka/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
-  end
-
   bottle :unneeded
 
   # https://github.com/akka/akka/issues/25046

--- a/Formula/archey.rb
+++ b/Formula/archey.rb
@@ -16,11 +16,6 @@ class Archey < Formula
     end
   end
 
-  livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle :unneeded
 
   deprecate! date: "2017-04-28", because: :repo_archived

--- a/Formula/archey.rb
+++ b/Formula/archey.rb
@@ -1,7 +1,7 @@
 class Archey < Formula
   desc "Graphical system information display for macOS"
   homepage "https://obihann.github.io/archey-osx/"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
   head "https://github.com/obihann/archey-osx.git"
 

--- a/Formula/erlang@20.rb
+++ b/Formula/erlang@20.rb
@@ -6,11 +6,6 @@ class ErlangAT20 < Formula
   sha256 "dce78b60938a48b887317e5222cff946fd4af36666153ab2f0f022aa91755813"
   license "Apache-2.0"
 
-  livecheck do
-    url "https://github.com/erlang/otp.git"
-    regex(/OTP[._-]v?(20(?:\.\d+)+)/i)
-  end
-
   bottle do
     cellar :any
     sha256 "130019a8e459654a92e7267b60932867c8c27957d5bd5b791e358407e6d2755b" => :catalina

--- a/Formula/erlang@20.rb
+++ b/Formula/erlang@20.rb
@@ -28,13 +28,11 @@ class ErlangAT20 < Formula
 
   resource "man" do
     url "https://www.erlang.org/download/otp_doc_man_20.3.tar.gz"
-    mirror "https://fossies.org/linux/misc/legacy/otp_doc_man_20.3.tar.gz"
     sha256 "17e0b2f94f11576a12526614a906ecad629b8804c25e6c18523f7c4346607112"
   end
 
   resource "html" do
     url "https://www.erlang.org/download/otp_doc_html_20.3.tar.gz"
-    mirror "https://fossies.org/linux/misc/legacy/otp_doc_html_20.3.tar.gz"
     sha256 "8099b62e9fa24b3f90eaeda151fa23ae729c8297e7d3fd8adaca865b35a3125d"
   end
 

--- a/Formula/helm@2.rb
+++ b/Formula/helm@2.rb
@@ -6,11 +6,6 @@ class HelmAT2 < Formula
       revision: "47f0b88409e71fd9ca272abc7cd762a56a1c613e"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-    regex(/^v?(2(?:\.\d+)+)$/i)
-  end
-
   bottle do
     cellar :any_skip_relocation
     sha256 "f842166eae515ed30c9f91c0ad27994640332b889fb490c2fe2f4ef818501dac" => :catalina

--- a/Formula/ooniprobe.rb
+++ b/Formula/ooniprobe.rb
@@ -8,10 +8,6 @@ class Ooniprobe < Formula
   license "BSD-2-Clause"
   revision 3
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     cellar :any
     sha256 "9a5d8c8b6bda3609642113631ba7c39b2cbf4fc27b09bd4b2fccc832befdd3e5" => :catalina

--- a/Formula/opencv@2.rb
+++ b/Formula/opencv@2.rb
@@ -6,11 +6,6 @@ class OpencvAT2 < Formula
   license "BSD-3-Clause"
   revision 11
 
-  livecheck do
-    url "https://github.com/opencv/opencv.git"
-    regex(/^(2(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 "180d6d38c261fbb8d8a874fe21018c0ad1fa9e9a526e9234ff5645affe04512f" => :catalina
     sha256 "9beadffa6f23d7c7ea58a501d88e8512a67ac4f0848b8a9920209fc6430ab0ed" => :mojave

--- a/Formula/vsts-cli.rb
+++ b/Formula/vsts-cli.rb
@@ -7,10 +7,6 @@ class VstsCli < Formula
   sha256 "27defe1d8aaa1fcbc3517274c0fdbd42b5ebe2c1c40edfc133d98fe4bb7114de"
   revision 2
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     cellar :any
     sha256 "b37f51f73b543f2c9403e0a982aa1ae625f170b971a75b1ab07a23a62aa01949" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This removes the `livecheck` blocks from deprecated formulae that aren't going to be updated in the future. `livecheck` blocks should be kept (or added) for any deprecated formulae that will continue to receive updates but that's not the case for any of these.

Livecheck will skip deprecated formulae unless the formula contains a `livecheck` block. In this case, we don't want to check these formulae, so it's appropriate to remove the `livecheck` blocks so they're skipped.

I suggested that we may want to create a RuboCop for this (along with an allowlist, to allow some formulae to be updated despite deprecation) in https://github.com/Homebrew/brew/pull/8842#issuecomment-703105746.

---

Besides that, this also addresses the following issues:

* Update the license for `archey` from `GPL-2.0` to `GPL-2.0-or-later` (referencing https://github.com/obihann/archey-osx/blob/master/LICENSE)
* Remove `erlang@20` resource mirrors where the files are no longer found