### PR TITLE
sdhash: disable formula

### DIFF
--- a/Formula/sdhash.rb
+++ b/Formula/sdhash.rb
@@ -13,6 +13,15 @@ class Sdhash < Formula
     sha256 "3d019e14266847dcfa7fa27f69ffa4aea25cc78a2ff62c1883a2a8c74fa02116" => :sierra
   end
 
+  # This version does not build on Big Sur, and the project seems to be unmaintained overall:
+  # * The homepage says that the latest version is 3.4, but github says 4.0 is
+  # * Even the github hasn't had a commit made to it since 2013 https://github.com/sdhash/sdhash/commits/master
+  # * Seems to have Python 2 dependencies.  There is an open PR on the project to
+  #   make it compatible with Python 3.7, but so far it hasn't been merged
+  # If there is ever a post-4.0 release on github this formula might be resurrected
+  # but for now it seems dead.
+  disable! because: :does_not_build
+
   depends_on "openssl@1.1"
 
   def install


### PR DESCRIPTION
Perhaps this is bold of me since I'm a homebrew noob, but I believe this formula is a goner (at least at the minute)  I took a quick look to see if I could resolve its Big Sur bottling issue.  It probably isn't too hard to fix the exact compile failure, but:

* The version is the formula is several versions old (3.1)  It's not even 100% clear what the recommended version *is* since the project homepage only talks about 3.4 and the official github repo has 4.0
* Even the github has gone 7 years without a commit
* There are apparently python 2 dependencies.  There are PRs open for a couple months on the project to update to 3.7, but as of yet no action has been taken: https://github.com/sdhash/sdhash/pull/14

Since it looks like this formula is long-unmaintained, probably the best thing to do is to put it out of its misery.  I know most other py2-dependent formulas are long-ago disabled.  I don't know enough about this particular package to know if it requires py2 for its basic functionality, but getting a complete build on top of homebrew's py3 support would probably require some serious effort.

```
==> Analytics
install: 6 (30 days), 21 (90 days), 66 (365 days)
install-on-request: 4 (30 days), 19 (90 days), 60 (365 days)
build-error: 0 (30 days)
```