### PR TITLE
xodotool: Migrate to depend on brewed X11

### DIFF
--- a/Formula/xdotool.rb
+++ b/Formula/xdotool.rb
@@ -3,7 +3,7 @@ class Xdotool < Formula
   homepage "https://www.semicomplete.com/projects/xdotool/"
   url "https://github.com/jordansissel/xdotool/archive/v3.20160805.1.tar.gz"
   sha256 "ddafca1239075c203769c17a5a184587731e56fbe0438c09d08f8af1704e117a"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "8dbfb2b1c32176c7cba00aaa2365f3cd438619dc0286e668e5d87412c3717d53" => :catalina
@@ -12,9 +12,10 @@ class Xdotool < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libx11"
+  depends_on "libxinerama"
   depends_on "libxkbcommon"
-
-  depends_on :x11
+  depends_on "libxtst"
 
   def install
     # Work around an issue with Xcode 8 on El Capitan, which


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Before:

➜ brew linkage xdotool
System libraries:
  /opt/X11/lib/libX11.6.dylib
  /opt/X11/lib/libXinerama.1.dylib
  /opt/X11/lib/libXtst.6.dylib
  /usr/lib/libSystem.B.dylib
Homebrew libraries:
  /usr/local/opt/libxkbcommon/lib/libxkbcommon.0.dylib (libxkbcommon)
  /usr/local/Cellar/xdotool/3.20160805.1_1/lib/libxdo.3.dylib (xdotool)

After:

➜ brew linkage xdotool
System libraries:
  /usr/lib/libSystem.B.dylib
Homebrew libraries:
  /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
  /usr/local/opt/libxinerama/lib/libXinerama.1.dylib (libxinerama)
  /usr/local/opt/libxkbcommon/lib/libxkbcommon.0.dylib (libxkbcommon)
  /usr/local/opt/libxtst/lib/libXtst.6.dylib (libxtst)
  /usr/local/Cellar/xdotool/3.20160805.1_2/lib/libxdo.3.dylib (xdotool)

