### PR TITLE
exa: fix completion installation

### DIFF
--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -30,13 +30,12 @@ class Exa < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    begin
-      # > 0.9
+    # Remove in 0.9+
+    if build.head?
       bash_completion.install "completions/completions.bash" => "exa"
       zsh_completion.install  "completions/completions.zsh"  => "_exa"
       fish_completion.install "completions/completions.fish" => "exa.fish"
-    rescue
-      # <= 0.9
+    else
       bash_completion.install "contrib/completions.bash" => "exa"
       zsh_completion.install  "contrib/completions.zsh"  => "_exa"
       fish_completion.install "contrib/completions.fish" => "exa.fish"

--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -30,11 +30,13 @@ class Exa < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    begin  # > 0.9
+    begin
+      # > 0.9
       bash_completion.install "completions/completions.bash" => "exa"
       zsh_completion.install  "completions/completions.zsh"  => "_exa"
       fish_completion.install "completions/completions.fish" => "exa.fish"
-    rescue  # <= 0.9
+    rescue
+      # <= 0.9
       bash_completion.install "contrib/completions.bash" => "exa"
       zsh_completion.install  "contrib/completions.zsh"  => "_exa"
       fish_completion.install "contrib/completions.fish" => "exa.fish"

--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -30,9 +30,15 @@ class Exa < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    bash_completion.install "contrib/completions.bash" => "exa"
-    zsh_completion.install  "contrib/completions.zsh"  => "_exa"
-    fish_completion.install "contrib/completions.fish" => "exa.fish"
+    begin  # > 0.9
+      bash_completion.install "completions/completions.bash" => "exa"
+      zsh_completion.install  "completions/completions.zsh"  => "_exa"
+      fish_completion.install "completions/completions.fish" => "exa.fish"
+    rescue  # <= 0.9
+      bash_completion.install "contrib/completions.bash" => "exa"
+      zsh_completion.install  "contrib/completions.zsh"  => "_exa"
+      fish_completion.install "contrib/completions.fish" => "exa.fish"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

exa recently moved completions from the `contrib` directory into `completions` on master. 0.9 will still need to install completions from `contrib`, but HEAD installs will need to install completions from `completions`. This tweak tries to install from `completions` and falls back to `contrib` if it fails, handling both cases.