### PR TITLE
knot-resolver service fails to start

### DIFF
--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -73,13 +73,14 @@ class KnotResolver < Formula
         <key>StandardOutPath</key>
         <string>/dev/null</string>
         <key>StandardErrorPath</key>
-        <string>#{var}/log/kresd.log</string>
+        <string>#{var}/log/knot-resolver.log</string>
       </dict>
       </plist>
     EOS
   end
 
   test do
+    assert_path_exist var/"knot-resolver"
     system sbin/"kresd", "--version"
   end
 end

--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -4,8 +4,8 @@ class KnotResolver < Formula
   url "https://secure.nic.cz/files/knot-resolver/knot-resolver-5.2.0.tar.xz"
   sha256 "8824267ca3331fa06d418c1351b68c648da0af121bcbc84c6e08f5b1e28d9433"
   license all_of: ["CC0-1.0", "GPL-3.0-or-later", "LGPL-2.1-or-later", "MIT"]
-  head "https://gitlab.labs.nic.cz/knot/knot-resolver.git"
   revision 1
+  head "https://gitlab.labs.nic.cz/knot/knot-resolver.git"
 
   livecheck do
     url "https://secure.nic.cz/files/knot-resolver/"

--- a/Formula/knot-resolver.rb
+++ b/Formula/knot-resolver.rb
@@ -5,6 +5,7 @@ class KnotResolver < Formula
   sha256 "8824267ca3331fa06d418c1351b68c648da0af121bcbc84c6e08f5b1e28d9433"
   license all_of: ["CC0-1.0", "GPL-3.0-or-later", "LGPL-2.1-or-later", "MIT"]
   head "https://gitlab.labs.nic.cz/knot/knot-resolver.git"
+  revision 1
 
   livecheck do
     url "https://secure.nic.cz/files/knot-resolver/"
@@ -35,6 +36,10 @@ class KnotResolver < Formula
     end
   end
 
+  def post_install
+    (var/"knot-resolver").mkpath
+  end
+
   # DNSSEC root anchor published by IANA (https://www.iana.org/dnssec/files)
   def root_keys
     <<~EOS
@@ -53,16 +58,15 @@ class KnotResolver < Formula
         <key>Label</key>
         <string>#{plist_name}</string>
         <key>WorkingDirectory</key>
-        <string>#{var}/kresd</string>
+        <string>#{var}/knot-resolver</string>
         <key>RunAtLoad</key>
         <true/>
         <key>ProgramArguments</key>
         <array>
           <string>#{sbin}/kresd</string>
           <string>-c</string>
-          <string>#{etc}/kresd/config</string>
-          <string>-f</string>
-          <string>1</string>
+          <string>#{etc}/knot-resolver/kresd.conf</string>
+          <string>-n</string>
         </array>
         <key>StandardInPath</key>
         <string>/dev/null</string>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The paths for knot-resolver have changed from `kresd` to `knot-resolver`:

https://github.com/CZ-NIC/knot-resolver/blob/master/meson.build#L47-L62

...so the formula's LaunchDaemon crashes. (`brew services list` still shows `knot-resolver` as started, however.) This corrects the file references in the `plist`.

## Re-creating the bug

1. `brew install knot-resolver`
1. `tail -f /var/log/system.log`
1. `sudo brew services start knot-resolver`.
  `system.log` will show a failure:
  `Service could not initialize: Unable to set current working directory. error = 2: No such file or directory, path = /usr/local/var/kresd: 20B29: xpcproxy + 23862 [673][E1C74752-9AA7-343F-88EA-2ADD1A373AC5]: 0x2`
  That makes sense since the `/usr/local/var/kresd` directory is never created.

This also replaces the `-f` flag in the `kresd` command with `-n` ("noninteractive mode") since [`-f` has apparently been deprecated](https://manpages.debian.org/testing/knot-resolver/kresd.8.en.html). I'm not sure if this will have some unintended consequences but it seems to work okay on my system.

`kresd` still crashes even after the formula is fixed because it tries to bind to an IPv6 address, but maybe that depends on the system? Removing IPv6 from the configuration file fixes the issue.

Should this formula publish its own kresd.conf, sans IPv6 bindings, similar to how [the knot formula publishes its own configuration](https://github.com/Homebrew/homebrew-core/blob/1a60e2e6309cd922b8dc50cd514472daa71b5fb2/Formula/knot.rb#L55-L80)?