### PR TITLE
pdf-redact-tools: deprecate

### DIFF
--- a/Formula/pdf-redact-tools.rb
+++ b/Formula/pdf-redact-tools.rb
@@ -3,7 +3,7 @@ class PdfRedactTools < Formula
   homepage "https://github.com/firstlookmedia/pdf-redact-tools"
   url "https://github.com/firstlookmedia/pdf-redact-tools/archive/v0.1.2.tar.gz"
   sha256 "5874a7b76be15ccaa4c20874299ef51fbaf520a858229a58678bc72a305305fc"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 1
   head "https://github.com/firstlookmedia/pdf-redact-tools.git"
 
@@ -13,6 +13,8 @@ class PdfRedactTools < Formula
     sha256 "1d5dddb4adc486d89537a5368550c787b9dbae0c6cd9cddba9b2e45820b025e1" => :mojave
     sha256 "1d5dddb4adc486d89537a5368550c787b9dbae0c6cd9cddba9b2e45820b025e1" => :high_sierra
   end
+
+  deprecate! because: :unmaintained
 
   depends_on "exiftool"
   depends_on "ghostscript"


### PR DESCRIPTION
From https://github.com/firstlookmedia/pdf-redact-tools:

> Warning: This project is no longer maintained. A much better tool is dangerzone.