### PR TITLE
pike: workarounds for building on Xcode 12

### DIFF
--- a/Formula/pike.rb
+++ b/Formula/pike.rb
@@ -4,7 +4,7 @@ class Pike < Formula
   url "https://pike.lysator.liu.se/pub/pike/latest-stable/Pike-v8.0.702.tar.gz"
   sha256 "c47aad2e4f2c501c0eeea5f32a50385b46bda444f922a387a5c7754302f12a16"
   license any_of: ["GPL-2.0-only", "LGPL-2.1-only", "MPL-1.1"]
-  revision 1
+  revision 2
 
   livecheck do
     url "https://pike.lysator.liu.se/download/pub/pike/latest-stable/"

--- a/Formula/pike.rb
+++ b/Formula/pike.rb
@@ -3,6 +3,7 @@ class Pike < Formula
   homepage "https://pike.lysator.liu.se/"
   url "https://pike.lysator.liu.se/pub/pike/latest-stable/Pike-v8.0.702.tar.gz"
   sha256 "c47aad2e4f2c501c0eeea5f32a50385b46bda444f922a387a5c7754302f12a16"
+  license any_of: ["GPL-2.0-only", "LGPL-2.1-only", "MPL-1.1"]
   revision 1
 
   livecheck do
@@ -18,6 +19,7 @@ class Pike < Formula
   end
 
   depends_on "gmp"
+  depends_on "librsvg"
   depends_on "libtiff"
   depends_on "nettle"
   depends_on "pcre"
@@ -25,6 +27,9 @@ class Pike < Formula
   def install
     ENV.append "CFLAGS", "-m64"
     ENV.deparallelize
+
+    # Workaround for https://git.lysator.liu.se/pikelang/pike/-/issues/10058
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
 
     system "make", "CONFIGUREARGS='--prefix=#{prefix} --without-bundles --with-abi=64'"
 


### PR DESCRIPTION
Issue also reported upstream.

Also needed to add a dependency on "librsvg" to get it to build correctly.  This is probably just because I already had it installed so at it detected its availability but then not all of the bits made it into the sandbox.  However, there are a bunch of sub-modules that don't build with our pike install that probably *could* if we added more dependencies.  Someone with more familiarity with this package might want to add more such dependencies.