### PR TITLE
deployer: update livecheck

### DIFF
--- a/Formula/deployer.rb
+++ b/Formula/deployer.rb
@@ -4,9 +4,11 @@ class Deployer < Formula
   url "https://deployer.org/releases/v6.8.0/deployer.phar"
   sha256 "25f639561cb7ebe5c2231b05cb10a0cf62f83469faf6b9248dfa6b7f94e3bd26"
 
+  # The first-party download page now uses client-side rendering, so we have to
+  # check a JSON file used on the page that contains the version information.
   livecheck do
-    url "https://deployer.org/download"
-    regex(%r{href=.*?/releases/v?(\d+(?:\.\d+)+)/deployer.phar}i)
+    url "https://deployer.org/manifest.json"
+    regex(%r{\\?/releases\\?/v?(\d+(?:\.\d+)+)\\?/deployer\.phar}i)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `deployer` was checking the [first-party download page](https://deployer.org/download) but this doesn't work anymore. The version information is no longer present in the HTML, as the page has moved to client-side rendering.

This updates the `livecheck` block to check the `manifest.json` file that's loaded on the download page, as that's where the version information is now found.