### PR TITLE
earthly 0.3.11

### DIFF
--- a/Formula/earthly.rb
+++ b/Formula/earthly.rb
@@ -1,8 +1,8 @@
 class Earthly < Formula
   desc "Build automation tool for the post-container era"
   homepage "https://earthly.dev/"
-  url "https://github.com/earthly/earthly/archive/v0.3.10.tar.gz"
-  sha256 "982dbadad6192d2b6fa6547e250a716495b26fbf4fbd467aa1f25504d42736fb"
+  url "https://github.com/earthly/earthly/archive/v0.3.11.tar.gz"
+  sha256 "f0e913bb577a38e9d455a36834f4627e9d9a3b5892d089d8d360950fa2e66d3f"
   license "MPL-2.0"
   head "https://github.com/earthly/earthly.git"
 
@@ -17,7 +17,7 @@ class Earthly < Formula
 
   def install
     ldflags = "-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} " \
-              "-X main.GitSha=3616f06d7919eb54bced4c48d59d137178d02b12 "
+              "-X main.GitSha=9f063bb67c60553bffca47861be33534874d3e47 "
     tags = "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork"
     system "go", "build",
         "-tags", tags,


### PR DESCRIPTION
-------------

#### Debug data

PR generated by the [Earthly build](https://github.com/earthly/earthly/blob/master/release/Earthfile) (target +release-homebrew)

* `RELEASE_TAG=v0.3.11`

* `GIT_USERNAME=vladaionescu`

* `NEW_URL=https://github.com/earthly/earthly/archive/v0.3.11.tar.gz`

* `NEW_SHA256=f0e913bb577a38e9d455a36834f4627e9d9a3b5892d089d8d360950fa2e66d3f`

* `TAGS=dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork`

* `LDFLAGS=-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} -X main.GitSha=9f063bb67c60553bffca47861be33534874d3e47 `

* `LDFLAGS1=-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} `

* `LDFLAGS2=-X main.GitSha=9f063bb67c60553bffca47861be33534874d3e47 `