### PR TITLE
uftp: fixes to plist for "brew audit --strict"

### DIFF
--- a/Formula/uftp.rb
+++ b/Formula/uftp.rb
@@ -3,7 +3,7 @@ class Uftp < Formula
   homepage "https://uftp-multicast.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/uftp-multicast/source-tar/uftp-5.0.tar.gz"
   sha256 "562f71ea5a24b615eb491f5744bad01e9c2e58244c1d6252d5ae98d320d308e0"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url :stable
@@ -41,7 +41,7 @@ class Uftp < Formula
         <string>#{plist_name}</string>
         <key>ProgramArguments</key>
         <array>
-          <string>#{opt_sbin}/uftpd</string>
+          <string>#{opt_bin}/uftpd</string>
           <string>-d</string>
         </array>
         <key>RunAtLoad</key>


### PR DESCRIPTION
I am not sure if this is what has been causing bottling issues for the formula.  For better or worse the `uftpd` binary definitely ends up in `bin/` not `sbin/` so it looks like the audit complaint was correct.

I haven't actually tried running this program, but it does build/test/audit ok with this change.

cc @dfberger @Bo98  