### PR TITLE
vsts-cli: migrate to python@3.9

### DIFF
--- a/Formula/vsts-cli.rb
+++ b/Formula/vsts-cli.rb
@@ -5,7 +5,7 @@ class VstsCli < Formula
   homepage "https://docs.microsoft.com/en-us/cli/vsts"
   url "https://files.pythonhosted.org/packages/f9/c2/3ed698480ab30d2807fc961eef152099589aeaec3f1407945a4e07275de5/vsts-cli-0.1.4.tar.gz"
   sha256 "27defe1d8aaa1fcbc3517274c0fdbd42b5ebe2c1c40edfc133d98fe4bb7114de"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any
@@ -17,7 +17,7 @@ class VstsCli < Formula
   # https://github.com/Azure/azure-devops-cli-extension/pull/219#issuecomment-456404611
   deprecate! date: "2019-01-22", because: :unsupported
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   uses_from_macos "libffi"
 


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12