### PR TITLE
restund: update livecheck url

### DIFF
--- a/Formula/restund.rb
+++ b/Formula/restund.rb
@@ -5,7 +5,7 @@ class Restund < Formula
   sha256 "3170441dc882352ab0275556b6fc889b38b14203d936071b5fa12f39a5c86d47"
 
   livecheck do
-    url "https://web.archive.org/web/20200425105956/www.creytiv.com/pub/"
+    url "https://sources.openwrt.org/"
     regex(/href=.*?restund[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

For whatever reason, the `livecheck` block in the `restund` formula was checking an archived archive.org page, which is useless. This updates the `livecheck` block to instead check the directory listing page where the `stable` archive is located.