### PR TITLE
Corrected version string in SlowHTTPTest 1.8.2

### DIFF
--- a/Formula/slowhttptest.rb
+++ b/Formula/slowhttptest.rb
@@ -4,6 +4,7 @@ class Slowhttptest < Formula
   url "https://github.com/shekyan/slowhttptest/archive/v1.8.2.tar.gz"
   sha256 "faa83dc45e55c28a88d3cca53d2904d4059fe46d86eca9fde7ee9061f37c0d80"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/shekyan/slowhttptest.git"
 
   bottle do
@@ -13,9 +14,15 @@ class Slowhttptest < Formula
     sha256 "c9b36ccf8aee0f6572e2eb1112caf25811c22f1500ad81c1277309c76bd6460b" => :high_sierra
   end
 
+  # Remove these in next version
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+
   depends_on "openssl@1.1"
 
   def install
+    inreplace "configure.ac", "1.8.1", "1.8.2"
+    system "autoconf" # Remove in next version
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end
@@ -23,5 +30,7 @@ class Slowhttptest < Formula
   test do
     system "#{bin}/slowhttptest", "-u", "https://google.com",
                                   "-p", "1", "-r", "1", "-l", "1", "-i", "1"
+
+    assert_match version.to_s, shell_output("#{bin}/slowhttptest -h", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

SlowHTTPTest incorrectly reports itself as version 1.8.1. This fixes that.