### PR TITLE
bash: add sha256

### DIFF
--- a/Formula/bash.rb
+++ b/Formula/bash.rb
@@ -5,6 +5,7 @@ class Bash < Formula
   mirror "https://ftpmirror.gnu.org/bash/bash-5.1.tar.gz"
   mirror "https://mirrors.kernel.org/gnu/bash/bash-5.1.tar.gz"
   mirror "https://mirrors.ocf.berkeley.edu/gnu/bash/bash-5.1.tar.gz"
+  sha256 "cc012bc860406dcf42f64431bcd3d2fa7560c02915a601aba9cd597a39329baa"
   license "GPL-3.0-or-later"
   head "https://git.savannah.gnu.org/git/bash.git"
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The checksum got removed by accident for the 5.1 update.