### PR TITLE
goad: deprecate

### DIFF
--- a/Formula/goad.rb
+++ b/Formula/goad.rb
@@ -16,6 +16,8 @@ class Goad < Formula
     sha256 "f0c6400909fbe194400717025ad64cba2ccd63b1db9cba5ec7a9195274614b41" => :el_capitan
   end
 
+  deprecate! because: :repo_archived
+
   depends_on "go" => :build
   depends_on "go-bindata" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This formula should be deprecated because https://github.com/goadapp/goad was archived