### PR TITLE
gtk+3: add adwaita-icon-theme default theme

### DIFF
--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -22,6 +22,7 @@ class Gtkx3 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
+  depends_on "adwaita-icon-theme"
   depends_on "atk"
   depends_on "gdk-pixbuf"
   depends_on "glib"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds Gtk+3 default icon themes. Otherwise applications failed with:

```
gmixvm:93688): Gtk-WARNING **: 23:27:58.900: Error loading theme icon 'document-open' for stock: Icon 'document-open' not present in theme Adwaita

(gmixvm:93688): Gtk-WARNING **: 23:27:58.900: Error loading theme icon 'system-run' for stock: Icon 'system-run' not present in theme Adwaita

(gmixvm:93688): Gtk-WARNING **: 23:27:58.900: Error loading theme icon 'format-justify-fill' for stock: Icon 'format-justify-fill' not present in theme Adwaita

....
```