### PR TITLE
subversion: revert use macOS's perl, use brewed perl

### DIFF
--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -5,7 +5,7 @@ class Subversion < Formula
   mirror "https://archive.apache.org/dist/subversion/subversion-1.14.0.tar.bz2"
   sha256 "6ba8e218f9f97a83a799e58a3c6da1221d034b18d9d8cbbcb6ec52ab11722102"
   license "Apache-2.0"
-  revision 5
+  revision 6
 
   livecheck do
     url :stable
@@ -35,16 +35,16 @@ class Subversion < Formula
   depends_on "apr-util"
 
   # build against Homebrew versions of
-  # gettext, lz4, sqlite and utf8proc for consistency
+  # gettext, lz4, perl, sqlite and utf8proc for consistency
   depends_on "gettext"
   depends_on "lz4"
   depends_on "openssl@1.1" # For Serf
+  depends_on "perl"
   depends_on "sqlite"
   depends_on "utf8proc"
 
   uses_from_macos "expat"
   uses_from_macos "krb5"
-  uses_from_macos "perl"
   uses_from_macos "ruby"
   uses_from_macos "zlib"
 
@@ -144,8 +144,8 @@ class Subversion < Formula
       system "make", "install-javahl"
     end
 
-    perl_version = Utils.safe_popen_read("perl", "--version")[/v(\d+\.\d+)(?:\.\d+)?/, 1]
-    perl_core = MacOS.sdk_path/"System/Library/Perl"/perl_version/"darwin-thread-multi-2level/CORE"
+    archlib = Utils.safe_popen_read("perl", "-MConfig", "-e", "print $Config{archlib}")
+    perl_core = Pathname.new(archlib)/"CORE"
     onoe "'#{perl_core}' does not exist" unless perl_core.exist?
 
     inreplace "Makefile" do |s|
@@ -180,7 +180,6 @@ class Subversion < Formula
   test do
     system "#{bin}/svnadmin", "create", "test"
     system "#{bin}/svnadmin", "verify", "test"
-    ENV["PERL5LIB"] = Dir["#{opt_lib}/perl5/site_perl/*/darwin-thread-multi-2level"][0]
     system "perl", "-e", "use SVN::Client; new SVN::Client()"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This changes subversion to use the brewed version of Perl, instead of attempting to use macOS' Perl. The change in #64221 broke for some users and also apparently doesn't work in Big Sur. The fix was originally proposed to make `git svn` work, but that change should be made at the `git svn` level, as @iMichka proposed.