### PR TITLE
snapcraft: add livecheck

### DIFF
--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -9,6 +9,11 @@ class Snapcraft < Formula
   license "GPL-3.0-only"
   revision 1
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any
     sha256 "9794d4f92c102bedb392a336ed3c8be6193f1567d7d553cead8fa44d925e8933" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The default check for `snapcraft` is reporting `062755d465f752108ab6` as the newest version (from an `untagged-062755d465f752108ab6` tag), instead of `4.4`. This PR resolves the issue by adding a `livecheck` block which uses the standard regex for Git tags like `1.2`, `1.2.3`, etc.