### PR TITLE
jhipster: no need to manually create lib dir anymore

### DIFF
--- a/Formula/jhipster.rb
+++ b/Formula/jhipster.rb
@@ -22,7 +22,6 @@ class Jhipster < Formula
   depends_on "openjdk"
 
   def install
-    mkdir_p libexec/"lib"
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install Dir["#{libexec}/bin/*"]
     bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The directory creation within the formula is no longer needed now that https://github.com/Homebrew/brew/pull/8973 is merged.