### PR TITLE
Add formula for lightsailctl AWS CLI plugin

### DIFF
--- a/Formula/lightsailctl.rb
+++ b/Formula/lightsailctl.rb
@@ -2,7 +2,7 @@ class Lightsailctl < Formula
   desc "AWS CLI plugin for publishing images to AWS Lightsail container services"
   homepage "https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-install-software"
   url "https://s3.us-west-2.amazonaws.com/lightsailctl/latest/darwin-amd64/lightsailctl"
-  version "latest"
+  version "1.0.0"
   license "Apache-2.0"
 
   depends_on "awscli" => ">2.1.1"

--- a/Formula/lightsailctl.rb
+++ b/Formula/lightsailctl.rb
@@ -1,0 +1,19 @@
+class Lightsailctl < Formula
+  desc "AWS CLI plugin for publishing images to AWS Lightsail container services"
+  homepage "https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-install-software"
+  url "https://s3.us-west-2.amazonaws.com/lightsailctl/latest/darwin-amd64/lightsailctl"
+  version "latest"
+  license "Apache-2.0"
+
+  depends_on "awscli" => ">2.1.1"
+
+  def install
+    chmod "+x", "lightsailctl"
+    system "xattr", "-c", "lightsailctl"
+    bin.install "lightsailctl"
+  end
+
+  test do
+    assert_path_exist "#{bin}/lightsailctl"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Regarding the last check, I'm getting:

```sh
lightsailctl:
  * Stable: version (latest) is set to a string without a digit
  * 4: col 3: https://s3.us-west-2.amazonaws.com/lightsailctl/latest/darwin-amd64/lightsailctl looks like a binary package, not a source archive; homebrew/core is source-only.
Error: 2 problems in 1 formula detected
```

This is supposed to be a cmd line application that's why I'm insisting on the PR. I'm happy move this somewhere else if needed. With regards to the version number, I couldn't find it anywhere so I decided to leave it as "latest".
