### PR TITLE
dvc: build rich, flatten-dict from source

### DIFF
--- a/Formula/dvc.rb
+++ b/Formula/dvc.rb
@@ -262,12 +262,6 @@ class Dvc < Formula
       # NOTE: we will uninstall Pillow anyway, so there is no need to build it
       # from source.
       "--only-binary", "Pillow",
-      # NOTE: building rich and flatten-dict requires poetry, which is
-      # problematic. See
-      # https://github.com/Homebrew/homebrew-core/pull/58501
-      # https://github.com/Homebrew/homebrew-core/pull/61103
-      "--only-binary", "rich",
-      "--only-binary", "flatten-dict",
       "--ignore-installed",
       # NOTE: pyarrow is already installed as a part of apache-arrow package,
       # so we don't need to specify `hdfs` option.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`poetry` now builds nicely from source so build resources that require poetry from source as well.