### PR TITLE
sslyze: fix license

### DIFF
--- a/Formula/sslyze.rb
+++ b/Formula/sslyze.rb
@@ -3,7 +3,7 @@ class Sslyze < Formula
 
   desc "SSL scanner"
   homepage "https://github.com/nabla-c0d3/sslyze"
-  license "AGPL-3.0-or-later"
+  license "AGPL-3.0-only"
   revision 1
 
   stable do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

License was added as `AGPL-3.0-or-later` in #62530 but I believe this was an error and it should be `AGPL-3.0-only`. I see no indication of the `-or-later` in any of the source files.
