### PR TITLE
rclone: Fix deprecation by removing the need for fuse while building

### DIFF
--- a/Formula/rclone.rb
+++ b/Formula/rclone.rb
@@ -13,17 +13,21 @@ class Rclone < Formula
     sha256 "cea1a5bf6e0346731ba8357e313ae6eb3633e14400c2e9e67bd5a3f8524721f6" => :high_sierra
   end
 
-  deprecate! because: "requires FUSE"
-
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-tags", "cmount", *std_go_args
+    system "go", "build", "-tags", "brew", *std_go_args
     man1.install "rclone.1"
     system bin/"rclone", "genautocomplete", "bash", "rclone.bash"
     system bin/"rclone", "genautocomplete", "zsh", "_rclone"
     bash_completion.install "rclone.bash" => "rclone"
     zsh_completion.install "_rclone"
+  end
+
+  def caveats
+    <<~EOS
+      Homebrew's installation does not include the `mount` subcommand.
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Following up from the discussion @ https://github.com/Homebrew/homebrew-core/commit/4f0402fb80551779c603add4c8b67a51bd324f09, this replaces the `cmount` tag with the `brew` tag that will remove the dependency on FUSE while building and throw the following error when using mount from the next major version of rclone:

```
2020/11/17 22:34:05 Fatal error: failed to mount FUSE fs: mount is not supported on MacOS when installed via Homebrew. Please install the binaries available at https://rclone.org/downloads/ instead if you want to use the mount command
```

References: https://github.com/rclone/rclone/pull/4782