### PR TITLE
semtag: reenable formula

### DIFF
--- a/Formula/semtag.rb
+++ b/Formula/semtag.rb
@@ -3,6 +3,7 @@ class Semtag < Formula
   homepage "https://github.com/pnikosis/semtag"
   url "https://github.com/pnikosis/semtag/archive/v0.1.0.tar.gz"
   sha256 "9e16a418b795363a9283318e5dc02da8a67ec96adaac0ae8eb23f1b21b06666f"
+  license "Apache-2.0"
 
   bottle :unneeded
 

--- a/Formula/semtag.rb
+++ b/Formula/semtag.rb
@@ -6,9 +6,6 @@ class Semtag < Formula
 
   bottle :unneeded
 
-  # https://github.com/pnikosis/semtag/issues/15
-  disable! because: :no_license
-
   def install
     bin.install "semtag"
   end


### PR DESCRIPTION
License has been added: https://github.com/pnikosis/semtag/blob/master/LICENSE

Reverts https://github.com/Homebrew/homebrew-core/pull/58432

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
