### PR TITLE
cookiecutter: migrate to python@3.9

### DIFF
--- a/Formula/cookiecutter.rb
+++ b/Formula/cookiecutter.rb
@@ -6,6 +6,7 @@ class Cookiecutter < Formula
   url "https://github.com/cookiecutter/cookiecutter/archive/1.7.2.tar.gz"
   sha256 "32d176621bbbe76f11012e015930d2382f0fbe803362091e79a5dddbf5612abc"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/cookiecutter/cookiecutter.git"
 
   bottle do
@@ -15,7 +16,7 @@ class Cookiecutter < Formula
     sha256 "ced26761fb874fe209564d63067b40713ae17de01c7bb16baed6b8e75675abc6" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "arrow" do
     url "https://files.pythonhosted.org/packages/17/d0/8a69308a5cf4f07c53dca744402606610ec910dda1a9cdc94b3fc4a0c3a5/arrow-0.15.5.tar.gz"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12