### PR TITLE
runit: add livecheck

### DIFF
--- a/Formula/runit.rb
+++ b/Formula/runit.rb
@@ -4,6 +4,11 @@ class Runit < Formula
   url "http://smarden.org/runit/runit-2.1.2.tar.gz"
   sha256 "6fd0160cb0cf1207de4e66754b6d39750cff14bb0aa66ab49490992c0c47ba18"
 
+  livecheck do
+    url "http://smarden.org/runit/install.html"
+    regex(/href=.*?runit[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `runit`. This PR adds a `livecheck` block that checks the "Install" page on the first-party website, which links to the `stable` archive.