### PR TITLE
a2ps: work around ./configure issues with Xcode 12

### DIFF
--- a/Formula/a2ps.rb
+++ b/Formula/a2ps.rb
@@ -6,6 +6,10 @@ class A2ps < Formula
   sha256 "f3ae8d3d4564a41b6e2a21f237d2f2b104f48108591e8b83497500182a3ab3a4"
   license "GPL-3.0-or-later"
 
+  livecheck do
+    url :stable
+  end
+
   bottle do
     rebuild 3
     sha256 "98a293e2d83134c9a1c35026f68207d9fc2ac1bde9d7d15dd29849d7d9c5b237" => :catalina
@@ -20,9 +24,6 @@ class A2ps < Formula
     # https://github.com/Homebrew/brew/issues/2005
     satisfy { HOMEBREW_PREFIX.to_s == Homebrew::DEFAULT_PREFIX }
   end
-
-  # Fails to build on Catalina. No new release since 2007
-  disable! because: :does_not_build
 
   # Software was last updated in 2007.
   # https://svn.macports.org/ticket/20867
@@ -44,6 +45,9 @@ class A2ps < Formula
   end
 
   def install
+    # Work around configure issues with Xcode 12
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--sysconfdir=#{etc}",
                           "--with-lispdir=#{elisp}"


### PR DESCRIPTION
I saw that a2ps had been having build issues and so disabled recently by @iMichka 

It is true that the a2ps project itself is long-dormant, but it does seem that it mostly has been continuing to work.  Anyway, I dug in to the build failure that we've been seeing with other old `./configure` scripts we've been having with Xcode 12 (see #65954 for another example I recently fixed)

This compiles fine for me on Big Sur now; hopefully this will bottle OK now.