### PR TITLE
iproute2mac: migrate to python@3.9

### DIFF
--- a/Formula/iproute2mac.rb
+++ b/Formula/iproute2mac.rb
@@ -6,10 +6,11 @@ class Iproute2mac < Formula
   url "https://github.com/brona/iproute2mac/releases/download/v1.3.0/iproute2mac-1.3.0.tar.gz"
   sha256 "3fefce6b0f5e166355fdb04934cbdd906211b64e5adb6a385469696dc51233b7"
   license "MIT"
+  revision 1
 
   bottle :unneeded
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     bin.install "src/ip.py" => "ip"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12