### PR TITLE
avian: deprecate

### DIFF
--- a/Formula/avian.rb
+++ b/Formula/avian.rb
@@ -17,7 +17,9 @@ class Avian < Formula
     sha256 "20dd7125d138e05021b473d026190d8f4652e807afcfe057614e5c2e66ce0ed1" => :mavericks
   end
 
-  depends_on java: "1.8"
+  deprecate! because: :unmaintained
+
+  depends_on "openjdk@8"
 
   uses_from_macos "zlib"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Deprecate with `:unmaintained`  since `avian` homepage states the following:

> PLEASE NOTE: This project is not currently being developed, maintained, or supported.

Also related to openjdk@8 migration (#63290)