### PR TITLE
workflows/tests-linux: respect CI-syntax-only

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -19,7 +19,31 @@ on:
       - "Formula/linux-headers.rb"
       - "Formula/strace.rb"
 jobs:
+  check_labels_linux:
+    runs-on: ubuntu-latest
+    outputs:
+      run-tests: ${{ steps.check-labels.outputs.result }}
+    steps:
+      - name: Check for CI-syntax-only label
+        id: check-labels
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: { labels: labels } } = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            })
+            if (!labels.map(label => label.name).includes('CI-syntax-only')) {
+              console.log('No CI-syntax-only label found. Running tests.')
+              return true
+            }
+            console.log('CI-syntax-only label found. Skipping tests.')
+
   tests_linux:
+    needs: check_labels_linux
+    if: needs.check_labels_linux.outputs.run-tests
     runs-on: ubuntu-latest
     container:
       image: homebrew/ubuntu16.04:master


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It appears that the `tests-linux` workflow doesn't respect the `CI-syntax-only` label, so it will still run if one of the affected formulae is modified in a PR. This is an attempt to resolve the issue by applying the same `if` condition to `tests-linux` as `tests` uses.

I tested this in #66134 and I can at least say that `tests_linux` was running before (due to `libseccomp` being modified) despite the `CI-syntax-only` label and it didn't run after pushing this change to that branch. ~I haven't tested whether `tests_linux` continues to work without the `CI-syntax-only` label, so that's something worth checking.~ [Edit: The original change simply broke `tests_linux`, which is why it wasn't running.]

_Caveat emptor_, I'm not well-versed in GitHub Actions and this may have unintended consequences due to my ignorance. I'm going to request review from some related maintainers, in hopes that we properly vet this before merging.