### PR TITLE
gegl: fix build from source with meson nofallback

### DIFF
--- a/Formula/gegl.rb
+++ b/Formula/gegl.rb
@@ -1,9 +1,10 @@
 class Gegl < Formula
   desc "Graph based image processing framework"
-  homepage "http://www.gegl.org/"
+  homepage "https://www.gegl.org/"
   url "https://download.gimp.org/pub/gegl/0.4/gegl-0.4.26.tar.xz"
   sha256 "0f371e2ed2b92162fefd3dde743e648ca08a6a1b2b05004867fbddc7e211e424"
-  license "LGPL-3.0"
+  license all_of: ["LGPL-3.0-or-later", "GPL-3.0-or-later", "BSD-3-Clause", "MIT"]
+  head "https://gitlab.gnome.org/GNOME/gegl.git"
 
   livecheck do
     url "https://download.gimp.org/pub/gegl/0.4/"
@@ -14,11 +15,6 @@ class Gegl < Formula
     sha256 "31cbb2a6960a6f2a1d48d30a8facd05c378ec29545eb8ba88b385b95c56f4e60" => :catalina
     sha256 "e40645711d7f5e2b2c511fb3c05981b99c4191faf2385dde53cbf20eed9f4319" => :mojave
     sha256 "ed58d1d1d9c5f388c24276436f03497ba59d33b34a14541b21df8887af9d4bcf" => :high_sierra
-  end
-
-  head do
-    # Use the Github mirror because official git unreliable.
-    url "https://github.com/GNOME/gegl.git"
   end
 
   depends_on "glib" => :build
@@ -46,6 +42,7 @@ class Gegl < Formula
       -Dwith-jasper=false
       -Dwith-umfpack=false
       -Dwith-libspiro=false
+      --force-fallback-for=libnsgif,poly2tri-c
     ]
 
     ### Temporary Fix ###


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Needed for https://github.com/Homebrew/homebrew-core/pull/61226 as a result of https://github.com/Homebrew/brew/pull/8649. Since basically only gegl uses libnsgif and poly2tri-c, they ship the source as part of their distribution tarballs. Re-enable fallbacks for these vendored dependencies since they won't be downloaded separately.