### PR TITLE
workflows/tests: fix CI-syntax-only label detection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ jobs:
   tap_syntax:
     if: github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
+    outputs:
+      run-tests: ${{ steps.check-labels.outputs.result }}
     env:
       HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
     steps:
@@ -40,9 +42,26 @@ jobs:
           fi
         done
 
+    - name: Check for CI-syntax-only label
+      id: check-labels
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { data: { labels: labels } } = await github.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          })
+          if (!labels.map(label => label.name).includes('CI-syntax-only')) {
+            console.log('No CI-syntax-only label found. Running tests.')
+            return true
+          }
+          console.log('CI-syntax-only label found. Skipping tests.')
+
   tests:
     needs: tap_syntax
-    if: github.event_name == 'pull_request' && ! contains(github.event.pull_request.labels.*.name, 'CI-syntax-only')
+    if: github.event_name == 'pull_request' && needs.tap_syntax.outputs.run-tests
     strategy:
       matrix:
         version: ['11.0', '10.15', '10.14']


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR modifies the `tests` workflow to correctly detect the `CI-syntax-only` label when a PR is created using `gh`. As I wrote in https://github.com/cli/cli/issues/2489, adding labels while creating a PR using `gh` does not work as expected. The labels are added using a follow-up API call, meaning that they don't make it into the `pull_request` event that is sent to GitHub actions. As a result, adding the `CI-syntax-only` label at PR creation does not get detected by the workflow and the tests are still run.

~As an example, I am creating this PR using `gh` and will add the `CI-syntax-only` label. All tests (not just `tap_syntax`) will run.~ Edit: see https://github.com/Homebrew/homebrew-core/pull/66380 for an example.

To solve this issue, I was advised that I should simply re-query the pull-request labels within the actions workflow. This PR adds a step to the `tap_syntax` job that queries the GitHub API to find the list of labels that have been applied. If it doesn't find `CI-syntax-only`, it sets the `run-tests` output to true. The `tests` job will only run if the `run-tests` output is present.

I've tested this PR using a modified workflow in a test repo. You can see an example of the tests running (i.e. no `CI-syntax-only` label) in https://github.com/Rylan12/gh-pr-creation-test/pull/12 and an example of the tests being skipped (i.e. the `CI-syntax-only` label is present) in https://github.com/Rylan12/gh-pr-creation-test/pull/13. Note that in these tests, the `get-labels` job is equivalent to our `tap_syntax` job and the `post-comment` job is equivalent to our `tests` job. Running the tests is indicated by an automated comment being added to the PR. Skipping the tests is indicated by no comment.
