### PR TITLE
libsigsegv: support build from head.

### DIFF
--- a/Formula/libsigsegv.rb
+++ b/Formula/libsigsegv.rb
@@ -4,7 +4,7 @@ class Libsigsegv < Formula
   url "https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.12.tar.gz"
   mirror "https://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.12.tar.gz"
   sha256 "3ae1af359eebaa4ffc5896a1aee3568c052c99879316a1ab57f8fe1789c390b6"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable
@@ -20,7 +20,16 @@ class Libsigsegv < Formula
     sha256 "b9808096e671482dffd3c4b7ea330d8fc58027bee92c6a774b953fefc1606eb1" => :el_capitan
   end
 
+  head do
+    url "https://git.savannah.gnu.org/git/libsigsegv.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+  end
+
   def install
+    system "./gitsub.sh", "pull" if build.head?
+    system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-shared"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Built and tested on Mojave. Big Sur ARM would not work before or after this as libsigsegv lacks ARM64 code path right now.