### PR TITLE
geomview: migrate to brewed X11

### DIFF
--- a/Formula/geomview.rb
+++ b/Formula/geomview.rb
@@ -4,7 +4,8 @@ class Geomview < Formula
   url "https://deb.debian.org/debian/pool/main/g/geomview/geomview_1.9.5.orig.tar.gz"
   mirror "https://downloads.sourceforge.net/project/geomview/geomview/1.9.5/geomview-1.9.5.tar.gz"
   sha256 "67edb3005a22ed2bf06f0790303ee3f523011ba069c10db8aef263ac1a1b02c0"
-  revision 1
+  license "LGPL-2.1-only"
+  revision 2
 
   livecheck do
     url "https://deb.debian.org/debian/pool/main/g/geomview/"
@@ -20,8 +21,15 @@ class Geomview < Formula
     sha256 "edc57089dc5ba7f2e7ec43c66202f19c460c4a1970f9c60984c0f3fe6c481012" => :yosemite
   end
 
+  depends_on "libice"
+  depends_on "libsm"
+  depends_on "libx11"
+  depends_on "libxext"
+  depends_on "libxmu"
+  depends_on "libxt"
+  depends_on "mesa"
+  depends_on "mesa-glu"
   depends_on "openmotif"
-  depends_on :x11
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -32,6 +40,6 @@ class Geomview < Formula
   end
 
   test do
-    system "#{bin}/geomview", "--version"
+    assert_match "Error: Can't open display:", shell_output("DISPLAY= #{bin}/geomview 2>&1", 1)
   end
 end


### PR DESCRIPTION
Also added license and proper (though still basic) test. Supports #64166.

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz
-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
