### PR TITLE
lua@5.3: update livecheck regex

### DIFF
--- a/Formula/lua@5.3.rb
+++ b/Formula/lua@5.3.rb
@@ -7,7 +7,7 @@ class LuaAT53 < Formula
 
   livecheck do
     url "https://www.lua.org/ftp/"
-    regex(/href=.*?lua[._-]v?(5.3+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?lua[._-]v?(5\.3(?:\.\d+)*)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#66643 modified the `regex` in the `lua@5.3` formula's `livecheck` block to restrict matching to `5.3` releases. However, the regex has a few issues and this PR addresses those:

* Periods should be escaped (i.e., to match a period instead of anything)
* When replacing the leading `\d+` part of the captured version with the first part of a fixed version (e.g., `1`, `1.2`, etc.), be sure to remove the trailing `+`.
* When using a fixed major and minor (e.g., `1.2`), consider making further numeric parts of the version optional (i.e., `(?:\.\d+)*`).