### PR TITLE
glslang: add livecheck

### DIFF
--- a/Formula/glslang.rb
+++ b/Formula/glslang.rb
@@ -5,6 +5,11 @@ class Glslang < Formula
   sha256 "639ebec56f1a7402f2fa094469a5ddea1eceecfaf2e9efe361376a0f73a7ee2f"
   head "https://github.com/KhronosGroup/glslang.git"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "9db9f4d0af3d3945270e3fcfbb2e502f377f15d76810facf80862093a18b7a5d" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `glslang` but it's wrongly reporting the newest version as `17964dc8f720e212dcb7` (instead of `8.13.3743`), due to an `untagged-17964dc8f720e212dcb7` tag.

This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3` or `v1.2.3`. The upstream GitHub repository has a ["latest" release](https://github.com/KhronosGroup/glslang/releases/tag/master-tot) but it's built from the main branch, so I'm sticking with the Git tags until the "latest" release is a stable release like `8.13.3743`. However, the [homepage](https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/) references the `master-tot` release, so I'm not entirely sure what to make of it.

If we think we should be using the `master-tot` release in the formula, I'll update the `livecheck` block to check the "latest" release on GitHub instead.