### PR TITLE
prestodb: add livecheck and license

### DIFF
--- a/Formula/prestodb.rb
+++ b/Formula/prestodb.rb
@@ -3,7 +3,19 @@ class Prestodb < Formula
   homepage "https://prestodb.io"
   url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-server/0.235.1/presto-server-0.235.1.tar.gz"
   sha256 "862871609b14eb5259530de04f1a1ed69e3bb3b172490f2a1585f8f31fd9453e"
+  license "Apache-2.0"
   revision 2
+
+  # The source of the Presto download page at https://prestodb.io/download.html
+  # contains old version information. The current version information is loaded
+  # from the JavaScript file below, so we check that instead. We don't check
+  # Maven because sometimes the directory listing page contains a newer version
+  # that hasn't been released yet and we probably don't want to upgrade until
+  # it's official on the first-party website, etc.
+  livecheck do
+    url "https://prestodb.io/static/js/version.js"
+    regex(/latest_presto_version.*?(\d+(?:\.\d+)+)/i)
+  end
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, none of livecheck's built-in strategies apply to the main URLs in the `prestodb` formula, so it can't identify versions. This PR adds a `livecheck` block that identifies the latest version from a JavaScript file found on the [first-party download page](https://prestodb.io/download.html). As mentioned in the comment, this is necessary because the source of the download page contains old version information and the latest version information is instead in the JavaScript file.

This also adds license information, referencing the [LICENSE file](https://github.com/prestodb/presto/blob/master/LICENSE) in the GitHub repository, which is Apache 2.0. The [homepage](https://prestodb.io) also has a "License" section in a sidebar with an "Apache License v2" link.