### PR TITLE
ponysay: migrate to python@3.9

### DIFF
--- a/Formula/ponysay.rb
+++ b/Formula/ponysay.rb
@@ -2,7 +2,7 @@ class Ponysay < Formula
   desc "Cowsay but with ponies"
   homepage "https://github.com/erkin/ponysay/"
   license "GPL-3.0"
-  revision 5
+  revision 6
   head "https://github.com/erkin/ponysay.git"
 
   stable do
@@ -25,7 +25,7 @@ class Ponysay < Formula
 
   depends_on "gzip" => :build
   depends_on "coreutils"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   uses_from_macos "texinfo" => :build
 
@@ -35,7 +35,7 @@ class Ponysay < Formula
            "--prefix=#{prefix}",
            "--cache-dir=#{prefix}/var/cache",
            "--sysconf-dir=#{prefix}/etc",
-           "--with-custom-env-python=#{Formula["python@3.8"].opt_bin}/python3",
+           "--with-custom-env-python=#{Formula["python@3.9"].opt_bin}/python3",
            "install"
   end
 


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12