### PR TITLE
pass: add patch to remove brew command

### DIFF
--- a/Formula/pass.rb
+++ b/Formula/pass.rb
@@ -3,7 +3,7 @@ class Pass < Formula
   homepage "https://www.passwordstore.org/"
   url "https://git.zx2c4.com/password-store/snapshot/password-store-1.7.3.tar.xz"
   sha256 "2b6c65846ebace9a15a118503dcd31b6440949a30d3b5291dfb5b1615b99a3f4"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://git.zx2c4.com/password-store.git"
 
   livecheck do
@@ -24,6 +24,11 @@ class Pass < Formula
   depends_on "gnupg"
   depends_on "qrencode"
   depends_on "tree"
+
+  patch do
+    url "https://git.zx2c4.com/password-store/patch/?id=07b169ec32ad6961ed8625a0b932a663abcb01d2"
+    sha256 "626ceb894a1b7367e90ee2a6b1ebf43528ebd2d28b70e3c4d39fb3e2ba7896bc"
+  end
 
   def install
     system "make", "PREFIX=#{prefix}", "WITH_ALLCOMP=yes", "BASHCOMPDIR=#{bash_completion}",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

`pass` installed via Homebrew is very slow, often taking between 1.5 and 2 seconds for every operation. This is because pass 1.7.3 (the most recent release) uses a ["platform" file][1] on macOS that sets the path to GNU getopt using the following:

```bash
GETOPT="$(brew --prefix gnu-getopt 2>/dev/null || { which port &>/dev/null && echo /opt/local; } || echo /usr/local)/bin/getopt"
```

The cause of the slowness is the `brew --prefix gnu-getopt` command. This has been fixed on `master` in [this commit][2], but a new release has not been created. In fact, the last release of `pass` was over 2 years ago, so there's no telling when there will be another one.

In the meantime, we can drastically improve the experience of using `pass` for Homebrew users by manually applying the above patch. If/when a new release is created, we can remove the patch.

[1]: https://git.zx2c4.com/password-store/tree/src/platform/darwin.sh?h=1.7.3
[2]: https://git.zx2c4.com/password-store/commit/?id=07b169ec32ad6961ed8625a0b932a663abcb01d2