### PR TITLE
deno: add Fish completion

### DIFF
--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -41,11 +41,14 @@ class Deno < Formula
       system "cargo", "install", "-vv", *std_cargo_args
     end
 
-    # Install bash and zsh completion
-    output = Utils.safe_popen_read("#{bin}/deno", "completions", "bash")
-    (bash_completion/"deno").write output
-    output = Utils.safe_popen_read("#{bin}/deno", "completions", "zsh")
-    (zsh_completion/"_deno").write output
+    bash_output = Utils.safe_popen_read("#{bin}/deno", "completions", "bash")
+    (bash_completion/"deno").write bash_output
+
+    zsh_output = Utils.safe_popen_read("#{bin}/deno", "completions", "zsh")
+    (zsh_completion/"_deno").write zsh_output
+
+    fish_output = Utils.safe_popen_read("#{bin}/deno", "completions", "fish"
+    (fish_completion/"deno.fish").write fish_output
   end
 
   test do

--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -47,7 +47,7 @@ class Deno < Formula
     zsh_output = Utils.safe_popen_read("#{bin}/deno", "completions", "zsh")
     (zsh_completion/"_deno").write zsh_output
 
-    fish_output = Utils.safe_popen_read("#{bin}/deno", "completions", "fish"
+    fish_output = Utils.safe_popen_read("#{bin}/deno", "completions", "fish")
     (fish_completion/"deno.fish").write fish_output
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fish currently has an outdated (and unreleased) completion for [deno](https://github.com/fish-shell/fish-shell/blob/master/share/completions/deno.fish), I have asked Fish to remove it.