### PR TITLE
nushell: update SHA256, add livecheck block

### DIFF
--- a/Formula/nushell.rb
+++ b/Formula/nushell.rb
@@ -2,9 +2,14 @@ class Nushell < Formula
   desc "Modern shell for the GitHub era"
   homepage "https://www.nushell.sh"
   url "https://github.com/nushell/nushell/archive/0.21.0.tar.gz"
-  sha256 "223df54901cf924c8018629827c00c73a3cf45bbb178503484318734e9d99e82"
+  sha256 "24598bcf6e61825fd3b6f17e083952926a4b072efff413748bbd5bc83a3158f1"
   license "MIT"
   head "https://github.com/nushell/nushell.git", branch: "main"
+
+  livecheck do
+    url "https://github.com/nushell/nushell/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:[._]\d+)+)["' >]}i)
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git repository tags for the `nushell` formula. However, the [`nushell` GitHub repository](https://github.com/nushell/nushell/) marks the "latest" release, so we should be using that instead.

It was also explained in https://github.com/Homebrew/homebrew-core/issues/63093#issuecomment-712975687 that it's best to wait until there's a release on GitHub before using a version. The check in this PR is more appropriate with this in mind as well.

This also updates the SHA256, as upstream confirmed in #63093 and nushell/nushell#2680 that the change was because "[they] had to pull a draft of the release and republish it after a fix was made".

Fixes #63093.