### PR TITLE
conan: update livecheck

### DIFF
--- a/Formula/conan.rb
+++ b/Formula/conan.rb
@@ -9,7 +9,8 @@ class Conan < Formula
   head "https://github.com/conan-io/conan.git"
 
   livecheck do
-    url :stable
+    url "https://github.com/conan-io/conan/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
currently, it got mapped to `untagged-xxx` tag, since upstream has the notation of the latest tag, use latest tag instead.
```
untagged-8324d45e0aaefc1ed986 => #<Version:0x00007f98d215ade8 @version="8324d45e0aaefc1ed986", @detected_from_url=false>
conan : 1.31.3 ==> 8324d45e0aaefc1ed986
```