### PR TITLE
allureofthestars: update license

### DIFF
--- a/Formula/allureofthestars.rb
+++ b/Formula/allureofthestars.rb
@@ -3,7 +3,7 @@ class Allureofthestars < Formula
   homepage "https://www.allureofthestars.com/"
   url "https://hackage.haskell.org/package/Allure-0.9.5.0/Allure-0.9.5.0.tar.gz"
   sha256 "8180fe070633bfa5515de8f7443421044e7ad4ee050f0a92c048cec5f2c88132"
-  license "AGPL-3.0"
+  license all_of: ["AGPL-3.0-or-later", "GPL-2.0-or-later", "OFL-1.1", "MIT", :cannot_represent]
   head "https://github.com/AllureOfTheStars/Allure.git"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

From [`COPYLEFT`](https://github.com/AllureOfTheStars/Allure/blob/master/COPYLEFT) file:

```
Files: *
Copyright: 2008-2011 Andres Loeh
           2010-2020 Mikolaj Konarski and others (see git history)
License: AGPL-3.0-or-later

Files: GameDefinition/fonts/*.fnt GameDefinition/fonts/*.bdf GameDefinition/fonts/16x16xw.woff
Copyright: 1997-2016 Leon Marrick
           1997-2016 Sheldon Simms III
           1997-2016 Nick McConnell
           2016-2020 Mikolaj Konarski
License: GPL-2.0-or-later

Files: GameDefinition/fonts/Binary*.woff
Copyright 2010-2019 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'
Copyright 2020 Mikolaj Konarski
License: OFL-1.1

Files: GameDefinition/fonts/DejaVu*.woff
Copyright: Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved.
 Bitstream Vera is a trademark of Bitstream, Inc.
 DejaVu changes are in public domain.
License: bitstream-vera
Comment:
 ...

Files: GameDefinition/fonts/Hack*.woff
Copyright:
 2003 Bitstream Inc.
 2018 Christopher Simpkins <chris@sourcefoundry.org>
License: Expat and bitstream-vera
Comment:
 ...

Files: debian/*
Copyright: held by the contributors mentioned in debian/changelog
License: AGPL-3.0-or-later
```