### PR TITLE
added env TARGET="HASWELL" to openblas build

### DIFF
--- a/Formula/openblas.rb
+++ b/Formula/openblas.rb
@@ -13,14 +13,14 @@ class Openblas < Formula
     sha256 "cf345fcf861d1a699832126476a7385b9cc212dc5b1b985749e219481473e836" => :mojave
     sha256 "09e6222e227fccb3d1a86aa0b0ac77fec3e512ba9266ecf72f235c58c6795009" => :high_sierra
   end
-  # This patch fixes a known issue with large matrices in numpy on Haswell and later
-  # chipsets.  See https://github.com/xianyi/OpenBLAS/pull/2729 for details
 
   keg_only :shadowed_by_macos, "macOS provides BLAS in Accelerate.framework"
 
   depends_on "gcc" # for gfortran
   fails_with :clang
 
+  # This patch fixes a known issue with large matrices in numpy on Haswell and later
+  # chipsets.  See https://github.com/xianyi/OpenBLAS/pull/2729 for details
   patch do
     url "https://github.com/xianyi/OpenBLAS/commit/6c33764ca43c7311bdd61e2371b08395cf3e3f01.diff?full_index=1"
     sha256 "a1b0c27384e424d8cabb5a4e3aeb47b9d0a1fbbc36507431b13719120b6d26d3"

--- a/Formula/openblas.rb
+++ b/Formula/openblas.rb
@@ -13,17 +13,29 @@ class Openblas < Formula
     sha256 "cf345fcf861d1a699832126476a7385b9cc212dc5b1b985749e219481473e836" => :mojave
     sha256 "09e6222e227fccb3d1a86aa0b0ac77fec3e512ba9266ecf72f235c58c6795009" => :high_sierra
   end
+  # This patch fixes a known issue with large matrices in numpy on Haswell and later
+  # chipsets.  See https://github.com/xianyi/OpenBLAS/pull/2729 for details
 
   keg_only :shadowed_by_macos, "macOS provides BLAS in Accelerate.framework"
 
   depends_on "gcc" # for gfortran
   fails_with :clang
 
+  patch do
+    url "https://github.com/xianyi/OpenBLAS/commit/6c33764ca43c7311bdd61e2371b08395cf3e3f01.diff?full_index=1"
+    sha256 "a1b0c27384e424d8cabb5a4e3aeb47b9d0a1fbbc36507431b13719120b6d26d3"
+  end
+
   def install
     ENV["DYNAMIC_ARCH"] = "1"
     ENV["USE_OPENMP"] = "1"
     ENV["NO_AVX512"] = "1"
-    ENV["TARGET"] = "HASWELL"
+    ENV["TARGET"] = case Hardware.oldest_cpu
+    when :arm_vortex_tempest
+      "VORTEX"
+    else
+      Hardware.oldest_cpu.upcase.to_s
+    end
 
     # Must call in two steps
     system "make", "CC=#{ENV.cc}", "FC=gfortran", "libs", "netlib", "shared"

--- a/Formula/openblas.rb
+++ b/Formula/openblas.rb
@@ -4,7 +4,7 @@ class Openblas < Formula
   url "https://github.com/xianyi/OpenBLAS/archive/v0.3.10.tar.gz"
   sha256 "0484d275f87e9b8641ff2eecaa9df2830cbe276ac79ad80494822721de6e1693"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://github.com/xianyi/OpenBLAS.git", branch: "develop"
 
   bottle do
@@ -23,6 +23,7 @@ class Openblas < Formula
     ENV["DYNAMIC_ARCH"] = "1"
     ENV["USE_OPENMP"] = "1"
     ENV["NO_AVX512"] = "1"
+    ENV["TARGET"] = "HASWELL"
 
     # Must call in two steps
     system "make", "CC=#{ENV.cc}", "FC=gfortran", "libs", "netlib", "shared"


### PR DESCRIPTION
Openblas currently builds with DYNAMIC_ARCH=1, but
if you don't specify the target CPU then the bottled
version can only be run on any machine whose CPU is
as least as new as the CPU which built openblas.

By specifying TARGET="HASWELL" older machine should
be able to use the bottled version of openblas
without having to build from scratch.

See https://github.com/Homebrew/discussions/discussions/54
for a discussion about how this error can cause
libraries like numpy, which are built on openblas, to
segfault.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
