### PR TITLE
onedrive-linux-client 2.4.5 (new formula)

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -21,6 +21,7 @@ on:
       - "Formula/libtirpc.rb"
       - "Formula/libva.rb"
       - "Formula/linux-headers.rb"
+      - "Formula/onedrive-linux-client.rb"
       - "Formula/strace.rb"
       - "Formula/valgrind.rb"
       - "Formula/wayland.rb"

--- a/Formula/onedrive-linux-client.rb
+++ b/Formula/onedrive-linux-client.rb
@@ -1,0 +1,30 @@
+class OnedriveLinuxClient < Formula
+  desc "Folder synchronization with OneDrive"
+  homepage "https://github.com/abraunegg/onedrive"
+  url "https://github.com/abraunegg/onedrive/archive/v2.4.5.tar.gz"
+  sha256 "1f1f5e1f2f37376b6d96bda2426552a94a8b195f545b4fb7f3668c4fe2e8f6a0"
+  license "GPL-3.0-only"
+
+  depends_on "dmd" => :build
+  depends_on "pkg-config" => :build
+  depends_on :linux
+  uses_from_macos "curl"
+  uses_from_macos "sqlite"
+
+  def install
+    ENV["DC"] = "dmd"
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+    bash_completion.install "contrib/completions/complete.bash"
+    zsh_completion.install "contrib/completions/complete.zsh" => "_onedrive"
+  end
+
+  test do
+    require "open3"
+    Open3.popen3("#{bin}/onedrive --synchronize") do |stdin, stdout, stderr|
+      stdin.close
+      assert_match("Invalid uri", stdout.read)
+      assert_match("Could not initialize the OneDrive API", stderr.read)
+    end
+  end
+end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Linuxbrew formula: https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/onedrive.rb

Depends on
- [x] `dmd` #64583
- [x] `openssl@1.1` #64589
- [x] `python@3.9` #66168
- [x] `cmake` #66959
- [x] `nghttp2` #67447
- [x] `openldap` #67534

<details><summary><code>brew deps onedrive --include-build</code></summary>

```
alsa-lib
apr
apr-util
autoconf
automake
berkeley-db
binutils
bison
brotli
bzip2
c-ares
cmake
cups
curl
dmd
docbook
docbook-xsl
expat
flex
fontconfig
freeglut
freetype
gcc
gdbm
gettext
ghostscript
glib
gmp
gpatch
gperf
groff
help2man
isl@0.18
jasper
jemalloc
jpeg
json-c
krb5
libbsd
libdrm
libedit
libelf
libev
libffi
libice
libidn
libidn2
libmetalink
libmpc
libpciaccess
libpng
libpthread-stubs
libsm
libssh2
libtiff
libtool
libunistring
libx11
libxau
libxcb
libxdamage
libxdmcp
libxext
libxfixes
libxi
libxinerama
libxml2
libxrandr
libxrender
libxshmfence
libxslt
libxt
libxtst
libxv
libxvmc
libxxf86vm
libyaml
linuxbrew/xorg/libomxil-bellagio
linuxbrew/xorg/libva-internal
linuxbrew/xorg/libvdpau
linuxbrew/xorg/wayland
linuxbrew/xorg/wayland-protocols
llvm
lm-sensors
lz4
m4
mawk
mesa
mesa-glu
meson
mpfr
ncurses
netpbm
nghttp2
ninja
openjdk
openldap
openssl@1.1
pcre
perl
pkg-config
psutils
python@3.9
readline
rtmpdump
ruby
scons
sphinx-doc
sqlite
subversion
swig
texinfo
uchardet
unixodbc
unzip
utf8proc
util-linux
util-macros
xcb-proto
xinput
xorgproto
xtrans
xz
zip
zlib
zstd
```

</details>