### PR TITLE
kore: add livecheck

### DIFF
--- a/Formula/kore.rb
+++ b/Formula/kore.rb
@@ -6,6 +6,11 @@ class Kore < Formula
   license "ISC"
   head "https://github.com/jorisvink/kore.git"
 
+  livecheck do
+    url "https://kore.io/source"
+    regex(/href=.*?kore[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 "ad77b830ab7265b3f1f3be5f25b82949672369ab53478b35428ccc39dc770c5f" => :catalina
     sha256 "766a72d1382f2edff8a4a479e6528fd3b3e952b978224d139dd1c602ea9c39c5" => :mojave


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `kore` but it's reporting `4.0.0` as newest (instead of `4.0.1`) because the repository doesn't have a tag for `4.0.1`.

This PR resolves the issue by adding a `livecheck` block that checks the [first-party "source" page](https://kore.io/source) (as there isn't a "releases" directory listing page). The "source" page contains links to the source archive files that we use in the formula, so it's the closest we can get. This naturally brings the check closer to the `stable` source, which we prefer when possible.