### PR TITLE
isl: fix URL

### DIFF
--- a/Formula/isl.rb
+++ b/Formula/isl.rb
@@ -1,6 +1,6 @@
 class Isl < Formula
   desc "Integer Set Library for the polyhedral model"
-  homepage "https://isl.gforge.inria.fr/"
+  homepage "https://isl.gforge.inria.fr"
   # NOTE: Always use tarball instead of git tag for stable version.
   #
   # Currently isl detects its version using source code directory name


### PR DESCRIPTION
Trying to avoid somehow a weird error:

```
Error: isl: redirection forbidden: https://isl.gforge.inria.fr/ -> http://isl.gforge.inria.fr

Formula:          isl
Livecheckable?:   Yes

URL:              https://isl.gforge.inria.fr/
Strategy:         PageMatch
Regex:            /href=.*?isl[._-]v?(\d+(?:\.\d+)+)\.t/i
```