### PR TITLE
libvoikko: add livecheck

### DIFF
--- a/Formula/libvoikko.rb
+++ b/Formula/libvoikko.rb
@@ -5,6 +5,11 @@ class Libvoikko < Formula
   sha256 "e843df002fcea2a90609d87e4d6c28f8a0e23332d3b42979ab1793e18f839307"
   revision 3
 
+  livecheck do
+    url "https://www.puimula.org/voikko-sources/libvoikko/"
+    regex(/href=.*?libvoikko[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "0d36dae546a309c83750f42e8eba3b6d9b51765f78093a9b6bffa5c9d5bc0cd8" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `libvoikko`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.