### PR TITLE
jrnl: migrate to python@3.9

### DIFF
--- a/Formula/jrnl.rb
+++ b/Formula/jrnl.rb
@@ -6,6 +6,7 @@ class Jrnl < Formula
   url "https://files.pythonhosted.org/packages/be/56/20e494eb2a7be914f05c43048ed1e42bc3eb34515319aa1a72e5fabb7d98/jrnl-2.4.5.tar.gz"
   sha256 "a5f069efcaa3f5d95cc7712178b3f92915f67eed4034e5f257cc063c6b0e74d9"
   license "GPL-3.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -19,7 +20,7 @@ class Jrnl < Formula
     sha256 "1c05607e857fa8d9f04732a76df2f76cfc1396f70425dbb2a572aa5c10e492ff" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   uses_from_macos "expect" => :test
 


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12