### PR TITLE
libgcrypt: remove unused dependency

### DIFF
--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -20,8 +20,6 @@ class Libgcrypt < Formula
 
   depends_on "libgpg-error"
 
-  uses_from_macos "libxslt"
-
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It seems `libxslt` was unintentionally added as a dependency in https://github.com/Homebrew/homebrew-core/commit/966cffabec8db88724bc98edbcc52ab7c6bc4594 (syncing `uses_from_macos` from Homebrew/linuxbrew-core)

If we take a look at the linuxbrew-core repo, the parent commit to https://github.com/Homebrew/linuxbrew-core/commit/966cffa is https://github.com/Homebrew/linuxbrew-core/commit/f861b6d, and `libgcrypt` does not reference `libxslt`:

https://github.com/Homebrew/linuxbrew-core/blob/f861b6d/Formula/libgcrypt.rb

Related: https://github.com/Homebrew/homebrew-core/pull/66966