### PR TITLE
embulk: update livecheck

### DIFF
--- a/Formula/embulk.rb
+++ b/Formula/embulk.rb
@@ -9,8 +9,8 @@ class Embulk < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/embulk/embulk.git"
-    regex(/^v?(0\.9(?:\.\d+)+)$/i)
+    url :homepage
+    regex(%r{Stable.+?href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}im)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` for `embulk` used a regex that only matched 0.9.x versions, as these are stable releases at the moment. However, this check would break and need to be manually updated whenever 0.10.x becomes stable, so we try to avoid these types of checks when there's a better alternative.

The goal of the aforementioned regex was to only match stable releases and we can do this instead by checking the homepage and matching the version that's listed as "Stable". This should continue to work in the future without needing to be manually updated when the stable version's major/minor changes.

-----

Besides that, it's worth noting that a note was added to this formula in #52996 to warn against updating `embulk` to 0.10.x versions, as they're currently development releases. This was prevented in #60152 but a self-merge in #60790 erroneously updated this formula to a development release and it's remained there since (e.g., being updated to another development release in #60935).

This formula should probably be downgraded back to the latest stable release (v0.9.23). @chenrui333 Please take care to avoid bumping formulae to development versions (when it's not appropriate).