### PR TITLE
Replace dormant stale bot with stale action

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,1 +1,0 @@
-_extends: .github

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: "Close stale issues"
+
+on:
+  schedule:
+    # Once every day
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark/Close Stale Issues and Pull Requests
+        uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          days-before-stale: 21
+          days-before-close: 7
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs.
+          exempt-issue-labels:
+            - gsoc-outreachy
+            - help wanted
+            - in progress
+          exempt-pr-labels:
+            - gsoc-outreachy
+            - help wanted
+            - in progress


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Our existing stale bot seems to have gone dormant. We haven't had any issues/PRs marked as stale for quite some time and users [upstream](https://github.com/probot/stale) have also reported issues.

This PR switches to using the [stale GitHub action](https://github.com/actions/stale) instead. I've tried to set it up to match our [existing configuration](https://github.com/Homebrew/.github/blob/master/.github/stale.yml).

Assuming this goes well (we'll give it some time) I plan on following up with similar/identical changes in our other repositories as needed.

CC: @jonchang