### PR TITLE
zxcc: add livecheck and update license

### DIFF
--- a/Formula/zxcc.rb
+++ b/Formula/zxcc.rb
@@ -3,7 +3,12 @@ class Zxcc < Formula
   homepage "https://www.seasip.info/Unix/Zxcc/"
   url "https://www.seasip.info/Unix/Zxcc/zxcc-0.5.7.tar.gz"
   sha256 "6095119a31a610de84ff8f049d17421dd912c6fd2df18373e5f0a3bc796eb4bf"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?zxcc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 "55897339c53884d74e51e270e458085e4c1a3c8494b7053d40205d511ae0759a" => :big_sur


### PR DESCRIPTION
```sh
$ brew livecheck zxcc -d
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/zxcc.rb

Formula:          zxcc
Livecheckable?:   Yes

URL:              https://www.seasip.info/Unix/Zxcc/
Strategy:         PageMatch
Regex:            /href=.*?zxcc[._-]v?(\d+(?:\.\d+)+)\.t/i

Matched Versions:
0.5.7, 0.4.0
zxcc : 0.5.7 ==> 0.5.7
```