### PR TITLE
remove unused audit_exceptions directory

### DIFF
--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -1,8 +1,0 @@
-{
-  "aws-sdk-cpp": 10,
-  "awscli@1": 10,
-  "balena-cli": 10,
-  "gatsby-cli": 10,
-  "quicktype": 10,
-  "vim": 50
-}

--- a/audit_exceptions/versioned_head_spec_allowlist.json
+++ b/audit_exceptions/versioned_head_spec_allowlist.json
@@ -1,4 +1,0 @@
-[
-  "bash-completion@2",
-  "imagemagick@6"
-]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As part of the formula lists migration.

In https://github.com/Homebrew/homebrew-core/pull/65061, these lists will be moved to the `audit_exceptions_lists/` directory. Once _both_ https://github.com/Homebrew/homebrew-core/pull/65061 and https://github.com/Homebrew/brew/pull/9178 have been merged there will be no need for the `audit_exceptions/` directory so this should be merged.

Marking as DNM until https://github.com/Homebrew/homebrew-core/pull/65061 and https://github.com/Homebrew/brew/pull/9178 have been merged

Note: CI failures are expected. Once the other PRs have been merged this will need to be rebased and CI should become green.