### PR TITLE
appledoc: add livecheck

### DIFF
--- a/Formula/appledoc.rb
+++ b/Formula/appledoc.rb
@@ -6,6 +6,11 @@ class Appledoc < Formula
   license "Apache-2.0"
   head "https://github.com/tomaz/appledoc.git"
 
+  livecheck do
+    url "https://github.com/tomaz/appledoc/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     rebuild 1
     sha256 "35ced2445cb6f9744a2b8ef09d1f5d504aefe4995a8463639bf4fa8b5271e5f8" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `appledoc` but it's wrongly reporting `3.0exp1` as newest instead of the latest stable release (`2.2.1`). The `3.0exp1` tag is from 2012-02-12 and newer [unstable] releases of 3.0 are `3.0dev` (2014-10-21) and `3.0-development` (2015-11-06), none of which are suitable to use in the formula.

This PR resolves the issue by checking the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.