### PR TITLE
sxiv: migrated to brewed X11

### DIFF
--- a/Formula/sxiv.rb
+++ b/Formula/sxiv.rb
@@ -3,7 +3,8 @@ class Sxiv < Formula
   homepage "https://github.com/muennich/sxiv"
   url "https://github.com/muennich/sxiv/archive/v26.tar.gz"
   sha256 "a382ad57734243818e828ba161fc0357b48d8f3a7f8c29cac183492b46b58949"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/muennich/sxiv.git"
 
   bottle do
@@ -16,15 +17,16 @@ class Sxiv < Formula
   depends_on "giflib"
   depends_on "imlib2"
   depends_on "libexif"
-  depends_on :x11
+  depends_on "libx11"
+  depends_on "libxft"
 
   def install
     system "make", "PREFIX=#{prefix}", "AUTORELOAD=nop",
-                   "CPPFLAGS=-I/opt/X11/include", "LDFLAGS=-L/opt/X11/lib",
+                   "CPPFLAGS=-I#{Formula["freetype2"].opt_include}/freetype2",
                    "LDLIBS=-lpthread", "install"
   end
 
   test do
-    system "#{bin}/sxiv", "-v"
+    assert_match "Error opening X display", shell_output("DISPLAY= #{bin}/sxiv #{test_fixtures("test.png")} 2>&1", 1)
   end
 end


### PR DESCRIPTION
Also fixed license and test. Supports #64166.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz
-----
