### PR TITLE
mesa: re-enable build for libGL

### DIFF
--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -6,7 +6,7 @@ class Mesa < Formula
   url "https://mesa.freedesktop.org/archive/mesa-20.2.1.tar.xz"
   sha256 "d1a46d9a3f291bc0e0374600bdcb59844fa3eafaa50398e472a36fc65fd0244a"
   license "MIT"
-  revision 1
+  revision 2
   head "https://gitlab.freedesktop.org/mesa/mesa.git"
 
   livecheck do
@@ -24,18 +24,26 @@ class Mesa < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.9" => :build
-  depends_on "freeglut" => :test
   depends_on "expat"
   depends_on "gettext"
+  depends_on "libx11"
+  depends_on "libxcb"
+  depends_on "libxdamage"
+  depends_on "libxext"
 
   resource "Mako" do
     url "https://files.pythonhosted.org/packages/72/89/402d2b4589e120ca76a6aed8fee906a0f5ae204b50e455edd36eda6e778d/Mako-1.1.3.tar.gz"
     sha256 "8195c8c1400ceb53496064314c6736719c6f25e7479cd24c77be3d9361cddc27"
   end
 
-  resource "gears.c" do
-    url "https://www.opengl.org/archives/resources/code/samples/glut_examples/mesademos/gears.c"
-    sha256 "7df9d8cda1af9d0a1f64cc028df7556705d98471fdf3d0830282d4dcfb7a78cc"
+  resource "glxgears.c" do
+    url "https://gitlab.freedesktop.org/mesa/demos/-/raw/faaa319d704ac677c3a93caadedeb91a4a74b7a7/src/xdemos/glxgears.c"
+    sha256 "3873db84d708b5d8b3cac39270926ba46d812c2f6362da8e6cd0a1bff6628ae6"
+  end
+
+  resource "gl_wrap.h" do
+    url "https://gitlab.freedesktop.org/mesa/demos/-/raw/faaa319d704ac677c3a93caadedeb91a4a74b7a7/src/util/gl_wrap.h"
+    sha256 "c727b2341d81c2a1b8a0b31e46d24f9702a1ec55c8be3f455ddc8d72120ada72"
   end
 
   def install
@@ -47,23 +55,24 @@ class Mesa < Formula
 
     ENV.prepend_path "PATH", "#{venv_root}/bin"
 
-    resource("gears.c").stage(pkgshare.to_s)
-
     mkdir "build" do
-      system "meson", *std_meson_args, "..", "-Db_ndebug=true",
-                      "-Dplatforms=surfaceless", "-Dglx=disabled"
+      system "meson", *std_meson_args, "..", "-Db_ndebug=true"
       system "ninja"
       system "ninja", "install"
     end
   end
 
   test do
+    %w[glxgears.c gl_wrap.h].each { |r| resource(r).stage(testpath) }
     flags = %W[
-      -framework OpenGL
-      -I#{Formula["freeglut"].opt_include}
-      -L#{Formula["freeglut"].opt_lib}
-      -lglut
+      -I#{include}
+      -L#{lib}
+      -L#{Formula["libx11"].lib}
+      -L#{Formula["libxext"].lib}
+      -lGL
+      -lX11
+      -lxext
     ]
-    system ENV.cc, "#{pkgshare}/gears.c", "-o", "gears", *flags
+    system ENV.cc, "glxgears.c", "-o", "gears", *flags
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----


Part of https://github.com/Homebrew/homebrew-core/issues/64166

This was originally disabled in https://github.com/Homebrew/homebrew-core/pull/46992 to avoid depending on X11, but now that X is in homebrew/core we can re-enable this so downstream formulae can depend on mesa for `libgl.dylib`

```console
% brew linkage mesa
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libXplugin.1.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/expat/lib/libexpat.1.dylib (expat)
  /usr/local/opt/libx11/lib/libX11-xcb.1.dylib (libx11)
  /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
  /usr/local/opt/libxcb/lib/libxcb-glx.0.dylib (libxcb)
  /usr/local/opt/libxcb/lib/libxcb.1.dylib (libxcb)
  /usr/local/opt/libxext/lib/libXext.6.dylib (libxext)
  /usr/local/Cellar/mesa/20.2.1_2/lib/libglapi.0.dylib (mesa)
Dependencies with no linkage:
  libxdamage
```