### PR TITLE
honcho: migrate to python@3.9

### DIFF
--- a/Formula/honcho.rb
+++ b/Formula/honcho.rb
@@ -4,7 +4,7 @@ class Honcho < Formula
   url "https://github.com/nickstenning/honcho/archive/v1.0.1.tar.gz"
   sha256 "3271f986ff7c4732cfd390383078bfce68c46f9ad74f1804c1b0fc6283b13f7e"
   license "MIT"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any_skip_relocation
@@ -13,7 +13,7 @@ class Honcho < Formula
     sha256 "986c98221b9bb025b0c8fa8c1f4ca150ee1853488f6060b603c54aa7e02c8be1" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     xy = Language::Python.major_minor_version "python3"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12