### PR TITLE
jpeginfo: re-run autoconf

### DIFF
--- a/Formula/jpeginfo.rb
+++ b/Formula/jpeginfo.rb
@@ -3,7 +3,9 @@ class Jpeginfo < Formula
   homepage "https://www.kokkonen.net/tjko/projects.html"
   url "https://www.kokkonen.net/tjko/src/jpeginfo-1.6.1.tar.gz"
   sha256 "629e31cf1da0fa1efe4a7cc54c67123a68f5024f3d8e864a30457aeaed1d7653"
+  license "GPL-2.0-or-later"
   revision 1
+  head "https://github.com/tjko/jpeginfo.git"
 
   bottle do
     cellar :any
@@ -15,11 +17,14 @@ class Jpeginfo < Formula
     sha256 "d28d3fcbf355139760d15d1869f57d180940e8114b150446214b18270275dcf8" => :yosemite
   end
 
+  depends_on "autoconf" => :build
   depends_on "jpeg"
 
   def install
     ENV.deparallelize
 
+    # The ./configure file inside the tarball is too old to work with Xcode 12, regenerate:
+    system "autoconf", "--force"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
The `./configure` file included in the 1.6.1 tarball is too old to work with Xcode 12, but the regenerated one works fine.  Normally I would do a full `autoreconf` but there are some fragile bits that need some tweaks before autoheader would run happily.  Just an autoconf run is enough to let us build.
