### PR TITLE
nudoku: build head without patch

### DIFF
--- a/Formula/nudoku.rb
+++ b/Formula/nudoku.rb
@@ -1,10 +1,20 @@
 class Nudoku < Formula
   desc "Ncurses based sudoku game"
   homepage "https://jubalh.github.io/nudoku/"
-  url "https://github.com/jubalh/nudoku/archive/2.0.0.tar.gz"
-  sha256 "44d3ec1ff34a010910ac7a92f6d84e8a7a4678a966999b7be27d224609ae54e1"
   license "GPL-3.0"
   head "https://github.com/jubalh/nudoku.git"
+
+  stable do
+    url "https://github.com/jubalh/nudoku/archive/2.0.0.tar.gz"
+    sha256 "44d3ec1ff34a010910ac7a92f6d84e8a7a4678a966999b7be27d224609ae54e1"
+
+    # gettext 0.20 compatibility.
+    # Remove with next release.
+    patch do
+      url "https://github.com/jubalh/nudoku/commit/9a4ffc359fe72f6af0e3654ae19ae421ab941ea8.patch?full_index=1"
+      sha256 "e4b52f5ac48bfd192f28ae4b3a2fb146c7bc1bec1a441e8e10f4ad90550d4e66"
+    end
+  end
 
   bottle do
     sha256 "bd5279ad0896787dadf5f2ef3c9796eed06d7dac60fb91ae337a7e372191082a" => :big_sur
@@ -19,13 +29,6 @@ class Nudoku < Formula
   depends_on "gettext"
 
   uses_from_macos "ncurses"
-
-  # gettext 0.20 compatibility.
-  # Remove with next release.
-  patch do
-    url "https://github.com/jubalh/nudoku/commit/9a4ffc359fe72f6af0e3654ae19ae421ab941ea8.patch?full_index=1"
-    sha256 "e4b52f5ac48bfd192f28ae4b3a2fb146c7bc1bec1a441e8e10f4ad90550d4e66"
-  end
 
   def install
     system "autoreconf", "-fiv"

--- a/Formula/nudoku.rb
+++ b/Formula/nudoku.rb
@@ -1,7 +1,7 @@
 class Nudoku < Formula
   desc "Ncurses based sudoku game"
   homepage "https://jubalh.github.io/nudoku/"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
   head "https://github.com/jubalh/nudoku.git"
 
   stable do

--- a/Formula/nudoku.rb
+++ b/Formula/nudoku.rb
@@ -1,7 +1,7 @@
 class Nudoku < Formula
   desc "Ncurses based sudoku game"
   homepage "https://jubalh.github.io/nudoku/"
-  license "GPL-3.0-only"
+  license "GPL-3.0-or-later"
   head "https://github.com/jubalh/nudoku.git"
 
   stable do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The patch was added to get the source/bottled version up to `2.0.0` as there is an issue with `gettext` in that version. However, `head` has more changes since then and the patch fails to apply since it's already included.

Also in regards to the license, the `LICENSE` file simply states GPL3. Although the source files have a header that reads:
>  This program is free software: you can redistribute it and/or modify
> it under the terms of the GNU General Public License as published by
> the Free Software Foundation, either version 3 of the License, or
> (at your option) any later version.

I have sided with `-only` but please advise if this needs to change.