### PR TITLE
gnuradio: Support plugins installed by other packages

### DIFF
--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -158,6 +158,11 @@ class Gnuradio < Formula
     pth_contents = "#{site_packages}\nimport homebrew_gr_plugins\n"
     (venv_site_packages/"homebrew-gnuradio.pth").write pth_contents
 
+    # Patch the grc config to change the search directory for blocks
+    inreplace etc/"gnuradio/conf.d/grc.conf" do |s|
+      s.gsub! share.to_s, "#{HOMEBREW_PREFIX}/share"
+    end
+
     rm bin.children.reject(&:executable?)
   end
 

--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -6,7 +6,7 @@ class Gnuradio < Formula
   url "https://github.com/gnuradio/gnuradio/releases/download/v3.8.2.0/gnuradio-3.8.2.0.tar.gz"
   sha256 "3e293541a9ac8d78660762bae8b80c0f6195b3494e1c50c01a9fd79cc60bb624"
   license "GPL-3.0-or-later"
-  revision 3
+  revision 4
   head "https://github.com/gnuradio/gnuradio.git"
 
   bottle do
@@ -141,9 +141,22 @@ class Gnuradio < Formula
     mv Dir[lib/"python#{xy}/dist-packages/*"], lib/"python#{xy}/site-packages/"
     rm_rf lib/"python#{xy}/dist-packages"
 
+    # Create a directory for Homebrew to put .pth files pointing to GNU Radio
+    # plugins installed by other packages. An automatically-loaded module adds
+    # this directory to the package search path.
+    plugin_pth_dir = etc/"gnuradio/plugins.d"
+    mkdir plugin_pth_dir
+
     site_packages = lib/"python#{xy}/site-packages"
-    pth_contents = "import site; site.addsitedir('#{site_packages}')\n"
-    (venv_root/"lib/python#{xy}/site-packages/homebrew-gnuradio.pth").write pth_contents
+    venv_site_packages = venv_root/"lib/python#{xy}/site-packages"
+
+    (venv_site_packages/"homebrew_gr_plugins.py").write <<~EOS
+      import site
+      site.addsitedir("#{plugin_pth_dir}")
+    EOS
+
+    pth_contents = "#{site_packages}\nimport homebrew_gr_plugins\n"
+    (venv_site_packages/"homebrew-gnuradio.pth").write pth_contents
 
     rm bin.children.reject(&:executable?)
   end

--- a/Formula/gr-osmosdr.rb
+++ b/Formula/gr-osmosdr.rb
@@ -6,6 +6,7 @@ class GrOsmosdr < Formula
   url "https://github.com/osmocom/gr-osmosdr/archive/v0.2.2.tar.gz"
   sha256 "5a7ce7afee38a56191b5d16cb4a91c92476729ff16ed09cbba5a3851ac619713"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 "c4a00d0ab33d277fbd036c7f496b09ca8259ec892a2a8877a3707a512f4ec705" => :big_sur
@@ -48,6 +49,10 @@ class GrOsmosdr < Formula
 
     system "cmake", ".", *std_cmake_args, "-DPYTHON_EXECUTABLE=#{venv_root}/bin/python"
     system "make", "install"
+
+    # Leave a pointer to our Python module directory where GNU Radio can find it
+    site_packages = lib/"python#{xy}/site-packages"
+    (etc/"gnuradio/plugins.d/gr-osmosdr.pth").write "#{site_packages}\n"
   end
 
   test do
@@ -60,5 +65,9 @@ class GrOsmosdr < Formula
     EOS
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lgnuradio-osmosdr", "-o", "test"
     system "./test"
+
+    # Make sure GNU Radio's Python can find our module
+    (testpath/"testimport.py").write "import osmosdr\n"
+    system Formula["gnuradio"].libexec/"venv/bin/python", testpath/"testimport.py"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

GNU Radio Companion (`gnuradio-companion`) is unable to find plugins such as `gr-osmosdr` because of the ways kegs are isolated. (I intend to upstream formulae for new plugins in the future.)

This change adds a new directory, `#{HOMEBREW_PREFIX}/etc/gnuradio/plugins.d`, into which Python `.pth` files ([documentation](https://docs.python.org/3/library/site.html)) can be installed by plugin packages. The GNU Radio Python virtual environment is then configured to automatically enumerate the `.pth` files in this directory in order to discover plugin modules.

I added a test to `gr-osmosdr` to make sure that it can be loaded by GNU Radio's `python` with this change.

Additionally, this patches the GNU Radio configuration file to search for blocks in `#{HOMEBREW_PREFIX}/share/gnuradio/grc/blocks`, which is where they were being installed already, but the software was not looking there for them.

I bumped the revision numbers of `gnuradio` and `gr-osmosdr` to force the bottles to be rebuilt.

Fixes #65387. 