### PR TITLE
composer 2.0.1

### DIFF
--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -1,8 +1,8 @@
 class Composer < Formula
   desc "Dependency Manager for PHP"
   homepage "https://getcomposer.org/"
-  url "https://getcomposer.org/download/2.0.0/composer.phar"
-  sha256 "139657aa2b37867800292724145e3c4895f7755d845758b403dc329d17bdd285"
+  url "https://getcomposer.org/download/2.0.1/composer.phar"
+  sha256 "4b4b118cc54662e4813ba86efb215fdb19c5b29944c5919b4f2803c915aa2234"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 2,174,888 bytes
- formula fetch time: 2.7 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.