### PR TITLE
Update some head URLs to use .git extension

### DIFF
--- a/Formula/eigen.rb
+++ b/Formula/eigen.rb
@@ -5,7 +5,7 @@ class Eigen < Formula
   sha256 "146a480b8ed1fb6ac7cd33fec9eb5e8f8f62c3683b3f850094d9d5c35a92419a"
   license "MPL-2.0"
   revision 1
-  head "https://gitlab.com/libeigen/eigen"
+  head "https://gitlab.com/libeigen/eigen.git"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/gobby.rb
+++ b/Formula/gobby.rb
@@ -5,7 +5,7 @@ class Gobby < Formula
   sha256 "8ceb3598d27cfccdf9c9889b781c4c5c8e1731ca6beb183f5d4555644c06bd98"
   license "ISC"
   revision 8
-  head "https://github.com/gobby/gobby"
+  head "https://github.com/gobby/gobby.git"
 
   bottle do
     sha256 "5e2914adc88813352b11d1db5e69d2aa9b4612b7fb4ae05443a18b9426a0f26d" => :catalina

--- a/Formula/jnethack.rb
+++ b/Formula/jnethack.rb
@@ -10,7 +10,7 @@ class Jnethack < Formula
     revision: "0ffd620440b5b61e21b40bf32e148d20c0c8349f"
   version "3.6.6-0.1"
   license "NGPL"
-  head "https://github.com/jnethack/jnethack-alpha"
+  head "https://github.com/jnethack/jnethack-alpha.git", branch: "develop"
 
   livecheck do
     url :stable

--- a/Formula/liblwgeom.rb
+++ b/Formula/liblwgeom.rb
@@ -4,7 +4,7 @@ class Liblwgeom < Formula
   url "https://download.osgeo.org/postgis/source/postgis-2.5.4.tar.gz"
   sha256 "146d59351cf830e2a2a72fa14e700cd5eab6c18ad3e7c644f57c4cee7ed98bbe"
   revision 1
-  head "https://git.osgeo.org/gitea/postgis/postgis"
+  head "https://git.osgeo.org/gitea/postgis/postgis.git"
 
   livecheck do
     url "https://download.osgeo.org/postgis/source/"

--- a/Formula/squashfs.rb
+++ b/Formula/squashfs.rb
@@ -4,8 +4,7 @@ class Squashfs < Formula
   url "https://github.com/plougher/squashfs-tools/archive/4.4.tar.gz"
   sha256 "a7fa4845e9908523c38d4acf92f8a41fdfcd19def41bd5090d7ad767a6dc75c3"
   license "GPL-2.0"
-  head "https://github.com/plougher/squashfs-tools",
-    using:  :git,
+  head "https://github.com/plougher/squashfs-tools.git",
     commit: "52eb4c279cd283ed9802dd1ceb686560b22ffb67"
 
   bottle do

--- a/Formula/wireguard-go.rb
+++ b/Formula/wireguard-go.rb
@@ -4,11 +4,11 @@ class WireguardGo < Formula
   url "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-0.0.20200320.tar.xz"
   sha256 "c8262da949043976d092859843d3c0cdffe225ec6f1398ba119858b6c1b3552f"
   license "MIT"
-  head "https://git.zx2c4.com/wireguard-go", using: :git
+  head "https://git.zx2c4.com/wireguard-go.git"
 
   livecheck do
     url :head
-    regex(/href=.*?wireguard-go[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -4,10 +4,11 @@ class WireguardTools < Formula
   url "https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-1.0.20200827.tar.xz"
   sha256 "51bc85e33a5b3cf353786ae64b0f1216d7a871447f058b6137f793eb0f53b7fd"
   license "GPL-2.0"
-  head "https://git.zx2c4.com/wireguard-tools", using: :git
+  head "https://git.zx2c4.com/wireguard-tools.git"
 
   livecheck do
-    url "https://github.com/WireGuard/wireguard-tools"
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -5,7 +5,7 @@ class Wireshark < Formula
   mirror "https://1.na.dl.wireshark.org/src/wireshark-3.4.0.tar.xz"
   sha256 "67e4ebbd9153fc589fd67dc21b93176674c73adc3d5a43934c3ac69d8594a8ae"
   license "GPL-2.0-or-later"
-  head "https://code.wireshark.org/review/wireshark", using: :git
+  head "https://code.wireshark.org/review/wireshark.git"
 
   livecheck do
     url "https://www.wireshark.org/download.html"

--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -5,7 +5,7 @@ class X265 < Formula
   sha256 "7f2771799bea0f53b5ab47603d5bea46ea2a221e047a7ff398115e9976fd5f86"
   license "GPL-2.0-only"
   revision 1
-  head "https://bitbucket.org/multicoreware/x265_git"
+  head "https://bitbucket.org/multicoreware/x265_git.git"
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates a number of `head` URLs in formulae to use a `.git` extension when supported. `brew install --HEAD` doesn't work for all of these formulae but this improves the status quo for some of these. I don't think these changes make things worse, at least, but I would appreciate some additional review.

I've also updated the `livecheck` blocks for `wireguard-go` and `wireguard-tools` with respect to these changes. Checking the `head` Git repository tags is appropriate for these two formulae, since it's the source of their `stable` archives.