### PR TITLE
zenith: use `IO#winsize` instead of `stty`

### DIFF
--- a/Formula/zenith.rb
+++ b/Formula/zenith.rb
@@ -21,16 +21,15 @@ class Zenith < Formula
 
   test do
     require "pty"
+    require "io/console"
 
-    begin
-      (testpath/"zenith").mkdir
-      cmd = "#{bin}/zenith --db zenith"
-      output, input, pid = PTY.spawn "stty rows 80 cols 43 && #{cmd}"
-      sleep 1
-      input.write "q"
-      assert_match /PID\s+USER\s+P\s+N\s+↓CPU%\s+MEM%/, output.read
-    ensure
-      Process.kill("TERM", pid)
-    end
+    (testpath/"zenith").mkdir
+    r, w, pid = PTY.spawn "#{bin}/zenith --db zenith"
+    r.winsize = [80, 43]
+    sleep 1
+    w.write "q"
+    assert_match /PID\s+USER\s+P\s+N\s+↓CPU%\s+MEM%/, r.read
+  ensure
+    Process.kill("TERM", pid)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?