### PR TITLE
aida 3.2.1 (new formula)

### DIFF
--- a/Formula/aida-header.rb
+++ b/Formula/aida-header.rb
@@ -1,0 +1,24 @@
+class AidaHeader < Formula
+  desc "Abstract Interfaces for Data Analysis define interfaces for physics analysis"
+  homepage "https://aida.freehep.org/index.thtml"
+  url "ftp://ftp.slac.stanford.edu/software/freehep/AIDA/v3.2.1/aida-3.2.1-src.tar.gz"
+  sha256 "882d351bc09e830ae2eb512a2cbf44af5a82ef8efe31fbe0d047363da8314c81"
+  license "LGPL-3.0-or-later"
+  def install
+    mkdir_p(include.to_s)
+    cp_r("src/cpp/AIDA", "#{include}/.")
+  end
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <AIDA/AIDA.h>
+
+      int main() {
+        std::cout<<"AIDA version "<<AIDA_VERSION<<std::endl;
+        return 0;
+      }
+    EOS
+
+    system ENV.cxx, "test.cpp", "-I#{include}"
+    system "./a.out"
+  end
+end

--- a/Formula/aida-header.rb
+++ b/Formula/aida-header.rb
@@ -4,9 +4,11 @@ class AidaHeader < Formula
   url "ftp://ftp.slac.stanford.edu/software/freehep/AIDA/v3.2.1/aida-3.2.1-src.tar.gz"
   sha256 "882d351bc09e830ae2eb512a2cbf44af5a82ef8efe31fbe0d047363da8314c81"
   license "LGPL-3.0-or-later"
+
   def install
     include.install "src/cpp/AIDA"
   end
+
   test do
     (testpath/"test.cpp").write <<~EOS
       #include <AIDA/AIDA.h>

--- a/Formula/aida-header.rb
+++ b/Formula/aida-header.rb
@@ -5,8 +5,7 @@ class AidaHeader < Formula
   sha256 "882d351bc09e830ae2eb512a2cbf44af5a82ef8efe31fbe0d047363da8314c81"
   license "LGPL-3.0-or-later"
   def install
-    mkdir_p(include.to_s)
-    cp_r("src/cpp/AIDA", "#{include}/.")
+    include.install "src/cpp/AIDA"
   end
   test do
     (testpath/"test.cpp").write <<~EOS
@@ -19,6 +18,6 @@ class AidaHeader < Formula
     EOS
 
     system ENV.cxx, "test.cpp", "-I#{include}"
-    system "./a.out"
+    assert_match "AIDA version 3.2.1", shell_output("./a.out")
   end
 end


### PR DESCRIPTION
Aida is a hearder only cpp package that define abstract interfaces for common physics analysis objects, such as histograms, ntuples, fitters, IO etc.. The adoption of these interfaces should make it easier for physicists to use different tools without having to learn new interfaces or change all of their code. Additional benefits will be interoperability of AIDA compliant applications (for example by making it possible for applications to exchange analysis objects via XML).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? 
Not needed actually, this is a header only package.
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
