### PR TITLE
nlohmann-json: include json_fwd.hpp

### DIFF
--- a/Formula/nlohmann-json.rb
+++ b/Formula/nlohmann-json.rb
@@ -4,6 +4,7 @@ class NlohmannJson < Formula
   url "https://github.com/nlohmann/json/archive/v3.9.1.tar.gz"
   sha256 "4cf0df69731494668bdd6460ed8cb269b68de9c19ad8c27abc24cd72605b2d5b"
   license "MIT"
+  revision 1
   head "https://github.com/nlohmann/json.git", branch: "develop"
 
   bottle do
@@ -17,7 +18,7 @@ class NlohmannJson < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", "-DJSON_BuildTests=OFF", *std_cmake_args
+      system "cmake", "..", "-DJSON_BuildTests=OFF", "-DJSON_MultipleHeaders=ON", *std_cmake_args
       system "make", "install"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `nlohmann-json` formula has been part of homebrew-core since April 2019.  Currently, the bundled `json.hpp` header is packaged by Homebrew.  However, this is a fairly big header file (314kB).  To optimise compilation times, the `json_fwd.hpp` header (2.1kB) is provided for forward-declaration use.  Unfortunately, this is not currently packaged by Homebrew. This PR aims to mitigate this.

Per `nlohmann-json`'s README.md:

> You can further use file `include/nlohmann/json_fwd.hpp` for forward-declarations. The installation of json_fwd.hpp (as part of cmake’s install step), can be achieved by setting `-DJSON_MultipleHeaders=ON`. 

The existing `json.hpp` will remain packaged, so existing users will not be adversely affected.

Full disclosure: I am filing this PR with https://github.com/OpenRCT2/OpenRCT2/pull/13068 in mind.