### PR TITLE
orc-tools: Add Apache License 2.0

### DIFF
--- a/Formula/orc-tools.rb
+++ b/Formula/orc-tools.rb
@@ -3,7 +3,7 @@ class OrcTools < Formula
   homepage "https://orc.apache.org/"
   url "https://search.maven.org/remotecontent?filepath=org/apache/orc/orc-tools/1.6.5/orc-tools-1.6.5-uber.jar"
   sha256 "3e3a0a3676a5c94d51dc0a5fda072eafa6a1ac09c9831b7d592c866ac1f02d67"
-
+  license "Apache-2.0"
   bottle :unneeded
 
   def install

--- a/Formula/orc-tools.rb
+++ b/Formula/orc-tools.rb
@@ -4,6 +4,7 @@ class OrcTools < Formula
   url "https://search.maven.org/remotecontent?filepath=org/apache/orc/orc-tools/1.6.5/orc-tools-1.6.5-uber.jar"
   sha256 "3e3a0a3676a5c94d51dc0a5fda072eafa6a1ac09c9831b7d592c866ac1f02d67"
   license "Apache-2.0"
+
   bottle :unneeded
 
   def install


### PR DESCRIPTION
`orc-tools` is based on Apache ORC whose license is Apache License 2.0.
- https://github.com/apache/orc/blob/master/LICENSE