### PR TITLE
libvncserver: add livecheck, update license

### DIFF
--- a/Formula/libvncserver.rb
+++ b/Formula/libvncserver.rb
@@ -3,7 +3,12 @@ class Libvncserver < Formula
   homepage "https://libvnc.github.io"
   url "https://github.com/LibVNC/libvncserver/archive/LibVNCServer-0.9.13.tar.gz"
   sha256 "0ae5bb9175dc0a602fe85c1cf591ac47ee5247b87f2bf164c16b05f87cbfa81a"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url "https://github.com/LibVNC/libvncserver/releases/latest"
+    regex(%r{href=.*?/tag/(?:LibVNCServer[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `libvncserver` but the newest version is being wrongly reported as `11VNC_0_9_12` instead of 0.9.13. This comes from one of the `X11VNC_`/`X11VNC_REL_` tags (`X11VNC_0_9_12`), whereas `libvncserver` tags are like `LibVNCServer-0.9.13`.

This PR resolves the issue by adding a `livecheck` block that checks the "latest" release on GitHub. We prefer this anyway for formulae that use an archive from GitHub, when a "latest" release is available and correct.

This also updates the license to `GPL-2.0-or-later`, referencing the [license information in the first-party GitHub repository's `README`](https://github.com/LibVNC/libvncserver/#license).