### PR TITLE
condure: depend on openssl

### DIFF
--- a/Formula/condure.rb
+++ b/Formula/condure.rb
@@ -16,6 +16,7 @@ class Condure < Formula
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "python@3.9" => :test
+  depends_on "openssl"
   depends_on "zeromq"
 
   resource "pyzmq" do

--- a/Formula/condure.rb
+++ b/Formula/condure.rb
@@ -16,7 +16,7 @@ class Condure < Formula
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "python@3.9" => :test
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "zeromq"
 
   resource "pyzmq" do


### PR DESCRIPTION
condure requires openssl and successfully builds against it, even though openssl is not specified as a dependency in the formula. Maybe that was just luck? Here's a patch to explicitly set the dependency, in case it's the right thing to do.