### PR TITLE
svg2pdf: add livecheck

### DIFF
--- a/Formula/svg2pdf.rb
+++ b/Formula/svg2pdf.rb
@@ -6,6 +6,11 @@ class Svg2pdf < Formula
   license "LGPL-2.1"
   revision 1
 
+  livecheck do
+    url "https://cairographics.org/snapshots/"
+    regex(/href=.*?svg2pdf[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "7dff42459bf1ab33b0938f062d42c1857cb8274d1935f356b4f7dec76aac865c" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds a `livecheck` block for `svg2pdf`, as livecheck was unable to find versions. The regex matches the stable archive URL in this case.

Note: `svg2pdf` doesn't seem to have been updated since 2005, although I may have missed something.