### PR TITLE
htmlcleaner: fix for newer openjdk versions

### DIFF
--- a/Formula/htmlcleaner.rb
+++ b/Formula/htmlcleaner.rb
@@ -23,10 +23,12 @@ class Htmlcleaner < Formula
   def install
     ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
 
-    # Homebrew's OpenJDK no longer accepts Java 5 source
     inreplace "pom.xml" do |s|
+      # Homebrew's OpenJDK no longer accepts Java 5 source
       s.gsub! "<source>1.5</source>", "<source>1.7</source>"
       s.gsub! "<target>1.5</target>", "<target>1.7</target>"
+      # OpenJDK >14 doesn't support older maven-javadoc-plugin versions
+      s.gsub! "<version>2.9</version>", "<version>3.2.0</version>"
     end
 
     system "mvn", "clean", "package", "-DskipTests=true", "-Dmaven.javadoc.skip=true"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Needed for https://github.com/Homebrew/homebrew-core/pull/61226. Fixes error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9:jar (attach-javadocs) on project htmlcleaner: Execution attach-javadocs of goal org.apache.maven.plugins:maven-javadoc-plugin:2.9:jar failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-javadoc-plugin:2.9:jar: java.lang.ExceptionInInitializerError: null
```