### PR TITLE
ffmpeg@2.8: actively prevent X11 linkage

### DIFF
--- a/Formula/ffmpeg@2.8.rb
+++ b/Formula/ffmpeg@2.8.rb
@@ -5,8 +5,8 @@ class FfmpegAT28 < Formula
   sha256 "d0734fec613fe12bee0b5a84f917779b854c1ede7882793f618490e6bbf0c148"
   # None of these parts are used by default, you have to explicitly pass `--enable-gpl`
   # to configure to activate them. In this case, FFmpeg's license changes to GPL v2+.
-  license "GPL-2.0"
-  revision 3
+  license "GPL-2.0-or-later"
+  revision 4
 
   livecheck do
     url "https://ffmpeg.org/download.html"
@@ -84,6 +84,8 @@ class FfmpegAT28 < Formula
       --enable-libspeex
       --enable-opencl
       --disable-indev=jack
+      --disable-libxcb
+      --disable-xlib
     ]
 
     # A bug in a dispatch header on 10.10, included via CoreFoundation,


### PR DESCRIPTION
Fixes #64654, #64941. Also fixes license.

(Tested by adding `depends_on "libx11"` to local formula, confirmed `brew linkage` reported X11 dependency with no linkage after rebuild.)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
