### PR TITLE
ladspa-sdk: add livecheck

### DIFF
--- a/Formula/ladspa-sdk.rb
+++ b/Formula/ladspa-sdk.rb
@@ -5,6 +5,11 @@ class LadspaSdk < Formula
   sha256 "4229959b09d20c88c8c86f4aa76427843011705df22d9c28b38359fd1829fded"
   license "LGPL-2.1-only"
 
+  livecheck do
+    url "https://www.ladspa.org/download/"
+    regex(/href=.*?ladspa[._-]sdk[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   depends_on :linux
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `ladspa-sdk`. This PR adds a `livecheck` block that checks the download page where the `stable` archive is found.

---

This is based on the `workflows/tests-linux` change found in #66413 and I've intentionally omitted the `CI-syntax-only` label for this initial run. This is to check whether `tests_linux` continues to work properly with respect to this proposed change when the `CI-syntax-only` label isn't found on a PR. I specifically chose `ladspa-sdk` because it's one of the formulae mentioned in `workflows/tests-linux.yml` (so it should seemingly trigger `tests_linux`).

Once I've finished testing the workflow change, I'll rebase this PR without it.