### PR TITLE
z80dasm: add livecheck

### DIFF
--- a/Formula/z80dasm.rb
+++ b/Formula/z80dasm.rb
@@ -5,6 +5,11 @@ class Z80dasm < Formula
   sha256 "76d3967bb028f380a0c4db704a894c2aa939951faa5c5630b3355c327c0bd360"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://www.tablix.org/~avian/z80dasm"
+    regex(/href=.*?z80dasm[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "5012e33c0fc342ec32a22462f9a75897fd69d44cf2918c64a593d268fa365c86" => :catalina


### PR DESCRIPTION
```sh
$ brew livecheck z80dasm --debug
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/z80dasm.rb

Formula:          z80dasm
Livecheckable?:   Yes

URL:              https://www.tablix.org/~avian/z80dasm
Strategy:         PageMatch
Regex:            /href=.*?z80dasm[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i

Matched Versions:
1.0.0, 1.0.1, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 1.1.6
z80dasm : 1.1.6 ==> 1.1.6
```
