### PR TITLE
get-flash-videos: fix test

### DIFF
--- a/Formula/get-flash-videos.rb
+++ b/Formula/get-flash-videos.rb
@@ -90,8 +90,7 @@ class GetFlashVideos < Formula
   end
 
   test do
-    file = testpath/"BBC_-__Do_whatever_it_takes_to_get_him_to_talk.flv"
-    system bin/"get_flash_videos", "http://news.bbc.co.uk/2/hi/programmes/hardtalk/9560793.stm"
-    assert_predicate file, :exist?, "Failed to download #{file}!"
+    assert_match "Filename: BBC_-__Do_whatever_it_takes_to_get_him_to_talk.flv",
+      shell_output("#{bin}/get_flash_videos --info http://news.bbc.co.uk/2/hi/programmes/hardtalk/9560793.stm")
   end
 end


### PR DESCRIPTION
Seen in https://github.com/Homebrew/homebrew-core/pull/61539

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----