### PR TITLE
python@3.9: find gdbm on ARM

### DIFF
--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -114,8 +114,8 @@ class PythonAT39 < Formula
       --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
     ]
 
-    cflags   = []
-    ldflags  = []
+    cflags   = ["-I#{HOMEBREW_PREFIX}/include"]
+    ldflags  = ["-L#{HOMEBREW_PREFIX}/lib"]
     cppflags = []
 
     if MacOS.sdk_path_if_needed


### PR DESCRIPTION
Without this patch, python does not find gdbm.

Yes, I know superenv should take care of this, but python does not play too well with that. But due to the code at https://github.com/python/cpython/blob/29afab6c5f656f07ac85c9b2cf089631b2557a11/setup.py#L784 the python setup code actually records the directories passed as `-I` and `-L` options in `CFLAGS` and `LDFLAGS`. So we use those to allow detection of `gdbm`, and possibly other things.

Why did it work on Intel? Because Python adds `/usr/local/{include,lib}` to its search paths anyway. But on ARM, we're not in those paths.