### PR TITLE
mariadb-connector-odbc 3.1.11

### DIFF
--- a/Formula/mariadb-connector-odbc.rb
+++ b/Formula/mariadb-connector-odbc.rb
@@ -1,7 +1,7 @@
 class MariadbConnectorOdbc < Formula
   desc "Database driver using the industry standard ODBC API"
   homepage "https://downloads.mariadb.org/connector-odbc/"
-  url "https://mirror.netcologne.de/mariadb/connector-odbc-3.1.11/mariadb-connector-odbc-3.1.11-ga-src.tar.gz"
+  url "https://downloads.mariadb.org/f/connector-odbc-3.1.11/mariadb-connector-odbc-3.1.11-ga-src.tar.gz"
   sha256 "d81a35cd9c9d2e1e732b7bd9ee704eb83775ed74bcc38d6cd5d367a3fc525a34"
   license "LGPL-2.1-or-later"
 

--- a/Formula/mariadb-connector-odbc.rb
+++ b/Formula/mariadb-connector-odbc.rb
@@ -1,9 +1,14 @@
 class MariadbConnectorOdbc < Formula
   desc "Database driver using the industry standard ODBC API"
   homepage "https://downloads.mariadb.org/connector-odbc/"
-  url "https://downloads.mariadb.org/f/connector-odbc-3.1.9/mariadb-connector-odbc-3.1.9-ga-src.tar.gz"
-  sha256 "5ead3f69ccde539fd7e3de6f4b8f0e6f9f6c32b4b4f082adf0e2ff110971fe1e"
-  license "LGPL-2.1"
+  url "https://mirror.netcologne.de/mariadb/connector-odbc-3.1.11/mariadb-connector-odbc-3.1.11-ga-src.tar.gz"
+  sha256 "d81a35cd9c9d2e1e732b7bd9ee704eb83775ed74bcc38d6cd5d367a3fc525a34"
+  license "LGPL-2.1-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/Download (\d+(?:\.\d+)+) Stable Now!/i)
+  end
 
   bottle do
     sha256 "339b4c5fa7121936bd5ed68e5d6c507400e43445bc46b63f6cea6212e047c66f" => :catalina
@@ -23,6 +28,10 @@ class MariadbConnectorOdbc < Formula
                          "-DWITH_SSL=OPENSSL",
                          "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
                          "-DWITH_IODBC=0",
+                         # Workaround 3.1.11 issues finding system's built-in -liconv
+                         # See https://jira.mariadb.org/browse/ODBC-299
+                         "-DICONV_LIBRARIES=#{MacOS.sdk_path}/usr/lib/libiconv.tbd",
+                         "-DICONV_INCLUDE_DIR=/usr/include",
                          *std_cmake_args
 
     # By default, the installer pkg is built - we don't want that.


### PR DESCRIPTION
This formula was failing to build due to library-detection issues on Big Sur.  I worked around it with some cmake variables and reported the issue upstream.

The downloads.mariadb.org web page now does some fancy redirection during interactive downlods; I had to dig and find the real URL that served me via their mirroring system.
