### PR TITLE
ydcv: migrate to python@3.9

### DIFF
--- a/Formula/ydcv.rb
+++ b/Formula/ydcv.rb
@@ -6,7 +6,7 @@ class Ydcv < Formula
   url "https://github.com/felixonmars/ydcv/archive/0.7.tar.gz"
   sha256 "03dd5de36ea8fce3170e678e63fc3694e2718b22bc5e1526e3e07f5c36ec9aa0"
   license "GPL-3.0"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any_skip_relocation
@@ -15,7 +15,7 @@ class Ydcv < Formula
     sha256 "906ce5ee60c5b2c8d4c90b42fbc8e08cafd67de0df9f9b63bd7f4a0f428073c7" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     ENV["SETUPTOOLS_SCM_PRETEND_VERSION"] = version


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12