### PR TITLE
wal2json: add livecheck

### DIFF
--- a/Formula/wal2json.rb
+++ b/Formula/wal2json.rb
@@ -5,6 +5,11 @@ class Wal2json < Formula
   sha256 "2ebf71ace3c9f4b66703bcf6e3fa6ef7b6b026f9e31db4cf864eb3deb4e1a5b3"
   license "BSD-3-Clause"
 
+  livecheck do
+    url "https://github.com/eulerto/wal2json/releases/latest"
+    regex(%r{href=.*?/tag/(?:wal2json[._-])?v?(\d+(?:[._]\d+)+)["' >]}i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "ec25d4dffbb7b4205565f2ec5ad6c17fa62a965d841a75b475b11bd7ff759c51" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `wal2json` but it's reporting `2json_2_3` as newest (from the `wal2json_2_3` tag), since livecheck removes leading non-numeric text from Git tags when a formula doesn't contain a `livecheck` block with a `regex`.

This PR resolves the issue by adding a `livecheck` block with a regex that accounts for the leading `wal2json_` text in tags. This also checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.