### PR TITLE
irrtoolset: add livecheck

### DIFF
--- a/Formula/irrtoolset.rb
+++ b/Formula/irrtoolset.rb
@@ -3,8 +3,13 @@ class Irrtoolset < Formula
   homepage "https://github.com/irrtoolset/irrtoolset"
   url "https://github.com/irrtoolset/irrtoolset/archive/release-5.1.3.tar.gz"
   sha256 "a3eff14c2574f21be5b83302549d1582e509222d05f7dd8e5b68032ff6f5874a"
-  license "GPL-2.0"
+  license :cannot_represent
   head "https://github.com/irrtoolset/irrtoolset.git"
+
+  livecheck do
+    url "https://github.com/irrtoolset/irrtoolset/releases/latest"
+    regex(%r{href=.*?/tag/[^"' >]*?v?(\d+(?:[._-]\d+)+)["' >]}i)
+  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `irrtoolset` but it's reporting `16667_base` as newest, due to an `rt16667_base` tag.

This PR resolves the issue by adding a `livecheck` block that checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.

Since checking the "latest" release only involves one version (compared to multiple tags when using the `Git` strategy), the regex is open-ended about how it matches the start of the tag. The current format is `release-1.2.3` (or `release-1_2_3` and `release-1-2-3` in the past) but this allows it to continue working if the tag format becomes `1.2.3`/`v1.2.3` or the leading text changes.