### PR TITLE
icarus-verilog: update livecheck

### DIFF
--- a/Formula/icarus-verilog.rb
+++ b/Formula/icarus-verilog.rb
@@ -8,8 +8,8 @@ class IcarusVerilog < Formula
   head "https://github.com/steveicarus/iverilog.git"
 
   livecheck do
-    url "https://ftp.openbsd.org/pub/OpenBSD/distfiles/"
-    regex(/href=.*?verilog[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://github.com/steveicarus/iverilog/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:[._]\d+)+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `icarus-verilog` formula has switched from using an OpenBSD `stable` archive to a GitHub release. The check is currently unable to find the latest version (`11.0`) as a result and reports `10.3` as newest instead.

This PR updates the `livecheck` block to align the check with the new `stable` source, so livecheck will properly find the latest release.