### PR TITLE
pass revision-1

### DIFF
--- a/Formula/pass.rb
+++ b/Formula/pass.rb
@@ -4,6 +4,7 @@ class Pass < Formula
   url "https://git.zx2c4.com/password-store/snapshot/password-store-1.7.3.tar.xz"
   sha256 "2b6c65846ebace9a15a118503dcd31b6440949a30d3b5291dfb5b1615b99a3f4"
   license "GPL-2.0"
+  revision 1
   head "https://git.zx2c4.com/password-store.git"
 
   livecheck do
@@ -30,6 +31,9 @@ class Pass < Formula
     inreplace "#{bin}/pass",
               /^SYSTEM_EXTENSION_DIR=.*$/,
               "SYSTEM_EXTENSION_DIR=\"#{HOMEBREW_PREFIX}/lib/password-store/extensions\""
+    inreplace "#{lib}/password-store/platform.sh",
+              /^GETOPT=.*$/,
+              "GETOPT=\"#{HOMEBREW_PREFIX}/opt/gnu-getopt/bin/getopt\""
     elisp.install "contrib/emacs/password-store.el"
     pkgshare.install "contrib"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

TL; DR: make pass get password quicker to have ansible job run faster

Before this revision:

```
$ time pass show site.com/login >/dev/null

real	0m1.509s
user	0m0.500s
sys	0m0.411s
$ time pass show site.com/login >/dev/null

real	0m1.339s
user	0m0.526s
sys	0m0.428s
```

Run `brew reinstall --build-from-source pass`, and then:

```
$ time pass show site.com/login >/dev/null
real	0m0.156s
user	0m0.018s
sys	0m0.016s
$ time pass show site.com/login >/dev/null

real	0m0.110s
user	0m0.020s
sys	0m0.020s
```

Most of time is consumed by `brew --prefix gnu-getopt` due to this issue: https://github.com/Homebrew/brew/issues/8189
