### PR TITLE
scummvm 2.2.0: fixed url

### DIFF
--- a/Formula/scummvm.rb
+++ b/Formula/scummvm.rb
@@ -1,7 +1,7 @@
 class Scummvm < Formula
   desc "Graphic adventure game interpreter"
   homepage "https://www.scummvm.org/"
-  url "https://www.scummvm.org/frs/scummvm/2.2.0/scummvm-2.2.0.tar.xz"
+  url "https://downloads.scummvm.org/frs/scummvm/2.2.0/scummvm-2.2.0.tar.xz"
   sha256 "1469657e593bd8acbcfac0b839b086f640ebf120633e93f116cab652b5b27387"
   license "GPL-2.0-or-later"
   head "https://github.com/scummvm/scummvm.git"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Old URL is no longer valid and points to the project page of ScummVM. Updated the url to reflect the new location.