### PR TITLE
libgr: revision bump for X11

### DIFF
--- a/Formula/libgr.rb
+++ b/Formula/libgr.rb
@@ -4,6 +4,7 @@ class Libgr < Formula
   url "https://github.com/sciapp/gr/archive/v0.53.0.tar.gz"
   sha256 "a348602c3e2d928b5c293a19ed91e126bf56e23720d4f0e12aa92767da767276"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 "a62524317ad69b3e60c8e30639b712c63cfb21c190045c3e81a96964aedaa7af" => :big_sur


### PR DESCRIPTION
From icu4c testing in https://github.com/Homebrew/homebrew-core/pull/65763/checks?check_run_id=1464473235:

```
==> brew linkage --test libgr
==> FAILED
Missing libraries:
  unexpected (/opt/X11/lib/libICE.6.dylib)
  unexpected (/opt/X11/lib/libSM.6.dylib)
  unexpected (/opt/X11/lib/libX11.6.dylib)
  unexpected (/opt/X11/lib/libXt.6.dylib)
```