### PR TITLE
Remove -fno-stack-check workarounds

### DIFF
--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -19,7 +19,6 @@ class Bat < Formula
 
   def install
     ENV["SHELL_COMPLETIONS_DIR"] = buildpath
-    ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
     system "cargo", "install", *std_cargo_args
 
     assets_dir = Dir["target/release/build/bat-*/out/assets"].first

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -35,10 +35,6 @@ class Gmp < Formula
   end
 
   def install
-    # Work around macOS Catalina / Xcode 11 code generation bug
-    # (test failure t-toom53, due to wrong code in mpn/toom53_mul.o)
-    ENV.append_to_cflags "-fno-stack-check"
-
     # Enable --with-pic to avoid linking issues with the static library
     args = %W[--prefix=#{prefix} --enable-cxx --with-pic]
 

--- a/Formula/luajit.rb
+++ b/Formula/luajit.rb
@@ -35,9 +35,6 @@ class Luajit < Formula
       f.change_make_var! "CCOPT_x86", ""
     end
 
-    # Xcode 11 fix
-    ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
-
     # Per https://luajit.org/install.html: If MACOSX_DEPLOYMENT_TARGET
     # is not set then it's forced to 10.4, which breaks compile on Mojave.
     ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version

--- a/Formula/mpfr.rb
+++ b/Formula/mpfr.rb
@@ -20,10 +20,6 @@ class Mpfr < Formula
   depends_on "gmp"
 
   def install
-    # Work around macOS Catalina / Xcode 11 code generation bug
-    # (test failure t-toom53, due to wrong code in mpn/toom53_mul.o)
-    ENV.append_to_cflags "-fno-stack-check"
-
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}",
                           "--disable-silent-rules"
     system "make"

--- a/Formula/mupdf-tools.rb
+++ b/Formula/mupdf-tools.rb
@@ -22,9 +22,6 @@ class MupdfTools < Formula
     because: "mupdf and mupdf-tools install the same binaries"
 
   def install
-    # Work around Xcode 11 clang bug
-    ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
-
     system "make", "install",
            "build=release",
            "verbose=yes",

--- a/Formula/mupdf.rb
+++ b/Formula/mupdf.rb
@@ -24,9 +24,6 @@ class Mupdf < Formula
     because: "mupdf and mupdf-tools install the same binaries"
 
   def install
-    # Work around Xcode 11 clang bug
-    ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
-
     system "make", "install",
            "build=release",
            "verbose=yes",

--- a/Formula/pachi.rb
+++ b/Formula/pachi.rb
@@ -27,11 +27,6 @@ class Pachi < Formula
     ENV["MAC"] = "1"
     ENV["DOUBLE_FLOATING"] = "1"
 
-    # Work around Xcode 11 clang bug
-    if DevelopmentTools.clang_build_version >= 1010
-      inreplace "Makefile", "CFLAGS       :=", "CFLAGS := -fno-stack-check"
-    end
-
     # https://github.com/pasky/pachi/issues/78
     inreplace "Makefile", "build.h: .git/HEAD .git/index", "build.h:"
     inreplace "Makefile", "DCNN=1", "DCNN=0"


### PR DESCRIPTION
The clang issues (in Xcode 11 to 11.4) that required this were fixed in later Xcode versions