### PR TITLE
embulk: revert to 0.9.23, migrate to openjdk@8

### DIFF
--- a/Formula/embulk.rb
+++ b/Formula/embulk.rb
@@ -3,10 +3,11 @@ class Embulk < Formula
   homepage "https://www.embulk.org/"
   # https://www.embulk.org/articles/2020/03/13/embulk-v0.10.html
   # v0.10.* is a "development" series, not for your production use.
-  # In your production, keep using v0.9.*.
-  url "https://github.com/embulk/embulk/releases/download/v0.10.15/embulk-0.10.15.jar"
-  sha256 "4f14f446eafc121297ffa08b17af86eef253289cec71cfe66b6f67059ceeb4e7"
+  # In your production, keep using v0.9.* stable series.
+  url "https://bintray.com/artifact/download/embulk/maven/embulk-0.9.23.jar"
+  sha256 "153977fad482bf52100dd96f47e897c87b48de4fb13bccd6b3101475d3a5ebb9"
   license "Apache-2.0"
+  version_scheme 1
 
   livecheck do
     url :homepage
@@ -15,14 +16,14 @@ class Embulk < Formula
 
   bottle :unneeded
 
-  depends_on java: "1.8"
+  depends_on "openjdk@8"
 
   def install
     # Execute through /bin/bash to be compatible with OS X 10.9.
     libexec.install "embulk-#{version}.jar" => "embulk.jar"
     (bin/"embulk").write <<~EOS
       #!/bin/bash
-      export JAVA_HOME="#{Language::Java.overridable_java_home_env("1.8")[:JAVA_HOME]}"
+      export JAVA_HOME="${JAVA_HOME:-#{Formula["openjdk@8"].opt_prefix}}"
       exec /bin/bash "#{libexec}/embulk.jar" "$@"
     EOS
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The latest stable version of `embulk` according to the [homepage](https://www.embulk.org/) is `0.9.23`. Versions in the 0.10.x series are listed as development releases and we previously closed a PR that attempted to update this formula to a development version (#60152).

However, this formula was bumped to 0.10.14 in #60790 (self-merged without review) and later bumped to 0.10.15 in #60935. This is in spite of the note above the `stable` URL warning not to bump the formula to a development release. [Note: I updated the livecheck in #63232 to specifically return the latest stable release, to help avoid this situation in the future.]

As such, this downgrades the formula back to the latest stable release (`0.9.23`). Do we think it would be appropriate to add `version_scheme 1` in this context?

This PR also migrates the formula from `depends_on java: "1.8"` to `depends_on "openjdk@8"` (per #63290).