### PR TITLE
jnettop: fix build with Xcode 12

### DIFF
--- a/Formula/jnettop.rb
+++ b/Formula/jnettop.rb
@@ -23,6 +23,10 @@ class Jnettop < Formula
   depends_on "glib"
 
   def install
+    # Work around "-Werror,-Wimplicit-function-declaration" issues with
+    # configure scripts on Xcode 12:
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
This package seems pretty unmaintained (there is a bug tracker on sourceforge but it seems untouched since 2006 or so) so probably the `$CFLAGS` workaround is the most pragmatic fix.