### PR TITLE
wla-dx: add livecheck

### DIFF
--- a/Formula/wla-dx.rb
+++ b/Formula/wla-dx.rb
@@ -6,6 +6,11 @@ class WlaDx < Formula
   license "GPL-2.0"
   revision 1
 
+  livecheck do
+    url "https://github.com/vhelin/wla-dx/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)(?:-fix)*["' >]}i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "8f0d4747eb9ef0885ddf6c08b3d4ac980bd2b6dbaaa9f5048ea7aa4bc6f681b8" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `wla-dx` but it's reporting `9.11-fix-fix-fix` as newest. The formula uses the `9.11-fix-fix-fix` release but the `version` is still `9.11`, so `9.11-fix-fix-fix` will always appear as newer.

This PR resolves the issue by adding a `livecheck` block with a regex that omits the trailing `-fix` text from the upstream version text. Unfortunately, livecheck won't report the `-fix` releases with this setup. There's not much we can do unless upstream adopts something sane like semver (e.g., `9.11.3` instead of `9.11-fix-fix-fix`) or we use `9.11-fix-fix-fix` as the formula version.

For what it's worth, I've left the license alone since there's an open issue in the GitHub repository where the author is debating about whether the license should be `GPL-2.0-only` or `GPL-2.0-or-later`.