### PR TITLE
ghc: remove head

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -17,19 +17,6 @@ class Ghc < Formula
     sha256 "40e2b31e3390cf784dedcd4357362bee577b6a5c1d911f5c072828fe01f42e8f" => :high_sierra
   end
 
-  head do
-    url "https://gitlab.haskell.org/ghc/ghc.git", branch: "ghc-8.10"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-
-    resource "cabal" do
-      url "https://hackage.haskell.org/package/cabal-install-3.2.0.0/cabal-install-3.2.0.0.tar.gz"
-      sha256 "a0555e895aaf17ca08453fde8b19af96725da8398e027aa43a49c1658a600cb0"
-    end
-  end
-
   depends_on "python@3.9" => :build
   depends_on "sphinx-doc" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?

-----

(Marking as `do not merge` until #67284 (ghc 8.10.3) is merged)

As of https://github.com/Homebrew/homebrew-core/commit/23190650057f6c96ea60ce8b2e016a1bdcbf1d2a, `ghc`'s `head` build is now _officially_ broken. (It hasn't worked for awhile now since `Language::Haskell::Cabal` was deprecated and then disabled quite some time ago.) Considering how complex the formula already is, it's probably best to simplify things and completely remove all references to `head`.