### PR TITLE
leiningen: depends on openjdk@8

### DIFF
--- a/Formula/leiningen.rb
+++ b/Formula/leiningen.rb
@@ -4,6 +4,7 @@ class Leiningen < Formula
   url "https://github.com/technomancy/leiningen/archive/2.9.4.tar.gz"
   sha256 "be1b1e43c5376f2fdc8666aeb671df16c19776d5cfe64339292a3d35ce3a7faa"
   license "EPL-1.0"
+  revision 1
   head "https://github.com/technomancy/leiningen.git"
 
   bottle do
@@ -12,6 +13,8 @@ class Leiningen < Formula
     sha256 "3e65cbf112fe60434c3b6f748342de048feeaa63f10da2e26721ce9e83dea081" => :mojave
     sha256 "3e65cbf112fe60434c3b6f748342de048feeaa63f10da2e26721ce9e83dea081" => :high_sierra
   end
+
+  depends_on "openjdk@8"
 
   resource "jar" do
     url "https://github.com/technomancy/leiningen/releases/download/2.9.4/leiningen-2.9.4-standalone.zip", using: :nounzip


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`leiningen` readme mentions
> Make sure you have Java installed; OpenJDK version 8 is recommended at this time.

This matches the bottling errors we got for Big Sur.