### PR TITLE
no version 6.22.04 listed on cern website

### DIFF
--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -1,7 +1,7 @@
 class Root < Formula
   desc "Object oriented framework for large scale data analysis"
   homepage "https://root.cern.ch/"
-  url "https://root.cern.ch/download/root_v6.22.04.source.tar.gz"
+  url "https://root.cern.ch/download/root_v6.22.02.source.tar.gz"
   sha256 "a2f066d85db8eb5b5f1c72573923484a6782a47b94954eff64879609f360e951"
   license "LGPL-2.1-or-later"
   head "https://github.com/root-project/root.git"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
