### PR TITLE
cairo: enable X11 on Linux

### DIFF
--- a/Formula/cairo.rb
+++ b/Formula/cairo.rb
@@ -37,25 +37,43 @@ class Cairo < Formula
   uses_from_macos "zlib"
 
   on_linux do
+    depends_on "libx11"
+    depends_on "libxcb"
     depends_on "libxext"
     depends_on "libxrender"
   end
 
   def install
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --enable-gobject
+      --enable-svg
+      --enable-tee
+      --disable-valgrind
+    ]
+    on_macos do
+      args += %w[
+        --enable-quartz-image
+        --disable-xcb
+        --disable-xlib
+        --disable-xlib-xrender
+      ]
+    end
+    on_linux do
+      args += %w[
+        --enable-xcb
+        --enable-xlib
+        --enable-xlib-xrender
+      ]
+    end
+
     if build.head?
       ENV["NOCONFIGURE"] = "1"
       system "./autogen.sh"
     end
 
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--enable-gobject=yes",
-                          "--enable-svg=yes",
-                          "--enable-tee=yes",
-                          "--enable-quartz-image",
-                          "--enable-xcb=no",
-                          "--enable-xlib=no",
-                          "--enable-xlib-xrender=no"
+    system "./configure", *args
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

License PR: https://github.com/Homebrew/homebrew-core/pull/67328

Linuxbrew formula: https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/cairo.rb

This also adds `--disable-valgrind` to prevent opportunistic linkage (see https://github.com/Homebrew/linuxbrew-core/pull/9441)