### PR TITLE
pwsafe: add livecheck

### DIFF
--- a/Formula/pwsafe.rb
+++ b/Formula/pwsafe.rb
@@ -6,6 +6,11 @@ class Pwsafe < Formula
   license "GPL-2.0"
   revision 4
 
+  livecheck do
+    url "https://src.fedoraproject.org/repo/pkgs/pwsafe/"
+    regex(/href=.*?pwsafe[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "5f952aa85147c86d2f77f9054fe228484820388c3b1e92c39c12432a15ca0f54" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `pwsafe` but it's reporting `1_23_2004` as newest, due to a `cur_1_23_2004` tag.

This PR resolves the issue by adding a `livecheck` block that checks the [directory listing page](https://src.fedoraproject.org/repo/pkgs/pwsafe/) where the `stable` archive is found, as this is preferred over the GitHub repository in this context (i.e., it doesn't have a tag for the 0.2.0 release we're using).