### PR TITLE
openjdk: Add support for Apple silicon

### DIFF
--- a/Aliases/openjdk@15
+++ b/Aliases/openjdk@15
@@ -1,1 +1,0 @@
-../Formula/openjdk.rb

--- a/Aliases/openjdk@16
+++ b/Aliases/openjdk@16
@@ -1,0 +1,1 @@
+../Formula/openjdk@16

--- a/Aliases/openjdk@16
+++ b/Aliases/openjdk@16
@@ -1,1 +1,1 @@
-../Formula/openjdk@16
+../Formula/openjdk.rb

--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -44,10 +44,14 @@ class Openjdk < Formula
   def install
     boot_jdk_dir = Pathname.pwd/"boot-jdk"
     resource("boot-jdk").stage boot_jdk_dir
-    boot_jdk = boot_jdk_dir
+    boot_jdk = ""
 
     on_macos do
-      boot_jdk << "/Contents/Home"
+      boot_jdk = boot_jdk_dir"/Contents/Home"
+    end
+
+    on_linux do
+      boot_jdk = boot_jdk_dir
     end
 
     java_options = ENV.delete("_JAVA_OPTIONS")
@@ -101,11 +105,25 @@ class Openjdk < Formula
     ENV["MAKEFLAGS"] = "JOBS=#{ENV.make_jobs}"
     system "make", "images"
 
-    jdk = Dir["build/*/images/jdk-bundle/*"].first
-    libexec.install jdk => "openjdk.jdk"
-    bin.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/bin/*"]
-    include.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/include/*.h"]
-    include.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/include/darwin/*.h"]
+    on_macos do
+      jdk = Dir["build/*/images/jdk-bundle/*"].first
+      libexec.install jdk => "openjdk.jdk"
+      bin.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/bin/*"]
+      include.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/include/*.h"]
+      include.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/include/darwin/*.h"]
+    end
+
+    on_linux do
+      jdk = Dir["build/*/jdk"].first
+      libexec.install jdk => "openjdk.jdk"
+      mkdir_p libexec/"support"
+      modules = Dir["build/*/support/modules_libs"].first
+      libexec.install modules => "support/modules_libs"
+      bin.install_symlink Dir["#{libexec}/openjdk.jdk/bin/*"]
+      lib.install_symlink Dir["#{libexec}/openjdk.jdk/lib/*"]
+      include.install_symlink Dir["#{libexec}/openjdk.jdk/include/*.h"]
+      include.install_symlink Dir["#{libexec}/openjdk.jdk/include/linux/*.h"]
+    end
   end
 
   def post_install

--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -1,16 +1,14 @@
 class Openjdk < Formula
+  # TODO: Update GA archive when JEP391 is merged
   desc "Development kit for the Java programming language"
   homepage "https://openjdk.java.net/"
-  url "https://hg.openjdk.java.net/jdk-updates/jdk15u/archive/jdk-15.0.1-ga.tar.bz2"
-  sha256 "9c5be662f5b166b5c82c27de29b71f867cff3ff4570f4c8fa646490c4529135a"
+  url "https://github.com/openjdk/jdk-sandbox/archive/a56ddad05cf1808342aeff1b1cd2b0568a6cdc3a.tar.gz"
+  version "16"
+  sha256 "29df31b5eefb5a6c016f50b2518ca29e8e61e3cfc676ed403214e1f13a78efd5"
   license :cannot_represent
 
   bottle do
     cellar :any
-    sha256 "6f31366f86a5eacf66673fca9ad647b98b207820f8cfea49a22af596395d3dba" => :big_sur
-    sha256 "9376a1c6fdf8b0268b6cb56c9878358df148b530fcb0e3697596155fad3ca8d7" => :catalina
-    sha256 "a4f00dc8b4c69bff53828f32c82b0a6be41b23a69a7775a95cdbc9e01d9bdb68" => :mojave
-    sha256 "bef2e4a43a6485253c655979cfc719332fb8631792720c0b9f6591559fb513f1" => :high_sierra
   end
 
   keg_only "it shadows the macOS `java` wrapper"
@@ -22,70 +20,75 @@ class Openjdk < Formula
     depends_on "alsa-lib"
   end
 
-  # From https://jdk.java.net/archive/
+  # From https://jdk.java.net/
+  # http://openjdk.java.net/groups/build/doc/building.html#boot-jdk-requirements
   resource "boot-jdk" do
     on_macos do
-      url "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz"
-      sha256 "386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84"
+      # TODO: Determine if N-1 is advised after arm backport
+      url "https://download.java.net/java/early_access/jdk16/26/GPL/openjdk-16-ea+26_osx-x64_bin.tar.gz"
+      sha256 "85a6bb4f73c1b7ab64cb044b368581d0c72eefed2142a06b143f62f0e4325353"
     end
     on_linux do
-      url "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz"
-      sha256 "91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d"
+      url "https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz"
+      sha256 "bb67cadee687d7b486583d03c9850342afea4593be4f436044d785fba9508fb7"
     end
   end
 
-  # Fix build on Xcode 12
-  # https://bugs.openjdk.java.net/browse/JDK-8253375
-  patch do
-    url "https://github.com/openjdk/jdk/commit/f80a6066e45c3d53a61715abfe71abc3b2e162a1.patch?full_index=1"
-    sha256 "5320e5e8db5f94432925d7c240f41c12b10ff9a0afc2f7a8ab0728a114c43cdb"
-  end
-
-  # Fix build on Xcode 12
-  # https://bugs.openjdk.java.net/browse/JDK-8253791
-  patch do
-    url "https://github.com/openjdk/jdk/commit/4622a18a72c30c4fc72c166bee7de42903e1d036.patch?full_index=1"
-    sha256 "4e4448a5bf68843c21bf96f510ea270aa795c5fac41fd9088f716822788d0f57"
+  # Calculate Xcode's dual-arch JavaNativeFoundation.framework path
+  def framework_path
+    File.expand_path("../SharedFrameworks/ContentDeliveryServices.framework/Versions/Current/itms/java/Frameworks",
+      MacOS::Xcode.prefix)
   end
 
   def install
     boot_jdk_dir = Pathname.pwd/"boot-jdk"
     resource("boot-jdk").stage boot_jdk_dir
     boot_jdk = boot_jdk_dir/"Contents/Home"
+
     java_options = ENV.delete("_JAVA_OPTIONS")
 
-    # Inspecting .hg_archival.txt to find a build number
+    # Inspecting .hgtags to find a build number
     # The file looks like this:
     #
-    # repo: fd16c54261b32be1aaedd863b7e856801b7f8543
-    # node: e3f940bd3c8fcdf4ca704c6eb1ac745d155859d5
-    # branch: default
-    # tag: jdk-15+36
-    # tag: jdk-15-ga
+    # fd07cdb26fc70243ef23d688b545514f4ddf1c2b jdk-16+13
+    # 36b29df125dc88f11657ce93b4998aa9ff5f5d41 jdk-16+14
     #
-    # Since openjdk has move their development from mercurial to git and GitHub
-    # this approach may need some changes in the future
-    #
-    build = File.read(".hg_archival.txt")
-                .scan(/^tag: jdk-#{version}\+(.+)$/)
+    build = File.read(".hgtags")
+                .scan(/ jdk-#{version}\+(.+)$/)
                 .map(&:first)
                 .map(&:to_i)
                 .max
-    raise "cannot find build number in .hg_archival.txt" if build.nil?
+    raise "cannot find build number in .hgtags" if build.nil?
+
+    configure_args = %W[
+      --without-version-pre
+      --without-version-opt
+      --with-version-build=#{build}
+      --with-toolchain-path=/usr/bin
+      --with-sysroot=#{MacOS.sdk_path}
+      --with-extra-ldflags=-headerpad_max_install_names
+      --with-boot-jdk=#{boot_jdk}
+      --with-boot-jdk-jvmargs=#{java_options}
+      --with-build-jdk=#{boot_jdk}
+      --with-debug-level=release
+      --with-native-debug-symbols=none
+      --enable-dtrace
+      --with-jvm-variants=server
+    ]
+    on_macos do
+      if Hardware::CPU.arm?
+        configure_args += %W[
+          --disable-warnings-as-errors
+          --openjdk-target=aarch64-apple-darwin
+          --with-extra-cflags=-arch\ arm64
+          --with-extra-ldflags=-arch\ arm64\ -F#{framework_path}
+          --with-extra-cxxflags=-arch\ arm64
+        ]
+      end
+    end
 
     chmod 0755, "configure"
-    system "./configure", "--without-version-pre",
-                          "--without-version-opt",
-                          "--with-version-build=#{build}",
-                          "--with-toolchain-path=/usr/bin",
-                          "--with-sysroot=#{MacOS.sdk_path}",
-                          "--with-extra-ldflags=-headerpad_max_install_names",
-                          "--with-boot-jdk=#{boot_jdk}",
-                          "--with-boot-jdk-jvmargs=#{java_options}",
-                          "--with-debug-level=release",
-                          "--with-native-debug-symbols=none",
-                          "--enable-dtrace",
-                          "--with-jvm-variants=server"
+    system "./configure", *configure_args
 
     ENV["MAKEFLAGS"] = "JOBS=#{ENV.make_jobs}"
     system "make", "images"
@@ -95,6 +98,17 @@ class Openjdk < Formula
     bin.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/bin/*"]
     include.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/include/*.h"]
     include.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/include/darwin/*.h"]
+  end
+
+  def post_install
+    on_macos do
+      # Copy JavaNativeFoundation.framework from Xcode after install to avoid signature corruption
+      if Hardware::CPU.arm?
+        cp_r "#{framework_path}/JavaNativeFoundation.framework",
+          "#{libexec}/openjdk.jdk/Contents/Home/lib/JavaNativeFoundation.framework",
+          remove_destination: true
+      end
+    end
   end
 
   def caveats

--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -44,7 +44,7 @@ class Openjdk < Formula
   def install
     boot_jdk_dir = Pathname.pwd/"boot-jdk"
     resource("boot-jdk").stage boot_jdk_dir
-    boot_jdk = "#{boot_jdk_dir}"
+    boot_jdk = boot_jdk_dir.to_s
 
     on_macos do
       boot_jdk += "/Contents/Home"

--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -44,14 +44,10 @@ class Openjdk < Formula
   def install
     boot_jdk_dir = Pathname.pwd/"boot-jdk"
     resource("boot-jdk").stage boot_jdk_dir
-    boot_jdk = ""
+    boot_jdk = "#{boot_jdk_dir}"
 
     on_macos do
-      boot_jdk = boot_jdk_dir"/Contents/Home"
-    end
-
-    on_linux do
-      boot_jdk = boot_jdk_dir
+      boot_jdk += "/Contents/Home"
     end
 
     java_options = ENV.delete("_JAVA_OPTIONS")

--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -26,12 +26,12 @@ class Openjdk < Formula
   #   e.g. "configure: (Your Build JDK must be version 16)"
   resource "boot-jdk" do
     on_macos do
-      url "https://download.java.net/java/early_access/jdk16/26/GPL/openjdk-16-ea+26_osx-x64_bin.tar.gz"
-      sha256 "85a6bb4f73c1b7ab64cb044b368581d0c72eefed2142a06b143f62f0e4325353"
+      url "https://download.java.net/java/early_access/jdk16/29/GPL/openjdk-16-ea+29_osx-x64_bin.tar.gz"
+      sha256 "f2f99ddc9faf2caf583043828104a67b88af73d010521aa1818d54ac850a932e"
     end
     on_linux do
-      url "https://download.java.net/java/early_access/jdk16/26/GPL/openjdk-16-ea+26_linux-x64_bin.tar.gz"
-      sha256 "e74300f3f770122358d768d45e181d29c710e8d41bbc4ab8e492929f2867347c"
+      url "https://download.java.net/java/early_access/jdk16/29/GPL/openjdk-16-ea+29_linux-x64_bin.tar.gz"
+      sha256 "484b901cea7c2b6fafea3a4215028f12f225c17807d5413a2d52edcd604ef6ec"
     end
   end
 

--- a/Formula/openjdk@15.rb
+++ b/Formula/openjdk@15.rb
@@ -13,7 +13,7 @@ class OpenjdkAT15 < Formula
     sha256 "bef2e4a43a6485253c655979cfc719332fb8631792720c0b9f6591559fb513f1" => :high_sierra
   end
 
-  keg_only "it shadows the macOS `java` wrapper"
+  keg_only :versioned_formula
 
   depends_on "autoconf" => :build
 

--- a/Formula/openjdk@15.rb
+++ b/Formula/openjdk@15.rb
@@ -1,0 +1,120 @@
+class OpenjdkAT15 < Formula
+  desc "Development kit for the Java programming language"
+  homepage "https://openjdk.java.net/"
+  url "https://hg.openjdk.java.net/jdk-updates/jdk15u/archive/jdk-15.0.1-ga.tar.bz2"
+  sha256 "9c5be662f5b166b5c82c27de29b71f867cff3ff4570f4c8fa646490c4529135a"
+  license :cannot_represent
+
+  bottle do
+    cellar :any
+    sha256 "6f31366f86a5eacf66673fca9ad647b98b207820f8cfea49a22af596395d3dba" => :big_sur
+    sha256 "9376a1c6fdf8b0268b6cb56c9878358df148b530fcb0e3697596155fad3ca8d7" => :catalina
+    sha256 "a4f00dc8b4c69bff53828f32c82b0a6be41b23a69a7775a95cdbc9e01d9bdb68" => :mojave
+    sha256 "bef2e4a43a6485253c655979cfc719332fb8631792720c0b9f6591559fb513f1" => :high_sierra
+  end
+
+  keg_only "it shadows the macOS `java` wrapper"
+
+  depends_on "autoconf" => :build
+
+  on_linux do
+    depends_on "pkg-config" => :build
+    depends_on "alsa-lib"
+  end
+
+  # From https://jdk.java.net/archive/
+  resource "boot-jdk" do
+    on_macos do
+      url "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_osx-x64_bin.tar.gz"
+      sha256 "386a96eeef63bf94b450809d69ceaa1c9e32a97230e0a120c1b41786b743ae84"
+    end
+    on_linux do
+      url "https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_linux-x64_bin.tar.gz"
+      sha256 "91310200f072045dc6cef2c8c23e7e6387b37c46e9de49623ce0fa461a24623d"
+    end
+  end
+
+  # Fix build on Xcode 12
+  # https://bugs.openjdk.java.net/browse/JDK-8253375
+  patch do
+    url "https://github.com/openjdk/jdk/commit/f80a6066e45c3d53a61715abfe71abc3b2e162a1.patch?full_index=1"
+    sha256 "5320e5e8db5f94432925d7c240f41c12b10ff9a0afc2f7a8ab0728a114c43cdb"
+  end
+
+  # Fix build on Xcode 12
+  # https://bugs.openjdk.java.net/browse/JDK-8253791
+  patch do
+    url "https://github.com/openjdk/jdk/commit/4622a18a72c30c4fc72c166bee7de42903e1d036.patch?full_index=1"
+    sha256 "4e4448a5bf68843c21bf96f510ea270aa795c5fac41fd9088f716822788d0f57"
+  end
+
+  def install
+    boot_jdk_dir = Pathname.pwd/"boot-jdk"
+    resource("boot-jdk").stage boot_jdk_dir
+    boot_jdk = boot_jdk_dir/"Contents/Home"
+    java_options = ENV.delete("_JAVA_OPTIONS")
+
+    # Inspecting .hg_archival.txt to find a build number
+    # The file looks like this:
+    #
+    # repo: fd16c54261b32be1aaedd863b7e856801b7f8543
+    # node: e3f940bd3c8fcdf4ca704c6eb1ac745d155859d5
+    # branch: default
+    # tag: jdk-15+36
+    # tag: jdk-15-ga
+    #
+    # Since openjdk has move their development from mercurial to git and GitHub
+    # this approach may need some changes in the future
+    #
+    build = File.read(".hg_archival.txt")
+                .scan(/^tag: jdk-#{version}\+(.+)$/)
+                .map(&:first)
+                .map(&:to_i)
+                .max
+    raise "cannot find build number in .hg_archival.txt" if build.nil?
+
+    chmod 0755, "configure"
+    system "./configure", "--without-version-pre",
+                          "--without-version-opt",
+                          "--with-version-build=#{build}",
+                          "--with-toolchain-path=/usr/bin",
+                          "--with-sysroot=#{MacOS.sdk_path}",
+                          "--with-extra-ldflags=-headerpad_max_install_names",
+                          "--with-boot-jdk=#{boot_jdk}",
+                          "--with-boot-jdk-jvmargs=#{java_options}",
+                          "--with-debug-level=release",
+                          "--with-native-debug-symbols=none",
+                          "--enable-dtrace",
+                          "--with-jvm-variants=server"
+
+    ENV["MAKEFLAGS"] = "JOBS=#{ENV.make_jobs}"
+    system "make", "images"
+
+    jdk = Dir["build/*/images/jdk-bundle/*"].first
+    libexec.install jdk => "openjdk.jdk"
+    bin.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/bin/*"]
+    include.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/include/*.h"]
+    include.install_symlink Dir["#{libexec}/openjdk.jdk/Contents/Home/include/darwin/*.h"]
+  end
+
+  def caveats
+    <<~EOS
+      For the system Java wrappers to find this JDK, symlink it with
+        sudo ln -sfn #{opt_libexec}/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
+    EOS
+  end
+
+  test do
+    (testpath/"HelloWorld.java").write <<~EOS
+      class HelloWorld {
+        public static void main(String args[]) {
+          System.out.println("Hello, world!");
+        }
+      }
+    EOS
+
+    system bin/"javac", "HelloWorld.java"
+
+    assert_match "Hello, world!", shell_output("#{bin}/java HelloWorld")
+  end
+end

--- a/style_exceptions/binary_bootstrap_formula_urls_allowlist.json
+++ b/style_exceptions/binary_bootstrap_formula_urls_allowlist.json
@@ -16,6 +16,7 @@
   "mlton",
   "openjdk",
   "openjdk@11",
+  "openjdk@15",
   "openjdk@8",
   "pypy",
   "sbcl",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds openjdk-16ea as a viable `openjdk` dependency, thanks to the help from @VladimirKempik [here](https://gist.github.com/claui/ea4248aa64d6a1b06c6d6ed80bc2d2b8#gistcomment-3535821).

PR is in draft because I have a feeling the Ruby syntax needs improvement.

* [x] Need advice on `do macos` for URL magic.
   * (Done) Removed URL magic, bumped formula to exclusively use JEP-391
* [x] Need to add the XCode 12 patches back in as conditional.
   * (Done) Kept patches, moved to versioned formula

---

<details>
<summary>Click to expand formula mirror</summary>

```bash
brew tap tresf/tresf
brew install tresf/tresf/openjdk
```

</summary>
</details>