### PR TITLE
dwm: migrate to brewed X11

### DIFF
--- a/Formula/dwm.rb
+++ b/Formula/dwm.rb
@@ -3,7 +3,8 @@ class Dwm < Formula
   homepage "https://dwm.suckless.org/"
   url "https://dl.suckless.org/dwm/dwm-6.2.tar.gz"
   sha256 "97902e2e007aaeaa3c6e3bed1f81785b817b7413947f1db1d3b62b8da4cd110e"
-  revision 1
+  license "MIT"
+  revision 2
   head "https://git.suckless.org/dwm", using: :git
 
   bottle do
@@ -15,7 +16,9 @@ class Dwm < Formula
   end
 
   depends_on "dmenu"
-  depends_on :x11
+  depends_on "libx11"
+  depends_on "libxft"
+  depends_on "libxinerama"
 
   def install
     # The dwm default quit keybinding Mod1-Shift-q collides with
@@ -24,7 +27,7 @@ class Dwm < Formula
     "{ MODKEY|ShiftMask,             XK_q,      quit,           {0} },",
     "{ MODKEY|ControlMask,           XK_q,      quit,           {0} },"
     inreplace "dwm.1", '.B Mod1\-Shift\-q', '.B Mod1\-Control\-q'
-    system "make", "PREFIX=#{prefix}", "install"
+    system "make", "FREETYPEINC=#{Formula["freetype2"].opt_include}/freetype2", "PREFIX=#{prefix}", "install"
   end
 
   def caveats
@@ -41,6 +44,7 @@ class Dwm < Formula
   end
 
   test do
-    assert_match /#{version}/, shell_output("#{bin}/dwm -v 2>&1", 1)
+    assert_match "dwm: cannot open display", shell_output("DISPLAY= #{bin}/dwm 2>&1", 1)
+    assert_match "dwm-#{version}", shell_output("DISPLAY= #{bin}/dwm -v 2>&1", 1)
   end
 end


### PR DESCRIPTION
Also added license and fixed test. Supports #64166.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz