### PR TITLE
cmake: backport cmake patch (unblock #64836)

### DIFF
--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -4,6 +4,7 @@ class Cmake < Formula
   url "https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0.tar.gz"
   sha256 "fdda688155aa7e72b7c63ef6f559fca4b6c07382ea6dca0beb5f45aececaf493"
   license "BSD-3-Clause"
+  revision 1
   head "https://gitlab.kitware.com/cmake/cmake.git"
 
   livecheck do
@@ -22,6 +23,12 @@ class Cmake < Formula
 
   on_linux do
     depends_on "openssl@1.1"
+  end
+
+  # Backport patch for 3.19.0: https://gitlab.kitware.com/cmake/cmake/-/issues/21469
+  patch do
+    url "https://gitlab.kitware.com/cmake/cmake/-/commit/30aa715fac06deba7eaa3e6167cf34eb4d2521d0.patch"
+    sha256 "471843b53ea5749eda8b32ef69f9ab20c17e0087992ce3bf8cba93e6e87c54b5"
   end
 
   # The completions were removed because of problems with system bash


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes a regression in the latest cmake that prevents some formulas from building. 
This should unblock the protobuf migration in https://github.com/Homebrew/homebrew-core/pull/64836#issuecomment-731582698

 
