### PR TITLE
{testdisk,flash}: Remove hdiutil-requiring tests

### DIFF
--- a/Formula/flash.rb
+++ b/Formula/flash.rb
@@ -10,10 +10,4 @@ class Flash < Formula
   def install
     bin.install "flash"
   end
-
-  test do
-    system "hdiutil", "create", "-size", "128k", "test.dmg"
-    output = shell_output("echo foo | #{bin}/flash --device /dev/disk42 test.dmg", 1)
-    assert_match "Please answer yes or no.", output
-  end
 end

--- a/Formula/testdisk.rb
+++ b/Formula/testdisk.rb
@@ -25,10 +25,4 @@ class Testdisk < Formula
                           "--prefix=#{prefix}"
     system "make", "install"
   end
-
-  test do
-    path = "test.dmg"
-    system "hdiutil", "create", "-megabytes", "10", path
-    system "#{bin}/testdisk", "/list", path
-  end
 end


### PR DESCRIPTION
As I discussed more in #66304, tests requiring `hdiutil` are failing, probably due to a sandbox limitation.

For gptfdisk I had an easy workaround, but these two would be harder.  Regrettably, I think the easiest thing is to just remove these tests since they never pass anymore.

This should also let `testdisk` re-bottle for Big Sur correctly -- it's currently on the #65000 leaderboard of top-downloaded formulae with bottling issues