### PR TITLE
glassfish: add livecheck

### DIFF
--- a/Formula/glassfish.rb
+++ b/Formula/glassfish.rb
@@ -5,6 +5,11 @@ class Glassfish < Formula
   sha256 "26f3fa6463d24c5ed3956e4cab24a97e834ca37d7a23d341aadaa78d9e0093ce"
   license "EPL-2.0"
 
+  livecheck do
+    url "https://projects.eclipse.org/projects/ee4j.glassfish/downloads"
+    regex(/href=.*?glassfish[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
   bottle :unneeded
 
   depends_on java: "1.8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `glassfish` but it's reporting an unstable version (`6.0.0-RC1`) as newest instead of the latest stable release (`5.1.0`).

This PR resolves the issue by adding a `livecheck` block that checks the Eclipse project's downloads page, matching against stable archive file URLs. This also aligns the check with the `stable` archive source, which we prefer when possible.