### PR TITLE
vitess 8.0.0 (new formula)

### DIFF
--- a/Formula/vitess.rb
+++ b/Formula/vitess.rb
@@ -1,0 +1,40 @@
+class Vitess < Formula
+  desc "Database clustering system for horizontal scaling of MySQL"
+  homepage "https://vitess.io"
+  url "https://github.com/vitessio/vitess/archive/v8.0.0.tar.gz"
+  sha256 "c47320b9bcb874b1a6dfca78ec677be7c4bb4c7b2a6470df80bd1bc0ad125e92"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+  depends_on "etcd"
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}", "VTROOT=#{buildpath}"
+    bin.install "bin/mysqlctl"
+    bin.install "bin/vtctl"
+    pkgshare.install "examples"
+  end
+
+  test do
+    etcd_server = "localhost:#{free_port}"
+    fork do
+      exec Formula["etcd"].opt_bin/"etcd", "--enable-v2=true",
+                                           "--data-dir=#{testpath}/etcd",
+                                           "--listen-client-urls=http://#{etcd_server}",
+                                           "--advertise-client-urls=http://#{etcd_server}"
+    end
+    sleep 3
+
+    port = free_port
+    fork do
+      exec bin/"vtgate", "-topo_implementation", "etcd2",
+                         "-topo_global_server_address", etcd_server,
+                         "-topo_global_root", testpath/"global",
+                         "-port", port.to_s
+    end
+    sleep 3
+
+    output = shell_output("curl -s localhost:#{port}/debug/health")
+    assert_equal "ok", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Notes

- `make install` doesn't install `mysqlctl` and `vtctl`, which are needed to run the [local examples](https://vitess.io/docs/get-started/local/) (called in `./101_initial_cluster.sh`). `make install-local` on master installs `mysqlctl` but not `vtctl` (PR to add `vtctl`: https://github.com/vitessio/vitess/pull/7125), so the formula hopefully won't need the `bin.install` lines in the future.