### PR TITLE
tmpwatch: fix unreliable "brew test"

### DIFF
--- a/Formula/tmpwatch.rb
+++ b/Formula/tmpwatch.rb
@@ -3,7 +3,7 @@ class Tmpwatch < Formula
   homepage "https://pagure.io/tmpwatch"
   url "https://releases.pagure.org/tmpwatch/tmpwatch-2.11.tar.bz2"
   sha256 "93168112b2515bc4c7117e8113b8d91e06b79550d2194d62a0c174fe6c2aa8d4"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     cellar :any_skip_relocation
@@ -25,7 +25,7 @@ class Tmpwatch < Formula
       ten_minutes_ago = Time.new - 600
       File.utime(ten_minutes_ago, ten_minutes_ago, "a")
       system "#{sbin}/tmpwatch", "2m", Pathname.pwd
-      assert_equal %w[b c], Dir["*"]
+      assert_equal %w[b c], Dir["*"].sort
     end
   end
 end


### PR DESCRIPTION
You can't assume what order `readdir()` returns files in
