### PR TITLE
lv2: add livecheck

### DIFF
--- a/Formula/lv2.rb
+++ b/Formula/lv2.rb
@@ -4,6 +4,11 @@ class Lv2 < Formula
   url "https://lv2plug.in/spec/lv2-1.18.0.tar.bz2"
   sha256 "90a3e5cf8bdca81b49def917e89fd6bba1d5845261642cd54e7888df0320473f"
 
+  livecheck do
+    url "https://lv2plug.in/spec/"
+    regex(/href=.*?lv2[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "6cafb26479b24f5b6746557359b665d03bc42dd47ee7acea5a9c0b742c23936e" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `lv2`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.