### PR TITLE
attr: remove -lintl flag

### DIFF
--- a/Formula/attr.rb
+++ b/Formula/attr.rb
@@ -9,7 +9,6 @@ class Attr < Formula
   depends_on :linux
 
   def install
-    ENV.append "LDFLAGS", "-lintl"
     system "./configure",
            "--disable-debug",
            "--disable-dependency-tracking",


### PR DESCRIPTION
As we now build gettext without internal gettext,
the -lintl flag is not necessary anymore and makes the build fail.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
