### PR TITLE
libcerf: update livecheck

### DIFF
--- a/Formula/libcerf.rb
+++ b/Formula/libcerf.rb
@@ -9,7 +9,7 @@ class Libcerf < Formula
 
   livecheck do
     url "https://jugit.fz-juelich.de/api/v4/projects/269/releases"
-    regex(/libcerf[._-]v?(1+(?:\.\d+)+)/i)
+    regex(/libcerf[._-]v?((?!2\.0)\d+(?:\.\d+)+)/i)
   end
 
   bottle do

--- a/Formula/libcerf.rb
+++ b/Formula/libcerf.rb
@@ -9,7 +9,7 @@ class Libcerf < Formula
 
   livecheck do
     url "https://jugit.fz-juelich.de/api/v4/projects/269/releases"
-    regex(/libcerf[._-]v?(\d+(?:\.\d+)+)/i)
+    regex(/libcerf[._-]v?(1+(?:\.\d+)+)/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Update the `livecheck` block to only match versions `1.*`, since the version `2.0` release have been withdrawn.

See https://github.com/Homebrew/homebrew-core/pull/63205#issuecomment-713412390 for background.

Output before:
```
|-> brew livecheck libcerf
libcerf : 1.14 ==> 2.0
```
Output after:
```
|-> brew livecheck libcerf
libcerf : 1.14 ==> 1.14
```