### PR TITLE
terraform@0.13: terraform 0.13.5 (new formula)

### DIFF
--- a/Formula/terraform@0.13.rb
+++ b/Formula/terraform@0.13.rb
@@ -1,0 +1,56 @@
+class TerraformAT013 < Formula
+  desc "Tool to build, change, and version infrastructure"
+  homepage "https://www.terraform.io/"
+  url "https://github.com/hashicorp/terraform/archive/v0.13.5.tar.gz"
+  sha256 "c4bdb9e636550795862f13e0ae667a1d381bf2f6cd30c4dde54411afdd07aeab"
+  license "MPL-2.0"
+
+  keg_only :versioned_formula
+
+  depends_on "go@1.14" => :build
+
+  def install
+    # v0.6.12 - source contains tests which fail if these environment variables are set locally.
+    ENV.delete "AWS_ACCESS_KEY"
+    ENV.delete "AWS_SECRET_KEY"
+
+    # resolves issues fetching providers while on a VPN that uses /etc/resolv.conf
+    # https://github.com/hashicorp/terraform/issues/26532#issuecomment-720570774
+    ENV["CGO_ENABLED"] = "1"
+
+    system "go", "build", *std_go_args, "-ldflags", "-s -w", "-mod=vendor"
+  end
+
+  test do
+    minimal = testpath/"minimal.tf"
+    minimal.write <<~EOS
+      variable "aws_region" {
+        default = "us-west-2"
+      }
+
+      variable "aws_amis" {
+        default = {
+          eu-west-1 = "ami-b1cf19c6"
+          us-east-1 = "ami-de7ab6b6"
+          us-west-1 = "ami-3f75767a"
+          us-west-2 = "ami-21f78e11"
+        }
+      }
+
+      # Specify the provider and access details
+      provider "aws" {
+        access_key = "this_is_a_fake_access"
+        secret_key = "this_is_a_fake_secret"
+        region     = var.aws_region
+      }
+
+      resource "aws_instance" "web" {
+        instance_type = "m1.small"
+        ami           = var.aws_amis[var.aws_region]
+        count         = 4
+      }
+    EOS
+    system "#{bin}/terraform", "init"
+    system "#{bin}/terraform", "graph"
+  end
+end

--- a/Formula/terraform@0.13.rb
+++ b/Formula/terraform@0.13.rb
@@ -18,7 +18,8 @@ class TerraformAT013 < Formula
     # https://github.com/hashicorp/terraform/issues/26532#issuecomment-720570774
     ENV["CGO_ENABLED"] = "1"
 
-    system "go", "build", *std_go_args, "-ldflags", "-s -w", "-mod=vendor"
+    system "go", "build", *std_go_args,
+      "-ldflags", "-s -w", "-mod=vendor", "-o", bin/"terraform"
   end
 
   test do


### PR DESCRIPTION
follow up PR of #66095

terraform 0.14 is a major release.
https://www.terraform.io/upgrade-guides/0-14.html

> Terraform v0.14 is a major release and so it includes some small changes in behavior that you may need to consider when upgrading. This guide is intended to help with that process.