### PR TITLE
todo-txt: add livecheck

### DIFF
--- a/Formula/todo-txt.rb
+++ b/Formula/todo-txt.rb
@@ -6,6 +6,11 @@ class TodoTxt < Formula
   license "GPL-3.0-only"
   head "https://github.com/todotxt/todo.txt-cli.git"
 
+  livecheck do
+    url "https://github.com/todotxt/todo.txt-cli/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle :unneeded
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `todo-txt` but a `archive/complete-bash31-fix` tag is causing the newest version to be reported as `31-fix` instead of `2.12.0`.

This PR resolves the issue by adding a `livecheck` block that checks the "latest" release on GitHub, which we prefer when it's available (and correct).