### PR TITLE
fuzzy-find: fix comment typo

### DIFF
--- a/Formula/fuzzy-find.rb
+++ b/Formula/fuzzy-find.rb
@@ -6,7 +6,7 @@ class FuzzyFind < Formula
   sha256 "104300ba16af18d60ef3c11d70d2ec2a95ddf38632d08e4f99644050db6035cb"
   head "https://github.com/silentbicycle/ff.git"
 
-  # This regex intentially allows anything to come after the numeric version
+  # This regex intentionally allows anything to come after the numeric version
   # (instead of using $ at the end like we normally do). These tags have a
   # format like `0.6-flag-features` or `v0.5-first-form`, where the trailing
   # text seems to be a release name. This regex may become a problem in the


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR simply fixes a typo in a comment that I introduced in #63924 but didn't notice until after the fact.