### PR TITLE
asciinema: migrate to python@3.9

### DIFF
--- a/Formula/asciinema.rb
+++ b/Formula/asciinema.rb
@@ -6,7 +6,7 @@ class Asciinema < Formula
   url "https://files.pythonhosted.org/packages/a7/71/771c859795e02c71c187546f34f7535487b97425bc1dad1e5f6ad2651357/asciinema-2.0.2.tar.gz"
   sha256 "32f2c1a046564e030708e596f67e0405425d1eca9d5ec83cd917ef8da06bc423"
   license "GPL-3.0"
-  revision 2
+  revision 3
   head "https://github.com/asciinema/asciinema.git"
 
   livecheck do
@@ -21,7 +21,7 @@ class Asciinema < Formula
     sha256 "1a941e2c0594a7c0a07c66f02c411e121ed2b3e869f3f015c6e69cb4fd92daba" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)