### PR TITLE
pius: migrate to python@3.9

### DIFF
--- a/Formula/pius.rb
+++ b/Formula/pius.rb
@@ -6,7 +6,7 @@ class Pius < Formula
   url "https://github.com/jaymzh/pius/archive/v3.0.0.tar.gz"
   sha256 "3454ade5540687caf6d8b271dd18eb773a57ab4f5503fc71b4769cc3c5f2b572"
   license "GPL-2.0"
-  revision 1
+  revision 2
   head "https://github.com/jaymzh/pius.git"
 
   bottle do
@@ -17,7 +17,7 @@ class Pius < Formula
   end
 
   depends_on "gnupg"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     # Replace hardcoded gpg path (WONTFIX)


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12