### PR TITLE
.github/workflows/stale.yml:  Don't re-run on forks.  

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   stale:
+    if: startsWith(github.repository, 'Homebrew/')
     runs-on: ubuntu-latest
     steps:
       - name: Mark/Close Stale Issues and Pull Requests


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?  
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?  
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?  (N/A; not a formula change.)  
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?   (N/A; not a formula change.)  
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?   (N/A; not a formula change.)  

-----

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;I caught said workflow running on my personal fork, so here's another PR similar to homebrew/homebrew-cask#89714 to prevent it from triggering outside of the Homebrew organization.  (And I remembered to use single quotes this time, ha.)  