### PR TITLE
starship: depend on openssl@1.1

### DIFF
--- a/Formula/starship.rb
+++ b/Formula/starship.rb
@@ -4,6 +4,7 @@ class Starship < Formula
   url "https://github.com/starship/starship/archive/v0.46.2.tar.gz"
   sha256 "39301c8118239eda7b6d8dbcae498f28bfd901932e69003c249d99ee7989c1bb"
   license "ISC"
+  revision 1
   head "https://github.com/starship/starship.git"
 
   bottle do
@@ -15,8 +16,13 @@ class Starship < Formula
   end
 
   depends_on "rust" => :build
+  depends_on "openssl@1.1"
 
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "pkg-config" => :build
+  end
 
   def install
     system "cargo", "install", "--features", "notify-rust", *std_cargo_args


### PR DESCRIPTION
and add linux-only dependency

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
