### PR TITLE
stern 1.12.1

### DIFF
--- a/Formula/stern.rb
+++ b/Formula/stern.rb
@@ -1,10 +1,11 @@
 class Stern < Formula
   desc "Tail multiple Kubernetes pods & their containers"
-  homepage "https://github.com/wercker/stern"
-  url "https://github.com/wercker/stern/archive/1.11.0.tar.gz"
-  sha256 "d6f47d3a6f47680d3e4afebc8b01a14f0affcd8fb625132af14bb77843f0333f"
+  homepage "https://github.com/stern/stern"
+  url "https://github.com/stern/stern.git",
+      tag:      "v1.12.1",
+      revision: "2d4bd0de2d950b189eba7a7ebf8120283b7009c0"
   license "Apache-2.0"
-  head "https://github.com/wercker/stern.git",
+  head "https://github.com/stern/stern.git",
     shallow: false
 
   bottle do
@@ -16,22 +17,11 @@ class Stern < Formula
   end
 
   depends_on "go" => :build
-  depends_on "govendor" => :build
 
   def install
-    contents = Dir["{*,.git,.gitignore}"]
-    gopath = buildpath/"gopath"
-    (gopath/"src/github.com/wercker/stern").install contents
-
-    ENV["GOPATH"] = gopath
-    ENV.prepend_create_path "PATH", gopath/"bin"
-
-    cd gopath/"src/github.com/wercker/stern" do
-      system "govendor", "sync"
-      system "go", "build", "-o", "bin/stern"
-      bin.install "bin/stern"
-      prefix.install_metafiles
-    end
+    system "go", "build", "-ldflags",
+             "-s -w -X github.com/stern/stern/cli.version=#{version} -X github.com/stern/stern/cli.commit=#{stable.specs[:revision]}",
+             *std_go_args
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR bumps the version of stern to v1.12.1.

https://github.com/wercker/stern, stern's original repository, is no longer maintained. Since the other day, stern has been maintained by volunteers at https://github.com/stern/stern. This PR has changed the referenced repository to stern/stern.

## REF

- [This repository has no activity · Issue \#140 · wercker/stern](https://github.com/wercker/stern/issues/140)