### PR TITLE
neko: fix Xcode 12 issues

### DIFF
--- a/Formula/neko.rb
+++ b/Formula/neko.rb
@@ -4,7 +4,7 @@ class Neko < Formula
   url "https://github.com/HaxeFoundation/neko/archive/v2-3-0/neko-2.3.0.tar.gz"
   sha256 "850e7e317bdaf24ed652efeff89c1cb21380ca19f20e68a296c84f6bad4ee995"
   license "MIT"
-  revision 3
+  revision 4
   head "https://github.com/HaxeFoundation/neko.git"
 
   bottle do
@@ -21,14 +21,46 @@ class Neko < Formula
   depends_on "openssl@1.1"
   depends_on "pcre"
 
+  uses_from_macos "sqlite"
+  uses_from_macos "zlib"
+
+  # Don't redefine MSG_NOSIGNAL -- https://github.com/HaxeFoundation/neko/pull/217
+  patch do
+    url "https://github.com/HaxeFoundation/neko/commit/24a5e8658a104ae0f3afe66ef1906bb7ef474bfa.patch?full_index=1"
+    sha256 "1a707e44b7c1596c4514e896211356d1b35d4e4b578b14b61169a7be47e91ccc"
+  end
+
+  # Fix -Wimplicit-function-declaration issue in libs/ui/ui.c
+  # https://github.com/HaxeFoundation/neko/pull/218
+  patch do
+    url "https://github.com/HaxeFoundation/neko/commit/908149f06db782f6f1aa35723d6a403472a2d830.patch?full_index=1"
+    sha256 "3e9605cccf56a2bdc49ff6812eb56f3baeb58e5359601a8215d1b704212d2abb"
+  end
+
+  # Fix -Wimplicit-function-declaration issue in libs/std/process.c
+  # https://github.com/HaxeFoundation/neko/pull/219
+  patch do
+    url "https://github.com/HaxeFoundation/neko/commit/1a4bfc62122aef27ce4bf27122ed6064399efdc4.patch?full_index=1"
+    sha256 "7fbe2f67e076efa2d7aa200456d4e5cc1e06d21f78ac5f2eed183f3fcce5db96"
+  end
+
   def install
     inreplace "libs/mysql/CMakeLists.txt",
               %r{https://downloads.mariadb.org/f/},
               "https://downloads.mariadb.com/Connectors/c/"
 
-    # Workaround for Xcode/Clang 12. Tracking issue:
-    # https://github.com/HaxeFoundation/neko/issues/215
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Workaround issue where lock_acquire(), lock_try(), and lock_release()
+    # conflict with some symbols in Mach headers:
+    #   https://github.com/HaxeFoundation/neko/issues/215#issuecomment-745617663
+    inreplace %w[vm/neko.h.in vm/others.c vm/threads.c libs/ui/ui.c], /\slock_/, " HOMEBREW_lock_"
+
+    # Work around for https://github.com/HaxeFoundation/neko/issues/216 where
+    # maria-connector fails to detect the location of iconv.dylib on Big Sur.
+    # Also, no reason for maria-connector to compile its own version of zlib,
+    # just link against the system copy.
+    inreplace "libs/mysql/CMakeLists.txt",
+              "-Wno-dev",
+              "-Wno-dev -DICONV_LIBRARIES=-liconv -DICONV_INCLUDE_DIR= -DWITH_EXTERNAL_ZLIB=1"
 
     # Let cmake download its own copy of MariaDBConnector during build and statically link it.
     # It is because there is no easy way to define we just need any one of mariadb, mariadb-connector-c,


### PR DESCRIPTION
This removes the $CFLAGS workaround in preference for some upstreamed patches.  However there are still a couple other issues that were preventing successful compilation on Xcode 12 which I've fixed.

I also bumped `revision` because the `MSG_NOSIGNAL` change might be a legitimate bug fix.