### PR TITLE
liquidprompt: update license

### DIFF
--- a/Formula/liquidprompt.rb
+++ b/Formula/liquidprompt.rb
@@ -3,7 +3,7 @@ class Liquidprompt < Formula
   homepage "https://github.com/nojhan/liquidprompt"
   url "https://github.com/nojhan/liquidprompt/archive/v1.12.1.tar.gz"
   sha256 "50d278ac16b62bdf9ea44f9421a1f4e467cc89122a2fee24693a4469616b866a"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   head "https://github.com/nojhan/liquidprompt.git", branch: "master"
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Update license to `AGPL-3.0-or-later`

[License reference](https://github.com/nojhan/liquidprompt/blob/ec891eaada5cd427292055603c7dbe977d478e67/liquidprompt#L6-L19):

```
# Licensed under the AGPL version 3
#
# This program is free software: you can redistribute it and/or modify
# it under the terms of the GNU Affero General Public License as
# published by the Free Software Foundation, either version 3 of the
# License, or (at your option) any later version.
#
# This program is distributed in the hope that it will be useful,
# but WITHOUT ANY WARRANTY; without even the implied warranty of
# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
# GNU Affero General Public License for more details.
#
# You should have received a copy of the GNU Affero General Public License
# along with this program.  If not, see <http://www.gnu.org/licenses/>.
```
