### PR TITLE
yosys: migrate to python@3.9

### DIFF
--- a/Formula/yosys.rb
+++ b/Formula/yosys.rb
@@ -4,7 +4,7 @@ class Yosys < Formula
   url "https://github.com/YosysHQ/yosys/archive/yosys-0.9.tar.gz"
   sha256 "f2e31371f9cf1b36cb4f57b23fd6eb849adc7d935dcf49f3c905aa5136382c2f"
   license "ISC"
-  revision 3
+  revision 4
   head "https://github.com/YosysHQ/yosys.git"
 
   bottle do


### PR DESCRIPTION
As part of the Python 3.9 migration (#62201).

This formula is independent from the all other Python formulas (if I didn't screw up my script or my logic)

Do not merge before the next Brew tag ships, expected on Monday 2020-10-12