### PR TITLE
deheader: migrate to python@3.9

### DIFF
--- a/Formula/deheader.rb
+++ b/Formula/deheader.rb
@@ -6,7 +6,7 @@ class Deheader < Formula
   url "http://www.catb.org/~esr/deheader/deheader-1.7.tar.gz"
   sha256 "6856e4fa3efa664a0444b81c2e1f0209103be3b058455625c79abe65cf8db70d"
   license "BSD-2-Clause"
-  revision 1
+  revision 2
   head "https://gitlab.com/esr/deheader.git"
 
   bottle do
@@ -17,7 +17,7 @@ class Deheader < Formula
   end
 
   depends_on "xmlto" => :build
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   on_linux do
     depends_on "libarchive" => :build


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12