### PR TITLE
gauche: update livecheck

### DIFF
--- a/Formula/gauche.rb
+++ b/Formula/gauche.rb
@@ -7,7 +7,7 @@ class Gauche < Formula
   livecheck do
     url :stable
     strategy :github_latest
-    regex(/Gauche-([0-9.]+)\.t/i)
+    regex(/href=.*?Gauche[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a follow-up to #66751, as I wasn't able to review before merging.

This PR updates the regex in the existing livecheck block to better adhere to our existing regex standards:

* Restrict matching to `href` attributes when targeting file names in an HTML page.
* Use `[._-]` in place of the `-` delimiter between the software name and version in the filename.
* Use the standard regex for matching versions like `1.2.3`, `v1.2.3`, etc. instead of the generic `[0-9.]+` (which doesn't adequately ensure we're matching a version like this).