### PR TITLE
faust 2.27.2

### DIFF
--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -1,9 +1,9 @@
 class Faust < Formula
   desc "Functional programming language for real time signal processing"
   homepage "https://faust.grame.fr"
-  url "https://github.com/grame-cncm/faust/releases/download/2.20.2/faust-2.20.2.tar.gz"
-  sha256 "bea8675446c5e5ef4ac4ba1fb1d64b3a2af99f5f293be0492ccaf32baf7fcb5c"
-  license "GPL-2.0"
+  url "https://github.com/grame-cncm/faust/releases/download/2.27.2/faust-2.27.2.tar.gz"
+  sha256 "c9b21de69253d5a02a779c2eed74491fc62209d86c24724b429f68098191c39c"
+  license "GPL-2.0-or-later"
 
   bottle do
     cellar :any


### PR DESCRIPTION
@chenrui333 tried to do this update back in September (#61552) but ran into llvm problems which may have been fixed now.  Therefore I am giving re-bottling another try.

The current (2.20.2) formula can't be built from source right now anyway because the sha256 changed upstream for some reason.
