### PR TITLE
libcaca: revision bump to remove freeglut linkage

### DIFF
--- a/Formula/libcaca.rb
+++ b/Formula/libcaca.rb
@@ -7,7 +7,7 @@ class Libcaca < Formula
   version "0.99b19"
   sha256 "128b467c4ed03264c187405172a4e83049342cc8cc2f655f53a2d0ee9d3772f4"
   license "WTFPL"
-  revision 2
+  revision 3
 
   # The regex here matches unstable releases and is loose about it (`.*`), as
   # there are currently only beta releases and we don't know if there will be

--- a/Formula/mplayer.rb
+++ b/Formula/mplayer.rb
@@ -3,7 +3,7 @@ class Mplayer < Formula
   homepage "https://mplayerhq.hu/"
   url "https://mplayerhq.hu/MPlayer/releases/MPlayer-1.4.tar.xz"
   sha256 "82596ed558478d28248c7bc3828eb09e6948c099bbd76bb7ee745a0e3275b548"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://mplayerhq.hu/MPlayer/releases/"


### PR DESCRIPTION
```
dyld: Library not loaded: /usr/local/opt/freeglut/lib/libglut.3.dylib
  Referenced from: /usr/local/opt/libcaca/lib/libcaca.0.dylib
```

in https://github.com/Homebrew/homebrew-core/pull/65473/checks?check_run_id=1473827682