### PR TITLE
libb2: Fix arm64 compilation

### DIFF
--- a/Formula/libb2.rb
+++ b/Formula/libb2.rb
@@ -14,10 +14,13 @@ class Libb2 < Formula
   end
 
   def install
+    extra_args = []
+    extra_args << "--enable-fat" unless Hardware::CPU.arm?
+
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
-                          "--enable-fat",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          *extra_args
     system "make", "install"
   end
 

--- a/Formula/libb2.rb
+++ b/Formula/libb2.rb
@@ -14,6 +14,8 @@ class Libb2 < Formula
   end
 
   def install
+    # SSE detection is broken on arm64 macos
+    # https://github.com/BLAKE2/libb2/issues/36
     extra_args = []
     extra_args << "--enable-fat" unless Hardware::CPU.arm?
 


### PR DESCRIPTION
When `--enable-fat` is passed the detection for supported compiler flags wrongly enables SSE and AVX:

```
checking whether C compiler accepts -msse2... yes
checking whether C compiler accepts -mssse3... yes
checking whether C compiler accepts -msse4.1... yes
checking whether C compiler accepts -mavx... yes
checking whether C compiler accepts -mxop... yes
```

Things go wrong from there:

```
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -DSUFFIX=_sse2 -msse2 -g -O2 -O3 -MT libblake2b_sse2_la-blake2b.lo -MD -MP -MF .deps/libblake2b_sse2_la-blake2b.Tpo -c blake2b.c  -fno-common -DPIC -o .libs/libblake2b_sse2_la-blake2b.o
clang: warning: argument unused during compilation: '-msse2' [-Wunused-command-line-argument]
In file included from blake2b.c:21:
./blake2-config.h:67:2: error: "This code requires at least SSE2."
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
