### PR TITLE
fizz 2020.10.26.00 (new formula)

### DIFF
--- a/Formula/double-conversion.rb
+++ b/Formula/double-conversion.rb
@@ -4,6 +4,7 @@ class DoubleConversion < Formula
   url "https://github.com/google/double-conversion/archive/v3.1.5.tar.gz"
   sha256 "a63ecb93182134ba4293fd5f22d6e08ca417caafa244afaa751cbfddf6415b13"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/google/double-conversion.git"
 
   bottle do
@@ -18,8 +19,13 @@ class DoubleConversion < Formula
 
   def install
     mkdir "dc-build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
       system "make", "install"
+      system "make", "clean"
+
+      system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", *std_cmake_args
+      system "make"
+      lib.install "libdouble-conversion.a"
     end
   end
 

--- a/Formula/fizz.rb
+++ b/Formula/fizz.rb
@@ -1,0 +1,53 @@
+class Fizz < Formula
+  desc "C++14 implementation of the TLS-1.3 standard"
+  homepage "https://github.com/facebookincubator/fizz"
+  url "https://github.com/facebookincubator/fizz/releases/download/v2020.10.26.00/fizz-v2020.10.26.00.tar.gz"
+  sha256 "e4803b5cedd1dc2b51963c5e75f4a17dfe872e96e67dcf62948297db90dc7d78"
+  license "BSD-2-Clause"
+  head "https://github.com/facebookincubator/fizz.git"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "double-conversion"
+  depends_on "fmt"
+  depends_on "folly"
+  depends_on "gflags"
+  depends_on "glog"
+  depends_on "libevent"
+  depends_on "libsodium"
+  depends_on "lz4"
+  depends_on "openssl@1.1"
+  depends_on "snappy"
+  depends_on "zstd"
+
+  def install
+    mkdir "fizz/build" do
+      system "cmake", "..", "-DBUILD_TESTS=OFF", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <fizz/client/AsyncFizzClient.h>
+      #include <iostream>
+
+      int main() {
+        auto context = fizz::client::FizzClientContext();
+        std::cout << toString(context.getSupportedVersions()[0]) << std::endl;
+      }
+    EOS
+    system ENV.cxx, "-std=c++14", "test.cpp", "-o", "test",
+                    "-I#{include}",
+                    "-I#{Formula["openssl@1.1"].opt_include}",
+                    "-L#{lib}", "-lfizz",
+                    "-L#{Formula["folly"].opt_lib}", "-lfolly",
+                    "-L#{Formula["gflags"].opt_lib}", "-lgflags",
+                    "-L#{Formula["glog"].opt_lib}", "-lglog",
+                    "-L#{Formula["libevent"].opt_lib}", "-levent",
+                    "-L#{Formula["libsodium"].opt_lib}", "-lsodium",
+                    "-L#{Formula["openssl@1.1"].opt_lib}", "-lcrypto", "-lssl"
+    assert_match "TLS", shell_output("./test")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Another attempt at #57117. Also, `folly` and `fizz` both depend on `double-conversion` and will link to a shared library if provided, so adjusted `double-conversion` to provide also provide shared libraries for linkage from `folly` and `fizz`. I decided to keep the static library build since `double-conversion` is a fairly small library that could understandably just be compiled into some other program rather than just linked to.

`folly` technically needs a `revision` bump in order to link against shared `double-conversion`, but since it's on a weekly release schedule anyways, we might as well wait for that.