### PR TITLE
go update gobootstrap on arm mac to a native arm version

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -37,8 +37,13 @@ class Go < Formula
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do
     on_macos do
-      url "https://storage.googleapis.com/golang/go1.7.darwin-amd64.tar.gz"
-      sha256 "51d905e0b43b3d0ed41aaf23e19001ab4bc3f96c3ca134b48f7892485fc52961"
+      if Hardware::CPU.arm?
+        url "https://storage.googleapis.com/golang/go1.16beta1.darwin-arm64.tar.gz"
+        sha256 "fd57f47987bb330fd9b438e7b4c8941b63c3807366602d99c1d99e0122ec62f1"
+      else
+        url "https://storage.googleapis.com/golang/go1.7.darwin-amd64.tar.gz"
+        sha256 "51d905e0b43b3d0ed41aaf23e19001ab4bc3f96c3ca134b48f7892485fc52961"
+      end
     end
 
     on_linux do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Update the gobootstrap to a native arm version on the M1 Macs,  This enables building --HEAD and then Formulae that depend on go. 
