### PR TITLE
ooni-cli 3.0.7 (new formula)

### DIFF
--- a/Formula/ooni-cli.rb
+++ b/Formula/ooni-cli.rb
@@ -10,10 +10,9 @@ class OoniCli < Formula
   conflicts_with "ooniprobe", because: "old version of the client, installs binary with the same name"
 
   def install
-    system "go", "build", "-ldflags",
-            "-s -w", "-tags", "DISABLE_QUIC",
-            "./cmd/ooniprobe"
-    bin.install "ooniprobe" => "ooniprobe"
+    system "go", "build", "-o", "#{bin}/ooniprobe",
+           "-ldflags", "-s -w", "-tags", "DISABLE_QUIC",
+           "./cmd/ooniprobe"
   end
 
   test do

--- a/Formula/ooni-cli.rb
+++ b/Formula/ooni-cli.rb
@@ -1,0 +1,41 @@
+class OoniCli < Formula
+  desc "Next generation OONI Probe CLI"
+  homepage "https://ooni.org/install"
+  url "https://github.com/ooni/probe-cli/archive/v3.0.7.tar.gz"
+  sha256 "01e1e1a8d7d8fff04a8c098cfd33c84c507cc6efb88c597714b4917b9d0d64e1"
+  license "BSD-3-Clause"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-ldflags",
+            "-s -w", "-tags", "DISABLE_QUIC",
+            "./cmd/ooniprobe"
+    bin.install "ooniprobe" => "ooniprobe"
+  end
+
+  test do
+    (testpath/"config.json").atomic_write <<~EOS
+      {
+        "_": "",
+        "_version": 1,
+        "_informed_consent": true,
+        "sharing": {
+          "include_ip": false,
+          "include_asn": false,
+          "upload_results": false
+        },
+        "nettests": {
+          "websites_url_limit": 1,
+          "websites_enabled_category_codes": ["SRCH"]
+        },
+        "advanced": {
+          "send_crash_reports": false
+        }
+      }
+    EOS
+
+    assert_match "[engine] Accessible",
+      shell_output("ooniprobe run websites --no-collector --config=#{testpath}/config.json")
+  end
+end

--- a/Formula/ooni-cli.rb
+++ b/Formula/ooni-cli.rb
@@ -7,6 +7,8 @@ class OoniCli < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "ooniprobe", because: "old version of the client, installs binary with the same name"
+
   def install
     system "go", "build", "-ldflags",
             "-s -w", "-tags", "DISABLE_QUIC",

--- a/Formula/ooniprobe.rb
+++ b/Formula/ooniprobe.rb
@@ -30,6 +30,8 @@ class Ooniprobe < Formula
   depends_on "openssl@1.1"
   depends_on "tor"
 
+  conflicts_with "ooni-cli", because: "new version of the client, installs binary with the same name"
+
   # these 4 need to come first or else cryptography will let setuptools
   # easy_install them (which is bad)
   resource "cffi" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is the new (go-based) version of the ooniprobe. It can replace the deprecated (Python-based) version which has a [homebrew formula](https://github.com/Homebrew/homebrew-core/tree/master/Formula/ooniprobe.rb). 

The old version has been deprecated for a while now. Therefore I think the new version should be preferred, even though it still lacks some notability.

The name `ooni-cli` was chosen to differentiate the formula of the new version from the old one. If (or when) the formula of the old version is removed, this formula could be renamed to `ooniprobe` as that is the executable's name. 