### PR TITLE
gdal: disable OpenEXR support

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -109,6 +109,7 @@ class Gdal < Formula
       # Explicitly disable some features
       "--with-armadillo=no",
       "--with-qhull=no",
+      "--without-exr",
       "--without-grass",
       "--without-jasper",
       "--without-jpeg12",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR explicitly disables OpenEXR support.  If OpenEXR is detected on the host system, `gdal` tries to find the headers and fails to compile.  Based on the discussion here: https://github.com/Homebrew/linuxbrew-core/pull/21639, it was decided to disable support since there have been no user requests to support this format and it is simpler to disable it so the build works in more environments than to add a seemingly unimportant dependency.  If someone more familiar with `gdal` believes there is a good reason to add OpenEXR support, let me know and I will change it to add support instead.  