### PR TITLE
jack: revision to rebuild bottles

### DIFF
--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -13,7 +13,7 @@ class Jack < Formula
       tag:      "0.125.0",
       revision: "f5e00e485e7aa4c5baa20355b27e3b84a6912790"
   license "GPL-2.0"
-  revision 4
+  revision 5
   head "https://github.com/jackaudio/jack1.git"
 
   bottle do


### PR DESCRIPTION
jack bottling fails with an audit bug:

```
  * stable sha256 changed without the url/version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed.
```

even though we are not changing the checksum. Revision bump to force a rebuild.