### PR TITLE
vde: disable python

### DIFF
--- a/Formula/vde.rb
+++ b/Formula/vde.rb
@@ -4,6 +4,7 @@ class Vde < Formula
   url "https://downloads.sourceforge.net/project/vde/vde2/2.3.2/vde2-2.3.2.tar.gz"
   sha256 "22df546a63dac88320d35d61b7833bbbcbef13529ad009c7ce3c5cb32250af93"
   license "GPL-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,7 +22,7 @@ class Vde < Formula
   end
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}", "--disable-python"
     # 2.3.1 built in parallel but 2.3.2 does not. See:
     # https://sourceforge.net/p/vde/bugs/54/
     ENV.deparallelize


### PR DESCRIPTION
```
vde:
  * python modules have explicit framework links
    These python extension modules were linked directly to a Python
    framework binary. They should be linked with -undefined dynamic_lookup
    instead of -lpython or -framework Python.
      /usr/local/opt/vde/lib/python2.7/site-packages/vdeplug_python.so
```

🐍 2 🔫 💀 