### PR TITLE
cvs: fix for Xcode 12

### DIFF
--- a/Formula/cvs.rb
+++ b/Formula/cvs.rb
@@ -8,7 +8,7 @@ class Cvs < Formula
   homepage "https://www.nongnu.org/cvs/"
   url "https://ftp.gnu.org/non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
   sha256 "78853613b9a6873a30e1cc2417f738c330e75f887afdaf7b3d0800cb19ca515e"
-  revision 3
+  revision 2
 
   livecheck do
     url "https://ftp.gnu.org/non-gnu/cvs/source/feature/"

--- a/Formula/cvs.rb
+++ b/Formula/cvs.rb
@@ -8,7 +8,7 @@ class Cvs < Formula
   homepage "https://www.nongnu.org/cvs/"
   url "https://ftp.gnu.org/non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
   sha256 "78853613b9a6873a30e1cc2417f738c330e75f887afdaf7b3d0800cb19ca515e"
-  revision 2
+  revision 3
 
   livecheck do
     url "https://ftp.gnu.org/non-gnu/cvs/source/feature/"
@@ -51,6 +51,9 @@ class Cvs < Formula
   patch :DATA
 
   def install
+    # Work around configure issues with Xcode 12
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
I noticed that cvs was no longer building under the new Xcode.  I don't regularly use cvs these days, but probably should be kept building.

The issue was similar to other formula like zsh (see cac377b1f2ba439f566d047c5a03726fb15b2a15) where the new xcode default flags of `-Werror,-Wimplicit-function-declaration` caused the ancient `./configure` script to detect things wrong and then all hell breaks loose while compiling.  Same fix as that formula works fine.

I don't think the upstream package is closely maintained these days (cvs 1.12.13 is from 2005!), so just a local workaround is probably the best thing for this one.