### PR TITLE
unbound: enable dnscrypt, dnstap, cachedb, and ipsecmod

### DIFF
--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -4,7 +4,7 @@ class Unbound < Formula
   url "https://nlnetlabs.nl/downloads/unbound/unbound-1.12.0.tar.gz"
   sha256 "5b9253a97812f24419bf2e6b3ad28c69287261cf8c8fa79e3e9f6d3bf7ef5835"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://github.com/NLnetLabs/unbound.git"
 
   # We check the GitHub repo tags instead of
@@ -22,8 +22,10 @@ class Unbound < Formula
   end
 
   depends_on "libevent"
+  depends_on "libsodium"
   depends_on "nghttp2"
   depends_on "openssl@1.1"
+  depends_on "protobuf-c"
 
   uses_from_macos "expat"
 
@@ -34,8 +36,14 @@ class Unbound < Formula
       --enable-event-api
       --enable-tfo-client
       --enable-tfo-server
+      --enable-dnstap
+      --enable-dnscrypt
+      --enable-cachedb
+      --enable-ipsecmod
       --with-libevent=#{Formula["libevent"].opt_prefix}
       --with-libnghttp2=#{Formula["nghttp2"].opt_prefix}
+      --with-libsodium=#{Formula["libsodium"].opt_prefix}
+      --with-protobuf-c=#{Formula["protobuf-c"].opt_prefix}
       --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
     ]
 


### PR DESCRIPTION
* `--enable-dnscrypt` allows unbound to interface with dnscrypt, see `man unbound.conf`. Requires `libsodium`.
* `--enable-dnstap` enables DNSTAP support. Requires `protobuf-c`.
* `--enable-cachedb` enables `cachedb` module that can use external cache storage. Comes 'for free' (no new dependencies).
* `--enable-ipsecmod` enables `ipsecmod` module. Comes 'for free' (no new dependencies).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
