### PR TITLE
python@3.9: overwrite python3-embed.pc

### DIFF
--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -54,6 +54,7 @@ class PythonAT39 < Formula
   link_overwrite "bin/wheel3"
   link_overwrite "share/man/man1/python3.1"
   link_overwrite "lib/pkgconfig/python3.pc"
+  link_overwrite "lib/pkgconfig/python3-embed.pc"
   link_overwrite "Frameworks/Python.framework/Headers"
   link_overwrite "Frameworks/Python.framework/Python"
   link_overwrite "Frameworks/Python.framework/Resources"


### PR DESCRIPTION
Fixes #63619 by adding a missing `link_overwrite`