### PR TITLE
exim: fix StringInreplaceExtension failure during build

### DIFF
--- a/Formula/exim.rb
+++ b/Formula/exim.rb
@@ -38,6 +38,8 @@ class Exim < Formula
       s.gsub! "/var/spool/exim", var/"spool/exim"
       # https://trac.macports.org/ticket/38654
       s.gsub! 'TMPDIR="/tmp"', "TMPDIR=/tmp"
+    end
+    open("Local/Makefile", "a") do |s|
       s << "AUTH_PLAINTEXT=yes\n"
       s << "SUPPORT_TLS=yes\n"
       s << "USE_OPENSSL=yes\n"


### PR DESCRIPTION
Building this formula was failing with:
```
Error: An exception occurred within a child process:
  NoMethodError: undefined method `<<' for #<StringInreplaceExtension:0x00007f8e14afe278>
```
I guess this formula syntax must have been valid at some point since it's been there for years, but it doesn't seem to work anymore. 🤷 

Just append to the file as a separate step.