### PR TITLE
freetype: remove shim references on ARM

### DIFF
--- a/Formula/freetype.rb
+++ b/Formula/freetype.rb
@@ -33,6 +33,9 @@ class Freetype < Formula
 
     inreplace [bin/"freetype-config", lib/"pkgconfig/freetype2.pc"],
       prefix, opt_prefix
+    inreplace bin/"freetype-config",
+      HOMEBREW_LIBRARY/"Homebrew/shims/mac/super/pkg-config",
+      Formula["pkg-config"].opt_bin/"pkg-config"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix an issue where installing freetype on Apple Silicon yields the following unwanted Homebrew shim references in `freetype-config`:

```
$ strings /opt/homebrew/Cellar/freetype/2.10.4/bin/freetype-config | grep homebrew
/opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config --atleast-pkgconfig-version 0.24 >/dev/null 2>&1
  prefix=`/opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config --variable prefix freetype2`
  exec_prefix=`/opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config --variable exec_prefix freetype2`
  includedir=`/opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config --variable includedir freetype2`
  libdir=`/opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config --variable libdir freetype2`
  version=`/opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config --modversion freetype2`
  cflags=`/opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config --cflags freetype2`
  dynamic_libs=`/opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config --libs freetype2`
  static_libs=`/opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config --static --libs freetype2`
```
