### PR TITLE
mytop: add livecheck to skip

### DIFF
--- a/Formula/mytop.rb
+++ b/Formula/mytop.rb
@@ -6,6 +6,10 @@ class Mytop < Formula
   sha256 "179d79459d0013ab9cea2040a41c49a79822162d6e64a7a85f84cdc44828145e"
   revision 8
 
+  livecheck do
+    skip "Upstream is gone and the formula uses archive.org URLs"
+  end
+
   bottle do
     cellar :any
     sha256 "69930f7d5c68b0d6ce75c89820732f269d3b3c6651358875b0db58ae1ead38f0" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `homepage` and `stable` URLs in the `mytop` formula are archive.org URLs and the original upstream source seems to have disappeared. The formula also has a Debian mirror but there's no point in checking that if no new development is occurring for this software.

As such, this adds a `livecheck` block that skips the formula, as there's no point in trying to check for new versions.