### PR TITLE
lizard-analyzer: migrate to python@3.9

### DIFF
--- a/Formula/lizard-analyzer.rb
+++ b/Formula/lizard-analyzer.rb
@@ -5,6 +5,7 @@ class LizardAnalyzer < Formula
   homepage "http://www.lizard.ws"
   url "https://files.pythonhosted.org/packages/ef/bc/c9b66e557203f2a6f5cf3eb704c640e433385dda639c1b2da56b966f9c42/lizard-1.17.4.tar.gz"
   sha256 "ae9485f66e824756a82589e0d9effe58826c3d9f66c9a59b93343d5a8c5ef5a5"
+  revision 1
 
   livecheck do
     url :stable
@@ -17,7 +18,7 @@ class LizardAnalyzer < Formula
     sha256 "2571285d55aa0c1653d78594291159f04898d7a0529701fca7f75dacd7e145c3" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12