### PR TITLE
gping: add comment before livecheck block

### DIFF
--- a/Formula/gping.rb
+++ b/Formula/gping.rb
@@ -6,6 +6,10 @@ class Gping < Formula
   license "MIT"
   head "https://github.com/orf/gping.git"
 
+  # The GitHub repository has a "latest" release but it can sometimes point to
+  # a release like `v1.2.3-post`, `v1.2.3-post2`, etc. We're checking the Git
+  # tags because the author of `gping` requested that we omit `post` releases:
+  # https://github.com/Homebrew/homebrew-core/pull/66366#discussion_r537339032
   livecheck do
     url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This simply adds a comment before the `livecheck` block in the `gping` formula to explain why we're not checking the "latest" release on GitHub. This is a follow-up to #66454 (also see: #66366).