### PR TITLE
rpg: deprecate

### DIFF
--- a/Formula/rpg.rb
+++ b/Formula/rpg.rb
@@ -6,6 +6,8 @@ class Rpg < Formula
   license "MIT"
   head "https://github.com/rtomayko/rpg.git"
 
+  deprecate! because: :repo_archived
+
   bottle do
     cellar :any_skip_relocation
     sha256 "826bacff2dddeeeb41cdf328b7702fa415d049b9d1d55b2f93e7f1084ebcb3e0" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [upstream repository for `rpg`](https://github.com/rtomayko/rpg/) is archived, so this deprecates the formula with `deprecate! because: :repo_archived`.