### PR TITLE
arabica: add livecheck

### DIFF
--- a/Formula/arabica.rb
+++ b/Formula/arabica.rb
@@ -7,6 +7,11 @@ class Arabica < Formula
   license "BSD-3-Clause"
   head "https://github.com/jezhiggins/arabica.git"
 
+  livecheck do
+    url "https://github.com/jezhiggins/arabica/releases/latest"
+    regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
+  end
+
   bottle do
     cellar :any
     sha256 "4fbf676c46941de213b095ab74f0b4973e5984c2bbaa7679757b0db4b369480a" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `arabica` but it's reporting `2020-February` as newest instead of `2020-April`, due to the alphabetical sorting of the month.

The formula version is manually set to a `YYYYMMDD` format (e.g., `20200425`), where the day comes from the release date (not present in the tag). We can't create a check that modifies `2020-April` to `202004` (let alone `20200425`) until I've implemented an `alterations` DSL that allows us to do string replacements on matched text. It remains to be seen whether we'll be able to combine two capture groups (e.g., `2020-April` and `25`) to produce the full `YYYYMMDD` version but I'll keep it in mind when I work on it in the future.

This PR improves the situation a little by adding a `livecheck` block that checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub. This at least gets us the latest tag (`2020-April`) instead of an older tag that's presented as newer due to the month name sorting. We can always revisit this check in the future when an `alterations` DSL is available and improve it further.