### PR TITLE
cabal-install: revision

### DIFF
--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -21,6 +21,12 @@ class CabalInstall < Formula
   depends_on "ghc@8.8"
   uses_from_macos "zlib"
 
+  # Update bootstrap dependencies to work with base-4.13.0.0
+  patch :p2 do
+    url "https://github.com/haskell/cabal/commit/b6f7ec5f3598f69288bddbdba352e246e337fb90.patch?full_index=1"
+    sha256 "f4c869e74968c5892cd1fa1001adf96eddcec73e03fb5cf70d3a0c0de08d9e4e"
+  end
+
   def install
     cd "cabal-install" if build.head?
 

--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -18,7 +18,9 @@ class CabalInstall < Formula
     sha256 "2946e5b36632d7e33e1312c0597d4858479748ee94eb1a52df9f4869c87eb2a7" => :high_sierra
   end
 
-  depends_on "ghc@8.8"
+  # cabal-install 3.2 needs to be bootstrapped with ghc 8.8
+  depends_on "ghc@8.8" => :build
+  depends_on "ghc"
   uses_from_macos "zlib"
 
   # Update bootstrap dependencies to work with base-4.13.0.0

--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -28,6 +28,7 @@ class CabalInstall < Formula
   end
 
   def install
+    ENV.prepend_path "PATH", Formula["ghc@8.8"].bin
     cd "cabal-install" if build.head?
 
     system "sh", "bootstrap.sh", "--sandbox"

--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -18,17 +18,10 @@ class CabalInstall < Formula
     sha256 "2946e5b36632d7e33e1312c0597d4858479748ee94eb1a52df9f4869c87eb2a7" => :high_sierra
   end
 
-  depends_on "ghc"
+  depends_on "ghc@8.8"
   uses_from_macos "zlib"
 
-  # Update bootstrap dependencies to work with base-4.13.0.0
-  patch :p2 do
-    url "https://github.com/haskell/cabal/commit/b6f7ec5f3598f69288bddbdba352e246e337fb90.patch?full_index=1"
-    sha256 "f4c869e74968c5892cd1fa1001adf96eddcec73e03fb5cf70d3a0c0de08d9e4e"
-  end
-
   def install
-    inreplace "cabal-install.cabal", "4.14", "4.15"
     cd "cabal-install" if build.head?
 
     system "sh", "bootstrap.sh", "--sandbox"

--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -4,6 +4,7 @@ class CabalInstall < Formula
   url "https://hackage.haskell.org/package/cabal-install-3.2.0.0/cabal-install-3.2.0.0.tar.gz"
   sha256 "a0555e895aaf17ca08453fde8b19af96725da8398e027aa43a49c1658a600cb0"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/haskell/cabal.git", branch: "3.2"
 
   livecheck do

--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -28,6 +28,7 @@ class CabalInstall < Formula
   end
 
   def install
+    inreplace "cabal-install.cabal", "4.14", "4.15"
     cd "cabal-install" if build.head?
 
     system "sh", "bootstrap.sh", "--sandbox"


### PR DESCRIPTION
It looks like it's not building from source anymore…

```
Setup: Encountered missing or private dependencies:
base >=4.5 && <4.14
```