### PR TITLE
gtksourceview3: fix test

### DIFF
--- a/Formula/gtksourceview3.rb
+++ b/Formula/gtksourceview3.rb
@@ -37,7 +37,7 @@ class Gtksourceview3 < Formula
 
   test do
     (testpath/"test.c").write <<~EOS
-      #include <gtksourceview/gtksourceview.h>
+      #include <gtksourceview/gtksource.h>
 
       int main(int argc, char *argv[]) {
         gchar *text = gtk_source_utils_unescape_search_text("hello world");


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently, a test for `gtksourceview3` fails like this:
```
==> brew test --retry --verbose gtksourceview3
==> FAILED
==> Testing gtksourceview3
/usr/bin/sandbox-exec -f /private/tmp/homebrew20201002-59274-1xlipgm.sb ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gtksourceview3.rb --verbose --retry
==> /usr/bin/clang test.c -o test -I/usr/local/opt/atk/include/atk-1.0 -I/usr/local/opt/cairo/include/cairo -I/usr/local/opt/fontconfig/include -I/usr/local/opt/freetype/include/freetype2 -I/usr/local/opt/gdk-pixbuf/include/gdk-pixbuf-2.0 -I/usr/local/opt/gettext/include -I/usr/local/opt/glib/include/gio-unix-2.0/ -I/usr/local/opt/glib/include/glib-2.0 -I/usr/local/opt/glib/lib/glib-2.0/include -I/usr/local/opt/gtk+3/include/gtk-3.0 -I/usr/local/opt/harfbuzz/include/harfbuzz -I/usr/local/Cellar/gtksourceview3/3.24.11_3/include/gtksourceview-3.0 -I/usr/local/opt/libepoxy/include -I/usr/local/opt/libpng/include/libpng16 -I/usr/local/opt/pango/include/pango-1.0 -I/usr/local/opt/pixman/include/pixman-1 -D_REENTRANT -L/usr/local/opt/atk/lib -L/usr/local/opt/cairo/lib -L/usr/local/opt/gdk-pixbuf/lib -L/usr/local/opt/gettext/lib -L/usr/local/opt/glib/lib -L/usr/local/opt/gtk+3/lib -L/usr/local/Cellar/gtksourceview3/3.24.11_3/lib -L/usr/local/opt/pango/lib -latk-1.0 -lcairo -lcairo-gobject -lgdk-3 -lgdk_pixbuf-2.0 -lgio-2.0 -lglib-2.0 -lgobject-2.0 -lgtk-3 -lgtksourceview-3.0 -lintl -lpango-1.0 -lpangocairo-1.0
In file included from test.c:1:
/usr/local/Cellar/gtksourceview3/3.24.11_3/include/gtksourceview-3.0/gtksourceview/gtksourceview.h:29:6: warning: "Only <gtksourceview/gtksource.h> can be included directly." [-W#warnings]
#    warning "Only <gtksourceview/gtksource.h> can be included directly."
     ^
In file included from test.c:1:
In file included from /usr/local/Cellar/gtksourceview3/3.24.11_3/include/gtksourceview-3.0/gtksourceview/gtksourceview.h:36:
/usr/local/Cellar/gtksourceview3/3.24.11_3/include/gtksourceview-3.0/gtksourceview/gtksourcetypes.h:27:6: warning: "Only <gtksourceview/gtksource.h> can be included directly." [-W#warnings]
#    warning "Only <gtksourceview/gtksource.h> can be included directly."
     ^
test.c:4:17: error: implicit declaration of function 'gtk_source_utils_unescape_search_text' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  gchar *text = gtk_source_utils_unescape_search_text("hello world");
                ^
test.c:4:10: warning: incompatible integer to pointer conversion initializing 'gchar *' (aka 'char *') with an expression of type 'int' [-Wint-conversion]
  gchar *text = gtk_source_utils_unescape_search_text("hello world");
         ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
3 warnings and 1 error generated.
```

From [Xcode 12 Release Notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes): 
> Clang now reports an error when you use a function without an explicit declaration when building C or Objective-C code for macOS (-Werror=implicit-function-declaration flag is on). This additional error detection unifies Clang’s behavior for iOS/tvOS and macOS 64-bit targets for this diagnostic. (49917738)