### PR TITLE
workflows/tests: don't check labels on push events

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Check for CI-syntax-only label
       id: check-labels
       uses: actions/github-script@v3
+      if: github.event_name == 'pull_request'
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Follow up to https://github.com/Homebrew/homebrew-core/pull/66379.

The step determining labels runs on push events as well, resulting in a HTTP error (seen in [this workflow run](https://github.com/Homebrew/homebrew-core/runs/1510853542)). This PR modifies the label-detection step to only run on `pull_request` events.
