### PR TITLE
afl-fuzz: make CPU independent

### DIFF
--- a/Formula/afl-fuzz.rb
+++ b/Formula/afl-fuzz.rb
@@ -3,8 +3,9 @@ class AflFuzz < Formula
   homepage "https://github.com/google/AFL"
   url "https://github.com/google/AFL/archive/v2.57b.tar.gz"
   version "2.57b"
-  sha256 "a6416350ef40e042085337b0cbc12ac95d312f124d11f37076672f511fe31608"
+  sha256 "6f05a6515c07abe49f6f292bd13c96004cc1e016bda0c3cc9c2769dd43f163ee"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -18,8 +19,8 @@ class AflFuzz < Formula
   end
 
   def install
-    system "make", "PREFIX=#{prefix}"
-    system "make", "install", "PREFIX=#{prefix}"
+    system "make", "PREFIX=#{prefix}", "AFL_NO_X86=1"
+    system "make", "install", "PREFIX=#{prefix}", "AFL_NO_X86=1"
   end
 
   test do


### PR DESCRIPTION
From the docs:
- The instrumentation is CPU-independent. At least in principle, you should
    be able to rely on it to fuzz programs on non-x86 architectures (after
    building afl-fuzz with AFL_NO_X86=1).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
