### PR TITLE
workflows: add a Big Sur bottling workflow

### DIFF
--- a/.github/workflows/dispatch-build-bottle-bigsur.yml
+++ b/.github/workflows/dispatch-build-bottle-bigsur.yml
@@ -1,0 +1,115 @@
+name: Dispatch build and upload Big Sur bottle
+
+on:
+  workflow_dispatch:
+    inputs:
+      formula:
+        description: Formula name
+        required: true
+      issue:
+        description: Issue number, where comment on failure would be posted
+        required: false
+
+env:
+  HOMEBREW_DEVELOPER: 1
+  HOMEBREW_GITHUB_ACTIONS: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+
+jobs:
+  bottle:
+    runs-on: 11.0
+    timeout-minutes: 4320
+    env:
+      PATH: '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+      GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED: 1
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - run: brew test-bot --only-cleanup-before
+
+      - run: brew test-bot --only-setup
+
+      - name: Run brew test-bot --only-formulae
+        run: |
+          mkdir bottles
+          cd bottles
+          brew test-bot --only-formulae ${{github.event.inputs.formula}}
+
+      - name: Output brew test-bot --only-formulae failures
+        if: always()
+        run: |
+          cat bottles/steps_output.txt
+          rm bottles/steps_output.txt
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name: logs
+          path: bottles/logs
+
+      - name: Delete logs and home
+        if: always()
+        run: |
+          rm -rvf bottles/logs
+          rm -rvf bottles/home
+
+      - name: Count bottles
+        id: bottles
+        if: always()
+        run: |
+          cd bottles
+          count=$(ls *.json | wc -l | xargs echo -n)
+          echo "$count bottles"
+          echo "::set-output name=count::$count"
+
+      - name: Upload bottles to GitHub Actions
+        if: always() && steps.bottles.outputs.count > 0
+        uses: actions/upload-artifact@main
+        with:
+          name: bottles
+          path: bottles
+
+      - run: brew test-bot --only-cleanup-after
+        if: always()
+
+      - name: Post Cleanup
+        if: always()
+        run: rm -rvf bottles
+  upload:
+    runs-on: ubuntu-latest
+    needs: bottle
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Download bottles from GitHub Actions
+        uses: actions/download-artifact@main
+        with:
+          name: bottles
+
+      - name: Setup git
+        uses: Homebrew/actions/git-user-config@master
+
+      - name: Upload and publish bottles on Bintray
+        env:
+          HOMEBREW_BINTRAY_USER: brewtestbot
+          HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
+        run: brew pr-upload --verbose --keep-old
+
+      - name: Push commits
+        uses: Homebrew/actions/git-try-push@master
+
+      - name: Post comment on failure
+        if: failure() && github.event.inputs.issue
+        uses: Homebrew/actions/post-comment@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          issue: ${{github.event.inputs.issue}}
+          body: ':x: @${{github.actor}} bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}).'
+          bot_body: ':x: Bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}).'
+          bot: BrewTestBot


### PR DESCRIPTION
The basis for this workflow is taken from `dispatch-build-bottle.yml` by @dawidd6 
We're going to build a lot of Big Sur bottles, so make our life easier with a specific workflow:
- for Big Sur
- that always uploads and commits on success

*Help wanted!* Ideally I would like to make it able to run on multiple formulas at once, and loop over the formulas passed as argument. I don't know the Github Actions syntax well enough to achieve that.