### PR TITLE
python@3.9: Fix crash on macOS 10.15

### DIFF
--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -4,7 +4,7 @@ class PythonAT39 < Formula
   url "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tar.xz"
   sha256 "991c3f8ac97992f3d308fefeb03a64db462574eadbff34ce8bc5bb583d9903ff"
   license "Python-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://www.python.org/ftp/python/"
@@ -155,7 +155,8 @@ class PythonAT39 < Formula
     # even if homebrew is not a /usr/local/lib. Try this with:
     # `brew install enchant && pip install pyenchant`
     inreplace "./Lib/ctypes/macholib/dyld.py" do |f|
-      f.gsub! "DEFAULT_LIBRARY_FALLBACK = [", "DEFAULT_LIBRARY_FALLBACK = [ '#{HOMEBREW_PREFIX}/lib',"
+      f.gsub! "DEFAULT_LIBRARY_FALLBACK = [",
+              "DEFAULT_LIBRARY_FALLBACK = [ '#{HOMEBREW_PREFIX}/lib', '#{Formula["openssl@1.1"].opt_lib}',"
       f.gsub! "DEFAULT_FRAMEWORK_FALLBACK = [", "DEFAULT_FRAMEWORK_FALLBACK = [ '#{HOMEBREW_PREFIX}/Frameworks',"
     end
 


### PR DESCRIPTION
Many packages[1] use 'crypto' to find the OpenSSL shared library. Unfortunately, It will crash[2] by SIGABRT with message `Invalid dylib load. Clients should not load the unversioned libcrypto dylib as it does not have a stable ABI.
` in macOS Catalina. The dyld emulation in the ctypes module has its own paths for searching library. So add library path of keg-only openssl@1.1 as a default fallback path to fix the problem.

How to reproduce? Save following snippet as a file and execute with arguments 'crypto' and 'crypto.44' respectively to see different results.

    import sys
    from ctypes.util import find_library
    from ctypes import CDLL

    name = sys.argv[1]
    path = find_library(name)
    print(f"path: {path}")
    lib = CDLL(path)

  [1]: https://github.com/search?l=&q=find_library+crypto+language%3APython&type=code
  [2]: https://stackoverflow.com/questions/58272830/python-crashing-on-macos-10-15-beta-19a582a-with-usr-lib-libcrypto-dylib

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
