### PR TITLE
flang 11.0.0 (new formula)

### DIFF
--- a/Formula/flang.rb
+++ b/Formula/flang.rb
@@ -23,8 +23,8 @@ class Flang < Formula
     llvmpath = buildpath/"llvm"
     mkdir llvmpath/"build" do
       system "cmake", "-G", "Unix Makefiles", "..", *(std_cmake_args + args)
-      system "make"
-      system "make", "install"
+      system "cmake", "--build", ".", "--target", "check-mlir", "check-flang"
+      system "cmake", "--install", "."
     end
   end
 

--- a/Formula/flang.rb
+++ b/Formula/flang.rb
@@ -7,20 +7,22 @@ class Flang < Formula
 
   depends_on "cmake" => :build
   depends_on "gcc" # for gfortran
-  depends_on "llvm"
+
+  uses_from_macos "libedit"
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
 
   def install
-    cd "flang"
-
-    llvm_cmake_dir = "#{Formula["llvm"].opt_prefix}/lib/cmake"
-
-    args = %W[
-      -DLLVM_DIR=#{llvm_cmake_dir}/llvm
-      -DMLIR_DIR=#{llvm_cmake_dir}/mlir
+    args = %w[
+      -DLLVM_ENABLE_PROJECTS=mlir;flang
+      -DLLVM_TARGETS_TO_BUILD=all
+      -DLLVM_ENABLE_ASSERTIONS=ON
     ]
 
-    mkdir "build" do
-      system "cmake", "-G", "Unix Makefiles", "..", *std_cmake_args, *args
+    llvmpath = buildpath/"llvm"
+    mkdir llvmpath/"build" do
+      system "cmake", "-G", "Unix Makefiles", "..", *(std_cmake_args + args)
       system "make"
       system "make", "install"
     end

--- a/Formula/flang.rb
+++ b/Formula/flang.rb
@@ -1,0 +1,39 @@
+class Flang < Formula
+  desc "Fortran front end for LLVM"
+  homepage "https://llvm.org"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/llvm-project-11.0.0.tar.xz"
+  sha256 "b7b639fc675fa1c86dd6d0bc32267be9eb34451748d2efd03f674b773000e92b"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "gcc" # for gfortran
+  depends_on "llvm"
+
+  def install
+    cd "flang"
+
+    llvm_cmake_dir = "#{Formula["llvm"].opt_prefix}/lib/cmake"
+
+    args = %W[
+      -DLLVM_DIR=#{llvm_cmake_dir}/llvm
+      -DMLIR_DIR=#{llvm_cmake_dir}/mlir
+    ]
+
+    mkdir "build" do
+      system "cmake", "-G", "Unix Makefiles", "..", *std_cmake_args, *args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.f90").write <<~EOS
+      PROGRAM test
+        WRITE(*,'(A)') 'Hello World!'
+      ENDPROGRAM
+    EOS
+
+    system "#{bin}/flang", "test.f90", "-o", "test"
+    assert_equal "Hello World!", shell_output("./test").chomp
+  end
+end

--- a/Formula/flang.rb
+++ b/Formula/flang.rb
@@ -23,7 +23,7 @@ class Flang < Formula
     llvmpath = buildpath/"llvm"
     mkdir llvmpath/"build" do
       system "cmake", "-G", "Unix Makefiles", "..", *(std_cmake_args + args)
-      system "cmake", "--build", ".", "--target", "check-mlir", "check-flang"
+      system "cmake", "--build", "."
       system "cmake", "--install", "."
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Sets up flang as a separate formula so that llvm can be built without a
gcc dependency. See https://github.com/Homebrew/homebrew-core/pull/63081

Follow up to https://github.com/Homebrew/homebrew-core/pull/65223

`brew audit` does not like the `depends_on "llvm"`, but I don't think
this will build with just Apple Clang. flang needs to be built with
mlir.