### PR TITLE
freexl: fix test

### DIFF
--- a/Formula/freexl.rb
+++ b/Formula/freexl.rb
@@ -31,11 +31,12 @@ class Freexl < Formula
 
   test do
     (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
       #include "freexl.h"
 
       int main()
       {
-          printf(freexl_version());
+          printf("%s", freexl_version());
           return 0;
       }
     EOS


### PR DESCRIPTION
Test failure due to lack of stdio.h header, as seen in https://github.com/Homebrew/homebrew-core/pull/61655

```
test.c:5:5: error: implicitly declaring library function 'printf' with type 'int (const char *, ...)' [-Werror,-Wimplicit-function-declaration]
    printf(freexl_version());
    ^
test.c:5:5: note: include the header <stdio.h> or explicitly provide a declaration for 'printf'
test.c:5:12: warning: format string is not a string literal (potentially insecure) [-Wformat-security]
    printf(freexl_version());
           ^~~~~~~~~~~~~~~~
test.c:5:12: note: treat the string as an argument to avoid this
    printf(freexl_version());
           ^
           "%s", 
```