### PR TITLE
reorder-python-imports: migrate to python@3.9

### DIFF
--- a/Formula/reorder-python-imports.rb
+++ b/Formula/reorder-python-imports.rb
@@ -6,6 +6,7 @@ class ReorderPythonImports < Formula
   url "https://github.com/asottile/reorder_python_imports/archive/v2.3.5.tar.gz"
   sha256 "e5c5b77efbd3a61fc2a4ab1ad36c57445dbec4313b8177725ead98ae05f8426e"
   license "MIT"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,7 +15,7 @@ class ReorderPythonImports < Formula
     sha256 "e068d759d9b9897c699e515c5a41791fd8029c990bb8bdedd2a38ce2f91122c1" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "aspy.refactor-imports" do
     url "https://files.pythonhosted.org/packages/34/6e/37cbfba703b06fca29c38079bef76cc01e8496197701fff8f0dded3b5b38/aspy.refactor_imports-2.1.1.tar.gz"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12