### PR TITLE
sha2: add livecheck, update urls

### DIFF
--- a/Formula/sha2.rb
+++ b/Formula/sha2.rb
@@ -1,8 +1,13 @@
 class Sha2 < Formula
   desc "Implementation of SHA-256, SHA-384, and SHA-512 hash algorithms"
-  homepage "https://www.aarongifford.com/computers/sha.html"
-  url "https://www.aarongifford.com/computers/sha2-1.0.1.tgz"
+  homepage "https://aarongifford.com/computers/sha.html"
+  url "https://aarongifford.com/computers/sha2-1.0.1.tgz"
   sha256 "67bc662955c6ca2fa6a0ce372c4794ec3d0cd2c1e50b124e7a75af7e23dd1d0c"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?sha2[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `sha2`. This PR adds a `livecheck` block that checks the homepage, where the `stable` archive is found.

This PR also updates the `homepage` and `stable` URLs to avoid the redirection to the same domain/path without the `www` subdomain. Just to be clear, the `stable` archive file is unchanged.