### PR TITLE
slrn: add livecheck and license

### DIFF
--- a/Formula/slrn.rb
+++ b/Formula/slrn.rb
@@ -3,8 +3,14 @@ class Slrn < Formula
   homepage "https://slrn.sourceforge.io/"
   url "https://jedsoft.org/releases/slrn/slrn-1.0.3a.tar.bz2"
   sha256 "3ba8a4d549201640f2b82d53fb1bec1250f908052a7983f0061c983c634c2dac"
+  license "GPL-2.0-or-later"
   revision 1
   head "git://git.jedsoft.org/git/slrn.git"
+
+  livecheck do
+    url "https://jedsoft.org/releases/slrn/"
+    regex(/href=.*?slrn[._-]v?(\d+(?:\.\d+)+(?:[a-z]?\d*)?)\.t/i)
+  end
 
   bottle do
     sha256 "de190a3f3793acd7d8e50dc82231e7ad94535621bc4c37a34efcc1907c295296" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `slrn` but it's reporting `1.0.1` (instead of `1.0.3a`) as newest, since it doesn't contain tags newer than `1.0.1`.

This PR resolves the issue by adding a `livecheck` block that checks the [first-party "releases" page for `slrn`](https://jedsoft.org/releases/slrn/), where the `stable` archive is found. The check uses a `regex` that allows for versions like `1.0.2`, `0.9.9p1`, and `1.0.3a`. This also brings the check in line with the `stable` source, which we prefer when possible.

Just to be clear, the `1.0.3a` release appears to be stable, as it's on the "releases" page rather than the ["snapshots" page](https://www.jedsoft.org/snapshots/) where development versions are found.

This also adds `license "GPL-2.0-or-later"`, referencing the `COPYING` file in the latest tarball (which is a GPL Version 2 license) and the `COPYRIGHT` file which states:

```
This program is free software; you can redistribute it and/or modify it
under the terms of the GNU General Public License as published by the Free
Software Foundation; either version 2 of the License, or (at your option)
any later version.
```