### PR TITLE
diff-pdf: remove X11 dependency, add proper test

### DIFF
--- a/Formula/diff-pdf.rb
+++ b/Formula/diff-pdf.rb
@@ -19,7 +19,6 @@ class DiffPdf < Formula
   depends_on "cairo"
   depends_on "poppler"
   depends_on "wxmac"
-  depends_on :x11
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -30,6 +29,8 @@ class DiffPdf < Formula
   end
 
   test do
-    system "#{bin}/diff-pdf", "-h"
+    testpdf = test_fixtures("test.pdf")
+    system "#{bin}/diff-pdf", "--output-diff=no_diff.pdf", testpdf, testpdf
+    assert (testpath/"no_diff.pdf").file?
   end
 end


### PR DESCRIPTION
`brew linkage diff-pdf` showed no X11 linkages, and `diff-pdf --view a.pdf a.pdf` opened an app window but did not start XQuartz. Therefore:
* removed `depends_on :x11`
* added a proper test case
* no `revision` bump

Supports #64166.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
