### PR TITLE
postgresql@*: Add deprecation dates

### DIFF
--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -13,6 +13,9 @@ class PostgresqlAT10 < Formula
 
   keg_only :versioned_formula
 
+  # https://www.postgresql.org/support/versioning/
+  deprecate! date: "2022-11-10", because: :unsupported
+
   depends_on "pkg-config" => :build
   depends_on "icu4c"
   depends_on "openssl@1.1"

--- a/Formula/postgresql@11.rb
+++ b/Formula/postgresql@11.rb
@@ -13,6 +13,9 @@ class PostgresqlAT11 < Formula
 
   keg_only :versioned_formula
 
+  # https://www.postgresql.org/support/versioning/
+  deprecate! date: "2023-11-09", because: :unsupported
+
   depends_on "pkg-config" => :build
   depends_on "icu4c"
   depends_on "openssl@1.1"

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -13,6 +13,9 @@ class PostgresqlAT12 < Formula
 
   keg_only :versioned_formula
 
+  # https://www.postgresql.org/support/versioning/
+  deprecate! date: "2024-11-14", because: :unsupported
+
   depends_on "pkg-config" => :build
   depends_on "icu4c"
 

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -14,7 +14,8 @@ class PostgresqlAT94 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-02-13", because: :versioned_formula
+  # https://www.postgresql.org/support/versioning/
+  deprecate! date: "2020-02-13", because: :unsupported
 
   depends_on "openssl@1.1"
   depends_on "readline"

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -18,6 +18,9 @@ class PostgresqlAT95 < Formula
 
   keg_only :versioned_formula
 
+  # https://www.postgresql.org/support/versioning/
+  deprecate! date: "2021-02-11", because: :unsupported
+
   depends_on "openssl@1.1"
   depends_on "readline"
 

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -18,6 +18,9 @@ class PostgresqlAT96 < Formula
 
   keg_only :versioned_formula
 
+  # https://www.postgresql.org/support/versioning/
+  deprecate! date: "2021-11-11", because: :unsupported
+
   depends_on "openssl@1.1"
   depends_on "readline"
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I added all the currently known deprecation dates for each postgresql@* formula.

Note that postgresql@9.4 is now already out of support upstream.