### PR TITLE
minio-mc: add livecheck

### DIFF
--- a/Formula/minio-mc.rb
+++ b/Formula/minio-mc.rb
@@ -7,6 +7,11 @@ class MinioMc < Formula
   version "20201003025456"
   license "Apache-2.0"
 
+  livecheck do
+    url "https://github.com/minio/mc/releases/latest"
+    regex(%r{href=.*?/tag/(?:RELEASE[._-]?)?([^"' >]+)["' >]}i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "1c9e4d77d0b729dc3957097b6ccb2ee6ad657cab6fc383501513c6b0a13567e8" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `minio-mc` and returns a version like `2020-10-03T02-54-56Z`, whereas the formula uses `version "20201003025456"`.

This PR adds a `livecheck` block that checks the "latest" release on the GitHub repository, which we prefer when it's available (and correct) for formulae with a `stable` URL on GitHub. This still produces a version like `2020-10-03T02-54-56Z` but it brings the check in line with what we're doing in the `minio` formula. As described there, we can resolve the difference in these version formats in the future when I implement an `alterations` feature (allowing us to make changes to version strings from livecheck) but contributors/maintainers will be able to make sense of this in the interim time.