### PR TITLE
stuntman: add livecheck

### DIFF
--- a/Formula/stuntman.rb
+++ b/Formula/stuntman.rb
@@ -6,6 +6,11 @@ class Stuntman < Formula
   license "Apache-2.0"
   head "https://github.com/jselbie/stunserver.git"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?stunserver[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "e337d1ad8978b0bb926bca46992575b686145f9e8eb43dbc990e4efe08539722" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `stuntman` but it's reporting `1.2.13` as newest (instead of `1.2.16`) because the repository doesn't seem to contain tags for releases past `1.2.13`.

This PR resolves the issue by adding a `livecheck` block that checks the homepage, identifying the version from the filename of the `stable` archive we use in the formula. This also aligns the check with the `stable` source, which we prefer when possible.