### PR TITLE
expect: work around build issue with Xcode 12

### DIFF
--- a/Formula/expect.rb
+++ b/Formula/expect.rb
@@ -38,6 +38,11 @@ class Expect < Formula
     ENV.prepend "CFLAGS",
       "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework/Versions/8.5/Headers/tcl-private"
 
+    # Temporarily workaround build issues with building 5.45.4 using Xcode 12.
+    # Upstream bug (with more complicated fix) is here:
+    #   https://core.tcl-lang.org/expect/tktview/0d5b33c00e5b4bbedb835498b0360d7115e832a0
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     # Regenerate configure script. Remove after patch applied in newer
     # releases.
     system "autoreconf", "--force", "--install", "--verbose"


### PR DESCRIPTION
In this case the upstream seems to be maintained (although with years between releases sometimes) so I made a real fix and sent it upstream.  However temporarily use the same CFLAGS fix that has been needed for other formula under Xcode 12.

Hopefully this will fix this formula's Big Sur bottling issues -- it installs fine on my machine now.