### PR TITLE
borgbackup: migrate to python@3.9

### DIFF
--- a/Formula/borgbackup.rb
+++ b/Formula/borgbackup.rb
@@ -6,6 +6,7 @@ class Borgbackup < Formula
   url "https://github.com/borgbackup/borg/releases/download/1.1.14/borgbackup-1.1.14.tar.gz"
   sha256 "7dbb0747cc948673f695cd6de284af215f810fed2eb2a615ef26ddc7c691edba"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     cellar :any
@@ -19,12 +20,12 @@ class Borgbackup < Formula
   depends_on "libb2"
   depends_on "lz4"
   depends_on "openssl@1.1"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "zstd"
 
   resource "llfuse" do
-    url "https://files.pythonhosted.org/packages/75/b4/5248459ec0e7e1608814915479cb13e5baf89034b572e3d74d5c9219dd31/llfuse-1.3.6.tar.bz2"
-    sha256 "31a267f7ec542b0cd62e0f1268e1880fdabf3f418ec9447def99acfa6eff2ec9"
+    url "https://files.pythonhosted.org/packages/8f/73/d35aaf5f650250756b40c1e718ee6a2d552700729476dee24c9837608e1b/llfuse-1.3.8.tar.gz"
+    sha256 "b9b573108a840fbaa5c8f037160cc541f21b8cbdc15c5c8a39d5ac8c1b6c4cbc"
   end
 
   def install


### PR DESCRIPTION
Splitting from https://github.com/Homebrew/homebrew-core/pull/62560
Should work according to https://github.com/borgbackup/borg/commit/7dc161067498703dca27b6e2437548a9cc4d981b