### PR TITLE
dafny: install z3 as resource

### DIFF
--- a/Formula/dafny.rb
+++ b/Formula/dafny.rb
@@ -3,7 +3,8 @@ class Dafny < Formula
   homepage "https://github.com/dafny-lang/dafny/blob/master/README.md"
   url "https://github.com/dafny-lang/dafny/archive/v2.3.0.tar.gz"
   sha256 "ea7ae310282c922772a46a9a85e2b4213043283038b74d012047b5294687d168"
-  revision 2
+  license "MIT"
+  revision 3
 
   livecheck do
     url :stable
@@ -20,11 +21,17 @@ class Dafny < Formula
   depends_on "mono-libgdiplus" => :build
   depends_on "nuget" => :build
   depends_on "mono"
-  depends_on "z3"
 
   resource "boogie" do
     url "https://github.com/boogie-org/boogie.git",
         revision: "9e74c3271f430adb958908400c6f6fce5b59000a"
+  end
+
+  # Use the following along with the z3 build below, as long as dafny
+  # cannot build with latest z3 (https://github.com/dafny-lang/dafny/issues/810)
+  resource "z3" do
+    url "https://github.com/Z3Prover/z3/archive/z3-4.8.4.tar.gz"
+    sha256 "5a18fe616c2a30b56e5b2f5b9f03f405cdf2435711517ff70b076a01396ef601"
   end
 
   def install
@@ -37,10 +44,14 @@ class Dafny < Formula
 
     libexec.install Dir["Binaries/*"]
 
-    # We don't want to resolve opt_bin here.
     dst_z3_bin = libexec/"z3/bin"
     dst_z3_bin.mkpath
-    ln_sf (Formula["z3"].opt_bin/"z3").relative_path_from(dst_z3_bin), dst_z3_bin/"z3"
+
+    resource("z3").stage do
+      system "./configure"
+      system "make", "-C", "build"
+      mv("build/z3", dst_z3_bin/"z3")
+    end
 
     (bin/"dafny").write <<~EOS
       #!/bin/bash
@@ -51,9 +62,16 @@ class Dafny < Formula
   test do
     (testpath/"test.dfy").write <<~EOS
       method Main() {
+        var i: nat;
+        assert i as int >= -1;
         print "hello, Dafny\\n";
       }
     EOS
-    system "#{bin}/dafny", testpath/"test.dfy"
+    assert_equal "\nDafny program verifier finished with 1 verified, 0 errors\n",
+                  shell_output("#{bin}/dafny /nologo /compile:0 #{testpath}/test.dfy")
+    assert_equal "\nDafny program verifier finished with 1 verified, 0 errors\nRunning...\n\nhello, Dafny\n",
+                  shell_output("#{bin}/dafny /nologo /compile:3 #{testpath}/test.dfy")
+    assert_equal "Z3 version 4.8.4 - 64 bit\n",
+                 shell_output("#{libexec}/z3/bin/z3 -version")
   end
 end


### PR DESCRIPTION
Dafny currently works with the older Z3 executable 4.8.4. There is an open issue to upgrade to the latest Z3, that work is not complete. Meanwhile, the brew download is broken and needs after the fact patching of the Z3 version. This PR fixes that problem.