### PR TITLE
xrick: disable https

### DIFF
--- a/Formula/xrick.rb
+++ b/Formula/xrick.rb
@@ -1,7 +1,9 @@
 class Xrick < Formula
   desc "Clone of Rick Dangerous"
-  homepage "https://www.bigorno.net/xrick/"
-  url "https://www.bigorno.net/xrick/xrick-021212.tgz"
+  homepage "http://www.bigorno.net/xrick/"
+  url "http://www.bigorno.net/xrick/xrick-021212.tgz"
+  # There is a repo at https://github.com/zpqrtbnk/xrick but it is organized
+  # differently than the tarball
   sha256 "aa8542120bec97a730258027a294bd16196eb8b3d66134483d085f698588fc2b"
 
   bottle do


### PR DESCRIPTION
As of 2020-12-21, bigorno.net is returning TLS errors on port 443, but the non-https site works fine.
```
$ curl https://www.bigorno.net/
curl: (35) error:14094438:SSL routines:ssl3_read_bytes:tlsv1 alert internal error
```
cc @zpqrtbnk