### PR TITLE
redis: fix build on arm64 with rosetta 2 homebrew

### DIFF
--- a/Formula/redis.rb
+++ b/Formula/redis.rb
@@ -22,7 +22,9 @@ class Redis < Formula
   depends_on "openssl@1.1"
 
   def install
-    system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}", "BUILD_TLS=yes"
+    system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}", "BUILD_TLS=yes",
+      "OPENSSL_CFLAGS=-I#{Formula["openssl@1.1"].include}",
+      "OPENSSL_LDFLAGS=-L#{Formula["openssl@1.1"].lib}"
 
     %w[run db/redis log].each { |p| (var/p).mkpath }
 


### PR DESCRIPTION
This fixes a build error for arm64 darwin in /opt/homebrew, when there is also an intel rosetta 2 homebrew in /usr/local that contains openssl.

The fix is needed because redis hardcodes the following values for Darwin in `src/Makefile`:

```
OPENSSL_CFLAGS=-I/usr/local/opt/openssl/include
OPENSSL_LDFLAGS=-L/usr/local/opt/openssl/lib
```

Since these are prepended when calling cc they take precedence over the flags injected by brew during build/install.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
