### PR TITLE
simh: add livecheck

### DIFF
--- a/Formula/simh.rb
+++ b/Formula/simh.rb
@@ -7,6 +7,13 @@ class Simh < Formula
   license "MIT"
   head "https://github.com/simh/simh.git"
 
+  # At the time this check was added, the "latest" release on GitHub was several
+  # versions behind the actual latest version, so we check the Git tags instead.
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+(?:-\d+)?)$/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "790feb234cf193ae6de2c076ad10024e5d9bd6d301020392a79cffc7ff6ccb15" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `simh` but it's reporting an unstable version (`4.0-Beta-1`) as newest instead of the latest stable release (`3.11.1`).

This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`/etc., with a modification to handle the `1.2-3` version format.