### PR TITLE
pygments: migrate to python@3.9

### DIFF
--- a/Formula/pygments.rb
+++ b/Formula/pygments.rb
@@ -6,6 +6,7 @@ class Pygments < Formula
   url "https://files.pythonhosted.org/packages/e2/07/25bd93c9c0175adfa5fb1513a20b25e7dd6c9a67c155e19b11b5f3662104/Pygments-2.7.1.tar.gz"
   sha256 "926c3f319eda178d1bd90851e4317e6d8cdb5e292a3386aac9bd75eca29cf9c7"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/pygments/pygments.git"
 
   livecheck do
@@ -19,7 +20,7 @@ class Pygments < Formula
     sha256 "538dd6dffdaf7327775f0b5df1dd08878338c225b58296f9164795df17b1960c" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     bash_completion.install "external/pygments.bashcomp" => "pygmentize"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12