### PR TITLE
ocaml: update livecheck url

### DIFF
--- a/Formula/ocaml.rb
+++ b/Formula/ocaml.rb
@@ -19,7 +19,7 @@ class Ocaml < Formula
   head "https://github.com/ocaml/ocaml.git", branch: "trunk"
 
   livecheck do
-    url "https://ocaml.org/releases"
+    url "https://ocaml.org/releases/"
     regex(/href=.*?v?(\d+(?:\.\d+)+)\.html/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This simply updates the `livecheck` block URL to have a trailing forward slash, to avoid the redirection from https://ocaml.org/releases to https://ocaml.org/releases/.