### PR TITLE
sshuttle: add psutil resource

### DIFF
--- a/Formula/sshuttle.rb
+++ b/Formula/sshuttle.rb
@@ -18,6 +18,11 @@ class Sshuttle < Formula
 
   depends_on "python@3.8"
 
+  resource "psutil" do
+    url "https://files.pythonhosted.org/packages/aa/3e/d18f2c04cf2b528e18515999b0c8e698c136db78f62df34eee89cee205f1/psutil-5.7.2.tar.gz"
+    sha256 "90990af1c3c67195c44c9a889184f84f5b2320dce3ee3acbd054e3ba0b4a7beb"
+  end
+
   def install
     # Building the docs requires installing
     # markdown & BeautifulSoup Python modules


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Upstream has added a python dependency on `psutil`. There is not a new tagged release that incorporates this new change however, this PR will allow `--HEAD` installs to work properly in the interim. Fixes #62489.
