### PR TITLE
libseccomp: add livecheck

### DIFF
--- a/Formula/libseccomp.rb
+++ b/Formula/libseccomp.rb
@@ -5,6 +5,11 @@ class Libseccomp < Formula
   sha256 "1ffa7038d2720ad191919816db3479295a4bcca1ec14e02f672539f4983014f3"
   license "LGPL-2.1-only"
 
+  livecheck do
+    url "https://github.com/seccomp/libseccomp/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "gperf" => :build


### PR DESCRIPTION
libseccomp: add livecheck

---

both 2.4.4 and 2.5.0 are formal releases (with the release artifact), while 2.5.1 is just a release tag yet. So using latest tag for the livecheck.