### PR TITLE
miniserve: require rust only at build-time

### DIFF
--- a/Formula/miniserve.rb
+++ b/Formula/miniserve.rb
@@ -14,7 +14,7 @@ class Miniserve < Formula
     sha256 "a00b82cfce9fecd067b62ec3135a0e9cc59d3133f97ed3c0e7b815e4921c32d0" => :sierra
   end
 
-  depends_on "rust" => [:build]
+  depends_on "rust" => :build
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/miniserve.rb
+++ b/Formula/miniserve.rb
@@ -14,7 +14,7 @@ class Miniserve < Formula
     sha256 "a00b82cfce9fecd067b62ec3135a0e9cc59d3133f97ed3c0e7b815e4921c32d0" => :sierra
   end
 
-  depends_on "rust"
+  depends_on "rust" => [:build]
 
   def install
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
rust should not be necessary to run miniserve, only to install it.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?