### PR TITLE
zita-convolver: inreplace only on mac

### DIFF
--- a/Formula/zita-convolver.rb
+++ b/Formula/zita-convolver.rb
@@ -3,7 +3,7 @@ class ZitaConvolver < Formula
   homepage "https://kokkinizita.linuxaudio.org/linuxaudio/"
   url "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/zita-convolver-4.0.3.tar.bz2"
   sha256 "9aa11484fb30b4e6ef00c8a3281eebcfad9221e3937b1beb5fe21b748d89325f"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/index.html"
@@ -22,7 +22,9 @@ class ZitaConvolver < Formula
 
   def install
     cd "source" do
-      inreplace "Makefile", "-Wl,-soname,", "-Wl,-install_name,"
+      on_macos do
+        inreplace "Makefile", "-Wl,-soname,", "-Wl,-install_name,"
+      end
       inreplace "Makefile", "ldconfig", "ln -sf $(ZITA-CONVOLVER_MIN) $(DESTDIR)$(LIBDIR)/$(ZITA-CONVOLVER_MAJ)"
       system "make", "install", "PREFIX=#{prefix}", "SUFFIX="
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
