### PR TITLE
Migrate automatic python resource list to Homebrew/core

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -1,0 +1,18 @@
+{
+  "ansible": false,
+  "ansible@2.8": false,
+  "cloudformation-cli": {
+    "extra_packages": ["cloudformation-cli-go-plugin", "cloudformation-cli-java-plugin"]
+  },
+  "diffoscope": "diffoscope[cmdline]",
+  "ipython": {
+    "extra_packages": ["ipykernel"]
+  },
+  "molecule": false,
+  "salt": {
+    "extra_packages": ["M2Crypto", "pygit2"]
+  },
+  "xdot": {
+    "extra_packages": ["graphviz"]
+  }
+}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR migrates the `AUTOMATIC_RESOURCE_UPDATE_BLOCKLIST` list to Homebrew/core in conjunction with https://github.com/Homebrew/brew/pull/9185.

This places control over the automatic resource bumps for Python formulae in this repo. Here is and example `automatic_resource_update_blocklist.json` file:

```json
{
  "foo": false,
  "bar": "abc",
  "baz": {
    "package_name": "abc",
    "extra_packages": ["extra1", "extra2"],
    "exclude_packages": ["exclude1", "exclude2"]
  }
}
```

There are three type of declarations:

1. `"foo": false` means that the `foo` formula will be prohibited from having its resources automatically bumped (similar to the existing blocklist)
1. `"bar": "bar[abc]"` means that the `bar` formulae will retrieve the resources from the `abc` PyPI package _instead of_ the `bar` package (this can also accept packages like `bar[abc]` or `bar[abc,def]`). This corresponds to the `--package-name` flag.
1. `"baz": {` is for more complex situations:
    - `"package_name": "abc"` is equivalent to number 2 above. It will use `abc` instead of `baz` for the package name.
        - This corresponds to the `--package-name` flag
    - `"extra_packages": ["extra1", "extra2"]` means that the resources and requirements for the `extra1` and `extra2` packages will be included _along with_ those from the main package. This is a way to add additional resource blocks that won't be picked up normally (you can also specify specific versions by using `extra1==1.2.3` in addition to packages like `abc[def]`).
        - This corresponds to the `--extra-packages` flag
    - `"exclude_packages": ["exclude1", "exclude2"]` means that the resources for the `exclude1` and `exclude2` packages will _not_ be in included. This is useful if `pipgrip` picks up unnecessary dependencies.
        - This corresponds to the `--exclude-packages ` flag