### PR TITLE
bento4: migrate to python@3.9

### DIFF
--- a/Formula/bento4.rb
+++ b/Formula/bento4.rb
@@ -4,7 +4,7 @@ class Bento4 < Formula
   url "https://www.bok.net/Bento4/source/Bento4-SRC-1-6-0-632.zip"
   version "1.6.0-632"
   sha256 "faa3a406dc24c3d34d29661bbbe94b42c7f7deee9a5c624696a055bb9b7da6ad"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +14,7 @@ class Bento4 < Formula
   end
 
   depends_on xcode: :build
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   on_linux do
     depends_on "cmake" => :build


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12