### PR TITLE
Deprecate formulae that depend on a Java 1.8 Requirement.

### DIFF
--- a/Formula/drip.rb
+++ b/Formula/drip.rb
@@ -16,11 +16,24 @@ class Drip < Formula
     sha256 "69207c24aa1f8e6ba406e6cc3f811cd7000ee14c713cc32b49d72f2c76a702bc" => :mavericks
   end
 
+  deprecate! because: :does_not_build
+
   depends_on java: "1.8"
 
   def install
     system "make"
     libexec.install %w[bin src Makefile]
     bin.install_symlink libexec/"bin/drip"
+  end
+
+  test do
+    (testpath/"Test.java").write <<~EOS
+      public class Test {
+        public static void main (String[] args) {
+          System.out.println("Homebrew");
+        }
+      }
+    EOS
+    assert_match "Homebrew", shell_output("#{bin}/drip Test.java")
   end
 end

--- a/Formula/druid.rb
+++ b/Formula/druid.rb
@@ -11,6 +11,8 @@ class Druid < Formula
 
   bottle :unneeded
 
+  deprecate! because: :does_not_build
+
   depends_on java: "1.8"
   depends_on "zookeeper"
 

--- a/Formula/groovyserv.rb
+++ b/Formula/groovyserv.rb
@@ -17,6 +17,8 @@ class Groovyserv < Formula
     sha256 "51aef6e15608021ae127aaa93e2aa39bfaf52cfea688b45841d315b6a04b55aa" => :el_capitan
   end
 
+  deprecate! because: :does_not_build
+
   depends_on "go" => :build
   depends_on "groovy"
   depends_on java: "1.8"

--- a/Formula/henplus.rb
+++ b/Formula/henplus.rb
@@ -17,6 +17,8 @@ class Henplus < Formula
     sha256 "21f7ee166b94b30dd78cee8a6757fecd285544b8b12b332db9141e6a94eb29a7" => :mavericks
   end
 
+  deprecate! because: :does_not_build
+
   depends_on "ant" => :build
   depends_on java: "1.8"
   depends_on "libreadline-java"

--- a/Formula/infer.rb
+++ b/Formula/infer.rb
@@ -6,6 +6,7 @@ class Infer < Formula
       tag:      "v0.17.0",
       revision: "99464c01da5809e7159ed1a75ef10f60d34506a4"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable
@@ -19,6 +20,8 @@ class Infer < Formula
     sha256 "74b2dddff2bea362066395e28a797078d33514774511cc64771d0f89eea2466d" => :mojave
     sha256 "7630571f8e391ce0ba991ffe7a5d7b2b4a1029cda1d56497800d8ae0a260d4b6" => :high_sierra
   end
+
+  deprecate! because: :does_not_build
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/jooby-bootstrap.rb
+++ b/Formula/jooby-bootstrap.rb
@@ -8,6 +8,8 @@ class JoobyBootstrap < Formula
 
   bottle :unneeded
 
+  deprecate! because: :unmaintained
+
   depends_on java: "1.8"
   depends_on "maven"
 

--- a/Formula/nailgun.rb
+++ b/Formula/nailgun.rb
@@ -13,6 +13,8 @@ class Nailgun < Formula
     sha256 "7f5d7051e631b174fd1d7d0c0aea2b957d3b4946e2176828ec687baddaaa4e04" => :high_sierra
   end
 
+  deprecate! because: :does_not_build
+
   depends_on "maven" => :build
   depends_on java: "1.8"
 

--- a/Formula/opentsdb.rb
+++ b/Formula/opentsdb.rb
@@ -17,6 +17,8 @@ class Opentsdb < Formula
     sha256 "5bcdc828069e124c16e1e6c8b2eb6732d0ef88533c27f60fcbb0bec369aca375" => :high_sierra
   end
 
+  deprecate! because: :does_not_build
+
   depends_on "gnuplot"
   depends_on "hbase"
   depends_on java: "1.8"

--- a/Formula/yeti.rb
+++ b/Formula/yeti.rb
@@ -4,6 +4,7 @@ class Yeti < Formula
   url "https://github.com/mth/yeti/archive/v1.0.tar.gz"
   sha256 "f1451a7c58cecaee41c46e886eb714a81e0dfe5557c10568421dcbd33ab9357c"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/mth/yeti.git"
 
   bottle do
@@ -12,6 +13,8 @@ class Yeti < Formula
     sha256 "9dffa6798409e7d40acf301547dc8508547331922eaa1b7365a0b04e020ae90f" => :mojave
     sha256 "1c49573337d0ca872a060038e3c7e5496d02b025e442c062314d98a786ab708a" => :high_sierra
   end
+
+  deprecate! because: :does_not_build
 
   depends_on "ant" => :build
   depends_on java: "1.8"


### PR DESCRIPTION
Rebottle these formula for `openjdk@8`. Part of #63290.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----