### PR TITLE
yle-dl: migrate to python@3.9

### DIFF
--- a/Formula/yle-dl.rb
+++ b/Formula/yle-dl.rb
@@ -4,7 +4,7 @@ class YleDl < Formula
   url "https://github.com/aajanki/yle-dl/archive/20200807.tar.gz"
   sha256 "9821e6cbe15a59aec78a0eff5fd63b0d5bb3eda9bab445812c213d73edb330fe"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/aajanki/yle-dl.git"
 
   bottle do


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12