### PR TITLE
pumba: fix sha256 mismatch

### DIFF
--- a/Formula/pumba.rb
+++ b/Formula/pumba.rb
@@ -2,8 +2,9 @@ class Pumba < Formula
   desc "Chaos testing tool for Docker"
   homepage "https://github.com/alexei-led/pumba"
   url "https://github.com/alexei-led/pumba/archive/0.7.7.tar.gz"
-  sha256 "5da828d47d7d46305fc921445ad47d9825a1d54f09b8be8a01ff2095c804fe2d"
+  sha256 "974f17df36bfdbb510b303db7acf1c3d637d7d50c87f3120b07e1e363792cf87"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/alexei-led/pumba.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

SHA mismatch. Author re-released `0.7.7`. Clarification issue here: https://github.com/alexei-led/pumba/issues/190

Some details:
- The original `0.7.7` was released probably on December 6th: https://github.com/homebrew/homebrew-core/commit/bae5e692d434f9fbb4db122b63abce8a8f2d4ef2#diff-159b8cf2bb441ea937927e3f905eaffc867f1a80bb54ac992df2d4f3f682f5c7
- The original author had republished `0.7.7` more than once, as it was published again **yesterday**: https://github.com/alexei-led/pumba/releases/tag/0.7.7
- It appears that the changes since December 6th are related to fixing Github Actions releases: https://github.com/alexei-led/pumba/commits/master

<img width="1254" alt="Screen Shot 2020-12-17 at 3 25 52 PM" src="https://user-images.githubusercontent.com/7211830/102539869-3d176d80-407c-11eb-9cd2-be18002040b1.png">

- I have confirmed that the tarball is the new `0.7.7` release from Github


Related to #66355