### PR TITLE
sdl: patch for CoreAudio

### DIFF
--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -36,7 +36,8 @@ class Sdl < Formula
       end
     end
 
-    # Fix audio initialization issues on Big Sur
+    # Fix audio initialization issues on Big Sur, upstream patch
+    # http://hg.libsdl.org/SDL/rev/45055c672931
     if MacOS.version >= :big_sur
       patch do
         url "http://hg.libsdl.org/SDL/raw-rev/45055c672931"

--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -2,7 +2,7 @@ class Sdl < Formula
   desc "Low-level access to audio, keyboard, mouse, joystick and graphics"
   homepage "https://www.libsdl.org/"
   license "LGPL-2.1-only"
-  revision 2
+  revision 3
 
   stable do
     url "https://www.libsdl.org/release/SDL-1.2.15.tar.gz"
@@ -33,6 +33,14 @@ class Sdl < Formula
       patch do
         url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=4288"
         sha256 "5a89ddce5deaf72348792d33e12b5f66d0dab4f9747718bb5021d3067bdab283"
+      end
+    end
+
+    # Fix audio initialization issues on Big Sur
+    if MacOS.version >= :big_sur
+      patch do
+        url "http://hg.libsdl.org/SDL/raw-rev/45055c672931"
+        sha256 "4bc838bcfe8f671e016d22d9319cb39ca94052b86ad45b805d9b4d32564ef836"
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It appears that the Big Sur SDK changed how the CoreAudio system is initialized.  Currently, if you attempt to run an application using a Big Sur version of SDL, you get an error on startup about being unable to initialize the CoreAudio system, and there's no audio output.  This is a patch from icculus which resolves that.

I couldn't find a Bugzilla entry for the issue.  Just the patch he checked into the SDL source tree, so I hope that's sufficient for documentation.