### PR TITLE
commandbox: add livecheck

### DIFF
--- a/Formula/commandbox.rb
+++ b/Formula/commandbox.rb
@@ -4,6 +4,11 @@ class Commandbox < Formula
   url "https://downloads.ortussolutions.com/ortussolutions/commandbox/5.1.1/commandbox-bin-5.1.1.zip"
   sha256 "0b6b358ae2466297a7ddbd16d72a8b8a83c66d3f6cada0c8ff1e786d2a88af8b"
 
+  livecheck do
+    url :homepage
+    regex(/Download CommandBox v?(\d+(?:\.\d+)+)/i)
+  end
+
   bottle :unneeded
 
   depends_on "openjdk"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `commandbox`. This PR adds a `livecheck` block that checks the homepage.

Unfortunately, the link to the `stable` archive on the homepage uses a static URL that instead redirects to the latest archive file. As such, we can't identify the version from a link to an archive file (like we normally do in this situation), so the best we can do right now is to identify the version from the text like "Download CommandBox v5.1.1".