### PR TITLE
zile: revert version bump back to stable

### DIFF
--- a/Formula/zile.rb
+++ b/Formula/zile.rb
@@ -1,10 +1,14 @@
 class Zile < Formula
   desc "Text editor development kit"
   homepage "https://www.gnu.org/software/zile/"
-  url "https://ftp.gnu.org/gnu/zile/zile-2.6.0.90.tar.gz"
-  mirror "https://ftpmirror.gnu.org/zile/zile-2.6.0.90.tar.gz"
-  sha256 "239b5b9575e3310205912cb87a25a6bff0d951feb7623722041ee2aa95e50dae"
+  # For version bumps, check the NEWS file in the tarball to make sure that
+  # this is a stable release. For context, see
+  # https://github.com/Homebrew/homebrew-core/issues/67379
+  url "https://ftp.gnu.org/gnu/zile/zile-2.4.15.tar.gz"
+  mirror "https://ftpmirror.gnu.org/zile/zile-2.4.15.tar.gz"
+  sha256 "39c300a34f78c37ba67793cf74685935a15568e14237a3a66fda8fcf40e3035e"
   license "GPL-3.0-or-later"
+  version_scheme 1
 
   livecheck do
     url :stable
@@ -20,8 +24,6 @@ class Zile < Formula
   depends_on "help2man" => :build
   depends_on "pkg-config" => :build
   depends_on "bdw-gc"
-  depends_on "glib"
-  depends_on "libgee"
 
   uses_from_macos "ncurses"
 

--- a/Formula/zile.rb
+++ b/Formula/zile.rb
@@ -11,7 +11,7 @@ class Zile < Formula
   version_scheme 1
 
   livecheck do
-    url :stable
+    skip "Version string does not distinguish stable from beta"
   end
 
   bottle do


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/issues/67379.

This reverts commit dd80dd1fc8549b955191f1db8677d7483aacbcb3.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
