### PR TITLE
rmtrash 0.0.1

### DIFF
--- a/Formula/rmtrash.rb
+++ b/Formula/rmtrash.rb
@@ -1,0 +1,17 @@
+class Rmtrash < Formula
+  desc "Command rmtrash moves directory entries to Trash on macOS"
+  homepage "https://changkun.de/s/rmtrash"
+  url "https://github.com/changkun/rmtrash/archive/v0.0.1.tar.gz"
+  sha256 "49f8034f334f46b1b5c9acbc177b43fe669036da7b1ce516faa8866aa57b9c39"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-o", "#{bin}/rmtrash"
+  end
+
+  test do
+    system "#{bin}/rmtrash", "-v"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As discussed in https://github.com/Homebrew/homebrew-core/pull/65438, the old `rmtrash` was removed recently (because of lack of response and unclear licensing), but this breaks my current workflow from setting up the environment (as a user of `rmtrash`).

To address the issue, I wrote a [new version](https://changkun.de/s/rmtrash) that is released under the MIT license and does the same job as the old `rmtrash`, hopefully this can bring the `rmtrash` command back to the core.

cc @waldyrious @SMillerDev 

