### PR TITLE
pandoc-citeproc: remove livecheck

### DIFF
--- a/Formula/pandoc-citeproc.rb
+++ b/Formula/pandoc-citeproc.rb
@@ -10,10 +10,6 @@ class PandocCiteproc < Formula
   license "BSD-3-Clause"
   head "https://github.com/jgm/pandoc-citeproc.git"
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     sha256 "518ed9646d3a165b413a4222d87d5148130891fc2505f2e71e20e05507131992" => :catalina
     sha256 "fbbe846a5843e8e0de7d7bafa3ff3af2600c4fbb8ee2e50a05286ac02de52f6e" => :mojave


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `pandoc-citeproc` formula is deprecated, as the upstream GitHub repository states, "This package is no longer maintained. Pandoc now uses the citeproc library, and no external filter is needed."

Since it's unlikely that this software will see any further updates in this state, I think it's appropriate to remove the `livecheck` block so that `brew livecheck` will automatically skip the formula (due to it being deprecated).