### PR TITLE
lastpass-cli: add file extension (.fish) to fish completion

### DIFF
--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -35,7 +35,7 @@ class LastpassCli < Formula
 
     bash_completion.install "contrib/lpass_bash_completion"
     zsh_completion.install "contrib/lpass_zsh_completion" => "_lpass"
-    fish_completion.install "contrib/completions-lpass.fish" => "lpass"
+    fish_completion.install "contrib/completions-lpass.fish" => "lpass.fish"
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Sorry, forgot to make an additional commit that adds the `.fish` file extension to make this work
Previous pull request was (#64912) 
