### PR TITLE
ydiff: migrate to python@3.9

### DIFF
--- a/Formula/ydiff.rb
+++ b/Formula/ydiff.rb
@@ -4,7 +4,7 @@ class Ydiff < Formula
   url "https://github.com/ymattw/ydiff/archive/1.2.tar.gz"
   sha256 "0a0acf326b1471b257f51d63136f3534a41c0f9a405a1bbbd410457cebfdd6a1"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
 
   bottle :unneeded
 


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12