### PR TITLE
go-jira: added zsh completion

### DIFF
--- a/Formula/go-jira.rb
+++ b/Formula/go-jira.rb
@@ -17,6 +17,13 @@ class GoJira < Formula
   def install
     system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"jira", "cmd/jira/main.go"
     prefix.install_metafiles
+
+    # Install zsh completion
+    output_zsh = Utils.popen_read("#{bin}/jira", "--completion-script-zsh").strip
+    # Strip out unneeded zsh module initialization and tell compinit to autoload
+    output_zsh = output_zsh.sub("autoload -U compinit && compinit", "#autoload")
+    output_zsh = output_zsh.sub("autoload -U bashcompinit && bashcompinit", "")
+    (zsh_completion/"_jira").write output_zsh
   end
 
   test do

--- a/Formula/go-jira.rb
+++ b/Formula/go-jira.rb
@@ -19,7 +19,11 @@ class GoJira < Formula
     prefix.install_metafiles
 
     # Install zsh completion
-    output_zsh = Utils.popen_read("#{bin}/jira", "--completion-script-zsh").strip
+    begin
+      output_zsh = Utils.safe_popen_read("#{bin}/jira", "--completion-script-zsh").strip
+    rescue ErrorDuringExecution => e
+      output_zsh = e.output.first.second.to_s.strip
+    end
     # Strip out unneeded zsh module initialization and tell compinit to autoload
     output_zsh = output_zsh.sub("autoload -U compinit && compinit", "#autoload")
     output_zsh = output_zsh.sub("autoload -U bashcompinit && bashcompinit", "")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR adds zsh completion for go-jira.

`brew audit` currently fails because of the usage of `Utils.popen_read`, however, the call that generates the completion script exits with code 1, therefore failing the build if `Utils.safe_popen_read` is used.

Can somebody help with this or point me in the right direction to fix the audit?