### PR TITLE
extract_url: fix curses-based UI on Big Sur

### DIFF
--- a/Formula/extract_url.rb
+++ b/Formula/extract_url.rb
@@ -4,6 +4,8 @@ class ExtractUrl < Formula
   url "https://github.com/m3m0ryh0l3/extracturl/archive/v1.6.2.tar.gz"
   sha256 "5f0b568d5c9449f477527b4077d8269f1f5e6d6531dfa5eb6ca72dbacab6f336"
   license "BSD-2-Clause"
+  revision 1
+  head "https://github.com/m3m0ryh0l3/extracturl.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -17,21 +19,22 @@ class ExtractUrl < Formula
     sha256 "d16fcc4c81a2ffb7f384f104396aae674bb8f6f08d336056ab858924d545f205" => :yosemite
   end
 
+  uses_from_macos "ncurses"
   uses_from_macos "perl"
 
   resource "MIME::Parser" do
-    url "https://cpan.metacpan.org/authors/id/D/DS/DSKOLL/MIME-tools-5.508.tar.gz"
-    sha256 "adffe86cd0b045d5a1553f48e72e89b9834fbda4f334c98215995b98cb17c917"
+    url "https://cpan.metacpan.org/authors/id/D/DS/DSKOLL/MIME-tools-5.509.tar.gz"
+    sha256 "64579f0c923d81d9a2194586e47c3475519e2646e4b5c102a8920759facf6973"
   end
 
   resource "HTML::Parser" do
-    url "https://cpan.metacpan.org/authors/id/G/GA/GAAS/HTML-Parser-3.72.tar.gz"
-    sha256 "ec28c7e1d9e67c45eca197077f7cdc41ead1bb4c538c7f02a3296a4bb92f608b"
+    url "https://cpan.metacpan.org/authors/id/C/CA/CAPOEIRAB/HTML-Parser-3.75.tar.gz"
+    sha256 "ac6b5e25a8df7af54885201e91c45fb9ab6744c08cedc1a38fcc7d95d21193a9"
   end
 
   resource "Pod::Usage" do
-    url "https://cpan.metacpan.org/authors/id/M/MA/MAREKR/Pod-Usage-1.69.tar.gz"
-    sha256 "1a920c067b3c905b72291a76efcdf1935ba5423ab0187b9a5a63cfc930965132"
+    url "https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/Pod-Usage-2.01.tar.gz"
+    sha256 "d6d28ff686c9761874321c3dc22cae39f3fb0a39d64fb140c694eef74d468152"
   end
 
   resource "Env" do
@@ -40,8 +43,8 @@ class ExtractUrl < Formula
   end
 
   resource "Getopt::Long" do
-    url "https://cpan.metacpan.org/authors/id/J/JV/JV/Getopt-Long-2.49.1.tar.gz"
-    sha256 "98fad4235509aa24608d9ef895b5c60fe2acd2bca70ebdf1acaf6824e17a882f"
+    url "https://cpan.metacpan.org/authors/id/J/JV/JV/Getopt-Long-2.52.tar.gz"
+    sha256 "9dc7a7c373353d5c05efae548e7b123aa8a31d1f506eb8dbbec8f0dca77705fa"
   end
 
   resource "URI::Find" do
@@ -50,8 +53,8 @@ class ExtractUrl < Formula
   end
 
   resource "Curses" do
-    url "https://cpan.metacpan.org/authors/id/G/GI/GIRAFFED/Curses-1.36.tar.gz"
-    sha256 "a414795ba031c5918c70279fe534fee594a96ec4b0c78f44ce453090796add64"
+    url "https://cpan.metacpan.org/authors/id/G/GI/GIRAFFED/Curses-1.37.tar.gz"
+    sha256 "74707ae3ad19b35bbefda2b1d6bd31f57b40cdac8ab872171c8714c88954db20"
   end
 
   resource "Curses::UI" do
@@ -71,6 +74,39 @@ class ExtractUrl < Formula
     %w[MIME::Parser HTML::Parser Pod::Usage Env Getopt::Long Curses Curses::UI].each do |r|
       resource(r).stage do
         system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+        if (r == "Curses") && (MacOS.version >= :big_sur)
+          # Work around a 11.0 problem in MakeMaker:
+          #   https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/381
+          #
+          # This issue is that due to the changes to how libraries
+          # exist (or, rather, DON'T exist) on the filesystem, usual ways
+          # of detecting libraries do not work.  This extends even
+          # to the MakeMaker that comes bundled with Apple's own
+          # copy of perl (at least as of OS 11.0.1)
+          #
+          # The result is that Makefile.PL generates a Makefile that
+          # does not contain the expected "LDLOADLIBS = -lcurses" line.
+          # The tell is when it prints the diagnostic:
+          #   Warning (mostly harmless): No library found for -lcurses
+          # Since it doesn't find the library, it assumes no flag is needed.
+          #
+          # Normally we could probably work around this by just specifying
+          # an explicit value of LDLOADLIBS on the "make" command line,
+          # but that doesn't work here.  That is because the Makefile
+          # runs the perl script "test.syms" which then opens and re-parses
+          # "Makefile" to find these values and then uses them to introspect
+          # the system's curses library.  If it doesn't find the right
+          # value of LDLOADLIBS *inside the Makefile* it won't find any
+          # symbols and the build will end up not working.
+          #
+          # Therefore we need to actually munge "Makefile" after "Makefile.PL"
+          # runs but before "make" does
+          mk_lines = File.readlines("Makefile")
+          if mk_lines.grep(/^LDLOADLIBS\s*=/).empty?
+            mv "Makefile", "Makefile.orig"
+            File.open("Makefile", "w") { |f| f << "LDLOADLIBS = -lcurses\n" << mk_lines.join << "\n" }
+          end
+        end
         system "make"
         system "make", "install"
       end
@@ -90,5 +126,23 @@ class ExtractUrl < Formula
   test do
     (testpath/"test.txt").write("Hello World!\nhttps://www.google.com\nFoo Bar")
     assert_match "https://www.google.com", pipe_output("#{bin}/extract_url -l test.txt")
+    # Make sure that each of the sub-resources can be imported into perl.  Some like
+    # Curses are optional and extract_url will quietly try to work without them, so
+    # double check they are all there.
+    resources.each do |r|
+      system "/usr/bin/perl", "-I#{libexec}/lib", "-I#{libexec}/lib/perl5", "-e", "use #{r.name}; 0"
+    end
+    unless ENV["CI"]
+      # If called without a "-l" flag and connected to a pty it should bring up a
+      # selection menu.  The first test makes sure that the URL extraction
+      # works, so just verify that it produces some sort of curses UI.
+      require "pty"
+      ENV["TERM"] = "xterm"
+      PTY.spawn("#{bin}/extract_url", "test.txt") do |r, w, _pid|
+        w << "q\n"
+        w.close
+        assert_match "\e", r.read
+      end
+    end
   end
 end


### PR DESCRIPTION
When called *without* the `-l` option, extract_url is supposed to be a curses-based app that lets you interactively pick which URL to open.  However if there is an issue with the perl Curses library it just silently falls back to `-l` mode.

This is what was happening on Big Sur; since Curses was failing in the same weird way as in the asciiquarium Forumla (see #66485) the package appeared to build OK but the curses-based UI didn't actually work.

I'm importing the same nasty workaround I made to get asciiquarium happy.  I also added some tests that would catch if this behavior happened again -- both by testing that our perl resources actually load OK and by running the TUI in a pty.  The pty test isn't CI-friendly (at least on the post-10.14 CI environments) but the resource-loading test should give CI some decent coverage for this condition.

Also bump up the versions of the resources while I'm here, and therefore bumping the revision.