### PR TITLE
dosbox-staging Add Fluidsynth Support

### DIFF
--- a/Formula/dosbox-staging.rb
+++ b/Formula/dosbox-staging.rb
@@ -4,6 +4,7 @@ class DosboxStaging < Formula
   url "https://github.com/dosbox-staging/dosbox-staging/archive/v0.76.0.tar.gz"
   sha256 "7df53c22f7ce78c70afb60b26b06742b90193b56c510219979bf12e0bb2dc6c7"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/dosbox-staging/dosbox-staging.git"
 
   bottle do

--- a/Formula/dosbox-staging.rb
+++ b/Formula/dosbox-staging.rb
@@ -30,9 +30,13 @@ class DosboxStaging < Formula
       --enable-core-inline
     ]
 
+    ENV.append_to_cflags "-DNDEBUG"
+    ENV.append_to_cflags "-O3"
+    ENV.append_to_cflags "-fno-math-errno"
+    ENV.append_to_cflags "-fno-strict-aliasing"
     system "./autogen.sh"
     system "./configure", *args
-    system "make", "install"
+    system "make", "CXXFLAGS=#{ENV.cflags}", "install"
     mv bin/"dosbox", bin/"dosbox-staging"
     mv man1/"dosbox.1", man1/"dosbox-staging.1"
   end

--- a/Formula/dosbox-staging.rb
+++ b/Formula/dosbox-staging.rb
@@ -16,6 +16,7 @@ class DosboxStaging < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
+  depends_on "fluid-synth"
   depends_on "libpng"
   depends_on "opusfile"
   depends_on "sdl2"
@@ -25,7 +26,6 @@ class DosboxStaging < Formula
     args = %W[
       --prefix=#{prefix}
       --disable-dependency-tracking
-      --disable-fluidsynth
       --disable-sdltest
       --enable-core-inline
     ]
@@ -34,6 +34,7 @@ class DosboxStaging < Formula
     system "./configure", *args
     system "make", "install"
     mv bin/"dosbox", bin/"dosbox-staging"
+    mv man1/"dosbox.1", man1/"dosbox-staging.1"
   end
 
   test do


### PR DESCRIPTION
Because Fluidsynth support is a signature feature of dosbox-staging 0.76.0 and was removed from the build when the version was bumped, this update creates a `fluid-synth` dependency and restores the functionality.

Renamed the man1 file basename (`dosbox -> dosbox-staging`) to prevent linking conflicts with Formula `dosbox`.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
