### PR TITLE
euler-py: migrate to python@3.9

### DIFF
--- a/Formula/euler-py.rb
+++ b/Formula/euler-py.rb
@@ -4,6 +4,7 @@ class EulerPy < Formula
   url "https://github.com/iKevinY/EulerPy/archive/v1.4.0.tar.gz"
   sha256 "0d2f633bc3985c8acfd62bc76ff3f19d0bfb2274f7873ec7e40c2caef315e46d"
   license "MIT"
+  revision 1
   head "https://github.com/iKevinY/EulerPy.git"
 
   bottle do
@@ -13,7 +14,7 @@ class EulerPy < Formula
     sha256 "e6bdba6e4de38fad5949439b3699fd81784f51c6e7ef211697e04c805e9a1264" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "click" do
     url "https://files.pythonhosted.org/packages/7b/61/80731d6bbf0dd05fe2fe9bac02cd7c5e3306f5ee19a9e6b9102b5784cf8c/click-4.0.tar.gz"
@@ -21,7 +22,7 @@ class EulerPy < Formula
   end
 
   def install
-    ENV["PYTHON"] = Formula["python@3.8"].opt_bin/"python3"
+    ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
 
     xy = Language::Python.major_minor_version "python3"
     ENV.prepend_create_path "PYTHONPATH", "#{libexec}/lib/python#{xy}/site-packages"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12