### PR TITLE
credstash: migrate to python@3.9

### DIFF
--- a/Formula/credstash.rb
+++ b/Formula/credstash.rb
@@ -6,6 +6,7 @@ class Credstash < Formula
   url "https://github.com/fugue/credstash/releases/download/v1.17.1/credstash-1.17.1.tar.gz"
   sha256 "6c04e8734ef556ab459018da142dd0b244093ef176b3be5583e582e9a797a120"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/fugue/credstash.git"
 
   bottle do
@@ -16,7 +17,7 @@ class Credstash < Formula
   end
 
   depends_on "openssl@1.1"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   uses_from_macos "libffi"
 


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12