### PR TITLE
flow-cli v0.12.1 (new formula)

### DIFF
--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -1,0 +1,19 @@
+class FlowCli < Formula
+  desc "Command-line interface that provides utilities for building Flow applications"
+  homepage "https://onflow.org"
+  url "https://github.com/onflow/flow-cli/archive/v0.12.1.tar.gz"
+  sha256 "ad231ca19296ca65522eb71115900c9bd6918335caafef5913689acc1ec7effe"
+  license "Apache-2.0"
+  head "https://github.com/onflow/flow-cli.git"
+
+  depends_on "go@1.14" => :build
+
+  def install
+    system "make", "cmd/flow/flow", "VERSION=v0.12.1"
+    bin.install "cmd/flow/flow"
+  end
+
+  test do
+    system "#{bin}/flow", "version"
+  end
+end

--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -14,6 +14,11 @@ class FlowCli < Formula
   end
 
   test do
-    system "#{bin}/flow", "version"
+    (testpath/"hello.cdc").write <<~EOS
+      pub fun main() {
+        log("Hello, world!")
+      }
+    EOS
+    system "#{bin}/flow", "cadence", "hello.cdc"
   end
 end

--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -6,7 +6,7 @@ class FlowCli < Formula
   license "Apache-2.0"
   head "https://github.com/onflow/flow-cli.git"
 
-  depends_on "go@1.14" => :build
+  depends_on "go" => :build
 
   def install
     system "make", "cmd/flow/flow", "VERSION=v0.12.1"

--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -9,7 +9,7 @@ class FlowCli < Formula
   depends_on "go" => :build
 
   def install
-    system "make", "cmd/flow/flow", "VERSION=v0.12.1"
+    system "make", "cmd/flow/flow", "VERSION=v#{version}"
     bin.install "cmd/flow/flow"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [Flow CLI](https://github.com/onflow/flow-cli) is now open-source. It provides utilities for developing applications on [Flow](https://onflow.org), such as the [Flow Emulator](https://github.com/onflow/flow-emulator/), and the [Cadence](https://github.com/onflow/cadence) language server, and commands to send transactions, run scripts, etc.

The Cadence stand-alone CLI [had already been added](https://github.com/Homebrew/homebrew-core/pull/57981) to Homebrew before.

