### PR TITLE
fwknop: add livecheck, update license

### DIFF
--- a/Formula/fwknop.rb
+++ b/Formula/fwknop.rb
@@ -3,8 +3,13 @@ class Fwknop < Formula
   homepage "https://www.cipherdyne.org/fwknop/"
   url "https://github.com/mrash/fwknop/archive/2.6.10.tar.gz"
   sha256 "a7c465ba84261f32c6468c99d5512f1111e1bf4701477f75b024bf60b3e4d235"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/mrash/fwknop.git"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 "3a4ff22b7de484deb6473ffdad63d3e927290925af925b5dbf1b868648824493" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `fwknop` but it's reporting an unstable version (`2.6.11-pre1`) as newest instead of the latest stable release (`2.6.10`).

This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`/etc., while also omitting unstable versions.

This also updates the license to `GPL-2.0-or-later` (from `GPL-2.0`), referencing the GitHub repository's [`README`](https://github.com/mrash/fwknop/blob/master/README.md). The `README` states "The fwknop project is released as open source software under the terms of the GNU General Public License (GPL v2) or (at your option) any later version."