### PR TITLE
fbi-servefiles: migrate to python@3.9

### DIFF
--- a/Formula/fbi-servefiles.rb
+++ b/Formula/fbi-servefiles.rb
@@ -6,7 +6,7 @@ class FbiServefiles < Formula
   url "https://github.com/Steveice10/FBI/archive/2.6.0.tar.gz"
   sha256 "4948d4c53d754cc411b51edbf35c609ba514ae21d9d0e8f4b66a26d5c666be68"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -15,10 +15,10 @@ class FbiServefiles < Formula
     sha256 "b0aae581bf9247f6e282df341dfcffed362587539e7a443433d376319837961f" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
-    venv = virtualenv_create(libexec, Formula["python@3.8"].opt_bin/"python3")
+    venv = virtualenv_create(libexec, Formula["python@3.9"].opt_bin/"python3")
     venv.pip_install_and_link buildpath/"servefiles"
   end
 


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12