### PR TITLE
pod2man: change install location inside keg

### DIFF
--- a/Formula/pod2man.rb
+++ b/Formula/pod2man.rb
@@ -3,6 +3,7 @@ class Pod2man < Formula
   homepage "https://www.eyrie.org/~eagle/software/podlators/"
   url "https://archives.eyrie.org/software/perl/podlators-4.14.tar.xz"
   sha256 "e504c3d9772b538d7ea31ce2c5e7a562d64a5b7f7c26277b1d7a0de1f6acfdf4"
+  revision 1
 
   livecheck do
     url "https://archives.eyrie.org/software/perl/"
@@ -19,9 +20,8 @@ class Pod2man < Formula
   keg_only :provided_by_macos
 
   def install
-    system "perl", "Makefile.PL", "PREFIX=#{prefix}",
-                   "INSTALLSCRIPT=#{bin}",
-                   "INSTALLMAN1DIR=#{man1}", "INSTALLMAN3DIR=#{man3}"
+    system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}",
+                   "INSTALLSITEMAN1DIR=#{man1}", "INSTALLSITEMAN3DIR=#{man3}"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
Investigating recent bottling failures and found that pod2man was failing due to `brew test` failing.  The issue is that the test assumes that this (keg-only) formula installed its binary as
  `.../Cellar/pod2man/4.14/bin/pod2text`
but it was actually ending up at:
  `.../Cellar/pod2man/4.14/local/bin/pod2text`

I'm going to assume that `brew test` worked at some point and that the former is the correct place to install it.  Hopefully I'm right about that; I am no perl expert.  It seems that if you specify `INSTALLDIRS=vendor` when you build it that's what you get.  Maybe the default `INSTALLDIRS` changed at some point and broke this formula?

cc @zachauten @mistydemeo 