### PR TITLE
vercel-cli: rename from now-cli

### DIFF
--- a/Formula/vercel-cli.rb
+++ b/Formula/vercel-cli.rb
@@ -3,8 +3,8 @@ require "language/node"
 class VercelCli < Formula
   desc "Command-line interface for Vercel"
   homepage "https://vercel.com/home"
-  url "https://registry.npmjs.org/vercel/-/vercel-21.0.2.tgz"
-  sha256 "c8d3eae160a892e32837db3dcae515e843e5383fef52b8141940c8bcf8b6d59f"
+  url "https://registry.npmjs.org/vercel/-/vercel-21.0.1.tgz"
+  sha256 "ff36b5ea66f741942e0f74fc1222f73f903b638fefc991fe68a25eefbd7f3a61"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/vercel-cli.rb
+++ b/Formula/vercel-cli.rb
@@ -19,8 +19,6 @@ class VercelCli < Formula
     sha256 "a52be7278a1492daa225ecd47b7326f41f60ea2070397903bc3ef09f7f6aec1a" => :high_sierra
   end
 
-  disable! date: "2021-01-31", because: :unmaintained
-
   depends_on "node"
 
   def install

--- a/Formula/vercel-cli.rb
+++ b/Formula/vercel-cli.rb
@@ -1,10 +1,10 @@
 require "language/node"
 
-class NowCli < Formula
-  desc "Command-line interface for Now"
-  homepage "https://zeit.co/now"
-  url "https://registry.npmjs.org/now/-/now-20.0.0.tgz"
-  sha256 "471d4fb8507b64d1caefa5a5a1433432ccf26b1a2965d9c47e88da3934320b96"
+class VercelCli < Formula
+  desc "Command-line interface for Vercel"
+  homepage "https://vercel.com/home"
+  url "https://registry.npmjs.org/vercel/-/vercel-21.0.2.tgz"
+  sha256 "c8d3eae160a892e32837db3dcae515e843e5383fef52b8141940c8bcf8b6d59f"
   license "Apache-2.0"
 
   livecheck do
@@ -26,13 +26,13 @@ class NowCli < Formula
   def install
     rm Dir["dist/{*.exe,xsel}"]
     inreplace "dist/index.js", "t.default=getUpdateCommand",
-                               "t.default=async()=>'brew upgrade now-cli'"
+                               "t.default=async()=>'brew upgrade vercel-cli'"
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 
   test do
-    system "#{bin}/now", "init", "jekyll"
+    system "#{bin}/vercel", "init", "jekyll"
     assert_predicate testpath/"jekyll/_config.yml", :exist?, "_config.yml must exist"
     assert_predicate testpath/"jekyll/README.md", :exist?, "README.md must exist"
   end

--- a/Formula/vercel-cli.rb
+++ b/Formula/vercel-cli.rb
@@ -23,8 +23,8 @@ class VercelCli < Formula
 
   def install
     rm Dir["dist/{*.exe,xsel}"]
-    inreplace "dist/index.js", "t.default=getUpdateCommand",
-                               "t.default=async()=>'brew upgrade vercel-cli'"
+    inreplace "dist/index.js", "exports.default = getUpdateCommand",
+                               "exports.default = async()=>'brew upgrade vercel-cli'"
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end

--- a/Formula/vercel-cli.rb
+++ b/Formula/vercel-cli.rb
@@ -11,14 +11,6 @@ class VercelCli < Formula
     url :stable
   end
 
-  bottle do
-    cellar :any_skip_relocation
-    rebuild 1
-    sha256 "a33ec53e45f2ef38fe23a0a2e66205783c4e9d6a037d4b5de38bac3b8a1448e8" => :catalina
-    sha256 "831da3bb99d51a4a0e566bc7f0494dda30be6b8f16170f97afc36a51c843eda7" => :mojave
-    sha256 "a52be7278a1492daa225ecd47b7326f41f60ea2070397903bc3ef09f7f6aec1a" => :high_sierra
-  end
-
   depends_on "node"
 
   def install

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -85,6 +85,7 @@
   "mysql56": "mysql@5.6",
   "newsbeuter": "newsboat",
   "nimrod": "nim",
+  "now-cli": "vercel-cli",
   "objective-caml": "ocaml",
   "offline-imap": "offlineimap",
   "open-cobol": "gnu-cobol",


### PR DESCRIPTION
Rename `now-cli` to `vercel-cli`

Also removes scheduled deprecations and fixes Brew's `vercel update` override

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
