### PR TITLE
krb5: add Linux-only dependency

### DIFF
--- a/Formula/krb5.rb
+++ b/Formula/krb5.rb
@@ -23,6 +23,10 @@ class Krb5 < Formula
 
   uses_from_macos "bison"
 
+  on_linux do
+    depends_on "gettext"
+  end
+
   def install
     cd "src" do
       # Newer versions of clang are very picky about missing includes.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Linuxbrew formula: https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/krb5.rb