### PR TITLE
puzzles: update livecheck

### DIFF
--- a/Formula/puzzles.rb
+++ b/Formula/puzzles.rb
@@ -7,9 +7,13 @@ class Puzzles < Formula
   sha256 "fd49aabdd7c7e521c990991dab59700a40719cca172113ac8df693afe11d284d"
   head "https://git.tartarus.org/simon/puzzles.git"
 
+  # There's no directory listing page and the homepage only lists an unversioned
+  # tarball. The Git repository doesn't report any tags when we use that. The
+  # version in the footer of the first-party documentation seems to be the only
+  # available source that's up to date (as of writing).
   livecheck do
-    url "https://www.freshports.org/games/sgt-puzzles"
-    regex(/puzzles[._-]v?(\d{6,8})\..*?\.t/i)
+    url "https://www.chiark.greenend.org.uk/~sgtatham/puzzles/doc/"
+    regex(/version v?(\d{6,8})(?:\.[a-z0-9]+)?/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `puzzles` was checking a third-party source and returning an older version as newest (`20200610` instead of `20201208`).

We were previously checking a third-party source because finding the current version on the first-party site is a puzzle itself. The tarball on the homepage doesn't have a version in the filename and there's otherwise no reference to the latest version in the page text. The Git repository in the formula also didn't return any tags when I used `git ls-remote --tags`.

The only place where I was able to find the current version is in the footer of the documentation pages (e.g., https://www.chiark.greenend.org.uk/~sgtatham/puzzles/doc/). This is better than the existing check and fixes the issue here, so I think it's our best bet for now.