### PR TITLE
Revert skaffold 1.17.1 due to incorrect binaries

### DIFF
--- a/Formula/skaffold.rb
+++ b/Formula/skaffold.rb
@@ -2,8 +2,8 @@ class Skaffold < Formula
   desc "Easy and Repeatable Kubernetes Development"
   homepage "https://skaffold.dev/"
   url "https://github.com/GoogleContainerTools/skaffold.git",
-      tag:      "v1.17.1",
-      revision: "aa0ab3eb52b9dd692408aaf3f2e05b37dddb9bc0"
+      tag:      "v1.17.0",
+      revision: "ad9c4899cf485f6931cb9de2ac3419b83081f73d"
   license "Apache-2.0"
   head "https://github.com/GoogleContainerTools/skaffold.git"
 

--- a/Formula/skaffold.rb
+++ b/Formula/skaffold.rb
@@ -9,9 +9,9 @@ class Skaffold < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "487907b1c24c5237fa479805a048e528d2350f27015c15f32a011eedce0f64e3" => :big_sur
-    sha256 "50c361687cf63daf9d9189f49729e10880d9afe17078712354c75f0d7a84e565" => :catalina
-    sha256 "a42adbf989f90fa81f6ad541a392461f56034e6228cae2884a507c6639e4ad47" => :mojave
+    sha256 "ac4cf5be3c7b5119ff0d85f9e1ef1daeccaf4adb07dee82c8258df3ee484e0c7" => :big_sur
+    sha256 "ac5fa32582326d2a6a9470515d9921bd7e88f29c07bb37ab832ea46d98400fe4" => :catalina
+    sha256 "8c5d7501b8ffc74e11b32983f7bcf36b0717cad26f3ac00b272c9392c04fcfff" => :mojave
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
This reverts commit bc9bec3f5a4db6e1a53bc56475bfda0501a8417f.

- [ X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
