### PR TITLE
screen: Fix build for Xcode 12

### DIFF
--- a/Formula/screen.rb
+++ b/Formula/screen.rb
@@ -43,6 +43,10 @@ class Screen < Formula
     # before osdef.sh script generates it.
     ENV.deparallelize
 
+    # Fix for Xcode 12 build errors.
+    # https://savannah.gnu.org/bugs/index.php?59465
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./autogen.sh"
     system "./configure", "--prefix=#{prefix}",
                           "--mandir=#{man}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----


- Without this flag to disable the implicit function declaration errors, `screen` fails to build on Big Sur and we get many errors including:

  ```
  configure: checking select with  -lnet -lnsl...
  configure: error: !!! no select - no screen
  ```

- This is an alternative to https://github.com/Homebrew/formula-patches/pull/315 and further patches.