### PR TITLE
Migrate license mismatch allowlist to Homebrew/core

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,3 +15,5 @@ tap_migrations.json   @MikeMcQuaid
 cmd/                  @MikeMcQuaid
 
 LICENSE.txt           @Homebrew/plc @MikeMcQuaid
+
+audit_exceptions/permitted_formula_license_mismatches.json   @Homebrew/plc

--- a/audit_exceptions/permitted_formula_license_mismatches.json
+++ b/audit_exceptions/permitted_formula_license_mismatches.json
@@ -1,0 +1,5 @@
+[
+  "cmockery",
+  "vapoursynth-ocr",
+  "vapoursynth-sub"
+]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR migrates the `PERMITTED_FORMULA_LICENSE_MISMATCHES` audit allowlist to Homebrew/core.

Corresponding Homebrew/brew PR: https://github.com/Homebrew/brew/pull/9178

Originally, the list contained:

```ruby
    PERMITTED_FORMULA_LICENSE_MISMATCHES = {
       "cmockery" => "0.1.2",
       "scw@1"    => "1.20",
     }.freeze
```

`scw@1` has since been removed from Homebrew/core. I have also added `vapoursynth-ocr` and `vapoursynth-sub` per discussion in https://github.com/Homebrew/homebrew-core/pull/59828.