### PR TITLE
config.yml: Change reference `brew cask`

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,7 +9,7 @@ contact_links:
   about: Having a `brew` problem that's not from a `brew install` or `brew upgrade` of a single formula/package? Report it to Homebrew/brew (the Homebrew package manager).
 - name: New issue on Homebrew/homebrew-cask
   url: https://github.com/Homebrew/homebrew-cask/issues/new/choose
-  about: Having a `brew cask` problem? Report it to Homebrew/homebrew-cask (the cask tap/repository)
+  about: Having a Homebrew Cask problem? Report it to Homebrew/homebrew-cask (the cask tap/repository)
 - name: New issue on Homebrew/linuxbrew-core
   url: https://github.com/Homebrew/linuxbrew-core/issues/new/choose
   about: On Linux? Having a `brew` problem with a `brew install` or `brew upgrade` of a single formula/package? Report it to Homebrew/linuxbrew-core (the Linux core tap/repository).


### PR DESCRIPTION
Given that `brew cask` is deprecated, I gave this line a tweak - feel free to feedback/change.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
