### PR TITLE
tiger-vnc: migrate to brewed X11

### DIFF
--- a/Formula/tiger-vnc.rb
+++ b/Formula/tiger-vnc.rb
@@ -5,8 +5,6 @@ class TigerVnc < Formula
   sha256 "3648eca472a92a4e8fe55b27cd397b1bf16bad0b24a3a1988661f44553f5e2c3"
   license "GPL-2.0-or-later"
 
-  revision 1
-
   bottle do
     sha256 "b9a09483c45610c81dd29fc20a41b4fa8120e1353f736bb637732d4788e4bb28" => :catalina
     sha256 "c90bdf1ac012129c5d4caecd3e5acf2d110ca8cd68a8bcff6de07373149424db" => :mojave

--- a/Formula/tiger-vnc.rb
+++ b/Formula/tiger-vnc.rb
@@ -5,6 +5,8 @@ class TigerVnc < Formula
   sha256 "3648eca472a92a4e8fe55b27cd397b1bf16bad0b24a3a1988661f44553f5e2c3"
   license "GPL-2.0-or-later"
 
+  revision 1
+
   bottle do
     sha256 "b9a09483c45610c81dd29fc20a41b4fa8120e1353f736bb637732d4788e4bb28" => :catalina
     sha256 "c90bdf1ac012129c5d4caecd3e5acf2d110ca8cd68a8bcff6de07373149424db" => :mojave
@@ -17,7 +19,20 @@ class TigerVnc < Formula
   depends_on "gnutls"
   depends_on "jpeg-turbo"
   depends_on "pixman"
-  depends_on :x11
+
+  on_linux do
+    depends_on "libx11"
+    depends_on "libxcursor"
+    depends_on "libxdamage"
+    depends_on "libxext"
+    depends_on "libxfixes"
+    depends_on "libxft"
+    depends_on "libxi"
+    depends_on "libxinerama"
+    depends_on "libxrandr"
+    depends_on "libxrender"
+    depends_on "libxtst"
+  end
 
   def install
     turbo = Formula["jpeg-turbo"]


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Part of #64166

x11 is used on Linux and now we have there:

```
$ brew linkage tiger-vnc 
System libraries:
  /usr/lib/libc.so.6
  /usr/lib/libm.so.6
  /usr/lib/libpam.so.0
  /usr/lib/libpthread.so.0
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/lib/libfltk.so.1.3 (fltk)
  /home/linuxbrew/.linuxbrew/lib/libfltk_images.so.1.3 (fltk)
  /home/linuxbrew/.linuxbrew/lib/libfontconfig.so.1 (fontconfig)
  /home/linuxbrew/.linuxbrew/lib/libgcc_s.so.1 (gcc)
  /home/linuxbrew/.linuxbrew/lib/libstdc++.so.6 (gcc)
  /home/linuxbrew/.linuxbrew/lib/libgnutls.so.30 (gnutls)
  /home/linuxbrew/.linuxbrew/opt/jpeg-turbo/lib/libjpeg.so.8 (jpeg-turbo)
  /home/linuxbrew/.linuxbrew/lib/libICE.so.6 (libice)
  /home/linuxbrew/.linuxbrew/lib/libSM.so.6 (libsm)
  /home/linuxbrew/.linuxbrew/lib/libX11.so.6 (libx11)
  /home/linuxbrew/.linuxbrew/lib/libXcursor.so.1 (libxcursor)
  /home/linuxbrew/.linuxbrew/lib/libXdamage.so.1 (libxdamage)
  /home/linuxbrew/.linuxbrew/lib/libXext.so.6 (libxext)
  /home/linuxbrew/.linuxbrew/lib/libXfixes.so.3 (libxfixes)
  /home/linuxbrew/.linuxbrew/lib/libXft.so.2 (libxft)
  /home/linuxbrew/.linuxbrew/lib/libXi.so.6 (libxi)
  /home/linuxbrew/.linuxbrew/lib/libXinerama.so.1 (libxinerama)
  /home/linuxbrew/.linuxbrew/lib/libXrandr.so.2 (libxrandr)
  /home/linuxbrew/.linuxbrew/lib/libXrender.so.1 (libxrender)
  /home/linuxbrew/.linuxbrew/lib/libXtst.so.6 (libxtst)
  /home/linuxbrew/.linuxbrew/lib/libpixman-1.so.0 (pixman)
  /home/linuxbrew/.linuxbrew/lib/libz.so.1 (zlib)
Indirect dependencies with linkage:
  fontconfig
  gcc
  libice
  libsm
  libx11
  libxdamage
  libxext
  libxfixes
  libxft
  libxrandr
  libxrender
  zlib
Undeclared dependencies with linkage:
  libxcursor
  libxi
  libxinerama
  libxtst
Unwanted system libraries:
  /usr/lib/libpam.so.0
```

A separate PR will be sent to linuxbrew to address hardcoded platform-specific shared/dynamic library extension, i.e. `dylib`.
