### PR TITLE
latex2rtf: update livecheck

### DIFF
--- a/Formula/latex2rtf.rb
+++ b/Formula/latex2rtf.rb
@@ -7,6 +7,7 @@ class Latex2rtf < Formula
 
   livecheck do
     url :stable
+    regex(%r{url=.*?/latex2rtf/files/latex2rtf-unix/[^/]+/latex2rtf[._-](\d+(?:[-.]\d+)+[a-z]?)\.t}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`latex2rtf` versions typically take a form like `1.2.3` but there can also be a trailing letter that increments like `1.2.3a`, `1.2.3b`, `1.2.3c`, etc. The default regex for livecheck's `SourceForge` strategy doesn't allow for trailing letters like these in the capture group (since sometimes a trailing `a` means alpha and `b` means beta), so livecheck reports the newest version as `2.3.18` instead of `2.3.18a` (found in the formula).

This PR adds a `regex` to the existing `livecheck` block that modifies the default `SourceForge` regex to be contextually appropriate for `latex2rtf`. It allows for an optional trailing letter in the version capture group while restricting matching to `latex2rtf` tarballs in `latex2rtf-unix` version folders. It's necessary to obtain versions from the tarball filenames because the version folders don't include the trailing letter (e.g., `latex2rtf-2.3.18a.tar.gz` is found in the `2.3.18` folder).