### PR TITLE
formulae*: Fix `deprecate!` or `disable!` stanza ordering

### DIFF
--- a/Formula/a2ps.rb
+++ b/Formula/a2ps.rb
@@ -21,6 +21,9 @@ class A2ps < Formula
     satisfy { HOMEBREW_PREFIX.to_s == Homebrew::DEFAULT_PREFIX }
   end
 
+  # Fails to build on Catalina. No new release since 2007
+  disable! because: :does_not_build
+
   # Software was last updated in 2007.
   # https://svn.macports.org/ticket/20867
   # https://trac.macports.org/ticket/18255
@@ -39,9 +42,6 @@ class A2ps < Formula
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/0ae366e6/a2ps/patch-lib__xstrrpl.c"
     sha256 "89fa3c95c329ec326e2e76493471a7a974c673792725059ef121e6f9efb05bf4"
   end
-
-  # Fails to build on Catalina. No new release since 2007
-  disable! because: :does_not_build
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/afuse.rb
+++ b/Formula/afuse.rb
@@ -5,8 +5,6 @@ class Afuse < Formula
   sha256 "c6e0555a65d42d3782e0734198bbebd22486386e29cb00047bc43c3eb726dca8"
   license "GPL-2.0"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "cf5a7aeba0e2504ea5bf7bf691ed2d0f8245cbac069b089359588e7df04140e0" => :catalina
@@ -16,6 +14,8 @@ class Afuse < Formula
     sha256 "a4c0f86a179ca8c5d1e3977ff167dbcd1abff4ec1ee17fd5700a3fb602c781a3" => :el_capitan
     sha256 "2a57c7752c7b461f6b628a1c30e845fe13685eab394d933e8da3aebf7102ae9c" => :yosemite
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on :osxfuse

--- a/Formula/apollo.rb
+++ b/Formula/apollo.rb
@@ -16,6 +16,9 @@ class Apollo < Formula
     sha256 "81b2a6a1110da6cf58c6725eb6e2c331668fa39d01644e0a754a2eb9241fdccd" => :high_sierra
   end
 
+  # https://github.com/apache/activemq-apollo/commit/049d68bf3f94cdf62ded5426d3cad4ef3e3c56ca
+  deprecate! date: "2019-03-11", because: :deprecated_upstream
+
   depends_on "openjdk"
 
   # https://www.oracle.com/technetwork/database/berkeleydb/overview/index-093405.html
@@ -29,9 +32,6 @@ class Apollo < Formula
     url "https://search.maven.org/remotecontent?filepath=org/fusesource/fuse-extra/fusemq-apollo-mqtt/1.3/fusemq-apollo-mqtt-1.3-uber.jar"
     sha256 "2795caacbc6086c7de46b588d11a78edbf8272acb7d9da3fb329cb34fcb8783f"
   end
-
-  # https://github.com/apache/activemq-apollo/commit/049d68bf3f94cdf62ded5426d3cad4ef3e3c56ca
-  deprecate! date: "2019-03-11", because: :deprecated_upstream
 
   def install
     prefix.install_metafiles

--- a/Formula/app-engine-java.rb
+++ b/Formula/app-engine-java.rb
@@ -4,9 +4,6 @@ class AppEngineJava < Formula
   url "https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.83.zip"
   sha256 "1d585a36303c14f4fa44790bba97d5d8b75a889ad48ffce8187333488511e43e"
 
-  # https://cloud.google.com/appengine/docs/standard/java/sdk-gcloud-migration
-  deprecate! date: "2019-07-30", because: :deprecated_upstream
-
   # This has received at least one update after the supposed end of life date
   # (2020-08-30), so there may be value in keeping this check around for a
   # little while longer. Once it's clear this won't receive any more updates,
@@ -18,6 +15,9 @@ class AppEngineJava < Formula
   end
 
   bottle :unneeded
+
+  # https://cloud.google.com/appengine/docs/standard/java/sdk-gcloud-migration
+  deprecate! date: "2019-07-30", because: :deprecated_upstream
 
   depends_on "openjdk@8"
 

--- a/Formula/archivemount.rb
+++ b/Formula/archivemount.rb
@@ -4,8 +4,6 @@ class Archivemount < Formula
   url "https://www.cybernoia.de/software/archivemount/archivemount-0.9.1.tar.gz"
   sha256 "c529b981cacb19541b48ddafdafb2ede47a40fcaf16c677c1e2cd198b159c5b3"
 
-  deprecate! because: "requires FUSE"
-
   livecheck do
     url :homepage
     regex(/href=.*?archivemount[._-]v?(\d+(?:\.\d+)+)\.t/i)
@@ -17,6 +15,8 @@ class Archivemount < Formula
     sha256 "439cdd8d7c962cf9a5144e20206ddaeaabc15c1752c58acd059e31976e254f6a" => :mojave
     sha256 "428113b60673b6bb8be9467587f1d82bf4c9447c7f0bbdea47749bed3ec86798" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on "libarchive"

--- a/Formula/aurora-cli.rb
+++ b/Formula/aurora-cli.rb
@@ -13,11 +13,11 @@ class AuroraCli < Formula
     sha256 "0a1b506e5d75c9fa8d587bfc9945e78c9cb5342c17a4062d18aafb942e111eca" => :high_sierra
   end
 
-  depends_on "python@3.7"
-
   # Does not build on Catalina
   # Has been moved to the Apache Attic: https://github.com/apache/attic-aurora
   disable! because: :does_not_build
+
+  depends_on "python@3.7"
 
   def install
     # No pants yet for Mojave, so we force High Sierra binaries there

--- a/Formula/avfs.rb
+++ b/Formula/avfs.rb
@@ -4,8 +4,6 @@ class Avfs < Formula
   url "https://downloads.sourceforge.net/project/avf/avfs/1.1.3/avfs-1.1.3.tar.bz2"
   sha256 "4f4ec1e8c0d5da94949e3dab7500ee29fa3e0dda723daf8e7d60e5f3ce4450df"
 
-  deprecate! because: "requires FUSE"
-
   livecheck do
     url :stable
     regex(%r{url=.*?/avfs[._-]v?(\d+(?:\.\d+)+)\.t}i)
@@ -16,6 +14,8 @@ class Avfs < Formula
     sha256 "1e75ce4753a0d9a9af12e4a718537a9e2398fd535413b72505dd126a33610fe6" => :mojave
     sha256 "690fbe0161f0c5ce4ec737e67624b54bfcd7825efa8b554e1773691365dcd6ed" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on macos: :sierra # needs clock_gettime

--- a/Formula/aws-apigateway-importer.rb
+++ b/Formula/aws-apigateway-importer.rb
@@ -6,8 +6,6 @@ class AwsApigatewayImporter < Formula
   license "Apache-2.0"
   revision 1
 
-  deprecate! because: :repo_archived
-
   bottle do
     cellar :any_skip_relocation
     sha256 "3a837a89af7bfd9454b2e12924323e82ab6cb6ab09f4088e47b672a6a79aedd2" => :catalina
@@ -17,6 +15,8 @@ class AwsApigatewayImporter < Formula
     sha256 "bbe12dac66d033674840eace741bcf5c3549e7317ab9ca6fa9f349418a6c9861" => :el_capitan
     sha256 "bbe12dac66d033674840eace741bcf5c3549e7317ab9ca6fa9f349418a6c9861" => :yosemite
   end
+
+  deprecate! because: :repo_archived
 
   depends_on "maven" => :build
   depends_on "openjdk@8"

--- a/Formula/bindfs.rb
+++ b/Formula/bindfs.rb
@@ -5,8 +5,6 @@ class Bindfs < Formula
   sha256 "e5ca5aff55204b993a025a77c3f8c0e2ee901ba8059d71bea11de2cc685ec497"
   license "GPL-2.0"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "bf4fb90d788651299973a3f48300824ae6b4ec4ce1441dd94d544180f54379bd" => :catalina
@@ -20,6 +18,8 @@ class Bindfs < Formula
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on :osxfuse

--- a/Formula/borgbackup.rb
+++ b/Formula/borgbackup.rb
@@ -8,8 +8,6 @@ class Borgbackup < Formula
   license "BSD-3-Clause"
   revision 1
 
-  deprecate! because: "requires FUSE"
-
   livecheck do
     url "https://github.com/borgbackup/borg/releases/latest"
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
@@ -21,6 +19,8 @@ class Borgbackup < Formula
     sha256 "c0caa9585403c77102d7b9d31f38bbcfa9ed26e8b4a0893daa43e6fe2b03f6e7" => :mojave
     sha256 "572afe4f34d36ae32c0ec48da8d4a2e9cc59b4ad891f884e5a1efe48e69c478c" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on osxfuse: :build
   depends_on "pkg-config" => :build

--- a/Formula/btfs.rb
+++ b/Formula/btfs.rb
@@ -6,14 +6,14 @@ class Btfs < Formula
   license "GPL-3.0-only"
   head "https://github.com/johang/btfs.git"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "d5b103b5b9004549a555352be373c2160bcd5b9f6a8e7e8b030cbf113ae76fcd" => :catalina
     sha256 "bb550107105c612e2c9b81478b352d053f5b8ac8658377e0d40e4ee1109519fc" => :mojave
     sha256 "934b8849eaecd08113b01e222c9583f9293100889f3f40f8452a476a6491e0d0" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/contacts.rb
+++ b/Formula/contacts.rb
@@ -9,8 +9,6 @@ class Contacts < Formula
   sha256 "e3dd7e592af0016b28e9215d8ac0fe1a94c360eca5bfbdafc2b0e5d76c60b871"
   license "GPL-2.0-only"
 
-  deprecate! because: :repo_archived
-
   bottle do
     cellar :any_skip_relocation
     sha256 "02f0086162efb3e8473f846252a6c4813e85a1bbf57a38e3420f20946eafa60f" => :catalina
@@ -20,6 +18,8 @@ class Contacts < Formula
     sha256 "7f6c6817310dacf83041d2017e8841b49e26df0d09039692576b6fe0fed52ecc" => :el_capitan
     sha256 "9a9c89e40f9ccf4ec45cf63414eaf31266dfc9b71dc96d8c02f7ab2b38e8f346" => :mavericks
   end
+
+  deprecate! because: :repo_archived
 
   depends_on xcode: :build
 

--- a/Formula/corectl.rb
+++ b/Formula/corectl.rb
@@ -7,14 +7,14 @@ class Corectl < Formula
   revision 2
   head "https://github.com/TheNewNormal/corectl.git", branch: "golang"
 
-  deprecate! because: :unmaintained
-
   bottle do
     cellar :any
     sha256 "b3d030cf97c738ef427b24cd492a7b746b738be84f234f5904eedbff14661570" => :mojave
     sha256 "74527235d27b207a4b4331f16cfbb4f5b72b1dac36f9c9a4470626c32e882d5f" => :high_sierra
     sha256 "89e963f61102d26d5fe756b06f50aa73bf9f827f81f92cefa2da6c195b7865da" => :sierra
   end
+
+  deprecate! because: :unmaintained
 
   depends_on "aspcud" => :build
   depends_on "go" => :build

--- a/Formula/coreos-ct.rb
+++ b/Formula/coreos-ct.rb
@@ -14,9 +14,9 @@ class CoreosCt < Formula
     sha256 "9a48da5217b7e4b57e56702ee884fbc3067ccd895c2144cf7b02571cbcb80b42" => :el_capitan
   end
 
-  depends_on "go" => :build
-
   deprecate! because: :repo_archived
+
+  depends_on "go" => :build
 
   def install
     system "make", "all", "VERSION=v#{version}"

--- a/Formula/cryfs.rb
+++ b/Formula/cryfs.rb
@@ -5,8 +5,6 @@ class Cryfs < Formula
   sha256 "5531351b67ea23f849b71a1bc44474015c5718d1acce039cf101d321b27f03d5"
   license "LGPL-3.0"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     rebuild 1
@@ -19,6 +17,8 @@ class Cryfs < Formula
   head do
     url "https://github.com/cryfs/cryfs.git", branch: "develop", shallow: false
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "cmake" => :build
   depends_on "boost"

--- a/Formula/cssembed.rb
+++ b/Formula/cssembed.rb
@@ -5,9 +5,9 @@ class Cssembed < Formula
   sha256 "8955016c0d32de8755d9ee33d365d1ad658a596aba48537a810ce62f3d32a1af"
   license "MIT"
 
-  deprecate! because: :repo_archived
-
   bottle :unneeded
+
+  deprecate! because: :repo_archived
 
   def install
     libexec.install "cssembed-#{version}.jar"

--- a/Formula/curlftpfs.rb
+++ b/Formula/curlftpfs.rb
@@ -6,8 +6,6 @@ class Curlftpfs < Formula
   revision 1
   head ":pserver:anonymous:@curlftpfs.cvs.sourceforge.net:/cvsroot/curlftpfs", using: :cvs
 
-  deprecate! because: "requires FUSE"
-
   livecheck do
     url :stable
   end
@@ -19,6 +17,8 @@ class Curlftpfs < Formula
     sha256 "edb3da0b0ccc3b5b3004096f89174786ad75838b82b6c6b621855291744147f1" => :high_sierra
     sha256 "5734dbff6e2a7c18232d08d22fe64e19610f32b07e48b276996df759baaef407" => :sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/dislocker.rb
+++ b/Formula/dislocker.rb
@@ -6,13 +6,13 @@ class Dislocker < Formula
   license "GPL-2.0"
   revision 4
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     sha256 "e0049b9ff51ad9f3e4008df1edac9b52aa0d8df55e119990553b4d9cec651b90" => :catalina
     sha256 "f6378852886b1d1793260ce411250751614428102a5fd07f792352ce0fc206c3" => :mojave
     sha256 "2b1e50229eb344c432db6cc35fd42b6e91d713f97f81d6f5067087f5c59b6cb3" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "cmake" => :build
   depends_on "mbedtls"

--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -9,14 +9,14 @@ class Encfs < Formula
   revision 3
   head "https://github.com/vgough/encfs.git"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     sha256 "c41dd4f6c6eae27645695e7540a6e1ec25cd4a15756e5f5ed97a345cd39372fc" => :catalina
     sha256 "1cc308274ff04d95ab12bc39be227517dbf264e5cf811d72b153d6f84b06c0cb" => :mojave
     sha256 "137944ecee75c5d82634bf1458316c4d64d841ed9f92a4638ad266503f92b66f" => :high_sierra
     sha256 "79e5d3548036ae74ed956bea6d9c4ab7f2e12faf7b49b541da9a72476159a557" => :sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/erlang@20.rb
+++ b/Formula/erlang@20.rb
@@ -13,10 +13,10 @@ class ErlangAT20 < Formula
     sha256 "a401feb22927ecc0e649f3f2f7aeba331725b6390985f826ed5639d59732ee6a" => :high_sierra
   end
 
+  keg_only :versioned_formula
+
   # Deprecated with OTP-23 release (https://erlang.org/pipermail/erlang-questions/2020-July/099747.html)
   disable! date: "2020-05-13", because: :unmaintained
-
-  keg_only :versioned_formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/ext2fuse.rb
+++ b/Formula/ext2fuse.rb
@@ -5,8 +5,6 @@ class Ext2fuse < Formula
   sha256 "431035797b2783216ec74b6aad5c721b4bffb75d2174967266ee49f0a3466cd9"
   revision 2
 
-  deprecate! because: "requires FUSE"
-
   livecheck do
     url :stable
   end
@@ -17,6 +15,8 @@ class Ext2fuse < Formula
     sha256 "541b0787069c0bf37607392a9789ed4e3b2f21ebe214b3274ec27023aa03335f" => :mojave
     sha256 "0b8e89292e91a8fbe00430ae16a3ebbfdbba1017f6dee4801bcf8e63d238962f" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "e2fsprogs"
   depends_on :osxfuse

--- a/Formula/ext4fuse.rb
+++ b/Formula/ext4fuse.rb
@@ -6,8 +6,6 @@ class Ext4fuse < Formula
   license "GPL-2.0"
   head "https://github.com/gerard/ext4fuse.git"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "446dde5e84b058966ead0cde5e38e9411f465732527f6decfa1c0dcdbd4abbef" => :catalina
@@ -17,6 +15,8 @@ class Ext4fuse < Formula
     sha256 "291047c821b7b205d85be853fb005510c6ab01bd4c2a2193c192299b6f049d35" => :el_capitan
     sha256 "b11f564b7e7c08af0b0a3e9854973d39809bf2d8a56014f4882772b2f7307ac1" => :yosemite
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on :osxfuse

--- a/Formula/fceux.rb
+++ b/Formula/fceux.rb
@@ -12,14 +12,14 @@ class Fceux < Formula
     sha256 "3f587de213706a92fb02b14676514f6cba079e3c3b7ded2e57a8e718ebf9cf20" => :high_sierra
   end
 
+  # Does not build: some build scripts rely on Python 2 syntax
+  disable! because: :does_not_build
+
   depends_on "pkg-config" => :build
   depends_on "scons" => :build
   depends_on "gd"
   depends_on "gtk+3"
   depends_on "sdl"
-
-  # Does not build: some build scripts rely on Python 2 syntax
-  disable! because: :does_not_build
 
   # Fix "error: ordered comparison between pointer and zero"
   if DevelopmentTools.clang_build_version >= 900

--- a/Formula/fuse-zip.rb
+++ b/Formula/fuse-zip.rb
@@ -8,8 +8,6 @@ class FuseZip < Formula
   license "GPL-3.0-or-later"
   head "https://bitbucket.org/agalanin/fuse-zip", using: :hg
 
-  deprecate! because: "requires FUSE"
-
   livecheck do
     url :stable
   end
@@ -21,6 +19,8 @@ class FuseZip < Formula
     sha256 "f99be52df0a2ff2842c615bb4fa255c4400b382d2bb98d14e023223956edb245" => :mojave
     sha256 "e72d442a43e1396c8a744e73bc9d197cbef7bb996bba97bff4b377c253c12ed8" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on "libzip"

--- a/Formula/gcsfuse.rb
+++ b/Formula/gcsfuse.rb
@@ -6,8 +6,6 @@ class Gcsfuse < Formula
   license "Apache-2.0"
   head "https://github.com/GoogleCloudPlatform/gcsfuse.git"
 
-  deprecate! because: "requires FUSE"
-
   livecheck do
     url "https://github.com/GoogleCloudPlatform/gcsfuse/releases/latest"
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
@@ -19,6 +17,8 @@ class Gcsfuse < Formula
     sha256 "a97edf4dbfa9e41d2e9d4de092507c9d5199de2324b0d95f454c50893d977889" => :mojave
     sha256 "e0f04b45a7fe6583e424fc81a7c34dace7b01e215739758930b6baab14d3d50c" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "go" => :build
   depends_on :osxfuse

--- a/Formula/git-hooks.rb
+++ b/Formula/git-hooks.rb
@@ -5,12 +5,6 @@ class GitHooks < Formula
   sha256 "8197ca1de975ff1f795a2b9cfcac1a6f7ee24276750c757eecf3bcb49b74808e"
   head "https://github.com/icefox/git-hooks.git"
 
-  # The icefox/git-hooks repository has been deleted and it doesn't appear to
-  # have moved to an alternative location. There is a rewrite in Go by a
-  # different author which someone may want to work into a new formula as a
-  # replacement: https://github.com/git-hooks/git-hooks
-  deprecate! because: :repo_removed
-
   bottle do
     cellar :any_skip_relocation
     sha256 "d33514436cb623e468314418876fe1e7bb8c31ee64fdcd3c9a297f26a7e7ae42" => :catalina
@@ -21,6 +15,12 @@ class GitHooks < Formula
     sha256 "d4c5fba7f1b80e8e68762356a2f64ac216bf4e9f3151cf2f236c92a9524b97ed" => :yosemite
     sha256 "ace6acaff04ef09795d26e6034bf411a89c9f348287dd95f756c82068cea123d" => :mavericks
   end
+
+  # The icefox/git-hooks repository has been deleted and it doesn't appear to
+  # have moved to an alternative location. There is a rewrite in Go by a
+  # different author which someone may want to work into a new formula as a
+  # replacement: https://github.com/git-hooks/git-hooks
+  deprecate! because: :repo_removed
 
   def install
     bin.install "git-hooks"

--- a/Formula/gitfs.rb
+++ b/Formula/gitfs.rb
@@ -9,14 +9,14 @@ class Gitfs < Formula
   revision 4
   head "https://github.com/presslabs/gitfs.git"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "c8c83c94da3b5f1dc480eec0ede90bf678eee59a97bb54a64cf94555d9c57752" => :catalina
     sha256 "189008579b9d28a9084536f62101051648b64a78cd6faf780b3f40041becc188" => :mojave
     sha256 "218c5f19bcecb33e4f18c19cf0f56ce6d9628d4cfad9f095fbb1071af3cd79c2" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "libgit2"
   depends_on :osxfuse

--- a/Formula/gobby.rb
+++ b/Formula/gobby.rb
@@ -13,6 +13,9 @@ class Gobby < Formula
     sha256 "76ec450b768f0d27bb032cfb34e337002ee9f45a547a07c01e03b73e03413ad0" => :high_sierra
   end
 
+  # open issue since 2017-04-23, https://github.com/gobby/gobby/issues/143
+  disable! date: "2018-08-26", because: :unmaintained
+
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
@@ -23,9 +26,6 @@ class Gobby < Formula
   depends_on "hicolor-icon-theme"
   depends_on "libinfinity"
   depends_on "libxml++"
-
-  # open issue since 2017-04-23, https://github.com/gobby/gobby/issues/143
-  disable! date: "2018-08-26", because: :unmaintained
 
   # Necessary to remove mandatory gtk-mac-integration
   # it's badly broken as it depends on an ancient version of ige-mac-integration

--- a/Formula/gocryptfs.rb
+++ b/Formula/gocryptfs.rb
@@ -5,14 +5,14 @@ class Gocryptfs < Formula
   sha256 "c4ca576c2a47f0ed395b96f70fb58fc8f7b4beced8ae67e356eeed6898f8352a"
   license "MIT"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "adf2a34cc99f353992e790c856971e9128d55caf5c51a2ae0a50ff5506e63c1c" => :catalina
     sha256 "3e4cd09514efbd074f41f6636f0df0b01708856446c1da1d6cfe766cd8cae121" => :mojave
     sha256 "a7e6b3d28c3e3cd78ff4be78adc8d2feeb8061c7459d2c8e6f04e61f0029bb51" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "go" => :build
   depends_on "pkg-config" => :build

--- a/Formula/goofys.rb
+++ b/Formula/goofys.rb
@@ -7,8 +7,6 @@ class Goofys < Formula
   license "Apache-2.0"
   head "https://github.com/kahing/goofys.git"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any_skip_relocation
     rebuild 1
@@ -16,6 +14,8 @@ class Goofys < Formula
     sha256 "cee50248f9ac4d33ef8ca585ad94e3c9e6226fc464dfad86de2b7f9497b9f2b7" => :mojave
     sha256 "eb0a3cfe49104292c16d76dce71db34000b1a7214f660b3cff3a39e4b3ba7a44" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "go" => :build
   depends_on :osxfuse

--- a/Formula/ifuse.rb
+++ b/Formula/ifuse.rb
@@ -6,14 +6,14 @@ class Ifuse < Formula
   license "LGPL-2.1"
   head "https://cgit.sukimashita.com/ifuse.git"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "cdce9fc5dbaf44641743b4a77434d340ae11cb8ed98f17b1a86a5653d2b6e1a2" => :catalina
     sha256 "e14e4f8e0f73324dc662b47f091261f682eddc73961e3d71a07bfeb62826a1f8" => :mojave
     sha256 "ff5577f28749cf18671eecd953e96f0c52a06dccf827dcf08e2d64f894dfdd5e" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/infrakit.rb
+++ b/Formula/infrakit.rb
@@ -6,8 +6,6 @@ class Infrakit < Formula
       revision: "3d2670e484176ce474d4b3d171994ceea7054c02"
   license "Apache-2.0"
 
-  deprecate! because: :repo_archived
-
   bottle do
     cellar :any_skip_relocation
     rebuild 1
@@ -16,6 +14,8 @@ class Infrakit < Formula
     sha256 "3d188727e1be0bdf150e152b0939560a209415fa9d3b5c2275eea163510d4994" => :high_sierra
     sha256 "8db80c4d2d7842486a4cedfa4952ed06e453f2e61f4e6818a08b17fa694d1a1c" => :sierra
   end
+
+  deprecate! because: :repo_archived
 
   depends_on "go" => :build
   depends_on "libvirt" => :build

--- a/Formula/lesstif.rb
+++ b/Formula/lesstif.rb
@@ -6,8 +6,6 @@ class Lesstif < Formula
   license all_of: ["GPL-2.0-or-later", "LGPL-2.0-or-later"]
   revision 1
 
-  deprecate! because: :unmaintained
-
   livecheck do
     url :stable
   end
@@ -18,6 +16,8 @@ class Lesstif < Formula
     sha256 "f522a309507b2f9c2aad4aea7a8bbb6cc7d845e922d6d49cd3ca81bccad7f5f5" => :mojave
     sha256 "6bc0a2511a83a9a15bc27a2385aa7fd944836eb4e685ee7878e590be7680e713" => :high_sierra
   end
+
+  deprecate! because: :unmaintained
 
   depends_on "freetype"
   depends_on "libice"

--- a/Formula/libinfinity.rb
+++ b/Formula/libinfinity.rb
@@ -13,16 +13,16 @@ class Libinfinity < Formula
     sha256 "6dd59d33bdc050e1e61d5a7a6efa79a83c0130c237f04c678f7e8fe6a455e4df" => :sierra
   end
 
+  # libinfinity is only used by gobby
+  # latest 0.7.1 does not work with gobby 0.5.0 due to open issue, https://github.com/gobby/gobby/issues/143
+  # gobby is disabled per #57501
+  disable! because: "is only used by gobby (which has been disabled)"
+
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "gnutls"
   depends_on "gsasl"
   depends_on "gtk+3"
-
-  # libinfinity is only used by gobby
-  # latest 0.7.1 does not work with gobby 0.5.0 due to open issue, https://github.com/gobby/gobby/issues/143
-  # gobby is disbled per #57501
-  disable! because: "is only used by gobby (which has been disabled)"
 
   # MacPorts patch to fix pam include. This is still applicable to 0.6.4.
   patch :p0 do

--- a/Formula/liblas.rb
+++ b/Formula/liblas.rb
@@ -7,13 +7,13 @@ class Liblas < Formula
   revision 3
   head "https://github.com/libLAS/libLAS.git"
 
-  deprecate! date: "2018-01-01", because: :unsupported
-
   bottle do
     sha256 "c63d0d75db5b8e129c13add1de8fe94b2a38d5c15d101b62d6a7f59b796f53a3" => :catalina
     sha256 "3224d154574e4cd07837dd1d1bd3e336964e8bede4cf4bb34dbaf4a63c75ed11" => :mojave
     sha256 "b47d0b9c82040703d212e22a436b7e11aff24632f0649db959e2073e0ae48548" => :high_sierra
   end
+
+  deprecate! date: "2018-01-01", because: :unsupported
 
   depends_on "cmake" => :build
   depends_on "boost"

--- a/Formula/mp3fs.rb
+++ b/Formula/mp3fs.rb
@@ -5,14 +5,14 @@ class Mp3fs < Formula
   sha256 "cbb52062d712e8dfd3491d0b105e2e05715d493a0fd14b53a23919694a348069"
   license "GPL-3.0"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "26d991c2fb34055035c01d12033f28b5a694954ad9b3f650658dfa1ebc9994ea" => :catalina
     sha256 "a9f6095147b767a892891bdc0a44b61eef40880e38bc50e54c0a30d96de89985" => :mojave
     sha256 "b3b2e431e9a782dbde9d758505c372a0d6ed60eff44ebc21c9b979c01b0df189" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on "flac"

--- a/Formula/now-cli.rb
+++ b/Formula/now-cli.rb
@@ -19,9 +19,9 @@ class NowCli < Formula
     sha256 "a52be7278a1492daa225ecd47b7326f41f60ea2070397903bc3ef09f7f6aec1a" => :high_sierra
   end
 
-  depends_on "node"
-
   disable! date: "2021-01-31", because: :unmaintained
+
+  depends_on "node"
 
   def install
     rm Dir["dist/{*.exe,xsel}"]

--- a/Formula/ntfs-3g.rb
+++ b/Formula/ntfs-3g.rb
@@ -13,8 +13,6 @@ class Ntfs3g < Formula
     end
   end
 
-  deprecate! because: "requires FUSE"
-
   livecheck do
     url :head
     regex(/^v?(\d+(?:\.\d+)+)$/i)
@@ -37,6 +35,8 @@ class Ntfs3g < Formula
     depends_on "libgcrypt" => :build
     depends_on "libtool" => :build
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on "coreutils" => :test

--- a/Formula/ocamlsdl.rb
+++ b/Formula/ocamlsdl.rb
@@ -6,14 +6,14 @@ class Ocamlsdl < Formula
   license "LGPL-2.1-or-later"
   revision 13
 
-  disable! because: :unmaintained
-
   bottle do
     cellar :any
     sha256 "8ccd0c9f59b9fad6fe084e57e726cd20d0f26497e71e4be94ff7f603512cbef8" => :catalina
     sha256 "6cd21f03d8a557368499d9cd61233dab4bab11fcd99c312036d58d660598c539" => :mojave
     sha256 "6ae2abcf123aef7ce6cc2c5aad0d912bc459fdd9e7e2abfa99135d672767ddb7" => :high_sierra
   end
+
+  disable! because: :unmaintained
 
   depends_on "ocaml"
   depends_on "sdl"

--- a/Formula/opencv@2.rb
+++ b/Formula/opencv@2.rb
@@ -13,10 +13,10 @@ class OpencvAT2 < Formula
     sha256 "b90a2e7e26ef9d18a2f87a954a786a6bc983047fbcae2280b662df66e254e76c" => :high_sierra
   end
 
+  keg_only :versioned_formula
+
   # https://www.slideshare.net/EugeneKhvedchenya/opencv-30-latest-news-and-the-roadmap
   deprecate! date: "2015-02-01", because: :unsupported
-
-  keg_only :versioned_formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/procyon-decompiler.rb
+++ b/Formula/procyon-decompiler.rb
@@ -7,9 +7,9 @@ class ProcyonDecompiler < Formula
 
   bottle :unneeded
 
-  depends_on "openjdk"
-
   disable! because: :repo_removed
+
+  depends_on "openjdk"
 
   def install
     libexec.install "procyon-decompiler-#{version}.jar"

--- a/Formula/rclone.rb
+++ b/Formula/rclone.rb
@@ -6,14 +6,14 @@ class Rclone < Formula
   license "MIT"
   head "https://github.com/rclone/rclone.git"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any_skip_relocation
     sha256 "3b50cc675b356f43b62f4f5a8acef082a56163ddf1dfdf03a4f360ee6969cdfe" => :catalina
     sha256 "a59703acea34bb4bff3fcd878af83d425a993fc1012b35b7a4210066e6279eab" => :mojave
     sha256 "cea1a5bf6e0346731ba8357e313ae6eb3633e14400c2e9e67bd5a3f8524721f6" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "go" => :build
 

--- a/Formula/rdesktop.rb
+++ b/Formula/rdesktop.rb
@@ -6,14 +6,14 @@ class Rdesktop < Formula
   license "GPL-3.0-or-later"
   revision 2
 
-  deprecate! because: :unmaintained
-
   bottle do
     sha256 "60d5a72e5a55cace788d0a28241b9080fbf039c25fd91eb3bf91a95a8e8e4a89" => :big_sur
     sha256 "8b22a2d1f52ff40334a16fc4614bc2f2c9e50386f0732e8e4478f68c7008f961" => :catalina
     sha256 "91b95a137be4361dee7d8bf2e442fa75eaf159469c09e238a127aa1186534638" => :mojave
     sha256 "84ca9f1d74ad63108e320f2cae63a2afdfafd3995aa2d37837d551cc5dda8688" => :high_sierra
   end
+
+  deprecate! because: :unmaintained
 
   depends_on "pkg-config" => :build
   depends_on "gnutls"

--- a/Formula/rofs-filtered.rb
+++ b/Formula/rofs-filtered.rb
@@ -5,8 +5,6 @@ class RofsFiltered < Formula
   sha256 "d66066dfd0274a2fb7b71dd929445377dd23100b9fa43e3888dbe3fc7e8228e8"
   license "GPL-2.0"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     rebuild 1
@@ -14,6 +12,8 @@ class RofsFiltered < Formula
     sha256 "6f220b4a193928a97dc8442cadf6d161224a1ddac098d496c8cf9a20fb7cd02a" => :mojave
     sha256 "74277c4f4cc2c60534cda38627450176f356da5bb7120334fd667eaa261fea7b" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "cmake" => :build
   depends_on :osxfuse

--- a/Formula/rpg.rb
+++ b/Formula/rpg.rb
@@ -6,8 +6,6 @@ class Rpg < Formula
   license "MIT"
   head "https://github.com/rtomayko/rpg.git"
 
-  deprecate! because: :repo_archived
-
   bottle do
     cellar :any_skip_relocation
     rebuild 1
@@ -15,6 +13,8 @@ class Rpg < Formula
     sha256 "fab3d032e629a4d20add14e9693919a074286990a16eb6fa8772180fc60730ee" => :mojave
     sha256 "f1c7e5d997a1f0ceb1cca6b1067408912ff8e14522fb411530649f0689f9d042" => :high_sierra
   end
+
+  deprecate! because: :repo_archived
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/s3-backer.rb
+++ b/Formula/s3-backer.rb
@@ -5,8 +5,6 @@ class S3Backer < Formula
   sha256 "deea48205347b24d1298fa16bf3252d9348d0fe81dde9cb20f40071b8de60519"
   license "GPL-2.0-or-later"
 
-  deprecate! because: "requires FUSE"
-
   livecheck do
     url "https://build.opensuse.org/package/view_file/openSUSE:Factory/s3backer/s3backer.spec"
     regex(/Version:\s+v?(\d+(?:\.\d+)+)/i)
@@ -18,6 +16,8 @@ class S3Backer < Formula
     sha256 "346fe1b085490959e17acf9930878b46b8224bf20b7aada21a1a48ab963c0da3" => :mojave
     sha256 "4d23cfd2c126c5f3efa1023e7c061830de6f1fdda69760bbd3ed70a169def288" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on "openssl@1.1"

--- a/Formula/s3fs.rb
+++ b/Formula/s3fs.rb
@@ -6,14 +6,14 @@ class S3fs < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/s3fs-fuse/s3fs-fuse.git"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "5183ab606057fbe8e46a737b25c1ad4e82dd67389f48827d7bfd567c67cf8417" => :catalina
     sha256 "d691bdeb4abd443bc1f1f3de46c286a97829f95ba3d47b026e535a6688085d07" => :mojave
     sha256 "f475d03b68102dd400a22de99b9ddc044653f6658e2cb84349adf507ffbddcad" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/s3ql.rb
+++ b/Formula/s3ql.rb
@@ -8,8 +8,6 @@ class S3ql < Formula
   license "GPL-3.0"
   revision 1
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     rebuild 1
@@ -17,6 +15,8 @@ class S3ql < Formula
     sha256 "5cb74d53c8529637963a543360365a83ea1c8cabab740cc2d9691d3a75ce261c" => :mojave
     sha256 "63b52252fa9acd84fe7af0812241ab35e72062044cfe0659163a39e47a76581d" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   # disable due to osxfuse API is with fuse2
   # logged an issue, https://github.com/s3ql/s3ql/issues/192

--- a/Formula/scala@2.11.rb
+++ b/Formula/scala@2.11.rb
@@ -6,11 +6,11 @@ class ScalaAT211 < Formula
   mirror "https://www.scala-lang.org/files/archive/scala-2.11.12.tgz"
   sha256 "b11d7d33699ca4f60bc3b2b6858fd953e3de2b8522c943f4cda4b674316196a8"
   revision 1
-  deprecate! date: "2017-11-09", because: :unsupported
-
   bottle :unneeded
 
   keg_only :versioned_formula
+
+  deprecate! date: "2017-11-09", because: :unsupported
 
   depends_on "openjdk@8"
 

--- a/Formula/securefs.rb
+++ b/Formula/securefs.rb
@@ -7,14 +7,14 @@ class Securefs < Formula
   license "MIT"
   head "https://github.com/netheril96/securefs.git"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "8a8c7dd74f9b3082b2b128cc058714a27206d910273e4148959a25b7d30c51b5" => :catalina
     sha256 "9bee23af87518f68df56b862ad0ef88f842ebe65f8feff02e90bf5ab8e91522e" => :mojave
     sha256 "632496d8e9ed9fe91d18e9a2c9fef49c920dc091e10108246f8ab2056f75ea38" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "cmake" => :build
   depends_on :osxfuse

--- a/Formula/simple-mtpfs.rb
+++ b/Formula/simple-mtpfs.rb
@@ -5,14 +5,14 @@ class SimpleMtpfs < Formula
   sha256 "1d011df3fa09ad0a5c09d48d84c03e6cddf86390af9eb4e0c178193f32f0e2fc"
   license "GPL-2.0"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "d902aae104d1f2ae07bdb28ecabbef8d9d97d9326a3e29050c83a4dd69597ed4" => :catalina
     sha256 "4f9c18fb88084e24773591124bdcfdc0ceb3741f2cdaffa2d67e7b22cfe5672e" => :mojave
     sha256 "0a22b0fd5ea759ce48068efabf40ac09b4a76d5dcf942db8b672edfd3e1b90a8" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "autoconf" => :build
   depends_on "autoconf-archive" => :build # required for AX_CXX_COMPILE_STDCXX_17

--- a/Formula/squashfuse.rb
+++ b/Formula/squashfuse.rb
@@ -5,8 +5,6 @@ class Squashfuse < Formula
   sha256 "42d4dfd17ed186745117cfd427023eb81effff3832bab09067823492b6b982e7"
   license "BSD-2-Clause"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "7e2e0499c0b9f98beb398319c949d2a1d45de6a3f0b546ef1d55214f68522312" => :catalina
@@ -15,6 +13,8 @@ class Squashfuse < Formula
     sha256 "c1898c81ae091097ae2502ecbdebdd1831db302dd74b814003191007a4d5f018" => :sierra
     sha256 "bf4e6ca88d094fd7d92fbab61dd1c3a4e71b60d7668d23b6044c90e8167833c5" => :el_capitan
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on "lz4"

--- a/Formula/sshfs.rb
+++ b/Formula/sshfs.rb
@@ -6,8 +6,6 @@ class Sshfs < Formula
   license "GPL-2.0"
   revision 2
 
-  deprecate! because: "requires FUSE"
-
   livecheck do
     url :stable
     regex(/^sshfs[._-]v?(\d+(?:\.\d+)+)$/i)
@@ -20,6 +18,8 @@ class Sshfs < Formula
     sha256 "58d222f37622b399352f16eaf823d3e564445d9e951629e965281ac31de5ef4a" => :high_sierra
     sha256 "dc4a7f24c2cbebd7c35891200b043d737ba6586a28992708ef849ffedff7bb01" => :sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/termtosvg.rb
+++ b/Formula/termtosvg.rb
@@ -8,8 +8,6 @@ class Termtosvg < Formula
   license "BSD-3-Clause"
   revision 2
 
-  deprecate! date: "2020-10-08", because: :repo_archived
-
   bottle do
     cellar :any_skip_relocation
     sha256 "16c74ac4446e7e91a1b7474ce3026f8546ba04430b8572944db7152fa9c3d48e" => :big_sur
@@ -17,6 +15,8 @@ class Termtosvg < Formula
     sha256 "22decfefbd2791ac22f3e267467f53a84524298a5cf1d9b285e97568555b12f0" => :mojave
     sha256 "26a80230af97da8f083d5e3004cb3a000e4cd16e33ce4e733400a9d9d0ade42a" => :high_sierra
   end
+
+  deprecate! date: "2020-10-08", because: :repo_archived
 
   depends_on "python@3.9"
 

--- a/Formula/tidyp.rb
+++ b/Formula/tidyp.rb
@@ -5,8 +5,6 @@ class Tidyp < Formula
   sha256 "20b0fad32c63575bd4685ed09b8c5ca222bbc7b15284210d4b576d0223f0b338"
   license "Zlib"
 
-  deprecate! because: :repo_archived
-
   bottle do
     cellar :any
     rebuild 1
@@ -15,6 +13,8 @@ class Tidyp < Formula
     sha256 "b48c3587cde0cbc77ff07e9cb6849dcd3a985d8360ab5e8e7a7d5f0691e5d68b" => :mojave
     sha256 "267b4c383278baa37d4bab8e10aba1ee73d2eba642332414fad77d262b602099" => :high_sierra
   end
+
+  deprecate! because: :repo_archived
 
   uses_from_macos "libxslt" => :build
 

--- a/Formula/tup.rb
+++ b/Formula/tup.rb
@@ -6,14 +6,14 @@ class Tup < Formula
   license "GPL-2.0-only"
   head "https://github.com/gittup/tup.git"
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "48009935b0e38be19c1d8a0afbbeef75109a970a57327dad9ecf5929b64b7bf2" => :catalina
     sha256 "155b58771fa74a27b20d4e668324ae97ca4c0f8a150691b8ceecd786064dcae1" => :mojave
     sha256 "78c5c8e96892dd07c467f7b86d3312689d33474e7e6a07d4c69905aa60941e10" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on :osxfuse

--- a/Formula/wdfs.rb
+++ b/Formula/wdfs.rb
@@ -5,8 +5,6 @@ class Wdfs < Formula
   sha256 "fcf2e1584568b07c7f3683a983a9be26fae6534b8109e09167e5dff9114ba2e5"
   revision 1
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     cellar :any
     sha256 "a00329ad59065dc12983272eb1da0e861aa73cbfa8b2edc69393a5a2eba4e49f" => :catalina
@@ -14,6 +12,8 @@ class Wdfs < Formula
     sha256 "f2f3ad809ea9104bb5fd49b4f903b0465707baf76be3329422ea34aeed8bacb4" => :high_sierra
     sha256 "7aab5f9c3d807f73dfe9df437a15806b74bc5a76cd3cd13e961ea781c7fa32fb" => :sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "pkg-config" => :build
   depends_on "glib"

--- a/Formula/xmount.rb
+++ b/Formula/xmount.rb
@@ -5,14 +5,14 @@ class Xmount < Formula
   sha256 "76e544cd55edc2dae32c42a38a04e11336f4985e1d59cec9dd41e9f9af9b0008"
   revision 2
 
-  deprecate! because: "requires FUSE"
-
   bottle do
     rebuild 1
     sha256 "55de429679b12e85dcfb854d4add045363a287c172b7b77765591d7d1d89324c" => :catalina
     sha256 "ae937d5fdba6c278bef72a4f87d62a6dafc2f78ad642ee6995bc228743ed37cd" => :mojave
     sha256 "a4436c7060d9b84abfa6450c7156cd994f42c130eebf1281e21319d6e5c00415" => :high_sierra
   end
+
+  deprecate! because: "requires FUSE"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

- This is a companion PR to https://github.com/Homebrew/brew/pull/9195 that enforces an order for `deprecate!` and `disable!` in formulae.
- This was mostly done with `brew style --fix`, but this orphaned some comments giving context about why a formula was deprecated or disabled. So I went back through and manually un-orphaned those comments.
- If the companion PR is approved,  please can this be merged with the **rebase and merge** button to preserve the commits. Thanks!