### PR TITLE
tests-linux.yml: disable bottle uploading for the time being

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -4,7 +4,6 @@ on:
     paths:
       - "Formula/alsa-lib.rb"
       - "Formula/device-mapper.rb"
-      - "Formula/hello.rb"
       - "Formula/libaio.rb"
       - "Formula/ladspa-sdk.rb"
       - "Formula/libbsd.rb"
@@ -44,39 +43,3 @@ jobs:
         run: |
           cat ~/bottles/steps_output.txt
           rm ~/bottles/steps_output.txt
-
-      - name: Upload logs
-        if: failure()
-        uses: actions/upload-artifact@main
-        with:
-          name: logs (Linux)
-          path: ~/bottles/logs
-
-      - name: Delete logs and home
-        if: always()
-        run: |
-          rm -rvf ~/bottles/logs
-          rm -rvf ~/bottles/home
-
-      - name: Count bottles
-        id: bottles
-        if: always()
-        run: |
-          cd ~/bottles
-          count=$(ls *.json | wc -l | xargs echo -n)
-          echo "$count bottles"
-          echo "::set-output name=count::$count"
-
-      - name: Upload bottles
-        if: always() && steps.bottles.outputs.count > 0
-        uses: actions/upload-artifact@main
-        with:
-          name: bottles
-          path: ~/bottles
-
-      - run: brew test-bot --only-cleanup-after
-        if: always()
-
-      - name: Post Cleanup
-        if: always()
-        run: rm -rvf ~/bottles


### PR DESCRIPTION
The first bottle upload was not a big success, and we will have to
refactor the bottling process before uploading linux bottles.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
