### PR TITLE
jmeter: declare openjdk dependency

### DIFF
--- a/Formula/jmeter.rb
+++ b/Formula/jmeter.rb
@@ -5,6 +5,7 @@ class Jmeter < Formula
   mirror "https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-5.3.tgz"
   sha256 "d0611b46268c4e24220fed56e76d770077713ff863665c271ed6521046f2f0d0"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -17,9 +18,11 @@ class Jmeter < Formula
     sha256 "e3f6544d4e7485525fa4cf8fd377f00ce7f7350fdbeeb1cfaba3b9539a6c1a88" => :high_sierra
   end
 
+  depends_on "openjdk"
+
   resource "jmeter-plugins-manager" do
-    url "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/1.3/jmeter-plugins-manager-1.3.jar"
-    sha256 "482b8a9cd82a69ef1b633fc4235bfa9bee96894f663e5085df7061410d6ab99a"
+    url "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/1.4/jmeter-plugins-manager-1.4.jar"
+    sha256 "473697bd4656e3277b2ba6e23ff023209db4f13524995fa18e4acabca0fc4425"
   end
 
   def install
@@ -27,7 +30,7 @@ class Jmeter < Formula
     rm_f Dir["bin/*.bat"]
     prefix.install_metafiles
     libexec.install Dir["*"]
-    bin.write_exec_script libexec/"bin/jmeter"
+    (bin/"jmeter").write_env_script libexec/"bin/jmeter", JAVA_HOME: Formula["openjdk"].opt_prefix
 
     resource("jmeter-plugins-manager").stage do
       (libexec/"lib/ext").install Dir["*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Noticed in https://github.com/Homebrew/homebrew-core/issues/64785#issuecomment-727277439. Also updated the version of `jmeter-plugins-manager` that we ship while we're here.