### PR TITLE
zig: patch CMakeLists only on stable

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -1,11 +1,18 @@
 class Zig < Formula
   desc "Programming language designed for robustness, optimality, and clarity"
   homepage "https://ziglang.org/"
-  url "https://ziglang.org/download/0.6.0/zig-0.6.0.tar.xz"
-  sha256 "5d167dc19354282dd35dd17b38e99e1763713b9be8a4ba9e9e69284e059e7204"
   license "MIT"
   revision 1
   head "https://github.com/ziglang/zig.git"
+
+  stable do
+    url "https://ziglang.org/download/0.6.0/zig-0.6.0.tar.xz"
+    sha256 "5d167dc19354282dd35dd17b38e99e1763713b9be8a4ba9e9e69284e059e7204"
+
+    # Fix linking issues
+    # https://github.com/Homebrew/homebrew-core/issues/53198
+    patch :DATA
+  end
 
   bottle do
     cellar :any
@@ -16,10 +23,6 @@ class Zig < Formula
 
   depends_on "cmake" => :build
   depends_on "llvm"
-
-  # Fix linking issues
-  # https://github.com/Homebrew/homebrew-core/issues/53198
-  patch :DATA
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
`head` has already been patched, hence explicit patching is only applicable to `stable` now.

Signed-off-by: Jakub Konka <kubkon@jakubkonka.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
