### PR TITLE
autolabel: python-3.9-migration

### DIFF
--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -80,6 +80,10 @@ jobs:
                     "path": "Formula/.+",
                     "content": "(?:depends_on|uses_from_macos) \"python@?.+"
                 }, {
+                    "label": "python-3.9-migration",
+                    "path": "Formula/.+",
+                    "content": "depends_on \"python@3.9\""
+                }, {
                     "label": "ruby",
                     "path": "Formula/.+",
                     "content": "(?:depends_on|uses_from_macos) \"ruby@?.+"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Autolabel with `python-3.9-migration` if a file contains `depends_on "python@3.9"`

This isn't a perfect solution because it will also mark non-migration PRs of formula that depend on Python 3.9

I don't think this will add to existing PRs, though. Can we run it manually on all open PRs?