### PR TITLE
infer, yeti: revert revision bumps

### DIFF
--- a/Formula/infer.rb
+++ b/Formula/infer.rb
@@ -6,7 +6,6 @@ class Infer < Formula
       tag:      "v0.17.0",
       revision: "99464c01da5809e7159ed1a75ef10f60d34506a4"
   license "MIT"
-  revision 1
 
   livecheck do
     url :stable

--- a/Formula/yeti.rb
+++ b/Formula/yeti.rb
@@ -4,7 +4,6 @@ class Yeti < Formula
   url "https://github.com/mth/yeti/archive/v1.0.tar.gz"
   sha256 "f1451a7c58cecaee41c46e886eb714a81e0dfe5557c10568421dcbd33ab9357c"
   license "BSD-3-Clause"
-  revision 1
   head "https://github.com/mth/yeti.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #66067

`infer` and `yeti` received revision bumps along with being disabled in https://github.com/Homebrew/homebrew-core/pull/64662. However, this PR was merged without bottles as these formulae could not be built from source. This means that users who are trying to install the existing formula bottle will be unsuccessful. `brew install` is unable to find `x.y.z_1` because it was never uploaded to Bintray. However, the `x.y.z` bottle is still available, so reverting the revision bumps tells `brew install` to look for the `x.y.z` version instead.

`brew test` works fine for both of these. One thing to note: since their bottles were built, the Java requirement was replaced with a dependency on `openjdk@8` so it's possible that there will be some incompatibilities.

**Note: this is intentionally marked as `CI-syntax-only` because I don't want new bottles to be made. They will fail.**
