### PR TITLE
flyway: update livecheck

### DIFF
--- a/Formula/flyway.rb
+++ b/Formula/flyway.rb
@@ -6,8 +6,8 @@ class Flyway < Formula
   license "Apache-2.0"
 
   livecheck do
-    url :homepage
-    regex(/Get Started with Flyway\s+v?(\d+(?:\.\d+)+) </im)
+    url "https://flywaydb.org/documentation/usage/maven/"
+    regex(/&lt;version&gt;.*?v?(\d+(?:\.\d+)+)&lt;/im)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The check for `flyway` is currently unable to find versions, as the first-party homepage has changed in such a way that the existing check no longer works. This PR updates the check to use the [documentation page that lists the latest version on Maven](https://flywaydb.org/documentation/usage/maven/) (the source of the stable archive).

Alternatively, we could check the [Maven directory listing page](https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-commandline/), like:

```ruby
livecheck do
  url "https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-commandline/"
  regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
end
```

The potential downside of checking Maven directly is that upstream may push a release to Maven before it's official (as we've seen with some other formulae), in which case checking the first-party website would be more appropriate. The Maven URL also involves a redirection, for what it's worth.

I'm fine with checking the first-party documentation until/unless we run into an issue with this approach.