### PR TITLE
sdl2: check latest snapshot

### DIFF
--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -1,9 +1,19 @@
 class Sdl2 < Formula
   desc "Low-level access to audio, keyboard, mouse, joystick, and graphics"
   homepage "https://www.libsdl.org/"
-  url "https://libsdl.org/release/SDL2-2.0.12.tar.gz"
-  sha256 "349268f695c02efbc9b9148a70b85e58cefbbf704abd3e91be654db7f1e2c863"
   revision 1
+
+  stable do
+    url "https://libsdl.org/release/SDL2-2.0.12.tar.gz"
+    sha256 "349268f695c02efbc9b9148a70b85e58cefbbf704abd3e91be654db7f1e2c863"
+
+    # Fix library extension in CMake config file.
+    # https://bugzilla.libsdl.org/show_bug.cgi?id=5039
+    patch do
+      url "https://bugzilla.libsdl.org/attachment.cgi?id=4263"
+      sha256 "07ea066e805f82d85e6472e767ba75d265cb262053901ac9a9e22c5f8ff187a5"
+    end
+  end
 
   livecheck do
     url "https://www.libsdl.org/download-2.0.php"
@@ -27,13 +37,6 @@ class Sdl2 < Formula
 
   on_linux do
     depends_on "pkg-config" => :build
-  end
-
-  # Fix library extension in CMake config file.
-  # https://bugzilla.libsdl.org/show_bug.cgi?id=5039
-  patch do
-    url "https://bugzilla.libsdl.org/attachment.cgi?id=4263"
-    sha256 "07ea066e805f82d85e6472e767ba75d265cb262053901ac9a9e22c5f8ff187a5"
   end
 
   def install

--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -1,19 +1,8 @@
 class Sdl2 < Formula
   desc "Low-level access to audio, keyboard, mouse, joystick, and graphics"
   homepage "https://www.libsdl.org/"
-  revision 1
-
-  stable do
-    url "https://libsdl.org/release/SDL2-2.0.12.tar.gz"
-    sha256 "349268f695c02efbc9b9148a70b85e58cefbbf704abd3e91be654db7f1e2c863"
-
-    # Fix library extension in CMake config file.
-    # https://bugzilla.libsdl.org/show_bug.cgi?id=5039
-    patch do
-      url "https://bugzilla.libsdl.org/attachment.cgi?id=4263"
-      sha256 "07ea066e805f82d85e6472e767ba75d265cb262053901ac9a9e22c5f8ff187a5"
-    end
-  end
+  url "https://libsdl.org/tmp/SDL-2.0.13-14058.tar.gz"
+  sha256 "4ea5d4ca109d064310a662f457a6811aeefa4a062ec83802f06cef122e5bba04"
 
   livecheck do
     url "https://www.libsdl.org/download-2.0.php"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Stable version of `sdl2` fails on Mojave only (see https://github.com/Homebrew/homebrew-core/pull/62173), I'd like to see if it was fixed in sdl2 in the latest snapshot