### PR TITLE
gnome-autoar: revision to rebottle

### DIFF
--- a/Formula/gnome-autoar.rb
+++ b/Formula/gnome-autoar.rb
@@ -4,6 +4,7 @@ class GnomeAutoar < Formula
   url "https://download.gnome.org/sources/gnome-autoar/0.2/gnome-autoar-0.2.4.tar.xz"
   sha256 "0a34c377f8841abbf4c29bc848b301fbd8e4e20c03d7318c777c58432033657a"
   license "LGPL-2.1"
+  revision 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
Need to rebottle because

```
Warning: String '/usr/local/Cellar' still exists in these files:
/usr/local/Cellar/gnome-autoar/0.2.4/lib/girepository-1.0/GnomeAutoar-0.1.typelib
 --> match '/usr/local/Cellar/gnome-autoar/0.2.4/lib/libgnome-autoar-0.0.dylib' at offset 0x11c
/usr/local/Cellar/gnome-autoar/0.2.4/lib/girepository-1.0/GnomeAutoarGtk-0.1.typelib
 --> match '/usr/local/Cellar/gnome-autoar/0.2.4/lib/libgnome-autoar-gtk-0.0.dylib' at offset 0x11c
Error: --keep-old was passed but there are changes in:
cellar: old: :any, new: "/usr/local/Cellar"
```