### PR TITLE
cmus: rebuild without musepack and wavpack linkage

### DIFF
--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -4,7 +4,7 @@ class Cmus < Formula
   url "https://github.com/cmus/cmus/archive/v2.8.0.tar.gz"
   sha256 "756ce2c6241b2104dc19097488225de559ac1802a175be0233cfb6fbc02f3bd2"
   license "GPL-2.0"
-  revision 2
+  revision 3
   head "https://github.com/cmus/cmus.git"
 
   bottle do


### PR DESCRIPTION
Problem identified during testing of #61226:

```
$ brew install cmus
$ brew linkage --test cmus
Broken dependencies:
  /usr/local/opt/musepack/lib/libmpcdec.dylib (musepack)
  /usr/local/opt/wavpack/lib/libwavpack.1.dylib (wavpack)
No broken library linkage detected
```