### PR TITLE
lha: fix Xcode 12 build issues

### DIFF
--- a/Formula/lha.rb
+++ b/Formula/lha.rb
@@ -37,6 +37,9 @@ class Lha < Formula
   conflicts_with "lhasa", because: "both install a `lha` binary"
 
   def install
+    # Work around configure/build issues with Xcode 12
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "autoreconf", "-is" if build.head?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
There are actually two separate problems that got triggered by Xcode 12's decision to make `-Werror,-Wimplicit-function-declaration` the default:
* The `./configure` script has problems.  Some of these can be fixed with an autoreconf run, but the non-HEAD version of the code needs other adjustments to work with modern autoconf.  However there are a couple other problems which I opened an upstream PR for already: https://github.com/jca02266/lha/pull/18
* There is also a build issue.  macports already has a fix for that: https://github.com/macports/macports-ports/pull/9197
However the simplest thing to do for the moment is to just disable the warning via `$CFLAGS` which allows the code to build as-is