### PR TITLE
ctemplate: migrate to python@3.9

### DIFF
--- a/Formula/ctemplate.rb
+++ b/Formula/ctemplate.rb
@@ -4,6 +4,7 @@ class Ctemplate < Formula
   url "https://github.com/OlafvdSpek/ctemplate/archive/ctemplate-2.4.tar.gz"
   sha256 "ccc4105b3dc51c82b0f194499979be22d5a14504f741115be155bd991ee93cfa"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/olafvdspek/ctemplate.git"
 
   bottle do
@@ -16,7 +17,7 @@ class Ctemplate < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "python@3.8" => :build
+  depends_on "python@3.9" => :build
 
   def install
     system "./autogen.sh"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12