### PR TITLE
Testing gh pr create with labels

### DIFF
--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -6,6 +6,7 @@ class YoutubeDl < Formula
   url "https://files.pythonhosted.org/packages/96/50/a91e7e398c359fd01293f82298d903fea182b744f98682e772b6f8d1ae3c/youtube_dl-2020.12.7.tar.gz"
   sha256 "bd127c3251a8e9f7a0eb18e4bbcf98409c0365354f735c985325bc19af669a24"
   license "Unlicense"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is just a PR to test the issue that I'm trying to fix in https://github.com/Homebrew/homebrew-core/pull/66379. I thought there would be an issue with PRs that were created using `gh` with the `CI-syntax-only` label.

If this PR runs _only_ the `tap_syntax` job, there is no issue and I can close both this and https://github.com/Homebrew/homebrew-core/pull/66379 (this would be strange because I know I experiencing this issue recently and I don't see any changes to the workflow that would have fixed it). If the `tap_syntax` _and_ the `test` jobs run, that indicates that there _is_ an issue that will be solved by https://github.com/Homebrew/homebrew-core/pull/66379.

**_Note: This PR should not be merged. It is just for testing_**
