### PR TITLE
lha: add livecheck

### DIFF
--- a/Formula/lha.rb
+++ b/Formula/lha.rb
@@ -7,6 +7,16 @@ class Lha < Formula
   sha256 "b5261e9f98538816aa9e64791f23cb83f1632ecda61f02e54b6749e9ca5e9ee4"
   license "MIT"
 
+  # OSDN releases pages use asynchronous requests to fetch the archive
+  # information for each release, rather than including this information in the
+  # page source. As such, we identify versions from the release names instead.
+  # The portion of the regex that captures the version is looser than usual
+  # because the version format is unusual and may change in the future.
+  livecheck do
+    url "https://osdn.net/projects/lha/releases/"
+    regex(%r{href=.*?/projects/lha/releases/[^>]+?>\s*?v?(\d+(?:[.-][\da-z]+)+)}im)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "27d0090517f08c929e062ea580515f38297ac00ff403830bc78c2b85caea0447" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `lha`. This PR adds a `livecheck` block that checks the [OSDN releases page](https://osdn.net/projects/lha/releases/) for the project, which contains links that are somewhat close to the `stable` archive (but not the same links).

Unfortunately, the archive information for each release is loaded asynchronously, so it's not present in the page source. Instead, this check identifies versions from the release names. The regex isn't as strict/straightforward as most checks but it gets the job done. The part that captures the version is looser than usual because the version format is unusual (e.g., `1.14i-ac20050924p1`) and there's always a chance it may change in some way in the future, so we don't want the check to break by being too specific.