### PR TITLE
taskd: add livecheck

### DIFF
--- a/Formula/taskd.rb
+++ b/Formula/taskd.rb
@@ -7,6 +7,11 @@ class Taskd < Formula
   revision 1
   head "https://github.com/GothenburgBitFactory/taskserver.git"
 
+  livecheck do
+    url "https://taskwarrior.org/download/"
+    regex(/href=.*?taskd[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `taskd` but it's reporting `110ToMaster` as newest instead of the latest stable release (`1.1.0`).

This PR resolves the issue by adding a `livecheck` block that checks the first-party download page, which also aligns the check with the `stable` source. This is the same as in the `task` formula but the regex here checks for `taskd` files instead of `task` files.