### PR TITLE
libgcrypt: fix build on Apple Silicon

### DIFF
--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -41,7 +41,7 @@ class Libgcrypt < Formula
       MachO::Tools.change_install_name("#{buildpath}/tests/.libs/random",
                                        "#{lib}/libgcrypt.20.dylib",
                                        "#{buildpath}/src/.libs/libgcrypt.20.dylib")
-      MachO.codesign!("#{buildpath}/tests/.libs/random")
+      MachO.codesign!("#{buildpath}/tests/.libs/random") if Hardware::CPU.arm?
     end
 
     system "make", "check"

--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -41,6 +41,7 @@ class Libgcrypt < Formula
       MachO::Tools.change_install_name("#{buildpath}/tests/.libs/random",
                                        "#{lib}/libgcrypt.20.dylib",
                                        "#{buildpath}/src/.libs/libgcrypt.20.dylib")
+      MachO.codesign!("#{buildpath}/tests/.libs/random")
     end
 
     system "make", "check"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`libgcrypt` fails to build on Apple Silicon at `make check` step. Log message reveals that the process `random`, one of the checks in `make check`, was killed by the OS. System log indicates that the process is killed because of invalid signature:
<img width="884" alt="random" src="https://user-images.githubusercontent.com/21075502/101892020-cb53a580-3bdd-11eb-84c1-0cfd454bbdd3.png">

The reason is that after `make` and before `make check`, a workaround procedure in Formula modified the binary `random` and broke its original code signature, so the executable was refused to run. The problem is solved by adding a step of creating an ad-hoc code signature.