### PR TITLE
ssh-audit: migrate to python@3.9

### DIFF
--- a/Formula/ssh-audit.rb
+++ b/Formula/ssh-audit.rb
@@ -6,11 +6,12 @@ class SshAudit < Formula
   url "https://github.com/jtesta/ssh-audit/releases/download/v2.3.0/ssh-audit-2.3.0.tar.gz"
   sha256 "776547591e7b69a2a8dcd1eaaac5d38321f2cb4a5de5f8e5a3e135b33236e812"
   license "MIT"
+  revision 1
   head "https://github.com/jtesta/ssh-audit.git"
 
   bottle :unneeded
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     rewrite_shebang detected_python_shebang, "ssh-audit.py"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12