### PR TITLE
borgbackup: add livecheck

### DIFF
--- a/Formula/borgbackup.rb
+++ b/Formula/borgbackup.rb
@@ -8,6 +8,11 @@ class Borgbackup < Formula
   license "BSD-3-Clause"
   revision 1
 
+  livecheck do
+    url "https://github.com/borgbackup/borg/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     cellar :any
     sha256 "c04342b9fb9a2ae30e7030fafb7ac38ef68a8cfb0c6f095bd66926dd41240bc9" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `borgbackup` but it's reporting an unstable version (`1.2.0a9`) as newest instead of the latest stable release (`1.1.14`).

This PR resolves the issue by checking the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.