### PR TITLE
Add -Djava.awt.headless=true flag to pdftk invocation

### DIFF
--- a/Formula/pdftk-java.rb
+++ b/Formula/pdftk-java.rb
@@ -24,7 +24,7 @@ class PdftkJava < Formula
   def install
     system "gradle", "shadowJar", "--no-daemon"
     libexec.install "build/libs/pdftk-all.jar"
-    bin.write_jar_script libexec/"pdftk-all.jar", "pdftk", java_version: "1.8"
+    bin.write_jar_script libexec/"pdftk-all.jar", "pdftk", " -Djava.awt.headless=true ", java_version: "1.8"
   end
 
   test do


### PR DESCRIPTION
When running pdftk from the command line a Java icon appears in the dock and disappears immediately. I find this unexpected for a command line application.

By passing `-Djava.awt.headless=true` to the java command when running the jar suppresses the appearance/disappearance of the Java icon.