### PR TITLE
snappy: remove Big Sur bottle

### DIFF
--- a/Formula/snappy.rb
+++ b/Formula/snappy.rb
@@ -8,7 +8,6 @@ class Snappy < Formula
 
   bottle do
     cellar :any
-    sha256 "5dcee751508e296a18938de3558438bc402c3d79a2cda9debcae62f99c93ab8f" => :big_sur
     sha256 "b15a258346dc93bd5c6900a405ccb2e9e02ebfeb5b16607b340cc6a5a021eba3" => :catalina
     sha256 "e996c3b0dfac02c8cdd06d849db47e853800389ff7d18fa66526d7d51d305589" => :mojave
     sha256 "77276307037cc20bf44c86fef60b1745c1d8f84d6f963332535b34868f5fc2b4" => :high_sierra


### PR DESCRIPTION
Being cautious after snappy was rebuilt for Big Sur, even though the cmake bottle it depends on wasn't available. Will rebuild after merging this, now that cmake has completed.