### PR TITLE
apache-arrow-glib: use meson, ninja

### DIFF
--- a/Formula/apache-arrow-glib.rb
+++ b/Formula/apache-arrow-glib.rb
@@ -18,15 +18,17 @@ class ApacheArrowGlib < Formula
   end
 
   depends_on "gobject-introspection" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "apache-arrow"
   depends_on "glib"
 
   def install
-    cd "c_glib" do
-      system "./configure", "--prefix=#{prefix}"
-      system "make"
-      system "make", "install"
+    mkdir "build" do
+      system "meson", *std_meson_args, "../c_glib"
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

On request by @kou 
```
Sutou Kouhei @kou 21:41
Ah, we can't use configure https://github.com/Homebrew/homebrew-core/blob/master/Formula/apache-arrow-glib.rb#L27 for --head.
configure isn't included in repository. It's an auto generated file.
We should change to use meson + ninja in Homebrew like https://github.com/Homebrew/homebrew-core/blob/master/Formula/glib.rb#L55-L57 .
Could you send a pull request for it to Homebrew?
```

I copied accordingly but I have no idea if the meson arguments are correct