### PR TITLE
tinc: add livecheck

### DIFF
--- a/Formula/tinc.rb
+++ b/Formula/tinc.rb
@@ -5,6 +5,11 @@ class Tinc < Formula
   sha256 "40f73bb3facc480effe0e771442a706ff0488edea7a5f2505d4ccb2aa8163108"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://www.tinc-vpn.org/download/"
+    regex(/href=.*?tinc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "fcaaca6b5abf4f30a55149f41871a7c4ec99fe8a9dc87ddb68ea735c03569a66" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds a `livecheck` block for `tinc` as livecheck was unable to get versions. The `url` used is that of the Downloads page, where the stable archive's URL is located as well.