### PR TITLE
workflows/tests: set HOMEBREW_FORCE_HOMEBREW_ON_LINUX.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ jobs:
   tap_syntax:
     if: github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
+    env:
+      HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
     steps:
     - name: Set up Homebrew
       id: set-up-homebrew


### PR DESCRIPTION
We want to ensure this is set when we're actually testing Homebrew/homebrew-core on Linux.