### PR TITLE
mariadb*: add deprecation information

### DIFF
--- a/Formula/mariadb@10.1.rb
+++ b/Formula/mariadb@10.1.rb
@@ -5,11 +5,6 @@ class MariadbAT101 < Formula
   sha256 "069d58b1e2c06bb1e6c31249eda34138f41fb8ae3dec7ecaeba8035812c87cf9"
   license "GPL-2.0-only"
 
-  livecheck do
-    url "https://downloads.mariadb.org/"
-    regex(/Download v?(10\.1(?:\.\d+)+) Stable Now/i)
-  end
-
   bottle do
     sha256 "6f47a7d1b4ad988b5a15e44b12a21774323b5dd6daf63525bebdeec98eda0599" => :big_sur
     sha256 "e1335be8a1627fec5f9f8b423b81498805f15ce3daf4169f7449eeb974094b6f" => :catalina
@@ -18,6 +13,9 @@ class MariadbAT101 < Formula
   end
 
   keg_only :versioned_formula
+
+  # See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-101/
+  deprecate! date: "2020-10-01", because: :unsupported
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/mariadb@10.2.rb
+++ b/Formula/mariadb@10.2.rb
@@ -19,6 +19,9 @@ class MariadbAT102 < Formula
 
   keg_only :versioned_formula
 
+  # See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-102/
+  deprecate! date: "2022-05-01", because: :unsupported
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "groonga"

--- a/Formula/mariadb@10.3.rb
+++ b/Formula/mariadb@10.3.rb
@@ -19,6 +19,9 @@ class MariadbAT103 < Formula
 
   keg_only :versioned_formula
 
+  # See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-103/
+  deprecate! date: "2023-05-01", because: :unsupported
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "groonga"

--- a/Formula/mariadb@10.4.rb
+++ b/Formula/mariadb@10.4.rb
@@ -19,6 +19,9 @@ class MariadbAT104 < Formula
 
   keg_only :versioned_formula
 
+  # See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-104/
+  deprecate! date: "2024-06-01", because: :unsupported
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "groonga"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In researching why `10.1` releases of `mariadb` were removed from the first-party downloads page, I noticed that it had been [recently deprecated as of 2020-10](https://mariadb.com/kb/en/changes-improvements-in-mariadb-101/). As such, I added the deprecation information and removed the `livecheck` block (so it's appropriately skipped).

The deprecation dates are mentioned on each major/minor release's "Changes and Improvements in MariaDB" page, so I also added deprecation information for the other versioned `mariadb` formulae.

Currently the `mariadb` formula uses `10.5`, which has [a deprecation date of 2025-06](https://mariadb.com/kb/en/changes-improvements-in-mariadb-105/) but I wasn't sure if we wanted to add this to the formula. On the one hand, when `10.6` is released and `mariadb.rb` is copied as `mariadb@10.5.rb`, it would already have the correct deprecation date. On the other hand, the deprecation date in the `mariadb` formula would need to be kept up to date with the current major/minor release (or commented out until the formula is versioned).

If we think that the `mariadb` formula should also have a deprecation date (for the former reason), then I'll update this PR accordingly.