### PR TITLE
nicovideo-dl: migrate to python@3.9

### DIFF
--- a/Formula/nicovideo-dl.rb
+++ b/Formula/nicovideo-dl.rb
@@ -6,11 +6,11 @@ class NicovideoDl < Formula
   # Canonical: https://osdn.net/dl/nicovideo-dl/nicovideo-dl-0.0.20190126.tar.gz
   url "https://dotsrc.dl.osdn.net/osdn/nicovideo-dl/70568/nicovideo-dl-0.0.20190126.tar.gz"
   sha256 "886980d154953bc5ff5d44758f352ce34d814566a83ceb0b412b8d2d51f52197"
-  revision 1
+  revision 2
 
   bottle :unneeded
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     rewrite_shebang detected_python_shebang, "nicovideo-dl"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12