### PR TITLE
tmux: Update bash_completion script

### DIFF
--- a/Formula/tmux.rb
+++ b/Formula/tmux.rb
@@ -4,6 +4,7 @@ class Tmux < Formula
   url "https://github.com/tmux/tmux/releases/download/3.1c/tmux-3.1c.tar.gz"
   sha256 "918f7220447bef33a1902d4faff05317afd9db4ae1c9971bef5c787ac6c88386"
   license "ISC"
+  revision 1
 
   livecheck do
     url "https://github.com/tmux/tmux/releases/latest"
@@ -34,8 +35,8 @@ class Tmux < Formula
   depends_on "utf8proc" if MacOS.version >= :high_sierra
 
   resource "completion" do
-    url "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/homebrew_1.0.0/completions/tmux"
-    sha256 "05e79fc1ecb27637dc9d6a52c315b8f207cf010cdcee9928805525076c9020ae"
+    url "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/f5d53239f7658f8e8fbaf02535cc369009c436d6/completions/tmux"
+    sha256 "b5f7bbd78f9790026bbff16fc6e3fe4070d067f58f943e156bd1a8c3c99f6a6f"
   end
 
   def install


### PR DESCRIPTION
The old tmux bash_completion script is from 2016, contains a
functional typo (checks for _init_completions failure but runs
_init_completion) and is of basic use. The upstream repository
is actively maintaining the completion, has fixed the bug and
has added new functionality, so use the latest completion.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
