### PR TITLE
man-db: depend on groff

### DIFF
--- a/Formula/man-db.rb
+++ b/Formula/man-db.rb
@@ -4,6 +4,8 @@ class ManDb < Formula
   url "https://download.savannah.gnu.org/releases/man-db/man-db-2.9.3.tar.xz"
   mirror "https://download-mirror.savannah.gnu.org/releases/man-db/man-db-2.9.3.tar.xz"
   sha256 "fa5aa11ab0692daf737e76947f45669225db310b2801a5911bceb7551c5597b8"
+  license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://download.savannah.gnu.org/releases/man-db/"

--- a/Formula/man-db.rb
+++ b/Formula/man-db.rb
@@ -18,8 +18,8 @@ class ManDb < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "groff"
 
-  uses_from_macos "groff"
   uses_from_macos "zlib"
 
   on_linux do


### PR DESCRIPTION
When used with the macOS provided groff, man-db converts all
dashes/hyphens to U+2010 HYPHEN or U+2212 MINUS SIGN. This makes it
hard to search for strings with hyphens. This issue goes away when the
newer groff from brew is available

Closes #66216.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
