### PR TITLE
autojump: migrate to python@3.9

### DIFF
--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -3,7 +3,8 @@ class Autojump < Formula
   homepage "https://github.com/wting/autojump"
   url "https://github.com/wting/autojump/archive/release-v22.5.3.tar.gz"
   sha256 "00daf3698e17ac3ac788d529877c03ee80c3790472a85d0ed063ac3a354c37b1"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/wting/autojump.git"
 
   bottle do
@@ -14,10 +15,10 @@ class Autojump < Formula
     sha256 "c95107719bd784e0e348be6dbfb3a780240d96f8d76710271c3642335babbd8f" => :sierra
   end
 
-  depends_on :macos # Due to Python 2
+  depends_on "python@3.9"
 
   def install
-    system "./install.py", "-d", prefix, "-z", zsh_completion
+    system Formula["python@3.9"].opt_bin/"python3", "install.py", "-d", prefix, "-z", zsh_completion
 
     # Backwards compatibility for users that have the old path in .bash_profile
     # or .zshrc


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [installation requirements](https://github.com/wting/autojump#requirements) of autojump specifies Python v2.6+ or Python v3.3+.