### PR TITLE
krb5: disable keyutils

### DIFF
--- a/Formula/krb5.rb
+++ b/Formula/krb5.rb
@@ -42,7 +42,8 @@ class Krb5 < Formula
                             "--disable-dependency-tracking",
                             "--disable-silent-rules",
                             "--prefix=#{prefix}",
-                            "--without-system-verto"
+                            "--without-system-verto",
+                            "--without-keyutils"
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR disables keyutils support in `krb5`. This fixes build failures on systems with `libkeyutils` installed. We do not currently have a formula for `libkeyutils`, so if we ever want to add support for it in `krb5`, we'd have to make a formula for `libkeyutils` and add it as a dependency.

Moved to homebrew-core from https://github.com/Homebrew/linuxbrew-core/pull/21872.