### PR TITLE
awscli: revert

### DIFF
--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -6,6 +6,7 @@ class Awscli < Formula
   url "https://github.com/aws/aws-cli/archive/2.1.1.tar.gz"
   sha256 "650bc1dd125dbb040917d5285f380abe8966369a7c6dd7f0cfc76e7cc18814b2"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/aws/aws-cli.git", branch: "v2"
 
   bottle do
@@ -15,10 +16,7 @@ class Awscli < Formula
     sha256 "01d374cd8bbe91ec3a210c79583f9e327c69af434e008df2e22a39181619447c" => :mojave
   end
 
-  # NOTE: Do not upgrade Python to 3.9+ until awscli officially supports it.
-  # See https://github.com/Homebrew/homebrew-core/issues/63990
-  # and https://github.com/aws/aws-cli/issues/5692.
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   uses_from_macos "groff"
 
@@ -59,7 +57,7 @@ class Awscli < Formula
 
   test do
     assert_match "topics", shell_output("#{bin}/aws help")
-    assert_include Dir["#{libexec}/lib/python3.8/site-packages/awscli/data/*"],
-                   "#{libexec}/lib/python3.8/site-packages/awscli/data/ac.index"
+    assert_include Dir["#{libexec}/lib/python3.9/site-packages/awscli/data/*"],
+                   "#{libexec}/lib/python3.9/site-packages/awscli/data/ac.index"
   end
 end

--- a/Formula/juju.rb
+++ b/Formula/juju.rb
@@ -5,6 +5,7 @@ class Juju < Formula
     tag:      "juju-2.8.6",
     revision: "5d0442d3e15952bfc0ce059cb43ef7949ca71aaa"
   license "AGPL-3.0-only"
+  revision 1
   version_scheme 1
 
   livecheck do
@@ -20,6 +21,12 @@ class Juju < Formula
   end
 
   depends_on "go" => :build
+
+  # Fixed in next 2.8.x release.
+  patch do
+    url "https://github.com/juju/juju/commit/29afb4b7fdbaa70a3e1a2c596e46a0c7962303a4.patch?full_index=1"
+    sha256 "edb6337d7bb75ae053eecbcf5704a4165130241b302832484ece19b5183c3ca7"
+  end
 
   def install
     git_commit = Utils.safe_popen_read("git", "rev-parse", "HEAD").chomp


### PR DESCRIPTION
This reverts commit 7338a9b097fb12f6c1ee8036a81e2b76ad5f3ed0.

This formula was downgraded to use python3.8 to build, but the [justification to revert this](https://github.com/Homebrew/homebrew-core/pull/65172) was based on a build-from-source installation with a non-standard Homebrew prefix, which we do not support. https://github.com/Homebrew/homebrew-core/issues/63990 and https://github.com/aws/aws-cli/issues/5692 was used to further justify using python3.8, but that was actually a Homebrew/brew bug, reported in https://github.com/Homebrew/homebrew-core/issues/63971 and fixed in https://github.com/Homebrew/brew/pull/9053.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----