### PR TITLE
gptfdisk: fix compile on Big Sur

### DIFF
--- a/Formula/gptfdisk.rb
+++ b/Formula/gptfdisk.rb
@@ -35,12 +35,9 @@ class Gptfdisk < Formula
 
   test do
     system "dd", "if=/dev/zero", "of=test.dmg", "bs=1m", "count=1"
-    output = shell_output("#{bin}/sgdisk -o test.dmg")
-    assert_match "completed successfully", output
-    output = shell_output("#{bin}/sgdisk -p test.dmg")
-    assert_match "GUID", output
-    output = shell_output("#{bin}/gdisk -l test.dmg")
-    assert_match "Found valid GPT with protective MBR", output
+    assert_match "completed successfully", shell_output("#{bin}/sgdisk -o test.dmg")
+    assert_match "GUID", shell_output("#{bin}/sgdisk -p test.dmg")
+    assert_match "Found valid GPT with protective MBR", shell_output("#{bin}/gdisk -l test.dmg")
   end
 end
 

--- a/Formula/gptfdisk.rb
+++ b/Formula/gptfdisk.rb
@@ -3,7 +3,7 @@ class Gptfdisk < Formula
   homepage "https://www.rodsbooks.com/gdisk/"
   url "https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/1.0.5/gptfdisk-1.0.5.tar.gz"
   sha256 "0e7d3987cd0488ecaf4b48761bc97f40b1dc089e5ff53c4b37abe30bc67dcb2f"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable
@@ -18,6 +18,13 @@ class Gptfdisk < Formula
 
   depends_on "popt"
 
+  uses_from_macos "ncurses"
+
+  # Fix Big Sur compilation issue with 1.0.5; the physical *.dylib files
+  # are no longer present directly on the filesystem, but the linker still
+  # knows what to do.
+  patch :DATA
+
   def install
     system "make", "-f", "Makefile.mac"
     %w[cgdisk fixparts gdisk sgdisk].each do |program|
@@ -27,8 +34,26 @@ class Gptfdisk < Formula
   end
 
   test do
-    system "hdiutil", "create", "-size", "128k", "test.dmg"
+    system "dd", "if=/dev/zero", "of=test.dmg", "bs=1m", "count=1"
+    output = shell_output("#{bin}/sgdisk -o test.dmg")
+    assert_match "completed successfully", output
+    output = shell_output("#{bin}/sgdisk -p test.dmg")
+    assert_match "GUID", output
     output = shell_output("#{bin}/gdisk -l test.dmg")
     assert_match "Found valid GPT with protective MBR", output
   end
 end
+
+__END__
+diff -ur a/Makefile.mac b/Makefile.mac
+--- a/Makefile.mac	2020-02-17 22:34:11.000000000 +0000
++++ b/Makefile.mac	2020-12-05 22:12:04.000000000 +0000
+@@ -21,7 +21,7 @@
+ #	$(CXX) $(LIB_OBJS) -L/usr/lib -licucore gpttext.o gdisk.o -o gdisk
+ 
+ cgdisk: $(LIB_OBJS) cgdisk.o gptcurses.o
+-	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o /usr/lib/libncurses.dylib $(LDFLAGS) $(FATBINFLAGS) -o cgdisk
++	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o -L/usr/lib -lncurses $(LDFLAGS) $(FATBINFLAGS) -o cgdisk
+ #	$(CXX) $(LIB_OBJS) cgdisk.o gptcurses.o $(LDFLAGS) -licucore -lncurses -o cgdisk
+ 
+ sgdisk: $(LIB_OBJS) gptcl.o sgdisk.o


### PR DESCRIPTION
* Starting on 11.0, OS/X doesn't have physical files appearing as `/usr/lib/*.dylib` for the standard libraries, but the toolchain can still link against them (using the `.tbd` files inside the SDK to guide it)  Just use`-lncurses` which seems to work.

Normally I would open an upstream PR first, but I'm having some issues with my long-unused Sourceforge account.  (support ticket opened)  I will ping the upstream dev though and will try to make sure this gets addressed in the next release.  In the meantime I just put the tiny patch inline to the formula.

* `brew test` wouldn't work for me.  The first problem was that `hdiutil` doesn't seem capable of creating a 128k disk image any more, but the command works when I run it manually with a 512k size. However, it still doesn't work due to a permission issue when running inside `brew test` -- I think something changed in how the test sandboxing works so that hdiutil can no longer run. (hdiutil can need expanded permissions since it temporarily mounts the new image I think)  I couldn't find a clean way to work around it so I just changed the test to use this package itself to make the test partition.  A better test in some ways, a worse test in others.

* Tweak the license info to make `brew audit` happy