### PR TITLE
rmlint 2.10.1

### DIFF
--- a/Formula/rmlint.rb
+++ b/Formula/rmlint.rb
@@ -1,9 +1,9 @@
 class Rmlint < Formula
   desc "Extremely fast tool to remove dupes and other lint from your filesystem"
   homepage "https://github.com/sahib/rmlint"
-  url "https://github.com/sahib/rmlint/archive/v2.9.0.tar.gz"
-  sha256 "a2d26863e0018efad60f0b1123e7cffd8ef764c8fb574a7987a49260e4e51c8f"
-  license "GPL-3.0"
+  url "https://github.com/sahib/rmlint/archive/v2.10.1.tar.gz"
+  sha256 "10e72ba4dd9672d1b6519c0c94eae647c5069c7d11f1409a46e7011dd0c6b883"
+  license "GPL-3.0-or-later"
 
   bottle do
     cellar :any
@@ -22,6 +22,16 @@ class Rmlint < Formula
   depends_on "libelf"
 
   def install
+    # patch to address bug affecting High Sierra & Mojave introduced in rmlint v2.10.0
+    # may be removed once the following issue / pull request are resolved & merged:
+    #   https://github.com/sahib/rmlint/issues/438
+    #   https://github.com/sahib/rmlint/pull/444
+    if MacOS.version < :catalina
+      inreplace "lib/cfg.c",
+      "    rc = faccessat(AT_FDCWD, path, R_OK, AT_EACCESS|AT_SYMLINK_NOFOLLOW);",
+      "    rc = faccessat(AT_FDCWD, path, R_OK, AT_EACCESS);"
+    end
+
     system "scons", "config"
     system "scons"
     bin.install "rmlint"


### PR DESCRIPTION
* bump version to 2.10.1
* patch lib/cfg.c on Mojave & High Sierra to fix bug introduced in
    rmlint v 2.10.0
* update license

Reference:
* https://github.com/sahib/rmlint/issues/438
* https://github.com/sahib/rmlint/pull/444
* https://github.com/Homebrew/homebrew-core/pull/58249
* https://github.com/Homebrew/homebrew-core/pull/61404

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This should get `rmlint` working on High Sierra & Mojave until the upstream [issue](https://github.com/sahib/rmlint/issues/438) introduced in `2.10.0` is [patched](https://github.com/sahib/rmlint/pull/444).