### PR TITLE
workflows/triage: add linux-only label

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -70,6 +70,10 @@ jobs:
                     "path": "Formula/.+",
                     "content": "depends_on \"?(?:java|openjdk@?).+"
                 }, {
+                    "label": "linux-only",
+                    "path": "Formula/.+",
+                    "content": "depends_on :linux"
+                }, {
                     "label": "lua",
                     "path": "Formula/.+",
                     "content": "depends_on \"lua(?:@[0-9.]+|jit)?\""


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This allows us to quickly identify bump PRs as updates to Linux formulae, which for the time being, should not be updated in `homebrew-core`; see https://github.com/Homebrew/homebrew-core/pull/64175#issuecomment-723311040

> I was not really expecting people to upgrade linux-only formulae here before completing the merging of both repositories. Especially as no bottles are built; and not reverse dependencies are tested. So we may introduce breakages in linuxbrew-core, which is far from ideal.