### PR TITLE
python@3.9: do not symlink as pip3 and wheel3

### DIFF
--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -230,7 +230,7 @@ class PythonAT39 < Formula
     end
 
     # post_install happens after link
-    %W[pip3 pip#{xy} easy_install-#{xy} wheel3].each do |e|
+    %W[pip#{xy} easy_install-#{xy}].each do |e|
       (HOMEBREW_PREFIX/"bin").install_symlink bin/e
     end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/issues/62911