### PR TITLE
pngquant: update license

### DIFF
--- a/Formula/pngquant.rb
+++ b/Formula/pngquant.rb
@@ -3,7 +3,7 @@ class Pngquant < Formula
   homepage "https://pngquant.org/"
   url "https://pngquant.org/pngquant-2.13.0-src.tar.gz"
   sha256 "0d1d5dcdb5785961abf64397fb0735f8a29da346b6fee6666e4ef082b516c07e"
-  license "GPL-3.0"
+  license :cannot_represent
   head "https://github.com/kornelski/pngquant.git"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Update license to `GPL-3.0-or-later`

[License reference](https://github.com/kornelski/pngquant/blob/b15515fbf0fafbf8ed706fc6ac97243b9be5ed7c/COPYRIGHT#L2-L5):

```
pngquant and libimagequant are derived from code by Jef Poskanzer and Greg Roelofs
licensed under pngquant's original licenses (near the end of this file),
and contain extensive changes and additions by Kornel Lesiński
licensed under GPL v3 or later.
```
