### PR TITLE
ssed: build on Xcode 12

### DIFF
--- a/Formula/ssed.rb
+++ b/Formula/ssed.rb
@@ -3,7 +3,7 @@ class Ssed < Formula
   homepage "https://sed.sourceforge.io/grabbag/ssed/"
   url "https://sed.sourceforge.io/grabbag/ssed/sed-3.62.tar.gz"
   sha256 "af7ff67e052efabf3fd07d967161c39db0480adc7c01f5100a1996fec60b8ec4"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     cellar :any_skip_relocation
@@ -16,6 +16,8 @@ class Ssed < Formula
   conflicts_with "gnu-sed", because: "both install share/info/sed.info"
 
   def install
+    # CFLAGS adjustment is needed to build on Xcode 12
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}",


### PR DESCRIPTION
I emailed the program's author (@bonzini) a proper patch for this as well, but since that also requires a re-run of autoconf it is probably easiest to just use the `$CFLAGS` workaround in this case.

For posterity, here are the source changes that would be needed:
```
--- sed-3.62/config/getline.m4.ORIG	2020-12-21 02:57:09.000000000 +0000
+++ sed-3.62/config/getline.m4	2020-12-21 02:57:21.000000000 +0000
@@ -27,7 +27,7 @@
       if (!in)
 	return 1;
       len = getline (&line, &siz, in);
-      exit ((len == 4 && line && strcmp (line, "foo\n") == 0) ? 0 : 1);
+      return (len == 4 && line && strcmp (line, "foo\n") == 0) ? 0 : 1;
     }
     ], am_cv_func_working_getline=yes dnl The library version works.
     , am_cv_func_working_getline=no dnl The library version does NOT work.
--- sed-3.62/sed/sed.h.ORIG	2020-12-21 03:04:33.000000000 +0000
+++ sed-3.62/sed/sed.h	2020-12-21 03:05:16.000000000 +0000
@@ -266,3 +266,4 @@
 
 extern int brlen P_ ((int ch, mbstate_t *ps));
 
+extern void initialize_mbcs P_ ((void));
--- sed-3.62/lib/getopt.c.ORIG	2020-12-21 03:01:34.000000000 +0000
+++ sed-3.62/lib/getopt.c	2020-12-21 03:02:04.000000000 +0000
@@ -90,6 +90,10 @@
 # endif
 #endif
 
+#if HAVE_STRING_H - 0
+# include <string.h>
+#endif
+
 /* This version of `getopt' appears to the caller like standard Unix `getopt'
    but it behaves differently for the user, since it allows the user
    to intersperse the options with the other arguments.
--- sed-3.62/lib/utils.c.ORIG	2020-12-21 03:02:37.000000000 +0000
+++ sed-3.62/lib/utils.c	2020-12-21 03:03:19.000000000 +0000
@@ -35,6 +35,10 @@
 # include <stdlib.h>
 #endif /* HAVE_STDLIB_H */
 
+#ifdef HAVE_UNISTD_H
+# include <unistd.h>
+#endif /* HAVE_UNISTD_H */
+ 
 #include "utils.h"
 
 const char *myname;
```