### PR TITLE
wcslib: add livecheck, update license

### DIFF
--- a/Formula/wcslib.rb
+++ b/Formula/wcslib.rb
@@ -3,7 +3,12 @@ class Wcslib < Formula
   homepage "https://www.atnf.csiro.au/people/mcalabre/WCS/"
   url "https://www.atnf.csiro.au/pub/software/wcslib/wcslib-7.3.tar.bz2"
   sha256 "4b01cf425382a26ca4f955ed6841a5f50c55952a2994367f8e067e4183992961"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?wcslib\.t.+?WCSLIB v?(\d+(?:\.\d+)+)</im)
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `wcslib`. This PR adds a `livecheck` block that checks the homepage.

Unfortunately, the `stable` archive isn't listed on the homepage and it instead links to `ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib.tar.bz2` (presumably maintained to be the latest version). This check matches this `href` attribute and identifies the version information from the inner text of the element (e.g., "WCSLIB 7.3"). This isn't as reliable as matching against archive file names but it works fine for now.

Alternatively, we can search on the atnf.csiro.au site for "wcslib" and filter to only see the "Other" results, which effectively gives us only the `wcslib` archive files: https://search.atnf.csiro.au/arch.php?q=wcslib&aa=Search&lang=en&ar_format=resultsBody&fq=(type%3AOther). This works at the moment but my concern about this approach is that the results are paginated (10 items per page) and I didn't see a way of sorting the information (e.g., so the newest is first). As with checking any paginated page, the issue is that the check won't work properly if the information we're interested in is pushed off the first page.

With this in mind, I think we should just check the homepage for now.

---

This also updates the `license` from `GPL-3.0` to `GPL-3.0-or-later`, referencing the [`wcslib` documentation](https://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/) which contains the following license summary in the "Copyright" section:

```
  WCSLIB 7.3 - an implementation of the FITS WCS standard.
  Copyright (C) 1995-2020, Mark Calabretta

  WCSLIB is free software: you can redistribute it and/or modify it under the
  terms of the GNU Lesser General Public License as published by the Free
  Software Foundation, either version 3 of the License, or (at your option)
  any later version.

  WCSLIB is distributed in the hope that it will be useful, but WITHOUT ANY
  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
  more details.

  You should have received a copy of the GNU Lesser General Public License
  along with WCSLIB.  If not, see http://www.gnu.org/licenses.

  Direct correspondence concerning WCSLIB to mark@calabretta.id.au

  Author: Mark Calabretta, Australia Telescope National Facility, CSIRO.
  http://www.atnf.csiro.au/people/Mark.Calabretta
  $Id: mainpage.dox,v 7.3 2020/06/03 03:37:03 mcalabre Exp $
```