### PR TITLE
doitlive: migrate to python@3.9

### DIFF
--- a/Formula/doitlive.rb
+++ b/Formula/doitlive.rb
@@ -5,7 +5,7 @@ class Doitlive < Formula
   homepage "https://doitlive.readthedocs.io/en/latest/"
   url "https://files.pythonhosted.org/packages/e5/d9/4ce969d98f521c253ec3b15a0c759104a01061ac90fb9d8636b015bcb4ea/doitlive-4.3.0.tar.gz"
   sha256 "4cb1030e082d8649f10a61d599d3ff3bcad7f775e08f0e68ee06882e06d0190f"
-  revision 8
+  revision 9
 
   livecheck do
     url :stable
@@ -18,7 +18,7 @@ class Doitlive < Formula
     sha256 "6362e404ef2f1af74b0a564186b5a16967f140ba549fda494c286143dd387bbe" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "click" do
     url "https://files.pythonhosted.org/packages/4e/ab/5d6bc3b697154018ef196f5b17d958fac3854e2efbc39ea07a284d4a6a9b/click-7.1.1.tar.gz"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12