### PR TITLE
silicon: fix sha256 mismatch

### DIFF
--- a/Formula/silicon.rb
+++ b/Formula/silicon.rb
@@ -2,7 +2,7 @@ class Silicon < Formula
   desc "Create beautiful image of your source code"
   homepage "https://github.com/Aloxaf/silicon/"
   url "https://github.com/Aloxaf/silicon/archive/v0.4.0.tar.gz"
-  sha256 "1534b7b4b5a309cf7f79132f3cd5fd7987642735ca7845efb1ec93df685a402d"
+  sha256 "423c03d9c92cbad8f5a136abaa680e85dfa5b5f31998aab4424c335d4d99b7ab"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
Upstream report: https://github.com/Aloxaf/silicon/issues/141

**Status:** Responded at https://github.com/Aloxaf/silicon/issues/141#issuecomment-745182050

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?