### PR TITLE
swift-format: update main branch for head build

### DIFF
--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -6,7 +6,7 @@ class SwiftFormat < Formula
     revision: "f22aade8a6ee061b4a7041601ededd8ad7bc2122"
   license "Apache-2.0"
   version_scheme 1
-  head "https://github.com/apple/swift-format.git"
+  head "https://github.com/apple/swift-format.git", branch: "main"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Upstream has renamed master -> main

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note there are separate issues affecting the swift-format formula (see also #61461) in terms of needing to match the swift-format version against the system's swift version.  For example, with the Swift 5.3 installed on my system, I must use the upstream "swift-5.3-branch" rather than "main".  However, that doesn't affect the correctness of this PR: the current "HEAD" is broken (points at a branch that no longer exists), and that should be fixed independently of the version alignment problem.