### PR TITLE
youtube-dlc 2020.11.11-3 (new formula)

### DIFF
--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -10,13 +10,11 @@ class YoutubeDlc < Formula
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
-  head do
-    url "https://github.com/blackjack4494/yt-dlc.git"
-  end
+  head "https://github.com/blackjack4494/yt-dlc.git"
 
   depends_on "make" => :build
   depends_on "pandoc" => :build
-  depends_on "python3"
+  depends_on "python@3.9"
   uses_from_macos "zip" => :build
 
   def install

--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -1,0 +1,37 @@
+class YoutubeDlc < Formula
+  desc "Media downloader supporting various sites such as youtube"
+  homepage "https://github.com/blackjack4494/yt-dlc"
+  url "https://github.com/blackjack4494/yt-dlc/archive/2020.10.31.tar.gz"
+  sha256 "0d23cc2e2f1cc7291e5d2a468b1cd282a6be228a215df188aaecae8951ac64d9"
+  license "Unlicense"
+
+  livecheck do
+    url "https://github.com/blackjack4494/yt-dlc/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
+  head do
+    url "https://github.com/blackjack4494/yt-dlc.git"
+  end
+
+  depends_on "make" => :build
+  depends_on "pandoc" => :build
+  depends_on "python3"
+  uses_from_macos "zip" => :build
+
+  def install
+    system "make"
+    bin.install "youtube-dlc"
+    bash_completion.install "youtube-dlc.bash-completion"
+    zsh_completion.install "youtube-dlc.zsh"
+    fish_completion.install "youtube-dlc.fish"
+    man1.install "youtube-dlc.1"
+  end
+
+  test do
+    # "History of homebrew-core", uploaded 3 Feb 2020
+    system "#{bin}/youtube-dlc", "--simulate", "https://www.youtube.com/watch?v=pOtd1cbOP7k"
+    # "homebrew", playlist last updated 3 Mar 2020
+    system "#{bin}/youtube-dlc", "--simulate", "--yes-playlist", "https://www.youtube.com/watch?v=pOtd1cbOP7k&list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj"
+  end
+end

--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -5,12 +5,12 @@ class YoutubeDlc < Formula
   sha256 "0d23cc2e2f1cc7291e5d2a468b1cd282a6be228a215df188aaecae8951ac64d9"
   license "Unlicense"
 
+  head "https://github.com/blackjack4494/yt-dlc.git"
+
   livecheck do
     url "https://github.com/blackjack4494/yt-dlc/releases/latest"
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
-
-  head "https://github.com/blackjack4494/yt-dlc.git"
 
   depends_on "make" => :build
   depends_on "pandoc" => :build

--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -4,7 +4,6 @@ class YoutubeDlc < Formula
   url "https://github.com/blackjack4494/yt-dlc/archive/2020.11.11-3.tar.gz"
   sha256 "649f8ba9a6916ca45db0b81fbcec3485e79895cec0f29fd25ec33520ffffca84"
   license "Unlicense"
-
   head "https://github.com/blackjack4494/yt-dlc.git"
 
   livecheck do

--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -9,7 +9,7 @@ class YoutubeDlc < Formula
 
   livecheck do
     url "https://github.com/blackjack4494/yt-dlc/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
   end
 
   depends_on "make" => :build

--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -1,8 +1,8 @@
 class YoutubeDlc < Formula
   desc "Media downloader supporting various sites such as youtube"
   homepage "https://github.com/blackjack4494/yt-dlc"
-  url "https://github.com/blackjack4494/yt-dlc/archive/2020.10.31.tar.gz"
-  sha256 "0d23cc2e2f1cc7291e5d2a468b1cd282a6be228a215df188aaecae8951ac64d9"
+  url "https://github.com/blackjack4494/yt-dlc/archive/2020.11.11-3.tar.gz"
+  sha256 "649f8ba9a6916ca45db0b81fbcec3485e79895cec0f29fd25ec33520ffffca84"
   license "Unlicense"
 
   head "https://github.com/blackjack4494/yt-dlc.git"


### PR DESCRIPTION
Adds a more complete formula for the community-fork youtube-dlc.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In light of the takedown against and updates to `youtube-dl` since committed to `youtube-dlc`, this PR adds a formula for the new version. See the previous [PR](https://github.com/Homebrew/homebrew-core/pull/61125)'s [Reddit](https://www.reddit.com/r/DataHoarder/comments/ir8ic6/youtubedlc_an_active_fork_of_youtubedl/) post for a word from the maintainer of the original over 1-month old repo.