### PR TITLE
tidyp: deprecate

### DIFF
--- a/Formula/tidyp.rb
+++ b/Formula/tidyp.rb
@@ -5,6 +5,8 @@ class Tidyp < Formula
   sha256 "20b0fad32c63575bd4685ed09b8c5ca222bbc7b15284210d4b576d0223f0b338"
   license "Zlib"
 
+  deprecate! because: :repo_archived
+
   bottle do
     cellar :any
     sha256 "ed67353f58e09c04387453c92536d7980c3408391bae0db77f3af421779cee57" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [upstream repository for `tidyp`](https://github.com/petdance/tidyp/) is archived, so this deprecates the formula with `deprecate! because: :repo_archived`.