### PR TITLE
ldns: migrate to python@3.9

### DIFF
--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -2,6 +2,7 @@ class Freeswitch < Formula
   desc "Telephony platform to route various communication protocols"
   homepage "https://freeswitch.org"
   license "MPL-1.1"
+  revision 1
   head "https://github.com/signalwire/freeswitch.git"
 
   stable do

--- a/Formula/ldns.rb
+++ b/Formula/ldns.rb
@@ -3,7 +3,7 @@ class Ldns < Formula
   homepage "https://nlnetlabs.nl/projects/ldns/"
   url "https://nlnetlabs.nl/downloads/ldns/ldns-1.7.1.tar.gz"
   sha256 "8ac84c16bdca60e710eea75782356f3ac3b55680d40e1530d7cea474ac208229"
-  revision 2
+  revision 3
 
   # https://nlnetlabs.nl/downloads/ldns/ since the first-party site has a
   # tendency to lead to an `execution expired` error.
@@ -21,7 +21,7 @@ class Ldns < Formula
 
   depends_on "swig" => :build
   depends_on "openssl@1.1"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     args = %W[
@@ -30,16 +30,14 @@ class Ldns < Formula
       --with-examples
       --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
       --with-pyldns
-      PYTHON_SITE_PKG=#{lib}/python3.8/site-packages
+      PYTHON_SITE_PKG=#{lib}/python3.9/site-packages
       --disable-dane-verify
     ]
 
-    if MacOS.version == :mojave
-      # Fixes: ./contrib/python/ldns_wrapper.c:2746:10: fatal error: 'ldns.h' file not found
-      inreplace "contrib/python/ldns.i", "#include \"ldns.h\"", "#include <ldns/ldns.h>"
-    end
+    # Fixes: ./contrib/python/ldns_wrapper.c:2746:10: fatal error: 'ldns.h' file not found
+    inreplace "contrib/python/ldns.i", "#include \"ldns.h\"", "#include <ldns/ldns.h>"
 
-    ENV["PYTHON"] = Formula["python@3.8"].opt_bin/"python3"
+    ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
     system "./configure", *args
 
     inreplace "Makefile" do |s|

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -6,6 +6,7 @@ class Openssh < Formula
   version "8.4p1"
   sha256 "5a01d22e407eb1c05ba8a8f7c654d388a13e9f226e4ed33bd38748dafa1d2b24"
   license "SSH-OpenSSH"
+  revision 1
 
   livecheck do
     url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/"


### PR DESCRIPTION
The issue that we thought was Mojave-only is reappearing with Xcode 12, and it's blocking the Python 3.9 migration: https://github.com/Homebrew/homebrew-core/pull/62560/commits/cf06c4b6ba877b16bb85b5081b4b5fb4ec523b83