### PR TITLE
ctop: fix 0.7.4 tag hash

### DIFF
--- a/Formula/ctop.rb
+++ b/Formula/ctop.rb
@@ -3,7 +3,7 @@ class Ctop < Formula
   homepage "https://bcicen.github.io/ctop/"
   url "https://github.com/bcicen/ctop.git",
     tag:      "v0.7.4",
-    revision: "5b2d180f6007fb2a8387d0e821f3b80bcfc9a1cb"
+    revision: "426dd2c9854786bdfba7a55272256502849ccfb5"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
Error: v0.7.4 tag should be 5b2d180f6007fb2a8387d0e821f3b80bcfc9a1cb
but is actually 426dd2c9854786bdfba7a55272256502849ccfb5

verified at https://github.com/bcicen/ctop/commit/426dd2c9854786bdfba7a55272256502849ccfb5

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
