### PR TITLE
Update PortAudio git repo url

### DIFF
--- a/Formula/portaudio.rb
+++ b/Formula/portaudio.rb
@@ -5,7 +5,7 @@ class Portaudio < Formula
   version "19.6.0"
   sha256 "f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513"
   version_scheme 1
-  head "https://git.assembla.com/portaudio.git"
+  head "https://github.com/PortAudio/portaudio.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
The PortAudio repo is now hosted on GitHub as linked from their website: http://www.portaudio.com/usinggit.html.
The old link is a repo that is several months stale.
Moreover, without a fix made on Oct 22 the library seems to be broken on Mac. It might make sense to update the default installation URL because they haven't made a release in 4 years.

Tested by editing the formula locally and running:
```bash
brew uninstall --force portaudio
brew install --HEAD portaudio
brew test portaudio
brew audit --strict portaudio
brew style portaudio
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
