### PR TITLE
zbar: update livecheck regex

### DIFF
--- a/Formula/zbar.rb
+++ b/Formula/zbar.rb
@@ -9,7 +9,7 @@ class Zbar < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/zbar[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The stable URL for `zbar` has changed since this `livecheck` block was created and the regex no longer applies to the current context, so the check is giving an `Unable to get versions` error.

This fixes the check by updating the regex to the standard regex for Git tags like `1.2.3`/`v1.2.3` (since the GitHub repository doesn't mark a "latest" release).