### PR TITLE
q: migrate to python@3.9

### DIFF
--- a/Formula/q.rb
+++ b/Formula/q.rb
@@ -6,6 +6,7 @@ class Q < Formula
   url "https://github.com/harelba/q/archive/2.0.19.tar.gz"
   sha256 "cd4c60923bc40f53d974b54849f76096bf9901407c618cd0a3ccbc322aacc97d"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/harelba/q.git"
 
   bottle do
@@ -15,7 +16,7 @@ class Q < Formula
     sha256 "68368b50bc4b208deda10fe9b47d617382166ebfea84f6fa1cb6a53b4c5706a6" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "six" do
     url "https://files.pythonhosted.org/packages/6b/34/415834bfdafca3c5f451532e8a8d9ba89a21c9743a0c59fbd0205c7f9426/six-1.15.0.tar.gz"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12