### PR TITLE
cssembed: deprecate

### DIFF
--- a/Formula/cssembed.rb
+++ b/Formula/cssembed.rb
@@ -5,6 +5,8 @@ class Cssembed < Formula
   sha256 "8955016c0d32de8755d9ee33d365d1ad658a596aba48537a810ce62f3d32a1af"
   license "MIT"
 
+  deprecate! because: :repo_archived
+
   bottle :unneeded
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [upstream repository for `cssembed`](https://github.com/nzakas/cssembed/) is archived, so this deprecates the formula with `deprecate! because: :repo_archived`.