### PR TITLE
opam: depend on gpatch

### DIFF
--- a/Formula/opam.rb
+++ b/Formula/opam.rb
@@ -14,6 +14,7 @@ class Opam < Formula
   end
 
   depends_on "ocaml" => [:build, :test]
+  depends_on "gpatch"
 
   uses_from_macos "unzip"
 


### PR DESCRIPTION
opam depends on GNU patch for some of its operations (https://github.com/ocaml/opam/issues/3639)

Signed-off-by: Anil Madhavapeddy <anil@recoil.org>