### PR TITLE
k3sup 0.9.7 (new formula)

### DIFF
--- a/Formula/k3sup.rb
+++ b/Formula/k3sup.rb
@@ -17,8 +17,7 @@ class K3sup < Formula
     commit = Utils.safe_popen_read("git", "rev-parse", "--short", "HEAD").chomp
 
     system "go", "build", "-ldflags",
-            "-s -w -X github.com/alexellis/k3sup/cmd.Version=#{version} -X github.com/alexellis/k3sup/cmd.GitCommit=#{commit}",
-            "-o", bin/"k3sup"
+            "-s -w -X github.com/alexellis/k3sup/cmd.Version=#{version} -X github.com/alexellis/k3sup/cmd.GitCommit=#{commit}", *std_go_args
   end
 
   test do

--- a/Formula/k3sup.rb
+++ b/Formula/k3sup.rb
@@ -1,0 +1,28 @@
+class K3sup < Formula
+  desc "Utility to create k3s clusters on any local or remote VM"
+  homepage "https://github.com/alexellis/k3sup"
+  url "https://github.com/alexellis/k3sup.git",
+      tag:      "0.9.7",
+      revision: "80383dde517ddaa1db7e56543955143aa99d24bf"
+  license "MIT"
+
+  livecheck do
+    url "https://github.com/alexellis/k3sup/releases/latest"
+    regex(%r{href=.*?/tag/?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
+  depends_on "go" => :build
+
+  def install
+    commit = Utils.safe_popen_read("git", "rev-parse", "--short", "HEAD").chomp
+
+    system "go", "build", "-ldflags",
+            "-s -w -X github.com/alexellis/k3sup/cmd.Version=#{version} -X github.com/alexellis/k3sup/cmd.GitCommit=#{commit}",
+            "-o", bin/"k3sup"
+  end
+
+  test do
+    output = shell_output("#{bin}/k3sup install 2>&1", 1).split("\n").pop
+    assert_match "unable to load the ssh key", output
+  end
+end


### PR DESCRIPTION
k3sup is a light-weight utility to create k3s clusters on any local or remote VM

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
