### PR TITLE
llvm: add upstream patch that fixes build for ARM.

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -71,6 +71,11 @@ class Llvm < Formula
     sha256 "70fe3836b423e593688cd1cc7a3d76ee6406e64b9909f1a2f780c6f018f89b1e"
   end
 
+  patch do
+    url "https://github.com/llvm/llvm-project/commit/03565ffd5da8370f5b89b69cd9868f32e2d75403.patch?full_index=1"
+    sha256 "4992364c7f4c0a20ae8bf26cce0e76307c0ccf2de0066aa819ca394bd490f43f"
+  end
+
   def install
     projects = %w[
       clang


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a patch from upstream that fixes the build for ARM macs (at least for me).