### PR TITLE
fades: migrate to python@3.9

### DIFF
--- a/Formula/fades.rb
+++ b/Formula/fades.rb
@@ -4,6 +4,7 @@ class Fades < Formula
   url "https://files.pythonhosted.org/packages/cd/b0/381b14139b36dcbd317349ce7c2bd2e2a66bfc772d13e568d71f3d98d977/fades-9.0.tar.gz"
   sha256 "77192b76efbd08dfabce65fe6012805a2383ec1b893c12091efe35fbfd9677f6"
   license "GPL-3.0"
+  revision 1
   head "https://github.com/PyAr/fades.git"
 
   livecheck do
@@ -17,7 +18,7 @@ class Fades < Formula
     sha256 "89d1989f379c15d5ad71b60fdb11422da663f371e6353028ec36df258d2aca72" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     pyver = Language::Python.major_minor_version "python3"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12