### PR TITLE
x264: rebuild with correct commit SHA

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -6,7 +6,7 @@ class Ffmpeg < Formula
   # None of these parts are used by default, you have to explicitly pass `--enable-gpl`
   # to configure to activate them. In this case, FFmpeg's license changes to GPL v2+.
   license "GPL-2.0-or-later"
-  revision 3
+  revision 4
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   livecheck do

--- a/Formula/ffmpeg@2.8.rb
+++ b/Formula/ffmpeg@2.8.rb
@@ -6,7 +6,7 @@ class FfmpegAT28 < Formula
   # None of these parts are used by default, you have to explicitly pass `--enable-gpl`
   # to configure to activate them. In this case, FFmpeg's license changes to GPL v2+.
   license "GPL-2.0"
-  revision 2
+  revision 3
 
   livecheck do
     url "https://ffmpeg.org/download.html"

--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -4,7 +4,7 @@ class Libav < Formula
   url "https://libav.org/releases/libav-12.3.tar.xz"
   sha256 "6893cdbd7bc4b62f5d8fd6593c8e0a62babb53e323fbc7124db3658d04ab443b"
   license "GPL-2.0"
-  revision 6
+  revision 7
   head "https://git.libav.org/libav.git"
 
   livecheck do

--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -1,13 +1,14 @@
 class X264 < Formula
   desc "H.264/AVC encoder"
   homepage "https://www.videolan.org/developers/x264.html"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
+  revision 1
   head "https://code.videolan.org/videolan/x264.git"
 
   stable do
     # the latest commit on the stable branch
     url "https://code.videolan.org/videolan/x264.git",
-        revision: "98ee9d2f215326feeb221a4434957fa586d55c18"
+        revision: "4121277b40a667665d4eea1726aefdc55d12d110"
     version "r3027"
   end
 
@@ -35,19 +36,7 @@ class X264 < Formula
     fails_with :clang
   end
 
-  # update config.* and configure: add Apple Silicon support.
-  # upstream PR https://code.videolan.org/videolan/x264/-/merge_requests/35
-  # Can be removed once it gets merged into stable branch
-  patch do
-    url "https://code.videolan.org/videolan/x264/-/commit/eb95c2965299ba5b8598e2388d71b02e23c9fba7.diff?full_index=1"
-    sha256 "7cdc60cffa8f3004837ba0c63c8422fbadaf96ccedb41e505607ead2691d49b9"
-  end
-
   def install
-    # Work around Xcode 11 clang bug
-    # https://bitbucket.org/multicoreware/x265/issues/514/wrong-code-generated-on-macos-1015
-    ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
-
     args = %W[
       --prefix=#{prefix}
       --disable-lsmash
@@ -63,6 +52,7 @@ class X264 < Formula
   end
 
   test do
+    assert_match version.to_s.delete("r"), shell_output("#{bin}/x264 --version").lines.first
     (testpath/"test.c").write <<~EOS
       #include <stdint.h>
       #include <x264.h>


### PR DESCRIPTION
The original commit SHA (#64198) was for r2971. Also fixed license and removed patch that has been merged upstream (https://code.videolan.org/videolan/x264/-/merge_requests/35). Closes #64650.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
