### PR TITLE
sync_gateway: migrate to python@3.9

### DIFF
--- a/Formula/sync_gateway.rb
+++ b/Formula/sync_gateway.rb
@@ -5,6 +5,7 @@ class SyncGateway < Formula
       tag:      "2.7.3",
       revision: "33d352f97798e45360155b63c022e8a39485134e"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/couchbase/sync_gateway.git"
 
   bottle do
@@ -18,7 +19,7 @@ class SyncGateway < Formula
   depends_on "gnupg" => :build
   depends_on "go" => :build
   depends_on "repo" => :build
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     # Cache the vendored Go dependencies gathered by depot_tools' `repo` command


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12