### PR TITLE
crf++: find a new URL for this old package

### DIFF
--- a/Formula/crf++.rb
+++ b/Formula/crf++.rb
@@ -1,9 +1,11 @@
 class Crfxx < Formula
   desc "Conditional random fields for segmenting/labeling sequential data"
   homepage "https://taku910.github.io/crfpp/"
-  url "https://ftp.heanet.ie/mirrors/gentoo.org/distfiles/CRF++-0.58.tar.gz"
+  url "https://mirrors.sohu.com/gentoo/distfiles/f2/CRF%2B%2B-0.58.tar.gz"
   mirror "https://drive.google.com/uc?id=0B4y35FiV1wh7QVR6VXJ5dWExSTQ&export=download"
   sha256 "9d1c0a994f25a5025cede5e1d3a687ec98cd4949bfb2aae13f2a873a13259cb2"
+  license any_of: ["LGPL-2.1-only", "BSD-3-Clause"]
+  head "https://github.com/taku910/crfpp.git"
 
   # Archive files from upstream are hosted on Google Drive, so we can't identify
   # versions from the tarballs, as the links on the homepage don't include this


### PR DESCRIPTION
Note that FreeBSD ports seems to have unilaterally(?) decided that the git head is "0.59" and treating that as a release ( https://github.com/freebsd/freebsd-ports/commit/cd29299117f5f101efb738f1c0359ddefbb6e000 )  For now I'm trying to stick with the last officially released version
