### PR TITLE
curl-openssl: fix optional dependency

### DIFF
--- a/Formula/curl-openssl.rb
+++ b/Formula/curl-openssl.rb
@@ -25,7 +25,7 @@ class CurlOpenssl < Formula
   depends_on "pkg-config" => :build
   depends_on "brotli"
   depends_on "c-ares"
-  depends_on "libidn"
+  depends_on "libidn2"
   depends_on "libmetalink"
   depends_on "libssh2"
   depends_on "nghttp2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

## Missing libidn2 dependency

In `curl-openssl`, the `install` block uses the `--with-libidn2` option, which causes the build process to pick up, and link against, the `libidn2` keg if it’s there.

However, unless `libidn2` is declared as a dependency, building a `curl-openssl` bottle **results in a corrupt bottle**, which links to the `libidn2` keg no matter if it’s installed on the target system or not, whenever `libidn2` happens to be installed at bottle build time.

As @mistydemeo has noted in https://github.com/Homebrew/brew/pull/9172, our linkage check doesn’t catch that. This may explain why the mistake remained unnoticed.

I don’t think bottles will have to be rebuilt because Homebrew’s CI removes all kegs before it runs `test-bot` afaik.
Feel free to remove the label if you disagree.

## Extraneous libidn dependency

Inspecting the `curl-openssl` bottle also reveals that it doesn’t link against `libidn`, which is to be expected given we specify the `--with-libidn2` option in the `install` block. So I assume the `libidn` dependency can be removed.
