### PR TITLE
Use the zip url when installing LanguageTool

### DIFF
--- a/Formula/languagetool.rb
+++ b/Formula/languagetool.rb
@@ -1,8 +1,8 @@
 class Languagetool < Formula
   desc "Style and grammar checker"
   homepage "https://www.languagetool.org/"
-  url "https://languagetool.org/download/LanguageTool-5.1.3.oxt"
-  sha256 "3c3288a4a651553b3f9e762a027fab75a38b35050f522cbf8fce2554977dc7f0"
+  url "https://languagetool.org/download/LanguageTool-5.1.zip"
+  sha256 "c91ff43d54c863a9389a81c5fa1a6723041b982435f220e9c2c4db843b66d1b6"
   license "LGPL-2.1-or-later"
 
   livecheck do


### PR DESCRIPTION
This essentially reverts https://github.com/Homebrew/homebrew-core/pull/62595/files
`.oxt` is only the OpenOffice extension file, not the full release.

This is causing issues when installing: https://github.com/languagetool-org/languagetool/issues/3719

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
