### PR TITLE
helm@2: remove livecheck

### DIFF
--- a/Formula/helm@2.rb
+++ b/Formula/helm@2.rb
@@ -6,13 +6,6 @@ class HelmAT2 < Formula
       revision: "a690bad98af45b015bd3da1a41f6218b1a451dbe"
   license "Apache-2.0"
 
-  # NOTE: Remove this livecheck block after deprecation takes effect, so we
-  # don't unnecessarily check for updates.
-  livecheck do
-    url :stable
-    regex(/^v?(2(?:\.\d+)+)$/i)
-  end
-
   bottle do
     cellar :any_skip_relocation
     sha256 "432e81bffefbb026bd50058e920a424b1805b84efc634d78c93dfedb9fec3d5a" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I had added the `livecheck` block in this formula temporarily until the upstream deprecation took effect. Now that the 2.x series is deprecated upstream (as of 2020-11-13) and there hasn't been a 2.x release in the interim time, I'm removing this `livecheck` block so the formula is automatically skipped due to being deprecated.