### PR TITLE
mame: migrate to python@3.9

### DIFF
--- a/Formula/mame.rb
+++ b/Formula/mame.rb
@@ -5,6 +5,7 @@ class Mame < Formula
   version "0.225"
   sha256 "ca4d5a429d72b30fd2bdf60350e490c7de4ac64b1e0dafcf38450f8ba84a1a95"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/mamedev/mame.git"
 
   bottle do
@@ -17,7 +18,7 @@ class Mame < Formula
   depends_on "glm" => :build
   depends_on "pkg-config" => :build
   depends_on "pugixml" => :build
-  depends_on "python@3.8" => :build
+  depends_on "python@3.9" => :build
   depends_on "rapidjson" => :build
   depends_on "sphinx-doc" => :build
   depends_on "flac"
@@ -39,7 +40,7 @@ class Mame < Formula
 
     # Use bundled asio and lua instead of latest version.
     # See: <https://github.com/mamedev/mame/issues/5721>
-    system "make", "PYTHON_EXECUTABLE=#{Formula["python@3.8"].opt_bin}/python3",
+    system "make", "PYTHON_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3",
                    "USE_LIBSDL=1",
                    "USE_SYSTEM_LIB_EXPAT=1",
                    "USE_SYSTEM_LIB_ZLIB=1",


### PR DESCRIPTION
Splitting from https://github.com/Homebrew/homebrew-core/pull/62560