### PR TITLE
coq 8.12.1

### DIFF
--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -1,8 +1,8 @@
 class Coq < Formula
   desc "Proof assistant for higher-order logic"
   homepage "https://coq.inria.fr/"
-  url "https://github.com/coq/coq/archive/V8.12.0.tar.gz"
-  sha256 "ecde14c6132f5abb459e7f4724788788928174ad4484fff88e86b0086779bcee"
+  url "https://github.com/coq/coq/archive/V8.12.1.tar.gz"
+  sha256 "dabad911239c69ecf79931b513cb427101c2f15f0451af056fbf181df526f8a5"
   license "LGPL-2.1"
   head "https://github.com/coq/coq.git"
 

--- a/Formula/math-comp.rb
+++ b/Formula/math-comp.rb
@@ -4,7 +4,7 @@ class MathComp < Formula
   url "https://github.com/math-comp/math-comp/archive/mathcomp-1.11.0.tar.gz"
   sha256 "b16108320f77d15dd19ecc5aad90775b576edfa50c971682a1a439f6d364fef6"
   license "CECILL-B"
-  revision 1
+  revision 2
   head "https://github.com/math-comp/math-comp.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The coq formula no longer passes `brew audit --strict` since it's using the deprecated "LGPL-2.1" license identifier without an -only or -or-later suffix. I don't know which one Coq intends to use so I opened an upstream issue for that: https://github.com/coq/coq/issues/13372.