### PR TITLE
xorgrgb 1.0.6 (new formula)

### DIFF
--- a/Formula/xorgrgb.rb
+++ b/Formula/xorgrgb.rb
@@ -1,0 +1,28 @@
+class Xorgrgb < Formula
+  desc "X.Org: color names database"
+  homepage "https://www.x.org/"
+  url "https://xorg.freedesktop.org/archive/individual/app/rgb-1.0.6.tar.bz2"
+  sha256 "bbca7c6aa59939b9f6a0fb9fff15dfd62176420ffd4ae30c8d92a6a125fbe6b0"
+  license "MIT"
+
+  depends_on "pkg-config" => :build
+  depends_on "util-macros" => :build
+  depends_on "xorgproto" => :build
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}
+      --localstatedir=#{var}
+      --disable-dependency-tracking
+      --disable-silent-rules
+    ]
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    assert_match "gray100", shell_output("#{bin}/showrgb").chomp
+  end
+end


### PR DESCRIPTION
Add RGB database missing from #57995, needed by `sng` in support of #64166.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
