### PR TITLE
openconnect: add livecheck and license

### DIFF
--- a/Formula/openconnect.rb
+++ b/Formula/openconnect.rb
@@ -4,6 +4,12 @@ class Openconnect < Formula
   url "ftp://ftp.infradead.org/pub/openconnect/openconnect-8.10.tar.gz"
   mirror "https://fossies.org/linux/privat/openconnect-8.10.tar.gz"
   sha256 "30e64c6eca4be47bbf1d61f53dc003c6621213738d4ea7a35e5cf1ac2de9bab1"
+  license "LGPL-2.1-only"
+
+  livecheck do
+    url "https://www.infradead.org/openconnect/download.html"
+    regex(/href=.*?openconnect[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 "b4144970e695adc8f049319408cd431c96eb2ca4714feb903e0f01f3926dfd1f" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `openconnect`. This adds a `livecheck` block that checks the [first-party downloads page](https://www.infradead.org/openconnect/download.html), which links to the `stable` archive that's downloaded over FTP.

This also adds a `license`, referencing the ["License" page on the first-party website](https://www.infradead.org/openconnect/licence.html) which says, "OpenConnect in publshed under the GNU Lesser Public License, v2.1."