### PR TITLE
Update license expressions to new syntax

### DIFF
--- a/Formula/hypre.rb
+++ b/Formula/hypre.rb
@@ -3,8 +3,7 @@ class Hypre < Formula
   homepage "https://computation.llnl.gov/casc/hypre/software.html"
   url "https://github.com/hypre-space/hypre/archive/v2.20.0.tar.gz"
   sha256 "5be77b28ddf945c92cde4b52a272d16fb5e9a7dc05e714fc5765948cba802c01"
-  # license ["MIT", "Apache-2.0"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "MIT"
+  license any_of: ["MIT", "Apache-2.0"]
   head "https://github.com/hypre-space/hypre.git"
 
   livecheck do

--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -4,8 +4,10 @@ class Ipfs < Formula
   url "https://github.com/ipfs/go-ipfs.git",
       tag:      "v0.7.0",
       revision: "ea77213e31ef2b3cad81d40bf82bb9baef3ea7b6"
-  # license ["Apache-2.0", "MIT"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "Apache-2.0"
+  license all_of: [
+    "MIT",
+    any_of: ["MIT", "Apache-2.0"],
+  ]
   head "https://github.com/ipfs/go-ipfs.git"
 
   livecheck do

--- a/Formula/libfreenect.rb
+++ b/Formula/libfreenect.rb
@@ -3,8 +3,7 @@ class Libfreenect < Formula
   homepage "https://openkinect.org/"
   url "https://github.com/OpenKinect/libfreenect/archive/v0.6.1.tar.gz"
   sha256 "a2e426cf42d9289b054115876ec39502a1144bc782608900363a0c38056b6345"
-  # license ["Apache-2.0", "GPL-2.0"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "GPL-2.0-only"]
   head "https://github.com/OpenKinect/libfreenect.git"
 
   bottle do

--- a/Formula/libical.rb
+++ b/Formula/libical.rb
@@ -3,8 +3,7 @@ class Libical < Formula
   homepage "https://libical.github.io/libical/"
   url "https://github.com/libical/libical/releases/download/v3.0.8/libical-3.0.8.tar.gz"
   sha256 "09fecacaf75ba5a242159e3a9758a5446b5ce4d0ab684f98a7040864e1d1286f"
-  # license ["LGPL-2.1", "MPL-2.0"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "LGPL-2.1"
+  license any_of: ["LGPL-2.1-or-later", "MPL-2.0"]
   revision 2
 
   bottle do

--- a/Formula/libiodbc.rb
+++ b/Formula/libiodbc.rb
@@ -3,8 +3,7 @@ class Libiodbc < Formula
   homepage "http://www.iodbc.org/dataspace/iodbc/wiki/iODBC/"
   url "https://github.com/openlink/iODBC/archive/v3.52.13.tar.gz"
   sha256 "4bf67fc6d4d237a4db19b292b5dd255ee09a0b2daa4e4058cf3a918bc5102135"
-  # license ["BSD-3-Clause", "LGPL-2.0"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "BSD-3-Clause"
+  license any_of: ["BSD-3-Clause", "LGPL-2.0-only"]
 
   bottle do
     cellar :any

--- a/Formula/libnice.rb
+++ b/Formula/libnice.rb
@@ -3,8 +3,7 @@ class Libnice < Formula
   homepage "https://wiki.freedesktop.org/nice/"
   url "https://nice.freedesktop.org/releases/libnice-0.1.18.tar.gz"
   sha256 "5eabd25ba2b54e817699832826269241abaa1cf78f9b240d1435f936569273f4"
-  # license ["LGPL-2.1", "MPL-1.1"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "LGPL-2.1"
+  license any_of: ["LGPL-2.1-only", "MPL-1.1"]
 
   livecheck do
     url "https://github.com/libnice/libnice.git"

--- a/Formula/log4cplus.rb
+++ b/Formula/log4cplus.rb
@@ -3,8 +3,7 @@ class Log4cplus < Formula
   homepage "https://sourceforge.net/p/log4cplus/wiki/Home/"
   url "https://downloads.sourceforge.net/project/log4cplus/log4cplus-stable/2.0.5/log4cplus-2.0.5.tar.xz"
   sha256 "6046f0867ce4734f298418c7b7db0d35c27403090bb751d98e6e76aa4935f1af"
-  # license ["Apache-2.0", "BSD-2-Clause"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "BSD-2-Clause"]
 
   livecheck do
     url :stable

--- a/Formula/log4cplus.rb
+++ b/Formula/log4cplus.rb
@@ -3,7 +3,7 @@ class Log4cplus < Formula
   homepage "https://sourceforge.net/p/log4cplus/wiki/Home/"
   url "https://downloads.sourceforge.net/project/log4cplus/log4cplus-stable/2.0.5/log4cplus-2.0.5.tar.xz"
   sha256 "6046f0867ce4734f298418c7b7db0d35c27403090bb751d98e6e76aa4935f1af"
-  license any_of: ["Apache-2.0", "BSD-2-Clause"]
+  license all_of: ["Apache-2.0", "BSD-2-Clause"]
 
   livecheck do
     url :stable

--- a/Formula/mongoose.rb
+++ b/Formula/mongoose.rb
@@ -3,8 +3,7 @@ class Mongoose < Formula
   homepage "https://github.com/cesanta/mongoose"
   url "https://github.com/cesanta/mongoose/archive/6.17.tar.gz"
   sha256 "5bff3cc70bb2248cf87d06a3543f120f3b29b9368d25a7715443cb10612987cc"
-  # license ["GPL-2.0", "Cesanta"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     cellar :any

--- a/Formula/nettle.rb
+++ b/Formula/nettle.rb
@@ -4,8 +4,7 @@ class Nettle < Formula
   url "https://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz"
   mirror "https://ftpmirror.gnu.org/nettle/nettle-3.6.tar.gz"
   sha256 "d24c0d0f2abffbc8f4f34dcf114b0f131ec3774895f3555922fe2f40f3d5e3f1"
-  # license ["GPL-2.0", "GPL-3.0", "LGPL-3.0"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "GPL-2.0"
+  license any_of: ["GPL-2.0-or-later", "LGPL-3.0-or-later"]
 
   livecheck do
     url :stable

--- a/Formula/osquery.rb
+++ b/Formula/osquery.rb
@@ -3,8 +3,7 @@ class Osquery < Formula
   homepage "https://osquery.io"
   url "https://github.com/facebook/osquery/archive/3.3.2.tar.gz"
   sha256 "74280181f45046209053a3e15114d93adc80929a91570cc4497931cfb87679e4"
-  # license ["Apache-2.0", "GPL-2.0-only"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "GPL-2.0-only"]
   revision 17
 
   bottle do

--- a/Formula/peg-markdown.rb
+++ b/Formula/peg-markdown.rb
@@ -3,8 +3,7 @@ class PegMarkdown < Formula
   homepage "https://github.com/jgm/peg-markdown"
   url "https://github.com/jgm/peg-markdown/archive/0.4.14.tar.gz"
   sha256 "111bc56058cfed11890af11bec7419e2f7ccec6b399bf05f8c55dae0a1712980"
-  # license ["GPL-2.0", "MIT"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "MIT"
+  license any_of: ["GPL-2.0-or-later", "MIT"]
   revision 1
   head "https://github.com/jgm/peg-markdown.git"
 

--- a/Formula/plenv.rb
+++ b/Formula/plenv.rb
@@ -3,8 +3,7 @@ class Plenv < Formula
   homepage "https://github.com/tokuhirom/plenv"
   url "https://github.com/tokuhirom/plenv/archive/2.3.1.tar.gz"
   sha256 "12004cfed7ed083911dbda3228a9fb9ce6e40e259b34e791d970c4f335935fa3"
-  # license ["Artistic-1.0", "GPL-1.0"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "Artistic-1.0"
+  license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   head "https://github.com/tokuhirom/plenv.git"
 
   bottle :unneeded

--- a/Formula/rainbarf.rb
+++ b/Formula/rainbarf.rb
@@ -3,8 +3,7 @@ class Rainbarf < Formula
   homepage "https://github.com/creaktive/rainbarf"
   url "https://github.com/creaktive/rainbarf/archive/v1.4.tar.gz"
   sha256 "066579c0805616075c49c705d1431fb4b7c94a08ef2b27dd8846bd3569a188a4"
-  # license ["Artistic-1.0", "GPL-1.0"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "Artistic-1.0"
+  license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   head "https://github.com/creaktive/rainbarf.git"
 
   bottle :unneeded

--- a/Formula/transmission-cli.rb
+++ b/Formula/transmission-cli.rb
@@ -3,8 +3,7 @@ class TransmissionCli < Formula
   homepage "https://www.transmissionbt.com/"
   url "https://github.com/transmission/transmission-releases/raw/d5ccf14/transmission-3.00.tar.xz"
   sha256 "9144652fe742f7f7dd6657716e378da60b751aaeda8bef8344b3eefc4db255f2"
-  # license ["GPL-2.0", "GPL-3.0"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "GPL-2.0"
+  license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
 
   livecheck do
     url "https://github.com/transmission/transmission-releases/"

--- a/Formula/ttf2eot.rb
+++ b/Formula/ttf2eot.rb
@@ -3,9 +3,7 @@ class Ttf2eot < Formula
   homepage "https://github.com/wget/ttf2eot"
   url "https://github.com/wget/ttf2eot/archive/v0.0.3.tar.gz"
   sha256 "f363c4f2841b6d0b0545b30462e3c202c687d002da3d5dec7e2b827a032a3a65"
-  # License: Derived from WebKit, so BSD/LGPL 2/LGPL 2.1.
-  # license ["LGPL-2.0", "BSD-*"] - pending https://github.com/Homebrew/brew/pull/7953
-  license "LGPL-2.0"
+  license any_of: ["LGPL-2.0-or-later", "BSD-2-Clause"]
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Updating formulae license expressions in the context of #58225, now that richer license syntax has been made available in #7953 and #8260.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
