### PR TITLE
apache-flink: migrate to openjdk11

### DIFF
--- a/Formula/apache-flink.rb
+++ b/Formula/apache-flink.rb
@@ -14,12 +14,12 @@ class ApacheFlink < Formula
 
   bottle :unneeded
 
-  depends_on java: "1.8"
+  depends_on "openjdk@11"
 
   def install
     rm_f Dir["bin/*.bat"]
     libexec.install Dir["*"]
-    (libexec/"bin").env_script_all_files(libexec/"libexec", Language::Java.java_home_env("1.8"))
+    (libexec/"bin").env_script_all_files(libexec/"libexec", Language::Java.java_home_env("11"))
     (libexec/"bin").install Dir["#{libexec}/libexec/*.jar"]
     chmod 0755, Dir["#{libexec}/bin/*"]
     bin.write_exec_script "#{libexec}/bin/flink"
@@ -37,8 +37,8 @@ class ApacheFlink < Formula
     ENV.prepend "FLINK_LOG_DIR", testpath/"log"
     system libexec/"bin/start-cluster.sh"
     system bin/"flink", "run", "-p", "1",
-           libexec/"examples/streaming/WordCount.jar", "--input", "input",
-           "--output", "result/1"
+           libexec/"examples/streaming/WordCount.jar", "--input", testpath/"input",
+           "--output", testpath/"result/1"
     system libexec/"bin/stop-cluster.sh"
     assert_predicate testpath/"result/1", :exist?
     assert_equal expected, (testpath/"result/1").read


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Upstream states that `apache-flink` supports both java 8 and 11. I couldn't get the test to work for `openjdk@8` but it works fine with `openjdk@11` when using full path for input and output.

Related to openjdk@8 migration (#63290)