### PR TITLE
gradio: remove from versioned_dependencies_conflicts_allowlist

### DIFF
--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -2,7 +2,6 @@
   "agda",
   "anjuta",
   "fdroidserver",
-  "gradio",
   "predictionio",
   "sqoop",
   "visp"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Follow up to https://github.com/Homebrew/homebrew-core/pull/65712. When writing https://github.com/Homebrew/homebrew-core/issues/65831, I realized that `gradio` can be removed from the `versioned_dependencies_conflicts_allowlist` because it is deprecated. Disabled and (non-versioned) deprecated formulae are skipped during the conflicting versioned dependency audit.