### PR TITLE
easy-rsa 3.0.8 (new formula)

### DIFF
--- a/Formula/easy-rsa.rb
+++ b/Formula/easy-rsa.rb
@@ -1,0 +1,49 @@
+class EasyRsa < Formula
+  desc "CLI utility to build and manage a PKI CA"
+  homepage "https://github.com/OpenVPN/easy-rsa"
+  url "https://github.com/OpenVPN/easy-rsa/archive/v3.0.8.tar.gz"
+  sha256 "fd6b67d867c3b8afd53efa2ca015477f6658a02323e1799432083472ac0dd200"
+  license "GPL-2.0-only"
+  head "https://github.com/OpenVPN/easy-rsa.git"
+
+  depends_on "openssl@1.1"
+
+  def install
+    libexec.install "easyrsa3/easyrsa"
+    (bin/"easyrsa").write_env_script libexec/"easyrsa",
+      EASYRSA:         etc/name,
+      EASYRSA_OPENSSL: Formula["openssl@1.1"].bin/"openssl",
+      EASYRSA_PKI:     "${EASYRSA_PKI:-#{etc}/pki}"
+
+    (etc/name).install %w[
+      easyrsa3/openssl-easyrsa.cnf
+      easyrsa3/x509-types
+      easyrsa3/vars.example
+    ]
+
+    doc.install %w[
+      ChangeLog
+      COPYING.md
+      KNOWN_ISSUES
+      README.md
+      README.quickstart.md
+    ]
+
+    doc.install Dir["doc/*"]
+  end
+
+  def caveats
+    <<~EOS
+      By default, keys will be created in:
+        #{etc}/pki
+
+      The configuration may be modified by editing and renaming:
+        #{etc}/#{name}/vars.example
+    EOS
+  end
+
+  test do
+    ENV["EASYRSA_PKI"] = testpath/"pki"
+    assert_match "init-pki complete", shell_output("easyrsa init-pki")
+  end
+end


### PR DESCRIPTION
    Reference: https://github.com/Homebrew/homebrew-core/pull/3462
    See Also: https://github.com/riboseinc/homebrew-easy-rsa

    Co-authored-by: Chris Rose <offbyone@users.noreply.github.com>
    Co-authored-by: Jin <jjr840430@users.noreply.github.com>
    Co-authored-by: Sergii Ovcharenko <sovcharenko@users.noreply.github.com>
    Co-authored-by: Steven Grimm <sgrimm@users.noreply.github.com>

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'd like to try to pick up and run with the work that @offbyone did in #3462. I think I've got all the files going to the preferred locations:

`easyrsa` in `#{bin}#`
docs in `#{docs}`
everything else in `#{etc}/pki`

To address the patching issue, I'm trying to use the `vars` file that comes with `easy-rsa` rather than modifying the executable script itself. While this seems more proper and I think also in line with the previous feedback, the downside is that I had to add a `caveats` block directing the user to set an environment variable so that `easyrsa` knows where to find `vars`. I'm open to other suggestions if there's a better way to handle that, but I've seen that done on other formulae, so it seemed like it would be acceptable here.

The formula modifies `vars` to point to Homebrew's `openssl@1.1` vice the system's LibreSSL. However, I am not sure this is having the intended effect:

```
$ easyrsa version
EasyRSA Version Information
Version:     ~VER~
Generated:   ~DATE~
SSL Lib:     LibreSSL 2.6.5
Git Commit:  ~GITHEAD~
Source Repo: https://github.com/OpenVPN/easy-rsa
```

This doesn't seem to change even if I explicitly set either the `EASYRSA_OPENSSL` or `OPENSSL` environment variables either:

```
$ EASYRSA_OPENSSL=/usr/local/opt/openssl@1.1/bin/openssl easyrsa version
...
SSL Lib:     LibreSSL 2.6.5
...
$ OPENSSL=/usr/local/opt/openssl@1.1/bin/openssl easyrsa version
...
SSL Lib:     LibreSSL 2.6.5
...
```

However, if I modify my `$PATH` to place Homebrew's OpenSSL ahead of the system's LibreSSL, things change:

```
PATH="/usr/local/opt/openssl@1.1/bin:$PATH" easyrsa version
...
SSL Lib:     OpenSSL 1.1.1h  22 Sep 2020
...
```

This seems like a bug in `easy-rsa` to me, but maybe it's something particular to my environment? I'm not sure if it's still important to force it to use `openssl@1.1` since `easy-rsa` apparently [now works fine with LibreSSL](https://github.com/OpenVPN/easy-rsa/commit/93b0f2e74bb600c7f05c20eaa97f7b12fb7ba670)? Regardless, I think the formula here makes the correct modifications, and the fix would actually be upstream with `easy-rsa` (although it's difficult to imagine that it's something that's been overlooked there).

For tests, I went with what @offbyone had previously. I'm not sure if it's something that's worthwhile to also query `easyrsa --version` to verify the OpenSSL configuration and/or `easyrsa --help` to verify the `$EASYRSA` and `$EASYRSA_PKI` directories:

```
$ easy-rsa help
...
DIRECTORY STATUS (commands would take effect on these locations)
  EASYRSA: /usr/local/etc/pki
      PKI: /usr/local/etc/pki
```