### PR TITLE
postgis: fix build against postgres 13.0 and license

### DIFF
--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -3,6 +3,8 @@ class Postgis < Formula
   homepage "https://postgis.net/"
   url "https://download.osgeo.org/postgis/source/postgis-3.0.2.tar.gz"
   sha256 "a3a1641dfd73c83924088a185bdb8b35567b3d1dc8d0887f9e4b492e228ab2ca"
+  license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://download.osgeo.org/postgis/source/"


### PR DESCRIPTION
- [X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Retry this. Last PR was turning into mush so redid the changes branched from a more recent master