### PR TITLE
imlib2: migrate to brewed x11

### DIFF
--- a/Formula/imlib2.rb
+++ b/Formula/imlib2.rb
@@ -4,7 +4,7 @@ class Imlib2 < Formula
   url "https://downloads.sourceforge.net/project/enlightenment/imlib2-src/1.7.0/imlib2-1.7.0.tar.bz2"
   sha256 "1976ca3db48cbae79cd0fc737dabe39cc81494fc2560e1d22821e7dc9c22b37d"
   license "Imlib2"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -22,7 +22,9 @@ class Imlib2 < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on :x11
+  depends_on "libx11"
+  depends_on "libxcb"
+  depends_on "libxext"
 
   def install
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The first salvo of our migration away from the XQuartz cask.

Before:

```console
% brew linkage imlib2
System libraries:
  /opt/X11/lib/libX11-xcb.1.dylib
  /opt/X11/lib/libX11.6.dylib
  /opt/X11/lib/libXext.6.dylib
  /opt/X11/lib/libxcb-shm.0.dylib
  /opt/X11/lib/libxcb.1.dylib
  /usr/lib/libSystem.B.dylib
  /usr/lib/libbz2.1.0.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/freetype/lib/libfreetype.6.dylib (freetype)
  /usr/local/opt/giflib/lib/libgif.dylib (giflib)
  /usr/local/Cellar/imlib2/1.7.0_2/lib/libImlib2.1.dylib (imlib2)
  /usr/local/opt/jpeg/lib/libjpeg.9.dylib (jpeg)
  /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
  /usr/local/opt/libtiff/lib/libtiff.5.dylib (libtiff)
```

After:

```console
% brew linkage imlib2
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libbz2.1.0.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/freetype/lib/libfreetype.6.dylib (freetype)
  /usr/local/opt/giflib/lib/libgif.dylib (giflib)
  /usr/local/Cellar/imlib2/1.7.0_2/lib/libImlib2.1.dylib (imlib2)
  /usr/local/opt/jpeg/lib/libjpeg.9.dylib (jpeg)
  /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
  /usr/local/opt/libtiff/lib/libtiff.5.dylib (libtiff)
  /usr/local/opt/libx11/lib/libX11-xcb.1.dylib (libx11)
  /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
  /usr/local/opt/libxcb/lib/libxcb-shm.0.dylib (libxcb)
  /usr/local/opt/libxcb/lib/libxcb.1.dylib (libxcb)
  /usr/local/opt/libxext/lib/libXext.6.dylib (libxext)
```