### PR TITLE
nifi: use java 11, overridable java home

### DIFF
--- a/Formula/nifi.rb
+++ b/Formula/nifi.rb
@@ -5,6 +5,7 @@ class Nifi < Formula
   mirror "https://archive.apache.org/dist/nifi/1.12.1/nifi-1.12.1-bin.tar.gz"
   sha256 "0bb0e24ac5f2f1bb90519cfa24e201fc34346b3bb4d1f79972aeaa2fd4a4bd75"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -12,14 +13,13 @@ class Nifi < Formula
 
   bottle :unneeded
 
-  depends_on "openjdk"
+  depends_on "openjdk@11"
 
   def install
     libexec.install Dir["*"]
 
     (bin/"nifi").write_env_script libexec/"bin/nifi.sh",
-                                  NIFI_HOME: libexec,
-                                  JAVA_HOME: Formula["openjdk"].opt_prefix
+                                  Language::Java.overridable_java_home_env("11").merge(NIFI_HOME: libexec)
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Java 11: https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#system_requirements