### PR TITLE
bit-git 0.8.1 (new formula)

### DIFF
--- a/Formula/bit-git.rb
+++ b/Formula/bit-git.rb
@@ -1,0 +1,30 @@
+class BitGit < Formula
+  desc "Bit is a modern Git CLI"
+  homepage "https://github.com/chriswalz/bit"
+  url "https://github.com/chriswalz/bit/archive/v0.8.1.tar.gz"
+  sha256 "80f19e249356f6adc46071bbf2a01f139c0af9997bc3e323eb62952863d7cf8b"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  conflicts_with "bit", because: "both install `bit` binaries"
+
+  def install
+    system "go", "build", *std_go_args
+    bin.install_symlink "bit-git" => "bit"
+  end
+
+  test do
+    system "git", "init", testpath/"test-repository"
+
+    cd testpath/"test-repository" do
+      (testpath/"test-repository/test.txt").write <<~EOS
+        Hello Homebrew!
+      EOS
+      system bin/"bit", "add", "test.txt"
+
+      output = shell_output("#{bin}/bit status").chomp
+      assert_equal "new file:   test.txt", output.lines.last.strip
+    end
+  end
+end


### PR DESCRIPTION
> bit is an experimental modernized git CLI built on top of git that provides happy defaults and other niceties

Adding it to homebrew-core was requested here https://github.com/chriswalz/bit/issues/9 and even yours truly @dawidd6 dropped by to comment

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
