### PR TITLE
workflows/stale: fix workflow syntax

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,9 @@
 name: "Close stale issues"
 
 on:
+  push:
+    paths:
+    - .github/workflows/stale.yml
   schedule:
     # Once every day
     - cron: "0 0 * * *"
@@ -18,11 +21,8 @@ jobs:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs.
-          exempt-issue-labels:
-            - gsoc-outreachy
-            - help wanted
-            - in progress
-          exempt-pr-labels:
-            - gsoc-outreachy
-            - help wanted
-            - in progress
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs.
+          exempt-issue-labels: 'gsoc-outreachy,help wanted,in progress'
+          exempt-pr-labels: 'gsoc-outreachy,help wanted,in progress'


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The stale action that I added yesterday failed with a message saying:

> #### Invalid workflow file:
> The workflow is not valid. .github/workflows/stale.yml (Line: 22, Col: 13): A sequence was not expected,.github/workflows/stale.yml (Line: 26, Col: 13): A sequence was not expected

You can see the failed workflow run [here](https://github.com/Homebrew/homebrew-core/actions/runs/384267467)

This PR (hopefully) fixes the syntax to match the examples given in the [upstream repo](https://github.com/actions/stale) (not sure why I didn't try to match them for the first round...)

For testing purposes, is it worth adding a `workflow_dispatch` trigger to allow manual testing? I don't think that is something we need to be able to do once the action seems to be working, but may be helpful if we continue to have problems. I'll hold off for now, but figured I'd through the idea out there.

CC: @jonchang
