### PR TITLE
pdf2image: migrate to brewed X11

### DIFF
--- a/Formula/pdf2image.rb
+++ b/Formula/pdf2image.rb
@@ -3,6 +3,8 @@ class Pdf2image < Formula
   homepage "https://code.google.com/p/pdf2image/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/pdf2image/pdf2image-0.53-source.tar.gz"
   sha256 "e8672c3bdba118c83033c655d90311db003557869c92903e5012cdb368a68982"
+  license "FSFUL"
+  revision 1
 
   bottle do
     sha256 "7a62006adfc88fc38c5333d94836127d4f51228291dfddc726f10a1cac1b6383" => :catalina
@@ -13,9 +15,9 @@ class Pdf2image < Formula
     sha256 "a0bb792123e4754d5cf80cf248e8932dd1885616af2c4c9c7f00e35cda962725" => :yosemite
   end
 
+  depends_on "libx11" => :build
   depends_on "freetype"
   depends_on "ghostscript"
-  depends_on :x11
 
   conflicts_with "pdftohtml", "poppler", "xpdf",
     because: "poppler, pdftohtml, pdf2image, and xpdf install conflicting executables"
@@ -29,10 +31,6 @@ class Pdf2image < Formula
 
     # Fix incorrect variable name in Makefile
     inreplace "src/Makefile", "$(srcdir)", "$(SRCDIR)"
-
-    # Add X11 libs manually; the Makefiles don't use LDFLAGS properly
-    inreplace ["src/Makefile", "xpdf/Makefile"],
-      "LDFLAGS =", "LDFLAGS=-L#{MacOS::XQuartz.lib}"
 
     system "make"
     system "make", "install"


### PR DESCRIPTION
License found [here](https://github.com/flexpaper/pdf2image/blob/master/configure).

Tracking issue: #64166

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz

-----

`libx11` appears to be an optional build dependency, so not 100% certain I did this right. Would appreciate a second opinion.

```
❯ brew linkage pdf2image
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
Homebrew libraries:
  /usr/local/opt/freetype/lib/libfreetype.6.dylib (freetype)
```