### PR TITLE
dopewars: add linux-only dependency

### DIFF
--- a/Formula/dopewars.rb
+++ b/Formula/dopewars.rb
@@ -18,6 +18,8 @@ class Dopewars < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
 
+  uses_from_macos "curl"
+
   def install
     inreplace "src/Makefile.in", "$(dopewars_DEPENDENCIES)", ""
     inreplace "auxbuild/ltmain.sh", "need_relink=yes", "need_relink=no"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
