### PR TITLE
docker-machine-driver-xhyve: deprecate

### DIFF
--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -7,6 +7,11 @@ class DockerMachineDriverXhyve < Formula
   license "BSD-3-Clause"
   head "https://github.com/machine-drivers/docker-machine-driver-xhyve.git"
 
+  # xhyve is no longer used by Docker. 
+  # It was introduced with 10.9 or 10.10 to take advantage of macOS' new Hyperkit.framework. 
+  # Docker replaced it with hyperkit (which is based on xhyve and maintained).
+  disable! date: "2020-12-18", because: :does_not_build
+
   bottle do
     cellar :any_skip_relocation
     rebuild 1

--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -7,9 +7,6 @@ class DockerMachineDriverXhyve < Formula
   license "BSD-3-Clause"
   head "https://github.com/machine-drivers/docker-machine-driver-xhyve.git"
 
-  # xhyve is no longer used by Docker, replaced by hyperkit
-  deprecate! date: "2020-12-18", because: :does_not_build
-
   bottle do
     cellar :any_skip_relocation
     rebuild 1
@@ -17,6 +14,9 @@ class DockerMachineDriverXhyve < Formula
     sha256 "b7e9879c8c5c734da5bd83ae00496dc26dcf8133e354662e7b6a8846bfbfc989" => :mojave
     sha256 "282868271a1e504ca8643bb6507eb2f99f8f8703d64050886e00175182b35668" => :high_sierra
   end
+
+  # xhyve is no longer used by Docker, replaced by hyperkit
+  deprecate! date: "2020-12-18", because: :does_not_build
 
   depends_on "go" => :build
   depends_on "docker-machine"

--- a/Formula/docker-machine-driver-xhyve.rb
+++ b/Formula/docker-machine-driver-xhyve.rb
@@ -7,10 +7,8 @@ class DockerMachineDriverXhyve < Formula
   license "BSD-3-Clause"
   head "https://github.com/machine-drivers/docker-machine-driver-xhyve.git"
 
-  # xhyve is no longer used by Docker. 
-  # It was introduced with 10.9 or 10.10 to take advantage of macOS' new Hyperkit.framework. 
-  # Docker replaced it with hyperkit (which is based on xhyve and maintained).
-  disable! date: "2020-12-18", because: :does_not_build
+  # xhyve is no longer used by Docker, replaced by hyperkit
+  deprecate! date: "2020-12-18", because: :does_not_build
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Get go1.15.6 merged in https://github.com/Homebrew/homebrew-core/pull/66355