### PR TITLE
fuzzy-find: add livecheck

### DIFF
--- a/Formula/fuzzy-find.rb
+++ b/Formula/fuzzy-find.rb
@@ -6,6 +6,16 @@ class FuzzyFind < Formula
   sha256 "104300ba16af18d60ef3c11d70d2ec2a95ddf38632d08e4f99644050db6035cb"
   head "https://github.com/silentbicycle/ff.git"
 
+  # This regex intentially allows anything to come after the numeric version
+  # (instead of using $ at the end like we normally do). These tags have a
+  # format like `0.6-flag-features` or `v0.5-first-form`, where the trailing
+  # text seems to be a release name. This regex may become a problem in the
+  # future if we encounter releases like `1.2-alpha1` `1.2-rc1`, etc.
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "4e58e0ac23df5dbd26787238c0160716db8eb673b4a62625a9edcb4ceaf38eac" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `fuzzy-find` but the tags seem to use a format like `1.2-release-name`, so the newest version is reported as `0.6-flag-features` instead of `0.6`.

This PR resolves the issue by adding a `livecheck` block that uses a modified version of the standard regex for Git tags like `1.2.3`/`v1.2.3`/etc. The regex in this formula omits the usual `$` at the end that we use to restrict matching to stable versions, as we need the regex to be a little looser due to the trailing tag text.

Alternatively, we could use something like `/^v?(\d+(?:\.\d+)+)(?:-\w+)*$/i` but making this a little more explicit doesn't really buy us anything, as we could still end up matching unstable tags in the future (e.g., if something like `1.2-alpha1`, `1.2-beta2`, `1.2-rc1`, etc. appears).

The license _appears_ to be [ISC](https://spdx.org/licenses/ISC.html), based on the license at the top of the [ff.c file](https://github.com/silentbicycle/ff/blob/master/ff.c#L1-L15) referenced in silentbicycle/ff#7. However, I'm not very knowledgeable about licenses, so I left it out until/unless someone more knowledgeable adds their thoughts on the matter.