### PR TITLE
redpen: add livecheck

### DIFF
--- a/Formula/redpen.rb
+++ b/Formula/redpen.rb
@@ -5,6 +5,11 @@ class Redpen < Formula
   sha256 "6c3dc4a6a45828f9cc833ca7253fdb036179036631248288251cb9ac4520c39d"
   license "Apache-2.0"
 
+  livecheck do
+    url "https://github.com/redpen-cc/redpen/releases/latest"
+    regex(%r{href=.*?/tag/(?:redpen[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle :unneeded
 
   depends_on "openjdk"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `redpen` but it's reporting `2.0` as newest instead of the latest stable release (`1.10.4`). `redpen` tags have a format like `redpen-1.10.4` but there's also a `2.0` tag that's causing this issue.

This PR resolves this by adding a `livecheck` block that checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.