### PR TITLE
mysql@5.7: update livecheck

### DIFF
--- a/Formula/mysql@5.7.rb
+++ b/Formula/mysql@5.7.rb
@@ -6,8 +6,8 @@ class MysqlAT57 < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://dev.mysql.com/downloads/mysql/5.7.html"
-    regex(/href=.*?mysql[._-]v?(\d+.\d+.\d+)-/i)
+    url "https://dev.mysql.com/downloads/mysql/5.7.html?tpl=files&os=src&version=5.7"
+    regex(/href=.*?mysql[._-](?:boost[._-])?v?(5\.7(?:\.\d+)*)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `mysql@5.7` was failing with `Unable to get versions`, as the format of the page we were checking evidently changed since the regex was originally written. This updates the `url` to include query string parameters that gets us to a page with the latest tarball names (no direct URLs, though) and updates the `regex` accordingly.

This PR aligns `mysql@5.7` with the recent `livecheck` block update for `mysql@5.6` in #66994.