### PR TITLE
exa: use cargo directly

### DIFF
--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -19,7 +19,6 @@ class Exa < Formula
     sha256 "9499359da5f5fffbd8b22c8cb8e78f0fdf99594c4d2b06e7ba58eb21afbcb582" => :sierra
   end
 
-  depends_on "cmake" => :build
   depends_on "rust" => :build
 
   uses_from_macos "zlib"
@@ -29,7 +28,7 @@ class Exa < Formula
   end
 
   def install
-    system "make", "install", "PREFIX=#{prefix}"
+    system "cargo", "install", *std_cargo_args
 
     bash_completion.install "contrib/completions.bash" => "exa"
     zsh_completion.install  "contrib/completions.zsh"  => "_exa"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

exa recently switched from make to just for building, which means installing from head is currently broken since the formula uses make. We can bypass the issue by just using cargo directly rather than going through make or just, especially since there is nothing extra needed from either. This seems to be what most other rust formulas are doing as well.