### PR TITLE
hashpump: migrate to python@3.9

### DIFF
--- a/Formula/hashpump.rb
+++ b/Formula/hashpump.rb
@@ -4,7 +4,7 @@ class Hashpump < Formula
   url "https://github.com/bwall/HashPump/archive/v1.2.0.tar.gz"
   sha256 "d002e24541c6604e5243e5325ef152e65f9fcd00168a9fa7a06ad130e28b811b"
   license "MIT"
-  revision 4
+  revision 5
 
   livecheck do
     url "https://github.com/bwall/HashPump/releases/latest"
@@ -19,7 +19,7 @@ class Hashpump < Formula
   end
 
   depends_on "openssl@1.1"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   # Remove on next release
   patch do


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12