### PR TITLE
gnu-typist: link against libiconv only on mac

### DIFF
--- a/Formula/gnu-typist.rb
+++ b/Formula/gnu-typist.rb
@@ -27,8 +27,10 @@ class GnuTypist < Formula
   end
 
   def install
-    # libiconv is not linked properly without this
-    ENV.append "LDFLAGS", "-liconv"
+    on_macos do
+      # libiconv is not linked properly without this
+      ENV.append "LDFLAGS", "-liconv"
+    end
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
