### PR TITLE
libsndfile: patch to fix autotools configure

### DIFF
--- a/Formula/libsndfile.rb
+++ b/Formula/libsndfile.rb
@@ -4,6 +4,7 @@ class Libsndfile < Formula
   url "https://github.com/erikd/libsndfile/releases/download/v1.0.30/libsndfile-1.0.30.tar.bz2"
   sha256 "9df273302c4fa160567f412e10cc4f76666b66281e7ba48370fb544e87e4611a"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url "https://github.com/erikd/libsndfile/releases/latest"
@@ -27,6 +28,14 @@ class Libsndfile < Formula
   depends_on "libogg"
   depends_on "libvorbis"
   depends_on "opus"
+
+  # Upstream commit to fix autotools configure on macOS, fixes
+  # https://github.com/libsndfile/libsndfile/issues/642
+  # Upstream fix is expected in release v1.0.31
+  patch do
+    url "https://github.com/libsndfile/libsndfile/commit/ecd63961.patch?full_index=1"
+    sha256 "419aad070487685157a515adf4c6de25ffbd34adb0ab52b6df0f7c1ed0644893"
+  end
 
   def install
     system "autoreconf", "-fvi"


### PR DESCRIPTION
The result is enabling support for FLAC, ogg, vorbis, and opus.

See: https://github.com/libsndfile/libsndfile/issues/642

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
