### PR TITLE
xmlto: prevent reference to brew shims

### DIFF
--- a/Formula/xmlto.rb
+++ b/Formula/xmlto.rb
@@ -3,7 +3,7 @@ class Xmlto < Formula
   homepage "https://pagure.io/xmlto/"
   url "https://releases.pagure.org/xmlto/xmlto-0.0.28.tar.bz2"
   sha256 "1130df3a7957eb9f6f0d29e4aa1c75732a7dfb6d639be013859b5c7ec5421276"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://releases.pagure.org/xmlto/?C=M&O=D"
@@ -36,6 +36,8 @@ class Xmlto < Formula
   def install
     # GNU getopt is keg-only, so point configure to it
     ENV["GETOPT"] = Formula["gnu-getopt"].opt_bin/"getopt"
+    # Prevent reference to Homebrew shim
+    ENV["SED"] = "/usr/bin/sed"
     # Find our docbook catalog
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
xmlto:
  * Files were found with references to the Homebrew shims directory.
    The offending files are:
      bin/xmlto
```

This will block most of gtk

_Originally posted by @fxcoudert in https://github.com/Homebrew/homebrew-core/issues/64785#issuecomment-727212307_