### PR TITLE
magic_enum 0.7.1 (new formula)

### DIFF
--- a/Formula/magic_enum.rb
+++ b/Formula/magic_enum.rb
@@ -1,0 +1,35 @@
+class MagicEnum < Formula
+  desc "Static reflection for enums (to string, from string, iteration) for modern C++"
+  homepage "https://github.com/Neargye/magic_enum"
+  url "https://github.com/Neargye/magic_enum/archive/v0.7.1.tar.gz"
+  sha256 "11bb590dd055194e92936fa4d0652084c14bd23ac8e4b5a02271b6259a05cec9"
+  license "MIT"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+    system "./test/test-cpp17"
+    system "./test/test-cpp17"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <iostream>
+      #include <magic_enum.hpp>
+
+      enum class Color : int { RED = -10, BLUE = 0, GREEN = 10 };
+
+      int main() {
+        Color c1 = Color::RED;
+        auto c1_name = magic_enum::enum_name(c1);
+        std::cout << c1_name << std::endl;
+        return 0;
+      }
+    EOS
+
+    system ENV.cxx, "test.cpp", "-I#{include}", "-Wall", "-Wextra", "-pedantic-errors", "-Werror", "-std=c++17"
+    system "./a.out"
+  end
+end


### PR DESCRIPTION
In this commit, the furmula for magic_header has been added, this is a header-only C++17 library which provides static reflection for enums, work with any enum type without any macro or boilerplate code.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
