### PR TITLE
shtools 4.7.1: use openblas instead of -framework accelerate

### DIFF
--- a/Formula/shtools.rb
+++ b/Formula/shtools.rb
@@ -4,6 +4,7 @@ class Shtools < Formula
   url "https://github.com/SHTOOLS/SHTOOLS/archive/v4.7.1.tar.gz"
   sha256 "6ed2130eed7b741df3b19052b29b3324601403581c7b9afb015e0370e299a2bd"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/SHTOOLS/homebrew-shtools.git"
 
   bottle do
@@ -15,6 +16,7 @@ class Shtools < Formula
 
   depends_on "fftw"
   depends_on "gcc"
+  depends_on "openblas"
 
   def install
     system "make", "fortran"
@@ -37,7 +39,7 @@ class Shtools < Formula
                    "LIBPATH=#{HOMEBREW_PREFIX}/lib",
                    "LIBNAME=SHTOOLS",
                    "FFTW=-L #{HOMEBREW_PREFIX}/lib -lfftw3 -lm",
-                   "LAPACK=-framework accelerate",
+                   "LAPACK=-L #{Formula["openblas"].opt_lib} -lopenblas",
                    "BLAS="
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Following the homebrew documentation suggestions, the tests in this formula now link to openblas instead of Apple's Accelerate framework. By linking to openblas, the tests on linuxbrew-core should run as well.