### PR TITLE
r3: add livecheck

### DIFF
--- a/Formula/r3.rb
+++ b/Formula/r3.rb
@@ -6,6 +6,11 @@ class R3 < Formula
   license "MIT"
   head "https://github.com/c9s/r3.git"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any
     sha256 "96787f402bbc3a37207c3d5c3468d3b98028a12335a66d176d18d268e2406462" => :catalina


### PR DESCRIPTION
r3: add livecheck

---

note, this does not use the `releases/latest`, as I dont think it is well maintained. However, the last release tag was Nov 2015.

submit an issue for the new release, https://github.com/c9s/r3/issues/136