### PR TITLE
iso-codes: bump to python@3.9

### DIFF
--- a/Formula/iso-codes.rb
+++ b/Formula/iso-codes.rb
@@ -14,7 +14,7 @@ class IsoCodes < Formula
   end
 
   depends_on "gettext" => :build
-  depends_on "python@3.8" => :build
+  depends_on "python@3.9" => :build
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
Realised `iso-codes` does not need a revision bump at all, it's merely a collection of text files with no Python reference in them.