### PR TITLE
zbar: use GraphicsMagick instead of ImageMagick

### DIFF
--- a/Formula/zbar.rb
+++ b/Formula/zbar.rb
@@ -26,7 +26,7 @@ class Zbar < Formula
   depends_on "pkg-config" => :build
   depends_on "xmlto" => :build
   depends_on "freetype"
-  depends_on "imagemagick"
+  depends_on "graphicsmagick"
   depends_on "jpeg"
   depends_on "libtool"
   depends_on "ufraw"
@@ -43,6 +43,8 @@ class Zbar < Formula
       --disable-video
       --without-gtk
       --without-x
+      --with-graphicsmagick
+      --disable-nls
     ]
 
     system "./configure", *args


### PR DESCRIPTION
GraphicsMagick is a fork of ImageMagicks which has proven to be better than the latter since.
When using GraphicsMagick instead, I've noticed that Zbar produces better results (at least for TIFF files decoding).
Therefore, I recommend using it.

NOTE: I've added `--disable-nls` because I got an error at libintl (gettext) linking. Feel free to remove it if possible.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
