### PR TITLE
rom-tools: migrate to python@3.9

### DIFF
--- a/Formula/rom-tools.rb
+++ b/Formula/rom-tools.rb
@@ -5,6 +5,7 @@ class RomTools < Formula
   version "0.225"
   sha256 "ca4d5a429d72b30fd2bdf60350e490c7de4ac64b1e0dafcf38450f8ba84a1a95"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/mamedev/mame.git"
 
   bottle do
@@ -15,7 +16,7 @@ class RomTools < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.8" => :build
+  depends_on "python@3.9" => :build
   depends_on "flac"
   # Need C++ compiler and standard library support C++17.
   depends_on macos: :high_sierra
@@ -31,7 +32,7 @@ class RomTools < Formula
 
     # Use bundled asio instead of latest version.
     # See: <https://github.com/mamedev/mame/issues/5721>
-    system "make", "PYTHON_EXECUTABLE=#{Formula["python@3.8"].opt_bin}/python3",
+    system "make", "PYTHON_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3",
                    "TOOLS=1",
                    "USE_LIBSDL=1",
                    "USE_SYSTEM_LIB_EXPAT=1",


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12