### PR TITLE
emscripten: reduce bundled llvm build size

### DIFF
--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -25,7 +25,6 @@ class Emscripten < Formula
 
   depends_on "cmake" => :build
   depends_on "binaryen"
-  depends_on "libffi"
   depends_on "node"
   depends_on "python@3.9"
   depends_on "yuicompressor"
@@ -82,9 +81,7 @@ class Emscripten < Formula
         -DLLVM_BUILD_LLVM_DYLIB=ON
         -DLLVM_INCLUDE_EXAMPLES=OFF
         -DLLVM_INCLUDE_TESTS=OFF
-        -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON
-        -DFFI_INCLUDE_DIR=#{Formula["libffi"].opt_lib}/libffi-#{Formula["libffi"].version}/include
-        -DFFI_LIBRARY_DIR=#{Formula["libffi"].opt_lib}
+        -DLLVM_INSTALL_UTILS=OFF
       ]
 
       sdk = MacOS.sdk_path_if_needed
@@ -123,10 +120,6 @@ class Emscripten < Formula
   end
 
   test do
-    # Minimal llvm install test
-    llvm_prefix = "#{libexec}/llvm"
-    assert_equal llvm_prefix, shell_output("#{llvm_prefix}/bin/llvm-config --prefix").chomp
-
     # Fixes "Unsupported architecture" Xcode prepocessor error
     ENV.delete "CPATH"
 

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -55,6 +55,11 @@ class Emscripten < Formula
         lld
       ]
 
+      targets = %w[
+        host
+        WebAssembly
+      ]
+
       llvmpath = Pathname.pwd/"llvm"
 
       # Apple's libstdc++ is too old to build LLVM
@@ -70,20 +75,12 @@ class Emscripten < Formula
       args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
         -DCMAKE_INSTALL_PREFIX=#{libexec}/llvm
         -DLLVM_ENABLE_PROJECTS=#{projects.join(";")}
-        -DLLVM_LINK_LLVM_DYLIB=ON
-        -DLLVM_BUILD_LLVM_C_DYLIB=ON
-        -DLLVM_ENABLE_EH=ON
-        -DLLVM_ENABLE_FFI=ON
-        -DLLVM_ENABLE_LIBCXX=ON
-        -DLLVM_ENABLE_RTTI=ON
-        -DLLVM_INCLUDE_DOCS=OFF
+        -DLLVM_TARGETS_TO_BUILD=#{targets.join(";")}
+        -DLLVM_INCLUDE_EXAMPLES=OFF
         -DLLVM_INCLUDE_TESTS=OFF
-        -DLLVM_ENABLE_Z3_SOLVER=OFF
-        -DLLVM_TARGETS_TO_BUILD=host;WebAssembly
-        -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON
+        -DLLVM_INSTALL_UTILS=OFF
         -DFFI_INCLUDE_DIR=#{Formula["libffi"].opt_lib}/libffi-#{Formula["libffi"].version}/include
         -DFFI_LIBRARY_DIR=#{Formula["libffi"].opt_lib}
-        -DCLANG_INCLUDE_TESTS=OFF
       ]
 
       sdk = MacOS.sdk_path_if_needed
@@ -126,21 +123,21 @@ class Emscripten < Formula
     # so we check that it contains what is needed
     # llvm dependendencies listed at
     # https://github.com/emscripten-core/emscripten/blob/master/docs/packaging.md#dependencies
-    required_llvm_exec = %w[
-      clang
-      clang++
-      wasm-ld
-      llc
-      llvm-nm
-      llvm-ar
-      llvm-dis
-      llvm-dwarfdump
-    ]
+    # required_llvm_exec = %w[
+    #   clang
+    #   clang++
+    #   wasm-ld
+    #   llc
+    #   llvm-nm
+    #   llvm-ar
+    #   llvm-dis
+    #   llvm-dwarfdump
+    # ]
 
-    required_llvm_exec.each do |exec|
-      assert_predicate "#{libexec}/llvm/bin/#{exec}", :exist?,
-        "Missing LLVM dependency: #{exec}"
-    end
+    # required_llvm_exec.each do |exec|
+    #   assert_predicate "#{libexec}/llvm/bin/#{exec}", :exist?,
+    #     "Missing LLVM dependency: #{exec}"
+    # end
 
     # Fixes "Unsupported architecture" Xcode prepocessor error
     ENV.delete "CPATH"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The emscripten depends on a non-stable build of llvm, and is therefore
packaged with with the required llvm build.

This PR does the following:
- removes unnecessary build targets in the llvm project
- makes llvm build commands consistent with llvm formula

Until https://github.com/Homebrew/homebrew-core/pull/63183, the
emscripten installation used nearly 2GB of storage space. Some
improvements were made in that PR, and this PR is meant to follow
through on that.

When this PR is merged, users with emscripten installed will have nearly
1GB of additional free space compared to last week. 🎉

I've omitted a revision bump, because emscripten is due a version bump
already anyway. (I'll get to that when this one is merged.)