### PR TITLE
lammps: add livecheck, update license

### DIFF
--- a/Formula/lammps.rb
+++ b/Formula/lammps.rb
@@ -7,7 +7,12 @@ class Lammps < Formula
   # We only track stable releases as announced on the LAMMPS homepage.
   version "2020-03-03"
   sha256 "a1a2e3e763ef5baecea258732518d75775639db26e60af1634ab385ed89224d1"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
+
+  livecheck do
+    url "https://github.com/lammps/lammps/releases/latest"
+    regex(%r{href=.*?/tag/stable[._-](\d+\w+\d+)["' >]}i)
+  end
 
   bottle do
     sha256 "9434567739e6497752d8b2e76b7dd06723b2d9773510e92d3e00aa601208c532" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `lammps` but the newest version is being wrongly reported as `15407` (instead of `29Oct2020`) due to a `r15407` tag. Stable tags have a format like `stable_29Oct2020` instead.

We can't currently create a check that will return a version like `2020-10-29`, as this requires us to alter the matched version into a different format. This is something that we'll be able to do once I implement an `alterations` DSL in the future but for now the best we can do is restrict matching to stable versions.

This PR adds a `livecheck` block that checks the "latest" release on GitHub (which is preferred, when available), which gives us a version like `29Oct2020`. This is something that maintainers/contributors can compare to the version from the formula (`2020-03-03`) in the interim time, to determine if there's a new version. The upstream version will always show as newer but it's better than the existing situation, at least. Once the `alterations` feature is implemented, we can easily update this check to work properly.

This also updates the `license` to `GPL-2.0-only`, referencing the [the first-party GitHub repository's README](https://github.com/lammps/lammps/blob/master/README).