### PR TITLE
tracebox: fix url

### DIFF
--- a/Formula/tracebox.rb
+++ b/Formula/tracebox.rb
@@ -1,6 +1,6 @@
 class Tracebox < Formula
   desc "Middlebox detection tool"
-  homepage "https://www.tracebox.org/"
+  homepage "https://www.github.com/tracebox/tracebox"
   url "https://github.com/tracebox/tracebox.git",
       tag:      "v0.4.4",
       revision: "4fc12b2e330e52d340ecd64b3a33dbc34c160390"


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (~after doing `brew install <formula>`~)?

-----

tracebox.org cert is broken, so `brew audit` fails when url is accessed
with HTTPS.

See also https://github.com/Homebrew/homebrew-core/pull/65993#issuecomment-737727962