### PR TITLE
transmission-cli: add livecheck strategy

### DIFF
--- a/Formula/transmission-cli.rb
+++ b/Formula/transmission-cli.rb
@@ -8,6 +8,7 @@ class TransmissionCli < Formula
 
   livecheck do
     url "https://github.com/transmission/transmission-releases/"
+    strategy :page_match
     regex(/href=.*?transmission[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently, livecheck uses the `PageMatch` strategy for the GitHub repository URL used in the `transmission-cli` `livecheck` block, since the `Git` strategy doesn't apply to it. We check the main GitHub page for this project because [this repository](https://github.com/transmission/transmission-releases/) simply contains archive files.

The `Git` strategy will apply to this URL if/when Homebrew/brew#9074 is merged, so I'm preemptively specifying the strategy here to prevent this check from breaking. This check is already using the `PageMatch` strategy, so this doesn't alter the current behavior and there's no harm in defensively adding it here.