### PR TITLE
a52dec - fix for arm64 build

### DIFF
--- a/Formula/a52dec.rb
+++ b/Formula/a52dec.rb
@@ -30,6 +30,11 @@ class A52dec < Formula
       ENV.append_to_cflags "-fPIC"
     end
 
+    on_macos do
+      # Fixes duplicate symbols errors on arm64
+      ENV.append_to_cflags "-std=gnu89"
+    end
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Builds on M1 fail with duplicate symbols errors. This can be fixed by enforcing gnu89 standard. This is not required on Intel but does not break the build so I didn't limit it just for the arm64 architecture.