### PR TITLE
pdf2htmlex: set -lintl flag only on mac

### DIFF
--- a/Formula/pdf2htmlex.rb
+++ b/Formula/pdf2htmlex.rb
@@ -3,7 +3,7 @@ class Pdf2htmlex < Formula
   homepage "https://coolwanglu.github.io/pdf2htmlEX/"
   url "https://github.com/coolwanglu/pdf2htmlEX/archive/v0.14.6.tar.gz"
   sha256 "320ac2e1c2ea4a2972970f52809d90073ee00a6c42ef6d9833fb48436222f0e5"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 24
   head "https://github.com/coolwanglu/pdf2htmlEX.git"
 
@@ -12,6 +12,8 @@ class Pdf2htmlex < Formula
     sha256 "0cf6aa3cd87e96aab2fc58b618f8a9127edec88a624bd6cf2f5816fd575c0a50" => :mojave
     sha256 "8a55a7cd0d373d223162ee92bc6f02c269b4f17fe987471ba3388ea257cf870f" => :high_sierra
   end
+
+  deprecate! date: "2016-12-12", because: :repo_archived
 
   depends_on "autoconf" => :build # for fontforge
   depends_on "automake" => :build # for fontforge
@@ -56,8 +58,10 @@ class Pdf2htmlex < Formula
       # https://github.com/coolwanglu/pdf2htmlEX/issues/713
       inreplace "gutils/gimagereadgif.c", "DGifCloseFile(gif)", "DGifCloseFile(gif, NULL)"
 
-      # Fix linker error; see: https://trac.macports.org/ticket/25012
-      ENV.append "LDFLAGS", "-lintl"
+      on_macos do
+        # Fix linker error; see: https://trac.macports.org/ticket/25012
+        ENV.append "LDFLAGS", "-lintl"
+      end
 
       system "./autogen.sh"
       system "./configure", "--prefix=#{libexec}/fontforge",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
