### PR TITLE
forego: fix build with go 1.16 (HEAD)

### DIFF
--- a/Formula/forego.rb
+++ b/Formula/forego.rb
@@ -20,6 +20,7 @@ class Forego < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "off"
     (buildpath/"src/github.com/ddollar/forego").install buildpath.children
     cd "src/github.com/ddollar/forego" do
       system "go", "build", "-o", bin/"forego", "-ldflags",


### PR DESCRIPTION
Go 1.16 changes the defaults for modules, so we need to explicitly disable module mode or the build will ask to convert from godeps to a go module and fail.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
