### PR TITLE
SwiftGen 6.4.0

### DIFF
--- a/Formula/swiftgen.rb
+++ b/Formula/swiftgen.rb
@@ -2,8 +2,8 @@ class Swiftgen < Formula
   desc "Swift code generator for assets, storyboards, Localizable.strings, …"
   homepage "https://github.com/SwiftGen/SwiftGen"
   url "https://github.com/SwiftGen/SwiftGen.git",
-      tag:      "6.3.0",
-      revision: "f79fa84e7088cdcadf43c69cd1f4e96d996ce171"
+      tag:      "6.4.0",
+      revision: "0c67b63f43814a8d7eb71f685f0bf504b03223f3"
   license "MIT"
   head "https://github.com/SwiftGen/SwiftGen.git", branch: "develop"
 
@@ -13,7 +13,7 @@ class Swiftgen < Formula
   end
 
   depends_on "ruby" => :build if MacOS.version <= :sierra
-  depends_on xcode: ["11.4", :build]
+  depends_on xcode: ["12.0", :build]
 
   def install
     # Disable swiftlint build phase to avoid build errors if versions mismatch


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

~Getting some issues locally with `brew install --build-from-source`, which seem to be Xcode related. Could just be my device, let's see if CI gets the same issue.~ Fixed! Leaving the notes below for posterity.

-----

To clarify, when I try `brew install --build-from-source -d` locally, I'm getting a build failure during the Xcode build (inside our `rake cli:install` step). It's failing for some reason on a missing Info.plist, but when I debug that step, the file is there. Error is this:

> ▸ Linking swiftgen
> 
> ❌  error: Build input file cannot be found: '/private/tmp/swiftgen-20201007-84951-175ao4f/build/Build/Products/Release/swiftgen.app/Contents/Info.plist' (in target 'swiftgen' from project 'SwiftGen')

When I try `rake cli:install` directly, or from inside that brew debug shell, it just works...