### PR TITLE
vcprompt: add livecheck

### DIFF
--- a/Formula/vcprompt.rb
+++ b/Formula/vcprompt.rb
@@ -5,6 +5,11 @@ class Vcprompt < Formula
   sha256 "fdf26566e2bd73cf734b7228f78c09a0f53d0166662fcd482a076ed01c9dbe36"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://hg.gerg.ca/vcprompt/tags"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+
   bottle do
     cellar :any
     rebuild 2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `vcprompt`. This PR adds a `livecheck` block that checks the [tags page](https://hg.gerg.ca/vcprompt/tags) at the upstream Mercurial repository, as `stable` is an autogenerated tag archive from there.