### PR TITLE
testdisk: use fixtures for test

### DIFF
--- a/Formula/testdisk.rb
+++ b/Formula/testdisk.rb
@@ -28,7 +28,8 @@ class Testdisk < Formula
 
   test do
     path = "test.dmg"
-    system "hdiutil", "create", "-megabytes", "10", path
+    cp test_fixtures(path + ".gz"), path + ".gz"
+    system "gunzip", path
     system "#{bin}/testdisk", "/list", path
   end
 end


### PR DESCRIPTION
Per the discussion on #66311, `hdiutil -create` no longer works inside of the testing sandbox; use the new gzip'ed disk image inside fixtures instead
