### PR TITLE
bit-git: fix version output

### DIFF
--- a/Formula/bit-git.rb
+++ b/Formula/bit-git.rb
@@ -4,6 +4,7 @@ class BitGit < Formula
   url "https://github.com/chriswalz/bit/archive/v0.9.11.tar.gz"
   sha256 "a6d7f31d92007725b18f6203c7b9c8f9eaaa49e22f807ad683473d7388350681"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -17,7 +18,7 @@ class BitGit < Formula
   conflicts_with "bit", because: "both install `bit` binaries"
 
   def install
-    system "go", "build", *std_go_args
+    system "go", "build", *std_go_args, "-ldflags", "-X main.version=v#{version}"
     bin.install_symlink "bit-git" => "bit"
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Not specifying `main.version` explicitly during the build led to `bit --version` always reporting `bit` as being `v0.8.0`.

This change fixes it and reports the proper version.