### PR TITLE
contacts: deprecate and update license

### DIFF
--- a/Formula/contacts.rb
+++ b/Formula/contacts.rb
@@ -7,7 +7,9 @@ class Contacts < Formula
   url "https://github.com/dhess/contacts/archive/4092a3c6615d7a22852a3bafc44e4aeeb698aa8f.tar.gz"
   version "1.1a-3"
   sha256 "e3dd7e592af0016b28e9215d8ac0fe1a94c360eca5bfbdafc2b0e5d76c60b871"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
+
+  deprecate! because: :repo_archived
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [upstream GitHub repository for `contacts`](https://github.com/dhess/contacts/) has been archived, so this deprecates the formula with an appropriate reason.

This also updates the license from `GPL-2.0` to `GPL-2.0-only`, referencing the archived [homepage](https://web.archive.org/web/20181108222900/gnufoo.org/contacts/contacts.html) which states, "Oh and contacts is licensed under the GPL." This is the only description of the license that I could find, as the repository only contains the GPL 2.0 license file and nothing explicitly describing whether later licenses can be optionally applied. The looseness of this statement could be taken as "GPL-2.0-only" or "GPL-2.0-or-later" but I'm taking a conservative interpretation of it.