### PR TITLE
minizinc: remove x86 architecture restriction

### DIFF
--- a/Formula/minizinc.rb
+++ b/Formula/minizinc.rb
@@ -15,7 +15,6 @@ class Minizinc < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on arch: :x86_64
   depends_on "cbc"
   depends_on "gecode"
 


### PR DESCRIPTION
MiniZinc compiles and works correctly on ARM architectures and the project intends to support the apple ARM architecture.
The full functionality of this formula, however, is still blocked by the CBC dependency, which in turn depends on GCC.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This removes the x86 architecture restriction from the `minizinc` formula. MiniZinc compiles and works correctly on ARM architectures and the project intends to support the apple ARM architecture.

The full functionality of this formula, however, is still blocked by the CBC dependency, which in turn depends on GCC. This means that the installing and testing is not yet successful on ARM. However, the general functionality and Gecode dependency have been tested correctly. Furthermore, manual compilations of MiniZinc with clang-based compilations of CBC do seem to function correctly, so I'm convinced that once this issue is resolved MiniZinc should function as intended.

This change should not affect the Intel targets and they should still install and test correctly.