### PR TITLE
hyperkit: x11 isn't needed

### DIFF
--- a/Formula/hyperkit.rb
+++ b/Formula/hyperkit.rb
@@ -4,6 +4,7 @@ class Hyperkit < Formula
   url "https://github.com/moby/hyperkit/archive/v0.20200908.tar.gz"
   sha256 "e13bdb9dc5c18ca59ae6cd2b447d704d8d58f27cf4ae5a1f0a026deeb13bd0d7"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -15,7 +16,6 @@ class Hyperkit < Formula
   depends_on "aspcud" => :build
   depends_on "ocaml" => :build
   depends_on "opam" => :build
-  depends_on x11: :build
   depends_on xcode: ["9.0", :build]
 
   depends_on "libev"

--- a/Formula/hyperkit.rb
+++ b/Formula/hyperkit.rb
@@ -4,7 +4,6 @@ class Hyperkit < Formula
   url "https://github.com/moby/hyperkit/archive/v0.20200908.tar.gz"
   sha256 "e13bdb9dc5c18ca59ae6cd2b447d704d8d58f27cf4ae5a1f0a026deeb13bd0d7"
   license "BSD-2-Clause"
-  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Part of #64166