### PR TITLE
openssl@1.1 1.1.1i

### DIFF
--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -1,10 +1,10 @@
 class OpensslAT11 < Formula
   desc "Cryptography and SSL/TLS Toolkit"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-1.1.1h.tar.gz"
-  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.1.1h.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.1.1h.tar.gz"
-  sha256 "5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9"
+  url "https://www.openssl.org/source/openssl-1.1.1i.tar.gz"
+  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.1.1i.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.1.1i.tar.gz"
+  sha256 "e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242"
   license "OpenSSL"
   version_scheme 1
 
@@ -44,13 +44,6 @@ class OpensslAT11 < Formula
       url "https://cpan.metacpan.org/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.48.tar.gz"
       sha256 "94e64a630fc37e80c0ca02480dccfa5f2f4ca4b0dd4eeecc1d65acd321c68289"
     end
-  end
-
-  # Add darwin64-arm64-cc build target.
-  # See: https://github.com/openssl/openssl/pull/12369
-  patch do
-    url "https://github.com/stuartcarnie/openssl/commit/4907cf01f63cc966a40d67eb2e030c4d8eb1d528.patch?full_index=1"
-    sha256 "2c0af13764c9d52bb9e04687d430d5e2682bb877b790f089c348c8de0434ad00"
   end
 
   # SSLv2 died with 1.1.0, so no-ssl2 no longer required.


### PR DESCRIPTION
Released 2020-Dec-08
Includes a fix for [CVE-2020-1971](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1971)