### PR TITLE
app-engine-java 1.9.83, migrate to openjdk@8, deprecate

### DIFF
--- a/Formula/app-engine-java.rb
+++ b/Formula/app-engine-java.rb
@@ -1,12 +1,25 @@
 class AppEngineJava < Formula
   desc "Google App Engine for Java"
   homepage "https://cloud.google.com/appengine/docs/java/"
-  url "https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.72.zip"
-  sha256 "66af92c909c0403730aba7c4b9fbdc6d7ceb0f5310e7c2f1a653622dfa76c6fb"
+  url "https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.83.zip"
+  sha256 "1d585a36303c14f4fa44790bba97d5d8b75a889ad48ffce8187333488511e43e"
+
+  # https://cloud.google.com/appengine/docs/standard/java/sdk-gcloud-migration
+  deprecate! date: "2019-07-30", because: :deprecated_upstream
+
+  # This has received at least one update after the supposed end of life date
+  # (2020-08-30), so there may be value in keeping this check around for a
+  # little while longer. Once it's clear this won't receive any more updates,
+  # this `livecheck` block should be removed, so the formula is skipped due to
+  # being deprecated.
+  livecheck do
+    url "https://cloud.google.com/appengine/docs/standard/java/setting-up-environment"
+    regex(/href=.*?appengine-java-sdk[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
 
   bottle :unneeded
 
-  depends_on java: "1.8"
+  depends_on "openjdk@8"
 
   def install
     rm Dir["bin/*.cmd"]
@@ -16,7 +29,7 @@ class AppEngineJava < Formula
       bin.install libexec/"bin/#{f}"
     end
 
-    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
+    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Formula["openjdk@8"].opt_prefix)
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR is primarily intended to migrate the `app-engine-java` formula to `openjdk@8`. Besides that, this tries to update the formula to the latest version. I saw that past attempts to update this formula didn't move forward due to a test failure, so let's see how it goes this time around.

This also deprecates the formula, as [the standalone App Engine SDK is deprecated](https://cloud.google.com/appengine/docs/standard/java/sdk-gcloud-migration) in favor of Cloud SDK. The deprecation took effect on 2019-07-30 and the App Engine SDK was supposed to become unavailable for download on 2020-08-30 but that may not have happened because the latest version (1.9.83) was seemingly published after that date (if the date on third-party directory listing pages is any indicator).

With that in mind, I've added a `livecheck` block so we can continue checking for new versions until they really stop. Once we haven't seen a new version in a while, we can simply remove the `livecheck` block and this formula will be automatically skipped due to the deprecation.