### PR TITLE
s3cmd: downgrade to python@3.8

### DIFF
--- a/Formula/s3cmd.rb
+++ b/Formula/s3cmd.rb
@@ -6,7 +6,7 @@ class S3cmd < Formula
   url "https://files.pythonhosted.org/packages/c7/eb/5143fe1884af2303cb7b23f453e5c9f337af46c2281581fc40ab5322dee4/s3cmd-2.1.0.tar.gz"
   sha256 "966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03"
   license "GPL-2.0"
-  revision 1
+  revision 2
   head "https://github.com/s3tools/s3cmd.git"
 
   livecheck do
@@ -20,7 +20,7 @@ class S3cmd < Formula
     sha256 "3f071500164cbeeab6b43eb832145b93610260f013257eee2736242032ec8ff0" => :high_sierra
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.8"
 
   resource "python-dateutil" do
     url "https://files.pythonhosted.org/packages/be/ed/5bbc91f03fa4c839c4c7360375da77f9659af5f7086b7a7bdda65771c8e0/python-dateutil-2.8.1.tar.gz"

--- a/Formula/s3cmd.rb
+++ b/Formula/s3cmd.rb
@@ -5,7 +5,7 @@ class S3cmd < Formula
   homepage "https://s3tools.org/s3cmd"
   url "https://files.pythonhosted.org/packages/c7/eb/5143fe1884af2303cb7b23f453e5c9f337af46c2281581fc40ab5322dee4/s3cmd-2.1.0.tar.gz"
   sha256 "966b0a494a916fc3b4324de38f089c86c70ee90e8e1cae6d59102103a4c0cc03"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 2
   head "https://github.com/s3tools/s3cmd.git"
 

--- a/Formula/s3cmd.rb
+++ b/Formula/s3cmd.rb
@@ -20,6 +20,11 @@ class S3cmd < Formula
     sha256 "3f071500164cbeeab6b43eb832145b93610260f013257eee2736242032ec8ff0" => :high_sierra
   end
 
+  # s3cmd version 2.1.0 is not compatible with Python 3.9, know issues are:
+  # - https://github.com/s3tools/s3cmd/issues/1146
+  # - https://github.com/s3tools/s3cmd/pull/1144
+  # - https://github.com/s3tools/s3cmd/pull/1137
+  # Do not bump Python version until these issues are fixed, probably when version 2.2.0 is released.
   depends_on "python@3.8"
 
   resource "python-dateutil" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
s3cmd 2.1.0 is not compatible with python 3.9. There are multiple issues on s3cmd site:

s3tools/s3cmd#1144
s3tools/s3cmd#1137
s3tools/s3cmd#1146

This PR downgrades Python dependency to version 3.8 and reverts the python dependency change made in this PR #63174.

Python dependency should not be changed to 3.9 until release of version 2.2.0 od s3cmd.

Also license is updated to `GPL-2.0-or-later` because `brew audit --strict` complained about it. 