### PR TITLE
Revert "tests.yml: force vendored Ruby on Catalina"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,9 +56,6 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
-      - name: Force vendored Ruby on Catalina
-        if: matrix.version == '10.15'
-        run: echo 'HOMEBREW_FORCE_VENDOR_RUBY=1' >> $GITHUB_ENV
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#66290

This will no longer be needed after https://github.com/Homebrew/brew/pull/9442 is merged.