### PR TITLE
lizard 1.0, update license, add livecheck

### DIFF
--- a/Formula/lizard.rb
+++ b/Formula/lizard.rb
@@ -1,9 +1,15 @@
 class Lizard < Formula
   desc "Efficient compressor with very fast decompression"
   homepage "https://github.com/inikep/lizard"
-  url "https://github.com/inikep/lizard/archive/v2.0.tar.gz"
-  sha256 "85456b7274c9f0e477ff8e3f06dbc2f8ee8619d737a73c730c8a1adacb45f6da"
-  license "GPL-2.0"
+  url "https://github.com/inikep/lizard/archive/v1.0.tar.gz"
+  sha256 "6f666ed699fc15dc7fdaabfaa55787b40ac251681b50c0d8df017c671a9457e6"
+  license all_of: ["BSD-2-Clause", "GPL-2.0-or-later"]
+  version_scheme 1
+
+  livecheck do
+    url "https://github.com/inikep/lizard/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

According to the [`lizard` 1.0 release notes](https://github.com/inikep/lizard/releases/tag/v1.0), "LZ5 v2.0 was renamed to Lizard". It follows that the "lizard v1.0" release (published 2017-03-15) is newer than the "LZ5 v2.0" release (published 2017-02-05), so I'm bumping the formula here. If it isn't appropriate to use this version for whatever reason, I'll pare this PR down to the changes below.

This PR also updates the license from `GPL-2.0` to `GPL-2.0-only`, referencing the [`LICENSE` file in the GitHub repository](https://github.com/inikep/lizard/blob/lizard/LICENSE). The files in the `lib` directory are licensed separately using BSD 2-Clause but I'm simply following suit with the existing `license` information in the formula.

I've also added a `livecheck` block here that checks the "latest" release on GitHub. By default, livecheck was checking the Git tags but the newest version was being reported as `132` instead of `1.0`, due to a `r132` tag.