### PR TITLE
aws-apigateway-importer: deprecate

### DIFF
--- a/Formula/aws-apigateway-importer.rb
+++ b/Formula/aws-apigateway-importer.rb
@@ -6,6 +6,8 @@ class AwsApigatewayImporter < Formula
   license "Apache-2.0"
   revision 1
 
+  deprecate! because: :repo_archived
+
   bottle do
     cellar :any_skip_relocation
     sha256 "3a837a89af7bfd9454b2e12924323e82ab6cb6ab09f4088e47b672a6a79aedd2" => :catalina

--- a/Formula/aws-apigateway-importer.rb
+++ b/Formula/aws-apigateway-importer.rb
@@ -19,7 +19,7 @@ class AwsApigatewayImporter < Formula
   end
 
   depends_on "maven" => :build
-  depends_on java: "1.8"
+  depends_on "openjdk@8"
 
   # Pin aws-sdk-java-core for JSONObject compatibility
   patch do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [upstream GitHub repository for `aws-apigateway-importer`](https://github.com/amazon-archives/aws-apigateway-importer/) has been archived, so this deprecates it with `deprecate! because: :repo_archived`.

I tried to migrate this formula to `openjdk@8` (in relation to #63290) but there were some tests that are run as part of the build that have errors and prevent it from working.