### PR TITLE
valgrind: disable mpicc and make Linux only

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -21,6 +21,7 @@ on:
       - "Formula/libtirpc.rb"
       - "Formula/linux-headers.rb"
       - "Formula/strace.rb"
+      - "Formula/valgrind.rb"
       - "Formula/wayland.rb"
       - "Formula/wayland-protocols.rb"
 jobs:

--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -1,22 +1,13 @@
 class Valgrind < Formula
   desc "Dynamic analysis tools (memory, debug, profiling)"
   homepage "https://www.valgrind.org/"
+  url "https://sourceware.org/pub/valgrind/valgrind-3.16.1.tar.bz2"
+  sha256 "c91f3a2f7b02db0f3bc99479861656154d241d2fdb265614ba918cc6720a33ca"
   license "GPL-2.0"
-
-  stable do
-    url "https://sourceware.org/pub/valgrind/valgrind-3.16.1.tar.bz2"
-    sha256 "c91f3a2f7b02db0f3bc99479861656154d241d2fdb265614ba918cc6720a33ca"
-
-    depends_on maximum_macos: :high_sierra
-  end
 
   livecheck do
     url "https://sourceware.org/pub/valgrind/"
     regex(/href=.*?valgrind[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
-  bottle do
-    sha256 "7170a66beb19ccfd79d1559fe57c67fb4a6a7b6369775621f5073af6fea07ea8" => :high_sierra
   end
 
   head do
@@ -27,17 +18,16 @@ class Valgrind < Formula
     depends_on "libtool" => :build
   end
 
-  # Valgrind needs vcpreload_core-*-darwin.so to have execute permissions.
-  # See #2150 for more information.
-  skip_clean "lib/valgrind"
+  depends_on :linux
 
   def install
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
       --enable-only64bit
-      --build=amd64-darwin
+      --without-mpicc
     ]
+
     system "./autogen.sh" if build.head?
 
     system "./configure", *args
@@ -46,6 +36,6 @@ class Valgrind < Formula
   end
 
   test do
-    system "#{bin}/valgrind", "ls", "-l"
+    assert_match "usage", shell_output("#{bin}/valgrind --help")
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This disables `mpicc` support in valgrind, which seems to cause build failures on host systems with `mpich` or OpenMPI installed. If we ever get a request to add support for `mpicc` to `valgrind`, we'd probably have to add `mpich` or `open-mpi` as a dependency.  Additionally the configure argument `--build=amd64-darwin` should only be used on macOS.

Moved to homebrew-core from https://github.com/Homebrew/linuxbrew-core/pull/21870.