### PR TITLE
vgmstream: add livecheck

### DIFF
--- a/Formula/vgmstream.rb
+++ b/Formula/vgmstream.rb
@@ -10,6 +10,11 @@ class Vgmstream < Formula
   version_scheme 1
   head "https://github.com/losnoco/vgmstream.git"
 
+  livecheck do
+    url "https://github.com/losnoco/vgmstream/releases/latest"
+    regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
+  end
+
   bottle do
     cellar :any
     sha256 "22245cda49c47f9e6fcace0938586ec6e7fc7e3b3fb3db5f81ae9d90ecfb4bc8" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `vgmstream` but the leading part of the tag is being stripped, since livecheck removes leading non-numeric text at the start of a tag when the formula doesn't have a `livecheck` block with a `regex`. As a result, livecheck reports the upstream version as `1050-3312-g70d20924` instead of `r1050-3312-g70d20924`. The lack of the leading `r` causes the check to always treat the upstream version as newer, as the formula version has the leading `r` (i.e., `r1050-3312-g70d20924`).

This PR resolves the issue by adding a `livecheck` block that checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.

Due to the complexity of the tag scheme, I've deliberately made the part of the regex that matches the version a bit open-ended (`([^"' >]+)`) instead of doing something more strict (e.g., `(r\d+(?:[._-]\d+[._-]\w+)?)`) that may fail in the future if the format changes. This should be fine, since GitHub "latest" checks only involve one release (whereas we would otherwise need to be more strict when matching Git tags).