### PR TITLE
libtcod: remove :macos dependency

### DIFF
--- a/Formula/libtcod.rb
+++ b/Formula/libtcod.rb
@@ -19,7 +19,6 @@ class Libtcod < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.9" => :build
-  depends_on :macos # Due to Python 2
   depends_on "sdl2"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This formula already has build dependency `python@3.9` and doesn't seem to require python in runtime.