### PR TITLE
libvnc 0.9.13 (new formula)

### DIFF
--- a/Formula/libvnc.rb
+++ b/Formula/libvnc.rb
@@ -1,0 +1,32 @@
+class Libvnc < Formula
+  desc "Cross-platform C libraries for easy implementation of VNC server or client"
+  homepage "https://libvnc.github.io/"
+  url "https://github.com/LibVNC/libvncserver/archive/LibVNCServer-0.9.13.tar.gz"
+  sha256 "0ae5bb9175dc0a602fe85c1cf591ac47ee5247b87f2bf164c16b05f87cbfa81a"
+  license "GPL-2.0-only"
+  head "https://github.com/LibVNC/libvncserver.git"
+
+  depends_on "cmake" => :build
+  depends_on "jpeg-turbo"
+  depends_on "libpng"
+  depends_on "lzo"
+  depends_on "openssl@1.1"
+  depends_on "sdl2"
+
+  def install
+    args = std_cmake_args
+    args << "-DWITH_OPENSSL=ON"
+    args << "-DWITH_GCRYPT=OFF"
+    args << "-DWITH_GNUTLS=OFF"
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make", "install"
+    end
+    pkgshare.install "examples"
+  end
+
+  test do
+    system ENV.cc, "-o", "test", pkgshare/"examples/example.c",
+     "-L#{lib}", "-lvncserver"
+  end
+end


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The GH repo, Debian/Ubuntu and ArchLinux source packages are called `libvncserver`, but in project description there is a state `LibVNCServer/LibVNCClient`, so I reduced it to `libvnc`.