### PR TITLE
Use GithubLatest strategy in livecheck blocks

### DIFF
--- a/Formula/abyss.rb
+++ b/Formula/abyss.rb
@@ -6,8 +6,8 @@ class Abyss < Formula
   license all_of: ["GPL-3.0-only", "LGPL-2.1-or-later", "MIT", "BSD-3-Clause"]
 
   livecheck do
-    url "https://github.com/bcgsc/abyss/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/ace.rb
+++ b/Formula/ace.rb
@@ -6,7 +6,8 @@ class Ace < Formula
   license "DOC"
 
   livecheck do
-    url "https://github.com/DOCGroup/ACE_TAO/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/ACE(?:%2B[A-Z]+)*?[._-]v?(\d+(?:[._]\d+)+)["' >]}i)
   end
 

--- a/Formula/advancemame.rb
+++ b/Formula/advancemame.rb
@@ -6,8 +6,8 @@ class Advancemame < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/amadvance/advancemame/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/algernon.rb
+++ b/Formula/algernon.rb
@@ -9,8 +9,8 @@ class Algernon < Formula
   head "https://github.com/xyproto/algernon.git"
 
   livecheck do
-    url "https://github.com/xyproto/algernon/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/amqp-cpp.rb
+++ b/Formula/amqp-cpp.rb
@@ -7,8 +7,8 @@ class AmqpCpp < Formula
   head "https://github.com/CopernicaMarketingSoftware/AMQP-CPP.git"
 
   livecheck do
-    url "https://github.com/CopernicaMarketingSoftware/AMQP-CPP/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/anycable-go.rb
+++ b/Formula/anycable-go.rb
@@ -7,8 +7,8 @@ class AnycableGo < Formula
   head "https://github.com/anycable/anycable-go.git"
 
   livecheck do
-    url "https://github.com/anycable/anycable-go/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/appledoc.rb
+++ b/Formula/appledoc.rb
@@ -7,8 +7,8 @@ class Appledoc < Formula
   head "https://github.com/tomaz/appledoc.git"
 
   livecheck do
-    url "https://github.com/tomaz/appledoc/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/arabica.rb
+++ b/Formula/arabica.rb
@@ -8,7 +8,8 @@ class Arabica < Formula
   head "https://github.com/jezhiggins/arabica.git"
 
   livecheck do
-    url "https://github.com/jezhiggins/arabica/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
   end
 

--- a/Formula/astrometry-net.rb
+++ b/Formula/astrometry-net.rb
@@ -9,8 +9,8 @@ class AstrometryNet < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/dstndstn/astrometry.net/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/atari800.rb
+++ b/Formula/atari800.rb
@@ -6,7 +6,8 @@ class Atari800 < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/atari800/atari800/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/ATARI800[._-]v?(\d+(?:[._]\d+)+)["' >]}i)
   end
 

--- a/Formula/autopsy.rb
+++ b/Formula/autopsy.rb
@@ -5,7 +5,8 @@ class Autopsy < Formula
   sha256 "ab787f519942783d43a561d12be0554587f11f22bc55ab79d34d8da703edc09e"
 
   livecheck do
-    url "https://github.com/sleuthkit/autopsy/releases/latest"
+    url "https://github.com/sleuthkit/autopsy.git"
+    strategy :github_latest
     regex(%r{href=.*?/tag/autopsy[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -10,7 +10,8 @@ class AzureCli < Formula
   head "https://github.com/Azure/azure-cli.git"
 
   livecheck do
-    url "https://github.com/Azure/azure-cli/releases/latest"
+    url :head
+    strategy :github_latest
     regex(%r{href=.*?/tag/azure-cli[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/bash-completion@2.rb
+++ b/Formula/bash-completion@2.rb
@@ -6,8 +6,8 @@ class BashCompletionAT2 < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/scop/bash-completion/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/bcal.rb
+++ b/Formula/bcal.rb
@@ -6,8 +6,8 @@ class Bcal < Formula
   license "GPL-3.0"
 
   livecheck do
-    url "https://github.com/jarun/bcal/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/bcftools.rb
+++ b/Formula/bcftools.rb
@@ -6,8 +6,8 @@ class Bcftools < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/samtools/bcftools/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/bluepill.rb
+++ b/Formula/bluepill.rb
@@ -8,8 +8,8 @@ class Bluepill < Formula
   head "https://github.com/linkedin/bluepill.git"
 
   livecheck do
-    url "https://github.com/linkedin/bluepill/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/borgbackup.rb
+++ b/Formula/borgbackup.rb
@@ -9,8 +9,8 @@ class Borgbackup < Formula
   revision 2
 
   livecheck do
-    url "https://github.com/borgbackup/borg/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/c7n.rb
+++ b/Formula/c7n.rb
@@ -8,8 +8,8 @@ class C7n < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/cloud-custodian/cloud-custodian/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/cacli.rb
+++ b/Formula/cacli.rb
@@ -6,8 +6,8 @@ class Cacli < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/cloud-annotations/training/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/caffe.rb
+++ b/Formula/caffe.rb
@@ -7,8 +7,8 @@ class Caffe < Formula
   revision 29
 
   livecheck do
-    url "https://github.com/BVLC/caffe/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/carla.rb
+++ b/Formula/carla.rb
@@ -8,8 +8,8 @@ class Carla < Formula
   head "https://github.com/falkTX/Carla.git"
 
   livecheck do
-    url "https://github.com/falkTX/Carla/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/cataclysm.rb
+++ b/Formula/cataclysm.rb
@@ -8,7 +8,8 @@ class Cataclysm < Formula
   head "https://github.com/CleverRaven/Cataclysm-DDA.git"
 
   livecheck do
-    url "https://github.com/CleverRaven/Cataclysm-DDA/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
   end
 

--- a/Formula/cbc.rb
+++ b/Formula/cbc.rb
@@ -7,7 +7,8 @@ class Cbc < Formula
   license "EPL-1.0"
 
   livecheck do
-    url "https://github.com/coin-or/Cbc/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:releases%2F)?v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/cdogs-sdl.rb
+++ b/Formula/cdogs-sdl.rb
@@ -7,8 +7,8 @@ class CdogsSdl < Formula
   head "https://github.com/cxong/cdogs-sdl.git"
 
   livecheck do
-    url "https://github.com/cxong/cdogs-sdl/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/cgl.rb
+++ b/Formula/cgl.rb
@@ -6,7 +6,8 @@ class Cgl < Formula
   license "EPL-1.0"
 
   livecheck do
-    url "https://github.com/coin-or/Cgl/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:releases%2F)?v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/chamber.rb
+++ b/Formula/chamber.rb
@@ -7,8 +7,8 @@ class Chamber < Formula
   head "https://github.com/segmentio/chamber.git"
 
   livecheck do
-    url "https://github.com/segmentio/chamber/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/ckan.rb
+++ b/Formula/ckan.rb
@@ -6,8 +6,8 @@ class Ckan < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/KSP-CKAN/CKAN/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/clair.rb
+++ b/Formula/clair.rb
@@ -6,8 +6,8 @@ class Clair < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/quay/clair/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -27,7 +27,8 @@ class ClangFormat < Formula
   end
 
   livecheck do
-    url "https://github.com/llvm/llvm-project/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/llvmorg[._-]v?(\d+(?:\.\d+)+)}i)
   end
 

--- a/Formula/clingo.rb
+++ b/Formula/clingo.rb
@@ -7,8 +7,8 @@ class Clingo < Formula
   revision 3
 
   livecheck do
-    url "https://github.com/potassco/clingo/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/clojurescript.rb
+++ b/Formula/clojurescript.rb
@@ -8,7 +8,8 @@ class Clojurescript < Formula
   head "https://github.com/clojure/clojurescript.git"
 
   livecheck do
-    url "https://github.com/clojure/clojurescript/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/r?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/clozure-cl.rb
+++ b/Formula/clozure-cl.rb
@@ -7,8 +7,8 @@ class ClozureCl < Formula
   head "https://github.com/Clozure/ccl.git"
 
   livecheck do
-    url "https://github.com/Clozure/ccl/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/conserver.rb
+++ b/Formula/conserver.rb
@@ -6,8 +6,8 @@ class Conserver < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://github.com/conserver/conserver/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/convox.rb
+++ b/Formula/convox.rb
@@ -7,8 +7,8 @@ class Convox < Formula
   version_scheme 1
 
   livecheck do
-    url "https://github.com/convox/convox/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/coredns.rb
+++ b/Formula/coredns.rb
@@ -7,8 +7,8 @@ class Coredns < Formula
   head "https://github.com/coredns/coredns.git"
 
   livecheck do
-    url "https://github.com/coredns/coredns/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/cortex.rb
+++ b/Formula/cortex.rb
@@ -6,8 +6,8 @@ class Cortex < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/cortexproject/cortex/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -9,8 +9,8 @@ class Csound < Formula
   head "https://github.com/csound/csound.git", branch: "develop"
 
   livecheck do
-    url "https://github.com/csound/csound/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/darkice.rb
+++ b/Formula/darkice.rb
@@ -6,8 +6,8 @@ class Darkice < Formula
   license "GPL-3.0"
 
   livecheck do
-    url "https://github.com/rafael2k/darkice/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/dcm2niix.rb
+++ b/Formula/dcm2niix.rb
@@ -7,8 +7,8 @@ class Dcm2niix < Formula
   head "https://github.com/rordenlab/dcm2niix.git"
 
   livecheck do
-    url "https://github.com/rordenlab/dcm2niix/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/dcos-cli.rb
+++ b/Formula/dcos-cli.rb
@@ -7,8 +7,8 @@ class DcosCli < Formula
   head "https://github.com/dcos/dcos-cli.git"
 
   livecheck do
-    url "https://github.com/dcos/dcos-cli/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/devspace.rb
+++ b/Formula/devspace.rb
@@ -7,8 +7,8 @@ class Devspace < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/devspace-cloud/devspace/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/dolt.rb
+++ b/Formula/dolt.rb
@@ -6,8 +6,8 @@ class Dolt < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/liquidata-inc/dolt/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/duktape.rb
+++ b/Formula/duktape.rb
@@ -6,8 +6,8 @@ class Duktape < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/svaarala/duktape/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/dynamips.rb
+++ b/Formula/dynamips.rb
@@ -6,8 +6,8 @@ class Dynamips < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/GNS3/dynamips/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/ethereum.rb
+++ b/Formula/ethereum.rb
@@ -7,8 +7,8 @@ class Ethereum < Formula
   head "https://github.com/ethereum/go-ethereum.git"
 
   livecheck do
-    url "https://github.com/ethereum/go-ethereum/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -7,8 +7,8 @@ class Exa < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/ogham/exa/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/exercism.rb
+++ b/Formula/exercism.rb
@@ -7,8 +7,8 @@ class Exercism < Formula
   head "https://github.com/exercism/cli.git"
 
   livecheck do
-    url "https://github.com/exercism/cli/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/expat.rb
+++ b/Formula/expat.rb
@@ -6,7 +6,8 @@ class Expat < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/libexpat/libexpat/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(/href=.*?expat[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/faas-cli.rb
+++ b/Formula/faas-cli.rb
@@ -7,8 +7,8 @@ class FaasCli < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/openfaas/faas-cli/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/fail2ban.rb
+++ b/Formula/fail2ban.rb
@@ -6,8 +6,8 @@ class Fail2ban < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/fail2ban/fail2ban/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/fcct.rb
+++ b/Formula/fcct.rb
@@ -7,8 +7,8 @@ class Fcct < Formula
   head "https://github.com/coreos/fcct.git"
 
   livecheck do
-    url "https://github.com/coreos/fcct/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/flank.rb
+++ b/Formula/flank.rb
@@ -6,8 +6,8 @@ class Flank < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/Flank/flank/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/fleet-cli.rb
+++ b/Formula/fleet-cli.rb
@@ -7,8 +7,8 @@ class FleetCli < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/rancher/fleet/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/flux.rb
+++ b/Formula/flux.rb
@@ -8,8 +8,8 @@ class Flux < Formula
   head "https://github.com/influxdata/flux.git"
 
   livecheck do
-    url "https://github.com/influxdata/flux/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/fnm.rb
+++ b/Formula/fnm.rb
@@ -7,8 +7,8 @@ class Fnm < Formula
   head "https://github.com/Schniz/fnm.git"
 
   livecheck do
-    url "https://github.com/Schniz/fnm/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/frege.rb
+++ b/Formula/frege.rb
@@ -7,7 +7,8 @@ class Frege < Formula
   revision 3
 
   livecheck do
-    url "https://github.com/Frege/frege/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(/href=.*?frege[._-]?(\d+(?:\.\d+)+)\.jar/i)
   end
 

--- a/Formula/gcsfuse.rb
+++ b/Formula/gcsfuse.rb
@@ -7,8 +7,8 @@ class Gcsfuse < Formula
   head "https://github.com/GoogleCloudPlatform/gcsfuse.git"
 
   livecheck do
-    url "https://github.com/GoogleCloudPlatform/gcsfuse/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/gdcm.rb
+++ b/Formula/gdcm.rb
@@ -7,8 +7,8 @@ class Gdcm < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/malaterre/GDCM/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/genders.rb
+++ b/Formula/genders.rb
@@ -7,7 +7,8 @@ class Genders < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/chaos/genders/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/genders[._-]v?(\d+(?:[.-]\d+)+)["' >]}i)
   end
 

--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -10,8 +10,8 @@ class Getdns < Formula
   # since the aforementioned first-party URL has a tendency to lead to an
   # `execution expired` error.
   livecheck do
-    url "https://github.com/getdnsapi/getdns/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :head
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/gh.rb
+++ b/Formula/gh.rb
@@ -6,8 +6,8 @@ class Gh < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/cli/cli/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/glm.rb
+++ b/Formula/glm.rb
@@ -8,8 +8,8 @@ class Glm < Formula
   head "https://github.com/g-truc/glm.git"
 
   livecheck do
-    url "https://github.com/g-truc/glm/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/gluon.rb
+++ b/Formula/gluon.rb
@@ -7,8 +7,8 @@ class Gluon < Formula
   head "https://github.com/gluon-lang/gluon.git"
 
   livecheck do
-    url "https://github.com/gluon-lang/gluon/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/gnupg-pkcs11-scd.rb
+++ b/Formula/gnupg-pkcs11-scd.rb
@@ -7,7 +7,8 @@ class GnupgPkcs11Scd < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/alonbl/gnupg-pkcs11-scd/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/gnupg-pkcs11-scd[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/gperftools.rb
+++ b/Formula/gperftools.rb
@@ -6,7 +6,8 @@ class Gperftools < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://github.com/gperftools/gperftools/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/gperftools[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/gpredict.rb
+++ b/Formula/gpredict.rb
@@ -7,8 +7,8 @@ class Gpredict < Formula
   revision 2
 
   livecheck do
-    url "https://github.com/csete/gpredict/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -10,8 +10,8 @@ class Grpc < Formula
   head "https://github.com/grpc/grpc.git"
 
   livecheck do
-    url "https://github.com/grpc/grpc/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/hackrf.rb
+++ b/Formula/hackrf.rb
@@ -7,8 +7,8 @@ class Hackrf < Formula
   head "https://github.com/mossmann/hackrf.git"
 
   livecheck do
-    url "https://github.com/mossmann/hackrf/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/halide.rb
+++ b/Formula/halide.rb
@@ -7,8 +7,8 @@ class Halide < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/halide/Halide/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/hashpump.rb
+++ b/Formula/hashpump.rb
@@ -7,8 +7,8 @@ class Hashpump < Formula
   revision 5
 
   livecheck do
-    url "https://github.com/bwall/HashPump/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/haskell-stack.rb
+++ b/Formula/haskell-stack.rb
@@ -7,8 +7,8 @@ class HaskellStack < Formula
   head "https://github.com/commercialhaskell/stack.git"
 
   livecheck do
-    url "https://github.com/commercialhaskell/stack/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/haxe.rb
+++ b/Formula/haxe.rb
@@ -7,8 +7,8 @@ class Haxe < Formula
   head "https://github.com/HaxeFoundation/haxe.git", branch: "development"
 
   livecheck do
-    url "https://github.com/HaxeFoundation/haxe/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/heimdal.rb
+++ b/Formula/heimdal.rb
@@ -6,7 +6,8 @@ class Heimdal < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://github.com/heimdal/heimdal/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/heimdal[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/hfstospell.rb
+++ b/Formula/hfstospell.rb
@@ -6,8 +6,8 @@ class Hfstospell < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/hfst/hfst-ospell/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/hsd.rb
+++ b/Formula/hsd.rb
@@ -9,8 +9,8 @@ class Hsd < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/handshake-org/hsd/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/htslib.rb
+++ b/Formula/htslib.rb
@@ -6,8 +6,8 @@ class Htslib < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/samtools/htslib/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/icarus-verilog.rb
+++ b/Formula/icarus-verilog.rb
@@ -8,7 +8,8 @@ class IcarusVerilog < Formula
   head "https://github.com/steveicarus/iverilog.git"
 
   livecheck do
-    url "https://github.com/steveicarus/iverilog/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:[._]\d+)+)["' >]}i)
   end
 

--- a/Formula/ice.rb
+++ b/Formula/ice.rb
@@ -6,8 +6,8 @@ class Ice < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/zeroc-ice/ice/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/icu4c.rb
+++ b/Formula/icu4c.rb
@@ -7,7 +7,8 @@ class Icu4c < Formula
   license "ICU"
 
   livecheck do
-    url "https://github.com/unicode-org/icu/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/release[._-]v?(\d+(?:[.-]\d+)+)["' >]}i)
   end
 

--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -7,8 +7,8 @@ class Influxdb < Formula
   head "https://github.com/influxdata/influxdb.git"
 
   livecheck do
-    url "https://github.com/influxdata/influxdb/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -7,8 +7,8 @@ class Inlets < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/inlets/inlets/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/irrtoolset.rb
+++ b/Formula/irrtoolset.rb
@@ -7,7 +7,8 @@ class Irrtoolset < Formula
   head "https://github.com/irrtoolset/irrtoolset.git"
 
   livecheck do
-    url "https://github.com/irrtoolset/irrtoolset/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/[^"' >]*?v?(\d+(?:[._-]\d+)+)["' >]}i)
   end
 

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -6,8 +6,8 @@ class Jack < Formula
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://github.com/jackaudio/jack2/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/javacc.rb
+++ b/Formula/javacc.rb
@@ -6,7 +6,8 @@ class Javacc < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://github.com/javacc/javacc/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/javacc[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/jbig2dec.rb
+++ b/Formula/jbig2dec.rb
@@ -6,7 +6,8 @@ class Jbig2dec < Formula
   license "AGPL-3.0-or-later"
 
   livecheck do
-    url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/jbig2dec[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 

--- a/Formula/jdnssec-tools.rb
+++ b/Formula/jdnssec-tools.rb
@@ -8,8 +8,8 @@ class JdnssecTools < Formula
   head "https://github.com/dblacka/jdnssec-tools.git"
 
   livecheck do
-    url "https://github.com/dblacka/jdnssec-tools/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/jdupes.rb
+++ b/Formula/jdupes.rb
@@ -6,8 +6,8 @@ class Jdupes < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/jbruchon/jdupes/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/jq.rb
+++ b/Formula/jq.rb
@@ -6,7 +6,8 @@ class Jq < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/stedolan/jq/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/jq[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/jsoncpp.rb
+++ b/Formula/jsoncpp.rb
@@ -8,8 +8,8 @@ class Jsoncpp < Formula
   head "https://github.com/open-source-parsers/jsoncpp.git"
 
   livecheck do
-    url "https://github.com/open-source-parsers/jsoncpp/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/jsonnet.rb
+++ b/Formula/jsonnet.rb
@@ -7,8 +7,8 @@ class Jsonnet < Formula
   head "https://github.com/google/jsonnet.git"
 
   livecheck do
-    url "https://github.com/google/jsonnet/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/jsonschema2pojo.rb
+++ b/Formula/jsonschema2pojo.rb
@@ -7,7 +7,8 @@ class Jsonschema2pojo < Formula
   revision 2
 
   livecheck do
-    url "https://github.com/joelittlejohn/jsonschema2pojo/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/jsonschema2pojo[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/k3sup.rb
+++ b/Formula/k3sup.rb
@@ -7,7 +7,8 @@ class K3sup < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/alexellis/k3sup/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -7,8 +7,8 @@ class Kakoune < Formula
   head "https://github.com/mawww/kakoune.git"
 
   livecheck do
-    url "https://github.com/mawww/kakoune/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/katago.rb
+++ b/Formula/katago.rb
@@ -6,8 +6,8 @@ class Katago < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/lightvector/KataGo/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/keychain.rb
+++ b/Formula/keychain.rb
@@ -6,8 +6,8 @@ class Keychain < Formula
   sha256 "16f5949b606691dea6e1832a77e697b8c0b2a536abfbd29e3a3f47222259c3b2"
 
   livecheck do
-    url "https://github.com/funtoo/keychain/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url "https://github.com/funtoo/keychain.git"
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/kona.rb
+++ b/Formula/kona.rb
@@ -7,7 +7,8 @@ class Kona < Formula
   head "https://github.com/kevinlawler/kona.git"
 
   livecheck do
-    url "https://github.com/kevinlawler/kona/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:Win(?:64)?[._-])?v?(\d+(?:\.\d+)*)[^"' >]*["' >]}i)
   end
 

--- a/Formula/kotlin.rb
+++ b/Formula/kotlin.rb
@@ -6,8 +6,8 @@ class Kotlin < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/JetBrains/kotlin/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/kvazaar.rb
+++ b/Formula/kvazaar.rb
@@ -7,8 +7,8 @@ class Kvazaar < Formula
   head "https://github.com/ultravideo/kvazaar.git"
 
   livecheck do
-    url "https://github.com/ultravideo/kvazaar/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/lablgtk.rb
+++ b/Formula/lablgtk.rb
@@ -7,8 +7,8 @@ class Lablgtk < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/garrigue/lablgtk/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/lammps.rb
+++ b/Formula/lammps.rb
@@ -10,7 +10,8 @@ class Lammps < Formula
   license "GPL-2.0-only"
 
   livecheck do
-    url "https://github.com/lammps/lammps/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/stable[._-](\d+\w+\d+)["' >]}i)
   end
 

--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -7,8 +7,8 @@ class Ldc < Formula
   head "https://github.com/ldc-developers/ldc.git", shallow: false
 
   livecheck do
-    url "https://github.com/ldc-developers/ldc/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/le.rb
+++ b/Formula/le.rb
@@ -6,8 +6,8 @@ class Le < Formula
   license "GPL-3.0"
 
   livecheck do
-    url "https://github.com/lavv17/le/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libatomic_ops.rb
+++ b/Formula/libatomic_ops.rb
@@ -6,8 +6,8 @@ class LibatomicOps < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/ivmai/libatomic_ops/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libgit2.rb
+++ b/Formula/libgit2.rb
@@ -7,8 +7,8 @@ class Libgit2 < Formula
   head "https://github.com/libgit2/libgit2.git"
 
   livecheck do
-    url "https://github.com/libgit2/libgit2/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/liboqs.rb
+++ b/Formula/liboqs.rb
@@ -6,8 +6,8 @@ class Liboqs < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/open-quantum-safe/liboqs/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libplctag.rb
+++ b/Formula/libplctag.rb
@@ -6,8 +6,8 @@ class Libplctag < Formula
   license any_of: ["LGPL-2.0-or-later", "MPL-2.0"]
 
   livecheck do
-    url "https://github.com/libplctag/libplctag/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/librealsense.rb
+++ b/Formula/librealsense.rb
@@ -7,8 +7,8 @@ class Librealsense < Formula
   head "https://github.com/IntelRealSense/librealsense.git"
 
   livecheck do
-    url "https://github.com/IntelRealSense/librealsense/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libsass.rb
+++ b/Formula/libsass.rb
@@ -8,8 +8,8 @@ class Libsass < Formula
   head "https://github.com/sass/libsass.git"
 
   livecheck do
-    url "https://github.com/sass/libsass/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libseccomp.rb
+++ b/Formula/libseccomp.rb
@@ -6,8 +6,8 @@ class Libseccomp < Formula
   license "LGPL-2.1-only"
 
   livecheck do
-    url "https://github.com/seccomp/libseccomp/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   depends_on "autoconf" => :build

--- a/Formula/libslax.rb
+++ b/Formula/libslax.rb
@@ -6,8 +6,8 @@ class Libslax < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://github.com/Juniper/libslax/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libsndfile.rb
+++ b/Formula/libsndfile.rb
@@ -7,8 +7,8 @@ class Libsndfile < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/erikd/libsndfile/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libtorch.rb
+++ b/Formula/libtorch.rb
@@ -10,8 +10,8 @@ class Libtorch < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/pytorch/pytorch/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libusb.rb
+++ b/Formula/libusb.rb
@@ -6,8 +6,8 @@ class Libusb < Formula
   license "LGPL-2.1"
 
   livecheck do
-    url "https://github.com/libusb/libusb/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libvncserver.rb
+++ b/Formula/libvncserver.rb
@@ -6,7 +6,8 @@ class Libvncserver < Formula
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://github.com/LibVNC/libvncserver/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:LibVNCServer[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/libyaml.rb
+++ b/Formula/libyaml.rb
@@ -6,8 +6,8 @@ class Libyaml < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/yaml/libyaml/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/lizard.rb
+++ b/Formula/lizard.rb
@@ -7,8 +7,8 @@ class Lizard < Formula
   version_scheme 1
 
   livecheck do
-    url "https://github.com/inikep/lizard/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/lnav.rb
+++ b/Formula/lnav.rb
@@ -6,8 +6,8 @@ class Lnav < Formula
   license "BSD-2-Clause"
 
   livecheck do
-    url "https://github.com/tstack/lnav/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/lz4.rb
+++ b/Formula/lz4.rb
@@ -7,8 +7,8 @@ class Lz4 < Formula
   head "https://github.com/lz4/lz4.git"
 
   livecheck do
-    url "https://github.com/lz4/lz4/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/mame.rb
+++ b/Formula/mame.rb
@@ -12,7 +12,8 @@ class Mame < Formula
   # text for the release title, since it contains the properly formatted version
   # (e.g., 0.226).
   livecheck do
-    url "https://github.com/mamedev/mame/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{release-header.*?/releases/tag/mame[._-]?\d+(?:\.\d+)*["' >]>MAME v?(\d+(?:\.\d+)+)}im)
   end
 

--- a/Formula/mapnik.rb
+++ b/Formula/mapnik.rb
@@ -8,8 +8,8 @@ class Mapnik < Formula
   head "https://github.com/mapnik/mapnik.git"
 
   livecheck do
-    url "https://github.com/mapnik/mapnik/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/masscan.rb
+++ b/Formula/masscan.rb
@@ -7,8 +7,8 @@ class Masscan < Formula
   head "https://github.com/robertdavidgraham/masscan.git"
 
   livecheck do
-    url "https://github.com/robertdavidgraham/masscan/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/maxwell.rb
+++ b/Formula/maxwell.rb
@@ -6,8 +6,8 @@ class Maxwell < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/zendesk/maxwell/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/mbedtls.rb
+++ b/Formula/mbedtls.rb
@@ -8,7 +8,8 @@ class Mbedtls < Formula
   head "https://github.com/ARMmbed/mbedtls.git", branch: "development"
 
   livecheck do
-    url "https://github.com/ARMmbed/mbedtls/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:mbedtls[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/metabase.rb
+++ b/Formula/metabase.rb
@@ -6,8 +6,8 @@ class Metabase < Formula
   license "AGPL-3.0-only"
 
   livecheck do
-    url "https://github.com/metabase/metabase/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :head
+    strategy :github_latest
   end
 
   head do

--- a/Formula/mgba.rb
+++ b/Formula/mgba.rb
@@ -8,8 +8,8 @@ class Mgba < Formula
   head "https://github.com/mgba-emu/mgba.git"
 
   livecheck do
-    url "https://github.com/mgba-emu/mgba/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/micronaut.rb
+++ b/Formula/micronaut.rb
@@ -6,8 +6,8 @@ class Micronaut < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/micronaut-projects/micronaut-starter/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -14,8 +14,8 @@ class Minetest < Formula
   end
 
   livecheck do
-    url "https://github.com/minetest/minetest/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/minio-mc.rb
+++ b/Formula/minio-mc.rb
@@ -8,7 +8,8 @@ class MinioMc < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/minio/mc/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:RELEASE[._-]?)?([^"' >]+)["' >]}i)
   end
 

--- a/Formula/minio.rb
+++ b/Formula/minio.rb
@@ -9,7 +9,8 @@ class Minio < Formula
   head "https://github.com/minio/minio.git"
 
   livecheck do
-    url "https://github.com/minio/minio/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:RELEASE[._-]?)?([^"' >]+)["' >]}i)
   end
 

--- a/Formula/mongrel2.rb
+++ b/Formula/mongrel2.rb
@@ -16,8 +16,8 @@ class Mongrel2 < Formula
   end
 
   livecheck do
-    url "https://github.com/mongrel2/mongrel2/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/mp3unicode.rb
+++ b/Formula/mp3unicode.rb
@@ -6,7 +6,8 @@ class Mp3unicode < Formula
   license "GPL-2.0-only"
 
   livecheck do
-    url "https://github.com/alonbl/mp3unicode/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:mp3unicode[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/mupen64plus.rb
+++ b/Formula/mupen64plus.rb
@@ -6,8 +6,8 @@ class Mupen64plus < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/mupen64plus/mupen64plus-core/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/nanomsg.rb
+++ b/Formula/nanomsg.rb
@@ -7,8 +7,8 @@ class Nanomsg < Formula
   head "https://github.com/nanomsg/nanomsg.git"
 
   livecheck do
-    url "https://github.com/nanomsg/nanomsg/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/nco.rb
+++ b/Formula/nco.rb
@@ -6,8 +6,8 @@ class Nco < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://github.com/nco/nco/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/never.rb
+++ b/Formula/never.rb
@@ -7,8 +7,8 @@ class Never < Formula
   head "https://github.com/never-lang/never.git"
 
   livecheck do
-    url "https://github.com/never-lang/never/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/nexus.rb
+++ b/Formula/nexus.rb
@@ -6,7 +6,8 @@ class Nexus < Formula
   license "EPL-1.0"
 
   livecheck do
-    url "https://github.com/sonatype/nexus-public/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/release[._-]v?(\d+(?:[.-]\d+)+)["' >]}i)
   end
 

--- a/Formula/ngt.rb
+++ b/Formula/ngt.rb
@@ -6,8 +6,8 @@ class Ngt < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/yahoojapan/NGT/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/ninja.rb
+++ b/Formula/ninja.rb
@@ -7,8 +7,8 @@ class Ninja < Formula
   head "https://github.com/ninja-build/ninja.git"
 
   livecheck do
-    url "https://github.com/ninja-build/ninja/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/nushell.rb
+++ b/Formula/nushell.rb
@@ -7,7 +7,8 @@ class Nushell < Formula
   head "https://github.com/nushell/nushell.git", branch: "main"
 
   livecheck do
-    url "https://github.com/nushell/nushell/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:[._]\d+)+)["' >]}i)
   end
 

--- a/Formula/ocamlbuild.rb
+++ b/Formula/ocamlbuild.rb
@@ -8,8 +8,8 @@ class Ocamlbuild < Formula
   head "https://github.com/ocaml/ocamlbuild.git"
 
   livecheck do
-    url "https://github.com/ocaml/ocamlbuild/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/octant.rb
+++ b/Formula/octant.rb
@@ -8,8 +8,8 @@ class Octant < Formula
   head "https://github.com/vmware-tanzu/octant.git"
 
   livecheck do
-    url "https://github.com/vmware-tanzu/octant/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/odin.rb
+++ b/Formula/odin.rb
@@ -7,8 +7,8 @@ class Odin < Formula
   head "https://github.com/odin-lang/Odin.git"
 
   livecheck do
-    url "https://github.com/odin-lang/Odin/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/ompl.rb
+++ b/Formula/ompl.rb
@@ -7,8 +7,8 @@ class Ompl < Formula
   head "https://github.com/ompl/ompl.git"
 
   livecheck do
-    url "https://github.com/ompl/ompl/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/onnxruntime.rb
+++ b/Formula/onnxruntime.rb
@@ -7,8 +7,8 @@ class Onnxruntime < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/microsoft/onnxruntime/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/openimageio.rb
+++ b/Formula/openimageio.rb
@@ -9,7 +9,8 @@ class Openimageio < Formula
   head "https://github.com/OpenImageIO/oiio.git"
 
   livecheck do
-    url "https://github.com/OpenImageIO/oiio/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/Release[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/openmsx.rb
+++ b/Formula/openmsx.rb
@@ -8,7 +8,8 @@ class Openmsx < Formula
   head "https://github.com/openMSX/openMSX.git"
 
   livecheck do
-    url "https://github.com/openMSX/openMSX/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/RELEASE[._-]v?(\d+(?:[._]\d+)+)["' >]}i)
   end
 

--- a/Formula/opensc.rb
+++ b/Formula/opensc.rb
@@ -7,8 +7,8 @@ class Opensc < Formula
   head "https://github.com/OpenSC/OpenSC.git"
 
   livecheck do
-    url "https://github.com/OpenSC/OpenSC/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/opentsdb.rb
+++ b/Formula/opentsdb.rb
@@ -6,8 +6,8 @@ class Opentsdb < Formula
   license "LGPL-2.1"
 
   livecheck do
-    url "https://github.com/OpenTSDB/opentsdb/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/or-tools.rb
+++ b/Formula/or-tools.rb
@@ -7,8 +7,8 @@ class OrTools < Formula
   head "https://github.com/google/or-tools.git"
 
   livecheck do
-    url "https://github.com/google/or-tools/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/osi.rb
+++ b/Formula/osi.rb
@@ -6,7 +6,8 @@ class Osi < Formula
   license "EPL-1.0"
 
   livecheck do
-    url "https://github.com/coin-or/Osi/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:releases%2F)?v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/ospray.rb
+++ b/Formula/ospray.rb
@@ -7,8 +7,8 @@ class Ospray < Formula
   head "https://github.com/ospray/ospray.git"
 
   livecheck do
-    url "https://github.com/ospray/ospray/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/ott.rb
+++ b/Formula/ott.rb
@@ -8,8 +8,8 @@ class Ott < Formula
   head "https://github.com/ott-lang/ott.git"
 
   livecheck do
-    url "https://github.com/ott-lang/ott/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/par2.rb
+++ b/Formula/par2.rb
@@ -6,8 +6,8 @@ class Par2 < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/Parchive/par2cmdline/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/pgrouting.rb
+++ b/Formula/pgrouting.rb
@@ -7,8 +7,8 @@ class Pgrouting < Formula
   head "https://github.com/pgRouting/pgrouting.git"
 
   livecheck do
-    url "https://github.com/pgRouting/pgrouting/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/picard-tools.rb
+++ b/Formula/picard-tools.rb
@@ -6,8 +6,8 @@ class PicardTools < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/broadinstitute/picard/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/pkcs11-helper.rb
+++ b/Formula/pkcs11-helper.rb
@@ -7,7 +7,8 @@ class Pkcs11Helper < Formula
   head "https://github.com/OpenSC/pkcs11-helper.git"
 
   livecheck do
-    url "https://github.com/OpenSC/pkcs11-helper/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/pkcs11-helper[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/prodigal.rb
+++ b/Formula/prodigal.rb
@@ -6,8 +6,8 @@ class Prodigal < Formula
   license "GPL-3.0-or-later"
 
   livecheck do
-    url "https://github.com/hyattpd/Prodigal/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/proftpd.rb
+++ b/Formula/proftpd.rb
@@ -11,7 +11,8 @@ class Proftpd < Formula
   # maintenance releases. Versions like `1.2.3a` and `1.2.3b` are not alpha and
   # beta respectively. Prerelease versions use a format like `1.2.3rc1`.
   livecheck do
-    url "https://github.com/proftpd/proftpd/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+[a-z]?)["' >]}i)
   end
 

--- a/Formula/proguard.rb
+++ b/Formula/proguard.rb
@@ -6,8 +6,8 @@ class Proguard < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/Guardsquare/proguard/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/prometheus.rb
+++ b/Formula/prometheus.rb
@@ -6,8 +6,8 @@ class Prometheus < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/prometheus/prometheus/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -6,8 +6,8 @@ class Protobuf < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://github.com/protocolbuffers/protobuf/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/pyenv-virtualenv.rb
+++ b/Formula/pyenv-virtualenv.rb
@@ -8,8 +8,8 @@ class PyenvVirtualenv < Formula
   head "https://github.com/pyenv/pyenv-virtualenv.git"
 
   livecheck do
-    url "https://github.com/pyenv/pyenv-virtualenv/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -8,8 +8,8 @@ class Pyenv < Formula
   head "https://github.com/pyenv/pyenv.git"
 
   livecheck do
-    url "https://github.com/pyenv/pyenv/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -34,8 +34,8 @@ class Qtads < Formula
   end
 
   livecheck do
-    url "https://github.com/realnc/qtads/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :head
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/rancher-cli.rb
+++ b/Formula/rancher-cli.rb
@@ -7,8 +7,8 @@ class RancherCli < Formula
   head "https://github.com/rancher/cli.git"
 
   livecheck do
-    url "https://github.com/rancher/cli/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/redpen.rb
+++ b/Formula/redpen.rb
@@ -6,7 +6,8 @@ class Redpen < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/redpen-cc/redpen/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:redpen[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/rgbds.rb
+++ b/Formula/rgbds.rb
@@ -7,8 +7,8 @@ class Rgbds < Formula
   head "https://github.com/rednex/rgbds.git"
 
   livecheck do
-    url "https://github.com/gbdev/rgbds/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/rhino.rb
+++ b/Formula/rhino.rb
@@ -6,7 +6,8 @@ class Rhino < Formula
   license "MPL-2.0"
 
   livecheck do
-    url "https://github.com/mozilla/rhino/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/.*?>Rhino (\d+(?:\.\d+)+)<}i)
   end
 

--- a/Formula/ripgrep.rb
+++ b/Formula/ripgrep.rb
@@ -7,8 +7,8 @@ class Ripgrep < Formula
   head "https://github.com/BurntSushi/ripgrep.git"
 
   livecheck do
-    url "https://github.com/BurntSushi/ripgrep/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/rm-improved.rb
+++ b/Formula/rm-improved.rb
@@ -7,8 +7,8 @@ class RmImproved < Formula
   head "https://github.com/nivekuil/rip.git"
 
   livecheck do
-    url "https://github.com/nivekuil/rip/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/rom-tools.rb
+++ b/Formula/rom-tools.rb
@@ -12,7 +12,8 @@ class RomTools < Formula
   # text for the release title, since it contains the properly formatted version
   # (e.g., 0.226).
   livecheck do
-    url "https://github.com/mamedev/mame/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{release-header.*?/releases/tag/mame[._-]?\d+(?:\.\d+)*["' >]>MAME v?(\d+(?:\.\d+)+)}im)
   end
 

--- a/Formula/s2n.rb
+++ b/Formula/s2n.rb
@@ -6,8 +6,8 @@ class S2n < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/awslabs/s2n/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/scalariform.rb
+++ b/Formula/scalariform.rb
@@ -6,8 +6,8 @@ class Scalariform < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/scala-ide/scalariform/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   head do

--- a/Formula/sentencepiece.rb
+++ b/Formula/sentencepiece.rb
@@ -7,8 +7,8 @@ class Sentencepiece < Formula
   head "https://github.com/google/sentencepiece.git"
 
   livecheck do
-    url "https://github.com/google/sentencepiece/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/shairport-sync.rb
+++ b/Formula/shairport-sync.rb
@@ -7,8 +7,8 @@ class ShairportSync < Formula
   head "https://github.com/mikebrady/shairport-sync.git", branch: "development"
 
   livecheck do
-    url "https://github.com/mikebrady/shairport-sync/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/sleuthkit.rb
+++ b/Formula/sleuthkit.rb
@@ -6,7 +6,8 @@ class Sleuthkit < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/sleuthkit/sleuthkit/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/sleuthkit[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/snap.rb
+++ b/Formula/snap.rb
@@ -7,8 +7,8 @@ class Snap < Formula
   license "GPL-3.0-only"
 
   livecheck do
-    url "https://github.com/snapcore/snapd/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -9,8 +9,8 @@ class Snapcraft < Formula
   license "GPL-3.0-only"
 
   livecheck do
-    url "https://github.com/snapcore/snapcraft/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/solidity.rb
+++ b/Formula/solidity.rb
@@ -6,8 +6,8 @@ class Solidity < Formula
   license all_of: ["GPL-3.0-or-later", "MIT", "BSD-3-Clause", "Apache-2.0", "CC0-1.0"]
 
   livecheck do
-    url "https://github.com/ethereum/solidity/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/srtp.rb
+++ b/Formula/srtp.rb
@@ -7,8 +7,8 @@ class Srtp < Formula
   head "https://github.com/cisco/libsrtp.git"
 
   livecheck do
-    url "https://github.com/cisco/libsrtp/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/stockfish.rb
+++ b/Formula/stockfish.rb
@@ -7,7 +7,8 @@ class Stockfish < Formula
   head "https://github.com/official-stockfish/Stockfish.git"
 
   livecheck do
-    url "https://github.com/official-stockfish/Stockfish/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:sf[._-])?v?(\d+(?:\.\d+)*)["' >]}i)
   end
 

--- a/Formula/supertux.rb
+++ b/Formula/supertux.rb
@@ -8,8 +8,8 @@ class Supertux < Formula
   head "https://github.com/SuperTux/supertux.git"
 
   livecheck do
-    url "https://github.com/SuperTux/supertux/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/swimat.rb
+++ b/Formula/swimat.rb
@@ -7,8 +7,8 @@ class Swimat < Formula
   head "https://github.com/Jintin/Swimat.git"
 
   livecheck do
-    url "https://github.com/Jintin/Swimat/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/sync_gateway.rb
+++ b/Formula/sync_gateway.rb
@@ -8,8 +8,8 @@ class SyncGateway < Formula
   head "https://github.com/couchbase/sync_gateway.git"
 
   livecheck do
-    url "https://github.com/couchbase/sync_gateway/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/sysdig.rb
+++ b/Formula/sysdig.rb
@@ -6,8 +6,8 @@ class Sysdig < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/draios/sysdig/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/taskwarrior-tui.rb
+++ b/Formula/taskwarrior-tui.rb
@@ -7,8 +7,8 @@ class TaskwarriorTui < Formula
   head "https://github.com/kdheepak/taskwarrior-tui.git"
 
   livecheck do
-    url "https://github.com/kdheepak/taskwarrior-tui/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/teleport.rb
+++ b/Formula/teleport.rb
@@ -7,8 +7,8 @@ class Teleport < Formula
   head "https://github.com/gravitational/teleport.git"
 
   livecheck do
-    url "https://github.com/gravitational/teleport/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/tfsec.rb
+++ b/Formula/tfsec.rb
@@ -6,8 +6,8 @@ class Tfsec < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/tfsec/tfsec/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/tintin.rb
+++ b/Formula/tintin.rb
@@ -6,8 +6,8 @@ class Tintin < Formula
   license "GPL-3.0-or-later"
 
   livecheck do
-    url "https://github.com/scandum/tintin/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/tmux.rb
+++ b/Formula/tmux.rb
@@ -7,7 +7,8 @@ class Tmux < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/tmux/tmux/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+[a-z]?)["' >]}i)
   end
 

--- a/Formula/todo-txt.rb
+++ b/Formula/todo-txt.rb
@@ -7,8 +7,8 @@ class TodoTxt < Formula
   head "https://github.com/todotxt/todo.txt-cli.git"
 
   livecheck do
-    url "https://github.com/todotxt/todo.txt-cli/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/tokei.rb
+++ b/Formula/tokei.rb
@@ -6,8 +6,8 @@ class Tokei < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/XAMPPRocky/tokei/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/tundra.rb
+++ b/Formula/tundra.rb
@@ -6,8 +6,8 @@ class Tundra < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/deplinenoise/tundra/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/uhd.rb
+++ b/Formula/uhd.rb
@@ -7,8 +7,8 @@ class Uhd < Formula
   head "https://github.com/EttusResearch/uhd.git"
 
   livecheck do
-    url "https://github.com/EttusResearch/uhd/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/unison.rb
+++ b/Formula/unison.rb
@@ -7,7 +7,8 @@ class Unison < Formula
   head "https://github.com/bcpierce00/unison.git", branch: "master"
 
   livecheck do
-    url "https://github.com/bcpierce00/unison/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+(?:v\d+)?)["' >]}i)
   end
 

--- a/Formula/vdirsyncer.rb
+++ b/Formula/vdirsyncer.rb
@@ -10,8 +10,8 @@ class Vdirsyncer < Formula
   head "https://github.com/pimutils/vdirsyncer.git"
 
   livecheck do
-    url "https://github.com/pimutils/vdirsyncer/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/vfuse.rb
+++ b/Formula/vfuse.rb
@@ -5,8 +5,8 @@ class Vfuse < Formula
   sha256 "fbf5f8a1c664b03c7513a70aa05c3fc501a7ebdb53f128f1f05c24395871a314"
 
   livecheck do
-    url "https://github.com/chilcote/vfuse/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/vgmstream.rb
+++ b/Formula/vgmstream.rb
@@ -10,7 +10,8 @@ class Vgmstream < Formula
   head "https://github.com/losnoco/vgmstream.git"
 
   livecheck do
-    url "https://github.com/losnoco/vgmstream/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
   end
 

--- a/Formula/vgrep.rb
+++ b/Formula/vgrep.rb
@@ -6,8 +6,8 @@ class Vgrep < Formula
   license "GPL-3.0"
 
   livecheck do
-    url "https://github.com/vrothberg/vgrep/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/vlmcsd.rb
+++ b/Formula/vlmcsd.rb
@@ -7,7 +7,8 @@ class Vlmcsd < Formula
   head "https://github.com/Wind4/vlmcsd.git"
 
   livecheck do
-    url "https://github.com/Wind4/vlmcsd/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
   end
 

--- a/Formula/vnu.rb
+++ b/Formula/vnu.rb
@@ -7,8 +7,8 @@ class Vnu < Formula
   version_scheme 1
 
   livecheck do
-    url "https://github.com/validator/validator/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/wabt.rb
+++ b/Formula/wabt.rb
@@ -7,8 +7,8 @@ class Wabt < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/WebAssembly/wabt/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/wal2json.rb
+++ b/Formula/wal2json.rb
@@ -6,7 +6,8 @@ class Wal2json < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://github.com/eulerto/wal2json/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/(?:wal2json[._-])?v?(\d+(?:[._]\d+)+)["' >]}i)
   end
 

--- a/Formula/wapm.rb
+++ b/Formula/wapm.rb
@@ -7,8 +7,8 @@ class Wapm < Formula
   head "https://github.com/wasmerio/wapm-cli.git"
 
   livecheck do
-    url "https://github.com/wasmerio/wapm-cli/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/wla-dx.rb
+++ b/Formula/wla-dx.rb
@@ -7,7 +7,8 @@ class WlaDx < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/vhelin/wla-dx/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)(?:-fix)*["' >]}i)
   end
 

--- a/Formula/wolfssl.rb
+++ b/Formula/wolfssl.rb
@@ -8,7 +8,8 @@ class Wolfssl < Formula
   head "https://github.com/wolfSSL/wolfssl.git"
 
   livecheck do
-    url "https://github.com/wolfSSL/wolfssl/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)[._-]stable["' >]}i)
   end
 

--- a/Formula/wp-cli.rb
+++ b/Formula/wp-cli.rb
@@ -6,8 +6,8 @@ class WpCli < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/wp-cli/wp-cli/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -8,8 +8,8 @@ class Wxmac < Formula
   head "https://github.com/wxWidgets/wxWidgets.git"
 
   livecheck do
-    url "https://github.com/wxWidgets/wxWidgets/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -7,8 +7,8 @@ class Xmrig < Formula
   head "https://github.com/xmrig/xmrig.git"
 
   livecheck do
-    url "https://github.com/xmrig/xmrig/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/xxhash.rb
+++ b/Formula/xxhash.rb
@@ -6,8 +6,8 @@ class Xxhash < Formula
   license "BSD-2-Clause"
 
   livecheck do
-    url "https://github.com/Cyan4973/xxHash/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/yaws.rb
+++ b/Formula/yaws.rb
@@ -7,7 +7,8 @@ class Yaws < Formula
   head "https://github.com/erlyaws/yaws.git"
 
   livecheck do
-    url "https://github.com/erlyaws/yaws/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/yaws[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 

--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -7,7 +7,8 @@ class YoutubeDlc < Formula
   head "https://github.com/blackjack4494/yt-dlc.git"
 
   livecheck do
-    url "https://github.com/blackjack4494/yt-dlc/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
   end
 

--- a/Formula/yuicompressor.rb
+++ b/Formula/yuicompressor.rb
@@ -7,8 +7,8 @@ class Yuicompressor < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/yui/yuicompressor/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/z.rb
+++ b/Formula/z.rb
@@ -10,8 +10,8 @@ class Z < Formula
   head "https://github.com/rupa/z.git"
 
   livecheck do
-    url "https://github.com/rupa/z/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle :unneeded

--- a/Formula/z3.rb
+++ b/Formula/z3.rb
@@ -8,7 +8,8 @@ class Z3 < Formula
   head "https://github.com/Z3Prover/z3.git"
 
   livecheck do
-    url "https://github.com/Z3Prover/z3/releases/latest"
+    url :stable
+    strategy :github_latest
     regex(%r{href=.*?/tag/z3[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Homebrew/brew#9381 will add a `GithubLatest` strategy to `brew livecheck`, so we can write simpler `livecheck` blocks with less repetition across formulae. For example, before we were having to write something like this:

```ruby
livecheck do
  url "https://github.com/username/repository/releases/latest"
  regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
end
```

Once the `GithubLatest` strategy is available, we'll typically be able to do something like this (for repositories with tags like `1.2.3`, `v1.2.3`, etc.):

```ruby
livecheck do
  url :stable
  strategy :github_latest
end
```

...or for formulae that need a custom regex (e.g., using tags that aren't like `1.2.3` or `v1.2.3`):

```ruby
livecheck do
  url :stable
  strategy :github_latest
  regex(%r{href=.*?/tag/example[._-]v?(\d+(?:\.\d+)+)["' >]}i)
end
```

---

With this in mind, this PR updates the existing formulae that have a `livecheck` block that checks the "latest" release on GitHub. The notable changes are as follows:

* Replace `url` with `:stable` (or `:head`), where possible. In a couple cases where the GitHub URL isn't in the formula, I used the URL of the GitHub Git repository, which `GithubLatest` turns into the "latest" URL.
* Add `strategy :github_latest`, as this is necessary to be able to use the `GithubLatest` strategy (i.e., it's only applied manually and never automatically).
* Remove the `regex` if the formula uses the standard regex for checking the tag URL on the "latest" release page (i.e., `%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i`), as the `GithubLatest` strategy provides this by default.

I've already gone through these and compared the output before/after these changes and everything works predictably (after I addressed any unusual cases). I'll rebase this PR and test it again after the `GithubLatest` PR is finished and merged but I wanted to push this in the interim time for anyone who's interested. Once I feel that it's ready to go, I'll remove the `do not merge` label.