### PR TITLE
mercury: fix build on Xcode 12

### DIFF
--- a/Formula/mercury.rb
+++ b/Formula/mercury.rb
@@ -3,6 +3,7 @@ class Mercury < Formula
   homepage "https://mercurylang.org/"
   url "https://dl.mercurylang.org/release/mercury-srcdist-20.06.tar.gz"
   sha256 "b9c6965d41af49b4218d2444440c4860630d6f50c18dc6f1f4f8374d114f79be"
+  license all_of: ["GPL-2.0-only", "LGPL-2.0-only", "MIT"]
 
   bottle do
     cellar :any
@@ -13,12 +14,17 @@ class Mercury < Formula
 
   depends_on "openjdk"
 
-  def install
-    args = ["--prefix=#{prefix}",
-            "--mandir=#{man}",
-            "--infodir=#{info}"]
+  # Disable advanced segfault handling due to broken header detection.
+  patch do
+    url "https://github.com/Mercury-Language/mercury/commit/37ed70d43878cd53c8da40bf410e0a312835c036.patch?full_index=1"
+    sha256 "f01aca048464341dcf6e345056050e2c45236839cca17ac01fc944131d1641c0"
+  end
 
-    system "./configure", *args
+  def install
+    system "./configure", "--prefix=#{prefix}",
+            "--mandir=#{man}",
+            "--infodir=#{info}",
+            "mercury_cv_is_littleender=yes" # Fix broken endianness detection
 
     system "make", "install", "PARALLEL=-j"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

(Probably) fixes the following error:

```
mercury_memory_handlers.c:64:6: error: "MR_HAVE_SIGINFO defined but don't know how to get it"
    #error "MR_HAVE_SIGINFO defined but don't know how to get it"
     ^
mercury_memory_handlers.c:83:6: error: "MR_HAVE_SIGINFO defined but don't know how to get it"
    #error "MR_HAVE_SIGINFO defined but don't know how to get it"
     ^
mercury_memory_handlers.c:270:41: error: use of undeclared identifier 'bus_handler'
    MR_setup_signal(SIGBUS, (MR_Code *) bus_handler, MR_TRUE,
                                        ^
mercury_memory_handlers.c:273:42: error: use of undeclared identifier 'segv_handler'
    MR_setup_signal(SIGSEGV, (MR_Code *) segv_handler, MR_TRUE,
                                         ^
4 errors generated.
make[2]: *** [mercury_memory_handlers.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [runtime] Error 2
make: *** [install] Error 2
```

This is caused by faulty detection of the proper `siginfo_t *` structs from signal.h. Needed for https://github.com/Homebrew/homebrew-core/pull/61226