### PR TITLE
eg-examples: migrate to python@3.9

### DIFF
--- a/Formula/eg-examples.rb
+++ b/Formula/eg-examples.rb
@@ -6,6 +6,7 @@ class EgExamples < Formula
   url "https://files.pythonhosted.org/packages/59/06/7281154a4cd961f56302d9cac300cc8fc965b16d04ce797ed622a2f53586/eg-1.2.0.tar.gz"
   sha256 "ac9827824c2c9aee0fd0a54ca57440021a0a87868b503b215c2c273a035bef59"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable
@@ -18,7 +19,7 @@ class EgExamples < Formula
     sha256 "ea5150fcaec60e13589296f700b39aa7ee1b210f989bea1deee548fdeaf849b5" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12