### PR TITLE
srt: fix GNUInstallDirs in cmake invocation

### DIFF
--- a/Formula/srt.rb
+++ b/Formula/srt.rb
@@ -22,6 +22,9 @@ class Srt < Formula
     openssl = Formula["openssl@1.1"]
     system "cmake", ".", "-DWITH_OPENSSL_INCLUDEDIR=#{openssl.opt_include}",
                          "-DWITH_OPENSSL_LIBDIR=#{openssl.opt_lib}",
+                         "-DCMAKE_INSTALL_BINDIR=bin",
+                         "-DCMAKE_INSTALL_LIBDIR=lib",
+                         "-DCMAKE_INSTALL_INCLUDEDIR=include",
                          *std_cmake_args
     system "make", "install"
   end


### PR DESCRIPTION
Building srt with Release build type and nonstandard prefix (/opt/homebrew) fails when GNUInstallDirs are not explicitly configured in cmake invocation. This fix adds these variables to the Formula: CMAKE_INSTALL_BINDIR, CMAKE_INSTALL_LIBDIR, and CMAKE_INSTALL_INCLUDEDIR.

This fix was implemented and tested on Apple Silicon M1.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
