### PR TITLE
freerdp: migrate to brewed x11

### DIFF
--- a/Formula/freerdp.rb
+++ b/Formula/freerdp.rb
@@ -4,7 +4,6 @@ class Freerdp < Formula
   url "https://github.com/FreeRDP/FreeRDP/archive/2.2.0.tar.gz"
   sha256 "883bc0396c6be9aba6bc07ebc8ff08457125868ada0f06554e62ef072f90cf59"
   license "Apache-2.0"
-
   revision 1
 
   bottle do

--- a/Formula/freerdp.rb
+++ b/Formula/freerdp.rb
@@ -5,6 +5,8 @@ class Freerdp < Formula
   sha256 "883bc0396c6be9aba6bc07ebc8ff08457125868ada0f06554e62ef072f90cf59"
   license "Apache-2.0"
 
+  revision 1
+
   bottle do
     sha256 "a2ca3e1a307c549ab620d98fc5e96870017d63dc3d279da5ca56dda76fc38075" => :catalina
     sha256 "67732bc5f1195cd4c959243b02f3f7a3f81c516f97b6f5eda7376cdf2ee73edd" => :mojave
@@ -19,8 +21,16 @@ class Freerdp < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "libusb"
+  depends_on "libx11"
+  depends_on "libxcursor"
+  depends_on "libxext"
+  depends_on "libxfixes"
+  depends_on "libxi"
+  depends_on "libxinerama"
+  depends_on "libxrandr"
+  depends_on "libxrender"
+  depends_on "libxv"
   depends_on "openssl@1.1"
-  depends_on :x11
 
   on_linux do
     depends_on "alsa-lib"


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Part of #64166

Before:
```
$ brew linkage freerdp
System libraries:
  /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
  /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
  /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
  /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
  /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
  /opt/X11/lib/libX11.6.dylib
  /opt/X11/lib/libXcursor.1.dylib
  /opt/X11/lib/libXext.6.dylib
  /opt/X11/lib/libXfixes.3.dylib
  /opt/X11/lib/libXi.6.dylib
  /opt/X11/lib/libXinerama.1.dylib
  /opt/X11/lib/libXrandr.2.dylib
  /opt/X11/lib/libXrender.1.dylib
  /opt/X11/lib/libXv.1.dylib
  /usr/lib/libSystem.B.dylib
  /usr/lib/libcups.2.dylib
  /usr/lib/libobjc.A.dylib
Homebrew libraries:
  /usr/local/opt/libusb/lib/libusb-1.0.0.dylib (libusb)
  /usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib (openssl@1.1)
  /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib (openssl@1.1)
Variable-referenced libraries:
  @rpath/libfreerdp-client2.2.dylib
  @rpath/libfreerdp2.2.dylib
  @rpath/libwinpr-tools2.2.dylib
  @rpath/libwinpr2.2.dylib
```
After:
```
$ brew linkage freerdp
System libraries:
  /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
  /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
  /System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox
  /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
  /System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio
  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
  /usr/lib/libSystem.B.dylib
  /usr/lib/libcups.2.dylib
  /usr/lib/libobjc.A.dylib
Homebrew libraries:
  /usr/local/opt/libusb/lib/libusb-1.0.0.dylib (libusb)
  /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
  /usr/local/opt/libxcursor/lib/libXcursor.1.dylib (libxcursor)
  /usr/local/opt/libxext/lib/libXext.6.dylib (libxext)
  /usr/local/opt/libxfixes/lib/libXfixes.3.dylib (libxfixes)
  /usr/local/opt/libxi/lib/libXi.6.dylib (libxi)
  /usr/local/opt/libxinerama/lib/libXinerama.1.dylib (libxinerama)
  /usr/local/opt/libxrandr/lib/libXrandr.2.dylib (libxrandr)
  /usr/local/opt/libxrender/lib/libXrender.1.dylib (libxrender)
  /usr/local/opt/libxv/lib/libXv.1.dylib (libxv)
  /usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib (openssl@1.1)
  /usr/local/opt/openssl@1.1/lib/libssl.1.1.dylib (openssl@1.1)
Variable-referenced libraries:
  @rpath/libfreerdp-client2.2.dylib
  @rpath/libfreerdp2.2.dylib
  @rpath/libwinpr-tools2.2.dylib
  @rpath/libwinpr2.2.dylib
```