### PR TITLE
mpack: update download URL

### DIFF
--- a/Formula/mpack.rb
+++ b/Formula/mpack.rb
@@ -1,9 +1,10 @@
 class Mpack < Formula
   desc "MIME mail packing and unpacking"
   homepage "https://web.archive.org/web/20190220145801/ftp.andrew.cmu.edu/pub/mpack/"
-  url "https://web.archive.org/web/20190220145801/ftp.andrew.cmu.edu/pub/mpack/mpack-1.6.tar.gz"
+  url "https://ftp.gwdg.de/pub/misc/mpack/mpack-1.6.tar.gz"
   mirror "https://fossies.org/linux/misc/old/mpack-1.6.tar.gz"
   sha256 "274108bb3a39982a4efc14fb3a65298e66c8e71367c3dabf49338162d207a94c"
+  license "BSD-3-Clause"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
archive.org links don't work for tar.gz downloads because they auto-gunzip and therefore break the sha256.

The license seems to match BSD-3-Clause based on the verbiage:
```
Permission to use, copy, modify, distribute, and sell this software
and its documentation for any purpose is hereby granted without fee,
provided that the above copyright notice appear in all copies and that
both that copyright notice and this permission notice appear in
supporting documentation, and that the name of Carnegie Mellon
University not be used in advertising or publicity pertaining to
distribution of the software without specific, written prior
permission.  Carnegie Mellon University makes no representations about
the suitability of this software for any purpose.  It is provided "as
is" without express or implied warranty.
```