### PR TITLE
bat: added zsh completion

### DIFF
--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -24,6 +24,7 @@ class Bat < Formula
     assets_dir = Dir["target/release/build/bat-*/out/assets"].first
     man1.install "#{assets_dir}/manual/bat.1"
     fish_completion.install "#{assets_dir}/completions/bat.fish"
+    zsh_completion.install "#{assets_dir}/completions/bat.zsh" => "_bat"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR adds zsh completion to bat.
Do I need to add a revision bump so that zsh completion becomes available to users that already upgraded to the latest version?