### PR TITLE
heppdt2 2.06.01 (new formula)

### DIFF
--- a/Formula/heppdt2.rb
+++ b/Formula/heppdt2.rb
@@ -1,0 +1,18 @@
+class Heppdt2 < Formula
+  desc "Translation for particle ID's to and from various MC generators and PDG standard"
+  homepage "https://cdcvs.fnal.gov/redmine/projects/heppdt/wiki"
+  url "https://cern.ch/lcgpackages/tarFiles/sources/HepPDT-2.06.01.tar.gz"
+  sha256 "12a1b6ffdd626603fa3b4d70f44f6e95a36f8f3b6d4fd614bac14880467a2c2e"
+  license "AFL-3.0"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    system ENV.cxx, "#{prefix}/examples/HepPDT/examMyPDT.cc", "-I#{include}", "-L#{lib}", "-lHepPDT", "-lHepPID"
+    system "./a.out"
+  end
+end


### PR DESCRIPTION
The HepPID library contains translation methods for particle ID's to and from various Monte Carlo generators and the PDG standard numbering scheme.  We realize that the generators adhere closely to the standard, but there are occasional differences.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
