### PR TITLE
rdesktop: migrate to brewed X11

### DIFF
--- a/Formula/rdesktop.rb
+++ b/Formula/rdesktop.rb
@@ -1,10 +1,12 @@
 class Rdesktop < Formula
   desc "UNIX client for connecting to Windows Remote Desktop Services"
-  homepage "https://www.rdesktop.org/"
+  homepage "https://github.com/rdesktop/rdesktop"
   url "https://github.com/rdesktop/rdesktop/releases/download/v1.9.0/rdesktop-1.9.0.tar.gz"
   sha256 "473c2f312391379960efe41caad37852c59312bc8f100f9b5f26609ab5704288"
   license "GPL-3.0-or-later"
   revision 2
+
+  deprecate! because: :unmaintained
 
   bottle do
     sha256 "4b504df078255fec4d85c94f9a815eb26e55cec1cd38ebf2755ead4d0bcda3be" => :catalina

--- a/Formula/rdesktop.rb
+++ b/Formula/rdesktop.rb
@@ -3,8 +3,8 @@ class Rdesktop < Formula
   homepage "https://www.rdesktop.org/"
   url "https://github.com/rdesktop/rdesktop/releases/download/v1.9.0/rdesktop-1.9.0.tar.gz"
   sha256 "473c2f312391379960efe41caad37852c59312bc8f100f9b5f26609ab5704288"
-  license "GPL-3.0"
-  revision 1
+  license "GPL-3.0-or-later"
+  revision 2
 
   bottle do
     sha256 "4b504df078255fec4d85c94f9a815eb26e55cec1cd38ebf2755ead4d0bcda3be" => :catalina
@@ -16,8 +16,10 @@ class Rdesktop < Formula
   depends_on "gnutls"
   depends_on "libao"
   depends_on "libtasn1"
+  depends_on "libx11"
+  depends_on "libxcursor"
+  depends_on "libxrandr"
   depends_on "nettle"
-  depends_on :x11
 
   def install
     args = %W[
@@ -25,8 +27,6 @@ class Rdesktop < Formula
       --disable-credssp
       --enable-smartcard
       --with-sound=libao
-      --x-includes=#{MacOS::XQuartz.include}
-      --x-libraries=#{MacOS::XQuartz.lib}
     ]
 
     system "./configure", *args


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Part of #64166

Before:

```
$ brew linkage rdesktop                                           
System libraries:
  /System/Library/Frameworks/PCSC.framework/Versions/A/PCSC
  /opt/X11/lib/libX11.6.dylib
  /opt/X11/lib/libXcursor.1.dylib
  /opt/X11/lib/libXrandr.2.dylib
  /usr/lib/libSystem.B.dylib
  /usr/lib/libiconv.2.dylib
Homebrew libraries:
  /usr/local/opt/gmp/lib/libgmp.10.dylib (gmp)
  /usr/local/opt/gnutls/lib/libgnutls.30.dylib (gnutls)
  /usr/local/opt/libao/lib/libao.4.dylib (libao)
  /usr/local/opt/libtasn1/lib/libtasn1.6.dylib (libtasn1)
  /usr/local/opt/nettle/lib/libhogweed.6.dylib (nettle)
  /usr/local/opt/nettle/lib/libnettle.8.dylib (nettle)
Indirect dependencies with linkage:
  gmp
```

After:

```
brew linkage rdesktop    
System libraries:
  /System/Library/Frameworks/PCSC.framework/Versions/A/PCSC
  /usr/lib/libSystem.B.dylib
  /usr/lib/libiconv.2.dylib
Homebrew libraries:
  /usr/local/opt/gmp/lib/libgmp.10.dylib (gmp)
  /usr/local/opt/gnutls/lib/libgnutls.30.dylib (gnutls)
  /usr/local/opt/libao/lib/libao.4.dylib (libao)
  /usr/local/opt/libtasn1/lib/libtasn1.6.dylib (libtasn1)
  /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
  /usr/local/opt/libxcursor/lib/libXcursor.1.dylib (libxcursor)
  /usr/local/opt/libxrandr/lib/libXrandr.2.dylib (libxrandr)
  /usr/local/opt/nettle/lib/libhogweed.6.dylib (nettle)
  /usr/local/opt/nettle/lib/libnettle.8.dylib (nettle)
Indirect dependencies with linkage:
  gmp
```
