### PR TITLE
throttle contentful-cli updates

### DIFF
--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -2,6 +2,7 @@
   "aws-sdk-cpp": 10,
   "awscli@1": 10,
   "balena-cli": 10,
+  "contentful-cli": 5,
   "checkov": 15,
   "gatsby-cli": 10,
   "quicktype": 10,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
There have be 7 updates in the last 4 days: https://www.npmjs.com/package/contentful-cli. This throttles it to be every 5 releases.