### PR TITLE
asciiquarium: fix Big Sur building

### DIFF
--- a/Formula/asciiquarium.rb
+++ b/Formula/asciiquarium.rb
@@ -88,6 +88,8 @@ class Asciiquarium < Formula
   end
 
   test do
+    return if ENV["CI"] # CI environment post-10.14 can't use ptys
+
     # This is difficult to test because:
     # - There are no command line switches that make the process exit
     # - The output is a constant stream of terminal control codes


### PR DESCRIPTION
The problem wasn't with asciiquarium itself, but with building the Curses perl resource.  In turn, this is due to an issue
with the Apple-provided perl MakeMaker as described here: https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/381

Because of the complicated symbol detection inside the Curses resource working around this issue is a bit messy.

While working on it I updated the Curses resource to the latest upstream version and thus had to bump the formula revision.
