### PR TITLE
bumpversion: migrate to python@3.9

### DIFF
--- a/Formula/bumpversion.rb
+++ b/Formula/bumpversion.rb
@@ -8,6 +8,7 @@ class Bumpversion < Formula
   url "https://github.com/c4urself/bump2version/archive/v1.0.0.tar.gz"
   sha256 "06a7cb0fb7155b9283c4d10180e477f658754595b4dedb249f1e143e899d0e6c"
   license "MIT"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +17,7 @@ class Bumpversion < Formula
     sha256 "0ef3a9a86d8504dc510d4ccff21d71b832335abb7d7c739b5e514ef654b3900c" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12