### PR TITLE
carton: add livecheck

### DIFF
--- a/Formula/carton.rb
+++ b/Formula/carton.rb
@@ -7,6 +7,10 @@ class Carton < Formula
   revision 2
   head "https://github.com/perl-carton/carton.git"
 
+  livecheck do
+    url :stable
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "a8346120d0c0c90969deffae1f9f6a62cd801b85d960236a027ac01a66bb8764" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Before a `head` URL was added to the `carton` formula, livecheck was checking the `stable` URL using the `Cpan` strategy by default. However, now that there's a `head` URL, livecheck checks the GitHub tags using the `Git` strategy. Currently, a `1.0.901` version is wrongly being reported as newest instead of `1.0.34`.

It's more appropriate to check the `stable` URL using the `Cpan` strategy instead and doing so resolves the version issue above as well. With that in mind, this PR adds a `livecheck` block that simply contains `url :stable`, to ensure that livecheck will use the `stable` URL instead of `head`.