### PR TITLE
fox: migrate to brewed X11

### DIFF
--- a/Formula/fox.rb
+++ b/Formula/fox.rb
@@ -4,7 +4,7 @@ class Fox < Formula
   url "http://fox-toolkit.org/ftp/fox-1.6.56.tar.gz"
   sha256 "c517e5fcac0e6b78ca003cc167db4f79d89e230e5085334253e1d3f544586cb2"
   license "LGPL-2.1-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "http://www.fox-toolkit.org/news.html"
@@ -25,9 +25,20 @@ class Fox < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on :x11
+  depends_on "libx11"
+  depends_on "libxcursor"
+  depends_on "libxext"
+  depends_on "libxfixes"
+  depends_on "libxft"
+  depends_on "libxi"
+  depends_on "libxrandr"
+  depends_on "libxrender"
+  depends_on "mesa"
+  depends_on "mesa-glu"
 
   def install
+    # Needed for libxft to find ftbuild2.h provided by freetype
+    ENV.append "CPPFLAGS", "-I#{Formula["freetype"].opt_include}/freetype2"
     system "./configure", "--disable-dependency-tracking",
                           "--enable-release",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
Tracking issue: #64166

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz

-----

Before:

    ❯ brew linkage fox #before
    System libraries:
      /opt/X11/lib/libGL.1.dylib
      /opt/X11/lib/libGLU.1.dylib
      /opt/X11/lib/libX11.6.dylib
      /opt/X11/lib/libXcursor.1.dylib
      /opt/X11/lib/libXext.6.dylib
      /opt/X11/lib/libXfixes.3.dylib
      /opt/X11/lib/libXft.2.dylib
      /opt/X11/lib/libXi.6.dylib
      /opt/X11/lib/libXrandr.2.dylib
      /opt/X11/lib/libXrender.1.dylib
      /usr/lib/libSystem.B.dylib
      /usr/lib/libbz2.1.0.dylib
      /usr/lib/libc++.1.dylib
      /usr/lib/libz.1.dylib
    Homebrew libraries:
      /usr/local/opt/fontconfig/lib/libfontconfig.1.dylib (fontconfig)
      /usr/local/Cellar/fox/1.6.56_1/lib/libFOX-1.6.0.dylib (fox)
      /usr/local/opt/freetype/lib/libfreetype.6.dylib (freetype)
      /usr/local/opt/jpeg/lib/libjpeg.9.dylib (jpeg)
      /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
      /usr/local/opt/libtiff/lib/libtiff.5.dylib (libtiff)

After:

    ❯ brew linkage fox
    System libraries:
      /usr/lib/libSystem.B.dylib
      /usr/lib/libbz2.1.0.dylib
      /usr/lib/libc++.1.dylib
      /usr/lib/libz.1.dylib
    Homebrew libraries:
      /usr/local/opt/fontconfig/lib/libfontconfig.1.dylib (fontconfig)
      /usr/local/Cellar/fox/1.6.56_2/lib/libFOX-1.6.0.dylib (fox)
      /usr/local/opt/freetype/lib/libfreetype.6.dylib (freetype)
      /usr/local/opt/jpeg/lib/libjpeg.9.dylib (jpeg)
      /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
      /usr/local/opt/libtiff/lib/libtiff.5.dylib (libtiff)
      /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
      /usr/local/opt/libxcursor/lib/libXcursor.1.dylib (libxcursor)
      /usr/local/opt/libxext/lib/libXext.6.dylib (libxext)
      /usr/local/opt/libxfixes/lib/libXfixes.3.dylib (libxfixes)
      /usr/local/opt/libxft/lib/libXft.2.dylib (libxft)
      /usr/local/opt/libxi/lib/libXi.6.dylib (libxi)
      /usr/local/opt/libxrandr/lib/libXrandr.2.dylib (libxrandr)
      /usr/local/opt/libxrender/lib/libXrender.1.dylib (libxrender)
      /usr/local/opt/mesa/lib/libGL.1.dylib (mesa)
      /usr/local/opt/mesa-glu/lib/libGLU.1.dylib (mesa-glu)