### PR TITLE
urlview 0.9-21

### DIFF
--- a/Formula/urlview.rb
+++ b/Formula/urlview.rb
@@ -2,9 +2,17 @@ class Urlview < Formula
   desc "URL extractor/launcher"
   homepage "https://packages.debian.org/sid/misc/urlview"
   url "https://deb.debian.org/debian/pool/main/u/urlview/urlview_0.9.orig.tar.gz"
-  version "0.9-20"
+  version "0.9-21"
   sha256 "746ff540ccf601645f500ee7743f443caf987d6380e61e5249fc15f7a455ed42"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
+
+  # Since this formula incorporates patches and uses a version like `0.9-21`,
+  # this check is open-ended (rather than targeting the .orig.tar.gz file), so
+  # we identify patch versions as well.
+  livecheck do
+    url "https://deb.debian.org/debian/pool/main/u/urlview/"
+    regex(/href=.*?urlview[._-]v?(\d+(?:[.-]\d+)+)/i)
+  end
 
   bottle do
     cellar :any_skip_relocation
@@ -16,8 +24,8 @@ class Urlview < Formula
   end
 
   patch do
-    url "https://deb.debian.org/debian/pool/main/u/urlview/urlview_0.9-20.diff.gz"
-    sha256 "0707956fd7195aefe6d6ff2eaabe8946e3d18821a1ce97c0f48d0f8d6e37514e"
+    url "https://deb.debian.org/debian/pool/main/u/urlview/urlview_0.9-21.diff.gz"
+    sha256 "efdf6a279d123952820dd6185ab9399ee1bf081ea3dd613dc96933cd1827a9e9"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates `urlview` to use the latest patch from Debian.

This also adds a `livecheck` block that checks the Debian directory listing page, using a slightly looser regex than usual to be able to match the version from the diff archive files. This is appropriate for this formula, since it applies the patches and uses a version like `0.9-21`.

Lastly, this updates the `license` from `GPL-2.0` to `GPL-2.0-or-later`, referencing the source files in the `stable` archive, which state:

```
 *     This program is free software; you can redistribute it and/or modify
 *     it under the terms of the GNU General Public License as published by
 *     the Free Software Foundation; either version 2 of the License, or
 *     (at your option) any later version.
 * 
 *     This program is distributed in the hope that it will be useful,
 *     but WITHOUT ANY WARRANTY; without even the implied warranty of
 *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 *     GNU General Public License for more details.
 * 
 *     You should have received a copy of the GNU General Public License
 *     along with this program; if not, write to the Free Software
 *     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
```