### PR TITLE
helm@2: add deprecation date, restore livecheck

### DIFF
--- a/Formula/helm@2.rb
+++ b/Formula/helm@2.rb
@@ -6,6 +6,13 @@ class HelmAT2 < Formula
       revision: "47f0b88409e71fd9ca272abc7cd762a56a1c613e"
   license "Apache-2.0"
 
+  # NOTE: Remove this livecheck block after deprecation takes effect, so we
+  # don't unnecessarily check for updates.
+  livecheck do
+    url :stable
+    regex(/^v?(2(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "f842166eae515ed30c9f91c0ad27994640332b889fb490c2fe2f4ef818501dac" => :catalina
@@ -15,8 +22,8 @@ class HelmAT2 < Formula
 
   keg_only :versioned_formula
 
-  # https://github.com/helm/helm/issues/2466#issuecomment-691177445
-  deprecate! because: :unsupported
+  # See: https://helm.sh/blog/helm-v2-deprecation-timeline/
+  deprecate! date: "2020-11-13", because: :deprecated_upstream
 
   depends_on "glide" => :build
   depends_on "go" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is one of two formulae that use `deprecate!` without a date and have been updated since `deprecate!` was added to the formula. In this case, [upstream has published a deprecation date for the v2 series](https://helm.sh/blog/helm-v2-deprecation-timeline/), so I've updated the call to `deprecate!` to include a date. Additionally, I've updated the `because` reason from `unsupported` to `deprecated_upstream`, as it seems like it may be more appropriate in this context.

There will be v2 security patches in the interim time until the deprecation takes effect, so I've temporarily restored the `livecheck` block. Once the deprecation takes effect, the `livecheck` block should be removed again (as there won't be further updates and we shouldn't waste effort checking).