### PR TITLE
psutils: add livecheck

### DIFF
--- a/Formula/psutils.rb
+++ b/Formula/psutils.rb
@@ -7,6 +7,17 @@ class Psutils < Formula
   sha256 "3853eb79584ba8fbe27a815425b65a9f7f15b258e0d43a05a856bdb75d588ae4"
   license "psutils"
 
+  # This regex is open-ended (i.e., it doesn't contain a trailing delimiter like
+  # `\.t`), since the homepage only links to an unversioned archive file
+  # (`psutils.tar.gz`) or a versioned archive file with additional trailing text
+  # (`psutils-p17-a4-nt.zip`). Relying on the trailing text of the versioned
+  # archive file remaining the same could make this check liable to break, so
+  # we'll simply leave it looser until/unless it causes a problem.
+  livecheck do
+    url :homepage
+    regex(/href=.*?psutils[._-](p\d+)/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `psutils`. This PR adds a `livecheck` block that checks the homepage where archive files (over FTP) are found.

This regex is open-ended (i.e., it doesn't contain a trailing delimiter like `\.t`), since the homepage only links to an unversioned archive file (`psutils.tar.gz`) or a versioned archive file with additional trailing text (`psutils-p17-a4-nt.zip`). Relying on the trailing text of the versioned archive file remaining the same could make this check liable to break, so we'll simply leave it looser until/unless it causes a problem.