### PR TITLE
solidity: add livecheck

### DIFF
--- a/Formula/solidity.rb
+++ b/Formula/solidity.rb
@@ -5,6 +5,11 @@ class Solidity < Formula
   sha256 "3994482ed1104f55cbd7614649c2129adaf3fc9a782d910e688d0010abeb7a9c"
   license all_of: ["GPL-3.0-or-later", "MIT", "BSD-3-Clause", "Apache-2.0", "CC0-1.0"]
 
+  livecheck do
+    url "https://github.com/ethereum/solidity/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "f5f68c1744f923e5e0028ec4380d9367174a8dd5cd48077d2eb8bea324ebaa16" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck was checking the Git tags for `solidity` but the latest version was being reported as `67220b6c6b5ba404ca`, due to an `untagged-eb67220b6c6b5ba404ca` tag.

This resolves the issue by checking the "latest" release on the GitHub repository, which we prefer anyway when it's available and correct.