### PR TITLE
isl@0.18 (new formula)

### DIFF
--- a/Aliases/isl@0.22
+++ b/Aliases/isl@0.22
@@ -1,0 +1,1 @@
+../Formula/isl.rb

--- a/Formula/isl@0.18.rb
+++ b/Formula/isl@0.18.rb
@@ -1,0 +1,46 @@
+class IslAT018 < Formula
+  desc "Integer Set Library for the polyhedral model"
+  homepage "http://isl.gforge.inria.fr"
+  # Note: Always use tarball instead of git tag for stable version.
+  #
+  # Currently isl detects its version using source code directory name
+  # and update isl_version() function accordingly.  All other names will
+  # result in isl_version() function returning "UNKNOWN" and hence break
+  # package detection.
+  url "http://isl.gforge.inria.fr/isl-0.18.tar.xz"
+  mirror "https://deb.debian.org/debian/pool/main/i/isl/isl_0.18.orig.tar.xz"
+  sha256 "0f35051cc030b87c673ac1f187de40e386a1482a0cfdf2c552dd6031b307ddc4"
+  license "MIT"
+
+  keg_only :versioned_formula
+
+  deprecate! because: :versioned_formula
+
+  depends_on "gmp"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-gmp=system",
+                          "--with-gmp-prefix=#{Formula["gmp"].opt_prefix}"
+    system "make", "check"
+    system "make", "install"
+    (share/"gdb/auto-load").install Dir["#{lib}/*-gdb.py"]
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <isl/ctx.h>
+
+      int main()
+      {
+        isl_ctx* ctx = isl_ctx_alloc();
+        isl_ctx_free(ctx);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lisl", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
This is needed for gcc@5 on linux.
I tried to use isl 0.18 built as a resource within the gcc@5 formula
but the gcc binaries are still linked to the system isl, whatever flags
or options I tried to set.
Using isl installed as a formula produces gcc@5 binaries that are linked
to that isl, so this is the only solution I found to make this work.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
