### PR TITLE
openmsx: add livecheck

### DIFF
--- a/Formula/openmsx.rb
+++ b/Formula/openmsx.rb
@@ -7,6 +7,11 @@ class Openmsx < Formula
   revision 1
   head "https://github.com/openMSX/openMSX.git"
 
+  livecheck do
+    url "https://github.com/openMSX/openMSX/releases/latest"
+    regex(%r{href=.*?/tag/RELEASE[._-]v?(\d+(?:[._]\d+)+)["' >]}i)
+  end
+
   bottle do
     cellar :any
     sha256 "10c3e39c22efbd11e11b352f8fabfcea03633088cb16fe24611ed631325ed05c" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `openmsx` and it's currently working properly but there are a number of different tags in the Git repository that don't correspond to releases.

This adds a `livecheck` block that checks the "latest" release on GitHub, which will help livecheck to avoid unwanted tags/versions. This also brings the check in line with the idea that we prefer to check the "latest" release on GitHub when it's available (and correct) for formulae with a `stable` archive from GitHub.