### PR TITLE
solr: make env vars configurable, solr@7.7: switch to openjdk@11

### DIFF
--- a/Formula/solr.rb
+++ b/Formula/solr.rb
@@ -5,6 +5,7 @@ class Solr < Formula
   mirror "https://archive.apache.org/dist/lucene/solr/8.6.3/solr-8.6.3.tgz"
   sha256 "c24925f3e8103673c2fceaaff4a04d6f1ab12b4ffd67da36fbbd2aa9aaaa6b55"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -20,11 +21,12 @@ class Solr < Formula
     prefix.install %w[contrib dist server]
     libexec.install "bin"
     bin.install [libexec/"bin/solr", libexec/"bin/post", libexec/"bin/oom_solr.sh"]
-    bin.env_script_all_files libexec,
-      JAVA_HOME:     Formula["openjdk"].opt_prefix,
-      SOLR_HOME:     var/"lib/solr",
-      SOLR_LOGS_DIR: var/"log/solr",
-      SOLR_PID_DIR:  var/"run/solr"
+
+    env = Language::Java.overridable_java_home_env
+    env["SOLR_HOME"] = "${SOLR_HOME:-#{var/"lib/solr"}}"
+    env["SOLR_LOGS_DIR"] = "${SOLR_LOGS_DIR:-#{var/"log/solr"}}"
+    env["SOLR_PID_DIR"] = "${SOLR_PID_DIR:-#{var/"run/solr"}}"
+    bin.env_script_all_files libexec, env
     (libexec/"bin").rmtree
   end
 
@@ -63,6 +65,7 @@ class Solr < Formula
   end
 
   test do
+    ENV["SOLR_PID_DIR"] = testpath
     port = free_port
 
     # Info detects no Solr node => exit code 3

--- a/Formula/solr@7.7.rb
+++ b/Formula/solr@7.7.rb
@@ -5,12 +5,13 @@ class SolrAT77 < Formula
   mirror "https://archive.apache.org/dist/lucene/solr/7.7.3/solr-7.7.3.tgz"
   sha256 "3ec67fa430afa5b5eb43bb1cd4a659e56ee9f8541e0116d6080c0d783870baee"
   license "Apache-2.0"
+  revision 1
 
   bottle :unneeded
 
   keg_only :versioned_formula
 
-  depends_on "openjdk"
+  depends_on "openjdk@11"
 
   def install
     pkgshare.install "bin/solr.in.sh"
@@ -18,11 +19,12 @@ class SolrAT77 < Formula
     prefix.install %w[contrib dist server]
     libexec.install "bin"
     bin.install [libexec/"bin/solr", libexec/"bin/post", libexec/"bin/oom_solr.sh"]
-    bin.env_script_all_files libexec,
-      JAVA_HOME:     Formula["openjdk"].opt_prefix,
-      SOLR_HOME:     var/"lib/solr",
-      SOLR_LOGS_DIR: var/"log/solr",
-      SOLR_PID_DIR:  var/"run/solr"
+
+    env = Language::Java.overridable_java_home_env("11")
+    env["SOLR_HOME"] = "${SOLR_HOME:-#{var/"lib/solr"}}"
+    env["SOLR_LOGS_DIR"] = "${SOLR_LOGS_DIR:-#{var/"log/solr"}}"
+    env["SOLR_PID_DIR"] = "${SOLR_PID_DIR:-#{var/"run/solr"}}"
+    bin.env_script_all_files libexec, env
     (libexec/"bin").rmtree
   end
 
@@ -59,6 +61,7 @@ class SolrAT77 < Formula
   end
 
   test do
+    ENV["SOLR_PID_DIR"] = testpath
     port = free_port
 
     # Info detects no Solr node => exit code 3


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is required for [java 15 upgrade](https://github.com/Homebrew/homebrew-core/pull/61226).
- `solr@7.7` doesn't support java 15 (because it uses deprecated and removed `UseConcMarkSweepGC` option), so it's switched to `openjdk@11`
- both `solr` and `solr@7.7` have overridable SOLR_HOME, SOLR_LOGS_DIR, SOLR_PID_DIR and JAVA_HOME env vars
- we set custom `ENV["SOLR_PID_DIR"]` for test to have written pid file to be cleanup after failed test. This should prevent the following test to fail with an unrelated error message `Solr process 97633 from /usr/local/var/run/solr/solr-49478.pid not found.` 
