### PR TITLE
dispatch-build-bottle.yml: set HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -30,6 +30,7 @@ jobs:
       PATH: '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
       GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED: 1
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: 1
     steps:
       - name: ${{github.event.inputs.formula}}
         id: print_details


### PR DESCRIPTION
When we dispatch a bottle build for a formula that has unbolted dependents, we want the build to fail: this is not a situation that should occur, unless we made a mistake when we launched the build.

Right now, it goes ahead and builds dependencies from source. Let's set `HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK=1` so it will fail instead.