### PR TITLE
robot-framework: migrate to python@3.9

### DIFF
--- a/Formula/robot-framework.rb
+++ b/Formula/robot-framework.rb
@@ -6,6 +6,7 @@ class RobotFramework < Formula
   url "https://github.com/robotframework/robotframework/archive/v3.2.2.tar.gz"
   sha256 "6b2bddcecb5d1c6198999e38aeaf4c0366542a5e7b5bd788c6a3a36b055d5ea2"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/robotframework/robotframework.git"
 
   livecheck do
@@ -21,7 +22,7 @@ class RobotFramework < Formula
   end
 
   depends_on "openssl@1.1"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on :x11
 
   resource "bcrypt" do


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12