### PR TITLE
structurizr-cli 1.4.4 (new formula)

### DIFF
--- a/Formula/structurizr-cli.rb
+++ b/Formula/structurizr-cli.rb
@@ -1,0 +1,25 @@
+class StructurizrCli < Formula
+  desc "Command-line utility for Structurizr"
+  homepage "https://structurizr.com"
+  url "https://github.com/structurizr/cli/releases/download/v1.4.4/structurizr-cli-1.4.4.zip"
+  sha256 "ac173013c397fd2180a2b8134e29f8dfd3e0884418252433bcc9982e15b03909"
+  license "Apache-2.0"
+
+  bottle :unneeded
+
+  depends_on "openjdk"
+
+  def install
+    libexec.install "structurizr-cli-#{version}.jar"
+    bin.write_jar_script libexec/"structurizr-cli-#{version}.jar", "structurizr-cli"
+  end
+
+  test do
+    expected_output = <<~EOS.strip
+      Structurizr CLI v#{version}
+      Usage: structurizr push|pull|export [options]
+    EOS
+    result = pipe_output("#{bin}/structurizr-cli").strip
+    assert_equal result, expected_output
+  end
+end


### PR DESCRIPTION
Add Structurizr CLI (https://github.com/structurizr/cli), the
command line utility for Structurizr.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
