### PR TITLE
openmotif, nedit: migrate to brewed X11

### DIFF
--- a/Formula/nedit.rb
+++ b/Formula/nedit.rb
@@ -3,7 +3,8 @@ class Nedit < Formula
   homepage "https://sourceforge.net/projects/nedit/"
   url "https://downloads.sourceforge.net/project/nedit/nedit-source/nedit-5.7-src.tar.gz"
   sha256 "add9ac79ff973528ad36c86858238bac4f59896c27dbf285cbe6a4d425fca17a"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -17,8 +18,14 @@ class Nedit < Formula
     sha256 "74a4e728ef503642b5ad4dc4466f26a2d6f241e7d495099c8b14defd4e12f350" => :high_sierra
   end
 
+  depends_on "libice"
+  depends_on "libsm"
+  depends_on "libx11"
+  depends_on "libxext"
+  depends_on "libxpm"
+  depends_on "libxp"
+  depends_on "libxt"
   depends_on "openmotif"
-  depends_on :x11
 
   def install
     system "make", "macosx", "MOTIFLINK='-lXm'"

--- a/Formula/openmotif.rb
+++ b/Formula/openmotif.rb
@@ -3,7 +3,8 @@ class Openmotif < Formula
   homepage "https://motif.ics.com/motif"
   url "https://downloads.sourceforge.net/project/motif/Motif%202.3.8%20Source%20Code/motif-2.3.8.tar.gz"
   sha256 "859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,8 +22,16 @@ class Openmotif < Formula
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "jpeg"
+  depends_on "libice"
   depends_on "libpng"
-  depends_on :x11
+  depends_on "libsm"
+  depends_on "libx11"
+  depends_on "libxext"
+  depends_on "libxft"
+  depends_on "libxmu"
+  depends_on "libxp"
+  depends_on "libxt"
+  depends_on "xbitmaps"
 
   conflicts_with "lesstif",
     because: "both Lesstif and Openmotif are complete replacements for each other"


### PR DESCRIPTION
Also fixed license. Supports #64166.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz