### PR TITLE
liblinear: add livecheck

### DIFF
--- a/Formula/liblinear.rb
+++ b/Formula/liblinear.rb
@@ -6,6 +6,11 @@ class Liblinear < Formula
   license "BSD-3-Clause"
   head "https://github.com/cjlin1/liblinear.git"
 
+  livecheck do
+    url "https://www.csie.ntu.edu.tw/~cjlin/liblinear/oldfiles/"
+    regex(/href=.*?liblinear[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "b1ff692bb0430cc95e14ef736a8b1730afa826887648f91835869181922a2136" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `liblinear` but the tag format is like `v242` for a `2.42` version. `242` is treated as the major version, so it will always be newer than `2.42`.

This PR resolves the issue by adding a `livecheck` block that checks the upstream directory listing page where the `stable` archive is found. This also aligns the check with the `stable` source, which we prefer when possible.