### PR TITLE
unoconv: migrate to python@3.9

### DIFF
--- a/Formula/unoconv.rb
+++ b/Formula/unoconv.rb
@@ -4,7 +4,7 @@ class Unoconv < Formula
   url "https://files.pythonhosted.org/packages/ab/40/b4cab1140087f3f07b2f6d7cb9ca1c14b9bdbb525d2d83a3b29c924fe9ae/unoconv-0.9.0.tar.gz"
   sha256 "308ebfd98e67d898834876348b27caf41470cd853fbe2681cc7dacd8fd5e6031"
   license "GPL-2.0"
-  revision 1
+  revision 2
   head "https://github.com/dagwieers/unoconv.git"
 
   livecheck do
@@ -18,7 +18,7 @@ class Unoconv < Formula
     sha256 "b8926bf449026133df038d3f6fa221803173193765a1de2de70da7b1e9ea4c7a" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     system "make", "install", "prefix=#{prefix}"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12