### PR TITLE
biosig 2.1.0

### DIFF
--- a/Formula/biosig.rb
+++ b/Formula/biosig.rb
@@ -1,9 +1,9 @@
 class Biosig < Formula
   desc "Tools for biomedical signal processing and data conversion"
   homepage "https://biosig.sourceforge.io"
-  url "https://downloads.sourceforge.net/project/biosig/BioSig%20for%20C_C%2B%2B/src/biosig-2.0.4.src.tar.gz"
-  sha256 "2b2b5d0cdb7a886b7c390d000bb9210b9b6e03f790c6443730dab96496926928"
-  license "GPL-3.0"
+  url "https://downloads.sourceforge.net/project/biosig/BioSig%20for%20C_C%2B%2B/src/biosig-2.1.0.src.tar.gz"
+  sha256 "562ff3d5aee834dc7d676128e769c8762e23a40e0c18e6995628ffdcaa3e1c7e"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url :stable
@@ -18,11 +18,10 @@ class Biosig < Formula
   end
 
   depends_on "gawk" => :build
-  depends_on "gnu-sed" => :build
   depends_on "gnu-tar" => :build
-  depends_on "pkg-config" => :build
   depends_on "dcmtk"
   depends_on "libb64"
+  depends_on "numpy"
   depends_on "suite-sparse"
   depends_on "tinyxml"
 
@@ -33,9 +32,9 @@ class Biosig < Formula
 
   def install
     system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+           "--disable-dependency-tracking",
+           "--disable-silent-rules",
+           "--prefix=#{prefix}"
     system "make"
     system "make", "install"
   end
@@ -44,7 +43,7 @@ class Biosig < Formula
     assert_match "usage: save2gdf [OPTIONS] SOURCE DEST", shell_output("#{bin}/save2gdf -h").strip
     assert_match "mV\t4274\t0x10b2\t0.001\tV", shell_output("#{bin}/physicalunits mV").strip
     assert_match "biosig_fhir provides fhir binary template for biosignal data",
-      shell_output("#{bin}/biosig_fhir 2>&1").strip
+                 shell_output("#{bin}/biosig_fhir 2>&1").strip
     testpath.install resource("test")
     assert_match "NumberOfChannels", shell_output("#{bin}/save2gdf -json TEST_44x86_e1.GDF").strip
     assert_match "NumberOfChannels", shell_output("#{bin}/biosig_fhir TEST_44x86_e1.GDF").strip


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same Xformula update/change?
There is another pull request vor 2.0.6, but that is now obsolete with this pull request for 2.1.0

- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

I still get "* 1: col 1: Missing frozen string literal comment", not sure how to fix it.  
-----
