### PR TITLE
posh: add livecheck, update license

### DIFF
--- a/Formula/posh.rb
+++ b/Formula/posh.rb
@@ -3,7 +3,12 @@ class Posh < Formula
   homepage "https://salsa.debian.org/clint/posh"
   url "https://salsa.debian.org/clint/posh/-/archive/debian/0.14.1/posh-debian-0.14.1.tar.bz2"
   sha256 "3c9ca430977d85ad95d439656269b878bd5bde16521b778c222708910d111c80"
-  license "GPL-2.0"
+  license "GPL-3.0-or-later"
+
+  livecheck do
+    url :stable
+    regex(%r{^debian/v?(\d+(?:\.\d+)+)$}i)
+  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `posh` but it's reporting `0--base-0` as newest, due to a `schizo@debian.org--etch,posh--dev--0--base-0` tag. For whatever reason, this is the only tag it's matching and it's not matching any of the version tags like `debian/0.14.1`.

This PR resolves the issue by adding a `livecheck` block that uses a version of the standard regex for Git tags like `1.2.3`/`v1.2.3`/etc., that I've modified to handle the leading `debian/` in the tags.

This also updates the license from "GPL-2.0" to "GPL-3.0-or-later", referencing the [`COPYING` file](https://salsa.debian.org/clint/posh/-/blob/master/COPYING) and the [`debian/copyright` file](https://salsa.debian.org/clint/posh/-/blob/master/debian/copyright), which states:

```
posh is Copyright © 2002-2020
by Clint Adams, and is distributed under the terms of the GNU
General Public License, version 3 or later, which can be found at
/usr/share/common-licenses/GPL-3 .
```