### PR TITLE
golo: add livecheck

### DIFF
--- a/Formula/golo.rb
+++ b/Formula/golo.rb
@@ -7,6 +7,11 @@ class Golo < Formula
   revision 2
   head "https://github.com/eclipse/golo-lang.git"
 
+  livecheck do
+    url "https://golo-lang.org/download/"
+    regex(/href=.*?golo[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
   bottle :unneeded
 
   depends_on "openjdk@11"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `golo` but it's reporting a development version (`3.4.0-M1`) as newest instead of the latest stable release (`3.3.0`).

This PR resolves the issue by adding a `livecheck` block that checks the [first-party download page](https://golo-lang.org/download/), which is where you find the link to the Bintray archive used in the formula. This brings the check closer to the `stable` source, which we prefer when possible.