### PR TITLE
sha2: fix compile on Xcode 12

### DIFF
--- a/Formula/sha2.rb
+++ b/Formula/sha2.rb
@@ -22,7 +22,9 @@ class Sha2 < Formula
   end
 
   def install
-    system ENV.cc, "-o", "sha2", "sha2prog.c", "sha2.c"
+    # Xcode 12 made -Wimplicit-function-declaration an error by default so we need to
+    # disable that warning to successfully compile:
+    system ENV.cc, "-o", "sha2", "-Wno-implicit-function-declaration", "sha2prog.c", "sha2.c"
     system "perl", "sha2test.pl"
     bin.install "sha2"
   end


### PR DESCRIPTION
I don't know if there is much point to trying to upstream a fix for this since the last update to this program seems to be 2004 or so, but I'll drop the author an email nonetheless.