### PR TITLE
migrate some audit exception lists to Homebrew/core

### DIFF
--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -1,0 +1,8 @@
+{
+  "aws-sdk-cpp": 10,
+  "awscli@1": 10,
+  "balena-cli": 10,
+  "gatsby-cli": 10,
+  "quicktype": 10,
+  "vim": 50
+}

--- a/audit_exceptions/versioned_head_spec_allowlist.json
+++ b/audit_exceptions/versioned_head_spec_allowlist.json
@@ -1,0 +1,4 @@
+[
+  "bash-completion@2",
+  "imagemagick@6"
+]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Moves the `THROTTLED_FORMULAE` and `VERSIONED_HEAD_SPEC_ALLOWLIST` lists from Homebrew/brew to Homebrew/core per discussion in  https://github.com/Homebrew/brew/pull/9039.

Marking as DNM until https://github.com/Homebrew/brew/pull/9039 has been approved and is ready to be merged.