### PR TITLE
subversion: rebuild bottles to avoid libmagic linkage

### DIFF
--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -5,7 +5,7 @@ class Subversion < Formula
   mirror "https://archive.apache.org/dist/subversion/subversion-1.14.0.tar.bz2"
   sha256 "6ba8e218f9f97a83a799e58a3c6da1221d034b18d9d8cbbcb6ec52ab11722102"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   livecheck do
     url :stable
@@ -124,7 +124,7 @@ class Subversion < Formula
     system "./autogen.sh" if build.head?
     system "./configure", *args
     system "make"
-    system "make", "install"
+    ENV.deparallelize { system "make", "install" }
     bash_completion.install "tools/client-side/bash_completion" => "subversion"
 
     system "make", "tools"


### PR DESCRIPTION
subversion got a opportunistic linkage to libmagic in the Python migration: https://github.com/Homebrew/brew/pull/8977
Let's rebuild it