### PR TITLE
link-grammar: migrate to python@3.9

### DIFF
--- a/Formula/link-grammar.rb
+++ b/Formula/link-grammar.rb
@@ -4,6 +4,7 @@ class LinkGrammar < Formula
   url "https://www.abisource.com/downloads/link-grammar/5.8.0/link-grammar-5.8.0.tar.gz"
   sha256 "ad65a6b47ca0665b814430a5a8ff4de51f4805f7fb76642ced90297b4e7f16ed"
   license "LGPL-2.1"
+  revision 1
 
   livecheck do
     url :homepage
@@ -22,7 +23,7 @@ class LinkGrammar < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.8" => :build
+  depends_on "python@3.9" => :build
 
   uses_from_macos "sqlite"
 


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12