### PR TITLE
maxima: create loadable core image instead of executable

### DIFF
--- a/Formula/maxima.rb
+++ b/Formula/maxima.rb
@@ -20,8 +20,8 @@ class Maxima < Formula
   depends_on "gawk" => :build
   depends_on "gnu-sed" => :build
   depends_on "perl" => :build
-  depends_on "sbcl" => :build
   depends_on "texinfo" => :build
+  depends_on "sbcl"
   depends_on "gettext"
   depends_on "gnuplot"
   depends_on "rlwrap"
@@ -33,7 +33,6 @@ class Maxima < Formula
                           "--prefix=#{prefix}",
                           "--enable-gettext",
                           "--enable-sbcl",
-                          "--enable-sbcl-exec",
                           "--with-emacs-prefix=#{share}/emacs/site-lisp/#{name}",
                           "--with-sbcl=#{Formula["sbcl"].opt_bin}/sbcl"
     system "make"

--- a/Formula/maxima.rb
+++ b/Formula/maxima.rb
@@ -21,20 +21,21 @@ class Maxima < Formula
   depends_on "gnu-sed" => :build
   depends_on "perl" => :build
   depends_on "texinfo" => :build
-  depends_on "sbcl"
   depends_on "gettext"
   depends_on "gnuplot"
   depends_on "rlwrap"
+  depends_on "sbcl"
 
   def install
     ENV["LANG"] = "C" # per build instructions
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--enable-gettext",
-                          "--enable-sbcl",
-                          "--with-emacs-prefix=#{share}/emacs/site-lisp/#{name}",
-                          "--with-sbcl=#{Formula["sbcl"].opt_bin}/sbcl"
+    system "./configure",
+           "--disable-debug",
+           "--disable-dependency-tracking",
+           "--prefix=#{prefix}",
+           "--enable-gettext",
+           "--enable-sbcl",
+           "--with-emacs-prefix=#{share}/emacs/site-lisp/#{name}",
+           "--with-sbcl=#{Formula["sbcl"].opt_bin}/sbcl"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
This allows Maxima to make use of ASDF and other libraries which are bundled with the Lisp implementation (i.e., SBCL) and which are not present in an executable image.

- [X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
