### PR TITLE
clozure-cl: fix build on Linux

### DIFF
--- a/Formula/clozure-cl.rb
+++ b/Formula/clozure-cl.rb
@@ -19,38 +19,70 @@ class ClozureCl < Formula
   end
 
   depends_on xcode: :build
+  depends_on macos: :catalina # The GNU assembler frontend which ships macOS 10.14 is incompatible with clozure-ccl: https://github.com/Clozure/ccl/issues/271
+
+  # Patch to build heap image with linker shipped with Big Sur.  Remove for next version.
+  on_macos do
+    if MacOS.version >= :catalina
+      patch do
+        url "https://github.com/Clozure/ccl/commit/553c0f25f38b2b0d5922ca7b4f62f09eb85ace1c.patch?full_index=1"
+        sha256 "deb9e35df75d82c1694fec569a246388485fb64ab7bae3addff6ff3650160b04"
+      end
+    end
+  end
+
+  on_linux do
+    depends_on "m4"
+  end
 
   resource "bootstrap" do
-    url "https://github.com/Clozure/ccl/releases/download/v1.12/darwinx86.tar.gz"
-    sha256 "9434fb5ebc01fc923625ad56726fdd217009e2d3c107cfa3c5435cb7692ba7ca"
+    on_macos do
+      url "https://github.com/Clozure/ccl/releases/download/v1.12/darwinx86.tar.gz"
+      sha256 "9434fb5ebc01fc923625ad56726fdd217009e2d3c107cfa3c5435cb7692ba7ca"
+    end
+
+    on_linux do
+      url "https://github.com/Clozure/ccl/releases/download/v1.12/linuxx86.tar.gz"
+      sha256 "7fbdb04fb1b19f0307c517aa5ee329cb4a21ecc0a43afd1b77531e4594638796"
+    end
   end
 
   def install
     tmpdir = Pathname.new(Dir.mktmpdir)
     tmpdir.install resource("bootstrap")
-    buildpath.install tmpdir/"dx86cl64.image"
-    buildpath.install tmpdir/"darwin-x86-headers64"
-    cd "lisp-kernel/darwinx8664" do
-      args = []
 
-      if DevelopmentTools.clang_build_version == 1100 && MacOS::CLT.installed?
-        # Xcode 11.0-11.3 assembler is broken. Try the CLT in case it is older.
-        # https://github.com/Clozure/ccl/issues/271
-        # NOTE: ccl NEEDS the system assembler - it is not compatible with Clang's
-        args << "AS=/Library/Developer/CommandLineTools/usr/bin/as"
+    on_macos do
+      buildpath.install tmpdir/"dx86cl64.image"
+      buildpath.install tmpdir/"darwin-x86-headers64"
+      cd "lisp-kernel/darwinx8664" do
+        system "make"
       end
+    end
 
-      system "make", *args
+    on_linux do
+      buildpath.install tmpdir/"lx86cl64"
+      buildpath.install tmpdir/"lx86cl64.image"
+      buildpath.install tmpdir/"x86-headers64"
     end
 
     ENV["CCL_DEFAULT_DIRECTORY"] = buildpath
 
-    system "./dx86cl64", "-n", "-l", "lib/x8664env.lisp",
-                         "-e", "(ccl:xload-level-0)",
-                         "-e", "(ccl:compile-ccl)",
-                         "-e", "(quit)"
-    (buildpath/"image").write('(ccl:save-application "dx86cl64.image")\n(quit)\n')
-    system "cat image | ./dx86cl64 -n --image-name x86-boot64.image"
+    on_macos do
+      system "./dx86cl64", "-n", "-l", "lib/x8664env.lisp",
+            "-e", "(ccl:xload-level-0)",
+            "-e", "(ccl:compile-ccl)",
+            "-e", "(quit)"
+      (buildpath/"image").write('(ccl:save-application "dx86cl64.image")\n(quit)\n')
+      system "cat image | ./dx86cl64 -n --image-name x86-boot64.image"
+    end
+
+    on_linux do
+      system "./lx86cl64", "-n", "-l", "lib/x8664env.lisp",
+            "-e", "(ccl:rebuild-ccl :full t)",
+            "-e", "(quit)"
+      (buildpath/"image").write('(ccl:save-application "lx86cl64.image")\n(quit)\n')
+      system "cat image | ./lx86cl64 -n --image-name x86-boot64"
+    end
 
     prefix.install "doc/README"
     doc.install Dir["doc/*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As discussed with @iMichka, I am upstreaming (this PR)[https://github.com/Homebrew/linuxbrew-core/pull/21805] to homebrew-core so that `clozure-cl` builds on Linux and macOS.  There is almost no overlap in commands for building on the two OSes, hence why almost everything is in `on_linux`/`on_macos` blocks.  