### PR TITLE
kamel 1.2.0

### DIFF
--- a/Formula/kamel.rb
+++ b/Formula/kamel.rb
@@ -3,8 +3,8 @@ class Kamel < Formula
   homepage "https://camel.apache.org/"
 
   url "https://github.com/apache/camel-k.git",
-    tag:      "v1.1.1",
-    revision: "b7b785db55faf33a95e4c3c337e248192510ce85"
+    tag:      "v1.2.0",
+    revision: "ab1a566458962b18fef1a1b594efe7d269fb85af"
   license "Apache-2.0"
   head "https://github.com/apache/camel-k.git"
 


### PR DESCRIPTION
Upgrade kamel formula to v1.2.0 as releases of today

Camel-K v1.2.0

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Below you can find the logs for _build from source_  and _audit_ runs.

**brew --build-from-source**
```
==> Downloading https://linuxbrew.bintray.com/bottles/go-1.15.2.x86_64_linux.bottle.tar.gz                                                                                                                                
==> Downloading from https://akamai.bintray.com/28/281c1f9c510a46fd3e7420798a7bb0887bb2d3c8d3605e0d484f824f1d1ae369?__gda__=exp=1602511915~hmac=edc37bc54ecb25444b9c9733b651b87dd1ea05278e0064902f0a1caccd5669a2&response-
content-disposition=attachment%3Bfilename%3D%22go-1.15.2.x86_64_linux.bottle.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1_rxQjPHntvEcscRqMc3neTqbYrFzbA1eZzwou_uT_xDCHJQucdvcvZ8vxtIymbsGP5rI
kgNKT5kHSwbFW1fBpRxVv5FH3fKXqEHvVShg25yA7N36cCN29zldrLHWAoqVRNnBWwWNu5wQ&response-X-Checksum-Sha1=b6f763d57ffe70d3a095560f8b8a2846831ca2c0&response-X-Checksum-Sha2=281c1f9c510a46fd3e7420798a7bb0887bb2d3c8d3605e0d484f82
4f1d1ae369                                                                                                                                                                                                                
==> Downloading https://linuxbrew.bintray.com/bottles/freetype-2.10.3.x86_64_linux.bottle.tar.gz                                                                                                                          
==> Downloading from https://akamai.bintray.com/3b/3b1a66a349f5a0e1757ea1d03631f2bd171e5998cf98f4bc802862922597a5dc?__gda__=exp=1602511917~hmac=d5143563061ef567b2642c943aa65a670a67ea565f52ebd5208418c276aef868&response-
content-disposition=attachment%3Bfilename%3D%22freetype-2.10.3.x86_64_linux.bottle.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1-BP5P6BUZSCVkzeZoVvXoFmxOXkYtsjbnLw54krAhWED37oAbLmVJMm86_tsdX
2SxDbD7bWeC607BaqtYhrsbWmONfYVt7Vldg2eQeySv_8Z9kG_ECi2iYj9ZMm3Ljq-B5Nk5EB8i5UQ&response-X-Checksum-Sha1=6d5ae7fa8abfe337e71b77d85c1f193d33e49dba&response-X-Checksum-Sha2=3b1a66a349f5a0e1757ea1d03631f2bd171e5998cf98f4bc
802862922597a5dc                                                                                                                                                                                                          
==> Downloading https://linuxbrew.bintray.com/bottles/expat-2.2.10.x86_64_linux.bottle.tar.gz                                                                                                                             
==> Downloading from https://akamai.bintray.com/83/838fc570ed11945abbb0ac7c663b0d3730d27952a479d2f730e5bbac1cbbad1f?__gda__=exp=1602511918~hmac=2ede8679e81f9230ba1ac43d2a563ee9ce82a9469df817dcd47bc2dae5acb90c&response-
content-disposition=attachment%3Bfilename%3D%22expat-2.2.10.x86_64_linux.bottle.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1-RH7KujMGXdM3thZDwvjQgDH7CZkqUgsJutPcRxJwx_hWLhteUlg6Ewa6KHlp2kBL
Hegwal3yZVGZVoqPDTBJakgPmEsJJ1DhlI8O564aV7JWKkh0LhHPX8bIzWJ-y-RVZ1ESCK3o4lQ&response-X-Checksum-Sha1=6597ff7a5745bffdebfbf36d15f6deb0514e4171&response-X-Checksum-Sha2=838fc570ed11945abbb0ac7c663b0d3730d27952a479d2f730e
5bbac1cbbad1f                                                                                                                                                                                                             
==> Downloading https://linuxbrew.bintray.com/bottles/util-linux-2.36.x86_64_linux.bottle.tar.gz                                                                                                                          
==> Downloading from https://akamai.bintray.com/92/927fad13947fe39814a11dec5e24d40a2db2ba9fe06fc00a8a71688f5a900c90?__gda__=exp=1602511918~hmac=b23649b6e52e54b7118e6fe35991ab037ef84a6881dbbf760d89c3877b198a7e&response-
content-disposition=attachment%3Bfilename%3D%22util-linux-2.36.x86_64_linux.bottle.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1-8_wGWqN9IDf6Tb6AK4IvpEgk7wP1OrgrFoGJRbONWl1O2hWVsEUHDQsGQKOSD
C7Kd_AGboaZkhq5IWzt-ZB-z3ajGqYuv8lgjFXWdwHU0hOq_BtN5wagX2hzC4mY3Rg1PYYj2kQyQoA&response-X-Checksum-Sha1=23b407946d0b12f99428a37d25432d92e21b11ab&response-X-Checksum-Sha2=927fad13947fe39814a11dec5e24d40a2db2ba9fe06fc00a
8a71688f5a900c90                                      
==> Downloading https://linuxbrew.bintray.com/bottles/openjdk-14.0.1_1.x86_64_linux.bottle.tar.gz                                                                                                                         
==> Downloading from https://akamai.bintray.com/20/20beecb201458d8a09a303826afed846358b189578e7afaab9f602de22ffb1d9?__gda__=exp=1602511919~hmac=063dbab5dfa0d2450fa0217c202f67c3f2dc0fd0dc17fdfabf66e0977c7a6936&response-
content-disposition=attachment%3Bfilename%3D%22openjdk-14.0.1_1.x86_64_linux.bottle.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1-VR5AYBDAnHUNd8jQsR6jLov6_6YDEPpRShjOjKkmDq-YvlVPmOEjGEyxXDOx
IFmmCdlyWmg7pUTFbuo4Z3b-xZST7zhMtZdV4or8SkvFOWUjUgIwDyA7_frRyCt5e8m7ADFdlvFeNaQ&response-X-Checksum-Sha1=2e094b91f5b0956f414c4bc9381f46c1a88abd77&response-X-Checksum-Sha2=20beecb201458d8a09a303826afed846358b189578e7afa
ab9f602de22ffb1d9                                     
==> Cloning https://github.com/apache/camel-k.git                                                            
Cloning into '/home/ipolyzos/.cache/Homebrew/kamel--git'...                                                  
==> Checking out tag v1.2.0                           
HEAD is now at ab1a566 Release 1.2.0                  
==> Installing dependencies for kamel: go, freetype, expat, util-linux and openjdk                                                                                                                                        
==> Installing kamel dependency: go                   
==> Pouring go-1.15.2.x86_64_linux.bottle.tar.gz                                                             
🍺  /home/linuxbrew/.linuxbrew/Cellar/go/1.15.2: 9,770 files, 474.5MB                                        
==> Installing kamel dependency: freetype                                                                    
==> Pouring freetype-2.10.3.x86_64_linux.bottle.tar.gz                                                       
🍺  /home/linuxbrew/.linuxbrew/Cellar/freetype/2.10.3: 65 files, 2.7MB                                       
==> Installing kamel dependency: expat                                                                       
==> Pouring expat-2.2.10.x86_64_linux.bottle.tar.gz                                                          
🍺  /home/linuxbrew/.linuxbrew/Cellar/expat/2.2.10: 17 files, 747.8KB                                        
==> Installing kamel dependency: util-linux                                                                  
==> Pouring util-linux-2.36.x86_64_linux.bottle.tar.gz                                                       
==> Caveats                                           
The following tools are not supported under macOS, and are therefore not included:                                                                                                                                        
addpart agetty blkdiscard blkzone blockdev chcpu chmem choom chrt ctrlaltdel                                                                                                                                              
delpart dmesg eject fallocate fdformat fincore findmnt fsck fsfreeze fstrim                                  
hwclock ionice ipcrm ipcs kill last ldattach losetup lsblk lscpu lsipc lslocks                                                                                                                                            
lslogins lsmem lsns mount mountpoint nsenter partx pivot_root prlimit raw                                    
readprofile resizepart rfkill rtcwake script scriptlive setarch setterm sulogin                                                                                                                                           
swapoff swapon switch_root taskset umount unshare utmpdump uuidd wall wdctl                                  
zramctl                                               

The following tools are already shipped by macOS, and are therefore not included:                                                                                                                                         
cal col colcrt colrm getopt hexdump logger look mesg more nologin renice rev ul                                                                                                                                           
whereis                                               


Bash completion has been installed to:                                                                       
  /home/linuxbrew/.linuxbrew/etc/bash_completion.d                                                           
==> Summary                                           
🍺  /home/linuxbrew/.linuxbrew/Cellar/util-linux/2.36: 391 files, 18.9MB                                     
==> Installing kamel dependency: openjdk                                                                     
==> Pouring openjdk-14.0.1_1.x86_64_linux.bottle.tar.gz                                                      
==> Caveats                                           
For the system Java wrappers to find this JDK, symlink it with                                               
  sudo ln -sfn /home/linuxbrew/.linuxbrew/opt/openjdk/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk                                                                                                   

openjdk is keg-only, which means it was not symlinked into /home/linuxbrew/.linuxbrew,                                                                                                                                    
because it shadows the macOS `java` wrapper.                                                                 

If you need to have openjdk first in your PATH run:                                                          
  echo 'export PATH="/home/linuxbrew/.linuxbrew/opt/openjdk/bin:$PATH"' >> ~/.zshrc                                                                                                                                       

For compilers to find openjdk you may need to set:                                                           
  export CPPFLAGS="-I/home/linuxbrew/.linuxbrew/opt/openjdk/include"                                         

==> Summary                                           
🍺  /home/linuxbrew/.linuxbrew/Cellar/openjdk/14.0.1_1: 627 files, 336.1MB                                   
==> Installing kamel                                  
==> make                                              
==> Caveats                                           
Bash completion has been installed to:                                                                       
  /home/linuxbrew/.linuxbrew/etc/bash_completion.d                                                           

zsh completions have been installed to:                                                                      
  /home/linuxbrew/.linuxbrew/share/zsh/site-functions                                                        
==> Summary                                           
🍺  /home/linuxbrew/.linuxbrew/Cellar/kamel/1.2.0: 9 files, 56MB, built in 1 minute 20 seconds 
==> Upgrading 2 dependents:                           
operator-sdk 0.18.0 -> 1.0.1, vim 8.2.1750 -> 8.2.1800_1                                                     
==> Upgrading operator-sdk 0.18.0 -> 1.0.1                                                                   
==> Downloading https://linuxbrew.bintray.com/bottles/operator-sdk-1.0.1.x86_64_linux.bottle.tar.gz                                                                                                                       
==> Downloading from https://akamai.bintray.com/0b/0bf3d49a6d3fab7df9a225b68d45db3c2ca210f622cc5b8b84f01f1485c4316a?__gda__=exp=1602512032~hmac=e396ab1d8df40a3732a0e4a7f6026a86371cc7fc63ac33639ba39c8850b80418&response-
content-disposition=attachment%3Bfilename%3D%22operator-sdk-1.0.1.x86_64_linux.bottle.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1_La8NmqvI4WsDVYgpuNnfBpul5sFmKPIXMPAoUwls5Crgg7aXFnpLRrKCRa
INnI7jKLa_pXM-6tdOfJCuur79DQOVaQumPV428qIL0Wibur9VQvd2NNDqPrJt6xxXGVwo-XVVnTwXJjehjdGc_G5VdRqcOQ0nMGeM&response-X-Checksum-Sha1=ef37d2d56863f9a0ceb11709ec9f9d2bbb4bbc88&response-X-Checksum-Sha2=0bf3d49a6d3fab7df9a225b6
8d45db3c2ca210f622cc5b8b84f01f1485c4316a              
==> Pouring operator-sdk-1.0.1.x86_64_linux.bottle.tar.gz                                                    
==> Caveats                                           
Bash completion has been installed to:                                                                       
  /home/linuxbrew/.linuxbrew/etc/bash_completion.d                                                           

zsh completions have been installed to:                                                                      
  /home/linuxbrew/.linuxbrew/share/zsh/site-functions                                                        
==> Summary                                           
🍺  /home/linuxbrew/.linuxbrew/Cellar/operator-sdk/1.0.1: 10 files, 159.2MB                                  
Removing: /home/linuxbrew/.linuxbrew/Cellar/operator-sdk/0.18.0... (8 files, 69.8MB)                                                                                                                                      
==> Upgrading vim 8.2.1750 -> 8.2.1800_1                                                                     
==> Downloading https://linuxbrew.bintray.com/bottles/openssl%401.1-1.1.1h.x86_64_linux.bottle.tar.gz                                                                                                                     
==> Downloading from https://akamai.bintray.com/61/61bf82b4b62e07589dec1fdc9eb9eb053da01565581fb18dd5df6232182238ec?__gda__=exp=1602512039~hmac=a6ac88cfd185bddf2589b1dcc50f8623396014e2e6d1d0b3399af98fdbab78a3&response-
content-disposition=attachment%3Bfilename%3D%22openssl%401.1-1.1.1h.x86_64_linux.bottle.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1-1ztWT4W_t0fc9cjzS7hz4jr7X7K7QR12AxhBBWkJU_9zKG8tCP9vtqgG
FtdeYV7s2xr1ZkEOb0Gyv8lmDfgVhvb2pn6H6jWPZ6ys35qWrq75xg5gI2rrGrOeCSwOUbRw28pZJp3BPnA&response-X-Checksum-Sha1=8c2c22eb5057e5f9ee5eb181d07f8c4143a9b305&response-X-Checksum-Sha2=61bf82b4b62e07589dec1fdc9eb9eb053da01565581
fb18dd5df6232182238ec                                 
==> Downloading https://linuxbrew.bintray.com/bottles/python%403.9-3.9.0.x86_64_linux.bottle.tar.gz                                                                                                                       
==> Downloading from https://akamai.bintray.com/6f/6fa42aeb029d536ea827f9afef4465d6406600b5fb08a77daf96eae122d7d198?__gda__=exp=1602512040~hmac=2bcd7b1ebe41ab16211527b9a03325c17d52a521d8e3d2e5f1f0e6451fccdb4a&response-
content-disposition=attachment%3Bfilename%3D%22python%403.9-3.9.0.x86_64_linux.bottle.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX18iuG3gLZ-GWw8cJG9yHXcjKLO6RExIWRYlsrQGpiwzJyprEMTAYD7RXOdC-
euDPb2SUVHSce5guSIG2nBOZWwjfExdyWL4fVVmUNx7PlHumnJ1n47yNNHKbVhIlIkSBB82Rt4kykA4og&response-X-Checksum-Sha1=9658c0e3a4a0d326bfa38b87176823705015b6b3&response-X-Checksum-Sha2=6fa42aeb029d536ea827f9afef4465d6406600b5fb08a
77daf96eae122d7d198                                   
==> Downloading https://linuxbrew.bintray.com/bottles/ruby-2.7.2.x86_64_linux.bottle.tar.gz                                                                                                                               
==> Downloading from https://akamai.bintray.com/57/57646a5fe27b89464990921e85773fba854fda0d2fdd17c24f2a3c303d6cea6d?__gda__=exp=1602512041~hmac=1ec03b9611761b72e174089df612dd04c113d663e6cb1ff14d593f5b1f5d340d&response-
content-disposition=attachment%3Bfilename%3D%22ruby-2.7.2.x86_64_linux.bottle.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1-Kb09frep1AocgYAqEII75X6Ta2pLCcblBck1Gpi3hkbKm_T3ZsapXOiFAklOsLHvMu
m8WXO4Jw2sCrGt2CNIuqRM30IoIQXLDDQ-wAerqtwHECviorIKxCGkjCrUlSv1ojDwM_bhtSg&response-X-Checksum-Sha1=643584ed8f142cffe763dcbd0fe7ee263dedacad&response-X-Checksum-Sha2=57646a5fe27b89464990921e85773fba854fda0d2fdd17c24f2a3
c303d6cea6d                                           
==> Downloading https://linuxbrew.bintray.com/bottles/vim-8.2.1800_1.x86_64_linux.bottle.tar.gz                                                                                                                           
==> Downloading from https://akamai.bintray.com/49/49cf8bca1aba25115eb8467db461199cc481a7f880ada379181495ea5fcaf3a0?__gda__=exp=1602512042~hmac=8487c2f94b0c6b3fbfd21aa4ccc8a09a85bbb8ced4de02bf91701d1455b60d74&response-
content-disposition=attachment%3Bfilename%3D%22vim-8.2.1800_1.x86_64_linux.bottle.tar.gz%22&response-content-type=application%2Fgzip&requestInfo=U2FsdGVkX1_ypA7KrV_VEO2Z1oRRDP6ZgwopmAcBBU21oPz23ENYYG4_BikCdNLxQ0uJUQ2ZD
qMheipGrfBQDKU0sFJEI3v67NsuSbi3J8wuyEG1CpfJMdlc_wV9_a3U-z9Y8SQj1LfzTGf7AyDsdA&response-X-Checksum-Sha1=3db482ef21e8ac6a078d38c813ab2f54d9b6c41a&response-X-Checksum-Sha2=49cf8bca1aba25115eb8467db461199cc481a7f880ada3791
81495ea5fcaf3a0                                       
==> Installing dependencies for vim: openssl@1.1, python@3.9 and ruby                                        
==> Installing vim dependency: openssl@1.1                                                                   
==> Pouring openssl@1.1-1.1.1h.x86_64_linux.bottle.tar.gz                                                    
==> Downloading https://curl.haxx.se/ca/cacert-2020-01-01.pem 
==> Caveats                                           
A CA file has been bootstrapped using certificates from the system                                           
keychain. To add additional certificates, place .pem files in                                                
  /home/linuxbrew/.linuxbrew/etc/openssl@1.1/certs                                                           

and run                                               
  /home/linuxbrew/.linuxbrew/opt/openssl@1.1/bin/c_rehash                                                    
==> Summary                                           
🍺  /home/linuxbrew/.linuxbrew/Cellar/openssl@1.1/1.1.1h: 8,308 files, 23.4MB                                                                                                                                             
==> Installing vim dependency: python@3.9                                                                    
==> Pouring python@3.9-3.9.0.x86_64_linux.bottle.tar.gz                                                      
==> /home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.0/bin/python3 -s setup.py --no-user-cfg install --force --verbose --install-scripts=/home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.0/bin --install-lib=/home/linuxb
rew/.linuxbrew/lib/python3.9/site-packages --single-version-externally-managed --record=installed.txt        
==> /home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.0/bin/python3 -s setup.py --no-user-cfg install --force --verbose --install-scripts=/home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.0/bin --install-lib=/home/linuxb
rew/.linuxbrew/lib/python3.9/site-packages --single-version-externally-managed --record=installed.txt        
==> /home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.0/bin/python3 -s setup.py --no-user-cfg install --force --verbose --install-scripts=/home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.0/bin --install-lib=/home/linuxb
rew/.linuxbrew/lib/python3.9/site-packages --single-version-externally-managed --record=installed.txt        
==> Caveats                                           
Python has been installed as                          
  /home/linuxbrew/.linuxbrew/bin/python3                                                                     

Unversioned symlinks `python`, `python-config`, `pip` etc. pointing to                                       
`python3`, `python3-config`, `pip3` etc., respectively, have been installed into                                                                                                                                          
  /home/linuxbrew/.linuxbrew/opt/python@3.9/libexec/bin                                                      

You can install Python packages with                  
  pip3 install <package>                              
They will install into the site-package directory                                                            
  /home/linuxbrew/.linuxbrew/lib/python3.9/site-packages                                                     

See: https://docs.brew.sh/Homebrew-and-Python                                                                

python@3.9 is keg-only, which means it was not symlinked into /home/linuxbrew/.linuxbrew,                                                                                                                                 
because this is an alternate version of another formula.                                                     

If you need to have python@3.9 first in your PATH run:                                                       
  echo 'export PATH="/home/linuxbrew/.linuxbrew/opt/python@3.9/bin:$PATH"' >> ~/.zshrc                                                                                                                                    

For compilers to find python@3.9 you may need to set:                                                        
  export LDFLAGS="-L/home/linuxbrew/.linuxbrew/opt/python@3.9/lib"                                           
  export CPPFLAGS="-I/home/linuxbrew/.linuxbrew/opt/python@3.9/include"                                      

For pkg-config to find python@3.9 you may need to set:                                                       
  export PKG_CONFIG_PATH="/home/linuxbrew/.linuxbrew/opt/python@3.9/lib/pkgconfig"                                                                                                                                        

==> Summary                                           
🍺  /home/linuxbrew/.linuxbrew/Cellar/python@3.9/3.9.0: 4,032 files, 74.7MB                                  
==> Installing vim dependency: ruby                   
==> Pouring ruby-2.7.2.x86_64_linux.bottle.tar.gz  
==> Caveats                                           
By default, binaries installed by gem will be placed into:                                                   
  /home/linuxbrew/.linuxbrew/lib/ruby/gems/2.7.0/bin                                                         

You may want to add this to your PATH.                                                                       

Emacs Lisp files have been installed to:                                                                     
  /home/linuxbrew/.linuxbrew/share/emacs/site-lisp/ruby                                                      
==> Summary                                           
🍺  /home/linuxbrew/.linuxbrew/Cellar/ruby/2.7.2: 20,157 files, 42.8MB                                       
==> Installing vim                                    
==> Pouring vim-8.2.1800_1.x86_64_linux.bottle.tar.gz                                                        
🍺  /home/linuxbrew/.linuxbrew/Cellar/vim/8.2.1800_1: 1,953 files, 37.8MB                                    
Removing: /home/linuxbrew/.linuxbrew/Cellar/vim/8.2.1750... (1,952 files, 37.6MB)     

```

**brew test**
```
==> Testing kamel
==> /usr/local/Cellar/kamel/1.2.0/bin/kamel 2>&1
==> echo $(/usr/local/Cellar/kamel/1.2.0/bin/kamel help 2>&1)
==> echo $(/usr/local/Cellar/kamel/1.2.0/bin/kamel get 2>&1)
==> echo $(/usr/local/Cellar/kamel/1.2.0/bin/kamel version 2>&1)
==> echo $(/usr/local/Cellar/kamel/1.2.0/bin/kamel run 2>&1)
==> echo $(/usr/local/Cellar/kamel/1.2.0/bin/kamel run None.java 2>&1)
==> echo $(/usr/local/Cellar/kamel/1.2.0/bin/kamel reset 2>&1)
==> echo $(/usr/local/Cellar/kamel/1.2.0/bin/kamel rebuild 2>&1)
==> echo $(/usr/local/Cellar/kamel/3.2.0/bin/kamel reset 2>&1)
```

**brew audit**
```
==> Installing 'bundler' gem
Fetching gem metadata from https://rubygems.org/.........
Fetching concurrent-ruby 1.1.7
Fetching minitest 5.14.2
Using thread_safe 0.3.6
Fetching zeitwerk 2.4.0
Installing zeitwerk 2.4.0
Installing minitest 5.14.2
Fetching ast 2.4.1
Fetching bindata 2.4.8
Installing concurrent-ruby 1.1.7
Installing ast 2.4.1
Using bundler 1.17.3
Fetching byebug 11.1.3
Installing bindata 2.4.8
Installing byebug 11.1.3 with native extensions
Fetching json 2.3.2
Installing json 2.3.1 with native extensions
Using docile 1.3.2
Fetching simplecov-html 0.12.3
Installing simplecov-html 0.12.3
Fetching coderay 1.1.3
Installing coderay 1.1.3
Fetching colorize 0.8.1
Fetching highline 2.0.3
Installing colorize 0.8.1
Fetching connection_pool 2.2.3
Installing connection_pool 2.2.3
Installing highline 2.0.3
Fetching diff-lcs 1.4.4
Using unf_ext 0.0.7.7
Using hpricot 0.8.6
Fetching mime-types-data 3.2020.0512
Installing diff-lcs 1.4.4
Using net-http-digest_auth 1.4.1
Using mini_portile2 2.4.0
Using ntlm-http 0.1.1
Using webrobots 0.1.2
Fetching method_source 1.0.0
Installing mime-types-data 3.2020.0512
Using mustache 1.1.1
Fetching parallel 1.19.2
Installing method_source 1.0.0
Using rainbow 3.0.0
Fetching sorbet-runtime 0.5.5943
Installing parallel 1.19.2
Using plist 3.5.0
Fetching rdiscount 2.2.0.2
Installing sorbet-runtime 0.5.5943
Fetching regexp_parser 1.8.1
Installing rdiscount 2.2.0.2 with native extensions
Installing regexp_parser 1.8.1
Using rexml 3.2.4
Fetching rspec-support 3.9.3
Installing rspec-support 3.9.3
Using ruby-progressbar 1.10.1
Using unicode-display_width 1.7.0
Using ruby-macho 2.2.0
Fetching sorbet-static 0.5.5943 (x86_64-linux)
Installing sorbet-static 0.5.5943 (x86_64-linux)
Fetching sorbet-runtime-stub 0.2.0
Installing sorbet-runtime-stub 0.2.0
Using thor 1.0.1
Using tzinfo 1.2.7
Fetching parser 2.7.2.0
Installing parser 2.7.2.0
Fetching elftools 1.1.3
Installing elftools 1.1.3
Fetching i18n 1.8.5
Installing i18n 1.8.5
Fetching simplecov 0.19.0
Installing simplecov 0.19.0
Fetching net-http-persistent 4.0.0
Installing net-http-persistent 4.0.0
Fetching commander 4.5.2
Installing commander 4.5.2
Using unf 0.1.4
Fetching nokogiri 1.10.10
Installing nokogiri 1.10.10 with native extensions
Using mime-types 3.3.1
Fetching pry 0.13.1
Fetching parallel_tests 3.3.0
Installing pry 0.13.1
Installing parallel_tests 3.3.0
Fetching rspec-core 3.9.3
Fetching rspec-expectations 3.9.2
Installing rspec-core 3.9.3
Installing rspec-expectations 3.9.2
Using rspec-mocks 3.9.1
Fetching sorbet 0.5.5943
Fetching rubocop-ast 0.7.1
Installing sorbet 0.5.5943
Fetching patchelf 1.3.0
Installing rubocop-ast 0.7.1
Fetching activesupport 6.0.3.4
Installing patchelf 1.3.0
Fetching parlour 4.0.1
Installing activesupport 6.0.3.4
Installing parlour 4.0.1
Using domain_name 0.5.20190701
Using ronn 0.7.3
Fetching codecov 0.2.12
Installing codecov 0.2.12
Using rspec-retry 0.6.2
Using rspec 3.9.0
Using rspec-its 1.3.0
Fetching spoom 1.0.4
Fetching rubocop 0.92.0
Installing spoom 1.0.4
Using http-cookie 1.0.3
Using rspec-wait 0.0.9
Fetching tapioca 0.4.7
Installing tapioca 0.4.7
Installing rubocop 0.92.0
Fetching rubocop-performance 1.8.1
Fetching rubocop-rspec 1.43.2
Installing rubocop-performance 1.8.1
Installing rubocop-rspec 1.43.2
Fetching rubocop-sorbet 0.5.1
Installing rubocop-sorbet 0.5.1
Fetching mechanize 2.7.6
Installing mechanize 2.7.6
Bundle complete! 23 Gemfile dependencies, 74 gems now installed.
Bundled gems are installed into `../../../../../linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle`
Post-install message from i18n:

HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

If you are upgrading your Rails application from an older version of Rails:

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.

If you are starting a NEW Rails application, you can ignore this notice.

For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0

Post-install message from sorbet:

  Thanks for installing Sorbet! To use it in your project, first run:

    bundle exec srb init

  which will get your project ready to use with Sorbet.
  After that whenever you want to typecheck your code, run:

    bundle exec srb tc

  For more docs see: https://sorbet.org/docs/adopting
Removing simplecov-html (0.10.2)
Removing rspec-core (3.9.1)
Removing connection_pool (2.2.2)
Removing activesupport (6.0.2.2)
Removing zeitwerk (2.3.0)
Removing rubocop (0.82.0)
Removing i18n (1.8.2)
Removing rspec-support (3.9.2)
Removing jaro_winkler (1.5.4)
Removing rdiscount (2.2.0.1)
Removing ast (2.4.0)
Removing parallel (1.19.1)
Removing parser (2.7.1.1)
Removing rubocop (0.81.0)
Removing parallel_tests (2.32.0)
Removing simplecov (0.16.1)
Removing term-ansicolor (1.7.1)
Removing rubocop-performance (1.5.2)
Removing minitest (5.14.0)
Removing parser (2.7.1.0)
Removing concurrent-ruby (1.1.6)
Removing rubocop-rspec (1.38.1)
Removing mime-types-data (3.2019.1009)
Removing nokogiri (1.10.9)
Removing json (2.3.0)
Removing net-http-persistent (3.1.0)
Removing coveralls (0.8.23)
Removing tins (1.24.1)
Removing diff-lcs (1.3)
Removing rspec-expectations (3.9.1)
```