### PR TITLE
fq 0.13.4

### DIFF
--- a/Formula/fq.rb
+++ b/Formula/fq.rb
@@ -1,8 +1,8 @@
 class Fq < Formula
   desc "Brokered message queue optimized for performance"
   homepage "https://github.com/circonus-labs/fq"
-  url "https://github.com/circonus-labs/fq/archive/v0.13.0.tar.gz"
-  sha256 "01fb729a0a2257c944e6489718ce6d334f3dd3639cb8d604592c291d1bd017ea"
+  url "https://github.com/circonus-labs/fq/archive/v0.13.4.tar.gz"
+  sha256 "1ec2e6293d092c0a2b560a5bd325488d1ae11f7c571494192792abf300549420"
   license "MIT"
   head "https://github.com/circonus-labs/fq.git"
 
@@ -18,6 +18,8 @@ class Fq < Formula
   depends_on "openssl@1.1"
 
   def install
+    ENV.append_to_cflags "-DNO_BCD=1"
+    inreplace "Makefile", "-lbcd", ""
     inreplace "Makefile", "/usr/lib/dtrace", "#{lib}/dtrace"
     system "make", "PREFIX=#{prefix}"
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/fq.rb
+++ b/Formula/fq.rb
@@ -28,7 +28,7 @@ class Fq < Formula
 
   test do
     pid = fork { exec sbin/"fqd", "-D", "-c", testpath/"test.sqlite" }
-    sleep 1
+    sleep 10
     begin
       assert_match /Circonus Fq Operational Dashboard/, shell_output("curl 127.0.0.1:8765")
     ensure


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Previous attempt: #61692

`brew test fq`:

```
==> Testing fq
==> curl 127.0.0.1:8765
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (7) Failed to connect to 127.0.0.1 port 8765: Connection refused
Error: fq: failed
An exception occurred within a child process:
  Test::Unit::AssertionFailedError: <0> expected but was
<7>.
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:55:in `block in assert_block'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:1636:in `_wrap_assertion'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:53:in `assert_block'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/gems/2.6.0/gems/test-unit-3.2.9/lib/test/unit/assertions.rb:240:in `assert_equal'
/usr/local/Homebrew/Library/Homebrew/formula_assertions.rb:19:in `shell_output'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/fq.rb:33:in `block in <class:Fq>'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1871:in `block (3 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/utils.rb:504:in `with_env'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1870:in `block (2 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/formula.rb:904:in `with_logging'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1869:in `block in run_test'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:63:in `block in run'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:63:in `chdir'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:63:in `run'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2116:in `mktemp'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1863:in `run_test'
/usr/local/Homebrew/Library/Homebrew/test.rb:43:in `block in <main>'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/usr/local/Homebrew/Library/Homebrew/test.rb:42:in `<main>'
```