### PR TITLE
workflows/scheduled-triage: update job name

### DIFF
--- a/.github/workflows/scheduled-triage.yml
+++ b/.github/workflows/scheduled-triage.yml
@@ -9,7 +9,7 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  stale:
+  scheduled-triage:
     if: startsWith(github.repository, 'Homebrew/')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hopefully the final saga of the scheduled-triage workflow.

I realized that when I renamed the file from `stale.yml` to `scheduled-triage.yml` I forgot to also change the job name to `scheduled-triage`. This PR fixes that.
