### PR TITLE
spatialite-tools: add livecheck, update license

### DIFF
--- a/Formula/spatialite-tools.rb
+++ b/Formula/spatialite-tools.rb
@@ -3,8 +3,13 @@ class SpatialiteTools < Formula
   homepage "https://www.gaia-gis.it/fossil/spatialite-tools/index"
   url "https://www.gaia-gis.it/gaia-sins/spatialite-tools-sources/spatialite-tools-4.3.0.tar.gz"
   sha256 "f739859bc04f38735591be2f75009b98a2359033675ae310dffc3114a17ccf89"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 5
+
+  livecheck do
+    url "https://www.gaia-gis.it/gaia-sins/spatialite-tools-sources/"
+    regex(/href=.*?spatialite-tools[._-]v?(\d+(?:\.\d+)+)\.(?:t|zip)/i)
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `spatialite-tools`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.

This also updates the `license` from `GPL-3.0` to `GPL-3.0-or-later`, referencing the [homepage] which says, "spatialite-tools are licensed under the GPL v3 (or any subsequent version) terms".