### PR TITLE
ruby@2.4: deprecate!

### DIFF
--- a/Formula/ruby@2.4.rb
+++ b/Formula/ruby@2.4.rb
@@ -14,6 +14,8 @@ class RubyAT24 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2020-04-05", because: :unsupported
+
   depends_on "pkg-config" => :build
   depends_on "libyaml"
   depends_on "openssl@1.1"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
According to [the official](https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/), Ruby@2.4 was unsupported from April 5th, 2020