### PR TITLE
openjdk: fix linux resource sha256

### DIFF
--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -28,7 +28,7 @@ class Openjdk < Formula
     end
     on_linux do
       url "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz"
-      sha256 "bb67cadee687d7b486583d03c9850342afea4593be4f436044d785fba9508fb7"
+      sha256 "91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d"
     end
   end
 


### PR DESCRIPTION
This was a copy-paste error from my side.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
