### PR TITLE
keychain: fix url, license, test

### DIFF
--- a/Formula/keychain.rb
+++ b/Formula/keychain.rb
@@ -1,9 +1,9 @@
 class Keychain < Formula
   desc "User-friendly front-end to ssh-agent(1)"
   homepage "https://www.funtoo.org/Keychain"
-  url "https://build.funtoo.org/distfiles/keychain/keychain-2.8.5.tar.bz2"
-  mirror "https://fossies.org/linux/privat/keychain-2.8.5.tar.bz2"
-  sha256 "16f5949b606691dea6e1832a77e697b8c0b2a536abfbd29e3a3f47222259c3b2"
+  url "https://github.com/funtoo/keychain/archive/2.8.5.tar.gz"
+  sha256 "dcce703e5001211c8ebc0528f45b523f84d2bceeb240600795b4d80cb8475a0b"
+  license "GPL-2.0-only"
 
   livecheck do
     url "https://github.com/funtoo/keychain.git"
@@ -18,6 +18,9 @@ class Keychain < Formula
   end
 
   test do
-    system "#{bin}/keychain", "--version"
+    system "#{bin}/keychain"
+    hostname = shell_output("hostname").chomp
+    assert_match "SSH_AGENT_PID", File.read(testpath/".keychain/#{hostname}-sh")
+    system "#{bin}/keychain", "--stop", "mine"
   end
 end


### PR DESCRIPTION
Main URL is defunct, mirror still works, but the home page says:
> The latest release of Keychain can be found on the keychain GitHub release page.

The GitHub tarball has more content, but none of it is used here, and the installed stuff is byte-identical with the originals, so no revision bump is needed.

Also added `license` and a proper test.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
