### PR TITLE
luajit: add symlink for head version

### DIFF
--- a/Formula/luajit.rb
+++ b/Formula/luajit.rb
@@ -50,6 +50,10 @@ class Luajit < Formula
     system "make", "amalg", *args
     system "make", "install", *args
 
+    # Unstable branch doesn't install symlink for luajit.
+    # This breaks tools like `luarock` who requires the `luajit` bin to be present.
+    bin.install_symlink Dir[bin/"luajit-*"].first => "luajit" if build.head?
+
     # LuaJIT doesn't automatically symlink unversioned libraries:
     # https://github.com/Homebrew/homebrew/issues/45854.
     lib.install_symlink lib/"libluajit-5.1.dylib" => "libluajit.dylib"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

New head version of neovim requires `luajit >= 2.1`.
The issue is: we cannot build latest neovim with the current head version of luajit because `/usr/local/opt/luajit/bin/luajit` does not exists.

This PR only adds a symlink when building the `HEAD` version (which does not this symlink by design, see: https://github.com/LuaJIT/LuaJIT/blob/351bb43a07eace6a5f67de7954c154566c06f2ca/Makefile#L133).

This will resolve partially this issue: neovim/neovim/issues/13529
