### PR TITLE
snap: add livecheck

### DIFF
--- a/Formula/snap.rb
+++ b/Formula/snap.rb
@@ -6,6 +6,11 @@ class Snap < Formula
   sha256 "c4f532018ca9d2a5f87a95909b3674f8e299e97ba5cb5575895bcdd29be23db3"
   license "GPL-3.0-only"
 
+  livecheck do
+    url "https://github.com/snapcore/snapd/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "0879922d7e220a6af8e6e14056e3785f105d79a1e5b7c8ed6152fedf891f32bf" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `snap` but it's reporting `50ee5bfb45daefc236` as newest, due to an `untagged-ec50ee5bfb45daefc236` tag.

This PR resolves the issue by adding a `livecheck` block that checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.