### PR TITLE
llvm: migrate to python@3.9

### DIFF
--- a/Formula/halide.rb
+++ b/Formula/halide.rb
@@ -4,6 +4,7 @@ class Halide < Formula
   url "https://github.com/halide/Halide/archive/v10.0.0.tar.gz"
   sha256 "23808f8e9746aea25349a16da92e89ae320990df3c315c309789fb209ee40f20"
   license "MIT"
+  revision 1
 
   bottle do
     cellar :any
@@ -17,7 +18,7 @@ class Halide < Formula
   depends_on "libomp"
   depends_on "libpng"
   depends_on "llvm"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     mkdir "build" do

--- a/Formula/ispc.rb
+++ b/Formula/ispc.rb
@@ -4,6 +4,7 @@ class Ispc < Formula
   url "https://github.com/ispc/ispc/archive/v1.14.1.tar.gz"
   sha256 "3a7ee9ab90b9e9932b7b4effc9bb3ef45ca271d60d9ec6bc8c335242b5ec097b"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,7 +16,7 @@ class Ispc < Formula
   depends_on "bison" => :build
   depends_on "cmake" => :build
   depends_on "flex" => :build
-  depends_on "python@3.8" => :build
+  depends_on "python@3.9" => :build
   depends_on "llvm"
 
   def install

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -3,7 +3,7 @@ class Llvm < Formula
   homepage "https://llvm.org/"
   # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/llvm/llvm-project.git"
 
   stable do
@@ -100,7 +100,7 @@ class Llvm < Formula
   # We intentionally use Make instead of Ninja.
   # See: Homebrew/homebrew-core/issues/35513
   depends_on "cmake" => :build
-  depends_on "python@3.8" => :build
+  depends_on "python@3.9" => :build
   depends_on "libffi"
 
   uses_from_macos "libedit"
@@ -130,7 +130,7 @@ class Llvm < Formula
       libunwind
     ]
     # Can likely be added to the base runtimes array when 11.0.0 is released.
-    runtimes << "libcxxabi" if build.head?
+    ecuntimes << "libcxxabi" if build.head?
 
     llvmpath = buildpath/"llvm"
     unless build.head?
@@ -138,7 +138,7 @@ class Llvm < Formula
       (projects + runtimes).each { |p| resource(p).stage(buildpath/p) }
     end
 
-    py_ver = "3.8"
+    py_ver = "3.9"
 
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -4,6 +4,7 @@ class Pyside < Formula
   url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.1-src/pyside-setup-opensource-src-5.15.1.tar.xz"
   sha256 "f175c1d8813257904cf0efeb58e44f68d53b9916f73adaf9ce19514c0271c3fa"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-3.0-only"]
+  revision 1
 
   livecheck do
     url "https://download.qt.io/official_releases/QtForPython/pyside2/"
@@ -18,7 +19,7 @@ class Pyside < Formula
 
   depends_on "cmake" => :build
   depends_on "llvm" => :build
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "qt"
 
   def install
@@ -30,14 +31,14 @@ class Pyside < Formula
       --install-scripts #{bin}
     ]
 
-    xy = Language::Python.major_minor_version Formula["python@3.8"].opt_bin/"python3"
+    xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
 
-    system Formula["python@3.8"].opt_bin/"python3",
+    system Formula["python@3.9"].opt_bin/"python3",
            *Language::Python.setup_install_args(prefix),
            "--install-lib", lib/"python#{xy}/site-packages", *args,
            "--build-type=shiboken2"
 
-    system Formula["python@3.8"].opt_bin/"python3",
+    system Formula["python@3.9"].opt_bin/"python3",
            *Language::Python.setup_install_args(prefix),
            "--install-lib", lib/"python#{xy}/site-packages", *args,
            "--build-type=pyside2"
@@ -47,7 +48,7 @@ class Pyside < Formula
   end
 
   test do
-    system Formula["python@3.8"].opt_bin/"python3", "-c", "import PySide2"
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2"
     %w[
       Core
       Gui
@@ -59,6 +60,6 @@ class Pyside < Formula
       WebEngineWidgets
       Widgets
       Xml
-    ].each { |mod| system Formula["python@3.8"].opt_bin/"python3", "-c", "import PySide2.Qt#{mod}" }
+    ].each { |mod| system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2.Qt#{mod}" }
   end
 end


### PR DESCRIPTION
Trying to separate some long-to-build formulas that depend only at build time on Python: https://github.com/Homebrew/homebrew-core/pull/62560