### PR TITLE
less: link against brewed ncurses

### DIFF
--- a/Formula/less.rb
+++ b/Formula/less.rb
@@ -31,9 +31,8 @@ class Less < Formula
     uses_from_macos "perl" => :build
   end
 
+  depends_on "ncurses"
   depends_on "pcre"
-
-  uses_from_macos "ncurses"
 
   def install
     system "make", "-f", "Makefile.aut", "dist" if build.head?


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

less should link against Homebrew ncurses rather than built-in (very
old) macOS ncurses.

This will improve compatibility with formulae that already depend on the
ncurses formula (e.g. zsh, tmux). This also enables features that depend
on modern ncurses (e.g. italics in bat).

macOS already provides a less binary that links against macOS ncurses.
It's therefore not very clear (to me) what the value the current less
formula adds unless it enables functionality like the one mentioned
above.