### PR TITLE
nifi-registry: depend on openjdk

### DIFF
--- a/Formula/nifi-registry.rb
+++ b/Formula/nifi-registry.rb
@@ -5,6 +5,7 @@ class NifiRegistry < Formula
   mirror "https://archive.apache.org/dist/nifi/nifi-registry/nifi-registry-0.8.0/nifi-registry-087.0-bin.tar.gz"
   sha256 "db9f390eb4e1f99fb861c437be95729dfcb203f49de4b9cb3130a612a4ae288d"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -12,12 +13,15 @@ class NifiRegistry < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     libexec.install Dir["*"]
     rm Dir[libexec/"bin/*.bat"]
 
     bin.install libexec/"bin/nifi-registry.sh" => "nifi-registry"
-    bin.env_script_all_files libexec/"bin/", NIFI_REGISTRY_HOME: libexec
+    bin.env_script_all_files libexec/"bin/",
+                             Language::Java.overridable_java_home_env.merge(NIFI_REGISTRY_HOME: libexec)
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
