### PR TITLE
bigloo: update livecheck

### DIFF
--- a/Formula/bigloo.rb
+++ b/Formula/bigloo.rb
@@ -7,8 +7,8 @@ class Bigloo < Formula
   revision 1
 
   livecheck do
-    url :homepage
-    regex(/>\s*?version v?(\d+(?:\.\d+)+[a-z]?)\s*?</i)
+    url "https://www-sop.inria.fr/indes/fp/Bigloo/download.html"
+    regex(/bigloo-latest\.t.+?\(([^)]+?)\)/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `bigloo` checked the homepage, which lists the latest version. This check stopped working because the latest version is `4.4a-2` but the check was written with the expectation that the version format would only contain the numeric portion (e.g., `4.4`) and optionally a trailing letter. At the time, we hadn't seen a version with a trailing `-2` part, so we didn't know to account for it.

This PR updates the `livecheck` block to check the [first-party "Download" page](https://www-sop.inria.fr/indes/fp/Bigloo/download.html), which also lists the latest version in text like `bigloo-latest.tgz (4.4a-2)`. The regex in this check is relatively loose, as it doesn't try to account for a specific version format in case it changes again in the future.

If this looseness comes back to bite us in the future, we can always revert to the previous `livecheck` block and modify the regex to allow for a trailing `-2` part (i.e., `/>\s*?version v?(\d+(?:\.\d+)+[a-z]?(?:[._-]\d+)?)\s*?</i`).