### PR TITLE
memtester: add livecheck

### DIFF
--- a/Formula/memtester.rb
+++ b/Formula/memtester.rb
@@ -5,6 +5,13 @@ class Memtester < Formula
   sha256 "8ed52b0d06d4aeb61954994146e2a5b2d20448a8f3ce3ee995120e6dbde2ae37"
   license "GPL-2.0-only"
 
+  # Despite the name, all the versions are seemingly found on this page. If this
+  # doesn't end up being true over time, we can check the homepage instead.
+  livecheck do
+    url "http://pyropus.ca/software/memtester/old-versions/"
+    regex(/href=.*?memtester[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "3a076907f16eea276860af92f2ce27ac3ffa5f7ddb6b107bcd0767a4d2ae8f9e" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `memtester`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.

This directory is named "old-versions" but it includes the latest version and the link to the file on the homepage references the tarball in this "old-versions" directory. With this in mind, I think it's fine to check for new versions on the directory listing page rather than the homepage. If this becomes a problem in the future, we can always modify the `livecheck` block to check the homepage instead.