### PR TITLE
folderify 2.0.0

### DIFF
--- a/Formula/folderify.rb
+++ b/Formula/folderify.rb
@@ -1,14 +1,19 @@
 class Folderify < Formula
   include Language::Python::Virtualenv
 
-  desc "Generate pretty, beveled macOS folder icons"
+  desc "Generate pixel-perfect macOS folder icons in the native style"
   homepage "https://github.com/lgarron/folderify"
-  url "https://github.com/lgarron/folderify/archive/v1.2.3.tar.gz"
-  sha256 "3a9eaadf1f2a9dde3ab58bb07ea5b1a5f5a182f62fe19e2cd79a88f6abe00f7e"
+  url "https://github.com/lgarron/folderify.git",
+    tag:      "v2.0.0",
+    revision: "84374fc7394f41035c07b9a7b37dd59d26747836"
   license "MIT"
-  revision 1
   # Default branch is "main" not "master"
   head "https://github.com/lgarron/folderify.git", branch: "main"
+
+  livecheck do
+    url :head
+    regex(/^v\d+\.\d+\.\d+$/i)
+  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
v2.0.0 includes support for the new folder icons in macOS 11.0 Big Sur.

![explanation](https://user-images.githubusercontent.com/248078/98924462-b45c4f00-2489-11eb-9cea-9fa16ccbd16b.png)

This PR also updates the description to match the project, and adds a livecheck based on the exact semantic versioning format used by releases: https://github.com/lgarron/folderify/releases

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
