### PR TITLE
xterm 361 (new formula)

### DIFF
--- a/Formula/xterm.rb
+++ b/Formula/xterm.rb
@@ -1,0 +1,35 @@
+class Xterm < Formula
+  desc "Terminal emulator for the X Window System"
+  homepage "https://invisible-island.net/xterm/"
+  url "https://invisible-mirror.net/archives/xterm/xterm-361.tgz"
+  mirror "https://deb.debian.org/debian/pool/main/x/xterm/xterm_361.orig.tar.gz"
+  sha256 "85610f20d5e47205cc1b6876f7a4da28d6ae051bd8eac0b932e92c37a73a623f"
+  license :cannot_represent
+
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "libice"
+  depends_on "libx11"
+  depends_on "libxaw"
+  depends_on "libxext"
+  depends_on "libxft"
+  depends_on "libxinerama"
+  depends_on "libxmu"
+  depends_on "libxpm"
+  depends_on "libxt"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    %w[koi8rxterm resize uxterm xterm].each do |exe|
+      assert_predicate bin/exe, :exist?
+      assert_predicate bin/exe, :executable?
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Related: #64166

`chezscheme` normally uses `/usr/X11/bin/resize`: https://github.com/cisco/ChezScheme/blob/3aa77f9/c/expeditor.c#L735

This formula provides `$HOMEBREW_PREFIX/opt/xterm/bin/resize`

```console
% brew linkage xterm
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libncurses.5.4.dylib
Homebrew libraries:
  /usr/local/opt/fontconfig/lib/libfontconfig.1.dylib (fontconfig)
  /usr/local/opt/freetype/lib/libfreetype.6.dylib (freetype)
  /usr/local/opt/libice/lib/libICE.6.dylib (libice)
  /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
  /usr/local/opt/libxaw/lib/libXaw.7.dylib (libxaw)
  /usr/local/opt/libxext/lib/libXext.6.dylib (libxext)
  /usr/local/opt/libxft/lib/libXft.2.dylib (libxft)
  /usr/local/opt/libxinerama/lib/libXinerama.1.dylib (libxinerama)
  /usr/local/opt/libxmu/lib/libXmu.6.dylib (libxmu)
  /usr/local/opt/libxpm/lib/libXpm.4.dylib (libxpm)
  /usr/local/opt/libxt/lib/libXt.6.dylib (libxt)
```

<details><summary>License ref (<code>COPYING</code>)</summary>

```
--- $XTermId: COPYING,v 1.3 2020/01/12 22:53:35 tom Exp $
-------------------------------------------------------------------------------

Copyright 1996-2019,2020 by Thomas E. Dickey

                        All Rights Reserved

Permission is hereby granted, free of charge, to any person obtaining a
copy of this software and associated documentation files (the
"Software"), to deal in the Software without restriction, including
without limitation the rights to use, copy, modify, merge, publish,
distribute, sublicense, and/or sell copies of the Software, and to
permit persons to whom the Software is furnished to do so, subject to
the following conditions:

The above copyright notice and this permission notice shall be included
in all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE ABOVE LISTED COPYRIGHT HOLDER(S) BE LIABLE FOR ANY
CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

Except as contained in this notice, the name(s) of the above copyright
holders shall not be used in advertising or otherwise to promote the
sale, use or other dealings in this Software without prior written
authorization.

Copyright 1987, 1988  X Consortium

Permission to use, copy, modify, distribute, and sell this software and its
documentation for any purpose is hereby granted without fee, provided that
the above copyright notice appear in all copies and that both that
copyright notice and this permission notice appear in supporting
documentation.

The above copyright notice and this permission notice shall be included in
all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
OPEN GROUP BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

Except as contained in this notice, the name of the X Consortium shall not be
used in advertising or otherwise to promote the sale, use or other dealings
in this Software without prior written authorization from the X Consortium.

Copyright 1987, 1988 by Digital Equipment Corporation, Maynard, Massachusetts.

                         All Rights Reserved

Permission to use, copy, modify, and distribute this software and its
documentation for any purpose and without fee is hereby granted,
provided that the above copyright notice appear in all copies and that
both that copyright notice and this permission notice appear in
supporting documentation, and that the name of Digital Equipment
Corporation not be used in advertising or publicity pertaining to
distribution of the software without specific, written prior permission.

DIGITAL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL
DIGITAL BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR
ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
SOFTWARE.

-- vile: txtmode
-------------------------------------------------------------------------------
```

</summary>