### PR TITLE
sile: switch to lua@5.4

### DIFF
--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -4,7 +4,7 @@ class Sile < Formula
   url "https://github.com/sile-typesetter/sile/releases/download/v0.10.13/sile-0.10.13.tar.xz"
   sha256 "d207d0ee9749a6da16fa2db217f51d3586955387a132c45423b47eedf8c964a6"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/sile-typesetter/sile.git", shallow: false
 
   bottle do
@@ -26,14 +26,14 @@ class Sile < Formula
   depends_on "harfbuzz"
   depends_on "icu4c"
   depends_on "libpng"
-
-  # Unable to upgrade to lua5.4 due to test failure.
-  # For a suggested fix:
-  # https://github.com/sile-typesetter/sile/issues/1115
-  depends_on "lua@5.3"
-
+  depends_on "lua"
   depends_on "openssl@1.1"
   depends_on "zlib"
+
+  resource "bit32" do
+    url "https://github.com/keplerproject/lua-compat-5.3/archive/v0.10.tar.gz"
+    sha256 "d1ed32f091856f6fffab06232da79c48b437afd4cd89e5c1fc85d7905b011430"
+  end
 
   resource "cassowary" do
     url "https://github.com/sile-typesetter/cassowary.lua/archive/v2.2.tar.gz"
@@ -111,7 +111,7 @@ class Sile < Formula
   end
 
   def install
-    lua = Formula["lua@5.3"]
+    lua = Formula["lua"]
     luaprefix = lua.opt_prefix
     luaversion = lua.version.major_minor
     luapath = libexec/"vendor"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Attempted follow up to #65993 (also see backstory comments in #65976, #57133, and upstream issue [№1115](https://github.com/sile-typesetter/sile/issues/1115)). SILE is fully compatible with Lua 5.4 so there shouldn't be any need to hold it back on 5.3 except the hassle of figuring out dependencies. This is my (blind) stab at that.