### PR TITLE
workflows: enable pull request Big Sur builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     if: github.event_name == 'pull_request' && ! contains(github.event.pull_request.labels.*.name, 'CI-syntax-only')
     strategy:
       matrix:
-        version: [10.15, 10.14, 10.13]
+        version: ['11.0', 10.15, 10.14, 10.13]
       fail-fast: false
     runs-on: ${{ matrix.version }}
     timeout-minutes: 4320


### PR DESCRIPTION
Companion issue: https://github.com/Homebrew/homebrew-core/issues/64785

Merge this when we have enough build dependents bottled. That way we can safely bottle from pull requests and can avoid building frankenbottles.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----