### PR TITLE
workflows/triage: reorder and add fix automerge-skip label

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,6 +6,15 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
+      - name: Check commit format
+        uses: Homebrew/actions/check-commit-format@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+      - name: Cancel previous runs
+        uses: Homebrew/actions/cancel-previous-runs@master
+        if: always()
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
       - name: Label pull request
         uses: Homebrew/actions/label-pull-requests@master
         if: always()
@@ -103,16 +112,7 @@ jobs:
                     "content": "system \"swift\", \"build\""
                 }, {
                     "label": "automerge-skip",
-                    "path": "Formula/(patchelf|binutils).rb"
+                    "path": "Formula/(patchelf|binutils).rb",
+                    "keep_if_no_match" true
                 }
             ]
-      - name: Check commit format
-        uses: Homebrew/actions/check-commit-format@master
-        if: always()
-        with:
-          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
-      - name: Cancel previous runs
-        uses: Homebrew/actions/cancel-previous-runs@master
-        if: always()
-        with:
-          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This truly (I hope) fixes the issues with our labelling workflow, specifically the `automerge-skip` label.

Here's a summary of the issue:

1. The `automerge-skip` label seems to toggle whether it's applied or not on each update, even though it is still applicable. It turns out that this was partially caused by an issue that I discovered independently. The `check-commit-format` workflow read the current labels of the PR from the `pull_request` event that it recieved. This did not include any changes made by the `label-pull-requests` workflow that ran before it. Due to the issue listed below, `label-pull-requests` was removing the `automerge-skip` label and `check-commit-format` didn't "know" so it wasn't re-adding.
1. `label-pull-requests` was removing the `automerge-skip` label. This is because the constraint for the label is met when the PR modifies either of these two files: `Formula/patchelf.rb` or `Formula/binutils.rb`. If the PR modified neither of those, `label-pull-requests` would consider the condition "not met" and would remove the label.

Problem 1 is fixed by https://github.com/Homebrew/actions/pull/125. Now, each action will read the existing labels on the PR by querying the GitHub API rather than relying on the `pull_request_event`. This means that if one action removes a label, the next action will "know" that the label was removed because it will re-query.

Problem 2 is fixed by https://github.com/Homebrew/actions/pull/126. That PR adds a `keep_if_no_match` constraint option to the `label-pull-requests` workflow. If set, the workflow will not remove that label if the condition is not matched. It will still add the label when the condition is matched.

This change does two things to the triage workflow:

1. Adds the `keep_if_no_match` option to the `automerge-skip` label. This means that the label will still be added when a PR modifies one of the files specified, but it will no longer be removed if the PR doesn't modify those files.
1. Moves the `label-pull-requests` action back to the end of the workflow. This was moved to the start of the workflow in 04e94313ab860159a9c99f62c6d16a89c205bfa1 to try to fix the `automerge-skip` issue. Now, though, it can be problematic if it's at the beginning. For the sake of an example, assume that a PR was opened that modified `Formula/patchelf.rb` will a correct-commit. If the `label` workflow runs first, it will add the `automerge-skip` label (because it meets the constrain). Then, the `check-commit-format` workflow will run and will remove the label because the commit format is correct. This is problematic. If, instead, the `check-commit-format` workflow is run first, it will no make any changes to labelling (because the commit format is correct) and the `label-pull-requests` workflow will then add the `automerge-skip` label because of the constraint.