### PR TITLE
app-engine-java: remove livecheck

### DIFF
--- a/Formula/app-engine-java.rb
+++ b/Formula/app-engine-java.rb
@@ -4,16 +4,6 @@ class AppEngineJava < Formula
   url "https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.83.zip"
   sha256 "1d585a36303c14f4fa44790bba97d5d8b75a889ad48ffce8187333488511e43e"
 
-  # This has received at least one update after the supposed end of life date
-  # (2020-08-30), so there may be value in keeping this check around for a
-  # little while longer. Once it's clear this won't receive any more updates,
-  # this `livecheck` block should be removed, so the formula is skipped due to
-  # being deprecated.
-  livecheck do
-    url "https://cloud.google.com/appengine/docs/standard/java/setting-up-environment"
-    regex(/href=.*?appengine-java-sdk[._-]v?(\d+(?:\.\d+)+)\.zip/i)
-  end
-
   bottle :unneeded
 
   # https://cloud.google.com/appengine/docs/standard/java/sdk-gcloud-migration


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The temporary `livecheck` block for `app-engine-java` has stopped working, as it seems that the version information is no longer published upstream. This software was deprecated on 2019-07-30 and became unsupported on 2020-08-30.

With the temporary check no longer working, I'm content to remove the `livecheck` block and allow it to be automatically skipped due to the formula being deprecated.