### PR TITLE
cmus: disable wavpack and musepack

### DIFF
--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -4,7 +4,7 @@ class Cmus < Formula
   url "https://github.com/cmus/cmus/archive/v2.8.0.tar.gz"
   sha256 "756ce2c6241b2104dc19097488225de559ac1802a175be0233cfb6fbc02f3bd2"
   license "GPL-2.0"
-  revision 4
+  revision 5
   head "https://github.com/cmus/cmus.git"
 
   bottle do
@@ -26,7 +26,8 @@ class Cmus < Formula
   depends_on "opusfile"
 
   def install
-    system "./configure", "prefix=#{prefix}", "mandir=#{man}"
+    system "./configure", "prefix=#{prefix}", "mandir=#{man}",
+                          "CONFIG_WAVPACK=n", "CONFIG_MPC=n"
     system "make", "install"
   end
 


### PR DESCRIPTION
Opportunistic linkage of cmus to wavpack and musepack has happened before (https://github.com/Homebrew/homebrew-core/pull/63595), typically when we update x264 and rebuild everything against it. This will prevent it in the future.