### PR TITLE
composer 2.0.3

### DIFF
--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -1,8 +1,8 @@
 class Composer < Formula
   desc "Dependency Manager for PHP"
   homepage "https://getcomposer.org/"
-  url "https://getcomposer.org/download/2.0.2/composer.phar"
-  sha256 "5e122edd0f2a4fb01172b6b1c156b3d252d9205105b4ad169a4b09913ba6a859"
+  url "https://getcomposer.org/download/2.0.3/composer.phar"
+  sha256 "5d377e9b504dc9f6c9228d81c321ba85290512cdb396a12d3708b0cd30d2e20c"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 2,177,735 bytes
- formula fetch time: 2.6 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.