### PR TITLE
ace: allow building on MacOS 11

### DIFF
--- a/Formula/ace.rb
+++ b/Formula/ace.rb
@@ -18,9 +18,15 @@ class Ace < Formula
     sha256 "67426f70081ea3aa5845f9d582a47f5795f9770b726e27242189a2d863967e22" => :high_sierra
   end
 
+  # Fix issues with detection of newer OS/X versions; makefiles 6.5.12 are OK with
+  # new versions in the form "10.X" but not "11.X":
+  patch :DATA
+
   def install
     ln_sf "config-macosx.h", "ace/config.h"
     ln_sf "platform_macosx.GNU", "include/makeinclude/platform_macros.GNU"
+    copy "include/makeinclude/platform_macosx_mojave.GNU", "include/makeinclude/platform_macosx_catalina.GNU"
+    copy "include/makeinclude/platform_macosx_catalina.GNU", "include/makeinclude/platform_macosx_bigsur.GNU"
 
     # Set up the environment the way ACE expects during build.
     ENV["ACE_ROOT"] = buildpath
@@ -46,3 +52,40 @@ class Ace < Formula
     system "./test_callback"
   end
 end
+
+__END__
+--- ACE_wrappers/include/makeinclude/platform_macosx.GNU.ORIG	2020-12-21 06:28:12.000000000 +0000
++++ ACE_wrappers/include/makeinclude/platform_macosx.GNU	2020-12-21 06:36:17.000000000 +0000
+@@ -20,19 +20,25 @@
+ MACOS_CODENAME_VER_10_12  := sierra
+ MACOS_CODENAME_VER_10_13  := highsierra
+ MACOS_CODENAME_VER_10_14  := mojave
+-MACOS_CODENAME_VER_latest := mojave
+-
+-MACOS_CODENAME = $(MACOS_CODENAME_VER_$(MACOS_MAJOR_VERSION)_$(MACOS_MINOR_VERSION))
++MACOS_CODENAME_VER_10_15  := catalina
++MACOS_CODENAME_VER_11     := bigsur
++MACOS_CODENAME_VER_latest := bigsur
+ 
+ ifeq ($(MACOS_MAJOR_VERSION),10)
+-  ifeq ($(shell test $(MACOS_MINOR_VERSION) -gt 14; echo $$?),0)
+-    ## if the detected version is greater than the latest know version,
+-    ## just use the latest known version
+-    MACOS_CODENAME = $(MACOS_CODENAME_VER_latest)
++  MACOS_CODENAME = $(MACOS_CODENAME_VER_$(MACOS_MAJOR_VERSION)_$(MACOS_MINOR_VERSION))
++  ifeq ($(shell test $(MACOS_MINOR_VERSION) -gt 15; echo $$?),0)
++    ## Unsupported minor version
++    $(error Unsupported MacOS version $(MACOS_RELEASE_VERSION))
+   else ifeq ($(shell test $(MACOS_MINOR_VERSION) -lt 2; echo $$?),0)
+     ## Unsupported minor version
+     $(error Unsupported MacOS version $(MACOS_RELEASE_VERSION))
+   endif
++else ifeq ($(shell test $(MACOS_MAJOR_VERSION) -gt 11; echo $$?),0)
++  ## if the detected version is greater than the latest know version,
++  ## just use the latest known version
++  MACOS_CODENAME = $(MACOS_CODENAME_VER_latest)
++else ifeq ($(shell test $(MACOS_MAJOR_VERSION) -gt 10; echo $$?),0)
++  MACOS_CODENAME = $(MACOS_CODENAME_VER_$(MACOS_MAJOR_VERSION))
+ else
+   ## Unsupported major version
+   $(error Unsupported MacOS version $(MACOS_RELEASE_VERSION))


### PR DESCRIPTION
The Makefile is prepared to work with a 10.X version that it isn't previously aware of, but if you try to build on MacOS 11 you get:
```
.../ACE_wrappers/include/makeinclude/platform_macros.GNU:38: *** Unsupported MacOS version 11.1.  Stop.
```
I'll send my report to their bug email (they don't appear to have a public tracker)