### PR TITLE
mp3unicode: add livecheck, update url and license

### DIFF
--- a/Formula/mp3unicode.rb
+++ b/Formula/mp3unicode.rb
@@ -1,9 +1,14 @@
 class Mp3unicode < Formula
   desc "Command-line utility to convert mp3 tags between different encodings"
   homepage "https://mp3unicode.sourceforge.io/"
-  url "https://github.com/downloads/alonbl/mp3unicode/mp3unicode-1.2.1.tar.bz2"
+  url "https://github.com/alonbl/mp3unicode/releases/download/mp3unicode-1.2.1/mp3unicode-1.2.1.tar.bz2"
   sha256 "375b432ce784407e74fceb055d115bf83b1bd04a83b95256171e1a36e00cfe07"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
+
+  livecheck do
+    url "https://github.com/alonbl/mp3unicode/releases/latest"
+    regex(%r{href=.*?/tag/(?:mp3unicode[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `mp3unicode` but it's reporting `3unicode-1.2.1` as newest, since livecheck removes any leading non-numeric text when the formula doesn't contain a `livecheck` block with a `regex`. Tags like `mp3unicode-1.2.1` should be parsed as `1.2.1` instead.

This PR resolves the issue by adding a `livecheck` block with a regex that properly handles the leading `mp3unicode-` portion of tags, so only the numeric version (e.g., `1.2.1`) is captured. This also checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.

Beyond the `livecheck` addition, this updates the `stable` url to use the current URL format for GitHub release downloads. Only a handful of formulae use the `https://github.com/downloads/user/repository/...` format and we should probably update all of these in the future.

Lastly, this updates the `license` from `GPL-2.0` to `GPL-2.0-only`. The source files include the following license text, which doesn't contain any "later" text:

```
This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License version 2
as published by the Free Software Foundation.
```