### PR TITLE
feedgnuplot: change install location inside keg #66367

### DIFF
--- a/Formula/feedgnuplot.rb
+++ b/Formula/feedgnuplot.rb
@@ -3,8 +3,14 @@ class Feedgnuplot < Formula
   homepage "https://github.com/dkogan/feedgnuplot"
   url "https://github.com/dkogan/feedgnuplot/archive/v1.55.tar.gz"
   sha256 "1205afedf8ce79d8531e0d0f8f9565df365a568a0ee6a8e17738602682095303"
-  # licensed under either "GPL-3.0" or "Artistic-1.0"
-  license "GPL-3.0"
+  license any_of: ["GPL-3.0-only", "Artistic-1.0"]
+  revision 1
+  head "https://github.com/dkogan/feedgnuplot.git"
+
+  livecheck do
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +22,7 @@ class Feedgnuplot < Formula
   depends_on "gnuplot"
 
   def install
-    system "perl", "Makefile.PL", "prefix=#{prefix}"
+    system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}", "INSTALLSITEMAN1DIR=#{man1}", "INSTALLSITEMAN3DIR=#{man3}"
     system "make"
     system "make", "install"
 

--- a/Formula/feedgnuplot.rb
+++ b/Formula/feedgnuplot.rb
@@ -3,7 +3,7 @@ class Feedgnuplot < Formula
   homepage "https://github.com/dkogan/feedgnuplot"
   url "https://github.com/dkogan/feedgnuplot/archive/v1.55.tar.gz"
   sha256 "1205afedf8ce79d8531e0d0f8f9565df365a568a0ee6a8e17738602682095303"
-  license any_of: ["GPL-3.0-only", "Artistic-1.0"]
+  license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   revision 1
   head "https://github.com/dkogan/feedgnuplot.git"
 

--- a/Formula/feedgnuplot.rb
+++ b/Formula/feedgnuplot.rb
@@ -17,7 +17,7 @@ class Feedgnuplot < Formula
   depends_on "gnuplot"
 
   def install
-    system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}", "INSTALLSITEMAN1DIR=#{man1}", "INSTALLSITEMAN3DIR=#{man3}"
+    system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}", "INSTALLSITEMAN1DIR=#{man1}"
     system "make"
     system "make", "install"
 

--- a/Formula/feedgnuplot.rb
+++ b/Formula/feedgnuplot.rb
@@ -7,11 +7,6 @@ class Feedgnuplot < Formula
   revision 1
   head "https://github.com/dkogan/feedgnuplot.git"
 
-  livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     cellar :any_skip_relocation
     sha256 "7d394a581a614dcc5130eac02310e58f994067b94a8dbd413c983157e3d37cc2" => :catalina


### PR DESCRIPTION
Investigating recent bottling failures and found that feedgnuplot was failing due to brew test failing. The issue is that the test assumes that this formula installed its binary as
```
  .../Cellar/feedgnuplot/1.550/bin/feedgnuplot
```
but it was actually ending up at:
```
  .../Cellar/feedgnuplot/1.550/local/bin/feedgnuplot
```
I'm going to assume that brew test worked at some point and that the former is the correct place to install it. Hopefully I'm right about that; I am no perl expert. It seems that if you specify `INSTALLDIRS=vendor` when you build it that's what you get. Maybe the default INSTALLDIRS changed at some point and broke this formula?

This exact same problem affected pod2man (#66367)   When investigating that failure I thought it was a one-off, but clearly there is some more systemic issue with perl package installation going on.  I can't claim to fully understand what is going on so willing to listen to any theories people have.

cc @alyssais @chenrui333 