### PR TITLE
hfsutils: update download URL

### DIFF
--- a/Formula/hfsutils.rb
+++ b/Formula/hfsutils.rb
@@ -1,10 +1,11 @@
 class Hfsutils < Formula
   desc "Tools for reading and writing Macintosh volumes"
   homepage "https://www.mars.org/home/rob/proj/hfs/"
-  url "https://www.mars.org/pub/hfs/hfsutils-3.2.6.tar.gz"
+  url "https://sources.voidlinux.org/hfsutils-3.2.6/hfsutils-3.2.6.tar.gz"
   mirror "https://fossies.org/linux/misc/old/hfsutils-3.2.6.tar.gz"
   mirror "https://ftp.osuosl.org/pub/clfs/conglomeration/hfsutils/hfsutils-3.2.6.tar.gz"
   sha256 "bc9d22d6d252b920ec9cdf18e00b7655a6189b3f34f42e58d5bb152957289840"
+  license "GPL-2.0-or-later"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
The homepage is still working, but it returns a 404 if you try to download the tarball over https.  Added another one I found,
although the two mirrors also work.

Also note the license while I'm here.
