### PR TITLE
libid3tag: fix arm64 build

### DIFF
--- a/Formula/libid3tag.rb
+++ b/Formula/libid3tag.rb
@@ -73,7 +73,9 @@ class Libid3tag < Formula
 
   def install
     # Run autoconf because config.{guess,sub} are outdated
-    touch "NEWS", "AUTHORS", "ChangeLog"
+    touch "NEWS"
+    touch "AUTHORS"
+    touch "ChangeLog"
     system "autoreconf", "-fiv"
 
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"

--- a/Formula/libid3tag.rb
+++ b/Formula/libid3tag.rb
@@ -72,7 +72,7 @@ class Libid3tag < Formula
   end
 
   def install
-    system "touch NEWS AUTHORS ChangeLog"
+    system "touch", "NEWS", "AUTHORS", "ChangeLog"
     system "autoreconf -fiv"
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make", "install"

--- a/Formula/libid3tag.rb
+++ b/Formula/libid3tag.rb
@@ -3,6 +3,7 @@ class Libid3tag < Formula
   homepage "https://www.underbit.com/products/mad/"
   url "https://downloads.sourceforge.net/project/mad/libid3tag/0.15.1b/libid3tag-0.15.1b.tar.gz"
   sha256 "63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151"
+  license "GPL-2.0-only"
 
   livecheck do
     url :stable
@@ -22,11 +23,11 @@ class Libid3tag < Formula
     sha256 "d832f73e16b185fed6a66d2f00199a7d76411e438854988262463f4769b40d5b" => :mavericks
   end
 
-  uses_from_macos "zlib"
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+
+  uses_from_macos "zlib"
 
   on_linux do
     depends_on "gperf"

--- a/Formula/libid3tag.rb
+++ b/Formula/libid3tag.rb
@@ -66,12 +66,13 @@ class Libid3tag < Formula
     sha256 "5e86270ebb179d82acee686700d203e90f42e82beeed455b0163d8611657d395"
   end
 
-  patch do
-    url "https://gist.githubusercontent.com/osheroff/afa7452c4512e5d045564f7cca37155f/raw/6c668888b01818865c1dc1ad6c58eeb2518116af/libid3tag_autoconf.patch"
-    sha256 "205df514ff15ab5f1d472d5603d4657e7eec38a629e7a77c2c4720565c5c7f5e"
-  end
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
 
   def install
+    system "touch NEWS AUTHORS ChangeLog"
+    system "autoreconf --install -f"
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make", "install"
 

--- a/Formula/libid3tag.rb
+++ b/Formula/libid3tag.rb
@@ -24,6 +24,10 @@ class Libid3tag < Formula
 
   uses_from_macos "zlib"
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
   on_linux do
     depends_on "gperf"
 
@@ -66,13 +70,9 @@ class Libid3tag < Formula
     sha256 "5e86270ebb179d82acee686700d203e90f42e82beeed455b0163d8611657d395"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
-
   def install
     system "touch NEWS AUTHORS ChangeLog"
-    system "autoreconf", "-fiv"
+    system "autoreconf -fiv"
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make", "install"
 

--- a/Formula/libid3tag.rb
+++ b/Formula/libid3tag.rb
@@ -72,8 +72,10 @@ class Libid3tag < Formula
   end
 
   def install
-    system "touch", "NEWS", "AUTHORS", "ChangeLog"
-    system "autoreconf -fiv"
+    # Run autoconf because config.{guess,sub} are outdated
+    touch "NEWS", "AUTHORS", "ChangeLog"
+    system "autoreconf", "-fiv"
+
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make", "install"
 

--- a/Formula/libid3tag.rb
+++ b/Formula/libid3tag.rb
@@ -66,6 +66,11 @@ class Libid3tag < Formula
     sha256 "5e86270ebb179d82acee686700d203e90f42e82beeed455b0163d8611657d395"
   end
 
+  patch do
+    url "https://gist.githubusercontent.com/osheroff/afa7452c4512e5d045564f7cca37155f/raw/6c668888b01818865c1dc1ad6c58eeb2518116af/libid3tag_autoconf.patch"
+    sha256 "205df514ff15ab5f1d472d5603d4657e7eec38a629e7a77c2c4720565c5c7f5e"
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make", "install"

--- a/Formula/libid3tag.rb
+++ b/Formula/libid3tag.rb
@@ -72,7 +72,7 @@ class Libid3tag < Formula
 
   def install
     system "touch NEWS AUTHORS ChangeLog"
-    system "autoreconf --install -f"
+    system "autoreconf", "-fiv"
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make", "install"
 


### PR DESCRIPTION
this approach will/should fix any package that gets "config.guess/ config.sub" errors during configure. In some ways I'd rather just copy the files wholesale instead of patching, but I couldn't figure out an elegant way to do that within a formula.