### PR TITLE
crf++: add livecheck

### DIFF
--- a/Formula/crf++.rb
+++ b/Formula/crf++.rb
@@ -5,6 +5,15 @@ class Crfxx < Formula
   mirror "https://drive.google.com/uc?id=0B4y35FiV1wh7QVR6VXJ5dWExSTQ&export=download"
   sha256 "9d1c0a994f25a5025cede5e1d3a687ec98cd4949bfb2aae13f2a873a13259cb2"
 
+  # Archive files from upstream are hosted on Google Drive, so we can't identify
+  # versions from the tarballs, as the links on the homepage don't include this
+  # information. This identifies versions from the "News" sections, which works
+  # for now but may encounter issues in the future due to the loose regex.
+  livecheck do
+    url :homepage
+    regex(/CRF\+\+ v?(\d+(?:\.\d+)+)[\s<]/i)
+  end
+
   bottle do
     cellar :any
     rebuild 2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `crf++`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive file (on Google Drive) and lists versions in the [News](https://taku910.github.io/crfpp/#news) section.

This check identifies versions from the text of the News section, as Google Drive URLs don't contain the filename. As noted in the comment, this type of check is less reliable than identifying versions in filenames (like we normally do) but I think it's the best we can do for now.

Past that, the `stable` archive URL doesn't seem to work right now, so I'm not sure how we want to handle that. **Do we have any other ideas for an alternative `stable` archive source** or should we replace it with the Google Drive URL? If I'm not mistaken, Google Drive URLs can temporarily stop working if there are too many downloads in a given span of time, so that's probably not ideal as the main `url`.