### PR TITLE
task: add livecheck

### DIFF
--- a/Formula/task.rb
+++ b/Formula/task.rb
@@ -6,6 +6,11 @@ class Task < Formula
   license "MIT"
   head "https://github.com/GothenburgBitFactory/taskwarrior.git", branch: "2.6.0", shallow: false
 
+  livecheck do
+    url "https://taskwarrior.org/download/"
+    regex(/href=.*?task[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 "24c80011867aa34766864a4bbac071493fb45c93bd3e08b3e9979b3ba4780fa2" => :catalina
     sha256 "bba98b6bdfb3f79f1434229d8ade4b0622119320353da0eb8fec39809d66947d" => :mojave


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck will check the Git tags for `task` but it's reporting a `251ToMaster` tag as newest instead of `2.5.1`.

This PR resolves the issue by checking the first-party download page instead. This also aligns the check with the `stable` source, which we prefer.