### PR TITLE
minio: add livecheck

### DIFF
--- a/Formula/minio.rb
+++ b/Formula/minio.rb
@@ -8,6 +8,11 @@ class Minio < Formula
   license "Apache-2.0"
   head "https://github.com/minio/minio.git"
 
+  livecheck do
+    url "https://github.com/minio/minio/releases/latest"
+    regex(%r{href=.*?/tag/(?:RELEASE[._-]?)?([^"' >]+)["' >]}i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "683225d7b4226cb85590b002bf58aecb68deae94933df531e09d4120ce8b6893" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `minio` but it's reporting `1434511043` as newest, due to a `release-1434511043` tag.

This PR partly resolves the issue by adding a `livecheck` block that checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` URL on GitHub. This produces a version like `2020-11-10T21-02-24Z` but the formula uses `version "20201110210224"`. We can resolve this in the future when I implement an `alterations` feature (allowing us to make changes to version strings from livecheck) but contributors/maintainers will be able to make sense of it in the interim time.