### PR TITLE
rav1e: update livecheck

### DIFF
--- a/Formula/rav1e.rb
+++ b/Formula/rav1e.rb
@@ -7,7 +7,7 @@ class Rav1e < Formula
 
   livecheck do
     url :stable
-    regex(/v([\d.]+)/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing check for `rav1e` was reporting `0.4.0` as the newest version, due to a `v0.4.0-alpha` Git tag. The regex in this check was both too loose (`[\d.]+`) and too strict (`v` instead of `v?`), so I've simply replaced it with the standard regex we use for Git tags like `1.2.3`/`v1.2.3`/etc.

The GitHub repository has a "latest" release but it's `v0.4.0-alpha`, so we have to stick with the Git tags.