### PR TITLE
gettext: build with brewed libxml2

### DIFF
--- a/Formula/gettext.rb
+++ b/Formula/gettext.rb
@@ -4,7 +4,7 @@ class Gettext < Formula
   url "https://ftp.gnu.org/gnu/gettext/gettext-0.21.tar.xz"
   mirror "https://ftpmirror.gnu.org/gettext/gettext-0.21.tar.xz"
   sha256 "d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url :stable
@@ -18,25 +18,33 @@ class Gettext < Formula
     sha256 "5ac5783e31205b92907b46bfaaa142620aea7ee3fc4d996876b0913fd2315695" => :high_sierra
   end
 
+  uses_from_macos "libxml2"
   uses_from_macos "ncurses"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--disable-debug",
-                          "--prefix=#{prefix}",
-                          "--with-included-gettext",
-                          "--with-included-glib",
-                          "--with-included-libcroco",
-                          "--with-included-libunistring",
-                          "--with-emacs",
-                          "--with-lispdir=#{elisp}",
-                          "--disable-java",
-                          "--disable-csharp",
-                          # Don't use VCS systems to create these archives
-                          "--without-git",
-                          "--without-cvs",
-                          "--without-xz"
+    args = [
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--disable-debug",
+      "--prefix=#{prefix}",
+      "--with-included-gettext",
+      "--with-included-glib",
+      "--with-included-libcroco",
+      "--with-included-libunistring",
+      "--with-included-libxml",
+      "--with-emacs",
+      "--with-lispdir=#{elisp}",
+      "--disable-java",
+      "--disable-csharp",
+      # Don't use VCS systems to create these archives
+      "--without-git",
+      "--without-cvs",
+      "--without-xz",
+    ]
+    on_linux do
+      args << "--with-libxml2-prefix=#{Formula["libxml2"].opt_prefix}"
+    end
+    system "./configure", *args
     system "make"
     ENV.deparallelize # install doesn't support multiple make jobs
     system "make", "install"


### PR DESCRIPTION
Aligns formula with linuxbrew-core and makes
sure we do not pick up a random libxml library.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
