### PR TITLE
awscli: downgrade Python to v3.8

### DIFF
--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -15,7 +15,10 @@ class Awscli < Formula
     sha256 "bdfa90c8a378d555a18fd56a35feb8a9458bc7826f51140ad3ddb5d834054773" => :high_sierra
   end
 
-  depends_on "python@3.9"
+  # NOTE: Do not upgrade Python to 3.9+ until awscli officially supports it.
+  # See https://github.com/Homebrew/homebrew-core/issues/63990
+  # and https://github.com/aws/aws-cli/issues/5692.
+  depends_on "python@3.8"
 
   uses_from_macos "groff"
 
@@ -56,7 +59,7 @@ class Awscli < Formula
 
   test do
     assert_match "topics", shell_output("#{bin}/aws help")
-    assert_include Dir["#{libexec}/lib/python3.9/site-packages/awscli/data/*"],
-                   "#{libexec}/lib/python3.9/site-packages/awscli/data/ac.index"
+    assert_include Dir["#{libexec}/lib/python3.8/site-packages/awscli/data/*"],
+                   "#{libexec}/lib/python3.8/site-packages/awscli/data/ac.index"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)? **Read but brew audit/style fail with Ruby gem install errors.**
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? **Yes, only https://github.com/Homebrew/homebrew-core/pull/65087 is open for awscli, but upgrades to 2.1.2. This PR deals with Python version.**
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? **Via `brew reinstall --build-from-source ./awscli.rb`**
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? **Yes, ran `brew test ./awscli.rb`.**
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? **No, the Ruby dependencies for this tool failed to install with `An error occurred while installing hpricot (0.8.6), and Bundler cannot continue.`**

-----

`awscli` fails to install with Python 3.9 (from the `python@3.9` formula). This is an already-reported issue: https://github.com/Homebrew/homebrew-core/issues/63990

The error looks like this when it fails on my macOS 10.15.7 system:

```
Last 15 lines from /Users/tdyas/Library/Logs/Homebrew/awscli/02.python3:
python3
-s
/private/tmp/awscli--homebrew-virtualenv-20201118-93388-1j1pl6q/target/bin/virtualenv
-p
python3
/Users/tdyas/.toolchain/homebrew/Cellar/awscli/2.1.1/libexec

Already using interpreter /Users/tdyas/.toolchain/homebrew/opt/python@3.9/bin/python3.9
Using base prefix '/Users/tdyas/.toolchain/homebrew/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9'
New python executable in /Users/tdyas/.toolchain/homebrew/Cellar/awscli/2.1.1/libexec/bin/python3.9
Also creating executable in /Users/tdyas/.toolchain/homebrew/Cellar/awscli/2.1.1/libexec/bin/python
ERROR: The executable /Users/tdyas/.toolchain/homebrew/Cellar/awscli/2.1.1/libexec/bin/python3.9 is not functioning
ERROR: It thinks sys.prefix is '/Users/tdyas/.toolchain/homebrew/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9' (should be '/Users/tdyas/.toolchain/homebrew/Cellar/awscli/2.1.1/libexec')
ERROR: virtualenv is not compatible with this system or executable
Running virtualenv with interpreter /Users/tdyas/.toolchain/homebrew/opt/python@3.9/bin/python3

Do not report this issue to Homebrew/brew or Homebrew/core!

These open issues may also help:
awscli 2.1.2 https://github.com/Homebrew/homebrew-core/pull/65087
```

The awscli maintainers recommend not using Python 3.9: https://github.com/aws/aws-cli/issues/5692

Thus, this PR downgrades the dependency to Python 3.8 so that awscli once again is installable.