### PR TITLE
rakudo-star 2020.10

### DIFF
--- a/Formula/rakudo-star.rb
+++ b/Formula/rakudo-star.rb
@@ -1,10 +1,9 @@
 class RakudoStar < Formula
   desc "Rakudo compiler and commonly used packages"
   homepage "https://rakudo.org/"
-  url "https://rakudo.org/dl/star/rakudo-star-2020.01.tar.gz"
-  sha256 "f1696577670d4ff5b464e572b1b0b8c390e6571e1fb8471cbf369fa39712c668"
+  url "https://rakudo.org/dl/star/rakudo-star-2020.10.tar.gz"
+  sha256 "b5742c40bd25e582bed29c994802781d76ca204be1bccafd48dbf3056f6dcf6b"
   license "Artistic-2.0"
-  revision 1
 
   livecheck do
     url "https://rakudo.org/dl/star/"
@@ -18,6 +17,7 @@ class RakudoStar < Formula
     sha256 "0938d963dc23119a1c4a2fa976d4b870f81d744c41986f122aad15858c0b9717" => :high_sierra
   end
 
+  depends_on "bash" => :build
   depends_on "gmp"
   depends_on "icu4c"
   depends_on "libffi"
@@ -28,6 +28,11 @@ class RakudoStar < Formula
   conflicts_with "parrot"
   conflicts_with "rakudo"
 
+  # Patch to resolve references to the Homebrew shims directory. This has been fixed
+  # upstream in https://github.com/rakudo/rakudo/commit/dd0a2a15c6fd79c2e8ff75bb1bd0684ef612a1ea
+  # so this patch can be removed for the next rakudo-star release.
+  patch :DATA
+
   def install
     libffi = Formula["libffi"]
     ENV.remove "CPPFLAGS", "-I#{libffi.include}"
@@ -35,15 +40,13 @@ class RakudoStar < Formula
 
     ENV.deparallelize # An intermittent race condition causes random build failures.
 
-    system "perl", "Configure.pl", "--prefix=#{prefix}",
-                   "--backends=moar", "--gen-moar"
-    system "make"
     # make install runs tests that can hang on sierra
     # set this variable to skip those tests
     ENV["NO_NETWORK_TESTING"] = "1"
-    system "make", "install"
+    system "bin/rstar", "install", "-p", prefix.to_s
 
-    # Panda is now in share/perl6/site/bin, so we need to symlink it too.
+    #  Installed scripts are now in share/perl/{site|vendor}/bin, so we need to symlink it too.
+    bin.install_symlink Dir[share/"perl6/vendor/bin/*"]
     bin.install_symlink Dir[share/"perl6/site/bin/*"]
 
     # Move the man pages out of the top level into share.
@@ -53,8 +56,57 @@ class RakudoStar < Formula
   end
 
   test do
-    out = `#{bin}/perl6 -e 'loop (my $i = 0; $i < 10; $i++) { print $i }'`
+    out = `#{bin}/raku -e 'loop (my $i = 0; $i < 10; $i++) { print $i }'`
     assert_equal "0123456789", out
     assert_equal 0, $CHILD_STATUS.exitstatus
   end
 end
+
+__END__
+
+diff --git a/src/rakudo-2020.10/rakudo-2020.10/lib/Test.rakumod b/src/rakudo-2020.10/rakudo-2020.10/lib/Test.rakumod
+index e8548aac6..f1f706658 100644
+--- a/src/rakudo-2020.10/rakudo-2020.10/lib/Test.rakumod
++++ b/src/rakudo-2020.10/rakudo-2020.10/lib/Test.rakumod
+@@ -4,11 +4,10 @@ unit module Test;
+ # Copyright (C) 2007 - 2020 The Perl Foundation.
+ 
+ # settable from outside
+-my %ENV := %*ENV;  # reduce dynamic lookups
+-my int $perl6_test_times =
+-  ?(%ENV<RAKU_TEST_TIME> // %ENV<PERL6_TEST_TIMES>);
++my int $raku_test_times =
++  ?(%*ENV<RAKU_TEST_TIME> // %*ENV<PERL6_TEST_TIMES>);
+ my int $die_on_fail =
+-  ?(%ENV<RAKU_TEST_DIE_ON_FAIL> // %ENV<PERL6_TEST_DIE_ON_FAIL>);
++  ?(%*ENV<RAKU_TEST_DIE_ON_FAIL> // %*ENV<PERL6_TEST_DIE_ON_FAIL>);
+ 
+ # global state
+ my @vars;
+@@ -113,7 +112,7 @@ multi sub plan($number_of_tests) is export {
+     $time_before = nqp::time_n;
+     $time_after  = nqp::time_n;
+     $str-message ~= "\n$indents# between two timestamps " ~ ceiling(($time_after-$time_before)*1_000_000) ~ ' microseconds'
+-        if nqp::iseq_i($perl6_test_times,1);
++        if nqp::iseq_i($raku_test_times,1);
+ 
+     $output.say: $str-message;
+ 
+@@ -691,7 +690,7 @@ sub _is_deeply(Mu $got, Mu $expected) {
+ sub die-on-fail {
+     if !$todo_reason && !$subtest_level && nqp::iseq_i($die_on_fail,1) {
+         _diag 'Test failed. Stopping test suite, because the '
+-          ~ (%ENV<RAKU_TEST_DIE_ON_FAIL> ?? 'RAKU' !! 'PERL6')
++          ~ (%*ENV<RAKU_TEST_DIE_ON_FAIL> ?? 'RAKU' !! 'PERL6')
+           ~ "_TEST_DIE_ON_FAIL\n"
+           ~ 'environmental variable is set to a true value.';
+         exit 255;
+@@ -749,7 +748,7 @@ sub proclaim(Bool(Mu) $cond, $desc is copy, $unescaped-prefix = '') {
+             !! "ok $num_of_tests_run - $unescaped-prefix$desc";
+ 
+     $tap ~= ("\n$indents# t=" ~ ceiling(($time_after - $time_before)*1_000_000))
+-        if nqp::iseq_i($perl6_test_times,1);
++        if nqp::iseq_i($raku_test_times,1);
+ 
+     $output.say: $tap;
+ 


### PR DESCRIPTION
Updated to use new build process in 2050.05. Added build dependency on bash, it's needed for the build
script which requires a >4.0 version.

Patch resolves shim references. Already fixed upstream and can be removed for next rakudo-star release bundle.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
