### PR TITLE
ykpers: backport device access fix

### DIFF
--- a/Formula/ykpers.rb
+++ b/Formula/ykpers.rb
@@ -4,7 +4,7 @@ class Ykpers < Formula
   url "https://developers.yubico.com/yubikey-personalization/Releases/ykpers-1.20.0.tar.gz"
   sha256 "0ec84d0ea862f45a7d85a1a3afe5e60b8da42df211bb7d27a50f486e31a79b93"
   license "BSD-2-Clause"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://developers.yubico.com/yubikey-personalization/Releases/"
@@ -30,6 +30,11 @@ class Ykpers < Formula
   patch do
     url "https://github.com/Yubico/yubikey-personalization/commit/0aa2e2cae2e1777863993a10c809bb50f4cde7f8.patch?full_index=1"
     sha256 "349064c582689087ad1f092e95520421562c70ff4a45e411e86878b63cf8f8bd"
+  end
+  # Fix device access issues on macOS Catalina and later. Remove with the next release.
+  patch do
+    url "https://github.com/Yubico/yubikey-personalization/commit/7ee7b1131dd7c64848cbb6e459185f29e7ae1502.patch?full_index=1"
+    sha256 "bf3efe66c3ef10a576400534c54fc7bf68e90d79332f7f4d99ef7c1286267d22"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See: Yubico/yubico-pam#201 Yubico/yubikey-personalization#165

PS: `brew audit` warned about `system "make", "check"`, which is not related to this PR.