### PR TITLE
gh-62589: extend test for grpc

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -26,6 +26,7 @@ class Grpc < Formula
   depends_on "automake" => :build
   depends_on "cmake" => :build
   depends_on "libtool" => :build
+  depends_on "pkg-config" => [:build, :test]
   depends_on "abseil"
   depends_on "c-ares"
   depends_on "gflags"
@@ -75,7 +76,9 @@ class Grpc < Formula
         return GRPC_STATUS_OK;
       }
     EOS
-    system ENV.cc, "test.cpp", "-I#{include}", "-L#{lib}", "-lgrpc", "-o", "test"
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@1.1"].opt_lib/"pkgconfig"
+    pkg_config_flags = shell_output("pkg-config --cflags --libs protobuf grpc++").chomp.split
+    system ENV.cc, "test.cpp", "-o", "test", *pkg_config_flags
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

@jonchang @SMillerDev can you help me out with this? (I can't test locally and no experience with ruby either.)

It's the change to extend the test coverage of `grpc` to use `pkg-config`.