### PR TITLE
Remove livecheck blocks using Google Code Archive

### DIFF
--- a/Formula/mp4v2.rb
+++ b/Formula/mp4v2.rb
@@ -4,11 +4,6 @@ class Mp4v2 < Formula
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mp4v2/mp4v2-2.0.0.tar.bz2"
   sha256 "0319b9a60b667cf10ee0ec7505eb7bdc0a2e21ca7a93db96ec5bd758e3428338"
 
-  livecheck do
-    url "https://www.googleapis.com/download/storage/v1/b/google-code-archive/o/v2%2Fcode.google.com%2Fmp4v2%2Fdownloads-page-1.json?&alt=media"
-    regex(/mp4v2[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     cellar :any
     rebuild 1

--- a/Formula/pssh.rb
+++ b/Formula/pssh.rb
@@ -7,11 +7,6 @@ class Pssh < Formula
   license "BSD-3-Clause"
   revision 3
 
-  livecheck do
-    url "https://www.googleapis.com/download/storage/v1/b/google-code-archive/o/v2%2Fcode.google.com%2Fparallel-ssh%2Fdownloads-page-1.json?&alt=media"
-    regex(/pssh[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     cellar :any_skip_relocation
     rebuild 1

--- a/Formula/reaver.rb
+++ b/Formula/reaver.rb
@@ -5,11 +5,6 @@ class Reaver < Formula
   sha256 "add3050a4a05fe0ab6bfb291ee2de8e9b8a85f1e64ced93ee27a75744954b22d"
   license "GPL-2.0"
 
-  livecheck do
-    url "https://www.googleapis.com/download/storage/v1/b/google-code-archive/o/v2%2Fcode.google.com%2Freaver-wps%2Fdownloads-page-1.json?&alt=media"
-    regex(/reaver[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 "73539f97836b5df80e030e429eb7f209dec3067c14b1bfd6753bcf7796c1f541" => :catalina
     sha256 "386ed8ae2562ae032f0d622d52d7302be2e99bbe671f1ca5ba3acb88b86f6417" => :mojave


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This removes `livecheck` blocks from formulae that use the Google Code Archive for their `stable` archive and `homepage`, as these formulae haven't seen updates and seemingly never will as long as they're archived.

With this in mind, I'm planning to modify livecheck to automatically skip formulae where `stable` and `homepage` are on the Google Code Archive and there's no `head` URL or `livecheck` block. I've already gone through all the related formulae and confirmed that none of them have been updated while in this state, so I think it's safe to automatically skip these (as we do with versioned or deprecated formulae with no `livecheck` block).