### PR TITLE
formula_renames: remove python3

### DIFF
--- a/formula_renames.json
+++ b/formula_renames.json
@@ -97,7 +97,6 @@
   "postgresql95": "postgresql@9.5",
   "presto": "prestodb",
   "pyqt5": "pyqt",
-  "python3": "python",
   "qt5": "qt",
   "racket": "minimal-racket",
   "rebar@3": "rebar3",


### PR DESCRIPTION
`python3` is already an alias for python@3.9 ([original commit](https://github.com/Homebrew/homebrew-core/commit/788b65e645bb342e82946b52173997cd00c322ac)).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
