### PR TITLE
foremost: fix build

### DIFF
--- a/Formula/foremost.rb
+++ b/Formula/foremost.rb
@@ -3,6 +3,7 @@ class Foremost < Formula
   homepage "https://foremost.sourceforge.io/"
   url "https://foremost.sourceforge.io/pkg/foremost-1.5.7.tar.gz"
   sha256 "502054ef212e3d90b292e99c7f7ac91f89f024720cd5a7e7680c3d1901ef5f34"
+  license :public_domain
 
   livecheck do
     url "http://foremost.sourceforge.net/"
@@ -22,7 +23,7 @@ class Foremost < Formula
     inreplace "Makefile" do |s|
       s.gsub! "/usr/", "#{prefix}/"
       s.change_make_var! "RAW_CC", ENV.cc
-      s.change_make_var! "RAW_FLAGS", ENV.cflags
+      s.gsub! /^RAW_FLAGS =/, "RAW_FLAGS = #{ENV.cflags}"
     end
 
     system "make", "mac"


### PR DESCRIPTION
Applying `change_make_var!` to `RAW_FLAGS` also nuked a line where the original Makefile used "+=" to add a `-DVERSION="..."` string, breaking the compile.  Just changing to a more limited `gsub!` fixes the compile.

Presumably this worked at some point since those lines are from 2010, so maybe the effect of `change_make_var!` got tweaked slightly wrt `+=` lines and broke something?

Also marked as public_domain per the lines in the source:
```
 * This is a work of the US Government. In accordance with 17 USC 105,
 * copyright protection is not available for any work of the US Government.
```
