### PR TITLE
Adding in FASTLANE_INSTALLED_VIA_HOMEBREW

### DIFF
--- a/Formula/fastlane.rb
+++ b/Formula/fastlane.rb
@@ -30,6 +30,7 @@ class Fastlane < Formula
     (bin/"fastlane").write <<~EOS
       #!/bin/bash
       export PATH="#{Formula["ruby"].opt_bin}:#{libexec}/bin:$PATH"
+      export FASTLANE_INSTALLED_VIA_HOMEBREW="true"
       GEM_HOME="#{libexec}" GEM_PATH="#{libexec}" \\
         exec "#{libexec}/bin/fastlane" "$@"
     EOS


### PR DESCRIPTION
This was used by the previous cask install of fastlane and was left out by accident. Adding it back in for backward compatibility.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This was used by the previous cask install of fastlane and was left out by accident. Adding it back in for backward compatibility.