### PR TITLE
petsc-64 3.14.2 (new formula, new variant of petsc)

### DIFF
--- a/Formula/petsc-64.rb
+++ b/Formula/petsc-64.rb
@@ -1,0 +1,54 @@
+class Petsc64 < Formula
+  desc "Portable, Extensible Toolkit for Scientific Computation (real, 64 bit indeces)"
+  homepage "https://www.mcs.anl.gov/petsc/"
+  url "https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.14.2.tar.gz"
+  sha256 "87a04fd05cac20a2ec47094b7d18b96e0651257d8c768ced2ef7db270ecfb9cb"
+  license "BSD-2-Clause"
+
+  livecheck do
+    url "https://www.mcs.anl.gov/petsc/download/index.html"
+    regex(/href=.*?petsc-lite[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  depends_on "hdf5"
+  depends_on "hwloc"
+  depends_on "metis"
+  depends_on "netcdf"
+  depends_on "open-mpi"
+  depends_on "scalapack"
+  depends_on "suite-sparse"
+
+  conflicts_with "petsc", because: "petsc must be installed with either 32 bit or 64 bit indeces, not both"
+  conflicts_with "petsc-complex", because: "petsc must be installed with either real or complex support, not both"
+
+  def install
+    system "./configure", "--prefix=#{prefix}",
+                          "--with-64-bit-indices=1",
+                          "--with-debugging=0",
+                          "--with-scalar-type=real",
+                          "--with-x=0",
+                          "--CC=mpicc",
+                          "--CXX=mpicxx",
+                          "--F77=mpif77",
+                          "--FC=mpif90",
+                          "MAKEFLAGS=$MAKEFLAGS"
+    system "make", "all"
+    system "make", "install"
+
+    # Avoid references to Homebrew shims
+    rm_f lib/"petsc/conf/configure-hash"
+    inreplace lib/"petsc/conf/petscvariables", "#{HOMEBREW_SHIMS_PATH}/mac/super/", ""
+  end
+
+  test do
+    test_case = "#{share}/petsc/examples/src/ksp/ksp/tutorials/ex1.c"
+    system "mpicc", test_case, "-I#{include}", "-L#{lib}", "-lpetsc", "-o", "test"
+    output = shell_output("./test")
+    # This PETSc example prints several lines of output. The last line contains
+    # an error norm, expected to be small.
+    line = output.lines.last
+    assert_match /^Norm of error .+, Iterations/, line, "Unexpected output format"
+    error = line.split[3].to_f
+    assert (error >= 0.0 && error < 1.0e-13), "Error norm too large"
+  end
+end


### PR DESCRIPTION
For many modern scientific applications the variant of the PETSC library with 64 bit indeces is required.
The PETSC library needs to be compiled with either 32 bit or 64 bit indeces, not both.
To avoid backwards compatibility issues it is proposed a new formula instead of modifying the current `petsc` formula.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
