### PR TITLE
bcrypt: update livecheck

### DIFF
--- a/Formula/bcrypt.rb
+++ b/Formula/bcrypt.rb
@@ -5,7 +5,7 @@ class Bcrypt < Formula
   sha256 "b9c1a7c0996a305465135b90123b0c63adbb5fa7c47a24b3f347deb2696d417d"
 
   livecheck do
-    url :homepage
+    url "http://bcrypt.sourceforge.net/"
     strategy :page_match
     regex(/href=.*?bcrypt[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Before:
```
Error: bcrypt: redirection forbidden: https://bcrypt.sourceforge.io/ -> http://bcrypt.sourceforge.net/

Formula:          bcrypt
Livecheckable?:   Yes

URL:              https://bcrypt.sourceforge.io/
Strategy:         PageMatch
Regex:            /href=.*?bcrypt[._-]v?(\d+(?:\.\d+)+)\.t/i
```