### PR TITLE
cdrtools 3.0.2a09

### DIFF
--- a/Formula/cdrtools.rb
+++ b/Formula/cdrtools.rb
@@ -1,14 +1,15 @@
 class Cdrtools < Formula
   desc "CD/DVD/Blu-ray premastering and recording software"
   homepage "http://cdrecord.org/"
-  url "https://downloads.sourceforge.net/project/cdrtools/cdrtools-3.01.tar.bz2"
-  mirror "https://fossies.org/linux/misc/cdrtools-3.01.tar.bz2"
-  sha256 "ed282eb6276c4154ce6a0b5dee0bdb81940d0cbbfc7d03f769c4735ef5f5860f"
-  revision 1
+  url "https://downloads.sourceforge.net/project/cdrtools/alpha/cdrtools-3.02a09.tar.gz"
+  mirror "https://fossies.org/linux/misc/cdrtools-3.02a09.tar.gz"
+  sha256 "c7e4f732fb299e9b5d836629dadf5512aa5e6a5624ff438ceb1d056f4dcb07c2"
 
   livecheck do
-    url :stable
-    regex(%r{url=.*?/cdrtools[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    # For 3.0.2a we are temporarily using the "alpha" due to a long wait for release.
+    # This can go back to "url :stable" later
+    url "https://downloads.sourceforge.net/project/cdrtools/alpha"
+    regex(%r{url=.*?/cdrtools[._-]v?(\d+(?:\.\d+)+(a\d\d)?)\.t}i)
   end
 
   bottle do
@@ -27,18 +28,16 @@ class Cdrtools < Formula
   conflicts_with "dvdrtools",
     because: "both dvdrtools and cdrtools install binaries by the same name"
 
-  patch do
-    url "https://downloads.sourceforge.net/project/cdrtools/cdrtools-3.01-fix-20151126-mkisofs-isoinfo.patch"
-    sha256 "4e07a2be599c0b910ab3401744cec417dbdabf30ea867ee59030a7ad1906498b"
-  end
-
   def install
     # Speed-up the build by skipping the compilation of the profiled libraries.
     # This could be done by dropping each occurence of *_p.mk from the definition
     # of MK_FILES in every lib*/Makefile. But it is much easier to just remove all
     # lib*/*_p.mk files. The latter method produces warnings but works fine.
     rm_f Dir["lib*/*_p.mk"]
-    system "smake", "INS_BASE=#{prefix}", "INS_RBASE=#{prefix}", "install"
+    # CFLAGS is required to work around autoconf breakages as of 3.02a
+    system "smake", "INS_BASE=#{prefix}", "INS_RBASE=#{prefix}",
+           "CFLAGS=-Wno-implicit-function-declaration",
+           "install"
     # cdrtools tries to install some generic smake headers, libraries and
     # manpages, which conflict with the copies installed by smake itself
     (include/"schily").rmtree


### PR DESCRIPTION
Per the discussion at https://github.com/Homebrew/homebrew-core/issues/66360#issuecomment-742633529 lets use this supposedly "alpha" version since we've been waiting 3 years for release.  It seems to be accepted as the latest in other places.

Still needs a bit of `CFLAGS` tweaking for the autoconf bits to work on Xcode 12
