### PR TITLE
geos fix mac os arm compile

### DIFF
--- a/Formula/geos.rb
+++ b/Formula/geos.rb
@@ -27,12 +27,15 @@ class Geos < Formula
       s.gsub! /PYTHON_CPPFLAGS=.*/, %Q(PYTHON_CPPFLAGS="#{`python3-config --includes`.strip}")
       s.gsub! /PYTHON_LDFLAGS=.*/, 'PYTHON_LDFLAGS="-Wl,-undefined,dynamic_lookup"'
     end
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --enable-python
+      PYTHON=#{Formula["python@3.9"].opt_bin}/python3
+    ]
+    args << "--disable-inline" if Hardware::CPU.arm?
 
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--enable-python",
-                          "PYTHON=#{Formula["python@3.9"].opt_bin}/python3",
-                          "--disable-inline"
+    system "./configure", *args
     system "make", "install"
   end
 

--- a/Formula/geos.rb
+++ b/Formula/geos.rb
@@ -31,7 +31,8 @@ class Geos < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-python",
-                          "PYTHON=#{Formula["python@3.9"].opt_bin}/python3"
+                          "PYTHON=#{Formula["python@3.9"].opt_bin}/python3",
+                          "--disable-inline"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This change address an issue that causes the GEOS library compilation failed on macOS Big Sur running on ARM. 