### PR TITLE
povray: work around build issue with newer boost

### DIFF
--- a/Formula/povray.rb
+++ b/Formula/povray.rb
@@ -3,8 +3,9 @@ class Povray < Formula
   homepage "https://www.povray.org/"
   url "https://github.com/POV-Ray/povray/archive/v3.7.0.8.tar.gz"
   sha256 "53d11ebd2972fc452af168a00eb83aefb61387662c10784e81b63e44aa575de4"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   revision 1
+  head "https://github.com/POV-Ray/povray.git"
 
   livecheck do
     url :stable
@@ -55,6 +56,14 @@ class Povray < Formula
     end
 
     system "./configure", *args
+
+    # The VERSION file in the root of the package is read by the autoconf bits.
+    # However, on a non-case-sensitive filesystem this breaks "#include <version>"
+    # deep inside the boost libraries.  See https://github.com/POV-Ray/povray/issues/403
+    rm "VERSION"
+    rm "unix/VERSION"
+    rm "libraries/tiff/VERSION"
+
     system "make", "install"
   end
 


### PR DESCRIPTION
Work around issue that had already been reported upstream: https://github.com/POV-Ray/povray/issues/403