### PR TITLE
inform6: add license

### DIFF
--- a/Formula/inform6.rb
+++ b/Formula/inform6.rb
@@ -5,6 +5,7 @@ class Inform6 < Formula
   mirror "https://ifarchive.org/if-archive/infocom/compilers/inform6/source/old/inform-6.34-6.12.2.tar.gz"
   version "6.34-6.12.2"
   sha256 "c149f143f2c29a4cb071e578afef8097647cc9e823f7fcfab518ac321d9d259f"
+  license "Artistic-2.0"
   head "https://gitlab.com/DavidGriffith/inform6unix.git"
 
   bottle do


### PR DESCRIPTION
add license for inform6

---

```
The compiler and standard library for Inform6 are licensed under
1) The traditional Inform license as described by the DM4, or
2) The Artistic License 2.0 (see ARTISTIC).

The user is free to choose which license to accept, i.e., free to choose
either set of terms and conditions.

Here is the relevant bit from the Inform Designer's Manual, 4th edition:

      Copyright on Inform, the program and its source code, its example
      games and documentation (including this book) is retained by Graham
      Nelson, who asserts the moral right to be identified as the author
      under the Copyrights, Designs and Patents Act 1988.  Having said
      this, I am happy for it to be freely distributed to anybody who wants
      a copy, provided that: (a) distributed copies are not substantially
      different from those archived by the author, (b) this and other
      copyright messages are always retained in full, and (c) no profit is
      involved.  (Exceptions to these rules must be negotiated directly
      with the author.)  However, a story file produced with the Inform
      compiler (and libraries) then belongs to its author, and may be sold
      for profit if desired, provided that its game banner contains the
      information that it was compiled by Inform, and the Inform version
      number.

* The license status of the contributed material (demos, include, tutor) is
  what it says in each file.

```