### PR TITLE
fpp: migrate to python@3.9

### DIFF
--- a/Formula/fpp.rb
+++ b/Formula/fpp.rb
@@ -4,12 +4,12 @@ class Fpp < Formula
   url "https://github.com/facebook/PathPicker/releases/download/0.9.2/fpp.0.9.2.tar.gz"
   sha256 "f2b233b1e18bdafb1cd1728305e926aabe217406e65091f1e58589e6157e1952"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/facebook/pathpicker.git"
 
   bottle :unneeded
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     # we need to copy the bash file and source python files


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12