### PR TITLE
python-markdown: migrate to python@3.9

### DIFF
--- a/Formula/python-markdown.rb
+++ b/Formula/python-markdown.rb
@@ -5,6 +5,7 @@ class PythonMarkdown < Formula
   homepage "https://pypi.python.org/pypi/Markdown"
   url "https://files.pythonhosted.org/packages/44/30/cb4555416609a8f75525e34cbacfc721aa5b0044809968b2cf553fd879c7/Markdown-3.2.2.tar.gz"
   sha256 "1fafe3f1ecabfb514a5285fca634a53c1b32a81cb0feb154264d55bf2ff22c17"
+  revision 1
 
   livecheck do
     url :stable
@@ -17,7 +18,7 @@ class PythonMarkdown < Formula
     sha256 "80a8cba20c744e0e49f211240883b9f8fbbd0676c95e9f43abbaf1b290f435b0" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12