### PR TITLE
openblas: force a large NUM_THREADS

### DIFF
--- a/Formula/openblas.rb
+++ b/Formula/openblas.rb
@@ -4,6 +4,7 @@ class Openblas < Formula
   url "https://github.com/xianyi/OpenBLAS/archive/v0.3.12.tar.gz"
   sha256 "65a7d3a4010a4e3bd5c0baa41a234797cd3a1735449a4a5902129152601dc57b"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/xianyi/OpenBLAS.git", branch: "develop"
 
   bottle do
@@ -22,6 +23,8 @@ class Openblas < Formula
     ENV["DYNAMIC_ARCH"] = "1"
     ENV["USE_OPENMP"] = "1"
     ENV["NO_AVX512"] = "1"
+    # Force a large NUM_THREADS to support larger Macs than the VMs that build the bottles
+    ENV["NUM_THREADS"] = "56"
     ENV["TARGET"] = case Hardware.oldest_cpu
     when :arm_vortex_tempest
       "VORTEX"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently, the `openblas` bottle ends up built with a max NUM_THREADS of 6, since that is auto-detected based on the size of the VM the bottles are built on, which are 6-vcore/3-hw-core. This means it runs with too few threads on Macs that have more CPU cores. This PR forces the build-time NUM_THREADS to be large enough to support any current Mac (current largest Mac Pro is 28 cores); it'll scale down automatically at run time based on the number of detected cores.

Reference: https://discourse.brew.sh/t/openblas-bottle-max-threads-is-fixed-to-6/9099