### PR TITLE
dmenu: migrate to brewed X11

### DIFF
--- a/Formula/dmenu.rb
+++ b/Formula/dmenu.rb
@@ -4,6 +4,7 @@ class Dmenu < Formula
   url "https://dl.suckless.org/tools/dmenu-5.0.tar.gz"
   sha256 "fe18e142c4dbcf71ba5757dbbdea93b1c67d58fc206fc116664f4336deef6ed3"
   license "MIT"
+  revision 1
   head "https://git.suckless.org/dmenu/", using: :git
 
   livecheck do
@@ -18,13 +19,16 @@ class Dmenu < Formula
     sha256 "ed800e10a28a770ff50b0a4462ecb18406d0dec7a4d59f42885b7f6e8ee387db" => :high_sierra
   end
 
-  depends_on :x11
+  depends_on "fontconfig"
+  depends_on "libx11"
+  depends_on "libxft"
+  depends_on "libxinerama"
 
   def install
-    system "make", "PREFIX=#{prefix}", "install"
+    system "make", "FREETYPEINC=#{HOMEBREW_PREFIX}/include/freetype2", "PREFIX=#{prefix}", "install"
   end
 
   test do
-    assert_match /#{version}/, shell_output("#{bin}/dmenu -v")
+    assert_match "warning: no locale support", shell_output("#{bin}/dmenu 2>&1", 1)
   end
 end


### PR DESCRIPTION
Also fixed test. Support #64166.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz
-----
