### PR TITLE
libmongocrypt 1.0.4 (new formula)

### DIFF
--- a/Formula/libmongocrypt.rb
+++ b/Formula/libmongocrypt.rb
@@ -1,0 +1,33 @@
+class Libmongocrypt < Formula
+  desc "C library for Client Side Encryption"
+  homepage "https://github.com/mongodb/libmongocrypt"
+  url "https://github.com/mongodb/libmongocrypt/archive/1.0.4.tar.gz"
+  sha256 "34244b473ceedd51f5885cd80ca3f818924fac4695b5cfcd5396092c726680d9"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "mongo-c-driver" => :build
+
+  def install
+    cmake_args = std_cmake_args
+    cmake_args << if build.head?
+      "-DBUILD_VERSION=1.1.0-pre"
+    else
+      "-DBUILD_VERSION=1.0.4"
+    end
+    system "cmake", ".", *cmake_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <mongocrypt/mongocrypt.h>
+      int main() {
+        const char* version = mongocrypt_version (0);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lmongocrypt", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
Add libmongocrypt, a library required for Client-Side Field Level Encryption support in MongoDB drivers.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note, this does not pass `brew audit --new-formula libmongocrypt` due to the following warning:
```
libmongocrypt:
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 formula detected
```

libmongocrypt is used as an internal component library for all MongoDB drivers. Currently macOS users of drivers that do not bundle libmongocrypt only have the option to build from source (e.g. for the [Go driver](https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#hdr-Client_Side_Encryption) and the [C driver](http://mongoc.org/libmongoc/current/using_client_side_encryption.html#libmongocrypt)).

Though if the "not notable enough" warning prevents this from being merged into core, we can maintain our own tap.

Thank you,
Kevin
