### PR TITLE
dlite: disable

### DIFF
--- a/Formula/dlite.rb
+++ b/Formula/dlite.rb
@@ -6,8 +6,6 @@ class Dlite < Formula
   license "MIT"
   head "https://github.com/nlf/dlite.git"
 
-  disable! date: "2020-12-17", because: :unmaintained
-
   bottle do
     cellar :any_skip_relocation
     sha256 "03fc30a6130e255cefda07f80ca76331b02dd244510d1dfaca00bec9f2c8c933" => :catalina
@@ -17,6 +15,8 @@ class Dlite < Formula
     sha256 "cab7bd9704df6b1f162a7d258ba3807a9d00cef93395b9fe4b4837a635969692" => :el_capitan
     sha256 "d1244ccccc75ab8747a86c01aceeb25fee219617d9d4a2c3a3c6cd0bad45c0ee" => :yosemite
   end
+
+  disable! date: "2020-12-17", because: :unmaintained
 
   depends_on "go" => :build
 

--- a/Formula/dlite.rb
+++ b/Formula/dlite.rb
@@ -6,6 +6,8 @@ class Dlite < Formula
   license "MIT"
   head "https://github.com/nlf/dlite.git"
 
+  disable! date: "2020-12-17", because: :unmaintained
+
   bottle do
     cellar :any_skip_relocation
     sha256 "03fc30a6130e255cefda07f80ca76331b02dd244510d1dfaca00bec9f2c8c933" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

dlite has seen the last commit in 2017, is without maintainer and hinders upgrade to go 1.15.6 in https://github.com/Homebrew/homebrew-core/pull/66355, hence I propose to remove.