### PR TITLE
mesalib-glu 9.0.1 (new formula)

### DIFF
--- a/Formula/mesalib-glu.rb
+++ b/Formula/mesalib-glu.rb
@@ -1,0 +1,39 @@
+class MesalibGlu < Formula
+  desc "Mesa OpenGL Utility library"
+  homepage "https://cgit.freedesktop.org/mesa/glu"
+  url "ftp://ftp.freedesktop.org/pub/mesa/glu/glu-9.0.1.tar.xz"
+  sha256 "fb5a4c2dd6ba6d1c21ab7c05129b0769544e1d68e1e3b0ffecb18e73c93055bc"
+  license "MIT"
+
+  livecheck do
+    url :head
+    regex(/^(?:glu[._-])?v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  head do
+    url "https://gitlab.freedesktop.org/mesa/glu.git"
+
+    depends_on "automake" => :build
+  end
+
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => [:build, :test]
+  depends_on "mesa"
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --disable-silent-rules
+    ]
+
+    system "./autogen.sh", *args if build.head?
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    assert_match "-I#{include}", shell_output("pkg-config --cflags glu")
+  end
+end


### PR DESCRIPTION
Continuation of #57995, migrating `glu` to core in support of #64166. Required by `geomview`, and any other formula that depends on `libGLU`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
