### PR TITLE
mp3info: add livecheck

### DIFF
--- a/Formula/mp3info.rb
+++ b/Formula/mp3info.rb
@@ -5,6 +5,11 @@ class Mp3info < Formula
   sha256 "0438ac68e9f04947fb14ca5573d27c62454cb9db3a93b7f1d2c226cd3e0b4e10"
   license "GPL-2.0"
 
+  livecheck do
+    url "https://www.ibiblio.org/pub/linux/apps/sound/mp3-utils/mp3info/"
+    regex(/href=.*?mp3info[._-]v?(\d+(?:\.\d+)+(?:[._-]?[a-z]\d*)?)\.(t|zip)/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `mp3info`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.