### PR TITLE
godep: disable

### DIFF
--- a/Formula/cig.rb
+++ b/Formula/cig.rb
@@ -17,14 +17,17 @@ class Cig < Formula
   end
 
   depends_on "go" => :build
-  depends_on "godep" => :build
+
+  # Patch to remove godep dependency.
+  # Remove when the following PR is merged into release:
+  # https://github.com/stevenjack/cig/pull/44
+  patch do
+    url "https://github.com/stevenjack/cig/compare/2d834ee..f0e78f0.patch?full_index"
+    sha256 "3aa14ecfa057ec6aba08d6be3ea0015d9df550b4ede1c3d4eb76bdc441a59a47"
+  end
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/stevenjack").mkpath
-    ln_s buildpath, "src/github.com/stevenjack/cig"
-    system "godep", "restore"
-    system "go", "build", "-o", bin/"cig"
+    system "go", "build", *std_go_args
   end
 
   test do

--- a/Formula/godep.rb
+++ b/Formula/godep.rb
@@ -15,7 +15,7 @@ class Godep < Formula
     sha256 "ed88d3864defb8f4773327d81be0f23c154669b4025a20ed5f92647c5b145d1a" => :high_sierra
   end
 
-  deprecate! date: "2018-01-26", because: :repo_archived
+  disable! date: "2018-01-26", because: :unmaintained
 
   depends_on "go"
 

--- a/Formula/the_platinum_searcher.rb
+++ b/Formula/the_platinum_searcher.rb
@@ -17,17 +17,16 @@ class ThePlatinumSearcher < Formula
   end
 
   depends_on "go" => :build
-  depends_on "godep" => :build
+
+  # Patch to remove godep dependency. Remove when this is merged into release:
+  # https://github.com/monochromegane/the_platinum_searcher/pull/211
+  patch do
+    url "https://github.com/monochromegane/the_platinum_searcher/commit/763f368fe26fa44a12e1a37598185322aa30ba8f.patch?full_index=1"
+    sha256 "2ee0f53065663f22f3c44b30c5804e37b8cb49200a30c4513b9ef668441dd543"
+  end
 
   def install
-    ENV["GOPATH"] = buildpath
-    dir = buildpath/"src/github.com/monochromegane/the_platinum_searcher"
-    dir.install buildpath.children
-    cd dir do
-      system "godep", "restore"
-      system "go", "build", "-o", bin/"pt", ".../cmd/pt"
-      prefix.install_metafiles
-    end
+    system "go", "build", *std_go_args, "-o", bin/"pt", "./cmd/pt"
   end
 
   test do


### PR DESCRIPTION
1. Disable `godep`
2. Remove `godep` dependencies from `cig` and `the_platinum_searcher`

`godep` has been deprecated for a while now. It's time that it's disabled, as no Homebrew formulae depend on it anymore.

This should also help fix some CI failures in https://github.com/Homebrew/homebrew-core/pull/66355.

I think https://github.com/Homebrew/homebrew-core/issues/47627 is also related.