### PR TITLE
opencv opencv@3: replace deprecated cmake flags

### DIFF
--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -88,14 +88,9 @@ class Opencv < Formula
       -DPYTHON3_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3
     ]
 
-    # The compiler on older Mac OS cannot build some OpenCV files using AVX2
-    # extensions, failing with errors such as
-    # "error: use of undeclared identifier '_mm256_cvtps_ph'"
-    # Work around this by not trying to build AVX2 code.
-    args << "-DCPU_DISPATCH=SSE4_1,SSE4_2,AVX" if MacOS.version <= :yosemite
-
-    args << "-DENABLE_AVX=OFF" << "-DENABLE_AVX2=OFF"
-    args << "-DENABLE_SSE41=OFF" << "-DENABLE_SSE42=OFF" unless MacOS.version.requires_sse42?
+    cpu_disable_flags = %w[AVX AVX2]
+    cpu_disable_flags << "SSE4_1" << "SSE4_2" unless MacOS.version.requires_sse42?
+    args << "-DCPU_BASELINE_DISABLE=#{cpu_disable_flags.join(",")}"
 
     mkdir "build" do
       system "cmake", "..", *args

--- a/Formula/opencv@3.rb
+++ b/Formula/opencv@3.rb
@@ -74,8 +74,9 @@ class OpencvAT3 < Formula
       -DPYTHON3_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3
     ]
 
-    args << "-DENABLE_AVX=OFF" << "-DENABLE_AVX2=OFF"
-    args << "-DENABLE_SSE41=OFF" << "-DENABLE_SSE42=OFF" unless MacOS.version.requires_sse42?
+    cpu_disable_flags = %w[AVX AVX2]
+    cpu_disable_flags << "SSE4_1" << "SSE4_2" unless MacOS.version.requires_sse42?
+    args << "-DCPU_BASELINE_DISABLE=#{cpu_disable_flags.join(",")}"
 
     mkdir "build" do
       system "cmake", "..", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The main goal of this PR — is to fix `opencv@3` on High Sierra with Penryn processor.
See https://github.com/Homebrew/homebrew-core/pull/61226#issuecomment-715334992
