### PR TITLE
cpmtools: ressurect with 2.21

### DIFF
--- a/Formula/cpmtools.rb
+++ b/Formula/cpmtools.rb
@@ -1,9 +1,9 @@
 class Cpmtools < Formula
   desc "Tools to access CP/M file systems"
   homepage "http://www.moria.de/~michael/cpmtools/"
-  url "http://www.moria.de/~michael/cpmtools/files/cpmtools-2.20.tar.gz"
-  sha256 "d8c7e78a9750994124f3aab6e461da8fa0021acc7dbad76eafbac8b0ed8279d3"
-  revision 1
+  url "http://www.moria.de/~michael/cpmtools/files/cpmtools-2.21.tar.gz"
+  sha256 "a0032a17f9350ad1a2b80dea52c94c66cb2b49dfb38e402b5df22bdc2c5029d0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 "2a7281836c39574fe905ee34110756703298b774984d6796663c55d04dee7ea2" => :mojave
@@ -12,11 +12,12 @@ class Cpmtools < Formula
     sha256 "e3fdab874e376cacefccd916de4c96bfaada75d1cc5af6f53e6bf9a625d3aa72" => :el_capitan
   end
 
-  disable! date: "2020-12-08", because: :unmaintained
-
+  depends_on "autoconf" => :build
   depends_on "libdsk"
 
   def install
+    # The ./configure script that comes with the 2.21 tarball is too old to work with Xcode 12
+    system "autoconf", "--force"
     system "./configure", "--prefix=#{prefix}", "--with-libdsk"
 
     bin.mkpath
@@ -34,14 +35,15 @@ class Cpmtools < Formula
     # copy a file into the disk image
     src = testpath/"foo"
     src.write "a" * 128
-    system "#{bin}/cpmcp", "-f", "ibm-3740", image, src, "0:foo"
+    # Note that the "-T raw" is needed to make cpmtools work correctly when linked against libdsk:
+    system "#{bin}/cpmcp", "-T", "raw", "-f", "ibm-3740", image, src, "0:foo"
 
     # check for the file in the cp/m directory
-    assert_match "foo", shell_output("#{bin}/cpmls -f ibm-3740 #{image}")
+    assert_match "foo", shell_output("#{bin}/cpmls -T raw -f ibm-3740 #{image}")
 
     # copy the file back out of the image
     dest = testpath/"bar"
-    system "#{bin}/cpmcp", "-f", "ibm-3740", image, "0:foo", dest
+    system "#{bin}/cpmcp", "-T", "raw", "-f", "ibm-3740", image, "0:foo", dest
     assert_equal src.read, dest.read
   end
 end


### PR DESCRIPTION
This was just marked deprecated, but it actually builds/runs OK

There was a previous attempt a few months ago by @alebcay to upgrade this package to 2.21 but it failed due to "brew test" failing.  (#61617)

However, I think the `brew test` failure was not due to the attempted upgrade but by @fxcoudert's removal of its "libdsk" option (#32207) which made what had been an optional component required.  However, when built in this mode you need to pass an extra `-T raw` to several utilities or they don't always work.
