### PR TITLE
overdrive 2.1.1 (new formula)

### DIFF
--- a/Formula/overdrive.rb
+++ b/Formula/overdrive.rb
@@ -1,0 +1,18 @@
+class Overdrive < Formula
+  desc "Bash script to download mp3s from the OverDrive audiobook service"
+  homepage "https://github.com/chbrown/overdrive"
+  url "https://github.com/chbrown/overdrive/archive/2.1.1.tar.gz"
+  sha256 "74ec42df2c5dda56bfe04c0f8b831d21fd1511c0ef2839dd2bd84d1fda2b8b6b"
+  license "MIT"
+  head "https://github.com/chbrown/overdrive.git"
+
+  bottle :unneeded
+
+  def install
+    bin.install "overdrive.sh"
+  end
+
+  test do
+    system "#{bin}/overdrive.sh", "-h"
+  end
+end

--- a/Formula/overdrive.rb
+++ b/Formula/overdrive.rb
@@ -10,8 +10,8 @@ class Overdrive < Formula
 
   depends_on "tidy-html5"
   uses_from_macos "curl"
+  uses_from_macos "libressl"
   uses_from_macos "libxml2"
-  uses_from_macos "openssl"
 
   def install
     bin.install "overdrive.sh" => "overdrive"

--- a/Formula/overdrive.rb
+++ b/Formula/overdrive.rb
@@ -8,6 +8,11 @@ class Overdrive < Formula
 
   bottle :unneeded
 
+  uses_from_macos "curl"
+  uses_from_macos "libxml2"
+  uses_from_macos "openssl"
+  depends_on "tidy-html5"
+
   def install
     bin.install "overdrive.sh"
   end

--- a/Formula/overdrive.rb
+++ b/Formula/overdrive.rb
@@ -8,16 +8,17 @@ class Overdrive < Formula
 
   bottle :unneeded
 
+  depends_on "tidy-html5"
   uses_from_macos "curl"
   uses_from_macos "libxml2"
   uses_from_macos "openssl"
-  depends_on "tidy-html5"
 
   def install
     bin.install "overdrive.sh"
   end
 
   test do
-    system "#{bin}/overdrive.sh", "-h"
+    # A full run would require an authentic file, which can only be used once
+    assert_match "warning: failed to load", shell_output("#{bin}/overdrive.sh download fake_file.odm 2>&1", 1)
   end
 end

--- a/Formula/overdrive.rb
+++ b/Formula/overdrive.rb
@@ -14,11 +14,11 @@ class Overdrive < Formula
   uses_from_macos "openssl"
 
   def install
-    bin.install "overdrive.sh"
+    bin.install "overdrive.sh" => "overdrive"
   end
 
   test do
     # A full run would require an authentic file, which can only be used once
-    assert_match "warning: failed to load", shell_output("#{bin}/overdrive.sh download fake_file.odm 2>&1", 1)
+    assert_match "warning: failed to load", shell_output("#{bin}/overdrive download fake_file.odm 2>&1", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Description:

> OverDrive is great and distributes DRM-free MP3s instead of some fragile DRM-ridden format, which is awesome. Way to go, Rakuten / OverDrive, fight the man!
> 
> Their "OverDrive Media Console" application for macOS is pretty simple... so simple, I'm like, why have an app?
> 
> So I wrote a shell script, overdrive.sh, which takes one or more .odm files (which are just XML), and downloads the audio content files locally, just like the app.

Github: https://github.com/chbrown/overdrive

This is especially important since the "OverDrive Media Console" application is 32-bit only and no longer works on macOS Catalina.