### PR TITLE
gdb formulas: migrate to python@3.9

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -5,7 +5,7 @@ class Gdb < Formula
   mirror "https://ftpmirror.gnu.org/gdb/gdb-9.2.tar.xz"
   sha256 "360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555"
   license "GPL-2.0"
-  revision 1
+  revision 2
   head "https://sourceware.org/git/binutils-gdb.git"
 
   livecheck do
@@ -18,7 +18,7 @@ class Gdb < Formula
     sha256 "cbf828704099f07e8c863c962ef8deb60b932e3d75146a16b20967e3ddca7cbe" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "xz" # required for lzma support
 
   uses_from_macos "expat"
@@ -30,6 +30,7 @@ class Gdb < Formula
   end
 
   conflicts_with "i386-elf-gdb", because: "both install include/gdb, share/gdb and share/info"
+  conflicts_with "x86_64-elf-gdb", because: "both install include/gdb, share/gdb and share/info"
 
   fails_with :clang do
     build 800
@@ -39,6 +40,13 @@ class Gdb < Formula
     EOS
   end
 
+  # Fix for Python 3.9, remove in next version
+  # https://sourceware.org/pipermail/gdb-patches/2020-May/169110.html
+  patch do
+    url "https://github.com/Homebrew/formula-patches/raw/88f56f8f/gdb/python39.diff"
+    sha256 "19e989104f54c09a30f06aac87e31706f109784d3e0fdc7ff0fd1bcfd261ebee"
+  end
+
   def install
     args = %W[
       --enable-targets=all
@@ -46,7 +54,7 @@ class Gdb < Formula
       --disable-debug
       --disable-dependency-tracking
       --with-lzma
-      --with-python=#{Formula["python@3.8"].opt_bin}/python3
+      --with-python=#{Formula["python@3.9"].opt_bin}/python3
       --disable-binutils
     ]
 

--- a/Formula/gdbgui.rb
+++ b/Formula/gdbgui.rb
@@ -6,6 +6,7 @@ class Gdbgui < Formula
   url "https://files.pythonhosted.org/packages/06/af/2953018117f73a9bcfd0939c7e801b36cff03590f1b52dd7451d8102a021/gdbgui-0.14.0.1.tar.gz"
   sha256 "4f1482b3bafb04d1d1d0b0ac140bb89befdf5456482ed1533734cd5ab1ca0656"
   license "GPL-3.0-only"
+  revision 1
 
   livecheck do
     url :stable
@@ -19,7 +20,7 @@ class Gdbgui < Formula
   end
 
   depends_on "gdb"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "Brotli" do
     url "https://files.pythonhosted.org/packages/2a/18/70c32fe9357f3eea18598b23aa9ed29b1711c3001835f7cf99a9818985d0/Brotli-1.0.9.zip"
@@ -130,6 +131,9 @@ class Gdbgui < Formula
     port = free_port
 
     fork do
+      # Work around a gevent/greenlet bug
+      # https://github.com/cs01/gdbgui/issues/359
+      ENV["PURE_PYTHON"] = "1"
       exec bin/"gdbgui", "-n", "-p", port.to_s
     end
     sleep 3

--- a/Formula/i386-elf-gdb.rb
+++ b/Formula/i386-elf-gdb.rb
@@ -5,6 +5,7 @@ class I386ElfGdb < Formula
   mirror "https://ftpmirror.gnu.org/gdb/gdb-9.2.tar.xz"
   sha256 "360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555"
   license "GPL-2.0"
+  revision 1
   head "https://sourceware.org/git/binutils-gdb.git"
 
   livecheck do
@@ -17,10 +18,18 @@ class I386ElfGdb < Formula
     sha256 "8dad06d6eea6ec145763819d982916d590edd45b40e4c91e328bba76f0aac0bf" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "xz" # required for lzma support
 
   conflicts_with "gdb", because: "both install include/gdb, share/gdb and share/info"
+  conflicts_with "x86_64-elf-gdb", because: "both install include/gdb, share/gdb and share/info"
+
+  # Fix for Python 3.9, remove in next version
+  # https://sourceware.org/pipermail/gdb-patches/2020-May/169110.html
+  patch do
+    url "https://github.com/Homebrew/formula-patches/raw/88f56f8f/gdb/python39.diff"
+    sha256 "19e989104f54c09a30f06aac87e31706f109784d3e0fdc7ff0fd1bcfd261ebee"
+  end
 
   def install
     args = %W[
@@ -29,7 +38,7 @@ class I386ElfGdb < Formula
       --disable-debug
       --disable-dependency-tracking
       --with-lzma
-      --with-python=#{Formula["python@3.8"].opt_bin}/python3
+      --with-python=#{Formula["python@3.9"].opt_bin}/python3
       --disable-binutils
     ]
 

--- a/Formula/x86_64-elf-gdb.rb
+++ b/Formula/x86_64-elf-gdb.rb
@@ -4,6 +4,7 @@ class X8664ElfGdb < Formula
   url "https://ftp.gnu.org/gnu/gdb/gdb-9.2.tar.xz"
   sha256 "360cd7ae79b776988e89d8f9a01c985d0b1fa21c767a4295e5f88cb49175c555"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 "dfe4806259f346a687fdd33e04c0380a3e29042359d0035649bc921197482472" => :catalina
@@ -11,10 +12,18 @@ class X8664ElfGdb < Formula
     sha256 "08a7d238e78d7cda369afbf7e00e5e778a6d089c7c28713da8eb81692525c849" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "xz"
 
   conflicts_with "gdb", because: "both install include/gdb, share/gdb and share/info"
+  conflicts_with "i386-elf-gdb", because: "both install include/gdb, share/gdb and share/info"
+
+  # Fix for Python 3.9, remove in next version
+  # https://sourceware.org/pipermail/gdb-patches/2020-May/169110.html
+  patch do
+    url "https://github.com/Homebrew/formula-patches/raw/88f56f8f/gdb/python39.diff"
+    sha256 "19e989104f54c09a30f06aac87e31706f109784d3e0fdc7ff0fd1bcfd261ebee"
+  end
 
   def install
     args = %W[
@@ -23,7 +32,7 @@ class X8664ElfGdb < Formula
       --disable-debug
       --disable-dependency-tracking
       --with-lzma
-      --with-python=#{Formula["python@3.8"].opt_bin}/python3
+      --with-python=#{Formula["python@3.9"].opt_bin}/python3
       --disable-binutils
     ]
 


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12