### PR TITLE
wordnet: migrate to brewed X11

### DIFF
--- a/Formula/wordnet.rb
+++ b/Formula/wordnet.rb
@@ -5,6 +5,8 @@ class Wordnet < Formula
   # Version 3.1 is version 3.0 with the 3.1 dictionary.
   version "3.1"
   sha256 "6c492d0c7b4a40e7674d088191d3aa11f373bb1da60762e098b8ee2dda96ef22"
+  license :cannot_represent
+  revision 1
 
   bottle do
     sha256 "a815dc11f451a82c84ed37266010f81bc4f5993467c1e6063edb3fc3f0fd95c5" => :catalina
@@ -16,7 +18,7 @@ class Wordnet < Formula
     sha256 "786bc9b811d958b71888cc87e0ef75a6cd66ebc05202278b7827f847f6b4dfe5" => :mavericks
   end
 
-  depends_on :x11
+  depends_on "tcl-tk"
 
   resource "dict" do
     url "https://wordnetcode.princeton.edu/wn3.1.dict.tar.gz"
@@ -32,8 +34,8 @@ class Wordnet < Formula
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}",
-                          "--with-tcl=#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework",
-                          "--with-tk=#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework"
+                          "--with-tcl=#{Formula["tcl-tk"].opt_prefix}/lib",
+                          "--with-tk=#{Formula["tcl-tk"].opt_prefix}/lib"
     ENV.deparallelize
     system "make", "install"
   end


### PR DESCRIPTION
Supports #64166. Note the following:

* It doesn't actually use X11 at all, but it now uses Homebrew Tcl/Tk.
* License is a custom Princeton job, looks somewhat similar to MIT.

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
