### PR TITLE
tests.yml: force vendored Ruby on Catalina

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,9 @@ jobs:
       GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED: 1
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
+      - name: Force vendored Ruby on Catalina
+        if: matrix.version == '10.15'
+        run: echo 'HOMEBREW_FORCE_VENDOR_RUBY=1' >> $GITHUB_ENV
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master


### PR DESCRIPTION
After their latest update, the Catalina CI nodes are hit by this bug: https://github.com/Homebrew/brew/issues/9410
This is a temporary workaround, so CI testing can resume