### PR TITLE
opencbm: update homepage, add livecheck, add license

### DIFF
--- a/Formula/opencbm.rb
+++ b/Formula/opencbm.rb
@@ -1,9 +1,15 @@
 class Opencbm < Formula
   desc "Provides access to various floppy drive formats"
-  homepage "https://spiro.trikaliotis.net/opencbm-alpha"
+  homepage "https://spiro.trikaliotis.net/opencbm"
   url "https://spiro.trikaliotis.net/Download/opencbm-0.4.99.99/opencbm-0.4.99.99.tar.bz2"
   sha256 "b1e4cd73c8459acd48c5e8536d47439bafea51f136f43fde5a4d6a5f7dbaf6c6"
+  license "GPL-2.0-only"
   head "https://git.code.sf.net/p/opencbm/code.git"
+
+  livecheck do
+    url :homepage
+    regex(/<h1[^>]*?>VERSION v?(\d+(?:\.\d+)+)/i)
+  end
 
   bottle do
     sha256 "0fcf92ca18ebde6b9d431dfd1ab8667ca93ee59c53f85e818eed9f0b8ba78306" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The upstream website for `opencbm` links to https://spiro.trikaliotis.net/opencbm instead of the [/opencbm-alpha](https://spiro.trikaliotis.net/opencbm-alpha) page that's currently used as the `homepage`, so I've updated it accordingly. These pages both appear to have the same content, for what it's worth.

This also adds a `livecheck` block that checks the homepage to identify versions. It's admittedly not a great check but the other options may not be appropriate. By default, livecheck is checking the Git tags and reporting `20110106-2128` as the newest version, from a `t20110106-2128` tag.

When we add a regex to restrict matching to tags like `1.2.3`/`v1.2.3`, the newest version is reported as `0.4.99.103`. This version isn't mentioned on the first-party site and an archive isn't available, so I decided against this approach for now. If checking the Git tags is more appropriate (or we use this approach in the future), we can use the following:

```ruby
livecheck do
  url :head
  regex(/^v?(\d+(?:[._]\d+)+)$/i)
end
```