### PR TITLE
lnav: update livecheck url

### DIFF
--- a/Formula/lnav.rb
+++ b/Formula/lnav.rb
@@ -6,7 +6,7 @@ class Lnav < Formula
   license "BSD-2-Clause"
 
   livecheck do
-    url "https://github.com/tstack/lnav/releases"
+    url "https://github.com/tstack/lnav/releases/latest"
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `livecheck` block for `lnav` checks the GitHub repository's "releases" page, which we specifically avoid because the latest release may be pushed off the first page (e.g., by prerelease versions) such that the check won't work. We either check the "latest" GitHub release (if available and reliably correct) or the Git tags (if a "latest" release isn't available/usable).

The upstream GitHub repository has a "latest" release, so this check should be using that instead. This PR updates the `livecheck` block accordingly.