### PR TITLE
heimdal: disable documentation

### DIFF
--- a/Formula/heimdal.rb
+++ b/Formula/heimdal.rb
@@ -54,6 +54,7 @@ class Heimdal < Formula
       --enable-pthread-support
       --disable-afs-support
       --disable-ndbm-db
+      --disable-heimdal-documentation
       --with-openldap=#{Formula["openldap"].opt_prefix}
       --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
       --with-hcrypto-default-backend=ossl


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is an upstream port of [this PR](https://github.com/Homebrew/linuxbrew-core/pull/21839) to disable documentation on heimdal, so that we don't need to add `texinfo` as dependency.