### PR TITLE
triage: automerge-skip for patchelf and binutils

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -110,5 +110,8 @@ jobs:
                     "label": "swift",
                     "path": "Formula/.+",
                     "content": "system \"swift\", \"build\""
+                }, {
+                    "label": "automerge-skip",
+                    "path": "Formula/(patchelf|binutils).rb"
                 }
             ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
