### PR TITLE
hardlink: add linux-only dependency

### DIFF
--- a/Formula/hardlink.rb
+++ b/Formula/hardlink.rb
@@ -20,6 +20,10 @@ class Hardlink < Formula
   depends_on "gnu-getopt"
   depends_on "pcre"
 
+  on_linux do
+    depends_on "attr"
+  end
+
   def install
     system "make", "PREFIX=#{prefix}", "MANDIR=#{man}", "BINDIR=#{bin}", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

linuxbrew-core formula: https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/hardlink.rb