### PR TITLE
sfcgal: fix sha256

### DIFF
--- a/Formula/sfcgal.rb
+++ b/Formula/sfcgal.rb
@@ -2,8 +2,9 @@ class Sfcgal < Formula
   desc "C++ wrapper library around CGAL"
   homepage "http://sfcgal.org/"
   url "https://gitlab.com/Oslandia/SFCGAL/-/archive/v1.3.9/SFCGAL-v1.3.9.tar.gz"
-  sha256 "4f8ecfaa0d9ac5d8d7969f767ce3abadc7cc64059a11481e4bc497f04d5f6598"
+  sha256 "2451cb6df24853c7e59173eec0068e3263ab625fcf61add4624f8bf8366ae4e3"
   license "LGPL-2.0+"
+  revision 1
 
   bottle do
     sha256 "8cc583e706bc2755d61c362afbdd0cc627c6126113d4d6c5c0cc1f1bb62e8dfa" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

v1.3.9 was re-released: https://gitlab.com/Oslandia/SFCGAL/-/issues/236

One of the header files has been modified, so I've updated the revision. If this isn't needed - let me know (first time doing a Homebrew PR!).