### PR TITLE
mesalib-glw: migrate to brewed X11

### DIFF
--- a/Formula/mesalib-glw.rb
+++ b/Formula/mesalib-glw.rb
@@ -3,6 +3,8 @@ class MesalibGlw < Formula
   homepage "https://www.mesa3d.org"
   url "https://mesa.freedesktop.org/archive/glw/glw-8.0.0.tar.bz2"
   sha256 "2da1d06e825f073dcbad264aec7b45c649100e5bcde688ac3035b34c8dbc8597"
+  license :cannot_represent
+  revision 1
 
   bottle do
     cellar :any
@@ -14,7 +16,9 @@ class MesalibGlw < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on :x11
+  depends_on "libx11"
+  depends_on "libxt"
+  depends_on "mesa"
 
   def install
     system "./configure", "--disable-debug",


### PR DESCRIPTION
I still need to add a test do block. However, upstream looks abandoned. From the [FAQ](https://docs.mesa3d.org/faq.html?highlight=glw):

>GLw (OpenGL widget library) is now available from a separate git repository. Unless you’re using very old Xt/Motif applications with OpenGL, you shouldn’t need it.

The last commit was two years ago. And, before that, in 2013. https://gitlab.freedesktop.org/mesa/glw/-/commits/master/

Tracking issue: #64166

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz

-----

[License](https://gitlab.freedesktop.org/mesa/glw/-/blob/master/configure.ac) doesn't give a standard identifier, but looks like many standard licenses:

> Copyright © 2011 Intel Corporation
>
> Permission is hereby granted, free of charge, to any person obtaining a
> copy of this software and associated documentation files (the "Software"),
> to deal in the Software without restriction, including without limitation
> the rights to use, copy, modify, merge, publish, distribute, sublicense,
> and/or sell copies of the Software, and to permit persons to whom the
> Software is furnished to do so, subject to the following conditions:
>
> The above copyright notice and this permission notice (including the next
> paragraph) shall be included in all copies or substantial portions of the
> Software.
>
> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
> THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
> FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
> IN THE SOFTWARE.

-----

Before:

    ❯ brew linkage mesalib-glw
    System libraries:
      /opt/X11/lib/libGL.1.dylib
      /opt/X11/lib/libX11.6.dylib
      /opt/X11/lib/libXt.6.dylib
      /usr/lib/libSystem.B.dylib

After:

    ❯ brew linkage mesalib-glw
    System libraries:
      /usr/lib/libSystem.B.dylib
    Homebrew libraries:
      /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
      /usr/local/opt/libxt/lib/libXt.6.dylib (libxt)
      /usr/local/opt/mesa/lib/libGL.1.dylib (mesa)
