### PR TITLE
jetty/jetty-runner: update livecheck

### DIFF
--- a/Formula/jetty-runner.rb
+++ b/Formula/jetty-runner.rb
@@ -7,7 +7,7 @@ class JettyRunner < Formula
   license any_of: ["Apache-2.0", "EPL-1.0"]
 
   livecheck do
-    url "https://www.eclipse.org/jetty/download.html"
+    url "https://www.eclipse.org/jetty/download.php"
     regex(/href=.*?jetty-distribution[._-]v?(\d+(?:\.\d+)+(?:\.v\d+)?)\.t/i)
   end
 

--- a/Formula/jetty.rb
+++ b/Formula/jetty.rb
@@ -7,7 +7,7 @@ class Jetty < Formula
   license any_of: ["Apache-2.0", "EPL-1.0"]
 
   livecheck do
-    url "https://www.eclipse.org/jetty/download.html"
+    url "https://www.eclipse.org/jetty/download.php"
     regex(/href=.*?jetty-distribution[._-]v?(\d+(?:\.\d+)+(?:\.v\d+)?)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [download page `url`](https://www.eclipse.org/jetty/download.html) in the existing `livecheck` blocks for `jetty` and `jetty-runner` was returning a `200` response but no versions were found because response only contained the following HTML:

```html
<meta http-equiv="Refresh" content="0; url=./download.php" />
```

This works fine in browsers but we need a response with a `location` header to be able to automatically follow a redirection in livecheck (unfortunately not the case here).

This PR resolves the issue by updating the `url` in these `livecheck` blocks to use the new [download page URL](https://www.eclipse.org/jetty/download.php).