### PR TITLE
fix_ntfs-3g_automount_script

### DIFF
--- a/Formula/ntfs-3g.rb
+++ b/Formula/ntfs-3g.rb
@@ -80,6 +80,7 @@ class Ntfs3g < Formula
           -o volname="${VOLUME_NAME}" \\
           -o local \\
           -o negative_vncache \\
+          -o auto_xattr \\
           -o auto_cache \\
           -o noatime \\
           -o windows_names \\


### PR DESCRIPTION
fix ntfs-3g automount script
workaround to show files in macOS Catalina Finder


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `mount_ntfs` script is provided by `ntfs-3g.rb`.
And this is a simple fix in `ntfs-3g.rb`. I just simply add a single line `-o auto_xattr \` to the script.
It can makes it run out of the box again.

Issue related:
Fixes https://github.com/Homebrew/homebrew-core/issues/63732
https://github.com/osxfuse/osxfuse/issues/574