### PR TITLE
dynein 0.1.2 (new formula)

### DIFF
--- a/Formula/dynein.rb
+++ b/Formula/dynein.rb
@@ -1,0 +1,22 @@
+class Dynein < Formula
+  desc "DynamoDB CLI written in Rust"
+  homepage "https://github.com/awslabs/dynein"
+  url "https://github.com/awslabs/dynein/archive/v0.1.2.tar.gz"
+  sha256 "701ed6d6a05fafa6bc54339bad6c84c8b85fc4c3d2d252f21415e047cbdc501c"
+  license "Apache-2.0"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+    bin.install_symlink "dy" => "dynein"
+  end
+
+  test do
+    require "open3"
+    assert_match "admin", shell_output("#{bin}/dynein --help")
+    assert_match "admin", shell_output("#{bin}/dy --help")
+    _, stderr = Open3.capture3("#{bin}/dy", "ls")
+    assert_match "Couldn't find AWS credentials", stderr
+  end
+end

--- a/Formula/dynein.rb
+++ b/Formula/dynein.rb
@@ -16,7 +16,6 @@ class Dynein < Formula
     require "open3"
     assert_match "admin", shell_output("#{bin}/dynein --help")
     assert_match "admin", shell_output("#{bin}/dy --help")
-    _, stderr = Open3.capture3("#{bin}/dy", "ls")
-    assert_match "Couldn't find AWS credentials", stderr
+    assert_match "Couldn't find AWS credentials", shell_output("#{bin}/dy ls &> /dev/stdout")
   end
 end


### PR DESCRIPTION
This commit adds the dynein formula, a CLI client for Dynamo DB. The dynein client installs the `dy` executable. For clarity, `dy` is also symlinked as `dynein`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
