### PR TITLE
docbook-xsl: use libxml2's xmlcatalog on linux

### DIFF
--- a/Formula/docbook-xsl.rb
+++ b/Formula/docbook-xsl.rb
@@ -60,6 +60,10 @@ class DocbookXsl < Formula
   end
 
   def post_install
+    on_linux do
+      ENV["PATH"] = "#{ENV["PATH"]}:#{Formula["libxml2"].opt_bin}"
+    end
+
     etc_catalog = etc/"xml/catalog"
     ENV["XML_CATALOG_FILES"] = etc_catalog
 
@@ -91,6 +95,10 @@ class DocbookXsl < Formula
   end
 
   test do
+    on_linux do
+      ENV["PATH"] = "#{ENV["PATH"]}:#{Formula["libxml2"].opt_bin}"
+    end
+
     system "xmlcatalog", "#{etc}/xml/catalog", "https://cdn.docbook.org/release/xsl-nons/current/"
     system "xmlcatalog", "#{etc}/xml/catalog", "https://cdn.docbook.org/release/xsl-nons/#{version}/"
     system "xmlcatalog", "#{etc}/xml/catalog", "https://cdn.docbook.org/release/xsl/current/"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Requires next `brew` release after 2.7.0, which will include https://github.com/Homebrew/brew/pull/10062 (activates `ENV` extensions for `postinstall`)