### PR TITLE
md: fix build under Xcode 12

### DIFF
--- a/Formula/md.rb
+++ b/Formula/md.rb
@@ -15,6 +15,9 @@ class Md < Formula
     sha256 "5faf5907b69c2a53c9bbbcfcb908d24c222181490b69116e09102212382be5ea" => :mavericks
   end
 
+  # https://github.com/Homebrew/homebrew-core/pull/66347#issuecomment-739548996
+  disable! because: :unmaintained
+
   def install
     cd "md" do
       # Xcode 12 made -Wimplicit-function-declaration an error by default so we need to

--- a/Formula/md.rb
+++ b/Formula/md.rb
@@ -17,7 +17,9 @@ class Md < Formula
 
   def install
     cd "md" do
-      system ENV.cc, ENV.cflags, "-o", "md", "md.c"
+      # Xcode 12 made -Wimplicit-function-declaration an error by default so we need to
+      # disable that warning to successfully compile:
+      system ENV.cc, ENV.cflags, "-o", "md", "-Wno-implicit-function-declaration", "md.c"
       bin.install "md"
       man1.install "md.1"
     end


### PR DESCRIPTION
Same fix as other old C programs (like #66307)

Doesn't look like there is anyplace to upstream fixes to since this is just compiling a file that has been dropped from later versions of Apple's adv_cmds bundle.