### PR TITLE
spotifyd: fix panic for coreaudio-sys

### DIFF
--- a/Formula/spotifyd.rb
+++ b/Formula/spotifyd.rb
@@ -3,7 +3,7 @@ class Spotifyd < Formula
   homepage "https://github.com/Spotifyd/spotifyd"
   url "https://github.com/Spotifyd/spotifyd/archive/v0.2.24.tar.gz"
   sha256 "d3763f4647217a8f98ee938b50e141d67a5f3d33e9378894fde2a92c9845ef80"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
   head "https://github.com/Spotifyd/spotifyd.git"
 
   livecheck do
@@ -23,6 +23,7 @@ class Spotifyd < Formula
   depends_on "dbus"
 
   def install
+    ENV["COREAUDIO_SDK_PATH"] = MacOS.sdk_path_if_needed
     system "cargo", "install", "--no-default-features",
                                "--features=dbus_keyring,rodio_backend",
                                *std_cargo_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----


```
error: failed to run custom build command for `coreaudio-sys v0.2.3`

Caused by:
  process didn't exit successfully: `/private/tmp/spotifyd-20201013-64019-1ofczz5/spotifyd-0.2.24/target/release/build/coreaudio-sys-a8bf25d682724226/build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-env-changed=COREAUDIO_SDK_PATH
  cargo:rustc-link-lib=framework=AudioUnit
  cargo:rustc-link-lib=framework=CoreAudio
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS
  cargo:warning=couldn't execute `llvm-config --prefix` (error: No such file or directory (os error 2))
  cargo:warning=set the LLVM_CONFIG_PATH environment variable to a valid `llvm-config` executable

  --- stderr
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:48:1: error: expected ')'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:48:1: note: to match this '('
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:48:19: error: a parameter list without types is only allowed in a function definition
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:93:24: error: unknown type name 'os_workgroup_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:116:1: error: unknown type name 'os_workgroup_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:116:16: error: nullability specifier '_Nullable' cannot be applied to non-pointer type 'int'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:137:1: error: unknown type name 'os_workgroup_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:138:65: error: unknown type name 'os_workgroup_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:137:16: error: nullability specifier '_Nullable' cannot be applied to non-pointer type 'int'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:177:19: error: unknown type name 'os_workgroup_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:202:20: error: unknown type name 'os_workgroup_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:241:32: error: unknown type name 'os_workgroup_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:271:32: error: unknown type name 'os_workgroup_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:299:21: error: unknown type name 'os_workgroup_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:311:25: error: unknown type name 'os_workgroup_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:350:35: error: unknown type name 'os_workgroup_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_interval.h:41:28: error: redefinition of parameter 'os_workgroup_interval'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_interval.h:41:28: error: a parameter list without types is only allowed in a function definition
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_interval.h:94:29: error: unknown type name 'os_workgroup_interval_t'
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_interval.h:123:30: error: unknown type name 'os_workgroup_interval_t'
  fatal error: too many errors emitted, stopping now [-ferror-limit=]
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:48:1: error: expected ')', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:48:19: error: a parameter list without types is only allowed in a function definition, err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:93:24: error: unknown type name 'os_workgroup_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:116:1: error: unknown type name 'os_workgroup_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:116:16: error: nullability specifier '_Nullable' cannot be applied to non-pointer type 'int', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:137:1: error: unknown type name 'os_workgroup_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:138:65: error: unknown type name 'os_workgroup_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:137:16: error: nullability specifier '_Nullable' cannot be applied to non-pointer type 'int', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:177:19: error: unknown type name 'os_workgroup_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:202:20: error: unknown type name 'os_workgroup_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:241:32: error: unknown type name 'os_workgroup_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:271:32: error: unknown type name 'os_workgroup_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:299:21: error: unknown type name 'os_workgroup_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:311:25: error: unknown type name 'os_workgroup_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_object.h:350:35: error: unknown type name 'os_workgroup_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_interval.h:41:28: error: redefinition of parameter 'os_workgroup_interval', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_interval.h:41:28: error: a parameter list without types is only allowed in a function definition, err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_interval.h:94:29: error: unknown type name 'os_workgroup_interval_t', err: true
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/usr/include/os/workgroup_interval.h:123:30: error: unknown type name 'os_workgroup_interval_t', err: true
  fatal error: too many errors emitted, stopping now [-ferror-limit=], err: true
  thread 'main' panicked at 'unable to generate bindings: ()', /Users/jonchang/Library/Caches/Homebrew/cargo_cache/registry/src/github.com-1ecc6299db9ec823/coreaudio-sys-0.2.3/build.rs:100:39
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: failed to compile `spotifyd v0.2.24 (/private/tmp/spotifyd-20201013-64019-1ofczz5/spotifyd-0.2.24)`, intermediate artifacts can be found at `/private/tmp/spotifyd-20201013-64019-1ofczz5/spotifyd-0.2.24/target`
```