### PR TITLE
patchelf: Fix unsupported overlap of SHT_NOTE and PT_NOTE

### DIFF
--- a/Formula/patchelf.rb
+++ b/Formula/patchelf.rb
@@ -4,6 +4,7 @@ class Patchelf < Formula
   url "https://github.com/NixOS/patchelf/releases/download/0.12/patchelf-0.12.tar.bz2"
   sha256 "699a31cf52211cf5ad6e35a8801eb637bc7f3c43117140426400d67b7babd792"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/NixOS/patchelf.git"
 
   livecheck do
@@ -21,6 +22,13 @@ class Patchelf < Formula
   resource "helloworld" do
     url "http://timelessname.com/elfbin/helloworld.tar.gz"
     sha256 "d8c1e93f13e0b7d8fc13ce75d5b089f4d4cec15dad91d08d94a166822d749459"
+  end
+
+  # Fix unsupported overlap of SHT_NOTE and PT_NOTE
+  # See https://github.com/NixOS/patchelf/pull/230
+  patch do
+    url "https://github.com/rmNULL/patchelf/commit/6edec83653ce1b5fc201ff6db93b966394766814.patch?full_index=1"
+    sha256 "072eff6c5b33298b423f47ec794c7765a42d58a2050689bb20bf66076afb98ac"
   end
 
   def install

--- a/Formula/patchelf.rb
+++ b/Formula/patchelf.rb
@@ -1,8 +1,8 @@
 class Patchelf < Formula
   desc "Modify dynamic ELF executables"
   homepage "https://github.com/NixOS/patchelf"
-  url "https://github.com/NixOS/patchelf/archive/0.12.tar.gz"
-  sha256 "3dca33fb862213b3541350e1da262249959595903f559eae0fbc68966e9c3f56"
+  url "https://github.com/NixOS/patchelf/releases/download/0.12/patchelf-0.12.tar.bz2"
+  sha256 "699a31cf52211cf5ad6e35a8801eb637bc7f3c43117140426400d67b7babd792"
   license "GPL-3.0-or-later"
   head "https://github.com/NixOS/patchelf.git"
 
@@ -18,9 +18,6 @@ class Patchelf < Formula
     sha256 "d7c841a08ca1f9e4cc24fa6378e14f82f46dac6124d860777fb53161ac82a426" => :high_sierra
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-
   resource "helloworld" do
     url "http://timelessname.com/elfbin/helloworld.tar.gz"
     sha256 "d8c1e93f13e0b7d8fc13ce75d5b089f4d4cec15dad91d08d94a166822d749459"
@@ -34,7 +31,6 @@ class Patchelf < Formula
       ENV["HOMEBREW_RPATH_PATHS"] = nil
     end
 
-    system "./bootstrap.sh"
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix unsupported overlap of SHT_NOTE and PT_NOTE
See https://github.com/NixOS/patchelf/pull/230

Remove the build dependency on autotools
The build dependencies on autoconf and automake can be avoided by using the bootstrapped tarball. Avoiding build dependencies is particularly helpful on Linux, where patchelf is required for bootstrapping.
