### PR TITLE
swift-format 5.3

### DIFF
--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -2,8 +2,8 @@ class SwiftFormat < Formula
   desc "Formatting technology for Swift source code"
   homepage "https://github.com/apple/swift-format"
   url "https://github.com/apple/swift-format.git",
-    tag:      "0.50200.1",
-    revision: "f22aade8a6ee061b4a7041601ededd8ad7bc2122"
+    tag:      "0.50300.0",
+    revision: "12089179aa1668a2478b2b2111d98fa37f3531e3"
   license "Apache-2.0"
   version_scheme 1
   head "https://github.com/apple/swift-format.git", branch: "main"
@@ -13,7 +13,14 @@ class SwiftFormat < Formula
     sha256 "d8f72c33efc125e2904e1bec2c8942cca75d75cf81dcab7fcf08ba124af16170" => :catalina
   end
 
-  depends_on xcode: ["11.4", :build]
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  pour_bottle? do
+    reason "The bottle needs the Xcode CLT to be installed."
+    satisfy { MacOS::CLT.installed? }
+  end
+
+  depends_on xcode: ["12.0", :build]
 
   def install
     system "swift", "build", "--disable-sandbox", "-c", "release"


### PR DESCRIPTION
Apple has a more recent release of `swift-format`.  See apple/swift-format#236.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
