### PR TITLE
freeglut: migrate to brewed X11

### DIFF
--- a/Formula/freeglut.rb
+++ b/Formula/freeglut.rb
@@ -3,6 +3,8 @@ class Freeglut < Formula
   homepage "https://freeglut.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/freeglut/freeglut/3.2.1/freeglut-3.2.1.tar.gz"
   sha256 "d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68"
+  license "MIT"
+  revision 1
 
   livecheck do
     url :stable
@@ -16,38 +18,33 @@ class Freeglut < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on :x11
+  depends_on "pkg-config" => :test
+  depends_on "libx11"
+  depends_on "libxi"
+  depends_on "libxrandr"
+  depends_on "libxxf86vm"
+  depends_on "mesa"
 
-  patch :DATA
+  resource "init_error_func.c" do
+    url "https://raw.githubusercontent.com/dcnieho/FreeGLUT/c63102d06d09f8a9d4044fd107fbda2034bb30c6/freeglut/freeglut/progs/demos/init_error_func/init_error_func.c"
+    sha256 "74ff9c3f722043fc617807f19d3052440073b1cb5308626c1cefd6798a284613"
+  end
 
   def install
-    inreplace "src/x11/fg_main_x11.c", "CLOCK_MONOTONIC", "UNDEFINED_GIBBERISH" if MacOS.version < :sierra
-    system "cmake", *std_cmake_args, "-DFREEGLUT_BUILD_DEMOS=OFF", "."
+    args = %W[
+      -DFREEGLUT_BUILD_DEMOS=OFF
+      -DOPENGL_INCLUDE_DIR=#{Formula["mesa"].include}
+      -DOPENGL_gl_LIBRARY=#{Formula["mesa"].lib}/#{shared_library("libGL")}
+    ]
+    system "cmake", *std_cmake_args, *args, "."
     system "make", "all"
     system "make", "install"
   end
+
+  test do
+    resource("init_error_func.c").stage(testpath)
+    flags = shell_output("pkg-config --cflags --libs glut gl xext x11").chomp.split
+    system ENV.cc, "init_error_func.c", "-o", "init_error_func", *flags
+    assert_match "Entering user defined error handler", shell_output("./init_error_func 2>&1", 1)
+  end
 end
-
-__END__
-
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 28f8651..d1f6a86 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -258,6 +258,16 @@
- IF(FREEGLUT_GLES)
-     LIST(APPEND PUBLIC_DEFINITIONS -DFREEGLUT_GLES)
-     LIST(APPEND LIBS GLESv2 GLESv1_CM EGL)
-+ELSEIF(APPLE)
-+  # on OSX FindOpenGL uses framework version of OpenGL, but we need X11 version
-+  FIND_PATH(GLX_INCLUDE_DIR GL/glx.h
-+            PATHS /opt/X11/include /usr/X11/include /usr/X11R6/include)
-+  FIND_LIBRARY(OPENGL_gl_LIBRARY GL
-+               PATHS /opt/X11/lib /usr/X11/lib /usr/X11R6/lib)
-+  FIND_LIBRARY(OPENGL_glu_LIBRARY GLU
-+               PATHS /opt/X11/lib /usr/X11/lib /usr/X11R6/lib)
-+  LIST(APPEND LIBS ${OPENGL_gl_LIBRARY})
-+  INCLUDE_DIRECTORIES(${GLX_INCLUDE_DIR})
- ELSE()
-   FIND_PACKAGE(OpenGL REQUIRED)
-   LIST(APPEND LIBS ${OPENGL_gl_LIBRARY})


### PR DESCRIPTION
Also added license and test. Supports #64166.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz