### PR TITLE
libmaa: xcode 12 fix for test code

### DIFF
--- a/Formula/libmaa.rb
+++ b/Formula/libmaa.rb
@@ -3,6 +3,8 @@ class Libmaa < Formula
   homepage "http://www.dict.org/"
   url "https://downloads.sourceforge.net/project/dict/libmaa/libmaa-1.4.7/libmaa-1.4.7.tar.gz"
   sha256 "4e01a9ebc5d96bc9284b6706aa82bddc2a11047fa9bd02e94cf8753ec7dcb98e"
+  license "MIT"
+  head "https://github.com/cheusov/libmaa.git"
 
   livecheck do
     url :stable
@@ -52,6 +54,7 @@ class Libmaa < Formula
        */
 
       #include <maa.h>
+      #include <stdlib.h>
 
       int main( int argc, char **argv )
       {


### PR DESCRIPTION
The package itself compiles fine under Xcode 12, but `brew test` compiles a little test program that is missing an `#include` causing a problem with the new `-Werror,-Wimplicit-function-declaration` default.
