### PR TITLE
bzip2: install shared libraries on linux

### DIFF
--- a/Formula/bzip2.rb
+++ b/Formula/bzip2.rb
@@ -24,6 +24,15 @@ class Bzip2 < Formula
     inreplace "Makefile", "$(PREFIX)/man", "$(PREFIX)/share/man"
 
     system "make", "install", "PREFIX=#{prefix}"
+
+    on_linux do
+      # Install shared libraries
+      system "make", "-f", "Makefile-libbz2_so", "clean"
+      system "make", "-f", "Makefile-libbz2_so"
+      lib.install "libbz2.so.#{version}", "libbz2.so.#{version.major_minor}"
+      lib.install_symlink "libbz2.so.#{version}" => "libbz2.so.#{version.major}"
+      lib.install_symlink "libbz2.so.#{version}" => "libbz2.so"
+    end
   end
 
   test do


### PR DESCRIPTION
There is no makefile to build shared libraries on mac,
so this does not seem officially supported without
manually patching bzip2, which we would like to avoid.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
