### PR TITLE
hledger: update livecheck

### DIFF
--- a/Formula/hledger.rb
+++ b/Formula/hledger.rb
@@ -5,8 +5,11 @@ class Hledger < Formula
   sha256 "d5c1eb6d8de5cf2d82771db1796b57a304095fa940773a6405c9cd8085f3da71"
   license "GPL-3.0-or-later"
 
+  # A new version is sometimes present on Hackage before it's officially
+  # released on the upstream homepage, so we check the first-party download
+  # page instead.
   livecheck do
-    url "https://github.com/simonmichael/hledger/releases/latest"
+    url "https://hledger.org/download.html"
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#66319 was merged before I had a chance to review it, so this PR contains comments/changes I would have proposed in review.

The previous `livecheck` block for `hledger` only contained `url :stable`, so livecheck was using the `Hackage` strategy to check for new versions. livecheck was erroneously reporting `1.20` as the newest version but `1.19.1` is the current version on the [first-party download page](https://hledger.org/download.html), [GitHub](https://github.com/simonmichael/hledger/releases/latest), etc. Since a new version may be added to Hackage before it's officially released, it's necessary for us to check a different source to find the current version.

Though the "latest" release on GitHub corresponds to the current release on the first-party download page at the present moment, it may be slightly more appropriate to check the first-party download page itself. My thinking here is that the first-party download page may be a more canonical representation of when a version is officially released. I've seen the "latest" version on GitHub for some other projects point to incorrect releases at times, so I think the first-party download page has the potential to be slightly less error-prone in the long run.

---

That said, regardless of whether we modify the `url` in the `livecheck` block, I think it's important to have a comment to explain why it's necessary to check a source that doesn't align with the `stable` URL for this formula. If we don't end up wanting to modify the `url`, I'll update the language in the comment accordingly.