### PR TITLE
logstash: fix version

### DIFF
--- a/style_exceptions/not_a_binary_url_prefix_allowlist.json
+++ b/style_exceptions/not_a_binary_url_prefix_allowlist.json
@@ -9,6 +9,5 @@
   "gcore",
   "cspice",
   "x264",
-  "vifm",
-  "logstash"
+  "vifm"
 ]


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/issues/66907

~This might be just a temporary fix, as it probably makes sense to look into why `brew` is picking up the `x86_64` part of the URL as the version.~

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?