### PR TITLE
Migrate airshare to python@3.9

### DIFF
--- a/Formula/airshare.rb
+++ b/Formula/airshare.rb
@@ -6,6 +6,7 @@ class Airshare < Formula
   url "https://files.pythonhosted.org/packages/cb/a2/d59c18cd6a143bf860c29acb70552b7351fd7e0f56213be86b624601106b/Airshare-0.1.6.tar.gz"
   sha256 "138976933bcf2c0bc99f18901242544919e9fafe43735b4f83b19d4ae5964be7"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable
@@ -18,7 +19,7 @@ class Airshare < Formula
     sha256 "4bfcf320c69005e2be499bb6e19d5fe1243354d72132e1e1935e5ce563e2aac8" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "aiohttp" do
     url "https://files.pythonhosted.org/packages/00/94/f9fa18e8d7124d7850a5715a0b9c0584f7b9375d331d35e157cee50f27cc/aiohttp-3.6.2.tar.gz"


### PR DESCRIPTION
First try of a script to migrate formulas to python 3.9