### PR TITLE
mosquitto: switch to use download page

### DIFF
--- a/Formula/mosquitto.rb
+++ b/Formula/mosquitto.rb
@@ -8,7 +8,7 @@ class Mosquitto < Formula
   license "EPL-1.0"
 
   livecheck do
-    url "https://mosquitto.org/files/source/"
+    url "https://mosquitto.org/download/"
     regex(/href=.*?mosquitto[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
update livecheck to use download page as check source.

relates to #66126