### PR TITLE
tree-sitter: make emscripten and node test-only dependencies

### DIFF
--- a/Formula/tree-sitter.rb
+++ b/Formula/tree-sitter.rb
@@ -15,8 +15,8 @@ class TreeSitter < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "emscripten"
-  depends_on "node"
+  depends_on "emscripten" => :test
+  depends_on "node" => :test
 
   def install
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Tree-sitter is meant to be a lightweight, dependency-free library: https://tree-sitter.github.io/tree-sitter/

However, this isn't how it's packaged in Homebrew. Instead, what was otherwise a ~400KB library turns into a multi-gigabyte installation. It, therefore, seems sensible to separate the CLI from the library.

See https://github.com/Homebrew/homebrew-core/issues/65669.

An alternative to this is for the existing tree-sitter formula to declare `node` and `emscripten` as test-only dependencies, as they are not actually needed at runtime. They are needed only if you want to generate tree-sitter parsers from Javascript, or to compile the library to WASM.

Based on analytics, most people aren't installing tree-sitter for the CLI, but for the tree-sitter library (70 installs-on-request vs 1,790 installs in the last 365 days). So I'm guessing that a fair (but, admittedly, small relative to Homebrew's user base) number of people are having large unnecessary dependencies installed on their systems.