### PR TITLE
mapnik: revision bump

### DIFF
--- a/Formula/mapnik.rb
+++ b/Formula/mapnik.rb
@@ -4,7 +4,7 @@ class Mapnik < Formula
   url "https://github.com/mapnik/mapnik/releases/download/v3.0.23/mapnik-v3.0.23.tar.bz2"
   sha256 "4b1352e01f7ce25ab099e586d7ae98e0b74145a3bf94dd365cb0a2bdab3b9dc2"
   license "LGPL-2.1"
-  revision 4
+  revision 5
   head "https://github.com/mapnik/mapnik.git"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Revision bump to build bottles. The revision was bumped in #66042, but no bottles were uploaded.

My guess is that there are some other build failures here that meant bottles couldn't be created. If that's the case and they can't be resolved, we can simply decrease the revision bump from #66042 to allow the old bottles to be used.

CC: @carlocab

Edit: this may conflict with #65895. I want to see what the CI issues are then we can make a better judgment about what to do here.