### PR TITLE
gpsbabel: add livecheck

### DIFF
--- a/Formula/gpsbabel.rb
+++ b/Formula/gpsbabel.rb
@@ -5,6 +5,11 @@ class Gpsbabel < Formula
   sha256 "30b186631fb43db576b8177385ed5c31a5a15c02a6bc07bae1e0d7af9058a797"
   license "GPL-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^gpsbabel[._-]v?(\d+(?:[._]\d+)+)$/i)
+  end
+
   bottle do
     sha256 "ef08f246d1d7321d1bb605591194f2d207fc0cd2465755dbbe86afc640cb41db" => :catalina
     sha256 "7a622c1a689d239e3a98185220428127cffee6f3d060519d509106a8a37fdbc1" => :mojave


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `gpsbabel` but it's reporting `20060521` as newest, due to a `snapshot_20060521` tag.

This PR resolves the issue by adding a `livecheck` block that uses a version of the standard regex for Git tags like `1.2.3`/`v1.2.3`/etc. The regex has been modified to use the `gpsbabel` prefix and to allow for underscores in the numeric version, as `gpsbabel` tags use a format like `gpsbabel_1_7_0`.