### PR TITLE
Re-add Catalina workaround

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,9 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
+      - name: Force vendored Ruby on Catalina
+        if: matrix.version == '10.15'
+        run: echo 'HOMEBREW_FORCE_VENDOR_RUBY=1' >> $GITHUB_ENV
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master


### PR DESCRIPTION
Reverts https://github.com/Homebrew/homebrew-core/pull/66400
Which reverted https://github.com/Homebrew/homebrew-core/pull/66290

Despite https://github.com/Homebrew/brew/pull/9442 the Catalina CI machines are still failing, so reintroducing the short-term fix  