### PR TITLE
open-mpi 4.1.0

### DIFF
--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -1,8 +1,8 @@
 class OpenMpi < Formula
   desc "High performance message passing library"
   homepage "https://www.open-mpi.org/"
-  url "https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.bz2"
-  sha256 "c58f3863b61d944231077f344fe6b4b8fbb83f3d1bc93ab74640bf3e5acac009"
+  url "https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.0.tar.bz2"
+  sha256 "73866fb77090819b6a8c85cb8539638d37d6877455825b74e289d647a39fd5b5"
   license "BSD-3-Clause"
 
   livecheck do
@@ -20,14 +20,6 @@ class OpenMpi < Formula
 
   head do
     url "https://github.com/open-mpi/ompi.git"
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
-
-  # Regenerate for Big Sur due to configure issues
-  # https://github.com/open-mpi/ompi/issues/8218
-  if MacOS.version >= :big_sur
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
@@ -73,13 +65,17 @@ class OpenMpi < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --enable-ipv6
-      --enable-mca-no-build=reachable-netlink
+      --enable-mca-no-build=op-avx,reachable-netlink
       --with-libevent=#{Formula["libevent"].opt_prefix}
       --with-sge
     ]
     args << "--with-platform-optimized" if build.head?
 
-    system "./autogen.pl", "--force" if build.head? || MacOS.version >= :big_sur
+    # Temporary workaround for atomics issue on ARM
+    # https://github.com/open-mpi/ompi/issues/8410
+    args << "--disable-builtin-atomics" if Hardware::CPU.arm?
+
+    system "./autogen.pl", "--force" if build.head?
     system "./configure", *args
     system "make", "all"
     system "make", "check"

--- a/Formula/petsc-complex.rb
+++ b/Formula/petsc-complex.rb
@@ -4,6 +4,7 @@ class PetscComplex < Formula
   url "https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.14.3.tar.gz"
   sha256 "63ed7e3440f2bbc732a6c44aa878364f88f5016ab375d9b36d742893a049053d"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     sha256 "6ac5b57d4d2de403a56d5789213d3f9b99ed434087b16bab042819cc5ebce9b6" => :big_sur

--- a/Formula/petsc.rb
+++ b/Formula/petsc.rb
@@ -4,6 +4,7 @@ class Petsc < Formula
   url "https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.14.3.tar.gz"
   sha256 "63ed7e3440f2bbc732a6c44aa878364f88f5016ab375d9b36d742893a049053d"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     url "https://www.mcs.anl.gov/petsc/download/index.html"


### PR DESCRIPTION
 - bump to 4.1.0
 - use ENV.refurbish_args to fix AVX512 detection
 - do not force autogen.pl on Big Sur

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
