### PR TITLE
fizmo: migrate to brewed X11

### DIFF
--- a/Formula/fizmo.rb
+++ b/Formula/fizmo.rb
@@ -4,7 +4,7 @@ class Fizmo < Formula
   url "https://fizmo.spellbreaker.org/source/fizmo-0.8.5.tar.gz"
   sha256 "1c259a29b21c9f401c12fc24d555aca4f4ff171873be56fb44c0c9402c61beaa"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://fizmo.spellbreaker.org/download/"
@@ -23,8 +23,8 @@ class Fizmo < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libsndfile"
+  depends_on "libx11"
   depends_on "sdl2"
-  depends_on :x11
 
   def install
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [ ] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz


Before:

```console
% brew linkage fizmo
System libraries:
  /opt/X11/lib/libX11.6.dylib
  /usr/lib/libSystem.B.dylib
  /usr/lib/libncurses.5.4.dylib
  /usr/lib/libxml2.2.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/freetype/lib/libfreetype.6.dylib (freetype)
  /usr/local/opt/jpeg/lib/libjpeg.9.dylib (jpeg)
  /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
  /usr/local/opt/libsndfile/lib/libsndfile.1.dylib (libsndfile)
  /usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib (sdl2)
```

After:

```console
% brew linkage fizmo
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libncurses.5.4.dylib
  /usr/lib/libxml2.2.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/freetype/lib/libfreetype.6.dylib (freetype)
  /usr/local/opt/jpeg/lib/libjpeg.9.dylib (jpeg)
  /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
  /usr/local/opt/libsndfile/lib/libsndfile.1.dylib (libsndfile)
  /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
  /usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib (sdl2)
```