### PR TITLE
tfsec: update livecheck

### DIFF
--- a/Formula/tfsec.rb
+++ b/Formula/tfsec.rb
@@ -6,8 +6,8 @@ class Tfsec < Formula
   license "MIT"
 
   livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://github.com/tfsec/tfsec/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#63280 added a `livecheck` block for the `tfsec` formula but it was merged before I had a chance to review it and provide feedback. The check was using the Git repository tags but we prefer to check the "latest" release on GitHub when it's available (and working properly). This updates the check accordingly.