### PR TITLE
mdf2iso: add livecheck to skip

### DIFF
--- a/Formula/mdf2iso.rb
+++ b/Formula/mdf2iso.rb
@@ -4,6 +4,10 @@ class Mdf2iso < Formula
   url "https://deb.debian.org/debian/pool/main/m/mdf2iso/mdf2iso_0.3.1.orig.tar.gz"
   sha256 "906f0583cb3d36c4d862da23837eebaaaa74033c6b0b6961f2475b946a71feb7"
 
+  livecheck do
+    skip "No longer developed or maintained"
+  end
+
   bottle do
     cellar :any_skip_relocation
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `mdf2iso`. This PR adds a `livecheck` block to skip the formula, as upstream is inactive and the formula simply uses Debian URLs.

The [first-party homepage](https://www.berlios.de/software/mdf2iso/) points to the [SourceForge project](https://sourceforge.net/projects/mdf2iso.berlios/), which is listed as inactive and doesn't contain any files. The latest release in the [Debian directory listing page](https://deb.debian.org/debian/pool/main/m/mdf2iso/) is from 2015-02-23, so I think it's best to simply skip this. If the upstream situation ever changes, we can always update the `livecheck` block but that seems unlikely at this point.