### PR TITLE
lua@5.3: fix livecheck

### DIFF
--- a/Formula/lua@5.3.rb
+++ b/Formula/lua@5.3.rb
@@ -7,7 +7,7 @@ class LuaAT53 < Formula
 
   livecheck do
     url "https://www.lua.org/ftp/"
-    regex(/href=.*?lua[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?lua[._-]v?(5.3+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
`brew livecheck lua@5.3` currently returns a version bump to 5.4.2.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? 
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
