### PR TITLE
Update python@3.9.rb

### DIFF
--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -122,10 +122,10 @@ class PythonAT39 < Formula
       cflags << "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
     end
     # Avoid linking to libgcc https://mail.python.org/pipermail/python-dev/2012-February/116205.html
-    if MacOS.version >= :big_sur
-      args << "MACOSX_DEPLOYMENT_TARGET=11.0.1"
+    args << if MacOS.version >= :big_sur
+      "MACOSX_DEPLOYMENT_TARGET=11.0.1"
     else
-      args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
+      "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
     end
 
     # We want our readline! This is just to outsmart the detection code,

--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -83,7 +83,13 @@ class PythonAT39 < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/33a9d63f/python/arm64-3.9.patch"
       sha256 "167e328cf68e9ec142f483fda9fafbb903be9a47dee2826614fdc24b2fbe6e06"
     end
-
+    
+  # Further patch for Big Sur, remove in 3.9.2
+     # https://github.com/python/cpython/pull/23556
+     patch do
+       url "https://github.com/fxcoudert/cpython/commit/cd26ccbb.patch?full_index=1"
+       sha256 "59c98f991f839d610d53ca5c4af1464a99adf6c85e807f8a676b3e41c5dbe0a2"
+     end
   end
 
   def install

--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -83,13 +83,13 @@ class PythonAT39 < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/33a9d63f/python/arm64-3.9.patch"
       sha256 "167e328cf68e9ec142f483fda9fafbb903be9a47dee2826614fdc24b2fbe6e06"
     end
-    
-  # Further patch for Big Sur, remove in 3.9.2
-     # https://github.com/python/cpython/pull/23556
-     patch do
-       url "https://github.com/fxcoudert/cpython/commit/cd26ccbb.patch?full_index=1"
-       sha256 "59c98f991f839d610d53ca5c4af1464a99adf6c85e807f8a676b3e41c5dbe0a2"
-     end
+
+    # Further patch for Big Sur, remove in 3.9.2
+    # https://github.com/python/cpython/pull/23556
+    patch do
+      url "https://github.com/fxcoudert/cpython/commit/6511bf56.patch?full_index=1"
+      sha256 "3a34fea8a133305bc337d67acfacc36dc8f9d47a808dd592f5b0cd8c9c9384d2"
+    end
   end
 
   def install

--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -84,12 +84,6 @@ class PythonAT39 < Formula
       sha256 "167e328cf68e9ec142f483fda9fafbb903be9a47dee2826614fdc24b2fbe6e06"
     end
 
-    # Further patch for Big Sur, remove in 3.9.2
-    # https://github.com/python/cpython/pull/23556
-    patch do
-      url "https://github.com/fxcoudert/cpython/commit/cd26ccbb.patch?full_index=1"
-      sha256 "59c98f991f839d610d53ca5c4af1464a99adf6c85e807f8a676b3e41c5dbe0a2"
-    end
   end
 
   def install
@@ -128,7 +122,11 @@ class PythonAT39 < Formula
       cflags << "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
     end
     # Avoid linking to libgcc https://mail.python.org/pipermail/python-dev/2012-February/116205.html
-    args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
+    if MacOS.version >= :big_sur
+      args << "MACOSX_DEPLOYMENT_TARGET=11.0.1"
+    else
+      args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
+    end
 
     # We want our readline! This is just to outsmart the detection code,
     # superenv makes cc always find includes/libs!

--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -4,7 +4,7 @@ class PythonAT39 < Formula
   url "https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz"
   sha256 "9c73e63c99855709b9be0b3cc9e5b072cb60f37311e8c4e50f15576a0bf82854"
   license "Python-2.0"
-  revision 3
+  revision 4
 
   livecheck do
     url "https://www.python.org/ftp/python/"


### PR DESCRIPTION
The reason the python37, 38, and 39 are failing to build in BigSur is because
``MacOS.version`` in in Ruby on BigSur evaluates to simply 11 without a sub-version.
This confuses Python when building.

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
 - There is a related request, but this change makes some notable improvements I believe
- [x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
