### PR TITLE
GDAL 3.2.0

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -1,10 +1,9 @@
 class Gdal < Formula
   desc "Geospatial Data Abstraction Library"
   homepage "https://www.gdal.org/"
-  url "https://download.osgeo.org/gdal/3.1.4/gdal-3.1.4.tar.xz"
-  sha256 "7b82486f71c71cec61f9b237116212ce18ef6b90f068cbbf9f7de4fc50b576a8"
+  url "https://download.osgeo.org/gdal/3.2.0/gdal-3.2.0.tar.xz"
+  sha256 "b051f852600ffdf07e337a7f15673da23f9201a9dbb482bd513756a3e5a196a6"
   license "MIT"
-  revision 1
 
   livecheck do
     url "https://download.osgeo.org/gdal/CURRENT/"

--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -165,7 +165,7 @@ class Gdal < Formula
     # basic tests to see if third-party dylibs are loading OK
     system "#{bin}/gdalinfo", "--formats"
     system "#{bin}/ogrinfo", "--formats"
-
-    system Formula["python@3.9"].opt_bin/"python3", "-c", "import gdal"
+    # Changed Python package name from "gdal" to "osgeo.gdal" in 3.2.0.
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "import osgeo.gdal"
   end
 end

--- a/Formula/gmt.rb
+++ b/Formula/gmt.rb
@@ -5,7 +5,7 @@ class Gmt < Formula
   mirror "https://mirrors.ustc.edu.cn/gmt/gmt-6.1.1-src.tar.xz"
   sha256 "d476cba999340648146ef53ab4a3f64858cbd2f5511cdec9f7f06f3fb7896625"
   license "LGPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/GenericMappingTools/gmt.git"
 
   bottle do

--- a/Formula/gmt.rb
+++ b/Formula/gmt.rb
@@ -5,6 +5,7 @@ class Gmt < Formula
   mirror "https://mirrors.ustc.edu.cn/gmt/gmt-6.1.1-src.tar.xz"
   sha256 "d476cba999340648146ef53ab4a3f64858cbd2f5511cdec9f7f06f3fb7896625"
   license "LGPL-3.0-or-later"
+  revision 1
   head "https://github.com/GenericMappingTools/gmt.git"
 
   bottle do

--- a/Formula/gmt.rb
+++ b/Formula/gmt.rb
@@ -5,7 +5,7 @@ class Gmt < Formula
   mirror "https://mirrors.ustc.edu.cn/gmt/gmt-6.1.1-src.tar.xz"
   sha256 "d476cba999340648146ef53ab4a3f64858cbd2f5511cdec9f7f06f3fb7896625"
   license "LGPL-3.0-or-later"
-  revision 2
+  revision 1
   head "https://github.com/GenericMappingTools/gmt.git"
 
   bottle do

--- a/Formula/gmt@5.rb
+++ b/Formula/gmt@5.rb
@@ -6,7 +6,7 @@ class GmtAT5 < Formula
   mirror "https://fossies.org/linux/misc/GMT/gmt-5.4.5-src.tar.gz"
   sha256 "225629c7869e204d5f9f1a384c4ada43e243f83e1ed28bdca4f7c2896bf39ef6"
   license "LGPL-3.0"
-  revision 6
+  revision 7
 
   bottle do
     sha256 "ccbfdc5293e264dfa68d6bd0bc6bbe84cda41df4b0dae485f44921a918762ff0" => :catalina

--- a/Formula/mapserver.rb
+++ b/Formula/mapserver.rb
@@ -3,7 +3,7 @@ class Mapserver < Formula
   homepage "https://mapserver.org/"
   url "https://download.osgeo.org/mapserver/mapserver-7.6.1.tar.gz"
   sha256 "2d250874d55bee44e0dbbb3a38e612f8572730705edada00c6ab8b2c9e890581"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/pdal.rb
+++ b/Formula/pdal.rb
@@ -4,6 +4,7 @@ class Pdal < Formula
   url "https://github.com/PDAL/PDAL/releases/download/2.2.0/PDAL-2.2.0-src.tar.gz"
   sha256 "421e94beafbfda6db642e61199bc4605eade5cab5d2e54585e08f4b27438e568"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/PDAL/PDAL.git"
 
   bottle do

--- a/Formula/points2grid.rb
+++ b/Formula/points2grid.rb
@@ -4,7 +4,7 @@ class Points2grid < Formula
   url "https://github.com/CRREL/points2grid/archive/1.3.1.tar.gz"
   sha256 "6e2f2d3bbfd6f0f5c2d0c7d263cbd5453745a6fbe3113a3a2a630a997f4a1807"
   license "BSD-4-Clause"
-  revision 8
+  revision 9
 
   bottle do
     cellar :any

--- a/Formula/simple-tiles.rb
+++ b/Formula/simple-tiles.rb
@@ -1,6 +1,6 @@
 class SimpleTiles < Formula
   desc "Image generation library for spatial data"
-  homepage "https://propublica.github.io/simple-tiles/"
+  homepage "https://github.com/propublica/simple-tiles"
   url "https://github.com/propublica/simple-tiles/archive/v0.6.1.tar.gz"
   sha256 "2391b2f727855de28adfea9fc95d8c7cbaca63c5b86c7286990d8cbbcd640d6f"
   license "MIT"

--- a/Formula/simple-tiles.rb
+++ b/Formula/simple-tiles.rb
@@ -4,7 +4,7 @@ class SimpleTiles < Formula
   url "https://github.com/propublica/simple-tiles/archive/v0.6.1.tar.gz"
   sha256 "2391b2f727855de28adfea9fc95d8c7cbaca63c5b86c7286990d8cbbcd640d6f"
   license "MIT"
-  revision 8
+  revision 9
   head "https://github.com/propublica/simple-tiles.git"
 
   bottle do


### PR DESCRIPTION
Update GDAL to 3.2.0 from 3.1.4.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Update GDAL to 3.2.0 from 3.1.4.

https://github.com/OSGeo/gdal/releases/tag/v3.2.0

Seeing this with `brew test gdal`:

```
❯ brew test gdal
==> Testing gdal
==> /usr/local/Cellar/gdal/3.2.0/bin/gdalinfo --formats
==> /usr/local/Cellar/gdal/3.2.0/bin/ogrinfo --formats
==> /usr/local/opt/python@3.9/bin/python3 -c import gdal
Last 15 lines from /Users/mike/Library/Logs/Homebrew/gdal/test.03.python3:
2020-11-02 09:49:33 -0500

/usr/local/opt/python@3.9/bin/python3
-c
import gdal

Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'gdal'
Error: gdal: failed
An exception occurred within a child process:
  BuildError: Failed executing: /usr/local/opt/python@3.9/bin/python3 -c import\ gdal
/usr/local/Homebrew/Library/Homebrew/formula.rb:2022:in `block in system'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1960:in `open'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1960:in `system'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gdal.rb:169:in `block in <class:Gdal>'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1831:in `block (3 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/utils.rb:497:in `with_env'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1830:in `block (2 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/formula.rb:901:in `with_logging'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1829:in `block in run_test'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:58:in `block in run'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:58:in `chdir'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:58:in `run'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2071:in `mktemp'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1823:in `run_test'
/usr/local/Homebrew/Library/Homebrew/test.rb:43:in `block in <main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/usr/local/Homebrew/Library/Homebrew/test.rb:42:in `<main>'
```