### PR TITLE
doctl 1.53.0

### DIFF
--- a/Formula/doctl.rb
+++ b/Formula/doctl.rb
@@ -1,8 +1,8 @@
 class Doctl < Formula
   desc "Command-line tool for DigitalOcean"
   homepage "https://github.com/digitalocean/doctl"
-  url "https://github.com/digitalocean/doctl/archive/v1.52.0.tar.gz"
-  sha256 "e4a0a08d5be545b9bb035ed377c0b7e7705e217bf55d4f4423d7dc8afb0a5819"
+  url "https://github.com/digitalocean/doctl/archive/v1.53.0.tar.gz"
+  sha256 "f36ea283d7be9d1f77c69b1f60eda64d83aea5995f55f16171683f58897ad19b"
   license "Apache-2.0"
   head "https://github.com/digitalocean/doctl.git"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 4,763,128 bytes
- formula fetch time: 1.8 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.