### PR TITLE
grc: migrate to python@3.9

### DIFF
--- a/Formula/grc.rb
+++ b/Formula/grc.rb
@@ -6,12 +6,12 @@ class Grc < Formula
   url "https://github.com/garabik/grc/archive/v1.11.3.tar.gz"
   sha256 "b167babd8f073a68f5a3091f833e4036fb8d86504e746694747a3ee5048fa7a9"
   license "GPL-2.0"
-  revision 1
+  revision 2
   head "https://github.com/garabik/grc.git"
 
   bottle :unneeded
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   conflicts_with "cc65", because: "both install `grc` binaries"
 


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12