### PR TITLE
bombadillo: use `IO#winsize` instead of `stty`

### DIFF
--- a/Formula/bombadillo.rb
+++ b/Formula/bombadillo.rb
@@ -20,10 +20,11 @@ class Bombadillo < Formula
 
   test do
     require "pty"
+    require "io/console"
 
-    cmd = bin/"bombadillo gopher://bombadillo.colorfield.space"
-    config = testpath/".config"
-    r, w, pid = PTY.spawn("stty rows 80 cols 43 && XDG_CONFIG_HOME=#{config} #{cmd}")
+    cmd = "#{bin}/bombadillo gopher://bombadillo.colorfield.space"
+    r, w, pid = PTY.spawn({ "XDG_CONFIG_HOME" => testpath/".config" }, cmd)
+    r.winsize = [80, 43]
     sleep 1
     w.write "q"
     assert_match /Bombadillo is a non-web browser/, r.read


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?