### PR TITLE
libav: actively prevent X11 linkage

### DIFF
--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -3,8 +3,8 @@ class Libav < Formula
   homepage "https://libav.org/"
   url "https://libav.org/releases/libav-12.3.tar.xz"
   sha256 "6893cdbd7bc4b62f5d8fd6593c8e0a62babb53e323fbc7124db3658d04ab443b"
-  license "GPL-2.0"
-  revision 7
+  license "GPL-2.0-or-later"
+  revision 8
   head "https://git.libav.org/libav.git"
 
   livecheck do
@@ -19,6 +19,8 @@ class Libav < Formula
     sha256 "30f9831bae193d6a9716e8e3aed399dfd8d62189079d91b5c4dfb893904a213f" => :mojave
     sha256 "02fa538e8c123a074967d4b4c8e122c167761d4c6425ed5061a1d15cf47945a7" => :high_sierra
   end
+
+  deprecate! date: "2019-04-16", because: :unmaintained
 
   depends_on "pkg-config" => :build
   # manpages won't be built without texi2html
@@ -36,6 +38,13 @@ class Libav < Formula
   depends_on "theora"
   depends_on "x264"
   depends_on "xvid"
+
+  # Cherry-picked hunk from https://github.com/libav/libav/commit/fe7bc1f16abaefe66d8a20f734ca3eb8a4ce4d43
+  # (second hunk in above commit conflicts with released source)
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/e07f287/libav/remove_unconditional_X11_probe.patch"
+    sha256 "093364c5cb0d79fb80566b5b466e6e8877d01c70e32b6f8ad624205005caba26"
+  end
 
   # https://bugzilla.libav.org/show_bug.cgi?id=1033
   patch do
@@ -82,6 +91,9 @@ class Libav < Formula
       --enable-vda
       --enable-version3
       --enable-libtheora
+      --disable-libxcb
+      --disable-vaapi
+      --disable-vdpau
     ]
 
     system "./configure", *args


### PR DESCRIPTION
Properly fixes #64654. Also fixes license.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Note the following:
* New patch was cherry-picked from upstream commit in master branch, but not merged in current release, even though the fix predates it. (Cherry-picking needed because the other hunk fails to apply against current release.)
* When checking with upstream why it was not merged for release, I received unofficial confirmation that this project is no longer maintained:
  * Email:
    * Last meaningful comms on dev mailing list almost a year ago
    * Query on project status in April 2020 netted one reply from a libav contributor: "It's dead" (https://lists.libav.org/pipermail/libav-devel/2020-April/thread.html)
    * My own query on official status has not yet been responded to
  * IRC:
    * My queries on #libav-devel net only off-the-record responses that no one is working on libav, but no one's willing to "call time of death", so there will probably not be an official announcement on libav.org
* Debian seems to have already deprecated libav: https://tracker.debian.org/pkg/libav

Since Homebrew libav installs still number in the thousands, I'm fixing the opportunistic X11 linkage, and deprecating as of last GitHub commit (16 Apr 2019).
