### PR TITLE
tasksh: add livecheck

### DIFF
--- a/Formula/tasksh.rb
+++ b/Formula/tasksh.rb
@@ -6,6 +6,13 @@ class Tasksh < Formula
   license "MIT"
   head "https://github.com/GothenburgBitFactory/taskshell.git", branch: "1.3.0"
 
+  # We check the upstream Git repository tags because the first-party download
+  # page doesn't list tasksh releases.
+  livecheck do
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "db065e61ef2e605a1987012eaf4c0f10b648a98da3d143b9a02e1c22d51216f7" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `tasksh` but it's reporting `120ToMaster` as newest instead of the latest stable release (`1.2.0`).

This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`/etc. We're checking the Git tags instead of the [first-party download page](https://taskwarrior.org/download/) (as in the `task` formula) since it only lists `task` and `taskd` versions.