### PR TITLE
pkg-config: adapt paths for linux and mac

### DIFF
--- a/Formula/pkg-config.rb
+++ b/Formula/pkg-config.rb
@@ -30,10 +30,16 @@ class PkgConfig < Formula
     pc_path = %W[
       #{HOMEBREW_PREFIX}/lib/pkgconfig
       #{HOMEBREW_PREFIX}/share/pkgconfig
-      /usr/local/lib/pkgconfig
-      /usr/lib/pkgconfig
-      #{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}
-    ].uniq.join(File::PATH_SEPARATOR)
+    ]
+    on_macos do
+      pc_path << "/usr/local/lib/pkgconfig"
+      pc_path << "/usr/lib/pkgconfig"
+      pc_path << "#{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"
+    end
+    on_linux do
+      pc_path << "#{HOMEBREW_LIBRARY}/Homebrew/os/linux/pkgconfig"
+    end
+    pc_path = pc_path.uniq.join(File::PATH_SEPARATOR)
 
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
On linux, we want to avoid system paths as we do not want to pick
these up.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
