### PR TITLE
vtk: use system or homebrew dependencies where possible

### DIFF
--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -4,7 +4,7 @@ class Opencv < Formula
   url "https://github.com/opencv/opencv/archive/4.5.0.tar.gz"
   sha256 "dde4bf8d6639a5d3fe34d5515eab4a15669ded609a1d622350c7ff20dace1907"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   livecheck do
     url :stable

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -4,7 +4,7 @@ class Vtk < Formula
   url "https://www.vtk.org/files/release/9.0/VTK-9.0.1.tar.gz"
   sha256 "1b39a5e191c282861e7af4101eaa8585969a2de05f5646c9199a161213a622c7"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://github.com/Kitware/VTK.git"
 
   bottle do
@@ -14,17 +14,31 @@ class Vtk < Formula
     sha256 "e0d7a74bbd039760bd71f95e33c4bb255d1c9769ce17898ca7f58179c811a263" => :high_sierra
   end
 
-  depends_on "cmake" => :build
+  depends_on "cmake" => [:build, :test]
   depends_on "boost"
+  depends_on "double-conversion"
+  depends_on "eigen"
   depends_on "fontconfig"
+  depends_on "gl2ps"
+  depends_on "glew"
   depends_on "hdf5"
   depends_on "jpeg"
+  depends_on "jsoncpp"
+  depends_on "libogg"
   depends_on "libpng"
   depends_on "libtiff"
+  depends_on "lz4"
   depends_on "netcdf"
+  depends_on "pugixml"
   depends_on "pyqt"
   depends_on "python@3.9"
   depends_on "qt"
+  depends_on "sqlite"
+  depends_on "theora"
+  depends_on "xz"
+  uses_from_macos "expat"
+  uses_from_macos "libxml2"
+  uses_from_macos "zlib"
 
   def install
     # Do not record compiler path because it references the shim directory
@@ -36,21 +50,32 @@ class Vtk < Formula
       -DCMAKE_INSTALL_NAME_DIR:STRING=#{lib}
       -DCMAKE_INSTALL_RPATH:STRING=#{lib}
       -DVTK_WRAP_PYTHON:BOOL=ON
-      -DVTK_PYTHON_VERSION=3
+      -DVTK_PYTHON_VERSION:STRING=3
       -DVTK_USE_COCOA:BOOL=ON
       -DVTK_LEGACY_REMOVE:BOOL=ON
       -DVTK_MODULE_ENABLE_VTK_InfovisBoost:STRING=YES
       -DVTK_MODULE_ENABLE_VTK_InfovisBoostGraphAlgorithms:STRING=YES
       -DVTK_MODULE_ENABLE_VTK_RenderingFreeTypeFontConfig:STRING=YES
+      -DVTK_MODULE_USE_EXTERNAL_VTK_doubleconversion:BOOL=ON
+      -DVTK_MODULE_USE_EXTERNAL_VTK_eigen:BOOL=ON
       -DVTK_MODULE_USE_EXTERNAL_VTK_expat:BOOL=ON
+      -DVTK_MODULE_USE_EXTERNAL_VTK_gl2ps:BOOL=ON
+      -DVTK_MODULE_USE_EXTERNAL_VTK_glew:BOOL=ON
       -DVTK_MODULE_USE_EXTERNAL_VTK_hdf5:BOOL=ON
       -DVTK_MODULE_USE_EXTERNAL_VTK_jpeg:BOOL=ON
+      -DVTK_MODULE_USE_EXTERNAL_VTK_jsoncpp:BOOL=ON
       -DVTK_MODULE_USE_EXTERNAL_VTK_libxml2:BOOL=ON
+      -DVTK_MODULE_USE_EXTERNAL_VTK_lz4:BOOL=ON
+      -DVTK_MODULE_USE_EXTERNAL_VTK_lzma:BOOL=ON
       -DVTK_MODULE_USE_EXTERNAL_VTK_netcdf:BOOL=ON
+      -DVTK_MODULE_USE_EXTERNAL_VTK_ogg:BOOL=ON
       -DVTK_MODULE_USE_EXTERNAL_VTK_png:BOOL=ON
+      -DVTK_MODULE_USE_EXTERNAL_VTK_pugixml:BOOL=ON
+      -DVTK_MODULE_USE_EXTERNAL_VTK_sqlite:BOOL=ON
+      -DVTK_MODULE_USE_EXTERNAL_VTK_theora:BOOL=ON
       -DVTK_MODULE_USE_EXTERNAL_VTK_tiff:BOOL=ON
       -DVTK_MODULE_USE_EXTERNAL_VTK_zlib:BOOL=ON
-      -DPython3_EXECUTABLE:PATH=#{Formula["python@3.9"].opt_bin}/python3
+      -DPython3_EXECUTABLE:FILEPATH=#{Formula["python@3.9"].opt_bin}/python3
       -DVTK_GROUP_ENABLE_Qt:STRING=YES
     ]
 
@@ -62,21 +87,38 @@ class Vtk < Formula
   end
 
   test do
-    vtk_include = Dir[opt_include/"vtk-*"].first
-    major, minor = vtk_include.match(/.*-(.*)$/)[1].split(".")
+    (testpath/"CMakeLists.txt").write <<~EOS
+      cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+      project(Distance2BetweenPoints LANGUAGES CXX)
+      find_package(VTK REQUIRED COMPONENTS vtkCommonCore CONFIG)
+      add_executable(Distance2BetweenPoints Distance2BetweenPoints.cxx)
+      target_link_libraries(Distance2BetweenPoints PRIVATE ${VTK_LIBRARIES})
+    EOS
 
-    (testpath/"version.cpp").write <<~EOS
-      #include <vtkVersion.h>
-      #include <assert.h>
-      int main(int, char *[]) {
-        assert (vtkVersion::GetVTKMajorVersion()==#{major});
-        assert (vtkVersion::GetVTKMinorVersion()==#{minor});
-        return EXIT_SUCCESS;
+    (testpath/"Distance2BetweenPoints.cxx").write <<~EOS
+      #include <cassert>
+      #include <vtkMath.h>
+      int main() {
+        double p0[3] = {0.0, 0.0, 0.0};
+        double p1[3] = {1.0, 1.0, 1.0};
+        assert(vtkMath::Distance2BetweenPoints(p0, p1) == 3.0);
+        return 0;
       }
     EOS
 
-    system ENV.cxx, "-std=c++11", "version.cpp", "-I#{vtk_include}"
-    system "./a.out"
-    system "#{bin}/vtkpython", "-c", "exit()"
+    vtk_dir = Dir[opt_lib/"cmake/vtk-*"].first
+    system "cmake", "-DCMAKE_BUILD_TYPE=Debug", "-DCMAKE_VERBOSE_MAKEFILE=ON",
+      "-DVTK_DIR=#{vtk_dir}", "."
+    system "make"
+    system "./Distance2BetweenPoints"
+
+    (testpath/"Distance2BetweenPoints.py").write <<~EOS
+      import vtk
+      p0 = (0, 0, 0)
+      p1 = (1, 1, 1)
+      assert vtk.vtkMath.Distance2BetweenPoints(p0, p1) == 3
+    EOS
+
+    system bin/"vtkpython", "Distance2BetweenPoints.py"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently compatibility/version issues with the `freetype` and `libharu` that are in Homebrew. There are not formulae for `loguru` and `utf8cpp`.
