### PR TITLE
nmap: add license

### DIFF
--- a/Formula/nmap.rb
+++ b/Formula/nmap.rb
@@ -4,6 +4,7 @@ class Nmap < Formula
   url "https://nmap.org/dist/nmap-7.90.tar.bz2"
   sha256 "5557c3458275e8c43e1d0cfa5dad4e71dd39e091e2029a293891ad54098a40e8"
   head "https://svn.nmap.org/nmap/"
+  license "GPL-2.0-only" => { with: "https://nmap.org/book/man-legal.html#nmap-copyright"}
 
   livecheck do
     url "https://nmap.org/dist/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I haven't tried it locally yet because I'm a little confused about how to add a GPL 2 license but with additional clarifications and exceptions described on their website. See https://nmap.org/book/man-legal.html#nmap-copyright for what I'm talking about. 

As of now, I've just specified the license as `GPL-2.0-only` with the link of the legal notice at the map website (the Github Action says its invalid, but I couldn't find anything in https://spdx.org/licenses/exceptions-index.html).

Any help/information would be appreciated. :)

_PS. Just wanted to add that I'm participating in [hacktoberfest](https://hacktoberfest.digitalocean.com/) so if you deem this PR worthy, I'd really appreciate a `hacktoberfest-accepted` label on this PR._