### PR TITLE
openjdk@8: remove hack for binary bootstrap URL

### DIFF
--- a/Formula/openjdk@8.rb
+++ b/Formula/openjdk@8.rb
@@ -21,8 +21,7 @@ class OpenjdkAT8 < Formula
 
   # Oracle doesn't serve JDK 7 downloads anymore, so use Zulu JDK 7 for bootstrapping.
   resource "boot-jdk" do
-    # FIXME: when https://github.com/Homebrew/brew/pull/8946 is merged.
-    url "https://cdn.azul.com/zulu/bin/zulu7.40.0.15-ca-jdk7.0.272-mac" + "osx_x64.tar.gz"
+    url "https://cdn.azul.com/zulu/bin/zulu7.40.0.15-ca-jdk7.0.272-macosx_x64.tar.gz"
     sha256 "d09468bda072deeadd2a5e39aeae96b57ece2ec5fdbdc75998b99b52c113706b"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Homebrew/brew#8946 is merged, so this hack can be removed.