### PR TITLE
rust 1.48

### DIFF
--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -4,6 +4,7 @@ class Deno < Formula
   url "https://github.com/denoland/deno/releases/download/v1.6.0/deno_src.tar.gz"
   sha256 "60491d842e04ce162face61bb8857bf18a41726afbcbcd9fa532055ace7431ae"
   license "MIT"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/findomain.rb
+++ b/Formula/findomain.rb
@@ -1,7 +1,7 @@
 class Findomain < Formula
   desc "Cross-platform subdomain enumerator"
-  homepage "https://github.com/Edu4rdSHL/findomain"
-  url "https://github.com/Edu4rdSHL/findomain/archive/2.1.5.tar.gz"
+  homepage "https://github.com/Findomain/findomain"
+  url "https://github.com/Findomain/findomain/archive/2.1.5.tar.gz"
   sha256 "31182a63f2d2002e5dc99e8f809157c18e660a9964cbbc9faa249e131493c635"
   license "GPL-3.0-or-later"
 

--- a/Formula/pike.rb
+++ b/Formula/pike.rb
@@ -4,7 +4,7 @@ class Pike < Formula
   url "https://pike.lysator.liu.se/pub/pike/latest-stable/Pike-v8.0.702.tar.gz"
   sha256 "c47aad2e4f2c501c0eeea5f32a50385b46bda444f922a387a5c7754302f12a16"
   license any_of: ["GPL-2.0-only", "LGPL-2.1-only", "MPL-1.1"]
-  revision 2
+  revision 3
 
   livecheck do
     url "https://pike.lysator.liu.se/download/pub/pike/latest-stable/"
@@ -19,7 +19,6 @@ class Pike < Formula
   end
 
   depends_on "gmp"
-  depends_on "librsvg"
   depends_on "libtiff"
   depends_on "nettle"
   depends_on "pcre"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Picks up from https://github.com/Homebrew/homebrew-core/pull/65286.

Fixes https://github.com/Homebrew/homebrew-core/issues/63202 (hopefully).

## 10.14

| Done? | Formula           | CI failure   | Comment                                       |
| ---   | ---               | ---          | ---                                           |
| ✅       | cargo-instruments | `install -s` | SHA256 mismatch (https://github.com/cmyr/cargo-instruments/issues/27, https://github.com/Homebrew/homebrew-core/pull/66872)                              |
| ✅       | deno              | `install -s` | #66482                                        |
| ✅       | findomain         | `install -s` | SHA256 mismatch (https://github.com/Findomain/Findomain/issues/121)                               |
| ✅       | ktmpl             | `test`       | https://github.com/jimmycuadra/ktmpl/issues/5, fixed in https://github.com/Homebrew/homebrew-core/pull/66914 |
|       | root              | `install -s` | connection failure                            |
| ✅       | silicon           | `install -s` | SHA256 mismatch, waiting for upstream response                               |
| ✅       | simgrid           | `install -s` | bad build script                              |

## 10.15

| Done? | Formula   | CI failure   | Comment                                      |
| ---   | ---       | ---          | ---                                          |
| ✅       | findomain | `install -s` | SHA256 mismatch (https://github.com/Findomain/Findomain/issues/121)                             |
|       | ktmpl     | `test`       | htps://github.com/jimmycuadra/ktmpl/issues/5, fixed in https://github.com/Homebrew/homebrew-core/pull/66914 |
|       | root      | `install -s` | connection failure                           |
| ✅       | silicon   | `install -s` | SHA256 mismatch, waiting for upstream response                              |
| ✅       | simgrid   | `install -s` | bad build script                             |

## 11.0

All `install --build-from-source` except for asuka (`test`), ktmpl (`test`), root (both - !)

| Done? | Formula           | CI failure           | Comment                                       |
| ---   | ---               | ---                  | ---                                           |
|       | asuka             | `test`               | `pty` allocation?, https://github.com/Homebrew/homebrew-core/issues/66450, https://github.com/Homebrew/homebrew-core/issues/65000                             |
| ✅       | cargo-instruments | `install -s`         | SHA256 mismatch (https://github.com/cmyr/cargo-instruments/issues/27, https://github.com/Homebrew/homebrew-core/pull/66872)                              |
| ✅       | deno              | `install -s`         | #66482                                        |
|       | echoprint-codegen | `install -s`         | #65000                                        |
| ✅       | findomain         | `install -s`         | SHA256 mismatch (https://github.com/Findomain/Findomain/issues/121)                              |
| ✅       | ktmpl             | `test`               | https://github.com/jimmycuadra/ktmpl/issues/5, fixed in https://github.com/Homebrew/homebrew-core/pull/66914 |
|       | root              | `install -s`, `test` | connection failure?                           |
| ✅       | silicon           | `install -s`         | SHA256 mismatch, waiting for upstream response                               |
| ✅       | simgrid           | `install -s`         | bad build script                              |
|       | visp              | `install -s`         | #65000                                        |

All three SHA256 mismatches have been reported upstream. Links visible down the thread.