### PR TITLE
git-remote-gcrypt: add livecheck

### DIFF
--- a/Formula/git-remote-gcrypt.rb
+++ b/Formula/git-remote-gcrypt.rb
@@ -5,6 +5,11 @@ class GitRemoteGcrypt < Formula
   sha256 "e1948dda848db845db404e4337b07206c96cb239b66392fd1c9c246279c2cb25"
   license "GPL-3.0"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "40fe96f458da47660ec153c19efc0271f9f8bcd987cf328081873adecffd6a88" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `git-remote-gcrypt` but the latest version was being reported as `1.3-1` instead of `1.3`. This is due to the existence of tags like `debian/1.3-1` and `archive/debian/1.3-1`, which appear alongside the `1.3` tag.

This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`/etc., which omits the `debian/` and `archive/debian/` tags.