### PR TITLE
portmidi: fix build on Big Sur

### DIFF
--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -3,6 +3,7 @@ class Portmidi < Formula
   homepage "https://sourceforge.net/projects/portmedia/"
   url "https://downloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip"
   sha256 "08e9a892bd80bdb1115213fb72dc29a7bf2ff108b378180586aa65f3cfd42e0f"
+  license "MIT"
   revision 2
 
   livecheck do
@@ -19,6 +20,12 @@ class Portmidi < Formula
   end
 
   depends_on "cmake" => :build
+
+  # Do not build pmjni.
+  patch do
+    url "https://sources.debian.org/data/main/p/portmidi/1:217-6/debian/patches/13-disablejni.patch"
+    sha256 "c11ce1e8fe620d5eb850a9f1ca56506f708e37d4390f1e7edb165544f717749e"
+  end
 
   def install
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra || MacOS.version == :el_capitan
@@ -37,5 +44,23 @@ class Portmidi < Formula
 
     system "make", "-f", "pm_mac/Makefile.osx"
     system "make", "-f", "pm_mac/Makefile.osx", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <portmidi.h>
+
+      int main()
+      {
+        int count = -1;
+        count = Pm_CountDevices();
+        if(count >= 0)
+            return 0;
+        else
+            return 1;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lportmidi", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I figure out portmidi is MIT license, its SourceForge project page (https://sourceforge.net/projects/portmedia/) says it's MIT license, but its license file add additional sentence (<https://sourceforge.net/p/portmedia/code/HEAD/tree/portmidi/trunk/license.txt>) cause it looks like "Artistic-2.0". Right now I choose "MIT".

When building portmidi, it will build its tools that not include in install target. A tool "pmjni" required Java headers, and Big Sur drop `JavaVM.framework` cause build failure, add a patch to skip related tool to build. This patch should not affect dynamic library.

Also add a simple test.