### PR TITLE
usb.ids: add livecheck

### DIFF
--- a/Formula/usb.ids.rb
+++ b/Formula/usb.ids.rb
@@ -5,6 +5,11 @@ class UsbIds < Formula
   sha256 "de972f2cde2b681f3350273c4cae9985364c1acd99d774bdd82ca7e7408574d6"
   license any_of: ["GPL-2.0-or-later", "BSD-3-Clause"]
 
+  livecheck do
+    url "https://deb.debian.org/debian/pool/main/u/usb.ids/"
+    regex(/href=.*?usb\.ids[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "2994769226c7815ef5eee9ba27f729005fd993341dfbca50f413139ef411ac5c" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `usb.ids`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.