### PR TITLE
kona: add livecheck

### DIFF
--- a/Formula/kona.rb
+++ b/Formula/kona.rb
@@ -6,6 +6,11 @@ class Kona < Formula
   license "ISC"
   head "https://github.com/kevinlawler/kona.git"
 
+  livecheck do
+    url "https://github.com/kevinlawler/kona/releases/latest"
+    regex(%r{href=.*?/tag/(?:Win(?:64)?[._-])?v?(\d+(?:\.\d+)*)[^"' >]*["' >]}i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "0b6a2f66ebbbaa1f13c31e8e08d0c3d9d98e1dbc91d83d6c0c7afba82dfec16f" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `kona` but it's reporting `64-20201009` (from the `Win64-20201009` tag) as newest because livecheck removes leading non-numeric text when the formula doesn't contain a `livecheck` block with a `regex`.

This PR resolves the issue by adding a `livecheck` block with a regex that handles the leading `Win64-` (or `Win.`) text, so it isn't treated as part of the version. I've tried to find a balance between the regex being too explicit and too loose but we may have to loosen this in the future if it ends up being too specific (leading to the check breaking if the tag format changes).

This also checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.