### PR TITLE
djvu2pdf: add livecheck

### DIFF
--- a/Formula/djvu2pdf.rb
+++ b/Formula/djvu2pdf.rb
@@ -4,6 +4,11 @@ class Djvu2pdf < Formula
   url "https://0x2a.at/site/projects/djvu2pdf/djvu2pdf-0.9.2.tar.gz"
   sha256 "afe86237bf4412934d828dfb5d20fe9b584d584ef65b012a893ec853c1e84a6c"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?djvu2pdf[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle :unneeded
 
   depends_on "djvulibre"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `djvu2pdf`. This adds a `livecheck` block that checks the download page where the `stable` archive is found.