### PR TITLE
sdl2: added configure flag required for controller input

### DIFF
--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -47,7 +47,7 @@ class Sdl2 < Formula
 
     system "./autogen.sh" if build.head?
 
-    args = %W[--prefix=#{prefix} --without-x]
+    args = %W[--prefix=#{prefix} --without-x --enable-hidapi]
     system "./configure", *args
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This flag appears to be required in order to have working joystick/gamepad input on macOS. This change modifies no behavior unexpectedly and is non-breaking.