### PR TITLE
formulae: drop setting GOOS|GOARCH

### DIFF
--- a/Formula/bazelisk.rb
+++ b/Formula/bazelisk.rb
@@ -25,9 +25,6 @@ class Bazelisk < Formula
   end
 
   def install
-    ENV["GOOS"] = "darwin"
-    ENV["GOARCH"] = "amd64"
-
     system "go", "build", *std_go_args, "-ldflags", "-X main.BazeliskVersion=#{version}"
 
     bin.install_symlink "bazelisk" => "bazel"

--- a/Formula/cwlogs.rb
+++ b/Formula/cwlogs.rb
@@ -20,8 +20,6 @@ class Cwlogs < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GOOS"] = "darwin"
-    ENV["GOARCH"] = "amd64"
     ENV["CGO_ENABLED"] = "0"
 
     path = buildpath/"src/github.com/segmentio/cwlogs"
@@ -29,9 +27,7 @@ class Cwlogs < Formula
 
     cd "src/github.com/segmentio/cwlogs" do
       system "govendor", "sync"
-      system "go", "build", "-o", bin/"cwlogs",
-                   "-ldflags", "-X main.Version=#{version}"
-      prefix.install_metafiles
+      system "go", "build", *std_go_args, "-ldflags", "-X main.Version=#{version}"
     end
   end
 

--- a/Formula/devd.rb
+++ b/Formula/devd.rb
@@ -18,13 +18,10 @@ class Devd < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOOS"] = "darwin"
-    ENV["GOARCH"] = "amd64"
     ENV["GOPATH"] = buildpath
     (buildpath/"src/github.com/cortesi/devd").install buildpath.children
     cd "src/github.com/cortesi/devd" do
-      system "go", "build", "-o", bin/"devd", ".../cmd/devd"
-      prefix.install_metafiles
+      system "go", "build", *std_go_args, "./cmd/devd"
     end
   end
 

--- a/Formula/govendor.rb
+++ b/Formula/govendor.rb
@@ -21,12 +21,10 @@ class Govendor < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GOOS"] = "darwin"
-    ENV["GOARCH"] = "amd64"
 
     (buildpath/"src/github.com/kardianos/").mkpath
     ln_sf buildpath, buildpath/"src/github.com/kardianos/govendor"
-    system "go", "build", "-o", bin/"govendor"
+    system "go", "build", *std_go_args
   end
 
   test do

--- a/Formula/hostess.rb
+++ b/Formula/hostess.rb
@@ -17,10 +17,7 @@ class Hostess < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOOS"] = "darwin"
-    ENV["GOARCH"] = "amd64"
-
-    system "go", "build", "-ldflags", "-s -w -X main.version=#{version}", "-o", bin/"hostess"
+    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.version=#{version}"
   end
 
   test do

--- a/Formula/iam-policy-json-to-terraform.rb
+++ b/Formula/iam-policy-json-to-terraform.rb
@@ -18,16 +18,13 @@ class IamPolicyJsonToTerraform < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GOOS"] = "darwin"
 
     dir = buildpath/"src/github.com/flosell/iam-policy-json-to-terraform"
     dir.install buildpath.children
     cd "src/github.com/flosell/iam-policy-json-to-terraform" do
-      # system "go", "build", "-o", "iam-policy-json-to-terraform", "*.go"
       system "make", "iam-policy-json-to-terraform_darwin"
       mv "iam-policy-json-to-terraform_darwin", "iam-policy-json-to-terraform"
       bin.install "iam-policy-json-to-terraform"
-      prefix.install_metafiles
     end
   end
 

--- a/Formula/modd.rb
+++ b/Formula/modd.rb
@@ -18,14 +18,10 @@ class Modd < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOOS"] = "darwin"
-    ENV["GOARCH"] = "amd64"
     ENV["GOPATH"] = buildpath
-    ENV["GOBIN"] = bin
     (buildpath/"src/github.com/cortesi/modd").install buildpath.children
     cd "src/github.com/cortesi/modd" do
-      system "go", "install", ".../cmd/modd"
-      prefix.install_metafiles
+      system "go", "build", *std_go_args, "./cmd/modd"
     end
   end
 

--- a/Formula/terrahelp.rb
+++ b/Formula/terrahelp.rb
@@ -17,19 +17,7 @@ class Terrahelp < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    ENV.prepend_create_path "PATH", buildpath/"bin"
-
-    dir = buildpath/"src/github.com/opencredo/terrahelp"
-    dir.install buildpath.children
-
-    cd dir do
-      ENV["GOOS"] = "darwin"
-      ENV["GOARCH"] = "amd64"
-
-      system "go", "build", "-mod=vendor", "-o", "dist/darwin/amd64/terrahelp"
-      bin.install "dist/darwin/amd64/terrahelp"
-    end
+    system "go", "build", *std_go_args, "-mod=vendor"
   end
 
   test do


### PR DESCRIPTION
Also drop GOPATH in some cases, and `prefix.install_metafiles`.

All those stanzas are not needed and removing GOOS enables us to use those formulae on linux without modifications.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
