### PR TITLE
freeimage: Include C stdlib header in test

### DIFF
--- a/Formula/freeimage.rb
+++ b/Formula/freeimage.rb
@@ -33,6 +33,7 @@ class Freeimage < Formula
 
   test do
     (testpath/"test.c").write <<~EOS
+      #include <stdlib.h>
       #include <FreeImage.h>
       int main() {
          FreeImage_Initialise(0);


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- Otherwise this [errors](https://github.com/Homebrew/homebrew-core/issues/64785#issuecomment-727619414) with:

```
=> /usr/bin/clang test.c -I/usr/local/Cellar/freeimage/3.18.0/include -L/usr/local/Cellar/freeimage/3.18.0/lib -lfreeimage -o test
test.c:5:4: error: implicitly declaring library function 'exit' with type 'void (int) __attribute__((noreturn))' [-Werror,-Wimplicit-function-declaration]
   exit(0);
   ^
test.c:5:4: note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'
1 error generated.
```

