### PR TITLE
apache-drill: update livecheck regex

### DIFF
--- a/Formula/apache-drill.rb
+++ b/Formula/apache-drill.rb
@@ -8,7 +8,7 @@ class ApacheDrill < Formula
 
   livecheck do
     url "https://drill.apache.org/download/"
-    /href=.*?apache-drill[._-]v?(\d+(?:\.\d+)+)\.t/i
+    regex(/href=.*?apache-drill[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes the syntax of the regex in the `apache-drill` formula's `livecheck` block, as it's currently just a regex literal and is missing the enclosing `regex()`. This was because I copy-pasted the regex as a suggestion in #60739 but accidentally replaced the entire line instead of just the regex literal within `regex()`.