### PR TITLE
statik: migrate to python@3.9

### DIFF
--- a/Formula/statik.rb
+++ b/Formula/statik.rb
@@ -6,7 +6,7 @@ class Statik < Formula
   url "https://github.com/thanethomson/statik/archive/v0.23.0.tar.gz"
   sha256 "6159066f486811e5773da318d6e8d1b1dd4c99ac140f1a3c660ef1c1f5e7124f"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/thanethomson/statik.git"
 
   bottle do
@@ -17,7 +17,7 @@ class Statik < Formula
   end
 
   depends_on "libpq"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   uses_from_macos "libffi"
 


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12