### PR TITLE
ncview: migrate to brewed X11

### DIFF
--- a/Formula/ncview.rb
+++ b/Formula/ncview.rb
@@ -4,7 +4,8 @@ class Ncview < Formula
   url "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.8.tar.gz"
   mirror "https://dl.bintray.com/homebrew/mirror/ncview-2.1.8.tar.gz"
   sha256 "e8badc507b9b774801288d1c2d59eb79ab31b004df4858d0674ed0d87dfc91be"
-  revision 3
+  license "GPL-3.0-only"
+  revision 4
 
   # The stable archive in the formula is fetched over FTP and the website for
   # the software hasn't been updated to list the latest release (it has been
@@ -21,10 +22,14 @@ class Ncview < Formula
     sha256 "5511d243f73fd1a7867bb4dd0263afe215dd0e4e29ef77199efee5db08c2d207" => :high_sierra
   end
 
+  depends_on "libice"
   depends_on "libpng"
+  depends_on "libsm"
+  depends_on "libx11"
+  depends_on "libxaw"
+  depends_on "libxt"
   depends_on "netcdf"
   depends_on "udunits"
-  depends_on :x11
 
   def install
     # Bypass compiler check (which fails due to netcdf's nc-config being


### PR DESCRIPTION
Test not passing. Same issue as with morse: https://github.com/Homebrew/homebrew-core/pull/64333#issuecomment-723530693

It builds fine, but doesn't really work outside of XQuartz. It does work inside XQuartz though. Will fix the test over the weekend.

Tracking issue: #64166

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- [x] `brew install FORMULA` on this list (should be poured from a bottle, not built from source)
- [x] Run `brew linkage FORMULA` and observe which X11 libraries it links against
- [x] Modify the formula to remove `depends_on :x11` and replace it with e.g. `depends_on "libx11"` and any additional X libraries
- [x] Update `/opt/X11` or `MacOS::XQuartz` references to instead point them to the brewed formula paths
- [x] `revision` bump
- [x] `brew install -s FORMULA` and `brew linkage FORMULA` to check that it's now linking against brewed X and not XQuartz

-----

Before:

    ❯ brew linkage ncview
    System libraries:
      /opt/X11/lib/libICE.6.dylib
      /opt/X11/lib/libSM.6.dylib
      /opt/X11/lib/libX11.6.dylib
      /opt/X11/lib/libXaw.7.dylib
      /opt/X11/lib/libXt.6.dylib
      /usr/lib/libSystem.B.dylib
      /usr/lib/libexpat.1.dylib
    Homebrew libraries:
      /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
      /usr/local/opt/netcdf/lib/libnetcdf.18.dylib (netcdf)
      /usr/local/opt/udunits/lib/libudunits2.dylib (udunits)

After:

    ❯ brew linkage ncview
    System libraries:
      /usr/lib/libSystem.B.dylib
      /usr/lib/libexpat.1.dylib
    Homebrew libraries:
      /usr/local/opt/libice/lib/libICE.6.dylib (libice)
      /usr/local/opt/libpng/lib/libpng16.16.dylib (libpng)
      /usr/local/opt/libsm/lib/libSM.6.dylib (libsm)
      /usr/local/opt/libx11/lib/libX11.6.dylib (libx11)
      /usr/local/opt/libxaw/lib/libXaw.7.dylib (libxaw)
      /usr/local/opt/libxt/lib/libXt.6.dylib (libxt)
      /usr/local/opt/netcdf/lib/libnetcdf.18.dylib (netcdf)
      /usr/local/opt/udunits/lib/libudunits2.dylib (udunits)