### PR TITLE
bandcamp-dl: revision for upstream patch

### DIFF
--- a/Formula/bandcamp-dl.rb
+++ b/Formula/bandcamp-dl.rb
@@ -4,7 +4,7 @@ class BandcampDl < Formula
   desc "Simple python script to download Bandcamp albums"
   homepage "https://github.com/iheanyi/bandcamp-dl"
   license "Unlicense"
-  revision 4
+  revision 5
   head "https://github.com/iheanyi/bandcamp-dl.git"
 
   stable do
@@ -16,6 +16,12 @@ class BandcampDl < Formula
     patch do
       url "https://github.com/iheanyi/bandcamp-dl/commit/3d3a524af27bac761bd2f8766c6f4951776c6c60.patch?full_index=1"
       sha256 "f776b23beb1149d2449c2187bbdc3843933d063a79254a354bfc69ce4d644091"
+    end
+
+    # fix script matching https://github.com/iheanyi/bandcamp-dl/pull/171
+    patch do
+      url "https://github.com/iheanyi/bandcamp-dl/commit/08c450385efe847e4f8ece1dc95034e69aaeaed0.patch?full_index=1"
+      sha256 "64808a6334994d847d0c5bdcfd49cfd6dbb4376c8c8d3fd4304b85f892d3915f"
     end
   end
 


### PR DESCRIPTION
Fixes the test error:

```
==> /usr/local/Cellar/bandcamp-dl/0.0.8-12_4/bin/bandcamp-dl --artist=iamsleepless --album=rivulets
Traceback (most recent call last):
  File "/usr/local/Cellar/bandcamp-dl/0.0.8-12_4/bin/bandcamp-dl", line 33, in <module>
    sys.exit(load_entry_point('bandcamp-downloader==0.0.9.post1', 'console_scripts', 'bandcamp-dl')())
  File "/usr/local/Cellar/bandcamp-dl/0.0.8-12_4/libexec/lib/python3.8/site-packages/bandcamp_dl/__main__.py", line 93, in main
    album = bandcamp.parse(url, True, arguments['--embed-lyrics'], arguments['--debug'])
  File "/usr/local/Cellar/bandcamp-dl/0.0.8-12_4/libexec/lib/python3.8/site-packages/bandcamp_dl/bandcamp.py", line 40, in parse
    bandcamp_json = BandcampJSON(self.soup, debugging).generate()
  File "/usr/local/Cellar/bandcamp-dl/0.0.8-12_4/libexec/lib/python3.8/site-packages/bandcamp_dl/bandcampjson.py", line 18, in generate
    self.get_js()
  File "/usr/local/Cellar/bandcamp-dl/0.0.8-12_4/libexec/lib/python3.8/site-packages/bandcamp_dl/bandcampjson.py", line 29, in get_js
    embedded_scripts_raw = [self.body.find("script", {"type": "application/json+ld"}).string]
AttributeError: 'NoneType' object has no attribute 'string'
```

Needed for https://github.com/Homebrew/homebrew-core/pull/61539

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----