### PR TITLE
icecast: add livecheck

### DIFF
--- a/Formula/icecast.rb
+++ b/Formula/icecast.rb
@@ -5,6 +5,11 @@ class Icecast < Formula
   sha256 "49b5979f9f614140b6a38046154203ee28218d8fc549888596a683ad604e4d44"
   revision 1
 
+  livecheck do
+    url "https://downloads.xiph.org/releases/icecast/"
+    regex(/href=.*?icecast[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "824f7d295c28fbdb17da3015b4e4d6ca76be536f6bf81e98d5312dd7b9a095cd" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `icecast`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.

For what it's worth, https://downloads.xiph.org/releases/icecast/ redirects to https://ftp.osuosl.org/pub/xiph/releases/icecast/ but the [first-party download page](https://www.icecast.org/download/) uses a xiph.org URL for the latest tarball, so I'm simply replicating this in the check for the sake of consistency.