### PR TITLE
jinja2-cli: migrate to python@3.9

### DIFF
--- a/Formula/jinja2-cli.rb
+++ b/Formula/jinja2-cli.rb
@@ -6,7 +6,7 @@ class Jinja2Cli < Formula
   url "https://files.pythonhosted.org/packages/23/67/6f05f5f8a9fc108c58e4eac9b9b7876b400985d33149fe2faa87a9ca502b/jinja2-cli-0.7.0.tar.gz"
   sha256 "9ccd8d530dad5d031230afd968cf54637b49842a13ececa6e17c2f67f6e9336e"
   license "BSD-2-Clause"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -19,7 +19,7 @@ class Jinja2Cli < Formula
     sha256 "972f68142054b8201968d19962ad237b29f9ab2d15b1f5b7b27d5798685db797" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "jinja2" do
     url "https://files.pythonhosted.org/packages/93/ea/d884a06f8c7f9b7afbc8138b762e80479fb17aedbbe2b06515a12de9378d/Jinja2-2.10.1.tar.gz"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12