### PR TITLE
gnu-prolog: switch to URL with original package

### DIFF
--- a/Formula/gnu-prolog.rb
+++ b/Formula/gnu-prolog.rb
@@ -7,6 +7,7 @@ class GnuProlog < Formula
   # for now download from GNU which still has the original 1.4.5 available:
   url "https://ftp.gnu.org/gnu/gprolog/gprolog-1.4.5.tar.gz"
   sha256 "bfdcf00e051e0628b4f9af9d6638d4fde6ad793401e58a5619d1cc6105618c7c"
+  license any_of: ["LGPL-3.0-or-later", "GPL-2.0-or-later"]
 
   livecheck do
     url :homepage

--- a/Formula/gnu-prolog.rb
+++ b/Formula/gnu-prolog.rb
@@ -1,8 +1,11 @@
 class GnuProlog < Formula
   desc "Prolog compiler with constraint solving"
   homepage "http://www.gprolog.org/"
-  url "http://www.gprolog.org/gprolog-1.4.5.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/g/gprolog/gprolog_1.4.5.orig.tar.gz"
+  # Normal download page is from the http://www.gprolog.org/, however in October 2020
+  # a slightly updated "1.4.5" version was posted there which broke the sha256 sum
+  # In the next release we can go back to using this as our official source, but
+  # for now download from GNU which still has the original 1.4.5 available:
+  url "https://ftp.gnu.org/gnu/gprolog/gprolog-1.4.5.tar.gz"
   sha256 "bfdcf00e051e0628b4f9af9d6638d4fde6ad793401e58a5619d1cc6105618c7c"
 
   livecheck do


### PR DESCRIPTION
This formula had been using the download pointed to by the project's homepage, with a fallback URL on debian.org.  Both of those were different than the sha256 expected, and were different from each other as well.

However, the version on gnu.org did match the sha256.  So what gives?

Looking at the tree tarballs it's clear that the one from debian.org isn't even close to the right size so we can rule that out immediately:
```
.rw-r--r-- 3.6M mitch  2 Oct  8:23 homepage/gprolog-1.4.5.tar.gz
.rw-r--r-- 1.1M mitch 11 Mar  2019 deb/gprolog_1.4.5.0.orig.tar.gz
.rw-r--r-- 3.6M mitch  7 Feb  2019 gnu/gprolog-1.4.5.tar.gz
```
Comparing the GNU tarball to the "homepage" tarball, it looks like recently the author pushed a couple minor changes to the project (and regenerated html documentation) while still calling it 1.4.5.  Notably:
```
--- gnu/gprolog-1.4.5/src/EnginePl/gprolog_cst.h        2018-07-13 17:28:27.000000000 +0100
+++ homepage/gprolog-1.4.5/src/EnginePl/gprolog_cst.h   2020-10-02 08:18:41.000000000 +0100
@@ -8,8 +8,8 @@
 #define PROLOG_DIALECT         "gprolog"
 #define PROLOG_NAME            "GNU Prolog"
 #define PROLOG_VERSION         "1.4.5"
-#define PROLOG_DATE            "Jul 13 2018"
-#define PROLOG_COPYRIGHT       "Copyright (C) 1999-2018 Daniel Diaz"
+#define PROLOG_DATE            "Oct  2 2020"
+#define PROLOG_COPYRIGHT       "Copyright (C) 1999-2020 Daniel Diaz"

[...]

--- gnu/gprolog-1.4.5/ChangeLog 2018-07-14 09:19:12.000000000 +0100
+++ homepage/gprolog-1.4.5/ChangeLog    2018-10-23 16:36:00.000000000 +0100
@@ -1,3 +1,7 @@
+Tue Oct 23 17:34:21 CEST 2018 <Daniel.Diaz@univ-paris1.fr>
+
+       * fix problem with old gcc (gcc < 6 does not produce PIE code by default)
+
```
I didn't see anything nefarious inserted.  Anyway, for now just switch the download URL to gnu.org so we can keep building from the source we were happy with before.

I will drop the upstream author a quick email just to be sure.