### PR TITLE
libpcap: add livecheck

### DIFF
--- a/Formula/libpcap.rb
+++ b/Formula/libpcap.rb
@@ -6,6 +6,11 @@ class Libpcap < Formula
   license "BSD-3-Clause"
   head "https://github.com/the-tcpdump-group/libpcap.git"
 
+  livecheck do
+    url "https://www.tcpdump.org/release/"
+    regex(/href=.*?libpcap[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "3a85693ff5d241ccdc689af9fa1281434ddf6ae3d0887cd679d07bbc1730ec29" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, `livecheck` checks the Git tags for `libpcap` and is wrongly reporting `1.10.0-bp` as the newest version instead of `1.9.1`.

This PR checks the [first-party directory listing page ](https://www.tcpdump.org/release/) instead, which resolves the aforementioned issue while also aligning the check with the `stable` source (which we prefer).