### PR TITLE
nzbget: use homebrew prefix

### DIFF
--- a/Formula/nzbget.rb
+++ b/Formula/nzbget.rb
@@ -62,12 +62,23 @@ class Nzbget < Formula
       <dict>
         <key>Label</key>
         <string>#{plist_name}</string>
+        <key>EnvironmentVariables</key>
+        <dict>
+          <key>PATH</key>
+          <string>#{HOMEBREW_PREFIX}/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        </dict>
         <key>ProgramArguments</key>
         <array>
           <string>#{opt_bin}/nzbget</string>
+          <string>-c</string>
+          <string>#{HOMEBREW_PREFIX}/etc/nzbget.conf</string>
           <string>-s</string>
           <string>-o</string>
           <string>OutputMode=Log</string>
+          <string>-o</string>
+          <string>ConfigTemplate=#{HOMEBREW_PREFIX}/opt/nzbget/share/nzbget/nzbget.conf</string>
+          <string>-o</string>
+          <string>WebDir=#{HOMEBREW_PREFIX}/opt/nzbget/share/nzbget/webui</string>
         </array>
         <key>RunAtLoad</key>
         <true/>

--- a/Formula/nzbget.rb
+++ b/Formula/nzbget.rb
@@ -3,7 +3,7 @@ class Nzbget < Formula
   homepage "https://nzbget.net/"
   url "https://github.com/nzbget/nzbget/releases/download/v21.0/nzbget-21.0-src.tar.gz"
   sha256 "65a5d58eb8f301e62cf086b72212cbf91de72316ffc19182ae45119ddd058d53"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
   head "https://github.com/nzbget/nzbget.git", branch: "develop"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This includes `HOMEBREW_PREFIX` which fixes two issues:

1. installing into a custom prefix (like `/opt/homebrew` on M1) now passes the config file path to nzbget so it launches
2. allows nzbget to find helpers like `unrar` which have been installed by brew (in `/usr/local/bin` or custom prefix)