### PR TITLE
tree-sitter 0.17.3 (new formula)

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -14,7 +14,6 @@ class Neovim < Formula
   head do
     url "https://github.com/neovim/neovim.git"
     depends_on "tree-sitter"
-    depends_on "utf8proc"
   end
 
   depends_on "cmake" => :build

--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -13,6 +13,7 @@ class Neovim < Formula
 
   head do
     url "https://github.com/neovim/neovim.git"
+    depends_on "tree-sitter"
     depends_on "utf8proc"
   end
 

--- a/Formula/tree-sitter.rb
+++ b/Formula/tree-sitter.rb
@@ -1,0 +1,44 @@
+class TreeSitter < Formula
+  desc "Parser generator tool and incremental parsing library"
+  homepage "https://tree-sitter.github.io/"
+  url "https://github.com/tree-sitter/tree-sitter/archive/0.17.3.tar.gz"
+  sha256 "a897e5c9a7ccb74271d9b20d59121d2d2e9de8b896c4d1cfaac0f8104c1ef9f8"
+  license "MIT"
+  head "https://github.com/tree-sitter/tree-sitter.git"
+
+  def install
+    system "make"
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <string.h>
+      #include <tree_sitter/api.h>
+      int main(int argc, char* argv[]) {
+        TSParser *parser = ts_parser_new();
+        if (parser == NULL) {
+          return 1;
+        }
+        // Because we have no language libraries installed, we cannot
+        // actually parse a string succesfully. But, we can verify
+        // that it can at least be attempted.
+        const char *source_code = "empty";
+        TSTree *tree = ts_parser_parse_string(
+          parser,
+          NULL,
+          source_code,
+          strlen(source_code)
+        );
+        if (tree == NULL) {
+          printf("tree creation failed");
+        }
+        ts_tree_delete(tree);
+        ts_parser_delete(parser);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-ltree-sitter", "-o", "test"
+    assert_equal "tree creation failed", shell_output("./test")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds tree-sitter 0.17.3 and adds it as a dependency for neovim HEAD.

See discussion in https://github.com/neovim/neovim/pull/12931 for why this is necessary and the Homebrew tap [ChimeHQ/tree-sitter](https://github.com/ChimeHQ/homebrew-tree-sitter) which I shamelessly took for inspiration.

~The strict audit fails on my machine, but I can't quite make out why it fails. Maybe someone from the Homebrew team can help me here—the PR is open for edits by maintainers.~