### PR TITLE
bettercap: add linux-only dependency

### DIFF
--- a/Formula/bettercap.rb
+++ b/Formula/bettercap.rb
@@ -19,6 +19,10 @@ class Bettercap < Formula
 
   uses_from_macos "libpcap"
 
+  on_linux do
+    depends_on "libnetfilter-queue"
+  end
+
   def install
     system "make", "build"
     bin.install "bettercap"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
