### PR TITLE
xlispstat: Migrate to depend on brewed X11

### DIFF
--- a/Formula/xlispstat.rb
+++ b/Formula/xlispstat.rb
@@ -4,6 +4,7 @@ class Xlispstat < Formula
   url "https://homepage.cs.uiowa.edu/~luke/xls/xlispstat/current/xlispstat-3-52-23.tar.gz"
   version "3.52.23"
   sha256 "9bf165eb3f92384373dab34f9a56ec8455ff9e2bf7dff6485e807767e6ce6cf4"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -15,7 +16,7 @@ class Xlispstat < Formula
     sha256 "c4004c8fc128a187c35923eff3cb0c5a641f7928aff558559279d5d98abe849d" => :yosemite
   end
 
-  depends_on :x11
+  depends_on "libx11"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Related issue: #64166.

----

Before:

➜ brew linkage xlispstat
System libraries:
  /opt/X11/lib/libX11.6.dylib
  /usr/lib/libSystem.B.dylib

After:

➜ brew linkage xlispstat
System libraries:
  /usr/lib/libSystem.B.dylib
Homebrew libraries:
  /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)

