### PR TITLE
gitlint 0.14.0 (new formula)

### DIFF
--- a/Formula/gitlint.rb
+++ b/Formula/gitlint.rb
@@ -1,0 +1,56 @@
+class Gitlint < Formula
+  include Language::Python::Virtualenv
+
+  desc "Linting for your git commit messages"
+  homepage "https://jorisroovers.github.io/gitlint"
+  url "https://github.com/jorisroovers/gitlint/archive/v0.14.0.tar.gz"
+  sha256 "c8e45c8ab9c2172e86f2cbfb916eb4ce7b903d75cd757432f8b05c5e73f7e5e1"
+  license "MIT"
+  head "https://github.com/jorisroovers/gitlint.git"
+
+  livecheck do
+    url :stable
+  end
+
+  depends_on "python@3.9"
+
+  resource "arrow" do
+    url "https://files.pythonhosted.org/packages/17/d0/8a69308a5cf4f07c53dca744402606610ec910dda1a9cdc94b3fc4a0c3a5/arrow-0.15.5.tar.gz"
+    sha256 "5390e464e2c5f76971b60ffa7ee29c598c7501a294bc9f5e6dadcb251a5d027b"
+  end
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/f8/5c/f60e9d8a1e77005f664b76ff8aeaee5bc05d0a91798afd7f53fc998dbc47/Click-7.0.tar.gz"
+    sha256 "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+  end
+
+  resource "python-dateutil" do
+    url "https://files.pythonhosted.org/packages/be/ed/5bbc91f03fa4c839c4c7360375da77f9659af5f7086b7a7bdda65771c8e0/python-dateutil-2.8.1.tar.gz"
+    sha256 "73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"
+  end
+
+  resource "sh" do
+    url "https://files.pythonhosted.org/packages/7c/71/199d27d3e7e78bf448bcecae0105a1d5b29173ffd2bbadaa95a74c156770/sh-1.12.14.tar.gz"
+    sha256 "b52bf5833ed01c7b5c5fb73a7f71b3d98d48e9b9b8764236237bdc7ecae850fc"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/6b/34/415834bfdafca3c5f451532e8a8d9ba89a21c9743a0c59fbd0205c7f9426/six-1.15.0.tar.gz"
+    sha256 "30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    # Install gitlint as a git commit-msg hook
+    system "git", "init"
+    system "#{bin}/gitlint", "install-hook"
+    assert_predicate testpath/".git/hooks/commit-msg", :exist?
+
+    # Verifies that the second line of the hook is the title
+    output = File.open(testpath/".git/hooks/commit-msg").each_line.take(2).last
+    assert_equal "### gitlint commit-msg hook start ###\n", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[gitlint](https://github.com/jorisroovers/gitlint) can currently be found in the [homebrew-devops](https://github.com/rockyluke/homebrew-devops) tap, where the [formula](https://github.com/rockyluke/homebrew-devops/blob/master/Formula/pip-gitlint.rb) hasn't been updated since 2017 nor the tap itself since 2018.

I've added a `license`, `head` and `livecheck` block, updated both the dependencies and the version number, and improved the tests.