### PR TITLE
isort 5.6.4 (new formula)

### DIFF
--- a/Formula/isort.rb
+++ b/Formula/isort.rb
@@ -1,0 +1,30 @@
+class Isort < Formula
+  include Language::Python::Virtualenv
+
+  desc "Sort Python imports automatically"
+  homepage "https://pycqa.github.io/isort/"
+  url "https://files.pythonhosted.org/packages/7b/b5/19e828baf02d3e441cd287a3f3cc172bec2d1210c0210294debeddbd3550/isort-5.6.4.tar.gz"
+  sha256 "dcaeec1b5f0eca77faea2a35ab790b4f3680ff75590bfcb7145986905aab2f58"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(%r{href=.*?/packages.*?/isort[._-]v?(\d+(?:\.\d+)*(?:[a-z]\d+)?)\.t}i)
+  end
+
+  depends_on "python@3.9"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    (testpath/"isort_test.py").write <<~EOS
+      from third_party import lib
+      import os
+    EOS
+    system bin/"isort", "isort_test.py"
+    assert_equal "import os\n\nfrom third_party import lib\n", (testpath/"isort_test.py").read
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

New formula: [isort](https://pycqa.github.io/isort/). This file is patterned after one for `black`. Fortunately, `isort` has no required Python dependencies, which makes it easier to package.