### PR TITLE
sng: migrate to brewed X11

### DIFF
--- a/Formula/sng.rb
+++ b/Formula/sng.rb
@@ -3,6 +3,8 @@ class Sng < Formula
   homepage "https://sng.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sng/sng-1.1.0.tar.gz"
   sha256 "119c55870c1d1bdc65f7de9dbc62929ccb0c301c2fb79f77df63f5d477f34619"
+  license "Zlib"
+  revision 1
 
   livecheck do
     url :stable
@@ -17,7 +19,7 @@ class Sng < Formula
   end
 
   depends_on "libpng"
-  depends_on :x11
+  depends_on "xorgrgb"
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
Also added license. Supports #64166.

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz
---
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
