### PR TITLE
netcdf: removed fortran.

### DIFF
--- a/Formula/netcdf-fortran.rb
+++ b/Formula/netcdf-fortran.rb
@@ -1,0 +1,83 @@
+class NetcdfFortran < Formula
+  desc "Fortran library for array-oriented scientific data"
+  homepage "https://www.unidata.ucar.edu/software/netcdf"
+  url "https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-fortran-4.5.2.tar.gz"
+  mirror "https://www.gfd-dennou.org/arch/netcdf/unidata-mirror/netcdf-fortran-4.5.2.tar.gz"
+  sha256 "b959937d7d9045184e9d2040a915d94a7f4d0185f4a9dceb8f08c94b0c3304aa"
+  license "BSD-3-Clause"
+  revision 2
+  head "https://github.com/Unidata/netcdf-fortran.git"
+
+  livecheck do
+    url :head
+    regex(/^(?:netcdf-|v)?(\d+(?:\.\d+)+)$/i)
+  end
+
+  # bottle do
+  #   rebuild 1
+  #   sha256 "945407cca07cd5096c8f9e00520e5b51fef5d30d6e4bf68775de508268100f4e" => :big_sur
+  #   sha256 "bf768c6f17428104b463b55420ed6a57c64870c13f2c475604a3446122a0e6de" => :catalina
+  #   sha256 "1ef8f155374e15879156ba393750ef0449f5cea5215f625fcb457176350ea17b" => :mojave
+  #   sha256 "1866c199aaa33565c687d83f163a50ad779949d98dd563e967d9b385bdc030f1" => :high_sierra
+  # end
+
+  keg_only "to avoid conflict with netcdf-fortran installations of compilers other than gfortran"
+
+  depends_on "cmake" => :build
+  depends_on "gcc" # for gfortran
+  depends_on "hdf5"
+  depends_on "netcdf"
+
+  uses_from_macos "curl"
+
+  def install
+    ENV.deparallelize
+
+    common_args = std_cmake_args << "-DBUILD_TESTING=OFF"
+    fortran_args = common_args.dup << "-DNETCDF_INCLUDE_DIR=#{Formula["netcdf"].opt_prefix}/include"
+    fortran_args = common_args.dup << "-DNETCDF_C_LIBRARY=#{Formula["netcdf"].opt_prefix}/lib/libnetcdf.dylib"
+    fortran_args << "-DENABLE_TESTS=OFF"
+
+    # Fix for netcdf-fortran with GCC 10, remove with next version
+    ENV.prepend "FFLAGS", "-fallow-argument-mismatch"
+
+    mkdir "build-fortran" do
+      system "cmake", "..", "-DBUILD_SHARED_LIBS=ON", "-DCMAKE_Fortran_COMPILER=gfortran", *fortran_args
+      system "make", "install"
+      system "make", "clean"
+      system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", *fortran_args
+      system "make"
+      lib.install "fortran/libnetcdff.a"
+    end
+
+    # Remove some shims path
+    inreplace [
+      bin/"nf-config", lib/"pkgconfig/netcdf-fortran.pc"
+    ], HOMEBREW_LIBRARY/"Homebrew/shims/mac/super/clang", "/usr/bin/clang"
+  end
+
+  test do
+    (testpath/"test.f90").write <<~EOS
+      program test
+        use netcdf
+        integer :: ncid, varid, dimids(2)
+        integer :: dat(2,2) = reshape([1, 2, 3, 4], [2, 2])
+        call check( nf90_create("test.nc", NF90_CLOBBER, ncid) )
+        call check( nf90_def_dim(ncid, "x", 2, dimids(2)) )
+        call check( nf90_def_dim(ncid, "y", 2, dimids(1)) )
+        call check( nf90_def_var(ncid, "data", NF90_INT, dimids, varid) )
+        call check( nf90_enddef(ncid) )
+        call check( nf90_put_var(ncid, varid, dat) )
+        call check( nf90_close(ncid) )
+      contains
+        subroutine check(status)
+          integer, intent(in) :: status
+          if (status /= nf90_noerr) call abort
+        end subroutine check
+      end program test
+    EOS
+    system "gfortran", "test.f90", "-L#{lib}", "-I#{include}", "-lnetcdff",
+                       "-o", "testf"
+    system "./testf"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
I have removed fortran from the netcdf formula. In a separate PR, I will submit a new formula for netcdf-fortran.

As explained in #65654 , the current netcdf formula automatically installs netcdf-c, netcdf-c++, and netcdf-fortran, which are three separate distributions. The latter two (C++ and Fortran) depend on the C-version, though. It is not possible to install the C-version only with the current netcdf formula.

This is problematic if you are using several Fortran compilers. Fortran uses .mod files that have the exact same purpose as the .h files in C. But these .mod files are produced by the compilers during compile time and they are not standardised. This means that different compilers use different formats for the .mod files. .mod files produced with GNU's gfortran cannot be used by Intel's ifort, for example.
This is why one has to install netcdf-fortran for Intel separately.

The current netcdf formula installs netcdf.mod, amongst others, produced with gfortran in /usr/local/include (/usr/local/Cellar/netcdf/4.7.4_1/include/ if unlinked) together with the C .h files. The same is true with the libraries libnetcdff.* together with libnetcdf.* (note the extra f on the first lib).

The intel compiler hence fails to install netcdf-fortran because it becomes confused by the different libraries, i.e. the gfortran version and the one it is currently building. The library compiles but running test programs fails.

This happens if I just leave netcdf in /usr/local/lib (and include) and also if I brew unlink netcdf, because then I have to tell the Intel compiler the location of the C-version of netcdf and it finds the same gfortran Fortran files as before.

I checked the source codes of all packages that depend on netcdf, as suggested by @carlocab : brew uses --include-build netcdf, and none seems to use the Fortran part of the formula.

So I have removed the ressource fortran. This is my first commit to homebrew so I tried to follow the Formula Cookbook and How to open a PR by word.
Because netcdf-c is still the same version, I set revision 2.
I have commented the bottle section.
All tests and audit work fine.

There is one audit recommended for new formulas that throws one error:
```
homebrew-core> brew audit --new-formula netcdf
netcdf:
  * Non-libraries were installed to "/usr/local/opt/netcdf/lib"
    Installing non-libraries to "lib" is discouraged.
    The offending files are:
      /usr/local/opt/netcdf/lib/libnetcdf.settings
            /usr/local/opt/netcdf/lib/libnetcdf-cxx.settings
Error: 1 problem in 1 formula detected
```
The formula copies the settings of netcdf and its associated libraries into the lib directory for reference. This was in the old formula and it is actually quite useful even if it discouraged. So I left it in the formula.
