### PR TITLE
buku: migrate to python@3.9

### DIFF
--- a/Formula/buku.rb
+++ b/Formula/buku.rb
@@ -6,6 +6,7 @@ class Buku < Formula
   url "https://github.com/jarun/buku/archive/v4.4.tar.gz"
   sha256 "c7d755569117ceb85fdda734dcca657e01f6d5252d7d3b9f757faeedfdcac741"
   license "GPL-3.0"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,7 +16,7 @@ class Buku < Formula
   end
 
   depends_on "openssl@1.1"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   uses_from_macos "expect" => :test
   uses_from_macos "libffi"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12