### PR TITLE
tarsnap: add livecheck

### DIFF
--- a/Formula/tarsnap.rb
+++ b/Formula/tarsnap.rb
@@ -6,6 +6,11 @@ class Tarsnap < Formula
   license "0BSD"
   revision 1
 
+  livecheck do
+    url "https://www.tarsnap.com/download/"
+    regex(/href=.*?tarsnap-autoconf[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "afa6ebfefbc93faf12ac6576f26edb0b68c6a47cc65b893d590ea1efd4301fb4" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `tarsnap` but the newest version is given as `1.0.39-deb-2`, which will always be treated as newer than `1.0.39`.

This PR resolves the issue by adding a `livecheck` block that checks the first-party download page (a directory listing), matching the archive file URLs. This also aligns the check with the `stable` source, which we prefer when possible.