### PR TITLE
 llvm@10 10.0.1 (new formula)

### DIFF
--- a/Formula/llvm@10.rb
+++ b/Formula/llvm@10.rb
@@ -1,0 +1,313 @@
+class LlvmAT10 < Formula
+  desc "Next-gen compiler infrastructure"
+  homepage "https://llvm.org/"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/llvm-10.0.1.src.tar.xz"
+  sha256 "c5d8e30b57cbded7128d78e5e8dad811bff97a8d471896812f57fa99ee82cdf3"
+  # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+  license "Apache-2.0"
+
+  # Clang cannot find system headers if Xcode CLT is not installed
+  pour_bottle? do
+    reason "The bottle needs the Xcode CLT to be installed."
+    satisfy { MacOS::CLT.installed? }
+  end
+
+  keg_only :versioned_formula
+
+  # https://llvm.org/docs/GettingStarted.html#requirement
+  # We intentionally use Make instead of Ninja.
+  # See: Homebrew/homebrew-core/issues/35513
+  depends_on "cmake" => :build
+  depends_on "python@3.9" => :build
+  depends_on "libffi"
+
+  uses_from_macos "libedit"
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
+  patch :p1 do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/c7da61787c62822804dd90192dd9dd254511192c/llvm/10.0.1-llvm.diff"
+    sha256 "86b4e2bf10dfb9a04153e3d4fc744c3f323f3e13fc7b3a7d22e6791d47eb2e2c"
+  end
+
+  resource "clang" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/clang-10.0.1.src.tar.xz"
+    sha256 "f99afc382b88e622c689b6d96cadfa6241ef55dca90e87fc170352e12ddb2b24"
+
+    patch :p1 do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/c7da61787c62822804dd90192dd9dd254511192c/llvm/10.0.1-clang.diff"
+      sha256 "44a605f614a26fb20d127b041e2a87e6adc9b8332e07cbbb6b457bc391cda660"
+    end
+  end
+
+  resource "clang-tools-extra" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/clang-tools-extra-10.0.1.src.tar.xz"
+    sha256 "d093782bcfcd0c3f496b67a5c2c997ab4b85816b62a7dd5b27026634ccf5c11a"
+  end
+
+  resource "compiler-rt" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/compiler-rt-10.0.1.src.tar.xz"
+    sha256 "d90dc8e121ca0271f0fd3d639d135bfaa4b6ed41e67bd6eb77808f72629658fa"
+
+    patch :p1 do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/c7da61787c62822804dd90192dd9dd254511192c/llvm/10.0.1-compiiler-rt.diff"
+      sha256 "8ad0ce521b010dfb941c0979c1c072a2b40e4a69424374541d28122ba74ce4a0"
+    end
+  end
+
+  resource "libcxx" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/libcxx-10.0.1.src.tar.xz"
+    sha256 "def674535f22f83131353b3c382ccebfef4ba6a35c488bdb76f10b68b25be86c"
+  end
+
+  resource "libunwind" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/libunwind-10.0.1.src.tar.xz"
+    sha256 "741903ec1ebff2253ff19d803629d88dc7612598758b6e48bea2da168de95e27"
+  end
+
+  resource "lld" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/lld-10.0.1.src.tar.xz"
+    sha256 "591449e0aa623a6318d5ce2371860401653c48bb540982ccdd933992cb88df7a"
+
+    patch :p1 do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/c7da61787c62822804dd90192dd9dd254511192c/llvm/10.0.1-lld.diff"
+      sha256 "734f87580e89d76507b8c41a5a75b5105c41a2d03a8dc2fad5c7ef027d771a3e"
+    end
+  end
+
+  resource "lldb" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/lldb-10.0.1.src.tar.xz"
+    sha256 "07abe87c25876aa306e73127330f5f37d270b6b082d50cc679e31b4fc02a3714"
+
+    patch :p1 do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/c7da61787c62822804dd90192dd9dd254511192c/llvm/10.0.1-lldb.diff"
+      sha256 "69c7d4c803a174dff6809d02255e7e4c19d80f25c73dd5fcf2657769db158e25"
+    end
+  end
+
+  resource "openmp" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/openmp-10.0.1.src.tar.xz"
+    sha256 "d19f728c8e04fb1e94566c8d76aef50ec926cd2f95ef3bf1e0a5de4909b28b44"
+  end
+
+  resource "polly" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/polly-10.0.1.src.tar.xz"
+    sha256 "d2fb0bb86b21db1f52402ba231da7c119c35c21dfb843c9496fe901f2d6aa25a"
+  end
+
+  def install
+    projects = %w[
+      clang
+      clang-tools-extra
+      lld
+      lldb
+      polly
+    ]
+    # OpenMP currently fails to build on ARM
+    # https://github.com/Homebrew/brew/issues/7857#issuecomment-661484670
+    projects << "openmp" unless Hardware::CPU.arm?
+    runtimes = %w[
+      compiler-rt
+      libcxx
+      libunwind
+    ]
+    # Can likely be added to the base runtimes array when 11.0.0 is released.
+    runtimes << "libcxxabi" if build.head?
+
+    llvmpath = buildpath/"llvm"
+    unless build.head?
+      llvmpath.install buildpath.children - [buildpath/".brew_home"]
+      (projects + runtimes).each { |p| resource(p).stage(buildpath/p) }
+    end
+
+    py_ver = "3.9"
+
+    # Apple's libstdc++ is too old to build LLVM
+    ENV.libcxx if ENV.compiler == :clang
+
+    # compiler-rt has some iOS simulator features that require i386 symbols
+    # I'm assuming the rest of clang needs support too for 32-bit compilation
+    # to work correctly, but if not, perhaps universal binaries could be
+    # limited to compiler-rt. llvm makes this somewhat easier because compiler-rt
+    # can almost be treated as an entirely different build from llvm.
+    ENV.permit_arch_flags
+
+    args = %W[
+      -DLLVM_ENABLE_PROJECTS=#{projects.join(";")}
+      -DLLVM_ENABLE_RUNTIMES=#{runtimes.join(";")}
+      -DLLVM_POLLY_LINK_INTO_TOOLS=ON
+      -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON
+      -DLLVM_LINK_LLVM_DYLIB=ON
+      -DLLVM_BUILD_LLVM_C_DYLIB=ON
+      -DLLVM_ENABLE_EH=ON
+      -DLLVM_ENABLE_FFI=ON
+      -DLLVM_ENABLE_LIBCXX=ON
+      -DLLVM_ENABLE_RTTI=ON
+      -DLLVM_INCLUDE_DOCS=OFF
+      -DLLVM_INCLUDE_TESTS=OFF
+      -DLLVM_INSTALL_UTILS=ON
+      -DLLVM_ENABLE_Z3_SOLVER=OFF
+      -DLLVM_OPTIMIZED_TABLEGEN=ON
+      -DLLVM_TARGETS_TO_BUILD=all
+      -DFFI_INCLUDE_DIR=#{Formula["libffi"].opt_lib}/libffi-#{Formula["libffi"].version}/include
+      -DFFI_LIBRARY_DIR=#{Formula["libffi"].opt_lib}
+      -DLLVM_CREATE_XCODE_TOOLCHAIN=#{MacOS::Xcode.installed? ? "ON" : "OFF"}
+      -DLLDB_USE_SYSTEM_DEBUGSERVER=ON
+      -DLLDB_ENABLE_PYTHON=OFF
+      -DLLDB_ENABLE_LUA=OFF
+      -DLLDB_ENABLE_LZMA=OFF
+      -DLIBOMP_INSTALL_ALIASES=OFF
+      -DCLANG_PYTHON_BINDINGS_VERSIONS=#{py_ver}
+    ]
+
+    sdk = MacOS.sdk_path_if_needed
+    args << "-DDEFAULT_SYSROOT=#{sdk}" if sdk
+
+    if MacOS.version == :mojave && MacOS::CLT.installed?
+      # Mojave CLT linker via software update is older than Xcode.
+      # Use it to retain compatibility.
+      args << "-DCMAKE_LINKER=/Library/Developer/CommandLineTools/usr/bin/ld"
+    end
+
+    mkdir llvmpath/"build" do
+      system "cmake", "-G", "Unix Makefiles", "..", *(std_cmake_args + args)
+      system "make"
+      system "make", "install"
+      system "make", "install-xcode-toolchain" if MacOS::Xcode.installed?
+    end
+
+    # Install LLVM Python bindings
+    # Clang Python bindings are installed by CMake
+    (lib/"python#{py_ver}/site-packages").install llvmpath/"bindings/python/llvm"
+
+    # Install Emacs modes
+    elisp.install Dir[llvmpath/"utils/emacs/*.el"] + Dir[share/"clang/*.el"]
+  end
+
+  def caveats
+    <<~EOS
+      To use the bundled libc++ please add the following LDFLAGS:
+        LDFLAGS="-L#{opt_lib} -Wl,-rpath,#{opt_lib}"
+    EOS
+  end
+
+  test do
+    assert_equal prefix.to_s, shell_output("#{bin}/llvm-config --prefix").chomp
+
+    (testpath/"omptest.c").write <<~EOS
+      #include <stdlib.h>
+      #include <stdio.h>
+      #include <omp.h>
+      int main() {
+          #pragma omp parallel num_threads(4)
+          {
+            printf("Hello from thread %d, nthreads %d\\n", omp_get_thread_num(), omp_get_num_threads());
+          }
+          return EXIT_SUCCESS;
+      }
+    EOS
+
+    clean_version = version.to_s[/(\d+\.?)+/]
+
+    system "#{bin}/clang", "-L#{lib}", "-fopenmp", "-nobuiltininc",
+      "-I#{lib}/clang/#{clean_version}/include",
+      "omptest.c", "-o", "omptest"
+      testresult = shell_output("./omptest")
+
+      sorted_testresult = testresult.split("\n").sort.join("\n")
+      expected_result = <<~EOS
+      Hello from thread 0, nthreads 4
+      Hello from thread 1, nthreads 4
+      Hello from thread 2, nthreads 4
+      Hello from thread 3, nthreads 4
+      EOS
+      assert_equal expected_result.strip, sorted_testresult.strip
+
+      (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      int main()
+      {
+        printf("Hello World!\\n");
+        return 0;
+      }
+      EOS
+
+      (testpath/"test.cpp").write <<~EOS
+      #include <iostream>
+      int main()
+      {
+        std::cout << "Hello World!" << std::endl;
+        return 0;
+      }
+      EOS
+
+      # Testing default toolchain and SDK location.
+      system "#{bin}/clang++", "-v",
+        "-std=c++11", "test.cpp", "-o", "test++"
+      assert_includes MachO::Tools.dylibs("test++"), "/usr/lib/libc++.1.dylib"
+      assert_equal "Hello World!", shell_output("./test++").chomp
+      system "#{bin}/clang", "-v", "test.c", "-o", "test"
+      assert_equal "Hello World!", shell_output("./test").chomp
+
+      # Testing Command Line Tools
+      if MacOS::CLT.installed?
+        toolchain_path = "/Library/Developer/CommandLineTools"
+        system "#{bin}/clang++", "-v",
+          "-isysroot", MacOS::CLT.sdk_path,
+          "-isystem", "#{toolchain_path}/usr/include/c++/v1",
+          "-isystem", "#{toolchain_path}/usr/include",
+          "-isystem", "#{MacOS::CLT.sdk_path}/usr/include",
+          "-std=c++11", "test.cpp", "-o", "testCLT++"
+        assert_includes MachO::Tools.dylibs("testCLT++"), "/usr/lib/libc++.1.dylib"
+        assert_equal "Hello World!", shell_output("./testCLT++").chomp
+        system "#{bin}/clang", "-v", "test.c", "-o", "testCLT"
+        assert_equal "Hello World!", shell_output("./testCLT").chomp
+      end
+
+      # Testing Xcode
+      if MacOS::Xcode.installed?
+        system "#{bin}/clang++", "-v",
+          "-isysroot", MacOS::Xcode.sdk_path,
+          "-isystem", "#{MacOS::Xcode.toolchain_path}/usr/include/c++/v1",
+          "-isystem", "#{MacOS::Xcode.toolchain_path}/usr/include",
+          "-isystem", "#{MacOS::Xcode.sdk_path}/usr/include",
+          "-std=c++11", "test.cpp", "-o", "testXC++"
+        assert_includes MachO::Tools.dylibs("testXC++"), "/usr/lib/libc++.1.dylib"
+        assert_equal "Hello World!", shell_output("./testXC++").chomp
+        system "#{bin}/clang", "-v",
+          "-isysroot", MacOS.sdk_path,
+          "test.c", "-o", "testXC"
+        assert_equal "Hello World!", shell_output("./testXC").chomp
+      end
+
+      # link against installed libc++
+      # related to https://github.com/Homebrew/legacy-homebrew/issues/47149
+      system "#{bin}/clang++", "-v",
+        "-isystem", "#{opt_include}/c++/v1",
+        "-std=c++11", "-stdlib=libc++", "test.cpp", "-o", "testlibc++",
+        "-L#{opt_lib}", "-Wl,-rpath,#{opt_lib}"
+      assert_includes MachO::Tools.dylibs("testlibc++"), "#{opt_lib}/libc++.1.dylib"
+      assert_equal "Hello World!", shell_output("./testlibc++").chomp
+
+      (testpath/"scanbuildtest.cpp").write <<~EOS
+      #include <iostream>
+      int main() {
+        int *i = new int;
+        *i = 1;
+        delete i;
+        std::cout << *i << std::endl;
+        return 0;
+      }
+      EOS
+      assert_includes shell_output("#{bin}/scan-build clang++ scanbuildtest.cpp 2>&1"),
+        "warning: Use of memory after it is freed"
+
+      (testpath/"clangformattest.c").write <<~EOS
+      int    main() {
+          printf("Hello world!"); }
+      EOS
+      assert_equal "int main() { printf(\"Hello world!\"); }\n",
+        shell_output("#{bin}/clang-format -style=google clangformattest.c")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
TL;DR
First, It is intuitive for users to support versions 7, 8, 9, 11, and NOT 10. Second, 10 is more popular than other versions.

---
I am aware of the 2 previous PRs (#63177 and #63316) that tried to bring LLVM v10 back into hombrew-core. I am also aware they have both been closed. 

First, I wanted to address the issue of,
> Upstream should have a release branch for each formula version, and release security updates for each version when necessary

The upstream llvm 10 project does meet this requirement. Here is a release branch - https://github.com/llvm/llvm-project/tree/llvmorg-10.0.0 and here is a release branch with a bug fix - https://github.com/llvm/llvm-project/tree/llvmorg-10.0.1. And here is mention of a security team on the llvm project - http://llvm.org/docs/Security.html

Next, I know there has been concern about introducing another llvm version, and I am aware of the requirement in the docs,
> No more than five versions of a formula (including the main one) will be supported at any given time, regardless of usage. When removing formulae that violate this, we will aim to do so based on usage and support status rather than age.

With this in mind, I still believe that version 10 should be supported. From an end user standpoint it is very confusing to be able to install versions 7, 8, 9 and 11 but, not 10. I imagine the project will continue to see issues and prs raised asking about version 10. That is to say, not having version 10 could introduce a lot more noise for maintainers.

I also wanted to see if I could make a statement on the popularity of the different versions. This wasn't all that trivial with only being able to search 30, 90, and 365 day statistics. However, there is a 60 day window where all of these versions overlapped. And for that window the number of installs broke down as follows,
```
installs for llvm from Fri Oct  2 22:38:13 EDT 2020 to Fri Oct  2 22:38:13 EDT 2020
40414
installs for llvm@7 from Fri Oct  2 22:38:14 EDT 2020 to Fri Oct  2 22:38:14 EDT 2020
400
installs for llvm@8 from Fri Oct  2 22:38:15 EDT 2020 to Fri Oct  2 22:38:15 EDT 2020
1044
installs for llvm@9 from Fri Oct  2 22:38:15 EDT 2020 to Fri Oct  2 22:38:15 EDT 2020
954
```
Where the first line was version 10 during the window. 

Now, I am not saying that everyone running `brew install llvm` was actively going for version 10 during that time. It is far more likely, that people didn't think twice about the version and just used what was given. Still though, that is a huge chunk of users who, aware of it or not, are on version 10, and that should be considered.

Thanks for any consideration!
nick

Script for stats...
```
#!/bin/bash
for ver in "" "@7" "@8" "@9"; do
  for len in 30d 90d; do
    curl -s "https://formulae.brew.sh/api/formula/llvm${ver}.json" |
      jq ".analytics.install.\"${len}\".\"llvm${ver}\"" > llvm${ver}_${len}
  done

  echo "installs for llvm${ver} from $(gdate -d '90 days ago') to $(gdate -d '30 days ago')"
  bc <<< "$(<llvm${ver}_90d) - $(<llvm${ver}_30d)"
done
```