### PR TITLE
xml2: add livecheck to skip

### DIFF
--- a/Formula/xml2.rb
+++ b/Formula/xml2.rb
@@ -5,6 +5,10 @@ class Xml2 < Formula
   sha256 "e3203a5d3e5d4c634374e229acdbbe03fea41e8ccdef6a594a3ea50a50d29705"
   license "GPL-2.0"
 
+  livecheck do
+    skip "Upstream is gone and the formula uses archive.org URLs"
+  end
+
   bottle do
     cellar :any_skip_relocation
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `xml2`. This PR adds a `livecheck` block to skip the formula, as upstream is gone (since 2016?) and the formula uses archive.org URLs.

The author seems to have a GitHub but `xml2` isn't present there, so I don't imagine there's going to be new development unless someone else starts working on it. There are some copies of the code here and there but no new development from what I saw in a cursory search. If this situation changes in the future, we can always update the `livecheck` block accordingly but I think skipping is most appropriate for now.