### PR TITLE
coq: use SPDX license identifier

### DIFF
--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -3,7 +3,7 @@ class Coq < Formula
   homepage "https://coq.inria.fr/"
   url "https://github.com/coq/coq/archive/V8.12.1.tar.gz"
   sha256 "dabad911239c69ecf79931b513cb427101c2f15f0451af056fbf181df526f8a5"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only"
   head "https://github.com/coq/coq.git"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----