### PR TITLE
gcsfuse: add livecheck

### DIFF
--- a/Formula/gcsfuse.rb
+++ b/Formula/gcsfuse.rb
@@ -6,6 +6,11 @@ class Gcsfuse < Formula
   license "Apache-2.0"
   head "https://github.com/GoogleCloudPlatform/gcsfuse.git"
 
+  livecheck do
+    url "https://github.com/GoogleCloudPlatform/gcsfuse/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "f17d670c7a662c8d16aa651b822b754507e22a2d6e4594aea1b0310d3aefb6f6" => :catalina


### PR DESCRIPTION
Since the upstream has the differentiation between the latest and prelease, add livecheck block.