### PR TITLE
cups: update test

### DIFF
--- a/Formula/cups.rb
+++ b/Formula/cups.rb
@@ -27,13 +27,14 @@ class Cups < Formula
   end
 
   test do
+    port = free_port.to_s
     pid = fork do
-      exec "#{bin}/ippeveprinter", "Homebrew Test Printer"
+      exec "#{bin}/ippeveprinter", "-p", port, "Homebrew Test Printer"
     end
 
     begin
       sleep 2
-      system "#{bin}/ippfind"
+      assert_match("Homebrew Test Printer", shell_output("curl localhost:#{port}"))
     ensure
       Process.kill("TERM", pid)
       Process.wait(pid)


### PR DESCRIPTION
* use `free_port` instead of defaulting to port 8000
* fixes test on Linux without zeroconf/avahi

Ref https://github.com/Homebrew/linuxbrew-core/pull/21739

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----