### PR TITLE
scipy: patches for Xcode 12

### DIFF
--- a/Formula/scipy.rb
+++ b/Formula/scipy.rb
@@ -26,6 +26,21 @@ class Scipy < Formula
 
   cxxstdlib_check :skip
 
+  # Fix compilation with Xcode 12
+  # https://github.com/scipy/scipy/issues/12935
+  # https://github.com/scipy/scipy/pull/12243
+  patch do
+    url "https://github.com/scipy/scipy/commit/b8e47064.diff?full_index=1"
+    sha256 "7b2fdb01fc3af54e189c3ec4785c6d69ea63d9bd12aac83c9eaedd393c01591d"
+  end
+
+  # Fix compilation with Xcode 12
+  # https://github.com/scipy/scipy/issues/12860
+  patch do
+    url "https://github.com/scipy/scipy/commit/de679deb.diff?full_index=1"
+    sha256 "23d957effb33494c73a12a6bca2866c9b6aa9ba94d69744a32231965dd6b949e"
+  end
+
   def install
     openblas = Formula["openblas"].opt_prefix
     ENV["ATLAS"] = "None" # avoid linking against Accelerate.framework


### PR DESCRIPTION
Splitting from https://github.com/Homebrew/homebrew-core/pull/62560
Fix scipy with Xcode 12