### PR TITLE
ejabberd 20.12

### DIFF
--- a/Formula/ejabberd.rb
+++ b/Formula/ejabberd.rb
@@ -1,9 +1,9 @@
 class Ejabberd < Formula
   desc "XMPP application server"
   homepage "https://www.ejabberd.im"
-  url "https://static.process-one.net/ejabberd/downloads/20.07/ejabberd-20.07.tgz"
-  sha256 "9e922b938458ae9d72d4e5fdd2d08a1fbad651aae47c9a9d15b79d0bbd1e11f8"
-  license "GPL-2.0"
+  url "https://static.process-one.net/ejabberd/downloads/20.12/ejabberd-20.12.tgz"
+  sha256 "9d9c5d617472bf851e8cf2c7353fe9e82aef5b6d8aa28eeb6528bde8a463a854"
+  license "GPL-2.0-only"
   revision 1
 
   bottle do
@@ -57,13 +57,15 @@ class Ejabberd < Formula
     (var/"lib/ejabberd").mkpath
     (var/"spool/ejabberd").mkpath
 
-    # Create the vm.args file, to generate a cookie
-    require "securerandom"
-    cookie = SecureRandom.hex
+    # Create the vm.args file, if it does not exist. Put a random cookie in it to secure the instance.
     vm_args_file = etc/"ejabberd/vm.args"
-    vm_args_file.write <<~EOS
-      -setcookie #{cookie}
-    EOS
+    unless vm_args_file.exist?
+      require "securerandom"
+      cookie = SecureRandom.hex
+      vm_args_file.write <<~EOS
+        -setcookie #{cookie}
+      EOS
+    end
   end
 
   def caveats

--- a/Formula/ejabberd.rb
+++ b/Formula/ejabberd.rb
@@ -4,7 +4,6 @@ class Ejabberd < Formula
   url "https://static.process-one.net/ejabberd/downloads/20.12/ejabberd-20.12.tgz"
   sha256 "9d9c5d617472bf851e8cf2c7353fe9e82aef5b6d8aa28eeb6528bde8a463a854"
   license "GPL-2.0-only"
-  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is an update for latest upstream ejabberd version.

I made a couple of changes to adapt to new license check and to make the upgrade more robust (do not show post install error message if vm.args file already exist.