### PR TITLE
feh: migrate to brewed X11

### DIFF
--- a/Formula/feh.rb
+++ b/Formula/feh.rb
@@ -21,6 +21,7 @@ class Feh < Formula
   depends_on "libexif"
   depends_on "libx11"
   depends_on "libxinerama"
+  depends_on "libxt"
 
   def install
     system "make", "PREFIX=#{prefix}", "verscmp=0", "exif=1"

--- a/Formula/feh.rb
+++ b/Formula/feh.rb
@@ -4,6 +4,7 @@ class Feh < Formula
   url "https://feh.finalrewind.org/feh-3.5.tar.bz2"
   sha256 "388f9dcc8284031023364355e23a82c276e79ca614f2dcd64d2f927857a4531e"
   license "MIT-feh"
+  revision 1
 
   livecheck do
     url :homepage
@@ -18,7 +19,8 @@ class Feh < Formula
 
   depends_on "imlib2"
   depends_on "libexif"
-  depends_on :x11
+  depends_on "libx11"
+  depends_on "libxinerama"
 
   def install
     system "make", "PREFIX=#{prefix}", "verscmp=0", "exif=1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [ ] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz

Before:

```console
% brew linkage feh
System libraries:
  /opt/X11/lib/libX11.6.dylib
  /opt/X11/lib/libXinerama.1.dylib
  /usr/lib/libSystem.B.dylib
  /usr/lib/libcurl.4.dylib
Homebrew libraries:
  /usr/local/opt/imlib2/lib/libImlib2.1.dylib (imlib2)
  /usr/local/opt/libexif/lib/libexif.12.dylib (libexif)
  /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
Indirect dependencies with linkage:
  libpng
```

After:

```console
% brew linkage feh
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libcurl.4.dylib
Homebrew libraries:
  /usr/local/opt/imlib2/lib/libImlib2.1.dylib (imlib2)
  /usr/local/opt/libexif/lib/libexif.12.dylib (libexif)
  /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
  /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
  /usr/local/opt/libxinerama/lib/libXinerama.1.dylib (libxinerama)
Indirect dependencies with linkage:
  libpng
```