### PR TITLE
deno: revert revision bump

### DIFF
--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -4,7 +4,6 @@ class Deno < Formula
   url "https://github.com/denoland/deno/releases/download/v1.6.0/deno_src.tar.gz"
   sha256 "60491d842e04ce162face61bb8857bf18a41726afbcbcd9fa532055ace7431ae"
   license "MIT"
-  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/issues/67042.

Deno was given a revision bump but not bottled here: https://github.com/Homebrew/homebrew-core/commit/3267cf4c025347d30ffa0eca9d0c69dc004e5dac

There are bottles available before the revision bump. Merge only if https://github.com/Homebrew/homebrew-core/pull/66920 appears unlikely to be merged soon.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
