### PR TITLE
rm-improved 0.13.1 (new formula)

### DIFF
--- a/Formula/rm-improved.rb
+++ b/Formula/rm-improved.rb
@@ -1,0 +1,25 @@
+class RmImproved < Formula
+  desc "Command-line deletion tool focused on safety, ergonomics, and performance"
+  homepage "https://github.com/nivekuil/rip"
+  url "https://github.com/nivekuil/rip/archive/0.13.1.tar.gz"
+  sha256 "73acdc72386242dced117afae43429b6870aa176e8cc81e11350e0aaa95e6421"
+  license "GPL-3.0-or-later"
+  head "https://github.com/nivekuil/rip.git"
+
+  livecheck do
+    url "https://github.com/nivekuil/rip/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    touch "test_file"
+    system "#{bin}/rip", "--graveyard", ".graveyard", "test_file"
+    assert_predicate testpath/".graveyard", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note that while this formula is called `rm-improved` it provides the binary `rip`. This is consistent with the project’s branding as well as makes it consistent with other package repos (e.g. AUR). If this is a problem, we can use `rip` as the formula name since it is also available.