### PR TITLE
glab: don't set LDFLAGS

### DIFF
--- a/Formula/glab.rb
+++ b/Formula/glab.rb
@@ -16,7 +16,7 @@ class Glab < Formula
   depends_on "go" => :build
 
   def install
-    system "make", "LDFLAGS=-s -w", "GLAB_VERSION=#{version}"
+    system "make", "GLAB_VERSION=#{version}"
     bin.install "bin/glab"
     output = Utils.safe_popen_read({ "SHELL" => "bash" }, bin/"glab", "completion", "bash")
     (bash_completion/"glab").write output


### PR DESCRIPTION
It's problematic when building with go1.15.5:

```
go build runtime/cgo: invalid flag in go:cgo_ldflag: -s
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/homebrew-core/pull/64679