### PR TITLE
cf: add livecheck

### DIFF
--- a/Formula/cf.rb
+++ b/Formula/cf.rb
@@ -4,6 +4,11 @@ class Cf < Formula
   url "https://ee.lbl.gov/downloads/cf/cf-1.2.5.tar.gz"
   sha256 "ef65e9eb57c56456dfd897fec12da8617c775e986c23c0b9cbfab173b34e5509"
 
+  livecheck do
+    url "https://ee.lbl.gov/downloads/cf/"
+    regex(/href=.*?cf[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "14a240b51f627599ebd4cbbffc27c52d40790c6537f91f20d978d6054e62571b" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `cf`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.