### PR TITLE
armadillo 10.1.0

### DIFF
--- a/Formula/armadillo.rb
+++ b/Formula/armadillo.rb
@@ -33,7 +33,6 @@ class Armadillo < Formula
   end
 
   test do
-    ENV.cxx11
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>
       #include <armadillo>
@@ -42,7 +41,7 @@ class Armadillo < Formula
         std::cout << arma::arma_version::as_string() << std::endl;
       }
     EOS
-    system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-larmadillo", "-o", "test"
+    system ENV.cxx, "-std=c++11", "test.cpp", "-I#{include}", "-L#{lib}", "-larmadillo", "-o", "test"
     assert_equal shell_output("./test").to_i, version.to_s.to_i
   end
 end

--- a/Formula/armadillo.rb
+++ b/Formula/armadillo.rb
@@ -1,8 +1,8 @@
 class Armadillo < Formula
   desc "C++ linear algebra library"
   homepage "https://arma.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/arma/armadillo-9.900.3.tar.xz"
-  sha256 "d615e736852a74b1753d217718e20f0d8dc4958ccc6dc975030563e18783fc0a"
+  url "https://downloads.sourceforge.net/project/arma/armadillo-10.1.0.tar.xz"
+  sha256 "72e3f1b4b4d1b4df70d9cb1e321a254ea04d7843f68a6c34d82691997d558395"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/armadillo.rb
+++ b/Formula/armadillo.rb
@@ -33,6 +33,7 @@ class Armadillo < Formula
   end
 
   test do
+    ENV.cxx11
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>
       #include <armadillo>

--- a/Formula/mlpack.rb
+++ b/Formula/mlpack.rb
@@ -3,7 +3,7 @@ class Mlpack < Formula
   homepage "https://www.mlpack.org"
   url "https://mlpack.org/files/mlpack-3.3.2.tar.gz"
   sha256 "11904a39a7e34ee66028292fd054afb460eacd07ec5e6c63789aba117e4d854c"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any


### PR DESCRIPTION
Update [armadillo](http://arma.sourceforge.net/) from 9.900.3 to 10.1.0.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

This recipe update is required for [RccpArmadillo](https://cran.r-project.org/package=RcppArmadillo) to build correctly on macOS.

-----

I'm seeing some `brew test armadillo` issues:

```
❯ brew test armadillo
==> Testing armadillo
==> /usr/bin/clang++ test.cpp -I/usr/local/Cellar/armadillo/10.1.0/include -L/usr/local/Cellar/armadillo/10.1.0/lib -larma
Last 15 lines from /Users/mike/Library/Logs/Homebrew/armadillo/test.01.clang++:
           ^
/usr/local/Cellar/armadillo/10.1.0/include/armadillo_bits/arma_forward.hpp:199:12: error: unknown type name 'constexpr'
    static constexpr bool is_xvec = T1::is_xvec;
           ^
/usr/local/Cellar/armadillo/10.1.0/include/armadillo_bits/arma_forward.hpp:209:12: error: unknown type name 'constexpr'
    static constexpr bool is_row  = false;
           ^
/usr/local/Cellar/armadillo/10.1.0/include/armadillo_bits/arma_forward.hpp:210:12: error: unknown type name 'constexpr'
    static constexpr bool is_col  = false;
           ^
/usr/local/Cellar/armadillo/10.1.0/include/armadillo_bits/arma_forward.hpp:211:12: error: unknown type name 'constexpr'
    static constexpr bool is_xvec = false;
           ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
Error: armadillo: failed
An exception occurred within a child process:
  BuildError: Failed executing: /usr/bin/clang++ test.cpp -I/usr/local/Cellar/armadillo/10.1.0/include -L/usr/local/Cellar/armadillo/10.1.0/lib -larmadillo -o test
/usr/local/Homebrew/Library/Homebrew/formula.rb:2033:in `block in system'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1971:in `open'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1971:in `system'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/armadillo.rb:44:in `block in <class:Armadillo>'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1842:in `block (3 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/utils.rb:497:in `with_env'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1841:in `block (2 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/formula.rb:901:in `with_logging'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1840:in `block in run_test'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:58:in `block in run'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:58:in `chdir'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:58:in `run'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2082:in `mktemp'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1834:in `run_test'
/usr/local/Homebrew/Library/Homebrew/test.rb:43:in `block in <main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/usr/local/Homebrew/Library/Homebrew/test.rb:42:in `<main>'
```