### PR TITLE
libuecc & safe-rm: fix head strategy detection

### DIFF
--- a/Formula/libuecc.rb
+++ b/Formula/libuecc.rb
@@ -3,7 +3,7 @@ class Libuecc < Formula
   homepage "https://git.universe-factory.net/libuecc/"
   url "https://git.universe-factory.net/libuecc/snapshot/libuecc-7.tar"
   sha256 "0120aee869f56289204255ba81535369816655264dd018c63969bf35b71fd707"
-  head "https://git.universe-factory.net/libuecc"
+  head "https://git.universe-factory.net/libuecc", using: :git
 
   livecheck do
     url :head

--- a/Formula/safe-rm.rb
+++ b/Formula/safe-rm.rb
@@ -4,7 +4,7 @@ class SafeRm < Formula
   url "https://launchpad.net/safe-rm/trunk/1.0.0/+download/safe-rm-1.0.0.tar.gz"
   sha256 "7258a1ed4518598cef4d478ed43ff5677023b897a8941585eddbdf63a56718f5"
   license "GPL-3.0-or-later"
-  head "https://git.launchpad.net/safe-rm"
+  head "https://git.launchpad.net/safe-rm", using: :git
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
