### PR TITLE
infrakit: Deprecate as the source repo is archived

### DIFF
--- a/Formula/infrakit.rb
+++ b/Formula/infrakit.rb
@@ -6,6 +6,8 @@ class Infrakit < Formula
       revision: "3d2670e484176ce474d4b3d171994ceea7054c02"
   license "Apache-2.0"
 
+  deprecate! because: :repo_archived
+
   bottle do
     cellar :any_skip_relocation
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] ~Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] ~Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- It appears to have been an experiment that has gone unmaintained since 2018, and the source repo is archived on GitHub.
- Once this is done it can be removed from the [GITHUB_PRERELEASE_ALLOWLIST in Homebrew/brew](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/utils/shared_audits.rb#L41).

