### PR TITLE
terraform: set CGO_ENABLED=1

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -28,7 +28,10 @@ class Terraform < Formula
     ENV.delete "AWS_ACCESS_KEY"
     ENV.delete "AWS_SECRET_KEY"
 
-    ENV["CGO_ENABLED"] = "0"
+    # resolves issues fetching providers while on a VPN that uses /etc/resolv.conf
+    # https://github.com/hashicorp/terraform/issues/26532#issuecomment-720570774
+    ENV["CGO_ENABLED"] = "1"
+
     system "go", "build", *std_go_args, "-ldflags", "-s -w", "-mod=vendor"
   end
 


### PR DESCRIPTION
This resolves an issue where golang doesn't respect the way MacOS does
DNS resolution via `/etc/resolv.conf`

https://github.com/hashicorp/terraform/issues/26532#issuecomment-720570774
https://github.com/golang/go/issues/12524

Without this setting whenever I try to `terraform init` to download
provider plugins while on my company's VPN, I get errors like the
following

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider
terraform-providers/heroku: no available releases match the given
constraints
```

```
Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider
terraform-providers/fastly: could not connect to registry.terraform.io:
Failed
to request discovery document: Get
"https://registry.terraform.io/.well-known/terraform.json": net/http:
request
canceled while waiting for connection (Client.Timeout exceeded while
awaiting
headers)
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----