### PR TITLE
rust: add rust-src

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -2,6 +2,7 @@ class Rust < Formula
   desc "Safe, concurrent, practical language"
   homepage "https://www.rust-lang.org/"
   license any_of: ["Apache-2.0", "MIT"]
+  revision 1
 
   stable do
     url "https://static.rust-lang.org/dist/rustc-1.49.0-src.tar.gz"
@@ -109,6 +110,7 @@ class Rust < Formula
       zsh_completion.install "src/etc/_cargo"
     end
 
+    (lib/"rustlib/src/rust").install "library"
     rm_rf prefix/"lib/rustlib/uninstall.sh"
     rm_rf prefix/"lib/rustlib/install.log"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds `rust-src` to  `rust` formula, which is required by some third-party programs (such as [`rust-analyzer`](https://github.com/rust-analyzer/rust-analyzer/issues/4172)).

Default installation with `rustup` comes `rust-src` (shown with `rustup component list --installed`):

```
cargo
clippy
rust-docs
rust-src
rust-std
rustc
rustfmt
```

While Homebrew's installation is approximately equivalent to:

```
cargo
rust-docs
rustc
```

Since `rust-src` is just 37MB (as of Rust 1.48.0), and `go` ships with `src` too (though that's a little different from Rust), I think it's worth adding it to Homebrew's installation as well.

~~Not sure if there are any environment variables or build flags for installing it with official build scripts, but I guess this won't hurt since it's just moving files around.~~