### PR TITLE
teleport: update livecheck

### DIFF
--- a/Formula/teleport.rb
+++ b/Formula/teleport.rb
@@ -6,9 +6,14 @@ class Teleport < Formula
   license "Apache-2.0"
   head "https://github.com/gravitational/teleport.git"
 
+  # We check the Git tags instead of using the `GithubLatest` strategy, as the
+  # "latest" version can be incorrect. As of writing, two major versions of
+  # `teleport` are being maintained side by side and the "latest" tag can point
+  # to a release from the older major version.
   livecheck do
     url :stable
-    strategy :github_latest
+    strategy :git
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `teleport` uses the `GithubLatest` strategy to check the "latest" release on the GitHub project. However, two major versions are being maintained upstream (4.x and 5.x), which causes a problem with the accuracy of the "latest" release indicator. A 4.x version can appear as the "latest" release on GitHub (instead of the newest 5.x version), which makes livecheck sad.

We've seen this specific issue occur with other GitHub projects, where 2+ major versions are maintained side by side but upstream isn't careful about their release order. Since we can't rely on the accuracy of the "latest" indicator for `teleport`, this PR modifies the `livecheck` block to use the `Git` strategy instead.

The `Git` strategy automatically applies to the `stable` URL, so it's technically not necessary to include `strategy :git` here. I added it to ensure that a change in strategy priority wouldn't quietly undo our work here.

I've also added the standard regex for Git tags, as there are a number of prerelease version tags in Git and we only want to work with versions like `v1.2.3` (not `v1.2.3-dev.1`, `v1.2.3-alpha.1`, `v1.2.3-beta.1`, `v1.2.3-rc.1`, etc.).