### PR TITLE
spack 0.16.0 (new formula)

### DIFF
--- a/Formula/spack.rb
+++ b/Formula/spack.rb
@@ -1,0 +1,48 @@
+class Spack < Formula
+  desc "Package manager that builds multiple versions and configurations of software"
+  homepage "https://spack.io"
+  url "https://github.com/spack/spack/archive/v0.16.0.tar.gz"
+  sha256 "064b2532c70916c7684d4c7c973416ac32dd2ea15f5c392654c75258bfc8c6c2"
+  license any_of: ["Apache-2.0", "MIT"]
+  head "https://github.com/spack/spack.git", branch: "develop"
+
+  bottle :unneeded
+
+  depends_on "python@3.9"
+
+  def install
+    cp_r Dir["bin", "etc", "lib", "share", "var"], prefix.to_s
+  end
+
+  def post_install
+    mkdir_p prefix/"var/spack/junit-report" unless (prefix/"var/spack/junit-report").exist?
+  end
+
+  test do
+    system "#{bin}/spack", "--version"
+    assert_match "zlib", shell_output("#{bin}/spack list zlib")
+
+    # Set up configuration file and build paths
+    %w[opt modules lmod stage test source misc cfg-store].each { |dir| (testpath/dir).mkpath }
+    (testpath/"cfg-store/config.yaml").write <<~EOS
+      config:
+        install_tree: #{testpath}/opt
+        module_roots:
+          tcl: #{testpath}/modules
+          lmod: #{testpath}/lmod
+        build_stage:
+          - #{testpath}/stage
+        test_stage: #{testpath}/test
+        source_cache: #{testpath}/source
+        misc_cache: #{testpath}/misc
+    EOS
+
+    # spack install using the config file
+    system "#{bin}/spack", "-C", "#{testpath}/cfg-store", "install", "--no-cache", "zlib"
+
+    # Get the path to one of the compiled library files
+    zlib_prefix = shell_output("#{bin}/spack -ddd -C #{testpath}/cfg-store find --format={prefix} zlib").strip
+    zlib_dylib_file = Pathname.new "#{zlib_prefix}/lib/libz.dylib"
+    assert_predicate zlib_dylib_file, :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Spack is a package manager for supercomputers, Linux, and macOS -- it makes it easy to install scientific software. It can be used to build and install multiple versions (and configurations) of the same library; I find this feature useful for testing software against multiple versions of libraries.