### PR TITLE
stress: fix download url

### DIFF
--- a/Formula/stress.rb
+++ b/Formula/stress.rb
@@ -1,10 +1,9 @@
 class Stress < Formula
   desc "Tool to impose load on and stress test a computer system"
-  homepage "https://people.seas.harvard.edu/~apw/stress/"
-  url "https://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/s/stress/stress_1.0.4.orig.tar.gz"
+  homepage "https://web.archive.org/web/20190702093856/https://people.seas.harvard.edu/~apw/stress/"
+  url "https://deb.debian.org/debian/pool/main/s/stress/stress_1.0.4.orig.tar.gz"
   sha256 "057e4fc2a7706411e1014bf172e4f94b63a12f18412378fca8684ca92408825b"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://deb.debian.org/debian/pool/main/s/stress/"


### PR DESCRIPTION
I'm sure most people are using the more modern stress-ng tool, but this old tool still builds fine as well.
