### PR TITLE
aspell: fix license and dependencies

### DIFF
--- a/Formula/aspell.rb
+++ b/Formula/aspell.rb
@@ -4,7 +4,7 @@ class Aspell < Formula
   url "https://ftp.gnu.org/gnu/aspell/aspell-0.60.8.tar.gz"
   mirror "https://ftpmirror.gnu.org/aspell/aspell-0.60.8.tar.gz"
   sha256 "f9b77e515334a751b2e60daab5db23499e26c9209f5e7b7443b05235ad0226f2"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only"
 
   livecheck do
     url :stable
@@ -552,8 +552,6 @@ class Aspell < Formula
     mirror "https://ftpmirror.gnu.org/aspell/dict/zu/aspell-zu-0.50-0.tar.bz2"
     sha256 "3fa255cd0b20e6229a53df972fd3c5ed8481db11cfd0347dd3da629bbb7a6796"
   end
-
-  uses_from_macos "ncurses"
 
   # const problems with llvm: https://www.freebsd.org/cgi/query-pr.cgi?pr=180565&cat=
   patch :DATA


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

License updated. Searching for 'license' in the aspell repo returned
many files specifying LGPL 2.0 or 2.1 only.

Formula specified `uses_from_macos "ncurses"` twice, so I removed the
second one:

https://github.com/Homebrew/homebrew-core/blob/c5904844cbf96dd629bb8ff71989483325892210/Formula/aspell.rb#L20

https://github.com/Homebrew/homebrew-core/blob/c5904844cbf96dd629bb8ff71989483325892210/Formula/aspell.rb#L556

