### PR TITLE
mysql@5.6: Update license to GPL-2.0-only

### DIFF
--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -3,7 +3,7 @@ class MysqlAT56 < Formula
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
   url "https://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-5.6.50.tar.gz"
   sha256 "efc48d8160a66b50fc498bb42ea730c3b6f30f036b709a7070d356edd645923e"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url "https://dev.mysql.com/downloads/mysql/5.6.html"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://downloads.mysql.com/docs/licenses/mysqld-5.6-gpl-en.pdf page 2 says:

> Election of GPLv2
>
> For the avoidance of doubt, except that if any license choice other than
> GPL or LGPL is available it will apply instead, Oracle elects to use
> only the General Public License version 2 (GPLv2) at this time for any
> software where a choice of GPL license versions is made available with
> the language indicating that GPLv2 or any later version may be used, or
> where a choice of which version of the GPL is applied is otherwise
> unspecified.

