### PR TITLE
nexus: update livecheck

### DIFF
--- a/Formula/nexus.rb
+++ b/Formula/nexus.rb
@@ -6,8 +6,8 @@ class Nexus < Formula
   license "EPL-1.0"
 
   livecheck do
-    url "https://help.sonatype.com/repomanager2/download/download-archives---repository-manager-oss"
-    regex(/href=.*?nexus[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)(?:-bundle)?\.t/i)
+    url "https://github.com/sonatype/nexus-public/releases/latest"
+    regex(%r{href=.*?/tag/release[._-]v?(\d+(?:[.-]\d+)+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `stable` source for `nexus` changed to GitHub in #64657.

This PR updates the `livecheck` block to check the "latest" release on GitHub, which we prefer when it's available (and correct) for formulae with a `stable` archive from GitHub.