### PR TITLE
workflows/triage: don't label openssl@3.0 as legacy

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -47,6 +47,7 @@ jobs:
                     "path": "Formula/.+@.+",
                     "except": [
                         "Formula/openssl@1.1.rb",
+                        "Formula/openssl@3.0.rb",
                         "Formula/python@3.9.rb"
                     ]
                 }, {


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Related: #64206