### PR TITLE
llvm: add mlir

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -79,6 +79,7 @@ class Llvm < Formula
       lldb
       openmp
       polly
+      mlir
     ]
     runtimes = %w[
       compiler-rt
@@ -106,6 +107,8 @@ class Llvm < Formula
       -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON
       -DLLVM_LINK_LLVM_DYLIB=ON
       -DLLVM_BUILD_LLVM_C_DYLIB=ON
+      -DLLVM_BUILD_EXAMPLES=ON
+      -DLLVM_ENABLE_ASSERTIONS=ON
       -DLLVM_ENABLE_EH=ON
       -DLLVM_ENABLE_FFI=ON
       -DLLVM_ENABLE_LIBCXX=ON

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -107,8 +107,6 @@ class Llvm < Formula
       -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON
       -DLLVM_LINK_LLVM_DYLIB=ON
       -DLLVM_BUILD_LLVM_C_DYLIB=ON
-      -DLLVM_BUILD_EXAMPLES=ON
-      -DLLVM_ENABLE_ASSERTIONS=ON
       -DLLVM_ENABLE_EH=ON
       -DLLVM_ENABLE_FFI=ON
       -DLLVM_ENABLE_LIBCXX=ON
@@ -142,8 +140,8 @@ class Llvm < Formula
     llvmpath = buildpath/"llvm"
     mkdir llvmpath/"build" do
       system "cmake", "-G", "Unix Makefiles", "..", *(std_cmake_args + args)
-      system "make"
-      system "make", "install"
+      system "cmake", "--build", "."
+      system "cmake", "--build", ".", "--target", "install"
       system "make", "install-xcode-toolchain" if MacOS::Xcode.installed?
     end
 

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -142,7 +142,7 @@ class Llvm < Formula
       system "cmake", "-G", "Unix Makefiles", "..", *(std_cmake_args + args)
       system "cmake", "--build", "."
       system "cmake", "--build", ".", "--target", "install"
-      system "make", "install-xcode-toolchain" if MacOS::Xcode.installed?
+      system "cmake", "--build", ".", "--target", "install-xcode-toolchain" if MacOS::Xcode.installed?
     end
 
     # Install LLVM Python bindings
@@ -209,6 +209,15 @@ class Llvm < Formula
         return 0;
       }
     EOS
+
+    # Testing mlir
+    (testpath/"test.mlir").write <<~EOS
+      func @bad_branch() {
+        br ^missing  // expected-error {{reference to an undefined block}}
+      }
+    EOS
+
+    system "#{bin}/mlir-opt", "--verify-diagnostics", "test.mlir"
 
     # Testing default toolchain and SDK location.
     system "#{bin}/clang++", "-v",


### PR DESCRIPTION
There's been some interest in the flang compiler for llvm:

https://github.com/Homebrew/discussions/discussions/143
https://github.com/Homebrew/homebrew-core/pull/63081

It seems possible to build flang separately from llvm, but it appears to
require having built mlir. See the flang [README](https://github.com/llvm/llvm-project/blob/master/flang/README.md). Aside from being a 
pre-requisite for flang, mlir is a mature project with [a number of
interesting applications](https://mlir.llvm.org/users/). 

mlir, therefore, seems worthy of inclusion in the llvm formula even if
flang is currently not suitable for homebrew/core. (flang does build
and test successfully upon declaring a dependency on llvm in this PR.)

Test failure appears to be [unrelated to the PR](https://github.com/Homebrew/homebrew-core/pull/65223#issuecomment-733654271), and has been reported
upstream: https://github.com/odin-lang/Odin/issues/792

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?