### PR TITLE
git-filter-repo: migrate to python@3.9

### DIFF
--- a/Formula/git-filter-repo.rb
+++ b/Formula/git-filter-repo.rb
@@ -6,6 +6,7 @@ class GitFilterRepo < Formula
   url "https://github.com/newren/git-filter-repo/releases/download/v2.28.0/git-filter-repo-2.28.0.tar.xz"
   sha256 "fdee8d2138d31d10d821bb05e9be52dd2ecc4e7f08b5c2d1451dda1aa6814669"
   license "MIT"
+  revision 1
 
   bottle :unneeded
 
@@ -14,7 +15,7 @@ class GitFilterRepo < Formula
   # But we require Git 2.22.0+
   # https://github.com/Homebrew/homebrew-core/pull/46550#issuecomment-563229479
   depends_on "git"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     rewrite_shebang detected_python_shebang, "git-filter-repo"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12