### PR TITLE
libgr: remove xcode build dep

### DIFF
--- a/Formula/libgr.rb
+++ b/Formula/libgr.rb
@@ -4,6 +4,7 @@ class Libgr < Formula
   url "https://github.com/sciapp/gr/archive/v0.52.0.tar.gz"
   sha256 "8c9149377bfd3fe61b05cda34b980f894f1a723d7c74c4ace5da2e31d3630870"
   license "MIT"
+  revision 1
 
   bottle do
     rebuild 1
@@ -13,7 +14,6 @@ class Libgr < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on xcode: :build
   depends_on "cairo"
   depends_on "glfw"
   depends_on "libtiff"
@@ -22,8 +22,7 @@ class Libgr < Formula
   depends_on "zeromq"
 
   def install
-    mkdir "build"
-    cd "build" do
+    mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make"
       system "make", "install"


### PR DESCRIPTION
```
xcodebuild: error: SDK "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" cannot be located.
xcrun: error: unable to lookup item 'PlatformPath' in SDK '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk'
tar xof /Users/rchen/Library/Caches/Homebrew/downloads/3f66aa76bb7d1aa577cc73a51dacd000a5a8c5e40d24fbe4bc6a34c1d11b371c--gr-0.52.0.tar.gz -C /private/tmp/d20201101-14026-h8qlh3
cp -pR /private/tmp/d20201101-14026-h8qlh3/gr-0.52.0/. /private/tmp/libgr-20201101-14026-1nut5kx/gr-0.52.0
chmod -Rf +w /private/tmp/d20201101-14026-h8qlh3
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

relates to #61401