### PR TITLE
game-music-emu: revision bump

### DIFF
--- a/Formula/game-music-emu.rb
+++ b/Formula/game-music-emu.rb
@@ -3,7 +3,7 @@ class GameMusicEmu < Formula
   homepage "https://bitbucket.org/mpyne/game-music-emu"
   url "https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-0.6.3.tar.xz"
   sha256 "aba34e53ef0ec6a34b58b84e28bf8cfbccee6585cebca25333604c35db3e051d"
-  revision 1
+  revision 2
   head "https://bitbucket.org/mpyne/game-music-emu.git"
 
   livecheck do


### PR DESCRIPTION
Trying to understand what's happening with the failure in https://github.com/Homebrew/homebrew-core/pull/61655

```
dyld: Library not loaded: @rpath/libclang_rt.ubsan_osx_dynamic.dylib
  Referenced from: /usr/local/opt/game-music-emu/lib/libgme.0.dylib
  Reason: image not found
```