### PR TITLE
workflows/scheduled-triage: add lock and support request actions

### DIFF
--- a/.github/support.yml
+++ b/.github/support.yml
@@ -1,1 +1,0 @@
-_extends: .github

--- a/.github/workflows/scheduled-triage.yml
+++ b/.github/workflows/scheduled-triage.yml
@@ -1,9 +1,9 @@
-name: "Close stale issues"
+name: Triage issues on a schedule
 
 on:
   push:
     paths:
-    - .github/workflows/stale.yml
+    - .github/workflows/scheduled-triage.yml
   schedule:
     # Once every day at midnight UTC
     - cron: "0 0 * * *"
@@ -27,3 +27,12 @@ jobs:
             recent activity. It will be closed if no further activity occurs.
           exempt-issue-labels: 'gsoc-outreachy,help wanted,in progress'
           exempt-pr-labels: 'gsoc-outreachy,help wanted,in progress'
+
+      - name: Lock Outdated Threads
+        uses: dessant/lock-threads@63786a6c74ee3cfc4584f36de4360305c55e5126
+        with:
+          github-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          issue-lock-inactive-days: 30
+          issue-lock-labels: outdated
+          pr-lock-inactive-days: 30
+          pr-lock-labels: outdated


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR is meant to replace our current [`no-response`](https://github.com/Homebrew/.github/blob/master/.github/no-response.yml) workflow. I adapted the [actions/stale](https://github.com/actions/stale) action to try to match our existing configuration.

Essentially, by setting the stale label to `no response` and not providing a stale message, I'm telling the action not to mark any issues as stale in the conventional way but to continue to close issues that are stale (meaning `no repsonse`) after 14 days.

One question, should I rename the workflow to something other than `stale`? This might be a good idea, especially if (as I'm anticipating), we continue to add more actions to this.

CC: @MikeMcQuaid (by the way, I haven't forgotten about adding this to Homebrew/brew. I'm just trying to get this configuration to be more complete before I start adding it elsewhere).
