### PR TITLE
rabbitmq: migrate to python@3.9

### DIFF
--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -4,6 +4,7 @@ class Rabbitmq < Formula
   url "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.9/rabbitmq-server-generic-unix-3.8.9.tar.xz"
   sha256 "fe1f1ef9b1bd8362421d689ec9b73cb33c8aaf96acf990df6549e3c0275b7aa0"
   license "MPL-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -12,7 +13,7 @@ class Rabbitmq < Formula
 
   bottle :unneeded
 
-  depends_on "python@3.8" => :build
+  depends_on "python@3.9" => :build
   depends_on "erlang"
 
   uses_from_macos "unzip" => :build


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12