### PR TITLE
sqlite-analyzer: add livecheck

### DIFF
--- a/Formula/sqlite-analyzer.rb
+++ b/Formula/sqlite-analyzer.rb
@@ -6,6 +6,11 @@ class SqliteAnalyzer < Formula
   sha256 "90bf7604a5aa26deece551af7a665fd4ce3d854ea809899c0e4bb19a69d609b8"
   license "blessing"
 
+  livecheck do
+    url "https://sqlite.org/news.html"
+    regex(%r{v?(\d+(?:\.\d+)+)</h3>}i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "9e59b093b696037bde52e57a1993961dde8233fbb7305157da8be0e54a986804" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `sqlite-analyzer`. This PR adds a `livecheck` block that checks the ["News" page on the first-party site](https://sqlite.org/news.html). This check is the one we use in the `sqlite` formula, since the `stable` archives for these formulae come from the same source and use the same version.