### PR TITLE
sdl2: remove patch which has already been merged

### DIFF
--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -1,9 +1,19 @@
 class Sdl2 < Formula
   desc "Low-level access to audio, keyboard, mouse, joystick, and graphics"
   homepage "https://www.libsdl.org/"
-  url "https://libsdl.org/release/SDL2-2.0.12.tar.gz"
-  sha256 "349268f695c02efbc9b9148a70b85e58cefbbf704abd3e91be654db7f1e2c863"
   revision 1
+
+  stable do
+    url "https://libsdl.org/release/SDL2-2.0.12.tar.gz"
+    sha256 "349268f695c02efbc9b9148a70b85e58cefbbf704abd3e91be654db7f1e2c863"
+
+    # Fix library extension in CMake config file.
+    # https://bugzilla.libsdl.org/show_bug.cgi?id=5039
+    patch do
+      url "https://bugzilla.libsdl.org/attachment.cgi?id=4263"
+      sha256 "07ea066e805f82d85e6472e767ba75d265cb262053901ac9a9e22c5f8ff187a5"
+    end
+  end
 
   livecheck do
     url "https://www.libsdl.org/download-2.0.php"
@@ -27,13 +37,6 @@ class Sdl2 < Formula
 
   on_linux do
     depends_on "pkg-config" => :build
-  end
-
-  # Fix library extension in CMake config file.
-  # https://bugzilla.libsdl.org/show_bug.cgi?id=5039
-  patch do
-    url "https://bugzilla.libsdl.org/attachment.cgi?id=4263"
-    sha256 "07ea066e805f82d85e6472e767ba75d265cb262053901ac9a9e22c5f8ff187a5"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR removes a patch which [has already been merged](https://bugzilla.libsdl.org/show_bug.cgi?id=5039#c4) into the main `sdl2` code base.

However, recent, more substantial changes to the code base now result in build failures when installing `sdl2` from ´HEAD´, as the diff is not applicable anymore.
