### PR TITLE
aften Fixing Apple Silicon compilation

### DIFF
--- a/Formula/aften.rb
+++ b/Formula/aften.rb
@@ -3,7 +3,7 @@ class Aften < Formula
   homepage "https://aften.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/aften/aften/0.0.8/aften-0.0.8.tar.bz2"
   sha256 "87cc847233bb92fbd5bed49e2cdd6932bb58504aeaefbfd20ecfbeb9532f0c0a"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   # Aften has moved from a version scheme like 0.07 to 0.0.8. We restrict
   # matching to versions with three parts, since a version like 0.07 is parsed
@@ -32,6 +32,10 @@ class Aften < Formula
     sha256 "949dd8ef74db1793ac6174b8d38b1c8e4c4e10fb3ffe7a15b4941fa0f1fbdc20"
   end
 
+  # The ToT actually compiles fine, but there's no official release made from that changeset.
+  # So fix the Apple Silicon compile issues.
+  patch :DATA
+
   def install
     mkdir "default" do
       system "cmake", "-DSHARED=ON", "..", *std_cmake_args
@@ -44,3 +48,30 @@ class Aften < Formula
     system "#{bin}/aften", "#{testpath}/1kHz_44100Hz_16bit_05sec.wav", "sample.ac3"
   end
 end
+__END__
+From dca9c03930d669233258c114e914a01f7c0aeb05 Mon Sep 17 00:00:00 2001
+From: jbr79 <jbr79@ef0d8562-5c19-0410-972e-841db63a069c>
+Date: Wed, 24 Sep 2008 22:02:59 +0000
+Subject: [PATCH] add fallback function for apply_simd_restrictions() on
+ non-x86/ppc
+
+git-svn-id: https://aften.svn.sourceforge.net/svnroot/aften@766 ef0d8562-5c19-0410-972e-841db63a069c
+---
+ libaften/cpu_caps.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libaften/cpu_caps.h b/libaften/cpu_caps.h
+index b7c6159..4db11f7 100644
+--- a/libaften/cpu_caps.h
++++ b/libaften/cpu_caps.h
+@@ -26,6 +26,7 @@
+ #include "ppc_cpu_caps.h"
+ #else
+ static inline void cpu_caps_detect(void){}
++static inline void apply_simd_restrictions(AftenSimdInstructions *simd_instructions){}
+ #endif
+ 
+ #endif /* CPU_CAPS_H */
+-- 
+2.24.3 (Apple Git-128)
+


### PR DESCRIPTION
- [Y] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [Y] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [Y] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Y] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Y] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes some compile issues on Apple Silicon by fixing a bug for a missing function when not SSE and not Altivec. Actually the ToT of the source project compiles fine but there is no recently released updated and there have been no source changes in the repo since 2011.