### PR TITLE
go: Apple Silicon updates

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -54,8 +54,10 @@ class Go < Formula
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
-      # Required for Apple Silicon Rosetta: Without it, Go will hang while building
-      ENV["GODEBUG"] = "asyncpreemptoff=1"
+      if MacOS.version >= :big_sur
+        # Required for Apple Silicon Rosetta: Without it, Go will hang while building
+        ENV["GODEBUG"] = "asyncpreemptoff=1"
+      end
       system "./make.bash", "--no-clean"
     end
 

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -54,6 +54,8 @@ class Go < Formula
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
+      # Required for Apple Silicon Rosetta: Without it, Go will hang while building
+      ENV["GODEBUG"] = "asyncpreemptoff=1"
       system "./make.bash", "--no-clean"
     end
 

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -38,8 +38,8 @@ class Go < Formula
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do
     on_macos do
-      url "https://storage.googleapis.com/golang/go1.7.darwin-amd64.tar.gz"
-      sha256 "51d905e0b43b3d0ed41aaf23e19001ab4bc3f96c3ca134b48f7892485fc52961"
+      url "https://golang.org/dl/go1.12.17.darwin-amd64.tar.gz"
+      sha256 "a2f58b4bf10f3e882c1a43eba27a2aba65fc815384fbdfc46331c13bca5f5f24"
     end
 
     on_linux do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hello!

I have a M1 computer, and am running macOS 11.1 beta. I am fully aware that this is a highly unsupported combination.

Up until today, macOS 11.1 forced homebrew to build everything from source, even in Rosetta mode.
Unfortunately, the Go formula fails to build in Rosetta. Same as https://github.com/Homebrew/brew/issues/7857 :  Bootstrapped Go crashes.

This has since been fixed by the use of bottles, but as Go is a bootstrapped language, I believe that fixing Rosetta Go makes for preparation for when Go 1.16 will be released.

**The first commit** updates to to the lowest version that successfully compiles Go on Rosetta.
I noticed that homebrew uses the lowest possible Go version. As I'm not familiar with the rationale of that decision, I tried to preserve this by starting with 1.7 and stopping when I got a working build.
However, as Rosetta is a moving target, I think that Homebrew should play it safe and use 1.14. We could even use 1.15, but it's kind of weird to compile 1.15 with go 1.15.

The formula explicitly says not to update the bootstrapped Go unless it is needed. I'm uneasy with this change as it is not strictly required on Intel machines (which will bottle a Go that works just fine under Rosetta).
Apple might fix rosetta down the road: this is why I'm using 11.1, which has Rosetta improvements.

**This PR also has a second commit**, that sets `GODEBUG=asyncpreemptoff=1`. This works around an issue where Goroutines will get stuck on Rosetta.
On my Intel machine, it doesn't affect the build time (which is around 1 minute anyway), and doesn't leak into the compiled go as it is a runtime flag.

I attached my logs from my M1 computer. Note that "ibrew" is a simple alias for "arch -x86_64 /usr/local/bin/brew".
`brew tests` fails on my machines because I'm using macOS 11 (even on a .0 intel machine), but it also fails on master so I ignored this. Hope it's not a problem.
Other tests (audit, style, test) are all fine.
`brew test go` requires the same env var as the second commit adds, but this is just a quirk of running Go in Rosetta.

Note that I've successfully built a native arm Go (bootstrapped by 1.15) by applying the patch mentioned here: https://github.com/golang/go/issues/42684#issuecomment-731821237
With this PR merged, Go 1.16 will probably work with the formula.

Have a nice day,
[output.txt](https://github.com/Homebrew/homebrew-core/files/5601840/output.txt)
