### PR TITLE
syncthing: fix HEAD build

### DIFF
--- a/Formula/syncthing.rb
+++ b/Formula/syncthing.rb
@@ -4,7 +4,7 @@ class Syncthing < Formula
   url "https://github.com/syncthing/syncthing/archive/v1.11.1.tar.gz"
   sha256 "741d339dad6335f9a2fb9259a1b57c82896d9363d92a5c9ac2573068bf1859b7"
   license "MPL-2.0"
-  head "https://github.com/syncthing/syncthing.git"
+  head "https://github.com/syncthing/syncthing.git", branch: "main"
 
   livecheck do
     url :head
@@ -22,7 +22,8 @@ class Syncthing < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "run", "build.go", "--version", "v#{version}", "--no-upgrade", "tar"
+    build_version = build.head? ? "v0.0.0-#{version}" : "v#{version}"
+    system "go", "run", "build.go", "--version", build_version, "--no-upgrade", "tar"
     bin.install "syncthing"
 
     man1.install Dir["man/*.1"]
@@ -65,7 +66,8 @@ class Syncthing < Formula
   end
 
   test do
-    assert_match "syncthing v#{version} ", shell_output("#{bin}/syncthing --version")
+    build_version = build.head? ? "v0.0.0-#{version}" : "v#{version}"
+    assert_match "syncthing #{build_version} ", shell_output("#{bin}/syncthing --version")
     system bin/"syncthing", "-generate", "./"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
    - No, due to an unrelated upstream issue: syncthing/syncthing#7128
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The HEAD build is broken because the upstream branch changed to `main`, and because the binary expects the version number to match a certain pattern that starts with `v\d+\.\d+\.\d+\`.