### PR TITLE
eigen: emergency patch for failures when used with OpenMP

### DIFF
--- a/Formula/eigen.rb
+++ b/Formula/eigen.rb
@@ -4,6 +4,7 @@ class Eigen < Formula
   url "https://gitlab.com/libeigen/eigen/-/archive/3.3.8/eigen-3.3.8.tar.gz"
   sha256 "146a480b8ed1fb6ac7cd33fec9eb5e8f8f62c3683b3f850094d9d5c35a92419a"
   license "MPL-2.0"
+  revision 1
   head "https://gitlab.com/libeigen/eigen"
 
   bottle do
@@ -16,6 +17,12 @@ class Eigen < Formula
   depends_on "cmake" => :build
 
   conflicts_with "freeling", because: "freeling ships its own copy of eigen"
+
+  # Emergency fix for build failures with OpenMP. Remove with the next release.
+  patch do
+    url "https://gitlab.com/libeigen/eigen/-/commit/ef3cc72cb65e2d500459c178c63e349bacfa834f.diff"
+    sha256 "b8877a84c4338f08ab8a6bb8b274c768e93d36ac05b733b078745198919a74bf"
+  end
 
   def install
     mkdir "eigen-build" do

--- a/Formula/pcl.rb
+++ b/Formula/pcl.rb
@@ -4,7 +4,7 @@ class Pcl < Formula
   url "https://github.com/PointCloudLibrary/pcl/archive/pcl-1.11.1.tar.gz"
   sha256 "a61558e53abafbc909e0996f91cfd2d7a400fcadf6b8cfb0ea3172b78422c74e"
   license "BSD-3-Clause"
-  revision 2
+  revision 3
   head "https://github.com/PointCloudLibrary/pcl.git"
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This patch fixes build failures caused by a bug introduced in Eigen 3.3.8. This patch is from upstream and should be included with 3.3.9.

I have cherry-picked this patch because `pcl` does not compile without it, and it was recently revbumped for the Python 3.8.6 release. As it stands, updating to Python 3.8.6 will completely break `pcl`, so we need this patch ahead of the 3.3.9 release to make `pcl` work again. I have also revbumped `pcl`.

This is also needed for OpenSSL 1.1.1h at https://github.com/Homebrew/homebrew-core/pull/61539 to go ahead.