### PR TITLE
dep: deprecated

### DIFF
--- a/Formula/dep.rb
+++ b/Formula/dep.rb
@@ -15,6 +15,8 @@ class Dep < Formula
     sha256 "ef9a0a978cbf2d4e537d21c4ff7b89a75b66228697b0aa348daa2284bc7362a9" => :sierra
   end
 
+  deprecate! because: :repo_archived
+
   depends_on "go"
 
   conflicts_with "deployer", because: "both install `dep` binaries"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This formula should be deprecated because https://github.com/golang/dep was archived