### PR TITLE
exa: install manual

### DIFF
--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -19,6 +19,7 @@ class Exa < Formula
     sha256 "e47d5005f3a6a05bc442ed8e12a8e3206f39d0e4daf4835e84545ab158c4f089" => :high_sierra
   end
 
+  depends_on "pandoc" => :build
   depends_on "rust" => :build
 
   uses_from_macos "zlib"
@@ -35,10 +36,22 @@ class Exa < Formula
       bash_completion.install "completions/completions.bash" => "exa"
       zsh_completion.install  "completions/completions.zsh"  => "_exa"
       fish_completion.install "completions/completions.fish" => "exa.fish"
+
+      args = %w[
+        --standalone
+        --to=man
+      ]
+
+      system "pandoc", *args, "man/exa.1.md", "-o", "exa.1"
+      system "pandoc", *args, "man/exa_colors.5.md", "-o", "exa_colors.5"
+
+      man1.install "exa.1"
+      man5.install "exa_colors.5"
     else
       bash_completion.install "contrib/completions.bash" => "exa"
       zsh_completion.install  "contrib/completions.zsh"  => "_exa"
       fish_completion.install "contrib/completions.fish" => "exa.fish"
+      man1.install "contrib/man/exa.1"
     end
   end
 


### PR DESCRIPTION
The current formula does not install a manual for `exa`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I don't actually know Ruby, so apologies if I've made a mess of the formula.