### PR TITLE
carrot2: allow formula to use latest gradle

### DIFF
--- a/Formula/carrot2.rb
+++ b/Formula/carrot2.rb
@@ -17,6 +17,11 @@ class Carrot2 < Formula
   depends_on "openjdk"
 
   def install
+    # Make possible to build the formula with the latest available in Homebrew gradle
+    inreplace "gradle/validation/check-environment.gradle",
+      /expectedGradleVersion = '[^']+'/,
+      "expectedGradleVersion = '#{Formula["gradle"].version}'"
+
     system "gradle", "assemble"
 
     cd "distribution/build/dist" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default `carrot2` can use only one specific version of `gradle`. This PR makes it possible to build it with the latest available in Homebrew `gradle`
