### PR TITLE
blazegraph: update stable, migrate to openjdk@8

### DIFF
--- a/Formula/blazegraph.rb
+++ b/Formula/blazegraph.rb
@@ -1,18 +1,19 @@
 class Blazegraph < Formula
   desc "Graph database supporting RDF data model, Sesame, and Blueprint APIs"
   homepage "https://www.blazegraph.com/"
-  url "https://downloads.sourceforge.net/project/bigdata/bigdata/2.1.5/blazegraph.jar"
+  url "https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_RELEASE_2_1_5/blazegraph.jar"
+  version "2.1.5"
   sha256 "fbaeae7e1b3af71f57cfc4da58b9c52a9ae40502d431c76bafa5d5570d737610"
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/v?(\d+(?:\.\d+)+)/blazegraph\.jar}i)
+    regex(/^BLAZEGRAPH(?:_RELEASE)?[._-]v?(\d+(?:[._]\d+)+)$/i)
   end
 
   bottle :unneeded
 
   # dependnecy can be lifted in the upcoming release, > 2.1.5
-  depends_on java: "1.8"
+  depends_on "openjdk@8"
 
   def install
     libexec.install "blazegraph.jar"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [previous SourceForge project for `blazegraph`](https://sourceforge.net/projects/bigdata/) has a link that says "As of 2020-02-06, this project can be found here." and points to [the project on GitHub](https://github.com/blazegraph/database/). This updates the `stable` URL to use `blazegraph.jar` from the latest stable release (2.1.5) on GitHub, which has the same `sha256`. It was necessary to specify the `version` because it isn't parsed properly from the URL.

This also updates the `livecheck` block to work properly with the new `stable` source. In this case, the GitHub repository has a "latest" release but it's pointing to a release candidate (instead of 2.1.5), so it's not correct. As a result, we're simply checking the Git tags for now.

Lastly, this migrates the formula to `openjdk@8`, in relation to #63290. As the comment in the formula hints at and the [release notes for the 2.1.6 RC mention](https://github.com/blazegraph/database/releases/tag/BLAZEGRAPH_2_1_6_RC), version 2.1.6 will support Java 9+.