### PR TITLE
ceres-solver: use lib instead of lib64

### DIFF
--- a/Formula/ceres-solver.rb
+++ b/Formula/ceres-solver.rb
@@ -27,7 +27,7 @@ class CeresSolver < Formula
                     "-DMETIS_LIBRARY=#{Formula["metis"].opt_lib}/#{shared_library("libmetis")}",
                     "-DGLOG_INCLUDE_DIR_HINTS=#{Formula["glog"].opt_include}",
                     "-DGLOG_LIBRARY_DIR_HINTS=#{Formula["glog"].opt_lib}",
-                    "-DTBB=OFF", "-DBUILD_EXAMPLES=OFF"
+                    "-DTBB=OFF", "-DBUILD_EXAMPLES=OFF", "-DLIB_SUFFIX=''"
     system "make"
     system "make", "install"
     pkgshare.install "examples", "data"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Although `ceres-solver` is built with CMake, it does not respect our recently added `CMAKE_INSTALL_LIBDIR=lib` addition to the CMake standard args. Instead it uses its own variable `LIB_SUFFIX` which must be set to `''` to stop it from appending `64` to the end of `lib` on some Linux systems.

Moved to homebrew-core from https://github.com/Homebrew/linuxbrew-core/pull/21810.