### PR TITLE
libfreenect: revision bump for X11

### DIFF
--- a/Formula/libfreenect.rb
+++ b/Formula/libfreenect.rb
@@ -4,6 +4,7 @@ class Libfreenect < Formula
   url "https://github.com/OpenKinect/libfreenect/archive/v0.6.1.tar.gz"
   sha256 "a2e426cf42d9289b054115876ec39502a1144bc782608900363a0c38056b6345"
   license any_of: ["Apache-2.0", "GPL-2.0-only"]
+  revision 1
   head "https://github.com/OpenKinect/libfreenect.git"
 
   bottle do


### PR DESCRIPTION
See linkage failure in https://github.com/Homebrew/homebrew-core/pull/65866/checks?check_run_id=1468374300