### PR TITLE
wartremover: migrate to openjdk@8

### DIFF
--- a/Formula/wartremover.rb
+++ b/Formula/wartremover.rb
@@ -4,6 +4,7 @@ class Wartremover < Formula
   url "https://github.com/wartremover/wartremover/archive/v2.4.12.tar.gz"
   sha256 "96aefb990757e1bb8e0bb1202e5abaf2831c671c61b0c567eed63871fb3d04c1"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/wartremover/wartremover.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Wartremover < Formula
   end
 
   depends_on "sbt" => :build
-  depends_on java: "1.8"
+  depends_on "openjdk@8"
 
   def install
     system "sbt", "-sbt-jar", Formula["sbt"].opt_libexec/"bin/sbt-launch.jar",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
migrate to openjdk@8 #63290