### PR TITLE
vlmcsd: add livecheck

### DIFF
--- a/Formula/vlmcsd.rb
+++ b/Formula/vlmcsd.rb
@@ -6,6 +6,11 @@ class Vlmcsd < Formula
   sha256 "62f55c48f5de1249c2348ab6b96dabbe7e38899230954b0c8774efb01d9c42cc"
   head "https://github.com/Wind4/vlmcsd.git"
 
+  livecheck do
+    url "https://github.com/Wind4/vlmcsd/releases/latest"
+    regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "3f3cc34de780b15b2c5eb32660f79a95bd28674c7cebb78452f9f8888d9d8b38" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `vlmcsd` but it's reporting `1113` as newest, since livecheck removes leading non-numeric text from tags when the formula doesn't contain a `livecheck` block with a `regex`. The version in the formula is `svn1113`, so livecheck needs to capture the entire tag for the `Version` comparison to work properly.

This PR resolves the issue by adding a `livecheck` block with a regex that captures the entire tag. This also checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.