### PR TITLE
cheat 4.1.1 (add zsh completions)

### DIFF
--- a/Formula/cheat.rb
+++ b/Formula/cheat.rb
@@ -22,6 +22,7 @@ class Cheat < Formula
 
     bash_completion.install "scripts/cheat.bash"
     fish_completion.install "scripts/cheat.fish"
+    zsh_completion.install "scripts/cheat.zsh"
   end
 
   test do


### PR DESCRIPTION
Zsh completions for cheat are available in their repo but they are not in the formula, this PR adds it.

I merely added this change through the Github UI and didn't go through the guidelines because it was a very simple change, but I can do those as well if you think that's necessary.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
