### PR TITLE
optool 0.1 (new formula)

### DIFF
--- a/Formula/optool.rb
+++ b/Formula/optool.rb
@@ -1,0 +1,29 @@
+class Optool < Formula
+  desc "Command-Line tool for interacting with MachO binaries on macOS/iOS"
+  homepage "https://github.com/alexzielenski/optool"
+  # pull from git tag to get submodules
+  url "https://github.com/alexzielenski/optool.git",
+      tag:      "0.1",
+      revision: "a20c514baa2018adf53a0a408b9ee72cba107155"
+  license "BSD-2-Clause"
+  head "https://github.com/alexzielenski/optool.git"
+
+  depends_on xcode: :build
+
+  def install
+    xcodebuild "SDKROOT=",
+               "SYMROOT=build", "OBJROOT=build", "DSTROOT=build",
+               "-project", "optool.xcodeproj",
+               "-target", "optool",
+               "-configuration", "Release",
+               "OTHER_LDFLAGS='-ObjC'"
+    bin.install "build/Release/optool"
+  end
+
+  test do
+    if build.stable?
+      result = shell_output("#{bin}/optool 2>&1", 13)
+      assert_match "optool v#{version}", result
+    end
+  end
+end


### PR DESCRIPTION
### Checklist
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

### Description
This adds `optool` as a formula.