### PR TITLE
macvim: migrate to python@3.9

### DIFF
--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -6,6 +6,7 @@ class Macvim < Formula
   version "8.2-166"
   sha256 "d9745f01c45fb2c1c99ce3b74bf1db6b888805bbb2d2a570bfb5742828ca601a"
   license "Vim"
+  revision 1
   head "https://github.com/macvim-dev/macvim.git"
 
   bottle do
@@ -18,7 +19,7 @@ class Macvim < Formula
   depends_on "cscope"
   depends_on "gettext"
   depends_on "lua"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "ruby"
 
   conflicts_with "vim",
@@ -66,7 +67,7 @@ class Macvim < Formula
     assert_match "+gettext", output
 
     # Simple test to check if MacVim was linked to Homebrew's Python 3
-    py3_exec_prefix = shell_output(Formula["python@3.8"].opt_bin/"python3-config --exec-prefix")
+    py3_exec_prefix = shell_output(Formula["python@3.9"].opt_bin/"python3-config --exec-prefix")
     assert_match py3_exec_prefix.chomp, output
     (testpath/"commands.vim").write <<~EOS
       :python3 import vim; vim.current.buffer[0] = 'hello python3'


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12