### PR TITLE
po4a: fix build on Big Sur and bump to version 0.62

### DIFF
--- a/Formula/po4a.rb
+++ b/Formula/po4a.rb
@@ -83,7 +83,7 @@ class Po4a < Formula
     end
 
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
- 
+
     system "perl", "Build.PL", "--install_base", libexec
     system "./Build"
     system "./Build", "install"

--- a/Formula/po4a.rb
+++ b/Formula/po4a.rb
@@ -83,7 +83,7 @@ class Po4a < Formula
     end
 
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
-    
+ 
     system "perl", "Build.PL", "--install_base", libexec
     system "./Build"
     system "./Build", "install"

--- a/Formula/po4a.rb
+++ b/Formula/po4a.rb
@@ -19,9 +19,8 @@ class Po4a < Formula
 
   depends_on "docbook-xsl" => :build
   depends_on "gettext"
-  # Term::ReadKey will not build using system perl on Big Sur, so we use Homebrew perl.
-  # If this changes, we can switch back.
-  depends_on "perl"
+
+  uses_from_macos "perl"
 
   resource "Locale::gettext" do
     url "https://cpan.metacpan.org/authors/id/P/PV/PVANDRY/gettext-1.07.tar.gz"
@@ -29,6 +28,8 @@ class Po4a < Formula
   end
 
   resource "Module::Build" do
+    # po4a requires Module::Build v0.4200 and above, while standard
+    # MacOS Perl installation has 0.4003
     url "https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-0.4231.tar.gz"
     sha256 "7e0f4c692c1740c1ac84ea14d7ea3d8bc798b2fb26c09877229e04f430b2b717"
   end
@@ -43,7 +44,7 @@ class Po4a < Formula
     sha256 "550c9245291c8df2242f7e88f7921a0f636c7eec92c644418e7d89cfea70b2bd"
   end
 
-  resource "Term::ReadKey" do
+  resource "TermReadKey" do
     url "https://cpan.metacpan.org/authors/id/J/JS/JSTOWE/TermReadKey-2.38.tar.gz"
     sha256 "5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290"
   end
@@ -82,10 +83,7 @@ class Po4a < Formula
     end
 
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
-
-    # This can be removed once po4a updates to 0.63
-    inreplace "Po4aBuilder.pm", "PERL5LIB=lib perl", "perl -Ilib"
-
+    
     system "perl", "Build.PL", "--install_base", libexec
     system "./Build"
     system "./Build", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
There is one for a version bump, but it is still broken on Big Sur. [https://github.com/Homebrew/homebrew-core/pull/66522](https://github.com/Homebrew/homebrew-core/pull/66522)
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As in issue #67333, po4a is completely broken on Big Sur. 

The first reason is that "Term::ReadKey" fails to build with system perl. Consequently, I have switched to Homebrew perl, and the build succeeds. Perhaps someone can figure out a way around this, but I think requiring Homebrew perl is a better solution than shipping a segfault'ing program.

The second reason is that the po4a build script was unnecessarily reseting the PERL5LIB environment variable. My PR on po4a to fix this just got accepted, so this issue will not be relevant in the next version of po4a. I have still included the patch here, but it can be removed soon.

In summary:
Changes:

- Version bump to 0.62
- The fix from https://github.com/Homebrew/homebrew-core/pull/66522
- Switch to Homebrew perl
- Include small patch to po4a

Fixes issue #67333