### PR TITLE
whatmask: re-run autoreconf

### DIFF
--- a/Formula/whatmask.rb
+++ b/Formula/whatmask.rb
@@ -3,7 +3,7 @@ class Whatmask < Formula
   homepage "http://www.laffeycomputer.com/whatmask.html"
   url "https://web.archive.org/web/20170107110521/downloads.laffeycomputer.com/current_builds/whatmask/whatmask-1.2.tar.gz"
   sha256 "7dca0389e22e90ec1b1c199a29838803a1ae9ab34c086a926379b79edb069d89"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +16,12 @@ class Whatmask < Formula
     sha256 "c07eb39e586dbc2b78b4c8cf8173c701ac654e4db0fd5fe12b3c7f80ee3ef577" => :mavericks
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+
   def install
+    # The included ./configure file is too old to work with Xcode 12
+    system "autoreconf", "--verbose", "--install", "--force"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--mandir=#{man}",


### PR DESCRIPTION
The `./configure` file included in the 1.2 tarball is too old to work with Xcode 12.
