### PR TITLE
asuka: update livecheck

### DIFF
--- a/Formula/asuka.rb
+++ b/Formula/asuka.rb
@@ -6,8 +6,8 @@ class Asuka < Formula
   license "MIT"
 
   livecheck do
-    url "https://git.sr.ht/~julienxx/asuka/refs"
-    regex(%r{href=.*?/archive/v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Now that Homebrew/brew#9074 has been merged, the existing `livecheck` block for `asuka` is no longer appropriate. The sourcehut URL is converted into the Git repository URL (via `Livecheck#preprocess_url`) but the existing regex expects an HTML context rather than Git tags.

It's possible to resolve this issue by removing the `livecheck` block but I opted to replace it with `url :stable` and the standard regex for Git tags like `1.2`, `1.2.3`, etc.