### PR TITLE
cloog: avoid /dev/stdin in "brew test"

### DIFF
--- a/Formula/cloog.rb
+++ b/Formula/cloog.rb
@@ -49,7 +49,7 @@ class Cloog < Formula
   end
 
   test do
-    cloog_source = <<~EOS
+    (testpath/"test.cloog").write <<~EOS
       c
 
       0 2
@@ -65,7 +65,7 @@ class Cloog < Formula
       0
     EOS
 
-    output = pipe_output("#{bin}/cloog /dev/stdin", cloog_source)
-    assert_match %r{Generated from /dev/stdin by CLooG}, output
+    assert_match %r{Generated from #{testpath}/test.cloog by CLooG},
+                 pipe_output("#{bin}/cloog #{testpath}/test.cloog")
   end
 end

--- a/Formula/cloog.rb
+++ b/Formula/cloog.rb
@@ -66,6 +66,6 @@ class Cloog < Formula
     EOS
 
     assert_match %r{Generated from #{testpath}/test.cloog by CLooG},
-                 pipe_output("#{bin}/cloog #{testpath}/test.cloog")
+                 shell_output("#{bin}/cloog #{testpath}/test.cloog")
   end
 end


### PR DESCRIPTION
The test runs find manually, but I am guessing that CI didn't like that which resulted in the Big Sur rebottling failure.

This is just an educated guess, but we've seen a lot of CI issues with pty-using tests, so maybe `/dev/stdin` is problematic as well?
