### PR TITLE
poetry: migrate to python@3.9

### DIFF
--- a/Formula/poetry.rb
+++ b/Formula/poetry.rb
@@ -6,6 +6,7 @@ class Poetry < Formula
   url "https://files.pythonhosted.org/packages/1b/e0/1f0edd3214986fb58ccda90acf43af763d31556499697b72f11186c5b1b1/poetry-1.1.0.tar.gz"
   sha256 "0a05625681c530c1ba3ffe0ae5b612de3a0434fd0a043259481da01b48e9b24a"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable
@@ -18,7 +19,7 @@ class Poetry < Formula
     sha256 "48383f505d280b96450ccfc0eee1df435b0c51528808a1533bba38ffab58cff7" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "appdirs" do
     url "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz"
@@ -177,22 +178,22 @@ class Poetry < Formula
   end
 
   def install
-    xy = Language::Python.major_minor_version Formula["python@3.8"].opt_bin/"python3"
+    xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
 
     vendor_site_packages = libexec/"vendor/lib/python#{xy}/site-packages"
     ENV.prepend_create_path "PYTHONPATH", vendor_site_packages
     resources.each do |r|
       r.stage do
-        system Formula["python@3.8"].opt_bin/"python3", *Language::Python.setup_install_args(libexec/"vendor")
+        system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec/"vendor")
       end
     end
 
     site_packages = libexec/"lib/python#{xy}/site-packages"
     ENV.prepend_create_path "PYTHONPATH", site_packages
-    system Formula["python@3.8"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)
+    system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)
 
     (bin/"poetry").write <<~PYTHON
-      #!#{Formula["python@3.8"].opt_bin/"python3"}
+      #!#{Formula["python@3.9"].opt_bin/"python3"}
       import sys
 
       sys.path.insert(0, "#{site_packages}")


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12