### PR TITLE
libsndfile: update homepage and livecheck block

### DIFF
--- a/Formula/libsndfile.rb
+++ b/Formula/libsndfile.rb
@@ -1,13 +1,13 @@
 class Libsndfile < Formula
   desc "C library for files containing sampled sound"
-  homepage "http://www.mega-nerd.com/libsndfile/"
+  homepage "https://libsndfile.github.io/libsndfile/"
   url "https://github.com/erikd/libsndfile/releases/download/v1.0.30/libsndfile-1.0.30.tar.bz2"
   sha256 "9df273302c4fa160567f412e10cc4f76666b66281e7ba48370fb544e87e4611a"
   license "LGPL-2.1-or-later"
 
   livecheck do
-    url :homepage
-    regex(/href=.*?libsndfile[._-]v?([\d.]+)\.t/i)
+    url "https://github.com/erikd/libsndfile/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `libsndfile` formula is using releases from the [GitHub repository](https://github.com/erikd/libsndfile/) and the README reports that http://libsndfile.github.io/libsndfile/ is the URL for the project homepage. The [old website](http://www.mega-nerd.com/libsndfile/) also doesn't have releases past 1.0.28, so this seems correct.

This PR also updates the `livecheck` block to check the GitHub repository for the "latest" release, which brings it in line with the source of the current `stable` URL.

Edit: The GitHub repository references the homepage URL using HTTP and when I originally tried HTTPS it was giving a Unicorn error. I checked again and it seems fine now, so I updated this to use HTTPS for the homepage (which will resolve the CI error).