### PR TITLE
libffi: move lib64/* to lib/ on Linux

### DIFF
--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -35,6 +35,15 @@ class Libffi < Formula
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", *extra_args
     system "make", "install"
+
+    # Move lib64/* to lib/ on Linux
+    on_linux do
+      lib64 = Pathname.new "#{lib}64"
+      if lib64.directory?
+        mv Dir[lib64/"*"], lib
+        rmdir lib64
+      end
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
