### PR TITLE
xshogi: Migrate to depend on brewed X11

### DIFF
--- a/Formula/xshogi.rb
+++ b/Formula/xshogi.rb
@@ -5,6 +5,7 @@ class Xshogi < Formula
   mirror "https://ftpmirror.gnu.org/gnushogi/xshogi-1.4.2.tar.gz"
   sha256 "2e2f1145e3317143615a764411178f538bd54945646b14fc2264aaeaa105dab6"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,7 +22,11 @@ class Xshogi < Formula
   end
 
   depends_on "gnu-shogi"
-  depends_on :x11
+  depends_on "libx11"
+  depends_on "libxaw"
+  depends_on "libxext"
+  depends_on "libxmu"
+  depends_on "libxt"
 
   def install
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Issue reference: #64166.
- There is no test to run, and so `brew test` doesn't work and `brew audit` fails.

----

Before:

➜ brew linkage xshogi
System libraries:
  /opt/X11/lib/libX11.6.dylib
  /opt/X11/lib/libXaw.7.dylib
  /opt/X11/lib/libXext.6.dylib
  /opt/X11/lib/libXmu.6.dylib
  /opt/X11/lib/libXt.6.dylib
  /usr/lib/libSystem.B.dylib

After:

➜ brew linkage xshogi
System libraries:
  /usr/lib/libSystem.B.dylib
Homebrew libraries:
  /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
  /usr/local/opt/libxaw/lib/libXaw.7.dylib (libxaw)
  /usr/local/opt/libxext/lib/libXext.6.dylib (libxext)
  /usr/local/opt/libxmu/lib/libXmu.6.dylib (libxmu)
  /usr/local/opt/libxt/lib/libXt.6.dylib (libxt)

