### PR TITLE
Rebuild failed formulae from openjdk update

### DIFF
--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -5,6 +5,7 @@ class Cbmc < Formula
       tag:      "cbmc-5.16.0",
       revision: "4451960f8b8172bc91bc8f1cc84ad78e05b12536"
   license "BSD-4-Clause"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/pax-construct.rb
+++ b/Formula/pax-construct.rb
@@ -3,6 +3,7 @@ class PaxConstruct < Formula
   homepage "https://ops4j1.jira.com/wiki/display/paxconstruct/Pax+Construct"
   url "https://search.maven.org/remotecontent?filepath=org/ops4j/pax/construct/scripts/1.5/scripts-1.5.zip"
   sha256 "d0325bbe571783097d4be782576569ea0a61529695c14e33a86bbebfe44859d1"
+  revision 1
 
   bottle :unneeded
 

--- a/Formula/solr@7.7.rb
+++ b/Formula/solr@7.7.rb
@@ -5,6 +5,7 @@ class SolrAT77 < Formula
   mirror "https://archive.apache.org/dist/lucene/solr/7.7.3/solr-7.7.3.tgz"
   sha256 "3ec67fa430afa5b5eb43bb1cd4a659e56ee9f8541e0116d6080c0d783870baee"
   license "Apache-2.0"
+  revision 1
 
   bottle :unneeded
 


### PR DESCRIPTION
I'm not able to reproduce [failures from OpenJDK 15 PR](https://github.com/Homebrew/homebrew-core/pull/61226#issuecomment-707011406) locally, so let's try to build problematic formulae (`cbmc` `pax-construct` `solr@7.7`) to see if it's really related to openjdk 15 update or it happens independently.

DO NOT MERGE