### PR TITLE
buildkit: update revision to v0.8.0 tag's commit

### DIFF
--- a/Formula/buildkit.rb
+++ b/Formula/buildkit.rb
@@ -3,7 +3,7 @@ class Buildkit < Formula
   homepage "https://github.com/moby/buildkit"
   url "https://github.com/moby/buildkit.git",
       tag:      "v0.8.0",
-      revision: "d5f179bb796e385076ec57978c08d8a4427b2f74"
+      revision: "73fe4736135645a342abc7b587bba0994cccf0f9"
   license "Apache-2.0"
   head "https://github.com/moby/buildkit.git"
 

--- a/Formula/buildkit.rb
+++ b/Formula/buildkit.rb
@@ -5,6 +5,7 @@ class Buildkit < Formula
       tag:      "v0.8.0",
       revision: "73fe4736135645a342abc7b587bba0994cccf0f9"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/moby/buildkit.git"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It appears that buildkit was retagged not long after this formula was bumped to v0.8.0 in #66110.

I'm not sure if the formula needs an additional `revision 1` to make the difference between the original v0.8.0 clear.