### PR TITLE
sshtrix: add livecheck

### DIFF
--- a/Formula/sshtrix.rb
+++ b/Formula/sshtrix.rb
@@ -5,6 +5,11 @@ class Sshtrix < Formula
   sha256 "30d1d69c1cac92836e74b8f7d0dc9d839665b4994201306c72e9929bee32e2e0"
   license "GPL-3.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?sshtrix[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "b3962b5211858eb4f6e1478665bfbb578c1f9d1c393237b841f9261aab4cdbf9" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `sshtrix`. This PR adds a `livecheck` block that checks the homepage, where the `stable` archive link is found.