### PR TITLE
sdl2: Add patch to make `make install` work

### DIFF
--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -22,7 +22,7 @@ class Sdl2 < Formula
       sha256 "df68efb43e451789c1bf2873dabc9a70c66264f8b7ad360a71ea4c643c6acc37"
     end
 
-    # Fix make install command.
+    # Fix make install command. Patch should be removed when updating to next version.
     # https://bugzilla.libsdl.org/show_bug.cgi?id=5399
     patch do
       url "https://hg.libsdl.org/SDL/raw-rev/cf83f816421c"

--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -21,6 +21,13 @@ class Sdl2 < Formula
       url "https://hg.libsdl.org/SDL/raw-rev/af22dd6c0787"
       sha256 "df68efb43e451789c1bf2873dabc9a70c66264f8b7ad360a71ea4c643c6acc37"
     end
+
+    # Fix make install command.
+    # https://bugzilla.libsdl.org/show_bug.cgi?id=5399
+    patch do
+      url "https://hg.libsdl.org/SDL/raw-rev/cf83f816421c"
+      sha256 "6a5979e05872d2d86df2cab5db30489ba2e7c743596c8c3ed0c4a2f2969f3970"
+    end
   end
 
   livecheck do


### PR DESCRIPTION
Without this patch, it's impossible to install the package sdl2 from source.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
