### PR TITLE
xcb-util-wm: uses m4 from macos for build

### DIFF
--- a/Formula/xcb-util-wm.rb
+++ b/Formula/xcb-util-wm.rb
@@ -23,6 +23,8 @@ class XcbUtilWm < Formula
   depends_on "pkg-config" => [:build, :test]
   depends_on "libxcb"
 
+  uses_from_macos "m4" => :build
+
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
