### PR TITLE
spoof-mac: migrate to python@3.9

### DIFF
--- a/Formula/spoof-mac.rb
+++ b/Formula/spoof-mac.rb
@@ -6,7 +6,7 @@ class SpoofMac < Formula
   url "https://files.pythonhosted.org/packages/9c/59/cc52a4c5d97b01fac7ff048353f8dc96f217eadc79022f78455e85144028/SpoofMAC-2.1.1.tar.gz"
   sha256 "48426efe033a148534e1d4dc224c4f1b1d22299c286df963c0b56ade4c7dc297"
   license "MIT"
-  revision 2
+  revision 3
   head "https://github.com/feross/SpoofMAC.git"
 
   livecheck do
@@ -20,7 +20,7 @@ class SpoofMac < Formula
     sha256 "96a6e3e0ea4b2eb07521dc4dfa887dd9fd9b4d1583da8ea3cddf503ca6113322" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "docopt" do
     url "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12