### PR TITLE
radare2: workaround for Xcode12

### DIFF
--- a/Formula/radare2.rb
+++ b/Formula/radare2.rb
@@ -3,7 +3,6 @@ class Radare2 < Formula
   homepage "https://radare.org"
   url "https://github.com/radareorg/radare2/archive/4.5.1.tar.gz"
   sha256 "4e85b35987bd2ca5881ad9585970b970fe7374814bd383bd1cd62e961a0c228b"
-  # Upstream package unclear if 3.0-only or 3.0-or-later, marking as 3.0-only for now:
   license "LGPL-3.0-only"
   head "https://github.com/radareorg/radare2.git"
 

--- a/Formula/radare2.rb
+++ b/Formula/radare2.rb
@@ -3,7 +3,8 @@ class Radare2 < Formula
   homepage "https://radare.org"
   url "https://github.com/radareorg/radare2/archive/4.5.1.tar.gz"
   sha256 "4e85b35987bd2ca5881ad9585970b970fe7374814bd383bd1cd62e961a0c228b"
-  license "LGPL-3.0"
+  # Upstream package unclear if 3.0-only or 3.0-or-later, marking as 3.0-only for now:
+  license "LGPL-3.0-only"
   head "https://github.com/radareorg/radare2.git"
 
   bottle do
@@ -13,6 +14,8 @@ class Radare2 < Formula
   end
 
   def install
+    # Workaround for Xcode 12 from https://github.com/radareorg/radare2/pull/17879/files
+    inreplace "mk/darwin.mk", "$(XCODE_VERSION_MAJOR),11", "$(shell test $(XCODE_VERSION_MAJOR) -gt 10;echo $$?),0"
     system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make", "install"


### PR DESCRIPTION
This change already exists in the upstream repository

It's also unclear if this license is "LGPL-3.0-only" or "3.0-or-later"; the individual source files don't include the traditional boilerplate.

This should fix this package's Big Sur packaging issue.