### PR TITLE
workflows/tests-linux: build from source.

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -57,11 +57,7 @@ jobs:
 
       - run: brew test-bot --only-cleanup-before
 
-      - name: Run brew test-bot --only-formulae
-        run: |
-          mkdir ~/bottles
-          cd ~/bottles
-          brew test-bot --only-formulae
+      - run: brew test-bot --only-formulae --build-from-source
 
       - name: Output brew test-bot --only-formulae failures
         if: always()


### PR DESCRIPTION
Now that https://github.com/Homebrew/homebrew-test-bot/pull/538 has been merged let's pass `--build-from-source` to not care about the fact that various dependencies having been built as bottles.

This will, of course, mean that bottles aren't built but they aren't currently being used anyway.

CC @homebrew/linux FYI
