### PR TITLE
googletest 1.10.0 (new formula)

### DIFF
--- a/Formula/googletest.rb
+++ b/Formula/googletest.rb
@@ -1,0 +1,28 @@
+class Googletest < Formula
+  desc "Google Testing and Mocking Framework"
+  homepage "https://github.com/google/googletest"
+  url "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
+  sha256 "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb"
+  license "BSD-3-Clause"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <gtest/gtest.h>
+      #include <gtest/gtest-death-test.h>
+
+      TEST(Simple, Boolean)
+      {
+        ASSERT_TRUE(true);
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-std=c++11", "-L#{lib}", "-lgtest", "-lgtest_main", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Now that https://github.com/Homebrew/brew/issues/8935 was closed by https://github.com/Homebrew/brew/pull/8947 it is possible to package googletest.

Is "googletest" OK unhyphenated to match upstream and other googletest package names (e.g. FreeBSD ports), or should it be called "google-test" to match other formulae?  Note that it's not called "gtest" since it also includes "gmock" since upstream now provide both as a single release under the "googletest" repository.