### PR TITLE
aws-rotate-key 1.0.7 (new formula)

### DIFF
--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -1,11 +1,19 @@
 class AwsRotateKey < Formula
-  desc "Easily rotate your AWS key. 🔑"
+  desc "Easily rotate your AWS access key. 🔑"
   homepage "https://github.com/stefansundin/aws-rotate-key"
-  version "1.0.7"
-  url "https://github.com/stefansundin/aws-rotate-key/releases/download/v#{version}/aws-rotate-key-#{version}-darwin_amd64.zip"
-  sha256 "972d52f480c8e6efe1d2b2a95756a5eef6dff595281b17126b39bc768eee3b9d"
+  url "https://github.com/stefansundin/aws-rotate-key/archive/v1.0.7.tar.gz"
+  sha256 "9dadb689583dc4d8869a346c2e7f12201e1fe65d5bf1d64eb09b69f65518bc44"
+  license "MIT"
+  head "https://github.com/stefansundin/aws-rotate-key.git"
+
+  depends_on "go" => :build
 
   def install
-    bin.install "aws-rotate-key"
+    system "go", "build", *std_go_args
+  end
+  
+  test do
+    assert_match(/^Usage of #{bin}\/aws-rotate-key:/, shell_output("#{bin}/aws-rotate-key --help 2>&1"))
+    assert_match("1.0.7", shell_output("#{bin}/aws-rotate-key --version"))
   end
 end

--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -22,7 +22,7 @@ class AwsRotateKey < Formula
       ^Using access key AKIA123 from profile "default"\\.
       Error getting caller identity\\. Is the key disabled\\?
       InvalidClientTokenId: The security token included in the request is invalid\\.
-      \tstatus code: \\d+, request id: [a-f0-9\\-]+$
+      \tstatus code: \\d+, request id: [a-f0-9\\-]+
     EOS
   end
 end

--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -19,11 +19,6 @@ class AwsRotateKey < Formula
       aws_secret_access_key=abc
     EOF
     output = shell_output("AWS_SHARED_CREDENTIALS_FILE=#{testpath}/credentials #{bin}/aws-rotate-key -y 2>&1", 1)
-    assert_match Regexp.new(<<~EOS), output
-      ^Using access key AKIA123 from profile "default"\\.
-      Error getting caller identity\\. Is the key disabled\\?\n
-      InvalidClientTokenId: The security token included in the request is invalid\\.
-      \tstatus code: \\d+, request id: [a-f0-9\\-]+
-    EOS
+    assert_match "InvalidClientTokenId: The security token included in the request is invalid", output
   end
 end

--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -1,0 +1,11 @@
+class AwsRotateKey < Formula
+  desc "Easily rotate your AWS key. 🔑"
+  homepage "https://github.com/stefansundin/aws-rotate-key"
+  version "1.0.7"
+  url "https://github.com/stefansundin/aws-rotate-key/releases/download/v#{version}/aws-rotate-key-#{version}-darwin_amd64.zip"
+  sha256 "972d52f480c8e6efe1d2b2a95756a5eef6dff595281b17126b39bc768eee3b9d"
+
+  def install
+    bin.install "aws-rotate-key"
+  end
+end

--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -5,15 +5,23 @@ class AwsRotateKey < Formula
   sha256 "9dadb689583dc4d8869a346c2e7f12201e1fe65d5bf1d64eb09b69f65518bc44"
   license "MIT"
   head "https://github.com/stefansundin/aws-rotate-key.git"
-
   depends_on "go" => :build
-
+  
   def install
     system "go", "build", *std_go_args
   end
-  
+
   test do
-    assert_match(%r{/^Usage of #{bin}/aws-rotate-key:/}, shell_output("#{bin}/aws-rotate-key --help 2>&1"))
-    assert_match("1.0.7", shell_output("#{bin}/aws-rotate-key --version"))
+    (testpath/"credentials").write <<~EOF
+      [default]
+      aws_access_key_id=AKIA123
+      aws_secret_access_key=abc
+    EOF
+    assert_match Regexp.new(<<~EOS), shell_output("AWS_SHARED_CREDENTIALS_FILE=#{testpath}/credentials #{bin}/aws-rotate-key -y 2>&1", 1)
+      ^Using access key AKIA123 from profile "default"\\.
+      Error getting caller identity\\. Is the key disabled\\?
+      InvalidClientTokenId: The security token included in the request is invalid\\.
+      \tstatus code: 403, request id: [a-f0-9\\-]+$
+    EOS
   end
 end

--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -6,7 +6,7 @@ class AwsRotateKey < Formula
   license "MIT"
   head "https://github.com/stefansundin/aws-rotate-key.git"
   depends_on "go" => :build
-  
+
   def install
     system "go", "build", *std_go_args
   end

--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -5,6 +5,7 @@ class AwsRotateKey < Formula
   sha256 "9dadb689583dc4d8869a346c2e7f12201e1fe65d5bf1d64eb09b69f65518bc44"
   license "MIT"
   head "https://github.com/stefansundin/aws-rotate-key.git"
+
   depends_on "go" => :build
 
   def install

--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -17,11 +17,12 @@ class AwsRotateKey < Formula
       aws_access_key_id=AKIA123
       aws_secret_access_key=abc
     EOF
-    assert_match Regexp.new(<<~EOS), shell_output("AWS_SHARED_CREDENTIALS_FILE=#{testpath}/credentials #{bin}/aws-rotate-key -y 2>&1", 1)
+    output = shell_output("AWS_SHARED_CREDENTIALS_FILE=#{testpath}/credentials #{bin}/aws-rotate-key -y 2>&1", 1)
+    assert_match Regexp.new(<<~EOS), output
       ^Using access key AKIA123 from profile "default"\\.
       Error getting caller identity\\. Is the key disabled\\?
       InvalidClientTokenId: The security token included in the request is invalid\\.
-      \tstatus code: 403, request id: [a-f0-9\\-]+$
+      \tstatus code: \\d+, request id: [a-f0-9\\-]+$
     EOS
   end
 end

--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -1,5 +1,5 @@
 class AwsRotateKey < Formula
-  desc "Easily rotate your AWS access key. 🔑"
+  desc "Easily rotate your AWS access key"
   homepage "https://github.com/stefansundin/aws-rotate-key"
   url "https://github.com/stefansundin/aws-rotate-key/archive/v1.0.7.tar.gz"
   sha256 "9dadb689583dc4d8869a346c2e7f12201e1fe65d5bf1d64eb09b69f65518bc44"

--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -20,7 +20,7 @@ class AwsRotateKey < Formula
     output = shell_output("AWS_SHARED_CREDENTIALS_FILE=#{testpath}/credentials #{bin}/aws-rotate-key -y 2>&1", 1)
     assert_match Regexp.new(<<~EOS), output
       ^Using access key AKIA123 from profile "default"\\.
-      Error getting caller identity\\. Is the key disabled\\?
+      Error getting caller identity\\. Is the key disabled\\?\n
       InvalidClientTokenId: The security token included in the request is invalid\\.
       \tstatus code: \\d+, request id: [a-f0-9\\-]+
     EOS

--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -13,7 +13,7 @@ class AwsRotateKey < Formula
   end
   
   test do
-    assert_match(/^Usage of #{bin}\/aws-rotate-key:/, shell_output("#{bin}/aws-rotate-key --help 2>&1"))
+    assert_match(%r{/^Usage of #{bin}/aws-rotate-key:/}, shell_output("#{bin}/aws-rotate-key --help 2>&1"))
     assert_match("1.0.7", shell_output("#{bin}/aws-rotate-key --version"))
   end
 end


### PR DESCRIPTION
- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I found this tool to be useful and the developer was kind enough to even make a fully tested formula

so I took his formula from https://github.com/stefansundin/homebrew-tap/blob/master/Formula/aws-rotate-key.rb
