### PR TITLE
Add VERSION envvar to istioctl install step

### DIFF
--- a/Formula/istioctl.rb
+++ b/Formula/istioctl.rb
@@ -18,6 +18,7 @@ class Istioctl < Formula
   depends_on "go-bindata" => :build
 
   def install
+    ENV["VERSION"] = version.to_s
     ENV["TAG"] = version.to_s
     ENV["ISTIO_VERSION"] = version.to_s
     ENV["HUB"] = "docker.io/istio"
@@ -32,6 +33,6 @@ class Istioctl < Formula
   end
 
   test do
-    assert_match version.major_minor.to_s, shell_output("#{bin}/istioctl version --remote=false")
+    assert_equal version.to_s, shell_output("#{bin}/istioctl version --remote=false").strip
   end
 end


### PR DESCRIPTION
Sets the `VERSION` environment variable when building from source (mimicking how `istio` release binaries are built). Fixes [https://github.com/istio/istio/issues/29142](https://github.com/istio/istio/issues/29142).

Requires new bottles to be built _without_ incrementing version (i.e. think this needs `rebuild: 1` but saw that only maintainers are meant to edit `bottles` section).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
