### PR TITLE
moco: add livecheck

### DIFF
--- a/Formula/moco.rb
+++ b/Formula/moco.rb
@@ -5,6 +5,11 @@ class Moco < Formula
   sha256 "cf970d4a74b834e8fc0df2059368c2d153924bb37c34f6a8cef5b8d886e71463"
   license "MIT"
 
+  livecheck do
+    url "https://search.maven.org/remotecontent?filepath=com/github/dreamhead/moco-runner/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+
   bottle :unneeded
 
   depends_on "openjdk"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `moco` but it's reporting `1.0.0` as newest because the repository doesn't contain tags past `v1.0.0`.

This PR resolves the issue by adding a `livecheck` block that checks the [directory listing page](https://search.maven.org/remotecontent?filepath=com/github/dreamhead/moco-runner/) where the `stable` archive is found. The archive files are stored in separate directories but thankfully the directories are named using the full version (e.g., `1.1.0/`) instead of just the major/minor, so we can identify versions this way. This also aligns the check with the `stable` source, which we prefer when possible.