### PR TITLE
fixes for libid3 on apple M1

### DIFF
--- a/Formula/libid3tag.rb
+++ b/Formula/libid3tag.rb
@@ -67,7 +67,10 @@ class Libid3tag < Formula
   end
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
+    configure_args = ["./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"]
+    configure_args << "--build=arm" if Hardware::CPU.arm?
+
+    system(*configure_args)
     system "make", "install"
 
     (lib+"pkgconfig/id3tag.pc").write pc_file


### PR DESCRIPTION
the ancient 'config.sub' script can't seem to get ahold of the correct architecture.  work around this.  open to better ways of approaching this problem.
