### PR TITLE
rgbds: add livecheck

### DIFF
--- a/Formula/rgbds.rb
+++ b/Formula/rgbds.rb
@@ -6,6 +6,11 @@ class Rgbds < Formula
   license "MIT"
   head "https://github.com/rednex/rgbds.git"
 
+  livecheck do
+    url "https://github.com/gbdev/rgbds/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     cellar :any
     sha256 "8adee69ec949c97750ea1aa84fb7ccabe219598902744f06cae3b49b4cbe6a08" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `rgbds` but it's reporting an unstable version (`0.4.2-pre`) as newest instead of the latest stable release (`0.4.1`).

This PR resolves the issue by adding a `livecheck` block that checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.