### PR TITLE
SDL formulas: fix build on ARM

### DIFF
--- a/Formula/sdl2_gfx.rb
+++ b/Formula/sdl2_gfx.rb
@@ -22,9 +22,13 @@ class Sdl2Gfx < Formula
   depends_on "sdl2"
 
   def install
+    extra_args = []
+    extra_args << "--disable-mmx" if Hardware::CPU.arm?
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--disable-sdltest"
+                          "--disable-sdltest",
+                          *extra_args
     system "make", "install"
   end
 

--- a/Formula/sdl_gfx.rb
+++ b/Formula/sdl_gfx.rb
@@ -21,9 +21,13 @@ class SdlGfx < Formula
   depends_on "sdl"
 
   def install
+    extra_args = []
+    extra_args << "--disable-mmx" if Hardware::CPU.arm?
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--disable-sdltest"
+                          "--disable-sdltest",
+                          *extra_args
     system "make", "install"
   end
 end

--- a/Formula/sdl_rtf.rb
+++ b/Formula/sdl_rtf.rb
@@ -19,7 +19,7 @@ class SdlRtf < Formula
   depends_on "sdl"
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}", "--disable-sdltest"
     system "make", "install"
   end
 end


### PR DESCRIPTION
- sdl test sometimes hang in `sdl_rtf`: avoid it, like we do for other SDL formulas
- ARM does not have MMX instructions 