### PR TITLE
curl: enable HSTS support

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -47,6 +47,7 @@ class Curl < Formula
       --disable-debug
       --disable-dependency-tracking
       --disable-silent-rules
+      --enable-hsts
       --prefix=#{prefix}
       --with-ssl=#{openssl.opt_prefix}
       --with-ca-bundle=#{openssl.pkgetc}/cert.pem
@@ -59,7 +60,6 @@ class Curl < Formula
       --with-librtmp
       --with-libssh2
       --without-libpsl
-      --enable-hsts
     ]
 
     system "./configure", *args

--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -1,12 +1,13 @@
 class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server"
-  homepage "https://curl.haxx.se/"
-  url "https://curl.haxx.se/download/curl-7.74.0.tar.bz2"
+  homepage "https://curl.se/"
+  url "https://curl.se/download/curl-7.74.0.tar.bz2"
   sha256 "0f4d63e6681636539dc88fa8e929f934cd3a840c46e0bf28c73be11e521b77a5"
   license "curl"
+  revision 1
 
   livecheck do
-    url "https://curl.haxx.se/download/"
+    url "https://curl.se/download/"
     regex(/href=.*?curl[._-]v?(.*?)\.t/i)
   end
 

--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -59,6 +59,7 @@ class Curl < Formula
       --with-librtmp
       --with-libssh2
       --without-libpsl
+      --enable-hsts
     ]
 
     system "./configure", *args


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
* enable HSTS
* update URLs to point to the new canonical domain
