### PR TITLE
fix futhark build failed in ghc 8.10.3

### DIFF
--- a/Formula/futhark.rb
+++ b/Formula/futhark.rb
@@ -4,8 +4,8 @@ class Futhark < Formula
   url "https://github.com/diku-dk/futhark/archive/v0.18.4.tar.gz"
   sha256 "262dd8024c58ebb05964010227bc76907c873f261ab3348ffeab5fa5b1def022"
   license "ISC"
-  head "https://github.com/diku-dk/futhark.git"
   revision 1
+  head "https://github.com/diku-dk/futhark.git"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/futhark.rb
+++ b/Formula/futhark.rb
@@ -5,6 +5,7 @@ class Futhark < Formula
   sha256 "262dd8024c58ebb05964010227bc76907c873f261ab3348ffeab5fa5b1def022"
   license "ISC"
   head "https://github.com/diku-dk/futhark.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -22,7 +23,8 @@ class Futhark < Formula
 
   def install
     system "cabal", "v2-update"
-    system "cabal", "v2-install", *std_cabal_v2_args
+    # see https://github.com/ddssff/listlike/issues/8#issuecomment-748985462 for detail
+    system "cabal", "v2-install", *std_cabal_v2_args, "--constraint=bytestring==0.10.10.1"
 
     system "make", "-C", "docs", "man"
     man1.install Dir["docs/_build/man/*.1"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
fixes for #67284, cause by `process-extras`'s transitive dependency of `ListLike` (ddssff/listlike#8)