### PR TITLE
zint: update livecheck regex

### DIFF
--- a/Formula/zint.rb
+++ b/Formula/zint.rb
@@ -8,7 +8,7 @@ class Zint < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/zint[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/zint[._-]v?(\d+(?:\.\d+)+)(?:-src)?\.t}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The format of the file name in the stable URL has changed to also include `-src` (i.e., `zint-2.9.0.tar.gz` -> `zint-2.9.1-src.tar.gz`) but the existing livecheck regex doesn't expect this text, so 2.9.0 was being reported as the latest version instead of 2.9.1.

This updates the regex in the `livecheck` block to optionally match the `-src` text in the file name, so it will also match newer versions that use this format.