### PR TITLE
allureofthestars: fix build

### DIFF
--- a/Formula/allureofthestars.rb
+++ b/Formula/allureofthestars.rb
@@ -18,14 +18,14 @@ class Allureofthestars < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@8.8" => :build
   depends_on "pkg-config" => :build
+  depends_on "ghc"
   depends_on "gmp"
   depends_on "sdl2_ttf"
 
   def install
     system "cabal", "v2-update"
-    system "cabal", "v2-install", *std_cabal_v2_args
+    system "cabal", "--store-dir=#{libexec}", "v2-install", *std_cabal_v2_args
   end
 
   test do
@@ -33,7 +33,7 @@ class Allureofthestars < Formula
       shell_output("#{bin}/Allure --dbgMsgSer --dbgMsgCli --logPriority 0 --newGame 3 --maxFps 100000 " \
                                  "--stopAfterFrames 50 --automateAll --keepAutomated --gameMode battle " \
                                  "--setDungeonRng 7 --setMainRng 7")
-    assert_equal "", shell_output("cat ~/.Allure/stderr.txt")
-    assert_match "UI client FactionId 1 stopped", shell_output("cat ~/.Allure/stdout.txt")
+    assert_equal "", (testpath/".Allure/stderr.txt").read
+    assert_match "UI client FactionId 1 stopped", (testpath/".Allure/stdout.txt").read
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes an error when running `Allure` compiled with cabal-install v2:

`Allure: user error (Font file does not exist: /private/tmp/allureofthestars-20201219-3344-kna33l/Allure-0.9.5.0/.brew_home/.cabal/store/ghc-8.10.1/Allr-0.9.5.0-9cd133ac/share/GameDefinition/fonts/16x16xw.bdf)`

The `GameDefinition` directory used to be installed at `<prefix>/share/x86_64-osx-ghc-8.8.3/Allure-0.9.5.0/GameDefinition` but I'm not sure if this is possible with cabal-install v2