### PR TITLE
ginac: migrate to python@3.9

### DIFF
--- a/Formula/ginac.rb
+++ b/Formula/ginac.rb
@@ -4,6 +4,7 @@ class Ginac < Formula
   url "https://www.ginac.de/ginac-1.7.11.tar.bz2"
   sha256 "96529ddef6ae9788aca0093f4b85fc4e34318bc6704e628e6423ab5a92dfe929"
   license "GPL-2.0"
+  revision 1
 
   bottle do
     cellar :any
@@ -14,7 +15,7 @@ class Ginac < Formula
 
   depends_on "pkg-config" => :build
   depends_on "cln"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "readline"
 
   def install


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12