### PR TITLE
pandocomatic: update license

### DIFF
--- a/Formula/pandocomatic.rb
+++ b/Formula/pandocomatic.rb
@@ -3,7 +3,7 @@ class Pandocomatic < Formula
   homepage "https://heerdebeer.org/Software/markdown/pandocomatic/"
   url "https://github.com/htdebeer/pandocomatic/archive/0.2.7.3.tar.gz"
   sha256 "bddd44f2d79bc4d99aa599331892cd954396abd679e606588c6b1ce9629644e4"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Update license to `GPL-3.0-or-later`

[License reference](https://github.com/htdebeer/pandocomatic/blob/ac4e0e5e4f705ed22a35446e7a9cc23b5d073246/lib/pandocomatic/pandocomatic.rb#L1-L18):

```ruby
#--
# Copyright 2014—2019, Huub de Beer <Huub@heerdebeer.org>
#
# This file is part of pandocomatic.
#
# Pandocomatic is free software: you can redistribute it and/or modify
# it under the terms of the GNU General Public License as published by the
# Free Software Foundation, either version 3 of the License, or (at your
# option) any later version.
#
# Pandocomatic is distributed in the hope that it will be useful, but
# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
# for more details.
#
# You should have received a copy of the GNU General Public License along
# with pandocomatic.  If not, see <http://www.gnu.org/licenses/>.
#++
```
