### PR TITLE
kerl 2.0.1

### DIFF
--- a/Formula/kerl.rb
+++ b/Formula/kerl.rb
@@ -1,8 +1,8 @@
 class Kerl < Formula
   desc "Easy building and installing of Erlang/OTP instances"
   homepage "https://github.com/kerl/kerl"
-  url "https://github.com/kerl/kerl/archive/2.0.0.tar.gz"
-  sha256 "76579a934d918e26731d7b0c7e2f41bb89512175b70886825ceb40f05110544f"
+  url "https://github.com/kerl/kerl/archive/2.0.1.tar.gz"
+  sha256 "0a23bfe5fb86da536ed0041d21eb775e82dfd6e8c07e5d90013beea5ef4af725"
   license "MIT"
   head "https://github.com/kerl/kerl.git"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 32,542 bytes
- formula fetch time: 1.1 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.