### PR TITLE
worklflows: add wheezy CI

### DIFF
--- a/.github/workflows/wheezy_tests.yml
+++ b/.github/workflows/wheezy_tests.yml
@@ -1,0 +1,49 @@
+name: Wheezy CI
+on:
+  pull_request:
+    paths:
+      - "Formula/patchelf.rb"
+      - "Formula/binutils.rb"
+jobs:
+  wheezy_tests:
+    if: github.repository == 'Homebrew/homebrew-core' && github.event_name == 'pull_request' && ! contains(github.event.pull_request.labels.*.name, 'CI-syntax-only')
+    runs-on: ubuntu-latest
+    env:
+      HOMEBREW_CORE_GIT_REMOTE: ${{github.event.repository.html_url}}
+      HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Setup bottles folder
+        run: |
+          rm -rf ~/bottles
+          mkdir ~/bottles
+      - name: Run Docker
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_ANALYTICS: 1
+          HOMEBREW_DEVELOPER: 1
+          HOMEBREW_ON_DEBIAN7: 1
+          HOMEBREW_CURL_PATH: "/usr/bin/curl"
+          HOMEBREW_GIT_PATH: "/usr/bin/git"
+        run: |
+          set -eux
+          docker pull homebrew/debian7:latest
+          docker run -v /home/linuxbrew:/home/linuxbrew -v ~/bottles:/home/linuxbrew/bottles -u root --env-file <(env | grep 'HOMEBREW\|GITHUB') homebrew/debian7:latest bash -c 'cd /root && brew test-bot --only-formulae && cp *.bottle.* /home/linuxbrew/bottles'
+      - name: Count bottles
+        if: always()
+        run: |
+          cd ~/bottles
+          count=$(ls *.json | wc -l | xargs echo -n)
+          echo "$count bottles"
+          echo "::set-output name=count::$count"
+      - name: Move bottles
+        if: always() && steps.bottles.outputs.count > 0
+        run: mv ~/bottles $GITHUB_WORKSPACE
+      - name: Upload bottles
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: bottles
+          path: ~/bottles


### PR DESCRIPTION
First CI implementation for patchelf and binutils that need to be built on wheezy,
to be able to support older linux versions.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
