### PR TITLE
x265 enabled HDR10+

### DIFF
--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -52,7 +52,7 @@ class X265 < Formula
     end
 
     cd "8bit" do
-      system "cmake", buildpath/"source", "-DENABLE_HDR10_PLUS=ON", *args
+      system "cmake", buildpath/"source", *args
       system "make"
       mv "libx265.a", "libx265_main.a"
       system "libtool", "-static", "-o", "libx265.a", "libx265_main.a",

--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -5,6 +5,7 @@ class X265 < Formula
   sha256 "7f2771799bea0f53b5ab47603d5bea46ea2a221e047a7ff398115e9976fd5f86"
   license "GPL-2.0-only"
   head "https://bitbucket.org/multicoreware/x265_git"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -40,7 +40,7 @@ class X265 < Formula
     (buildpath/"8bit").mkpath
 
     mkdir "10bit" do
-      system "cmake", buildpath/"source", *high_bit_depth_args
+      system "cmake", buildpath/"source", "-DENABLE_HDR10_PLUS=ON", *high_bit_depth_args
       system "make"
       mv "libx265.a", buildpath/"8bit/libx265_main10.a"
     end
@@ -52,7 +52,7 @@ class X265 < Formula
     end
 
     cd "8bit" do
-      system "cmake", buildpath/"source", *args
+      system "cmake", buildpath/"source", "-DENABLE_HDR10_PLUS=ON", *args
       system "make"
       mv "libx265.a", "libx265_main.a"
       system "libtool", "-static", "-o", "libx265.a", "libx265_main.a",

--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -4,8 +4,8 @@ class X265 < Formula
   url "https://bitbucket.org/multicoreware/x265_git/get/3.4.tar.gz"
   sha256 "7f2771799bea0f53b5ab47603d5bea46ea2a221e047a7ff398115e9976fd5f86"
   license "GPL-2.0-only"
-  head "https://bitbucket.org/multicoreware/x265_git"
   revision 1
+  head "https://bitbucket.org/multicoreware/x265_git"
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Enabled HDR10+ to be able to use it with FFMPEG