### PR TITLE
cntlm: Add test

### DIFF
--- a/Formula/cntlm.rb
+++ b/Formula/cntlm.rb
@@ -3,6 +3,7 @@ class Cntlm < Formula
   homepage "https://cntlm.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cntlm/cntlm/cntlm%200.92.3/cntlm-0.92.3.tar.bz2"
   sha256 "7b603d6200ab0b26034e9e200fab949cc0a8e5fdd4df2c80b8fc5b1c37e7b930"
+  license "GPL-2.0-only"
 
   livecheck do
     url :stable
@@ -57,5 +58,26 @@ class Cntlm < Formula
         </dict>
       </plist>
     EOS
+  end
+
+  test do
+    assert_match "version #{version}", shell_output("#{bin}/cntlm -h 2>&1", 1)
+
+    bind_port = free_port
+    (testpath/"cntlm.conf").write <<~EOS
+      # Cntlm Authentication Proxy Configuration
+      Username	testuser
+      Domain		corp-uk
+      Password	password
+      Proxy		localhost:#{free_port}
+      NoProxy		localhost, 127.0.0.*, 10.*, 192.168.*
+      Listen		#{bind_port}
+    EOS
+
+    fork do
+      exec "#{bin}/cntlm -c #{testpath}/cntlm.conf -v"
+    end
+    sleep 2
+    assert_match /502 Parent proxy unreacheable/, shell_output("curl -s localhost:#{bind_port}")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

First, the test verifies the installed version. Second, it configures the proxy destination to an unbound localhost port as a mock proxy, spins up cntlm, and verifies that cntlm correctly responds that the mock parent proxy is unreachable. 