### PR TITLE
xclip: migrate to brewed x11

### DIFF
--- a/Formula/xclip.rb
+++ b/Formula/xclip.rb
@@ -3,7 +3,8 @@ class Xclip < Formula
   homepage "https://github.com/astrand/xclip"
   url "https://github.com/astrand/xclip/archive/0.13.tar.gz"
   sha256 "ca5b8804e3c910a66423a882d79bf3c9450b875ac8528791fb60ec9de667f758"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +17,8 @@ class Xclip < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on :x11
+  depends_on "libx11"
+  depends_on "libxmu"
 
   def install
     system "autoreconf", "-fiv"

--- a/Formula/xclip.rb
+++ b/Formula/xclip.rb
@@ -3,7 +3,7 @@ class Xclip < Formula
   homepage "https://github.com/astrand/xclip"
   url "https://github.com/astrand/xclip/archive/0.13.tar.gz"
   sha256 "ca5b8804e3c910a66423a882d79bf3c9450b875ac8528791fb60ec9de667f758"
-  license "GPL-2.0-only"
+  license "GPL-2.0-or-later"
   revision 1
 
   bottle do


### PR DESCRIPTION
Tracking issue: https://github.com/Homebrew/homebrew-core/issues/64166

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----
- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz
-----
`brew audit --strict` complained about the license, but I'm not sure about the correct license to use. 

I looked at the license at the repo, but it doesn't seem to indicate anything explicitly. I assume it's safer to presume "only" rather than "or-later" for the license.

Before:

    ❯ brew linkage xclip
    System libraries:
      /opt/X11/lib/libX11.6.dylib
      /opt/X11/lib/libXmu.6.dylib
      /usr/lib/libSystem.B.dylib
      /usr/lib/libiconv.2.dylib

After:

    ❯ brew linkage xclip
    System libraries:
      /usr/lib/libSystem.B.dylib
      /usr/lib/libiconv.2.dylib
    Homebrew libraries:
      /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
      /usr/local/opt/libxmu/lib/libXmu.6.dylib (libxmu)