### PR TITLE
whatmp3: migrate to python@3.9

### DIFF
--- a/Formula/whatmp3.rb
+++ b/Formula/whatmp3.rb
@@ -6,7 +6,7 @@ class Whatmp3 < Formula
   url "https://github.com/RecursiveForest/whatmp3/archive/v3.8.tar.gz"
   sha256 "0d8ba70a1c72835663a3fde9ba8df0ff7007268ec0a2efac76c896dea4fcf489"
   license "MIT"
-  revision 4
+  revision 5
   head "https://github.com/RecursiveForest/whatmp3.git"
 
   bottle do


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12