### PR TITLE
python@3.X fix sitecustomize.py for when running in virtual environments

### DIFF
--- a/Formula/python@3.7.rb
+++ b/Formula/python@3.7.rb
@@ -294,9 +294,9 @@ class PythonAT37 < Formula
           long_prefix = re.compile(r'#{rack}/[0-9\._abrc]+/Frameworks/Python\.framework/Versions/#{xy}/lib/python#{xy}/site-packages')
           sys.path = [long_prefix.sub('#{HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"}', p) for p in sys.path]
 
-          # Set the sys.executable to use the opt_prefix, unless explicitly set
-          # with PYTHONEXECUTABLE:
-          if 'PYTHONEXECUTABLE' not in os.environ:
+          # Set the sys.executable to use the opt_prefix. Only do this if PYTHONEXECUTABLE is not
+          # explicitly set and we are not in a virtualenv:
+          if 'PYTHONEXECUTABLE' not in os.environ and sys.prefix == sys.base_prefix:
               sys.executable = '#{opt_bin}/python#{xy}'
     EOS
   end

--- a/Formula/python@3.8.rb
+++ b/Formula/python@3.8.rb
@@ -287,9 +287,9 @@ class PythonAT38 < Formula
           # site_packages; prefer the shorter paths
           long_prefix = re.compile(r'#{rack}/[0-9\._abrc]+/Frameworks/Python\.framework/Versions/#{xy}/lib/python#{xy}/site-packages')
           sys.path = [long_prefix.sub('#{HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"}', p) for p in sys.path]
-          # Set the sys.executable to use the opt_prefix, unless explicitly set
-          # with PYTHONEXECUTABLE:
-          if 'PYTHONEXECUTABLE' not in os.environ:
+          # Set the sys.executable to use the opt_prefix. Only do this if PYTHONEXECUTABLE is not
+          # explicitly set and we are not in a virtualenv:
+          if 'PYTHONEXECUTABLE' not in os.environ and sys.prefix == sys.base_prefix:
               sys.executable = '#{opt_bin}/python#{xy}'
     EOS
   end

--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -306,9 +306,9 @@ class PythonAT39 < Formula
           # site_packages; prefer the shorter paths
           long_prefix = re.compile(r'#{rack}/[0-9\._abrc]+/Frameworks/Python\.framework/Versions/#{xy}/lib/python#{xy}/site-packages')
           sys.path = [long_prefix.sub('#{HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"}', p) for p in sys.path]
-          # Set the sys.executable to use the opt_prefix, unless explicitly set
-          # with PYTHONEXECUTABLE:
-          if 'PYTHONEXECUTABLE' not in os.environ:
+          # Set the sys.executable to use the opt_prefix. Only do this if PYTHONEXECUTABLE is not
+          # explicitly set and we are not in a virtualenv:
+          if 'PYTHONEXECUTABLE' not in os.environ and sys.prefix == sys.base_prefix:
               sys.executable = '#{opt_bin}/python#{xy}'
     EOS
   end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

These commits fix #58248 and (duplicate) #60843. Both are currently closed as they are stale, but the underlying problems persist. #58248 has a good exposition of the issue, but I'll quickly summarise here.

When using a Python `virtualenv` based on a brewed Python, the homebrew installed `sitecustomize.py` modifies the `sys.executable` even though this isn't appropriate when you're using a virtualenv. This causes a number of subtle problems:
- #58248 highlights the fact that shebangs for scripts installed get the wrong executable added.
- More problematically, I find that this breaks the isolation of the virtualenv as editable pip package installs place the package in the parent environment, and not the virtual environment. I've included steps to reproduce this below.

The underlying issue with `sys.executable` can be demonstrated fairly easily:
```bash
$ brew install python@3.9
$ pip3 install virtualenv
$ python3.9 -m virtualenv -p python3.9 --system-site-packages venv
$ source venv/bin/activate
$ python3.9 -c 'import sys; print(f"Executable {sys.executable}"); print(f"Real prefix: {sys.prefix}\nBase prefix {sys.base_prefix}")'
Executable /usr/local/opt/python@3.9/bin/python3.9
Real prefix: /Users/richard/tmp/homebrew_bug_fix/venv
Base prefix /usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9
```
The desired behaviour is that the "Executable" line in the output points to the virtualenv python. Running the final command after apply the patches gives:
```bash
$ python3.9 -c 'import sys; print(f"Executable {sys.executable}"); print(f"Real prefix: {sys.prefix}\nBase prefix {sys.base_prefix}")'
Executable /Users/richard/tmp/homebrew_bug_fix/venv/bin/python3.9
Real prefix: /Users/richard/tmp/homebrew_bug_fix/venv
Base prefix /usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9
```
which is correct.

The commits in this PR simply change the `sitecustomize.py` installed by the Python 3 formulas (`python@3.7`, `python@3.8`, `python@3.9`) to only modify the `sys.executable` variable if not running within a virtualenv (using the standard `sys.prefix == sys.base_prefix` test).



To reproduce the issue where the virtualenv isolation is broken, simply do:
```bash
$ brew install python@3.9
$ pip3 install virtualenv
$ python3.9 -m virtualenv -p python3.9 --system-site-packages venv
$ source venv/bin/activate
$ pip install -e "git+https://github.com/psf/requests#egg=requests"  # The egg link gets placed in the parent site-packages not the virtualenv site-packages
$ deactivate
$ pip3 list --local
Package    Version Location
---------- ------- ---------------------------------------------------------------
appdirs    1.4.4
distlib    0.3.1
filelock   3.0.12
future     0.18.2
GDAL       3.2.0
pip        20.2.4  /usr/local/lib/python3.9/site-packages
protobuf   3.13.0
requests   2.25.0  /Users/richard/tmp/homebrew_bug_fix/venv/src/requests   # <----- this should only be present in the venv
setuptools 50.3.2
six        1.15.0
testpkg    0.0.0   /Users/richard/Projects/CHIME/pipeline/daily_rev01/code/testpkg
virtualenv 20.1.0
wheel      0.35.1
```

Thanks!