### PR TITLE
assimp: update license and fix rpath issue.

### DIFF
--- a/Formula/assimp.rb
+++ b/Formula/assimp.rb
@@ -3,7 +3,7 @@ class Assimp < Formula
   homepage "https://www.assimp.org/"
   url "https://github.com/assimp/assimp/archive/v5.0.1.tar.gz"
   sha256 "11310ec1f2ad2cd46b95ba88faca8f7aaa1efe9aa12605c55e3de2b977b3dbfc"
-  license "LGPL-3.0"
+  license :cannot_represent
   head "https://github.com/assimp/assimp.git"
 
   bottle do
@@ -21,6 +21,7 @@ class Assimp < Formula
   def install
     args = std_cmake_args
     args << "-DASSIMP_BUILD_TESTS=OFF"
+    args << "-DCMAKE_INSTALL_RPATH=#{lib}"
     system "cmake", *args
     system "make", "install"
   end


### PR DESCRIPTION
CMAKE_INSTALL_RPATH is used so that assimp will work in alternative location such as /opt/homebrew

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
