### PR TITLE
rclone: enables mount for linux

### DIFF
--- a/Formula/rclone.rb
+++ b/Formula/rclone.rb
@@ -4,6 +4,7 @@ class Rclone < Formula
   url "https://github.com/rclone/rclone/archive/v1.53.3.tar.gz"
   sha256 "46fb317057ada21add1fa683a004e1ad5b2a1523c381f59b40ed1b18f2856ad0"
   license "MIT"
+  revision 1
   head "https://github.com/rclone/rclone.git"
 
   bottle do
@@ -16,7 +17,13 @@ class Rclone < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-tags", "brew", *std_go_args
+    args = *std_go_args
+    on_macos do
+      args += ["-tags", "brew"]
+    end
+    system "go", "build",
+      "-ldflags", "-s -X github.com/rclone/rclone/fs.Version=v#{version}",
+      *args
     man1.install "rclone.1"
     system bin/"rclone", "genautocomplete", "bash", "rclone.bash"
     system bin/"rclone", "genautocomplete", "zsh", "_rclone"
@@ -26,7 +33,7 @@ class Rclone < Formula
 
   def caveats
     <<~EOS
-      Homebrew's installation does not include the `mount` subcommand.
+      Homebrew's installation does not include the `mount` subcommand on MacOS.
     EOS
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

i know there are problems with fuse on macosx but it works perfectly fine under linux. so why we shouldnt use it there?