### PR TITLE
Python 3.9.1 bigsur

### DIFF
--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -1,8 +1,8 @@
 class PythonAT39 < Formula
   desc "Interpreted, interactive, object-oriented programming language"
   homepage "https://www.python.org/"
-  url "https://www.python.org/ftp/python/3.9.1/Python-3.9.1rc1.tar.xz"
-  sha256 "ca0fa2ddc5cf07770d128cfe2dda44b8e47885e4bab6012ce40a7de1be084138"
+  url "https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz"
+  sha256 "9c73e63c99855709b9be0b3cc9e5b072cb60f37311e8c4e50f15576a0bf82854"
   license "Python-2.0"
   revision 2
 
@@ -12,10 +12,9 @@ class PythonAT39 < Formula
   end
 
   bottle do
-    sha256 "bd4ebe03f4c8371c87b2e2db46d5a8ebe0d3f2940f64d8228b901048f1dd9290" => :big_sur
-    sha256 "fb4e0fa1e5bd0801809e88ee99df2640974bb3953e0ebfe56541ff1ba2fd4865" => :catalina
-    sha256 "77254b7bca66680c41db33e78d40bef288924fb142deb73648ce67255c6dda83" => :mojave
-    sha256 "2e1dec264883dd4ee263a89ff41c5bb6579bbf68982ca40652bb8131d1f51e66" => :high_sierra
+    sha256 "9ad938e5803a6c8ce6fb183f479968cadc1d6b6cb75dd7a11d4761c5e3635131" => :big_sur
+    sha256 "a39639719e49bf3631ef41705267eae5ae06b78aebc0e8c3ffd9fdb91e75d56c" => :catalina
+    sha256 "4462c76fea0dc7abb9ea959d82594aa0b10191f5bc3e43d8d44131a05bee3950" => :mojave
   end
 
   # setuptools remembers the build flags python is built with and uses them to
@@ -76,6 +75,16 @@ class PythonAT39 < Formula
     sha256 "99a22d87add3f634ff917310a3d87e499f19e663413a52eb9232c447aa646c9f"
   end
 
+  # Remove this block when upstream adds arm64 and Big Sur compatibility
+  if MacOS.version >= :big_sur
+    # Upstream PRs #20171, #21114, #21224 and #21249
+    # Backport of https://github.com/python/cpython/pull/22855
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/33a9d63f/python/arm64-3.9.patch"
+      sha256 "167e328cf68e9ec142f483fda9fafbb903be9a47dee2826614fdc24b2fbe6e06"
+    end
+  end
+
   def install
     # Unset these so that installing pip and setuptools puts them where we want
     # and not into some other Python the user has installed.
@@ -112,16 +121,7 @@ class PythonAT39 < Formula
       cflags << "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
     end
     # Avoid linking to libgcc https://mail.python.org/pipermail/python-dev/2012-February/116205.html
-
-    # Big Sur normally returns a value of 11.0 for the macOS version, but Python expects
-    # 10.x version numbers
-    if MacOS.version >= :big_sur
-      ENV["SYSTEM_VERSION_COMPAT"] = "1"
-      macosversion = system "sw_vers", "-productVersion"
-      args << "MACOSX_DEPLOYMENT_TARGET=#{macosversion}"
-    else
-      args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
-    end
+    args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
 
     # We want our readline! This is just to outsmart the detection code,
     # superenv makes cc always find includes/libs!
@@ -305,9 +305,9 @@ class PythonAT39 < Formula
           # site_packages; prefer the shorter paths
           long_prefix = re.compile(r'#{rack}/[0-9\._abrc]+/Frameworks/Python\.framework/Versions/#{xy}/lib/python#{xy}/site-packages')
           sys.path = [long_prefix.sub('#{HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"}', p) for p in sys.path]
-          # Set the sys.executable to use the opt_prefix, unless explicitly set
-          # with PYTHONEXECUTABLE:
-          if 'PYTHONEXECUTABLE' not in os.environ:
+          # Set the sys.executable to use the opt_prefix. Only do this if PYTHONEXECUTABLE is not
+          # explicitly set and we are not in a virtualenv:
+          if 'PYTHONEXECUTABLE' not in os.environ and sys.prefix == sys.base_prefix:
               sys.executable = '#{opt_bin}/python#{xy}'
     EOS
   end
@@ -321,16 +321,20 @@ class PythonAT39 < Formula
     <<~EOS
       Python has been installed as
         #{HOMEBREW_PREFIX}/bin/python3
+
       Unversioned symlinks `python`, `python-config`, `pip` etc. pointing to
       `python3`, `python3-config`, `pip3` etc., respectively, have been installed into
         #{opt_libexec}/bin
+
       You can install Python packages with
         pip3 install <package>
       They will install into the site-package directory
         #{HOMEBREW_PREFIX/"lib/python#{xy}/site-packages"}
+
       See: https://docs.brew.sh/Homebrew-and-Python
     EOS
   end
+
   test do
     xy = (prefix/"Frameworks/Python.framework/Versions").children.min.basename.to_s
     # Check if sqlite is ok, because we build with --enable-loadable-sqlite-extensions


### PR DESCRIPTION
- [*] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [*] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [*] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? - Having some issues with this - says I need to have latest python 3.9 version.

- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? - Yes, once the Python 3.9.1 upstream version is released

-----
Hi everyone - this is my first contribution to Homebrew so please forgive me if I make any mistakes along the way. I've been in the process of testing Brew packages on my M1 MacBook Pro, and Python 3.9 currently doesn't work. 3.9.1 is going to be the first version of Python that will support M1 out of the box, but changing the existing formula to the 3.9.1 RC doesn't work 
because Python expects a MacOS version number 10.x whereas Big Sur reports 11.x. Therefore, I have set the environment variable SYSTEM_VERSION_COMPAT to 1 and then got the version of macOS using sw_vers, which will report 10.16: Python is happy with that. This avoids the following error, which I get with both 3.9.0 and 3.9.1:

```
Last 15 lines from /Users/jbeckitt/Library/Logs/Homebrew/python@3.9/02.make:
    self.run_command(cmd_name)
  File "/private/tmp/python@3.9-20201127-62347-16hz8ht/Python-3.9.1rc1/Lib/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/private/tmp/python@3.9-20201127-62347-16hz8ht/Python-3.9.1rc1/Lib/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/private/tmp/python@3.9-20201127-62347-16hz8ht/Python-3.9.1rc1/Lib/distutils/command/build_ext.py", line 340, in run
    self.build_extensions()
  File "/private/tmp/python@3.9-20201127-62347-16hz8ht/Python-3.9.1rc1/./setup.py", line 447, in build_extensions
    self.detect_modules()
  File "/private/tmp/python@3.9-20201127-62347-16hz8ht/Python-3.9.1rc1/./setup.py", line 1784, in detect_modules
    self.detect_readline_curses()
  File "/private/tmp/python@3.9-20201127-62347-16hz8ht/Python-3.9.1rc1/./setup.py", line 1015, in detect_readline_curses
    (tuple(int(n) for n in dep_target.split('.')[0:2])
AttributeError: 'int' object has no attribute 'split'
```
