### PR TITLE
fixes python@3.9 gdbm build on ARM Mac

### DIFF
--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -129,6 +129,8 @@ class PythonAT39 < Formula
     end
     # Avoid linking to libgcc https://mail.python.org/pipermail/python-dev/2012-February/116205.html
     args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
+    cflags << "-I#{Formula["gdbm"].opt_include}"
+    ldflags << "-L#{Formula["gdbm"].opt_lib}"
 
     # We want our readline! This is just to outsmart the detection code,
     # superenv makes cc always find includes/libs!
@@ -138,6 +140,8 @@ class PythonAT39 < Formula
 
     inreplace "setup.py" do |s|
       s.gsub! "sqlite_setup_debug = False", "sqlite_setup_debug = True"
+      s.gsub! "db_setup_debug = False", "db_setup_debug = True"
+      s.gsub! "dbm_setup_debug = False", "dbm_setup_debug = True"
       s.gsub! "for d_ in self.inc_dirs + sqlite_inc_paths:",
               "for d_ in ['#{Formula["sqlite"].opt_include}']:"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

related to https://github.com/Homebrew/homebrew-core/pull/64869

The previous issue was

```
$ brew test python@3.9
==> Testing python@3.9
==> /opt/homebrew/Cellar/python@3.9/3.9.0_4/bin/python3.9 -c import sqlite3
==> /opt/homebrew/Cellar/python@3.9/3.9.0_4/bin/python3.9 -c import _gdbm
Last 15 lines from /var/brew/Library/Logs/Homebrew/python@3.9/test.02.python3.9:
2020-12-06 16:22:26 +0100

/opt/homebrew/Cellar/python@3.9/3.9.0_4/bin/python3.9
-c
import _gdbm

Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named '_gdbm'
Error: python@3.9: failed
```

Here in this commit should fix the real issue of not being able to find /opt/homebrew/Cellar/gdbm/1.18.1_1/lib/libgdbm.dylib

Passes the brew test on my M1 mac:
```
$brew test python
==> Testing python@3.9
==> /opt/homebrew/Cellar/python@3.9/3.9.0_4/bin/python3.9 -c import sqlite3
==> /opt/homebrew/Cellar/python@3.9/3.9.0_4/bin/python3.9 -c import tkinter; root = tkinter.Tk()
==> /opt/homebrew/Cellar/python@3.9/3.9.0_4/bin/python3.9 -c import _gdbm
==> /opt/homebrew/Cellar/python@3.9/3.9.0_4/bin/python3.9 -c import zlib
==> /opt/homebrew/Cellar/python@3.9/3.9.0_4/bin/pip3 list --format=columns
```
