### PR TITLE
gambit-scheme: add livecheck

### DIFF
--- a/Formula/gambit-scheme.rb
+++ b/Formula/gambit-scheme.rb
@@ -6,6 +6,11 @@ class GambitScheme < Formula
   license "Apache-2.0"
   revision 2
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 "cc4d0841423822b27fd424f7eba3a0482f01266ef61c25ec4b1d49d211d6c50e" => :catalina
     sha256 "9fc086d950cb20c99d1d24947a0599fab72525c8a2dbd2d448f94791a5a8f481" => :mojave


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `gambit-scheme` but it reports versions like `v1.2.3-bootstrap` as newer than a `v1.2.3` tag.

This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`/etc.