### PR TITLE
udptunnel: fix build on Xcode 12

### DIFF
--- a/Formula/udptunnel.rb
+++ b/Formula/udptunnel.rb
@@ -1,8 +1,10 @@
 class Udptunnel < Formula
   desc "Tunnel UDP packets over a TCP connection"
+  # The original webpage (and download) is still available at the original
+  # site, but currently www.cs.columbia.edu returns a 404 error if you
+  # try to fetch them over https instead of http
   homepage "https://web.archive.org/web/20161224191851/www.cs.columbia.edu/~lennox/udptunnel/"
-  url "https://web.archive.org/web/20161224191851/www.cs.columbia.edu/~lennox/udptunnel/udptunnel-1.1.tar.gz"
-  mirror "https://ftp.nsysu.edu.tw/FreeBSD/ports/local-distfiles/leeym/udptunnel-1.1.tar.gz"
+  url "https://sources.voidlinux.org/udptunnel-1.1/udptunnel-1.1.tar.gz"
   sha256 "45c0e12045735bc55734076ebbdc7622c746d1fe4e6f7267fa122e2421754670"
   license "BSD-3-Clause"
 
@@ -21,6 +23,10 @@ class Udptunnel < Formula
   depends_on "automake" => :build
 
   def install
+    # Work around build issues with Xcode 12:
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
+    system "autoreconf", "--verbose", "--install", "--force"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
* The included configure script is too old to work now, so force an `autoreconf`
* There are still some issues with Xcode 12's treatment of `-Wimplicit-function-declaration` as an error, so tweak `CFLAGS` too
* It also was failing to download correctly because archive.org auto-gunzip'ed the response, breaking the sha256 check.  The other provided mirror URL was even more broken, failing to negotiate an https connection.  I found this voidlinux.org site that has the tarball with the expected sha though.  None of this would be needed except that the original source of this package at cs.columbia.edu returns 404 if you try to access the URL over https instead of http.