### PR TITLE
qt: patch for Big Sur

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -41,6 +41,12 @@ class Qt < Formula
     directory "qt3d"
   end
 
+  # Patches for Xcode 12 / Metal API changes. Remove when Qt updates its Chromium.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/f42f80503399061eab165b8e83a5519446128d5f/qt/qt-webengine-xcode-12.diff"
+    sha256 "3a3186b32ee358a25841c96d520d5d5e5ca7fba3912b2fc3b338b4f45256bcdb"
+  end
+
   def install
     args = %W[
       -verbose


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Qt bottle: https://github.com/Homebrew/homebrew-core/runs/1399724540?check_suite_focus=true

```
ERROR at //build/config/mac/mac_sdk.gni:80:5: Script returned non-zero exit code.
exec_script("//build/mac/find_sdk.py", find_sdk_args, "list lines")
^----------
Current dir: /private/tmp/qt-20201114-71251-zayscx/qt-everywhere-src-5.15.1/qtwebengine/src/core/release/
Command: /usr/bin/python2 /private/tmp/qt-20201114-71251-zayscx/qt-everywhere-src-5.15.1/qtwebengine/src/3rdparty/chromium/build/mac/find_sdk.py --p
--print_bin_path 11.0
Returned 1.
stderr:

Traceback (most recent call last):
File "/private/tmp/qt-20201114-71251-zayscx/qt-everywhere-src-5.15.1/qtwebengine/src/3rdparty/chromium/build/mac/find_sdk.py", line 127, in <modul

print(main())
File "/private/tmp/qt-20201114-71251-zayscx/qt-everywhere-src-5.15.1/qtwebengine/src/3rdparty/chromium/build/mac/find_sdk.py", line 96, in main
raise Exception('No %s+ SDK found' % min_sdk_version)
Exception: No 11.0+ SDK found

See //build/config/sysroot.gni:65:3: whence it was imported.
import("//build/config/mac/mac_sdk.gni")
^--------------------------------------
See //BUILD.gn:76:5: which caused the file to be included.
"//net:net_unittests",
^--------------------
Project ERROR: GN run error!
make[3]: *** [sub-gn_run-pro-make_first] Error 3
make[2]: *** [sub-core-make_first] Error 2
make[1]: *** [sub-src-make_first] Error 2
make: *** [module-qtwebengine-make_first] Error 2
```

Qtwebengine will need this chromium patch: https://github.com/chromium/chromium/commit/cdd96213435c7cb21042e84720d9343ca35b37cf#diff-195dca8233761e55ae153d3c49dca30f6ffa6abc0422af9d65c86c8c8e445569

_Originally posted by @jonchang in https://github.com/Homebrew/homebrew-core/issues/64785#issuecomment-727210695_