### PR TITLE
libtorrent-rakshasa: add livecheck

### DIFF
--- a/Formula/libtorrent-rakshasa.rb
+++ b/Formula/libtorrent-rakshasa.rb
@@ -5,6 +5,11 @@ class LibtorrentRakshasa < Formula
   sha256 "0f6c2e7ffd3a1723ab47fdac785ec40f85c0a5b5a42c1d002272205b988be722"
   license "GPL-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any
     sha256 "207e33009028a8721a89c91139fe78fea1cd9fb8a05862286264dfc53548886a" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `libtorrent-rakshasa` but it's reporting `1` as newest, due to a `pre-merge-1` tag.

This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`/etc.