### PR TITLE
dispatch-build-bottle.yml: add ARM PATH

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{github.event.inputs.macos}}
     timeout-minutes: 4320
     env:
-      PATH: '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+      PATH: '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
       GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED: 1
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:


### PR DESCRIPTION
On ARM runners (yeah!) the `PATH` should include `/opt/homebrew/bin`