### PR TITLE
mame: add livecheck

### DIFF
--- a/Formula/mame.rb
+++ b/Formula/mame.rb
@@ -8,6 +8,15 @@ class Mame < Formula
   revision 1
   head "https://github.com/mamedev/mame.git"
 
+  # MAME tags (and filenames) are formatted like `mame0226`, so livecheck will
+  # report the version like `0226`. We work around this by matching the link
+  # text for the release title, since it contains the properly formatted version
+  # (e.g., 0.226).
+  livecheck do
+    url "https://github.com/mamedev/mame/releases/latest"
+    regex(%r{release-header.*?/releases/tag/mame[._-]?\d+(?:\.\d+)*["' >]>MAME v?(\d+(?:\.\d+)+)}im)
+  end
+
   bottle do
     cellar :any
     sha256 "3680dd9e5f826552b289f521f11cb91c52fa037b215285f1e47f1a1319409eb4" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `mame` but the tags have a format like `mame0226`, so the version is returned as `0226`. From the standpoint of `Version` comparison, `0226` is treated as `226`, which is treated as newer than `0.226`.

I'm planning to implement an `alterations` DSL for livecheck in the future, where we could modify `0226` to be `0.226`. In the interim time, this adds a `livecheck` block which checks the "latest" release on GitHub (which we prefer, when available) and matches the formatted version in the release header (`MAME 0.226`) instead of the tag (`mame0226`).