### PR TITLE
Disable unmaintained formulas

### DIFF
--- a/Formula/ape.rb
+++ b/Formula/ape.rb
@@ -14,6 +14,8 @@ class Ape < Formula
     sha256 "83c7ef23309dec2e7bd4bec3ae75b6f0e04fcfecbda489c90810b6948eb3bb28" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "./build.sh"
     # The Makefile installs a configuration file in the bindir which our bot red-flags

--- a/Formula/balance.rb
+++ b/Formula/balance.rb
@@ -16,6 +16,8 @@ class Balance < Formula
     sha256 "ee916620a28cde87c90824125bf418b61eea80bc99e3aa32936e39af8acf0432" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "make"
     bin.install "balance"

--- a/Formula/bbcolors.rb
+++ b/Formula/bbcolors.rb
@@ -15,6 +15,8 @@ class Bbcolors < Formula
     sha256 "68b63b5913be9e20b8ebc726c5272e030f7572aeb6baab709a70725f632c69b1" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     bin.install "bbcolors"
   end

--- a/Formula/colorsvn.rb
+++ b/Formula/colorsvn.rb
@@ -16,6 +16,8 @@ class Colorsvn < Formula
     sha256 "2711d058fa4c892f350b6309a82f7eeb85455bc1b336afc75587c467121a553d" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/85fa66a9/colorsvn/0.3.3.patch"
     sha256 "2fa2c40e90c04971865894933346f43fc1d85b8b4ba4f1c615a0b7ab0fea6f0a"

--- a/Formula/contacts.rb
+++ b/Formula/contacts.rb
@@ -19,7 +19,7 @@ class Contacts < Formula
     sha256 "9a9c89e40f9ccf4ec45cf63414eaf31266dfc9b71dc96d8c02f7ab2b38e8f346" => :mavericks
   end
 
-  deprecate! because: :repo_archived
+  disable! date: "2020-12-08", because: :unmaintained
 
   depends_on xcode: :build
 

--- a/Formula/csv-fix.rb
+++ b/Formula/csv-fix.rb
@@ -20,6 +20,8 @@ class CsvFix < Formula
     sha256 "0b86933c8e32830d5abd0f26ef83b1a60e0254da67542b695fd50ab1e3ba2e68" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     # clang on Mt. Lion will try to build against libstdc++,
     # despite -std=gnu++0x

--- a/Formula/dnsrend.rb
+++ b/Formula/dnsrend.rb
@@ -16,6 +16,8 @@ class Dnsrend < Formula
     sha256 "d9f91e7344b0457ec4d0ab29c95a91bf91c4c8d3ee8432b4159b1818785c043f" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   resource "Net::Pcap" do
     url "https://cpan.metacpan.org/authors/id/S/SA/SAPER/Net-Pcap-0.17.tar.gz"
     sha256 "aaee41ebea17924abdc2d683ec940b3e6b0dc1e5e344178395f57774746a5452"

--- a/Formula/drip.rb
+++ b/Formula/drip.rb
@@ -16,7 +16,7 @@ class Drip < Formula
     sha256 "69207c24aa1f8e6ba406e6cc3f811cd7000ee14c713cc32b49d72f2c76a702bc" => :mavericks
   end
 
-  deprecate! because: :does_not_build
+  disable! date: "2020-12-08", because: :unmaintained
 
   depends_on "openjdk@8"
 

--- a/Formula/dupseek.rb
+++ b/Formula/dupseek.rb
@@ -15,6 +15,8 @@ class Dupseek < Formula
     sha256 "ff34b6c5ac5fcf84bf532008fb5fd2b2cfd9db7736854efb09e451e54b370c37" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     bin.install "dupseek"
     doc.install %w[changelog.txt doc.txt copyright credits.txt]

--- a/Formula/es.rb
+++ b/Formula/es.rb
@@ -16,6 +16,8 @@ class Es < Formula
     sha256 "14f203383d01f581bdb63e7240ff57d1174553467314351d49ea41d3052148f9" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "./configure", "--prefix=#{prefix}", "--with-editline"
     system "make"

--- a/Formula/eventlog.rb
+++ b/Formula/eventlog.rb
@@ -16,6 +16,8 @@ class Eventlog < Formula
     sha256 "9d747019f60dfa8fc13472815c18c20c46c2cb2cd53dd754a99e8029afb85cbf" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/flasm.rb
+++ b/Formula/flasm.rb
@@ -16,6 +16,8 @@ class Flasm < Formula
     sha256 "73568b00e6ecdde3baa228ef27e2c43a4879cb15bfd3d0ca036510a5d2dcbd3a" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"
     bin.install "flasm"

--- a/Formula/fondu.rb
+++ b/Formula/fondu.rb
@@ -16,6 +16,8 @@ class Fondu < Formula
     sha256 "cc8bb3c5213b0b792929fa1658077da60717993f0dbdaa56c0fe6004930309f4" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   conflicts_with "cspice", because: "both install `tobin` binaries"
 
   resource "cminch.ttf" do

--- a/Formula/gf-complete.rb
+++ b/Formula/gf-complete.rb
@@ -15,6 +15,8 @@ class GfComplete < Formula
     sha256 "9f82edf4ac3d0207b91075dbc7656ab21f6ab82b7df12053bdbcbf9886109cd3" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/git-sh.rb
+++ b/Formula/git-sh.rb
@@ -17,6 +17,8 @@ class GitSh < Formula
     sha256 "1b9aa141f32145516db62304dda799611e1fc35ec57275ee75bf566325a6bfa5" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "make"
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/henplus.rb
+++ b/Formula/henplus.rb
@@ -17,6 +17,8 @@ class Henplus < Formula
     sha256 "21f7ee166b94b30dd78cee8a6757fecd285544b8b12b332db9141e6a94eb29a7" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   deprecate! because: :does_not_build
 
   depends_on "ant" => :build

--- a/Formula/httptunnel.rb
+++ b/Formula/httptunnel.rb
@@ -18,6 +18,8 @@ class Httptunnel < Formula
     sha256 "cd8ea90f49b98d3cbe213bfd750eb0a095d06a19a4705a9e7e08b153571c27a9" => :mojave
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 

--- a/Formula/kakasi.rb
+++ b/Formula/kakasi.rb
@@ -15,6 +15,8 @@ class Kakasi < Formula
     sha256 "86403b2e2a45e2ea81b78bbe7edc7bf2b01d464f351ea265441413e63bf85822" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/l-smash.rb
+++ b/Formula/l-smash.rb
@@ -19,6 +19,8 @@ class LSmash < Formula
     sha256 "78c5c52a90e1609694b43a45240126515f97be8a1d129a57215d4a7ba9e3717f" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   # failed to upgrade since 02-11-2018
   # https://github.com/l-smash/l-smash/issues/80
   disable! because: "is unable to be upgraded, necessary patches not merged upstream"

--- a/Formula/libbind.rb
+++ b/Formula/libbind.rb
@@ -16,6 +16,8 @@ class Libbind < Formula
     sha256 "f59cf59e14f6192c962592a4411391413d929c8dfff81fdd8b4a82ce7c0d3f02" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make" # You need to call make, before you can call make install

--- a/Formula/libpuzzle.rb
+++ b/Formula/libpuzzle.rb
@@ -17,6 +17,8 @@ class Libpuzzle < Formula
     sha256 "ed3d860aa40203a73921fc7f6919828599a28fb39e2d95f0c963ae4eb5c7811b" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   depends_on "gd"
 
   def install

--- a/Formula/libvbucket.rb
+++ b/Formula/libvbucket.rb
@@ -17,6 +17,8 @@ class Libvbucket < Formula
     sha256 "920f0656e62f10e6fc6649b0edc4a6f46dc196f931b7c14833608d9e926a4d09" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/m2c.rb
+++ b/Formula/m2c.rb
@@ -21,6 +21,8 @@ class M2c < Formula
     sha256 "7bf62153eeb0976851785db04e1319f745709294aa9d0bc99e47ffee3eba1315" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   # Hacks purely for this 0.7 release. Git head already fixes installation glitches.
   # Will remove hacks on release of next version.
   def install

--- a/Formula/makeicns.rb
+++ b/Formula/makeicns.rb
@@ -20,6 +20,8 @@ class Makeicns < Formula
     sha256 "8c54ce9e5f819dda4eb274f8bf8a22d49e1d0086e33300f236840acf1a46837f" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/e59da9d/makeicns/patch-IconFamily.m.diff"
     sha256 "f5ddbf6a688d6f153cf6fc2e15e75309adaf61677ab423cb67351e4fbb26066e"

--- a/Formula/makepp.rb
+++ b/Formula/makepp.rb
@@ -20,6 +20,8 @@ class Makepp < Formula
     sha256 "d54e884aac7589f363d2c67920c87861878777a59771cd2457ed86053cf6e6b8" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
     system "make", "install"

--- a/Formula/marst.rb
+++ b/Formula/marst.rb
@@ -21,6 +21,8 @@ class Marst < Formula
     sha256 "7fddf8023d17c4bfcb6fc4141c6202b3e856ee2ecd684236daef058592b79335" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/mboxgrep.rb
+++ b/Formula/mboxgrep.rb
@@ -20,6 +20,8 @@ class Mboxgrep < Formula
     sha256 "bb5cefa83e2fb8b37dac858f3119aedb338b29e0eb2715cbff08b4644689ad86" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   depends_on "pcre"
 
   def install

--- a/Formula/md.rb
+++ b/Formula/md.rb
@@ -16,7 +16,7 @@ class Md < Formula
   end
 
   # https://github.com/Homebrew/homebrew-core/pull/66347#issuecomment-739548996
-  disable! because: :unmaintained
+  disable! date: "2020-12-08", because: :unmaintained
 
   def install
     cd "md" do

--- a/Formula/namazu.rb
+++ b/Formula/namazu.rb
@@ -16,6 +16,8 @@ class Namazu < Formula
     sha256 "ca6e854a626eaafd4ac26661b9a3db86dc9bc140f4aa98effd5843882aba7ecb" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     cd "File-MMagic" do
       system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"

--- a/Formula/num-utils.rb
+++ b/Formula/num-utils.rb
@@ -16,6 +16,8 @@ class NumUtils < Formula
     sha256 "188ff1f94691f8bf5099ec1012d4732be8fa385bf738671f86780376dd2597b9" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   conflicts_with "normalize", because: "both install `normalize` binaries"
   conflicts_with "crush-tools", because: "both install an `range` binary"
   conflicts_with "argyll-cms", because: "both install `average` binaries"

--- a/Formula/postmark.rb
+++ b/Formula/postmark.rb
@@ -15,6 +15,8 @@ class Postmark < Formula
     sha256 "2ccb3812b371bc02e66d84ff853cb9684f8941485af3287424b4c183205bc649" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system ENV.cc, "-o", "postmark", "postmark-#{version}.c"
     bin.install "postmark"

--- a/Formula/shorten.rb
+++ b/Formula/shorten.rb
@@ -15,6 +15,8 @@ class Shorten < Formula
     sha256 "a802da618fffa3eb292705140c882fcedbffae09017f0efdf69085004952a148" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/srmio.rb
+++ b/Formula/srmio.rb
@@ -17,19 +17,9 @@ class Srmio < Formula
     sha256 "d0c35e531e9defc37adc487e00a18ce46b59181bbdf74d46cbc9f5618153d5e4" => :mavericks
   end
 
-  head do
-    url "https://github.com/rclasen/srmio.git"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
+  disable! date: "2020-12-08", because: :unmaintained
 
   def install
-    if build.head?
-      chmod 0755, "genautomake.sh"
-      system "./genautomake.sh"
-    end
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/svdlibc.rb
+++ b/Formula/svdlibc.rb
@@ -17,6 +17,8 @@ class Svdlibc < Formula
     sha256 "3be9467077ff9035209957c3c8111b3a50be89cce873726119efba60856eca38" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     # make only builds - no configure or install targets, have to copy files manually
     system "make", "HOSTTYPE=target"

--- a/Formula/torrentcheck.rb
+++ b/Formula/torrentcheck.rb
@@ -19,6 +19,8 @@ class Torrentcheck < Formula
     sha256 "ed300dfc8d1f7f7fe3c9c161b8f86cc6a379c7a4cca3914bb0c665d66ec6596a" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     inreplace "torrentcheck.c", "#include <malloc.h>", ""
     system ENV.cc, "torrentcheck.c", "sha1.c", "-o", "torrentcheck", *ENV.cflags.to_s.split

--- a/Formula/udns.rb
+++ b/Formula/udns.rb
@@ -15,6 +15,8 @@ class Udns < Formula
     sha256 "d6be7acb570845e63c6ac69b8169c4ce1d5a31f5f76f60bad10168a5b13126ff" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   # Build target for dylib. See:
   # https://www.corpit.ru/pipermail/udns/2011q3/000154.html
   patch do

--- a/Formula/vavrdiasm.rb
+++ b/Formula/vavrdiasm.rb
@@ -16,6 +16,8 @@ class Vavrdiasm < Formula
     sha256 "f881c5a6d94581c4fc9efb13118c84c40700f13d130302f6ee4cb16968d1f6b0" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   # Patch:
   # - BSD `install(1)' does not have a GNU-compatible `-D' (create intermediate
   #   directories) flag. Switch to using `mkdir -p'.

--- a/Formula/whitedb.rb
+++ b/Formula/whitedb.rb
@@ -16,6 +16,8 @@ class Whitedb < Formula
     sha256 "ba756975f0dbdfa4259a5a4271414765644b0abe8c771d0c091238909f0968d2" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     # https://github.com/priitj/whitedb/issues/15
     ENV.append "CFLAGS", "-std=gnu89"

--- a/Formula/xtail.rb
+++ b/Formula/xtail.rb
@@ -15,6 +15,8 @@ class Xtail < Formula
     sha256 "939117402a33f5037aa7e49f5228e0d0b852e0e39e85d81357b8955864bd26eb" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/zdelta.rb
+++ b/Formula/zdelta.rb
@@ -16,6 +16,8 @@ class Zdelta < Formula
     sha256 "86f93c2e260d321d3bf30b34c2313d2cec5bc6d23bfb5a86cf99ab6b5f64f157" => :mavericks
   end
 
+  disable! date: "2020-12-08", because: :unmaintained
+
   def install
     system "make"
     system "make", "install", "prefix=#{prefix}"


### PR DESCRIPTION
As discussed in https://github.com/Homebrew/homebrew-core/issues/66360, a bunch of unmaintained software that doesn't build anymore *and* has very low usage