### PR TITLE
tiger-vnc: migrate to brewed X11

### DIFF
--- a/Formula/tiger-vnc.rb
+++ b/Formula/tiger-vnc.rb
@@ -17,7 +17,6 @@ class TigerVnc < Formula
   depends_on "gnutls"
   depends_on "jpeg-turbo"
   depends_on "pixman"
-  depends_on :x11
 
   def install
     turbo = Formula["jpeg-turbo"]


### PR DESCRIPTION
This one seems to have not needed X11, as removing the `depends_on`
clause changed nothing. To be sure, I uninstalled XQuartz before building,
and then did `brew test`. No errors.

Tracking issue: #64166

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz

-----

Before **and** after:
```
❯ brew linkage tiger-vnc
System libraries:
  /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
  /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon
  /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa
  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
  /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics
  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
  /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
  /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libiconv.2.dylib
  /usr/lib/libobjc.A.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /usr/local/opt/fltk/lib/libfltk.1.3.dylib (fltk)
  /usr/local/opt/fltk/lib/libfltk_images.1.3.dylib (fltk)
  /usr/local/opt/gettext/lib/libintl.8.dylib (gettext)
  /usr/local/opt/gnutls/lib/libgnutls.30.dylib (gnutls)
  /usr/local/ot/jpeg-turbo/lib/libjpeg.8.dylib (jpeg-turbo)
  /usr/local/opt/pixman/lib/libpixman-1.0.dylib (pixman)
```