### PR TITLE
PostgreSQL formulaes: Fix displayed data dir in caveats

### DIFF
--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -91,13 +91,13 @@ class PostgresqlAT10 < Formula
         brew postgresql-upgrade-database
 
       This formula has created a default database cluster with:
-        initdb #{var}/postgres
+        initdb #{var}/#{name}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS
   end
 
-  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql@10 start"
+  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/#{name} start"
 
   def plist
     <<~EOS

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -87,9 +87,6 @@ class PostgresqlAT10 < Formula
 
   def caveats
     <<~EOS
-      To migrate existing data from a previous major version of PostgreSQL run:
-        brew postgresql-upgrade-database
-
       This formula has created a default database cluster with:
         initdb #{var}/#{name}
       For more details, read:

--- a/Formula/postgresql@11.rb
+++ b/Formula/postgresql@11.rb
@@ -79,9 +79,6 @@ class PostgresqlAT11 < Formula
 
   def caveats
     <<~EOS
-      To migrate existing data from a previous major version of PostgreSQL run:
-        brew postgresql-upgrade-database
-
       This formula has created a default database cluster with:
         initdb --locale=C -E UTF-8 #{var}/#{name}
       For more details, read:

--- a/Formula/postgresql@11.rb
+++ b/Formula/postgresql@11.rb
@@ -83,13 +83,13 @@ class PostgresqlAT11 < Formula
         brew postgresql-upgrade-database
 
       This formula has created a default database cluster with:
-        initdb --locale=C -E UTF-8 #{var}/postgres
+        initdb --locale=C -E UTF-8 #{var}/#{name}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS
   end
 
-  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql@11 start"
+  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/#{name} start"
 
   def plist
     <<~EOS

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -86,13 +86,13 @@ class PostgresqlAT94 < Formula
         https://docs.brew.sh/Gems,-Eggs-and-Perl-Modules
 
       This formula has created a default database cluster with:
-        initdb #{var}/postgres
+        initdb #{var}/#{name}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS
   end
 
-  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql@9.4 start"
+  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/#{name} start"
 
   def plist
     <<~EOS

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -76,9 +76,6 @@ class PostgresqlAT94 < Formula
       you may need to remove the previous version first. See:
         https://github.com/Homebrew/legacy-homebrew/issues/2510
 
-      To migrate existing data from a previous major version (pre-9.3) of PostgreSQL, see:
-        https://www.postgresql.org/docs/9.3/static/upgrading.html
-
       When installing the postgres gem, including ARCHFLAGS is recommended:
         ARCHFLAGS="-arch x86_64" gem install pg
 

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -95,12 +95,6 @@ class PostgresqlAT95 < Formula
       you may need to remove the previous version first. See:
         https://github.com/Homebrew/legacy-homebrew/issues/2510
 
-      To migrate existing data from a previous major version (pre-9.0) of PostgreSQL, see:
-        https://www.postgresql.org/docs/9.5/static/upgrading.html
-
-      To migrate existing data from a previous minor version (9.0-9.4) of PostgreSQL, see:
-        https://www.postgresql.org/docs/9.5/static/pgupgrade.html
-
         You will need your previous PostgreSQL installation from brew to perform `pg_upgrade`.
         Do not run `brew cleanup postgresql@9.5` until you have performed the migration.
 

--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -105,13 +105,13 @@ class PostgresqlAT95 < Formula
         Do not run `brew cleanup postgresql@9.5` until you have performed the migration.
 
       This formula has created a default database cluster with:
-        initdb #{var}/postgres
+        initdb #{var}/#{name}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS
   end
 
-  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql@9.5 start"
+  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/#{name} start"
 
   def plist
     <<~EOS

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -105,13 +105,13 @@ class PostgresqlAT96 < Formula
           Do not run `brew cleanup postgresql@9.6` until you have performed the migration.
 
       This formula has created a default database cluster with:
-        initdb #{var}/postgres
+        initdb #{var}/#{name}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
     EOS
   end
 
-  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/postgresql@9.6 start"
+  plist_options manual: "pg_ctl -D #{HOMEBREW_PREFIX}/var/#{name} start"
 
   def plist
     <<~EOS


### PR DESCRIPTION
The versioned PostgreSQL formulaes use a versioned data dir, so they can coexist on the same system. However, the data dir path displayed in `caveats` was not correct.

Also, this updated the `plist_options` call to use the name of the formula instead of hardcoding it.

Note: PostgreSQL@12 is not included in this PR, as this is fixed in #65102


-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
