### PR TITLE
giflossy: deprecate

### DIFF
--- a/Formula/giflossy.rb
+++ b/Formula/giflossy.rb
@@ -16,6 +16,8 @@ class Giflossy < Formula
     sha256 "50e8538008faf1bb05e8d44801cacd6e8f41fbf392ed23b639c7d05d36b5c8d8" => :el_capitan
   end
 
+  deprecate! because: :repo_archived
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This formula should be deprecated because https://github.com/kornelski/giflossy was archived