### PR TITLE
root: use ninja instead of make

### DIFF
--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -31,6 +31,7 @@ class Root < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "ninja" => :build
   depends_on "cfitsio"
   depends_on "davix"
   depends_on "fftw"
@@ -90,6 +91,7 @@ class Root < Formula
       -Dssl=ON
       -Dtmva=ON
       -Dxrootd=ON
+      -GNinja
     ]
 
     cxx_version = (MacOS.version < :mojave) ? 14 : 17
@@ -101,7 +103,7 @@ class Root < Formula
     mkdir "builddir" do
       system "cmake", "..", *args
 
-      system "make", "install"
+      system "ninja", "install"
 
       chmod 0755, Dir[bin/"*.*sh"]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There're some problems on Catalina with parallel `make install` (https://github.com/root-project/root/issues/6366). 
In https://github.com/Homebrew/homebrew-core/pull/61226 it looks like
```
...
make[2]: *** read jobs pipe: Resource temporarily unavailable.  Stop.
make[2]: *** Waiting for unfinished jobs....
...
```

Upstream suggests switching to `ninja`.