### PR TITLE
zig 0.7.0

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -1,10 +1,9 @@
 class Zig < Formula
   desc "Programming language designed for robustness, optimality, and clarity"
   homepage "https://ziglang.org/"
-  url "https://ziglang.org/download/0.6.0/zig-0.6.0.tar.xz"
-  sha256 "5d167dc19354282dd35dd17b38e99e1763713b9be8a4ba9e9e69284e059e7204"
+  url "https://ziglang.org/download/0.7.0/zig-0.7.0.tar.xz"
+  sha256 "0efd2cf6c3b05723db80e9cf193bc55150bba84ca41f855a90f53fc756445f83"
   license "MIT"
-  revision 1
   head "https://github.com/ziglang/zig.git"
 
   bottle do
@@ -16,10 +15,6 @@ class Zig < Formula
 
   depends_on "cmake" => :build
   depends_on "llvm"
-
-  # Fix linking issues
-  # https://github.com/Homebrew/homebrew-core/issues/53198
-  patch :DATA
 
   def install
     system "cmake", ".", *std_cmake_args
@@ -38,15 +33,3 @@ class Zig < Formula
     assert_equal "Hello, world!", shell_output("./hello")
   end
 end
-
-__END__
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -384,6 +384,9 @@ target_link_libraries(zig_cpp LINK_PUBLIC
-     ${CLANG_LIBRARIES}
-     ${LLD_LIBRARIES}
-     ${LLVM_LIBRARIES}
-+    "-Wl,/usr/local/opt/llvm/lib/libPolly.a"
-+    "-Wl,/usr/local/opt/llvm/lib/libPollyPPCG.a"
-+    "-Wl,/usr/local/opt/llvm/lib/libPollyISL.a"
- )


### PR DESCRIPTION
Updates zig recipe to latest released version `0.7.0`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
