### PR TITLE
nim: fix checksum

### DIFF
--- a/Formula/nim.rb
+++ b/Formula/nim.rb
@@ -2,7 +2,7 @@ class Nim < Formula
   desc "Statically typed compiled systems programming language"
   homepage "https://nim-lang.org/"
   url "https://nim-lang.org/download/nim-1.4.0.tar.xz"
-  sha256 "be3120ab6b737f6ce0dd63fabf9e7c2c7625992b1145e5ebccf0573f3b09905d"
+  sha256 "9dfba2bed31a21a5a34231016dd556b1b5e0db23c01357cfab26aa8f27a6c23d"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [See below] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [See below] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [See below] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Nim's SHA256 was not working correctly for me. I think it's because the SHA256 provided in #62997 was for the Linux archive; but the source archive seems to be `9dfba2bed31a21a5a34231016dd556b1b5e0db23c01357cfab26aa8f27a6c23d` listed on Nim's download page. 

I can't test it, because I'm currently using an El Cap machine and it apparently won't build on it. However, the download seems fine and it installs most of it. 

_This PR was started around 2:50 Eastern time_