### PR TITLE
Make gauche depend on mbedtls

### DIFF
--- a/Formula/gauche.rb
+++ b/Formula/gauche.rb
@@ -3,6 +3,7 @@ class Gauche < Formula
   homepage "https://practical-scheme.net/gauche/"
   url "https://downloads.sourceforge.net/project/gauche/Gauche/Gauche-0.9.9.tgz"
   sha256 "4ca9325322a7efadb9680d156eb7b53521321c9ca4955c4cbe738bc2e1d7f7fb"
+  revision 1
 
   livecheck do
     url :stable
@@ -15,11 +16,13 @@ class Gauche < Formula
     sha256 "719f5826572a2aec1383ef5501ee4f92580f8a769205c03e47f9e610fa0b5abd" => :high_sierra
   end
 
+  depends_on "mbedtls"
+
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking",
-                          "--enable-multibyte=utf-8"
+                          "--enable-multibyte=utf-8",
+                          "--with-mbedtls"
     system "make"
-    system "make", "check"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, Gauche uses the built-in axTLS library which is missing support for some ciphers that are important on today's web. Enable mbedtls for more up-to-date cipher support.