### PR TITLE
workflows/triage: don't label latest openssl or python as legacy

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -44,7 +44,11 @@ jobs:
                     "content": "\n  disable!.*\n"
                 }, {
                     "label": "legacy",
-                    "path": "Formula/.+@.+"
+                    "path": "Formula/.+@.+",
+                    "except": [
+                        "Formula/openssl@1.1.rb",
+                        "Formula/python@3.9.rb"
+                    ]
                 }, {
                     "label": "missing license",
                     "path": "Formula/.+",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
