### PR TITLE
eye-d3: migrate to python@3.9

### DIFF
--- a/Formula/eye-d3.rb
+++ b/Formula/eye-d3.rb
@@ -4,9 +4,10 @@ class EyeD3 < Formula
   desc "Work with ID3 metadata in .mp3 files"
   homepage "https://eyed3.nicfit.net/"
   url "https://eyed3.nicfit.net/releases/eyeD3-0.9.5.tar.gz"
+  mirror "https://files.pythonhosted.org/packages/3a/7a/07fc7a0e4f7913f599dae950ea5024f006ccef2bc1bbffba288ed8fdfcab/eyeD3-0.9.5.tar.gz"
   sha256 "faf5806197f2093e82c2830d41f2378f07b3a9da07a16fafb14fc6fbdebac50a"
   license "GPL-3.0"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://eyed3.nicfit.net/releases/"
@@ -20,7 +21,7 @@ class EyeD3 < Formula
     sha256 "643842f3f4a5d4f2598765ad8b4ec44180ecd530d9f91f606c9dc182ca264116" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   # Looking for documentation? Please submit a PR to build some!
   # See https://github.com/Homebrew/homebrew/issues/32770 for previous attempt.


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12