### PR TITLE
lua@5.3: fix pc file

### DIFF
--- a/Formula/lua@5.3.rb
+++ b/Formula/lua@5.3.rb
@@ -63,7 +63,7 @@ class LuaAT53 < Formula
     <<~EOS
       V= #{version.major_minor}
       R= #{version}
-      prefix=#{HOMEBREW_PREFIX}
+      prefix=#{opt_prefix}
       INSTALL_BIN= ${prefix}/bin
       INSTALL_INC= ${prefix}/include/lua
       INSTALL_LIB= ${prefix}/lib
@@ -78,7 +78,7 @@ class LuaAT53 < Formula
       Description: An Extensible Extension Language
       Version: #{version}
       Requires:
-      Libs: -L${libdir} -llua -lm
+      Libs: -L${libdir} -llua.#{version.major_minor} -lm
       Cflags: -I${includedir}
     EOS
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The generated pc file points to `lua[@5.4]`, not `lua@5.3`. This commit
fixes that. After this change:

    ❯ export PKG_CONFIG_PATH="/usr/local/opt/lua@5.3/lib/pkgconfig"
    ❯ pkg-config --libs --cflags lua5.3
    -I/usr/local/opt/lua@5.3/include/lua -L/usr/local/opt/lua@5.3/lib -llua.5.3 -lm

One caveat is that adding `lua@5.3` to `PKG_CONFIG_PATH` now means that
using `pkg-config` to generate build flags for lua without specifying a
version will point to `lua@5.3`. I'm not hugely bothered by this, since
`lua@5.3` is keg-only. One can also work around this by specifying
versions explicitly.