### PR TITLE
morse: migrate to brewed X11

### DIFF
--- a/Formula/morse.rb
+++ b/Formula/morse.rb
@@ -3,6 +3,8 @@ class Morse < Formula
   homepage "http://www.catb.org/~esr/morse/"
   url "http://www.catb.org/~esr/morse/morse-2.5.tar.gz"
   sha256 "476d1e8e95bb173b1aadc755db18f7e7a73eda35426944e1abd57c20307d4987"
+  license "BSD-2-Clause"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -14,11 +16,15 @@ class Morse < Formula
     sha256 "c89c45cdc2ff59d6ac327188c484659c769fe94a07e5e1f38f4d568f0b1a943d" => :yosemite
   end
 
-  depends_on :x11
+  depends_on "libx11"
 
   def install
     system "make", "all", "DEVICE=X11"
     bin.install "morse"
     man1.install "morse.1"
+  end
+
+  test do
+    system "#{bin}/morse"
   end
 end


### PR DESCRIPTION
I patterned a test block after some other formulae, but it still seems like this formula needs XQuartz to do anything useful.

Tracking issue: #64166

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz

-----

License classification found on [GitLab](https://gitlab.com/esr/morse-classic/-/blob/master/COPYING).

-----

Before:

    ❯ brew linkage morse
    System libraries:
      /opt/X11/lib/libX11.6.dylib
      /usr/lib/libSystem.B.dylib

After:

    ❯ brew linkage morse
    System libraries:
      /usr/lib/libSystem.B.dylib
    Homebrew libraries:
      /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)