### PR TITLE
terragrunt 0.26.2

### DIFF
--- a/Formula/terragrunt.rb
+++ b/Formula/terragrunt.rb
@@ -1,7 +1,7 @@
 class Terragrunt < Formula
   desc "Thin wrapper for Terraform e.g. for locking state"
   homepage "https://github.com/gruntwork-io/terragrunt"
-  url "https://github.com/gruntwork-io/terragrunt/archive/v0.26.1.tar.gz"
+  url "https://github.com/gruntwork-io/terragrunt/archive/v0.26.0.tar.gz"
   sha256 "723b6111a8c0f105de5fb687cad3fff3930bcd34eebe5d6c039e4931fb06bd5e"
   license "MIT"
 

--- a/Formula/terragrunt.rb
+++ b/Formula/terragrunt.rb
@@ -1,8 +1,8 @@
 class Terragrunt < Formula
   desc "Thin wrapper for Terraform e.g. for locking state"
   homepage "https://github.com/gruntwork-io/terragrunt"
-  url "https://github.com/gruntwork-io/terragrunt/archive/v0.26.0.tar.gz"
-  sha256 "723b6111a8c0f105de5fb687cad3fff3930bcd34eebe5d6c039e4931fb06bd5e"
+  url "https://github.com/gruntwork-io/terragrunt/archive/v0.26.2.tar.gz"
+  sha256 "f58d9a1bba7ea5821d4b925d58c426fe3b26b39542f7eaf7cfc03aeaa71f6328"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
We've deleted the tag v0.26.1 (the released code is the same, but the version number was wrong). 
Since then, we've released what was supposed to be the next stable version of terragrunt - v0.26.0.

The URL should be changed to: https://github.com/gruntwork-io/terragrunt/archive/v0.26.0.tar.gz 
[ ] I'm not sure how the SHAs get generated and updated, so haven't proposed changes for them.

You can find the release notes here: https://github.com/gruntwork-io/terragrunt/releases/tag/v0.26.0

Could advise on next steps how to update this brew tap? I've filed an issue describing this: https://github.com/Homebrew/homebrew-core/issues/64095#issue-736084321

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
