### PR TITLE
libxshmfence: add missing test dependency

### DIFF
--- a/Formula/libxshmfence.rb
+++ b/Formula/libxshmfence.rb
@@ -13,7 +13,7 @@ class Libxshmfence < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "xorgproto" => :build
+  depends_on "xorgproto" => [:build, :test]
 
   def install
     args = %W[


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
