### PR TITLE
fleet-cli 0.3.0 (new formula)

### DIFF
--- a/Formula/fleet-cli.rb
+++ b/Formula/fleet-cli.rb
@@ -1,0 +1,27 @@
+class FleetCli < Formula
+  desc "Manage large fleets of Kubernetes clusters"
+  homepage "https://github.com/rancher/fleet"
+  url "https://github.com/rancher/fleet.git",
+    tag:      "v0.3.0",
+    revision: "55cda24b980e8539f827af521ed59771ac681d86"
+  license "Apache-2.0"
+
+  livecheck do
+    url "https://github.com/rancher/fleet/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
+  depends_on "go" => :build
+
+  def install
+    commit = Utils.safe_popen_read("git", "rev-parse", "--short", "HEAD").chomp
+    system "go", "build", "-ldflags",
+           "-X github.com/rancher/fleet/pkg/version.Version=#{version} -X github.com/rancher/fleet/pkg/version.GitCommit=#{commit}",
+           "-o", bin/"fleet"
+  end
+
+  test do
+    system "git", "clone", "https://github.com/rancher/fleet-examples"
+    assert_match "kind: Deployment", shell_output("#{bin}/fleet test fleet-examples/simple 2>&1")
+  end
+end

--- a/Formula/fleet-cli.rb
+++ b/Formula/fleet-cli.rb
@@ -15,7 +15,7 @@ class FleetCli < Formula
 
   def install
     commit = Utils.safe_popen_read("git", "rev-parse", "--short", "HEAD").chomp
-    system "go", "build", "-ldflags",
+    system "go", "build", *std_go_args, "-ldflags",
            "-X github.com/rancher/fleet/pkg/version.Version=#{version} -X github.com/rancher/fleet/pkg/version.GitCommit=#{commit}",
            "-o", bin/"fleet"
   end


### PR DESCRIPTION
Fleet (https://github.com/rancher/fleet) is a controller to manage a large fleet of Kubernetes clusters centrally with a GitOps approach. The fleet-cli can be used to interact with the fleet controller running inside a cluster.
Fleet is already included into Rancher (https://github.com/rancher/rancher) as of 2.5.0 (https://github.com/rancher/rancher/releases/tag/v2.5.0).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
