### PR TITLE
aescrypt-packetizer: do not enable iconv on linux

### DIFF
--- a/Formula/aescrypt-packetizer.rb
+++ b/Formula/aescrypt-packetizer.rb
@@ -31,8 +31,16 @@ class AescryptPacketizer < Formula
     if build.head?
       cd "linux"
       system "autoreconf", "-ivf"
-      system "./configure", "prefix=#{prefix}", "--enable-iconv",
-              "--disable-gui"
+
+      args = %W[
+        prefix=#{prefix}
+        --disable-gui
+      ]
+      on_macos do
+        args << "--enable-iconv"
+      end
+
+      system "./configure", *args
       system "make", "install"
     else
       cd "src" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
