### PR TITLE
libslirp 4.4.0

### DIFF
--- a/Formula/libslirp.rb
+++ b/Formula/libslirp.rb
@@ -1,8 +1,8 @@
 class Libslirp < Formula
   desc "General purpose TCP-IP emulator"
   homepage "https://gitlab.freedesktop.org/slirp/libslirp"
-  url "https://elmarco.fedorapeople.org/libslirp-4.3.1.tar.xz"
-  sha256 "388b4b08a8cc0996cc5155cb027a097dc1a7f2cfe84b1121496608ab5366cc48"
+  url "https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v4.4.0/libslirp-v4.4.0.tar.gz"
+  sha256 "43513390c57bee8c23b31545bfcb765200fccf859062b1c8101e72befdabce2e"
   license "BSD-3-Clause"
 
   bottle do
@@ -19,7 +19,6 @@ class Libslirp < Formula
   depends_on "glib"
 
   def install
-    inreplace "meson.build", ",--version-script", ""
     system "meson", "build", "-Ddefault_library=both", *std_meson_args
     system "ninja", "-C", "build", "install", "all"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR updates libslirp to v4.4.0. It removes the `--version-script` patch because that was fixed.