### PR TITLE
vint: add livecheck

### DIFF
--- a/Formula/vint.rb
+++ b/Formula/vint.rb
@@ -7,6 +7,11 @@ class Vint < Formula
   sha256 "ebbb4ffd790324331aabf82d0b8777db8ce41d72d7c4c1c328bc099359ae06d6"
   license "MIT"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "75161a294d40430a9146e35a9e3871f3d8761cc6b60f66f8b9abd22630f8e579" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `vint` but it's reporting an unstable version (`0.4a4`) as newest instead of the latest stable release (`0.3.21`).

This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`/etc., which also omits unstable versions. The GitHub repository has a "latest" release but it's an unstable release (`v0.4a1`), so we have to stick with the Git tags.