### PR TITLE
wakatime-cli: migrate to python@3.9

### DIFF
--- a/Formula/wakatime-cli.rb
+++ b/Formula/wakatime-cli.rb
@@ -4,6 +4,7 @@ class WakatimeCli < Formula
   url "https://files.pythonhosted.org/packages/0f/45/4d3bd56a3840d384ee0a24270658d139780ceb5a2f3e7aa3cb10d5e46360/wakatime-13.0.7.tar.gz"
   sha256 "07a6d07e1227e3bd45242a2a4861d105bddc6220174a9b739c551bd2d45ce0fd"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -16,7 +17,7 @@ class WakatimeCli < Formula
     sha256 "6415adc12bbcea7ae69fa5ca29848dac754e9f09cc0f21a2c246d4118e8aa90a" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     xy = Language::Python.major_minor_version "python3"


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12