### PR TITLE
codemod: migrate to python@3.9

### DIFF
--- a/Formula/codemod.rb
+++ b/Formula/codemod.rb
@@ -6,7 +6,7 @@ class Codemod < Formula
   url "https://files.pythonhosted.org/packages/9b/e3/cb31bfcf14f976060ea7b7f34135ebc796cde65eba923f6a0c4b71f15cc2/codemod-1.0.0.tar.gz"
   sha256 "06e8c75f2b45210dd8270e30a6a88ae464b39abd6d0cab58a3d7bfd1c094e588"
   license "Apache-2.0"
-  revision 3
+  revision 4
   version_scheme 1
   head "https://github.com/facebook/codemod.git"
 
@@ -21,7 +21,7 @@ class Codemod < Formula
     sha256 "31f1ef7e3e6867ef52f0922c807762363b3a4f1c520b0de5bbd448282f95a5e5" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12