### PR TITLE
stockfish: add livecheck

### DIFF
--- a/Formula/stockfish.rb
+++ b/Formula/stockfish.rb
@@ -6,6 +6,11 @@ class Stockfish < Formula
   license "GPL-3.0-only"
   head "https://github.com/official-stockfish/Stockfish.git"
 
+  livecheck do
+    url "https://github.com/official-stockfish/Stockfish/releases/latest"
+    regex(%r{href=.*?/tag/(?:sf[._-])?v?(\d+(?:\.\d+)*)["' >]}i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "33e7b97bde0b94856ef6e14087f2c1e40d8e17f5a4878123bedeacfd6329fdd3" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `stock`fish and returns the latest version fine at the moment. However, we prefer to check the "latest" release on GitHub when it's available and correct and this adds a `livecheck` block to do so.