### PR TITLE
make zeromq depend on libsodium again

### DIFF
--- a/Formula/ntopng.rb
+++ b/Formula/ntopng.rb
@@ -39,6 +39,7 @@ class Ntopng < Formula
   depends_on "geoip"
   depends_on "json-c"
   depends_on "libmaxminddb"
+  depends_on "libsodium"
   depends_on "mysql-client"
   depends_on "redis"
   depends_on "rrdtool"

--- a/Formula/zeromq.rb
+++ b/Formula/zeromq.rb
@@ -28,6 +28,7 @@ class Zeromq < Formula
   depends_on "asciidoc" => :build
   depends_on "pkg-config" => [:build, :test]
   depends_on "xmlto" => :build
+  depends_on "libsodium"
 
   def install
     # Work around "error: no member named 'signbit' in the global namespace"
@@ -42,7 +43,7 @@ class Zeromq < Formula
     # https://github.com/Homebrew/homebrew-core/pull/35940#issuecomment-454177261
 
     system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}", "--with-libsodium"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
zeromq recommends always building with libsodium for CURVE security, when available. Back when Formulae had options, zeromq dependency on libsodium was [recommended](https://github.com/Homebrew/legacy-homebrew/pull/33241), since that's zeromq's own recommendation. It was then later [disabled](https://github.com/Homebrew/legacy-homebrew/pull/33708) due to a static-linking issue in ntopng. I believe this has been [fixed](https://github.com/ntop/ntopng/commit/843625d6d1884d440cb54f02e6549f1391dc4911) in more recent versions of ntopng, so we can restore the zeromq 'recommended' behavior as the only behavior for zeromq. I've done my best to verify that this works. I've run

```
brew install --build-from-source zeromq
brew install --build-from-source ntopng
```

with these changes, and `brew test` for both packages passes. Let me know if there are any other tests I can do to help ensure that this doesn't reintroduce the issues it did years ago.

Background: 

- zeromq [build recommendations](http://wiki.zeromq.org/build:encryption)
- zeromq with libsodium recommended: https://github.com/Homebrew/legacy-homebrew/pull/33241
- zeromq with libsodium demoted to optional: https://github.com/Homebrew/legacy-homebrew/pull/33708
- ntopng build failure that prompted removal: https://github.com/Homebrew/legacy-homebrew/issues/33677
- ntopng patch to support libsodium: https://github.com/ntop/ntopng/commit/843625d6d1884d440cb54f02e6549f1391dc4911

References:

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
