### PR TITLE
cups: use author's fork as upstream

### DIFF
--- a/Formula/cups.rb
+++ b/Formula/cups.rb
@@ -1,9 +1,12 @@
 class Cups < Formula
   desc "Common UNIX Printing System"
-  homepage "https://www.cups.org"
-  url "https://github.com/apple/cups/releases/download/v2.3.3/cups-2.3.3-source.tar.gz"
-  sha256 "261fd948bce8647b6d5cb2a1784f0c24cc52b5c4e827b71d726020bcc502f3ee"
+  homepage "https://github.com/OpenPrinting/cups"
+  url "https://github.com/OpenPrinting/cups/releases/download/v2.3.3op1/cups-2.3.3op1-source.tar.gz"
+  # This is the author's fork of CUPS. Debian have switched to this fork:
+  # https://lists.debian.org/debian-printing/2020/12/msg00006.html
+  sha256 "5cf7988081d9003f589ba173b37bc2bbf81db43bb94e5e7d3e7d4c0afb0f9bc2"
   license "Apache-2.0"
+  head "https://github.com/OpenPrinting/cups.git"
 
   bottle do
     sha256 "00bdcf0cb9e681d4e10bc7ec87eb57ccc9c63a5b76816a8545b77e454a8a0021" => :big_sur


### PR DESCRIPTION
The author of cups left Apple at the end of 2019. [1] He also nearly
single-handedly wrote and maintained cups during his time at Apple. [2]
There is far less work being done on the original repo [3] than on the
author's new fork [4].

I think we should use the author's fork as upstream, but I'm open to
hearing people's thoughts on this one.

This is a follow up to https://github.com/Homebrew/homebrew-core/pull/66463#issuecomment-740614619

[1] https://www.msweet.org/blog/2019-12-20-left-apple.html
[2] https://github.com/apple/cups/graphs/contributors
[3] https://github.com/apple/cups/commits/master
[4] https://github.com/OpenPrinting/cups/commits/master

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
