### PR TITLE
Remove livecheck blocks from disabled formulae

### DIFF
--- a/Formula/a2ps.rb
+++ b/Formula/a2ps.rb
@@ -6,10 +6,6 @@ class A2ps < Formula
   sha256 "f3ae8d3d4564a41b6e2a21f237d2f2b104f48108591e8b83497500182a3ab3a4"
   license "GPL-3.0-or-later"
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     rebuild 3
     sha256 "98a293e2d83134c9a1c35026f68207d9fc2ac1bde9d7d15dd29849d7d9c5b237" => :catalina

--- a/Formula/aurora-cli.rb
+++ b/Formula/aurora-cli.rb
@@ -6,10 +6,6 @@ class AuroraCli < Formula
   sha256 "d3c20a09dcc62cac98cb83889099e845ce48a1727ca562d80b9a9274da2cfa12"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     cellar :any_skip_relocation
     sha256 "b3b61ca0da323c10be32bfb19af28a48b7cf393729076c3ce6608c69d79bff7d" => :catalina

--- a/Formula/fceux.rb
+++ b/Formula/fceux.rb
@@ -5,10 +5,6 @@ class Fceux < Formula
   sha256 "4be6dda9a347f941809a3c4a90d21815b502384adfdd596adaa7b2daf088823e"
   revision 4
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     cellar :any
     sha256 "7c7550b97011321d5d48f8f689c7158223aee5054698a6c707a185404e469e35" => :catalina

--- a/Formula/libinfinity.rb
+++ b/Formula/libinfinity.rb
@@ -6,11 +6,6 @@ class Libinfinity < Formula
   license "LGPL-2.1"
   revision 2
 
-  livecheck do
-    url "http://releases.0x539.de/libinfinity/"
-    regex(/href=.*?libinfinity[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 "4d367978cb9ee0612c37947080939b3006c5bb7972673cc2c6175242c5809c28" => :catalina
     sha256 "8c9bdd8c7cfb58b1f8c9ce451881c620d574ac749ff0f40e4efa87c0faebba26" => :mojave

--- a/Formula/ocamlsdl.rb
+++ b/Formula/ocamlsdl.rb
@@ -6,10 +6,6 @@ class Ocamlsdl < Formula
   license "LGPL-2.1-or-later"
   revision 13
 
-  livecheck do
-    url :stable
-  end
-
   disable! because: :unmaintained
 
   bottle do

--- a/Formula/procyon-decompiler.rb
+++ b/Formula/procyon-decompiler.rb
@@ -5,10 +5,6 @@ class ProcyonDecompiler < Formula
   sha256 "74f9f1537113207521a075fafe64bd8265c47a9c73574bbf9fa8854bbf7126bc"
   revision 1
 
-  livecheck do
-    skip "Bitbucket repository is missing"
-  end
-
   bottle :unneeded
 
   depends_on "openjdk"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

With Homebrew/brew#9112 merged, disabled formulae are now automatically skipped if they don't contain a `livecheck` block. This PR removes `livecheck` blocks from some formulae that are disabled and it's appropriate for us to skip checking for new versions.