### PR TITLE
MMseqs2: Add support for Apple Silicon

### DIFF
--- a/Formula/mmseqs2.rb
+++ b/Formula/mmseqs2.rb
@@ -5,6 +5,7 @@ class Mmseqs2 < Formula
   version "12-113e3"
   sha256 "81fa0d77eab9d74b429567da00aa7ec2d46049537ce469595d7356b6d8b5458a"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/soedinglab/MMseqs2.git"
 
   bottle do
@@ -30,7 +31,11 @@ class Mmseqs2 < Formula
   def install
     args = *std_cmake_args << "-DHAVE_TESTS=0" << "-DHAVE_MPI=0"
     args << "-DVERSION_OVERRIDE=#{version}"
-    args << "-DHAVE_SSE4_1=1"
+    args << if Hardware::CPU.arm?
+      "-DHAVE_ARM8=1"
+    else
+      "-DHAVE_SSE4_1=1"
+    end
 
     libomp = Formula["libomp"]
     args << "-DOpenMP_C_FLAGS=-Xpreprocessor\ -fopenmp\ -I#{libomp.opt_include}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I don't have a M1 Mac to test myself, but MMseqs2 works on Linux ARM without issues and (after minor problems with cross compiling on x64) we are also already shipping universal binaries that contain ARM code for Macs.

Is it okay to enable ARM support in brew already?