### PR TITLE
vfuse: add livecheck

### DIFF
--- a/Formula/vfuse.rb
+++ b/Formula/vfuse.rb
@@ -4,6 +4,11 @@ class Vfuse < Formula
   url "https://github.com/chilcote/vfuse/archive/2.2.6.tar.gz"
   sha256 "fbf5f8a1c664b03c7513a70aa05c3fc501a7ebdb53f128f1f05c24395871a314"
 
+  livecheck do
+    url "https://github.com/chilcote/vfuse/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle :unneeded
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `vfuse` but it's reporting a pre-release version (`3.0.0`) as newest instead of the latest stable release (`2.2.6`).

This PR resolves the issue by adding a `livecheck` block that checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.