### PR TITLE
wmctrl: migrate to brewed X11

### DIFF
--- a/Formula/wmctrl.rb
+++ b/Formula/wmctrl.rb
@@ -3,7 +3,8 @@ class Wmctrl < Formula
   homepage "https://sites.google.com/site/tstyblo/wmctrl"
   url "https://sites.google.com/site/tstyblo/wmctrl/wmctrl-1.07.tar.gz"
   sha256 "d78a1efdb62f18674298ad039c5cbdb1edb6e8e149bb3a8e3a01a4750aa3cca9"
-  revision 1
+  license "GPL-2.0-or-later"
+  revision 2
 
   livecheck do
     url :homepage
@@ -21,7 +22,10 @@ class Wmctrl < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "glib"
-  depends_on :x11
+  depends_on "libice"
+  depends_on "libsm"
+  depends_on "libx11"
+  depends_on "libxmu"
 
   # Fix for 64-bit arch. See:
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=362068


### PR DESCRIPTION
License in `main.c` of tarball.

Tracking issue: #64166

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz

-----

Before:

    ❯ brew linkage wmctrl
    System libraries:
      /opt/X11/lib/libICE.6.dylib
      /opt/X11/lib/libSM.6.dylib
      /opt/X11/lib/libX11.6.dylib
      /opt/X11/lib/libXmu.6.dylib
      /usr/lib/libSystem.B.dylib
    Homebrew libraries:
      /usr/local/opt/gettext/lib/libintl.8.dylib (gettext)
      /usr/local/opt/glib/lib/libglib-2.0.0.dylib (glib)

After:

    ❯ brew linkage wmctrl
    System libraries:
      /usr/lib/libSystem.B.dylib
    Homebrew libraries:
      /usr/local/opt/gettext/lib/libintl.8.dylib (gettext)
      /usr/local/opt/glib/lib/libglib-2.0.0.dylib (glib)
      /usr/local/opt/libice/lib/libICE.6.dylib (libice)
      /usr/local/opt/libsm/lib/libSM.6.dylib (libsm)
      /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
      /usr/local/opt/libxmu/lib/libXmu.6.dylib (libxmu)
