### PR TITLE
pcl: revision bump for X11

### DIFF
--- a/Formula/pcl.rb
+++ b/Formula/pcl.rb
@@ -4,7 +4,7 @@ class Pcl < Formula
   url "https://github.com/PointCloudLibrary/pcl/archive/pcl-1.11.1.tar.gz"
   sha256 "a61558e53abafbc909e0996f91cfd2d7a400fcadf6b8cfb0ea3172b78422c74e"
   license "BSD-3-Clause"
-  revision 5
+  revision 6
   head "https://github.com/PointCloudLibrary/pcl.git"
 
   bottle do


### PR DESCRIPTION
In https://github.com/Homebrew/homebrew-core/pull/65763/checks?check_run_id=1464473235

```
==> FAILED
Missing libraries:
  unexpected (/opt/X11/lib/libglut.3.dylib)
```