### PR TITLE
audit: add logstash url to the allowlist

### DIFF
--- a/style_exceptions/not_a_binary_url_prefix_allowlist.json
+++ b/style_exceptions/not_a_binary_url_prefix_allowlist.json
@@ -9,5 +9,6 @@
   "gcore",
   "cspice",
   "x264",
-  "vifm"
+  "vifm",
+  "logstash"
 ]


### PR DESCRIPTION
logstash recently changed their artifact format from `logstash-oss-7.9.3.tar.gz` to `logstash-oss-7.10.1-darwin-x86_64.tar.gz`

relates to #66841
