### PR TITLE
libxp: add livecheck

### DIFF
--- a/Formula/libxp.rb
+++ b/Formula/libxp.rb
@@ -5,6 +5,11 @@ class Libxp < Formula
   sha256 "bd1e449572359921dd5fa20707757f57d7535aff1772570ab2c29c6b49b86266"
   license "MIT"
 
+  livecheck do
+    url :stable
+    regex(/^libXp[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any
     sha256 "e70342d93c5cf690582f559318b05b26da9175fc7620493fa15a224a847ec1da" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `libxp` but it's reporting `20040421_xprint_branch_landing` as newest, due to a `before_20040421_xprint_branch_landing` tag. `libxp` tags are instead like `libXp-1.0.3`.

This PR resolves the issue by adding a `livecheck` block that uses a version of the standard regex for Git tags like `1.2.3`/`v1.2.3`/etc. The regex has been modified to account for the `libXp` prefix, so we only match those tags.