### PR TITLE
PostgreSQL@12: Use its own data dir and log files when run via services

### DIFF
--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -85,7 +85,7 @@ class Postgresql < Formula
   end
 
   def postgresql_datadir
-    var/name
+    var/"postgres"
   end
 
   def postgresql_log_path

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -80,10 +80,20 @@ class Postgresql < Formula
     return if ENV["CI"]
 
     (var/"log").mkpath
-    (var/"postgres").mkpath
-    unless File.exist? "#{var}/postgres/PG_VERSION"
-      system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", "#{var}/postgres"
-    end
+    postgresql_datadir.mkpath
+    system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", postgresql_datadir unless pg_version_exists?
+  end
+
+  def postgresql_datadir
+    var/name
+  end
+
+  def postgresql_log_path
+    var/"log/#{name}.log"
+  end
+
+  def pg_version_exists?
+    (postgresql_datadir/"PG_VERSION").exist?
   end
 
   def caveats
@@ -92,7 +102,7 @@ class Postgresql < Formula
         brew postgresql-upgrade-database
 
       This formula has created a default database cluster with:
-        initdb --locale=C -E UTF-8 #{var}/postgres
+        initdb --locale=C -E UTF-8 #{postgresql_datadir}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS
@@ -114,16 +124,16 @@ class Postgresql < Formula
         <array>
           <string>#{opt_bin}/postgres</string>
           <string>-D</string>
-          <string>#{var}/postgres</string>
+          <string>#{postgresql_datadir}</string>
         </array>
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>
         <key>StandardOutPath</key>
-        <string>#{var}/log/postgres.log</string>
+        <string>#{postgresql_log_path}</string>
         <key>StandardErrorPath</key>
-        <string>#{var}/log/postgres.log</string>
+        <string>#{postgresql_log_path}</string>
       </dict>
       </plist>
     EOS

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -89,7 +89,7 @@ class Postgresql < Formula
   end
 
   def postgresql_log_path
-    var/"log/#{name}.log"
+    var/"log/postgres.log"
   end
 
   def pg_version_exists?

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -81,17 +81,26 @@ class PostgresqlAT10 < Formula
     return if ENV["CI"]
 
     (var/"log").mkpath
-    (var/name).mkpath
-    system "#{bin}/initdb", "#{var}/#{name}" unless File.exist? "#{var}/#{name}/PG_VERSION"
+    postgresql_datadir.mkpath
+    system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", postgresql_datadir unless pg_version_exists?
+  end
+
+  def postgresql_datadir
+    var/name
+  end
+
+  def postgresql_log_path
+    var/"log/#{name}.log"
+  end
+
+  def pg_version_exists?
+    (postgresql_datadir/"PG_VERSION").exist?
   end
 
   def caveats
     <<~EOS
-      To migrate existing data from a previous major version of PostgreSQL run:
-        brew postgresql-upgrade-database
-
       This formula has created a default database cluster with:
-        initdb #{var}/postgres
+        initdb --locale=C -E UTF-8 #{postgresql_datadir}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS
@@ -113,16 +122,16 @@ class PostgresqlAT10 < Formula
         <array>
           <string>#{opt_bin}/postgres</string>
           <string>-D</string>
-          <string>#{var}/#{name}</string>
+          <string>#{postgresql_datadir}</string>
         </array>
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>
         <key>StandardOutPath</key>
-        <string>#{var}/log/#{name}.log</string>
+        <string>#{postgresql_log_path}</string>
         <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
+        <string>#{postgresql_log_path}</string>
       </dict>
       </plist>
     EOS

--- a/Formula/postgresql@11.rb
+++ b/Formula/postgresql@11.rb
@@ -71,19 +71,26 @@ class PostgresqlAT11 < Formula
     return if ENV["CI"]
 
     (var/"log").mkpath
-    (var/name).mkpath
-    unless File.exist? "#{var}/#{name}/PG_VERSION"
-      system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", "#{var}/#{name}"
-    end
+    postgresql_datadir.mkpath
+    system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", postgresql_datadir unless pg_version_exists?
+  end
+
+  def postgresql_datadir
+    var/name
+  end
+
+  def postgresql_log_path
+    var/"log/#{name}.log"
+  end
+
+  def pg_version_exists?
+    (postgresql_datadir/"PG_VERSION").exist?
   end
 
   def caveats
     <<~EOS
-      To migrate existing data from a previous major version of PostgreSQL run:
-        brew postgresql-upgrade-database
-
       This formula has created a default database cluster with:
-        initdb --locale=C -E UTF-8 #{var}/postgres
+        initdb --locale=C -E UTF-8 #{postgresql_datadir}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS
@@ -105,16 +112,16 @@ class PostgresqlAT11 < Formula
         <array>
           <string>#{opt_bin}/postgres</string>
           <string>-D</string>
-          <string>#{var}/#{name}</string>
+          <string>#{postgresql_datadir}</string>
         </array>
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>
         <key>StandardOutPath</key>
-        <string>#{var}/log/#{name}.log</string>
+        <string>#{postgresql_log_path}</string>
         <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
+        <string>#{postgresql_log_path}</string>
       </dict>
       </plist>
     EOS

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -136,6 +136,11 @@ class PostgresqlAT12 < Formula
           the regular PostgreSQL formula. This causes a conflict if you
           try to use both at the same time.
 
+          In order to avoid this conflict, you should make sure that the
+          #{name} data directory is located at:
+
+            #{var}/#{name}
+
         EOS
       else
         # Only PostgreSQL@12 is installed, not PostgreSQL

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -89,9 +89,6 @@ class PostgresqlAT12 < Formula
 
   def caveats
     <<~EOS
-      To migrate existing data from a previous major version of PostgreSQL run:
-        brew postgresql-upgrade-database
-
       This formula has created a default database cluster with:
         initdb --locale=C -E UTF-8 #{var}/#{name}
       For more details, read:

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -121,7 +121,7 @@ class PostgresqlAT12 < Formula
     (versioned_data_dir/"PG_VERSION").exist?
   end
 
-  def conflicts_with_postgresql_formula?
+  def postgresql_formula_present?
     Formula["postgresql"].any_version_installed?
   end
 
@@ -140,7 +140,7 @@ class PostgresqlAT12 < Formula
     # ... and check it against the old data dir postgres version number
     # to see if we need to print a warning re: data dir
     if old_postgresql_datadir_version == pg_formula_version
-      caveats += if conflicts_with_postgresql_formula?
+      caveats += if postgresql_formula_present?
         # Both PostgreSQL and PostgreSQL@12 are installed
         <<~EOS
           Previous versions of this formula used the same data directory as

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -93,7 +93,7 @@ class PostgresqlAT12 < Formula
         brew postgresql-upgrade-database
 
       This formula has created a default database cluster with:
-        initdb --locale=C -E UTF-8 #{var}/postgres
+        initdb --locale=C -E UTF-8 #{var}/#{name}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -82,7 +82,7 @@ class PostgresqlAT12 < Formula
 
     (var/"log").mkpath
     versioned_data_dir.mkpath
-    unless versioned_data_dir_exists?
+    unless versioned_pg_version_exists?
       system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", versioned_data_dir
     end
   end
@@ -92,7 +92,7 @@ class PostgresqlAT12 < Formula
   # and has a PG_VERSION file, which should indicate that the versioned
   # data dir is in use. Otherwise, returns the old data dir path.
   def postgresql_datadir
-    if versioned_data_dir_exists?
+    if versioned_pg_version_exists?
       versioned_data_dir
     else
       old_postgres_data_dir
@@ -110,14 +110,14 @@ class PostgresqlAT12 < Formula
   # Same as with the data dir - use old log file if the old data dir
   # is version 12
   def postgresql_log_path
-    if versioned_data_dir_exists?
+    if versioned_pg_version_exists?
       "#{var}/log/#{name}"
     else
       "#{var}/log/postgres"
     end
   end
 
-  def versioned_data_dir_exists?
+  def versioned_pg_version_exists?
     File.exist?("#{versioned_postgresql_data_dir}/PG_VERSION")
   end
 

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -100,20 +100,20 @@ class PostgresqlAT12 < Formula
   end
 
   def versioned_data_dir
-    "#{var}/#{name}"
+    var/name
   end
 
   def old_postgres_data_dir
-    "#{var}/postgres"
+    var/"postgres"
   end
 
   # Same as with the data dir - use old log file if the old data dir
   # is version 12
   def postgresql_log_path
     if versioned_pg_version_exists?
-      "#{var}/log/#{name}"
+      var/"log/#{name}"
     else
-      "#{var}/log/postgres"
+      var/"log/postgres"
     end
   end
 

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -95,7 +95,7 @@ class PostgresqlAT12 < Formula
     if versioned_data_dir_exists?
       versioned_data_dir
     else
-      old_postgresql_data_dir
+      old_postgres_data_dir
     end
   end
 
@@ -103,7 +103,7 @@ class PostgresqlAT12 < Formula
     "#{var}/#{name}"
   end
 
-  def old_postgresql_data_dir
+  def old_postgres_data_dir
     "#{var}/postgres"
   end
 
@@ -128,8 +128,8 @@ class PostgresqlAT12 < Formula
   # Figure out what version of PostgreSQL the old data dir is
   # using
   def old_postgresql_datadir_version_12?
-    File.exist?("#{old_postgresql_data_dir}/PG_VERSION") &&
-      File.read("#{old_postgresql_data_dir}/PG_VERSION").chomp == "12"
+    File.exist?("#{old_postgres_data_dir}/PG_VERSION") &&
+      File.read("#{old_postgres_data_dir}/PG_VERSION").chomp == "12"
   end
 
   def caveats
@@ -156,9 +156,8 @@ class PostgresqlAT12 < Formula
           the postgresql formula. This will cause a conflict if you
           try to use both at the same time.
 
-          You can migrate to a versioned data directory by running this command:
-
-            mv -v "#{old_postgresql_data_dir}" "#{versioned_data_dir}"
+          You can migrate to a versioned data directory by running:
+            mv -v "#{old_postgres_data_dir}" "#{versioned_data_dir}"
 
           (Make sure PostgreSQL is stopped before executing this command)
 

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -82,9 +82,7 @@ class PostgresqlAT12 < Formula
 
     (var/"log").mkpath
     versioned_data_dir.mkpath
-    unless versioned_pg_version_exists?
-      system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", versioned_data_dir
-    end
+    system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", versioned_data_dir unless versioned_pg_version_exists?
   end
 
   # Previous versions of this formula used the same data dir as the regular

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -99,7 +99,8 @@ class PostgresqlAT12 < Formula
     end
   end
 
-  # Same as with the data dir - use old log file if 
+  # Same as with the data dir - use old log file if the old data dir
+  # is version 12
   def postgresql_log_path
     if versioned_data_dir_exists?
       "#{var}/log/#{name}"

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -92,19 +92,19 @@ class PostgresqlAT12 < Formula
   # and has a PG_VERSION file, which should indicate that the versioned
   # data dir is in use. Otherwise, returns the old data dir path.
   def postgresql_datadir
-    unless versioned_data_dir_exists?
-      "#{var}/postgres"
-    else
+    if versioned_data_dir_exists?
       "#{var}/#{name}"
+    else
+      "#{var}/postgres"
     end
   end
 
   # Same as with the data dir - use old log file if 
   def postgresql_log_path
-    unless versioned_data_dir_exists?
-      "#{var}/log/postgres"
-    else
+    if versioned_data_dir_exists?
       "#{var}/log/#{name}"
+    else
+      "#{var}/log/postgres"
     end
   end
 

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -99,7 +99,7 @@ class PostgresqlAT12 < Formula
     EOS
   end
 
-  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgres@12 start"
+  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/#{name} start"
 
   def plist
     <<~EOS

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -81,9 +81,9 @@ class PostgresqlAT12 < Formula
     return if ENV["CI"]
 
     (var/"log").mkpath
-    postgresql_datadir.mkpath
+    versioned_postgresql_data_dir.mkpath
     unless versioned_data_dir_exists?
-      system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", postgresql_datadir
+      system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", versioned_postgresql_data_dir
     end
   end
 

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -81,9 +81,9 @@ class PostgresqlAT12 < Formula
     return if ENV["CI"]
 
     (var/"log").mkpath
-    (var/"postgres").mkpath
-    unless File.exist? "#{var}/postgres/PG_VERSION"
-      system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", "#{var}/postgres"
+    (var/name).mkpath
+    unless File.exist? "#{var}/#{name}/PG_VERSION"
+      system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", "#{var}/#{name}"
     end
   end
 

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -140,15 +140,15 @@ class PostgresqlAT12 < Formula
       else
         # Only PostgreSQL@12 is installed, not PostgreSQL
         <<~EOS
-          Previous versions of this formula used the same data directory as
-          the regular PostgreSQL formula. This will cause a conflict if you
+          Previous versions of #{name} used the same data directory as
+          the postgresql formula. This will cause a conflict if you
           try to use both at the same time.
 
           You can migrate to a versioned data directory by running this command:
 
             mv -v "#{var}/postgres" "#{var}/#{name}"
 
-          (Make sure PostgreSQL is not running before executing this command)
+          (Make sure PostgreSQL is stopped before executing this command)
 
         EOS
       end

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -129,9 +129,9 @@ class PostgresqlAT12 < Formula
 
     # Check if we need to print a warning re: data dir
     if old_postgresql_datadir_version_12?
-      if conflicts_with_postgresql_formula?
+      caveats += if conflicts_with_postgresql_formula?
         # Both PostgreSQL and PostgreSQL@12 are installed
-        caveats += <<~EOS
+        <<~EOS
           Previous versions of this formula used the same data directory as
           the regular PostgreSQL formula. This causes a conflict if you
           try to use both at the same time.
@@ -139,7 +139,7 @@ class PostgresqlAT12 < Formula
         EOS
       else
         # Only PostgreSQL@12 is installed, not PostgreSQL
-        caveats += <<~EOS
+        <<~EOS
           Previous versions of this formula used the same data directory as
           the regular PostgreSQL formula. This will cause a conflict if you
           try to use both at the same time.

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -127,16 +127,19 @@ class PostgresqlAT12 < Formula
 
   # Figure out what version of PostgreSQL the old data dir is
   # using
-  def old_postgresql_datadir_version_12?
-    File.exist?("#{old_postgres_data_dir}/PG_VERSION") &&
-      File.read("#{old_postgres_data_dir}/PG_VERSION").chomp == "12"
+  def old_postgresql_datadir_version
+    pg_version = old_postgres_data_dir/"PG_VERSION"
+    pg_version.exist? && pg_version.read.chomp
   end
 
   def caveats
     caveats = ""
 
-    # Check if we need to print a warning re: data dir
-    if old_postgresql_datadir_version_12?
+    # Extract the version from the formula name
+    pg_formula_version = name.split("@", 2)[1]
+    # ... and check it against the old data dir postgres version number
+    # to see if we need to print a warning re: data dir
+    if old_postgresql_datadir_version == pg_formula_version
       caveats += if conflicts_with_postgresql_formula?
         # Both PostgreSQL and PostgreSQL@12 are installed
         <<~EOS

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -118,7 +118,7 @@ class PostgresqlAT12 < Formula
   end
 
   def versioned_pg_version_exists?
-    File.exist?("#{versioned_postgresql_data_dir}/PG_VERSION")
+    (versioned_data_dir/"PG_VERSION").exist?
   end
 
   def conflicts_with_postgresql_formula?

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -134,7 +134,7 @@ class PostgresqlAT12 < Formula
     caveats = ""
 
     # Extract the version from the formula name
-    pg_formula_version = name.split("@", 2)[1]
+    pg_formula_version = name.split("@", 2).last
     # ... and check it against the old data dir postgres version number
     # to see if we need to print a warning re: data dir
     if old_postgresql_datadir_version == pg_formula_version

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -109,9 +109,9 @@ class PostgresqlAT12 < Formula
   # is version 12
   def postgresql_log_path
     if versioned_pg_version_exists?
-      var/"log/#{name}"
+      var/"log/#{name}.log"
     else
-      var/"log/postgres"
+      var/"log/postgres.log"
     end
   end
 
@@ -199,9 +199,9 @@ class PostgresqlAT12 < Formula
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>
         <key>StandardOutPath</key>
-        <string>#{postgresql_log_path}.log</string>
+        <string>#{postgresql_log_path}</string>
         <key>StandardErrorPath</key>
-        <string>#{postgresql_log_path}.log</string>
+        <string>#{postgresql_log_path}</string>
       </dict>
       </plist>
     EOS

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -81,9 +81,9 @@ class PostgresqlAT12 < Formula
     return if ENV["CI"]
 
     (var/"log").mkpath
-    versioned_postgresql_data_dir.mkpath
+    versioned_data_dir.mkpath
     unless versioned_data_dir_exists?
-      system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", versioned_postgresql_data_dir
+      system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", versioned_data_dir
     end
   end
 
@@ -93,13 +93,13 @@ class PostgresqlAT12 < Formula
   # data dir is in use. Otherwise, returns the old data dir path.
   def postgresql_datadir
     if versioned_data_dir_exists?
-      versioned_postgresql_data_dir
+      versioned_data_dir
     else
       old_postgresql_data_dir
     end
   end
 
-  def versioned_postgresql_data_dir
+  def versioned_data_dir
     "#{var}/#{name}"
   end
 
@@ -146,8 +146,7 @@ class PostgresqlAT12 < Formula
 
           In order to avoid this conflict, you should make sure that the
           #{name} data directory is located at:
-
-            #{versioned_postgresql_data_dir}
+            #{versioned_data_dir}
 
         EOS
       else
@@ -159,7 +158,7 @@ class PostgresqlAT12 < Formula
 
           You can migrate to a versioned data directory by running this command:
 
-            mv -v "#{old_postgresql_data_dir}" "#{versioned_postgresql_data_dir}"
+            mv -v "#{old_postgresql_data_dir}" "#{versioned_data_dir}"
 
           (Make sure PostgreSQL is stopped before executing this command)
 

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -115,16 +115,16 @@ class PostgresqlAT12 < Formula
         <array>
           <string>#{opt_bin}/postgres</string>
           <string>-D</string>
-          <string>#{var}/postgres</string>
+          <string>#{var}/#{name}</string>
         </array>
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>
         <key>StandardOutPath</key>
-        <string>#{var}/log/postgres.log</string>
+        <string>#{var}/log/#{name}.log</string>
         <key>StandardErrorPath</key>
-        <string>#{var}/log/postgres.log</string>
+        <string>#{var}/log/#{name}.log</string>
       </dict>
       </plist>
     EOS

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -66,8 +66,20 @@ class PostgresqlAT94 < Formula
     return if ENV["CI"]
 
     (var/"log").mkpath
-    (var/name).mkpath
-    system "#{bin}/initdb", "#{var}/#{name}" unless File.exist? "#{var}/#{name}/PG_VERSION"
+    postgresql_datadir.mkpath
+    system "#{bin}/initdb", postgresql_datadir unless pg_version_exists?
+  end
+
+  def postgresql_datadir
+    var/name
+  end
+
+  def postgresql_log_path
+    var/"log/#{name}.log"
+  end
+
+  def pg_version_exists?
+    (postgresql_datadir/"PG_VERSION").exist?
   end
 
   def caveats
@@ -76,9 +88,6 @@ class PostgresqlAT94 < Formula
       you may need to remove the previous version first. See:
         https://github.com/Homebrew/legacy-homebrew/issues/2510
 
-      To migrate existing data from a previous major version (pre-9.3) of PostgreSQL, see:
-        https://www.postgresql.org/docs/9.3/static/upgrading.html
-
       When installing the postgres gem, including ARCHFLAGS is recommended:
         ARCHFLAGS="-arch x86_64" gem install pg
 
@@ -86,7 +95,7 @@ class PostgresqlAT94 < Formula
         https://docs.brew.sh/Gems,-Eggs-and-Perl-Modules
 
       This formula has created a default database cluster with:
-        initdb #{var}/postgres
+        initdb #{postgresql_datadir}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS
@@ -108,14 +117,14 @@ class PostgresqlAT94 < Formula
         <array>
           <string>#{opt_bin}/postgres</string>
           <string>-D</string>
-          <string>#{var}/#{name}</string>
+          <string>#{postgresql_datadir}</string>
         </array>
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>
         <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
+        <string>#{postgresql_log_path}</string>
       </dict>
       </plist>
     EOS

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -85,8 +85,20 @@ class PostgresqlAT95 < Formula
     return if ENV["CI"]
 
     (var/"log").mkpath
-    (var/name).mkpath
-    system "#{bin}/initdb", "#{var}/#{name}" unless File.exist? "#{var}/#{name}/PG_VERSION"
+    postgresql_datadir.mkpath
+    system "#{bin}/initdb", postgresql_datadir unless pg_version_exists?
+  end
+
+  def postgresql_datadir
+    var/name
+  end
+
+  def postgresql_log_path
+    var/"log/#{name}.log"
+  end
+
+  def pg_version_exists?
+    (postgresql_datadir/"PG_VERSION").exist?
   end
 
   def caveats
@@ -95,17 +107,8 @@ class PostgresqlAT95 < Formula
       you may need to remove the previous version first. See:
         https://github.com/Homebrew/legacy-homebrew/issues/2510
 
-      To migrate existing data from a previous major version (pre-9.0) of PostgreSQL, see:
-        https://www.postgresql.org/docs/9.5/static/upgrading.html
-
-      To migrate existing data from a previous minor version (9.0-9.4) of PostgreSQL, see:
-        https://www.postgresql.org/docs/9.5/static/pgupgrade.html
-
-        You will need your previous PostgreSQL installation from brew to perform `pg_upgrade`.
-        Do not run `brew cleanup postgresql@9.5` until you have performed the migration.
-
       This formula has created a default database cluster with:
-        initdb #{var}/postgres
+        initdb #{postgresql_datadir}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS
@@ -127,14 +130,14 @@ class PostgresqlAT95 < Formula
         <array>
           <string>#{opt_bin}/postgres</string>
           <string>-D</string>
-          <string>#{var}/#{name}</string>
+          <string>#{postgresql_datadir}</string>
         </array>
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>
         <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
+        <string>#{postgresql_log_path}</string>
       </dict>
       </plist>
     EOS

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -85,8 +85,20 @@ class PostgresqlAT96 < Formula
     return if ENV["CI"]
 
     (var/"log").mkpath
-    (var/name).mkpath
-    system "#{bin}/initdb", "#{var}/#{name}" unless File.exist? "#{var}/#{name}/PG_VERSION"
+    postgresql_datadir.mkpath
+    system "#{bin}/initdb", postgresql_datadir unless pg_version_exists?
+  end
+
+  def postgresql_datadir
+    var/name
+  end
+
+  def postgresql_log_path
+    var/"log/#{name}.log"
+  end
+
+  def pg_version_exists?
+    (postgresql_datadir/"PG_VERSION").exist?
   end
 
   def caveats
@@ -95,17 +107,8 @@ class PostgresqlAT96 < Formula
       you may need to remove the previous version first. See:
         https://github.com/Homebrew/legacy-homebrew/issues/2510
 
-      To migrate existing data from a previous major version (pre-9.0) of PostgreSQL, see:
-        https://www.postgresql.org/docs/9.6/static/upgrading.html
-
-      To migrate existing data from a previous minor version (9.0-9.5) of PostgreSQL, see:
-        https://www.postgresql.org/docs/9.6/static/pgupgrade.html
-
-        You will need your previous PostgreSQL installation from brew to perform `pg_upgrade`.
-          Do not run `brew cleanup postgresql@9.6` until you have performed the migration.
-
       This formula has created a default database cluster with:
-        initdb #{var}/postgres
+        initdb #{postgresql_datadir}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS
@@ -127,14 +130,14 @@ class PostgresqlAT96 < Formula
         <array>
           <string>#{opt_bin}/postgres</string>
           <string>-D</string>
-          <string>#{var}/#{name}</string>
+          <string>#{postgresql_datadir}</string>
         </array>
         <key>RunAtLoad</key>
         <true/>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>
         <key>StandardErrorPath</key>
-        <string>#{var}/log/#{name}.log</string>
+        <string>#{postgresql_log_path}</string>
       </dict>
       </plist>
     EOS


### PR DESCRIPTION
This updates the plist definition for `brew services` to work analogous to the one for PostgreSQL@11, so it uses `/usr/local/var/postgresql@12` instead of `/usr/local/var/postgres`, which collides with the existing PostgreSQL 13 formula.

(Note: This does not change anything about the formula itself, only the plist definition)

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
