### PR TITLE
dotnet: add livecheck

### DIFF
--- a/Formula/dotnet.rb
+++ b/Formula/dotnet.rb
@@ -6,6 +6,11 @@ class Dotnet < Formula
       revision: "a5bf06c9d45144d6e152f5e53155e41839aa4a55"
   license "MIT"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)-SDK$/i)
+  end
+
   bottle do
     cellar :any
     sha256 "f6c4d1db106a901e28fb32cbd7d5eadf09ad4b934c5329acafc1d126ce0c4300" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `dotnet`, which uses tags like `v3.1.109-SDK`. The formula version is reported as `3.1.109` and the same version with a trailing `-SDK` is always treated as newer by livecheck.

This PR resolves the issue by adding a `livecheck` block with a regex that causes the trailing `-SDK` to be omitted from the newest version.