### PR TITLE
xcinfo 0.5.0 (new formula)

### DIFF
--- a/Formula/xcinfo.rb
+++ b/Formula/xcinfo.rb
@@ -9,9 +9,9 @@ class Xcinfo < Formula
 
   def install
     system "swift", "build",
-        "--configuration", "release",
-        "--disable-sandbox"
-    bin.install '.build/release/xcinfo'
+           "--configuration", "release",
+           "--disable-sandbox"
+    bin.install ".build/release/xcinfo"
   end
 
   test do

--- a/Formula/xcinfo.rb
+++ b/Formula/xcinfo.rb
@@ -1,0 +1,20 @@
+class Xcinfo < Formula
+  desc "Tool to get information about and install available Xcode versions"
+  homepage "https://github.com/xcodereleases/xcinfo"
+  url "https://github.com/xcodereleases/xcinfo/archive/0.5.0.tar.gz"
+  sha256 "07b6c2f5a5b6a5f3cd6d190ac16c36c5011a87f2a1da2a109ccaa909eb6bcc2c"
+  license "MIT"
+
+  depends_on xcode: "12.0"
+
+  def install
+    system "swift", "build",
+        "--configuration", "release",
+        "--disable-sandbox"
+    bin.install '.build/release/xcinfo'
+  end
+
+  test do
+    system "true"
+  end
+end

--- a/Formula/xcinfo.rb
+++ b/Formula/xcinfo.rb
@@ -15,6 +15,6 @@ class Xcinfo < Formula
   end
 
   test do
-    system "true"
+    assert_match /12.3 RC 1 \(12C33\)/, shell_output("#{bin}/xcinfo list --all --no-ansi")
   end
 end

--- a/Formula/xcinfo.rb
+++ b/Formula/xcinfo.rb
@@ -5,6 +5,7 @@ class Xcinfo < Formula
   sha256 "07b6c2f5a5b6a5f3cd6d190ac16c36c5011a87f2a1da2a109ccaa909eb6bcc2c"
   license "MIT"
 
+  depends_on macos: :catalina
   depends_on xcode: "12.0"
 
   def install

--- a/Formula/xcinfo.rb
+++ b/Formula/xcinfo.rb
@@ -5,8 +5,8 @@ class Xcinfo < Formula
   sha256 "07b6c2f5a5b6a5f3cd6d190ac16c36c5011a87f2a1da2a109ccaa909eb6bcc2c"
   license "MIT"
 
+  depends_on xcode: ["12.0", :build]
   depends_on macos: :catalina
-  depends_on xcode: "12.0"
 
   def install
     system "swift", "build",


### PR DESCRIPTION
Adds xcinfo to Homebrew. With xcinfo you can access all information available at xcodereleases.com and install available Xcode versions from Apple's Developer Portal. It also finds and lists installed Xcode applications on hard drive and you can remove them safely.