### PR TITLE
valgrind: add livecheck

### DIFF
--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -10,6 +10,11 @@ class Valgrind < Formula
     depends_on maximum_macos: :high_sierra
   end
 
+  livecheck do
+    url "https://sourceware.org/pub/valgrind/"
+    regex(/href=.*?valgrind[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 "7170a66beb19ccfd79d1559fe57c67fb4a6a7b6369775621f5073af6fea07ea8" => :high_sierra
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `valgrind` but it's reporting an older version (`3_15_0`) as newest instead of the latest stable release (`3.16.1`).

This PR resolves the issue by adding a `livecheck` block that checks the directory listing page where the `stable` archive is found. This also aligns the check with the `stable` source, which we prefer when possible.