### PR TITLE
rcm: add livecheck

### DIFF
--- a/Formula/rcm.rb
+++ b/Formula/rcm.rb
@@ -5,6 +5,13 @@ class Rcm < Formula
   sha256 "9b11ae37449cf4d234ec6d1348479bfed3253daba11f7e9e774059865b66c24a"
   license "BSD-3-Clause"
 
+  # The first-party website doesn't appear to provide links to archive files, so
+  # we check the Git repository tags instead.
+  livecheck do
+    url "https://github.com/thoughtbot/rcm.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "86ac10a7254567afb24c9816f6a80dd90a81bc8cd8619c112e59c0950929ef14" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `rcm`. This PR adds a `livecheck` block that checks the GitHub repository, as the first-party website doesn't link to any archive files and `https://thoughtbot.github.io/rcm/dist/` isn't a directory listing page.

The `dist` archive files can be found in the [GitHub repository's `gh-pages` branch's `dist` folder](https://github.com/thoughtbot/rcm/tree/gh-pages/dist) but checking the Git tags has a chance of being more reliable in the long run. That is to say, checking the Git tags would continue to tell us the newest version if upstream ever stops publishing the `dist` archive files.