### PR TITLE
pike: rebottle

### DIFF
--- a/Formula/pike.rb
+++ b/Formula/pike.rb
@@ -2,9 +2,11 @@ class Pike < Formula
   desc "Dynamic programming language"
   homepage "https://pike.lysator.liu.se/"
   url "https://pike.lysator.liu.se/pub/pike/latest-stable/Pike-v8.0.702.tar.gz"
+  # Homepage has an expired SSL cert as of 16/12/2020, so we add a Debian mirror
+  mirror "http://deb.debian.org/debian/pool/main/p/pike8.0/pike8.0_8.0.702.orig.tar.gz"
   sha256 "c47aad2e4f2c501c0eeea5f32a50385b46bda444f922a387a5c7754302f12a16"
   license any_of: ["GPL-2.0-only", "LGPL-2.1-only", "MPL-1.1"]
-  revision 3
+  revision 4
 
   livecheck do
     url "https://pike.lysator.liu.se/download/pub/pike/latest-stable/"


### PR DESCRIPTION
This was modified but not bottled in https://github.com/Homebrew/homebrew-core/pull/66285, https://github.com/Homebrew/homebrew-core/commit/1ee9564e7ca1afd4b4469c334f18514bc8ebfc6e

I also added a Debian mirror, as the homepage currently has an expired
SSL certificate.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?