### PR TITLE
chezscheme: migrate to brewed X11

### DIFF
--- a/Formula/chezscheme.rb
+++ b/Formula/chezscheme.rb
@@ -4,6 +4,7 @@ class Chezscheme < Formula
   url "https://github.com/cisco/ChezScheme/archive/v9.5.4.tar.gz"
   sha256 "258a4b5284bb13ac6e8b56acf89a7ab9e8726a90cc57ea1cd71c5da442323840"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -12,7 +13,8 @@ class Chezscheme < Formula
     sha256 "062b486d9b8fc1d81716361b5f0267a12599dea779f3cf37e5879c33b41bf568" => :high_sierra
   end
 
-  depends_on x11: :build
+  depends_on "libx11" => :build
+  depends_on "xterm"
   uses_from_macos "ncurses"
 
   def install
@@ -26,6 +28,11 @@ class Chezscheme < Formula
         s.gsub! "CLOCK_THREAD_CPUTIME_ID", "UNDEFINED_GIBBERISH"
       end
     end
+
+    inreplace "configure", "/opt/X11", Formula["libx11"].opt_prefix
+    inreplace Dir["c/Mf-*osx"], "/opt/X11", Formula["libx11"].opt_prefix
+    inreplace "c/version.h", "/usr/X11R6", Formula["libx11"].opt_prefix
+    inreplace "c/expeditor.c", "/usr/X11/bin/resize", Formula["xterm"].opt_bin/"resize"
 
     system "./configure",
               "--installprefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [ ] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz

```console
% brew linkage chezscheme
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libiconv.2.dylib
  /usr/lib/libncurses.5.4.dylib
```