### PR TITLE
glibmm 2.68.0

### DIFF
--- a/Aliases/glibmm@2.68
+++ b/Aliases/glibmm@2.68
@@ -1,0 +1,1 @@
+../Formula/glibmm.rb

--- a/Formula/atkmm.rb
+++ b/Formula/atkmm.rb
@@ -4,6 +4,7 @@ class Atkmm < Formula
   url "https://download.gnome.org/sources/atkmm/2.28/atkmm-2.28.1.tar.xz"
   sha256 "116876604770641a450e39c1f50302884848ce9cc48d43c5dc8e8efc31f31bad"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -20,7 +21,7 @@ class Atkmm < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "atk"
-  depends_on "glibmm"
+  depends_on "glibmm@2.64"
 
   def install
     ENV.cxx11
@@ -44,7 +45,7 @@ class Atkmm < Formula
     atk = Formula["atk"]
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     libsigcxx = Formula["libsigc++@2"]
     flags = %W[
       -I#{atk.opt_include}/atk-1.0

--- a/Formula/glibmm.rb
+++ b/Formula/glibmm.rb
@@ -1,8 +1,8 @@
 class Glibmm < Formula
   desc "C++ interface to glib"
   homepage "https://www.gtkmm.org/"
-  url "https://download.gnome.org/sources/glibmm/2.64/glibmm-2.64.5.tar.xz"
-  sha256 "508fc86e2c9141198aa16c225b16fd6b911917c0d3817602652844d0973ea386"
+  url "https://download.gnome.org/sources/glibmm/2.68/glibmm-2.68.0.tar.xz"
+  sha256 "c1f38573191dceed85a05600888cf4cf4695941f339715bd67d51c2416f4f375"
   license "LGPL-2.1-or-later"
 
   livecheck do
@@ -20,7 +20,7 @@ class Glibmm < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "glib"
-  depends_on "libsigc++@2"
+  depends_on "libsigc++"
 
   def install
     ENV.cxx11
@@ -44,26 +44,26 @@ class Glibmm < Formula
     EOS
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    libsigcxx = Formula["libsigc++@2"]
+    libsigcxx = Formula["libsigc++"]
     flags = %W[
       -I#{gettext.opt_include}
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include
-      -I#{include}/glibmm-2.4
-      -I#{libsigcxx.opt_include}/sigc++-2.0
-      -I#{libsigcxx.opt_lib}/sigc++-2.0/include
-      -I#{lib}/glibmm-2.4/include
+      -I#{include}/glibmm-2.68
+      -I#{libsigcxx.opt_include}/sigc++-3.0
+      -I#{libsigcxx.opt_lib}/sigc++-3.0/include
+      -I#{lib}/glibmm-2.68/include
       -L#{gettext.opt_lib}
       -L#{glib.opt_lib}
       -L#{libsigcxx.opt_lib}
       -L#{lib}
       -lglib-2.0
-      -lglibmm-2.4
+      -lglibmm-2.68
       -lgobject-2.0
       -lintl
-      -lsigc-2.0
+      -lsigc-3.0
     ]
-    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
+    system ENV.cxx, "-std=c++17", "test.cpp", "-o", "test", *flags
     system "./test"
   end
 end

--- a/Formula/glibmm@2.64.rb
+++ b/Formula/glibmm@2.64.rb
@@ -1,0 +1,62 @@
+class GlibmmAT264 < Formula
+  desc "C++ interface to glib"
+  homepage "https://www.gtkmm.org/"
+  url "https://download.gnome.org/sources/glibmm/2.64/glibmm-2.64.5.tar.xz"
+  sha256 "508fc86e2c9141198aa16c225b16fd6b911917c0d3817602652844d0973ea386"
+  license "LGPL-2.1-or-later"
+
+  livecheck do
+    url :stable
+  end
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "libsigc++@2"
+
+  def install
+    ENV.cxx11
+
+    mkdir "build" do
+      system "meson", *std_meson_args, ".."
+      system "ninja"
+      system "ninja", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <glibmm.h>
+
+      int main(int argc, char *argv[])
+      {
+         Glib::ustring my_string("testing");
+         return 0;
+      }
+    EOS
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    libsigcxx = Formula["libsigc++@2"]
+    flags = %W[
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{include}/glibmm-2.4
+      -I#{libsigcxx.opt_include}/sigc++-2.0
+      -I#{libsigcxx.opt_lib}/sigc++-2.0/include
+      -I#{lib}/glibmm-2.4/include
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{libsigcxx.opt_lib}
+      -L#{lib}
+      -lglib-2.0
+      -lglibmm-2.4
+      -lgobject-2.0
+      -lintl
+      -lsigc-2.0
+    ]
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Formula/gsmartcontrol.rb
+++ b/Formula/gsmartcontrol.rb
@@ -3,7 +3,7 @@ class Gsmartcontrol < Formula
   homepage "https://gsmartcontrol.sourceforge.io"
   url "https://downloads.sourceforge.net/project/gsmartcontrol/1.1.3/gsmartcontrol-1.1.3.tar.bz2"
   sha256 "b64f62cffa4430a90b6d06cd52ebadd5bcf39d548df581e67dfb275a673b12a9"
-  revision 6
+  revision 7
 
   livecheck do
     url :stable

--- a/Formula/gstreamermm.rb
+++ b/Formula/gstreamermm.rb
@@ -3,7 +3,7 @@ class Gstreamermm < Formula
   homepage "https://gstreamer.freedesktop.org/bindings/cplusplus.html"
   url "https://download.gnome.org/sources/gstreamermm/1.10/gstreamermm-1.10.0.tar.xz"
   sha256 "be58fe9ef7d7e392568ec85e80a84f4730adbf91fb0355ff7d7c616675ea8d60"
-  revision 4
+  revision 5
 
   livecheck do
     url :stable
@@ -19,7 +19,7 @@ class Gstreamermm < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "glibmm"
+  depends_on "glibmm@2.64"
   depends_on "gst-plugins-base"
   depends_on "gstreamer"
 
@@ -43,7 +43,7 @@ class Gstreamermm < Formula
     EOS
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     gst_plugins_base = Formula["gst-plugins-base"]
     gstreamer = Formula["gstreamer"]
     libsigcxx = Formula["libsigc++@2"]

--- a/Formula/gtkmm.rb
+++ b/Formula/gtkmm.rb
@@ -4,7 +4,7 @@ class Gtkmm < Formula
   url "https://download.gnome.org/sources/gtkmm/2.24/gtkmm-2.24.5.tar.xz"
   sha256 "0680a53b7bf90b4e4bf444d1d89e6df41c777e0bacc96e9c09fc4dd2f5fe6b72"
   license "LGPL-2.1-or-later"
-  revision 5
+  revision 6
 
   livecheck do
     url :stable
@@ -21,7 +21,7 @@ class Gtkmm < Formula
   depends_on "pkg-config" => :build
   depends_on "atkmm"
   depends_on "cairomm@1.14"
-  depends_on "glibmm"
+  depends_on "glibmm@2.64"
   depends_on "gtk+"
   depends_on "libsigc++@2"
   depends_on "pangomm"
@@ -50,7 +50,7 @@ class Gtkmm < Formula
     gdk_pixbuf = Formula["gdk-pixbuf"]
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     gtkx = Formula["gtk+"]
     harfbuzz = Formula["harfbuzz"]
     libpng = Formula["libpng"]

--- a/Formula/gtkmm3.rb
+++ b/Formula/gtkmm3.rb
@@ -4,6 +4,7 @@ class Gtkmm3 < Formula
   url "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.3.tar.xz"
   sha256 "60497c4f7f354c3bd2557485f0254f8b7b4cf4bebc9fee0be26a77744eacd435"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -54,7 +55,7 @@ class Gtkmm3 < Formula
     gdk_pixbuf = Formula["gdk-pixbuf"]
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     gtkx3 = Formula["gtk+3"]
     harfbuzz = Formula["harfbuzz"]
     libepoxy = Formula["libepoxy"]

--- a/Formula/gtksourceviewmm.rb
+++ b/Formula/gtksourceviewmm.rb
@@ -4,7 +4,7 @@ class Gtksourceviewmm < Formula
   url "https://download.gnome.org/sources/gtksourceviewmm/2.10/gtksourceviewmm-2.10.3.tar.xz"
   sha256 "0000df1b582d7be2e412020c5d748f21c0e6e5074c6b2ca8529985e70479375b"
   license "LGPL-2.1-or-later"
-  revision 8
+  revision 9
 
   livecheck do
     url :stable
@@ -47,7 +47,7 @@ class Gtksourceviewmm < Formula
     gdk_pixbuf = Formula["gdk-pixbuf"]
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     gtkx = Formula["gtk+"]
     gtkmm = Formula["gtkmm"]
     gtksourceview = Formula["gtksourceview"]

--- a/Formula/gtksourceviewmm3.rb
+++ b/Formula/gtksourceviewmm3.rb
@@ -4,7 +4,7 @@ class Gtksourceviewmm3 < Formula
   url "https://download.gnome.org/sources/gtksourceviewmm/3.18/gtksourceviewmm-3.18.0.tar.xz"
   sha256 "51081ae3d37975dae33d3f6a40621d85cb68f4b36ae3835eec1513482aacfb39"
   license "LGPL-2.1-or-later"
-  revision 7
+  revision 8
 
   livecheck do
     url :stable
@@ -47,7 +47,7 @@ class Gtksourceviewmm3 < Formula
     gdk_pixbuf = Formula["gdk-pixbuf"]
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     gtkx3 = Formula["gtk+3"]
     gtkmm3 = Formula["gtkmm3"]
     gtksourceview3 = Formula["gtksourceview3"]

--- a/Formula/libglademm.rb
+++ b/Formula/libglademm.rb
@@ -4,7 +4,7 @@ class Libglademm < Formula
   url "https://download.gnome.org/sources/libglademm/2.6/libglademm-2.6.7.tar.bz2"
   sha256 "38543c15acf727434341cc08c2b003d24f36abc22380937707fc2c5c687a2bc3"
   license "LGPL-2.1-or-later"
-  revision 8
+  revision 9
 
   livecheck do
     url :stable
@@ -51,7 +51,7 @@ class Libglademm < Formula
     gdk_pixbuf = Formula["gdk-pixbuf"]
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     gtkx = Formula["gtk+"]
     gtkmm = Formula["gtkmm"]
     harfbuzz = Formula["harfbuzz"]

--- a/Formula/libgnomecanvasmm.rb
+++ b/Formula/libgnomecanvasmm.rb
@@ -4,7 +4,7 @@ class Libgnomecanvasmm < Formula
   url "https://download.gnome.org/sources/libgnomecanvasmm/2.26/libgnomecanvasmm-2.26.0.tar.bz2"
   sha256 "996577f97f459a574919e15ba7fee6af8cda38a87a98289e9a4f54752d83e918"
   license "LGPL-2.1-or-later"
-  revision 8
+  revision 9
 
   livecheck do
     url :stable
@@ -45,7 +45,7 @@ class Libgnomecanvasmm < Formula
     gdk_pixbuf = Formula["gdk-pixbuf"]
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     gtkx = Formula["gtk+"]
     gtkmm = Formula["gtkmm"]
     harfbuzz = Formula["harfbuzz"]

--- a/Formula/libxml++.rb
+++ b/Formula/libxml++.rb
@@ -4,6 +4,7 @@ class Libxmlxx < Formula
   url "https://download.gnome.org/sources/libxml++/2.42/libxml++-2.42.0.tar.xz"
   sha256 "3d032aede98a033eb5e815b4bfa9fa7b4e745268e6fd1ce8b1d0f70bcaf4736d"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,7 +22,7 @@ class Libxmlxx < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "glibmm"
+  depends_on "glibmm@2.64"
 
   uses_from_macos "libxml2"
 
@@ -49,7 +50,7 @@ class Libxmlxx < Formula
     ENV.libxml2
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     libsigcxx = Formula["libsigc++@2"]
     flags = %W[
       -I#{gettext.opt_include}

--- a/Formula/libxml++3.rb
+++ b/Formula/libxml++3.rb
@@ -4,6 +4,7 @@ class Libxmlxx3 < Formula
   url "https://download.gnome.org/sources/libxml++/3.2/libxml++-3.2.2.tar.xz"
   sha256 "a53d0af2c9bf566b4d5d57d1c6495b189555c54785941d7e3bef666728952f0b"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -20,7 +21,7 @@ class Libxmlxx3 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "glibmm"
+  depends_on "glibmm@2.64"
 
   uses_from_macos "libxml2"
 
@@ -48,7 +49,7 @@ class Libxmlxx3 < Formula
     ENV.libxml2
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     libsigcxx = Formula["libsigc++@2"]
     flags = %W[
       -I#{gettext.opt_include}

--- a/Formula/pangomm.rb
+++ b/Formula/pangomm.rb
@@ -4,6 +4,7 @@ class Pangomm < Formula
   url "https://download.gnome.org/sources/pangomm/2.42/pangomm-2.42.2.tar.xz"
   sha256 "1b24c92624ae1275ccb57758175d35f7c39ad3342d8c0b4ba60f0d9849d2d08a"
   license "LGPL-2.1-only"
+  revision 1
 
   livecheck do
     url :stable
@@ -20,7 +21,7 @@ class Pangomm < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "cairomm@1.14"
-  depends_on "glibmm"
+  depends_on "glibmm@2.64"
   depends_on "pango"
 
   def install
@@ -47,7 +48,7 @@ class Pangomm < Formula
     freetype = Formula["freetype"]
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     harfbuzz = Formula["harfbuzz"]
     libpng = Formula["libpng"]
     libsigcxx = Formula["libsigc++@2"]

--- a/Formula/prefixsuffix.rb
+++ b/Formula/prefixsuffix.rb
@@ -3,8 +3,8 @@ class Prefixsuffix < Formula
   homepage "https://github.com/murraycu/prefixsuffix"
   url "https://download.gnome.org/sources/prefixsuffix/0.6/prefixsuffix-0.6.9.tar.xz"
   sha256 "fc3202bddf2ebbb93ffd31fc2a079cfc05957e4bf219535f26e6d8784d859e9b"
-  license "GPL-2.0"
-  revision 6
+  license "GPL-2.0-or-later"
+  revision 7
 
   livecheck do
     url :stable

--- a/Formula/synfig.rb
+++ b/Formula/synfig.rb
@@ -4,6 +4,8 @@ class Synfig < Formula
   url "https://downloads.sourceforge.net/project/synfig/releases/1.4.0/source/synfig-1.4.0.tar.gz"
   mirror "https://github.com/synfig/synfig/releases/download/v1.4.0/synfig-1.4.0.tar.gz"
   sha256 "7f36d57eba9dc959e1deae89e6908585a08db7f2d9399915a46a9eff33080c9c"
+  license "GPL-3.0-or-later"
+  revision 1
   head "https://svn.code.sf.net/p/synfig/code/"
 
   livecheck do
@@ -61,7 +63,7 @@ class Synfig < Formula
     freetype = Formula["freetype"]
     gettext = Formula["gettext"]
     glib = Formula["glib"]
-    glibmm = Formula["glibmm"]
+    glibmm = Formula["glibmm@2.64"]
     libpng = Formula["libpng"]
     libsigcxx = Formula["libsigc++@2"]
     libxmlxx = Formula["libxml++"]

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -9,6 +9,7 @@
   "gcc@7",
   "gcc@8",
   "gcc@9",
+  "glibmm@2.64",
   "gnupg@1.4",
   "libsigc++@2",
   "lua@5.1",


### PR DESCRIPTION
Since this release breaks API, we need to keep the old version around as glibmm@2.64 (2.66 was never released).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----