### PR TITLE
ossp-uuid: update livecheck

### DIFF
--- a/Formula/ossp-uuid.rb
+++ b/Formula/ossp-uuid.rb
@@ -6,8 +6,8 @@ class OsspUuid < Formula
   revision 2
 
   livecheck do
-    url :homepage
-    regex(/href=.*?uuid[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://deb.debian.org/debian/pool/main/o/ossp-uuid/"
+    regex(/href=["']?ossp-uuid[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `ossp-uuid` was checking the `homepage`, which is currently an archive.org page. Since the page is static and will never change, this check isn't useful.

This PR updates the `livecheck` block to check the Debian directory listing page where the `stable` archive is found.