### PR TITLE
optipng: fix build on Apple Silicon

### DIFF
--- a/Formula/optipng.rb
+++ b/Formula/optipng.rb
@@ -19,10 +19,16 @@ class Optipng < Formula
     sha256 "f59e3cedb808003915ee214f6487b968e3e6dcea669452f0a732fcced03aaa8f" => :el_capitan
   end
 
+  depends_on "libpng"
+
   uses_from_macos "zlib"
 
   def install
+    # find Homebrew's libpng
+    ENV.append "CPPFLAGS", "-I#{Formula["libpng"].opt_include}"
+    ENV.append "LDFLAGS", "-L#{Formula["libpng"].opt_lib}"
     system "./configure", "--with-system-zlib",
+                          "--with-system-libpng",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}"
     system "make", "install"

--- a/Formula/optipng.rb
+++ b/Formula/optipng.rb
@@ -25,9 +25,6 @@ class Optipng < Formula
   uses_from_macos "zlib"
 
   def install
-    # find Homebrew's libpng
-    ENV.append "CPPFLAGS", "-I#{Formula["libpng"].opt_include}"
-    ENV.append "LDFLAGS", "-L#{Formula["libpng"].opt_lib}"
     system "./configure", "--with-system-zlib",
                           "--with-system-libpng",
                           "--prefix=#{prefix}",

--- a/Formula/optipng.rb
+++ b/Formula/optipng.rb
@@ -3,6 +3,7 @@ class Optipng < Formula
   homepage "https://optipng.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.7/optipng-0.7.7.tar.gz"
   sha256 "4f32f233cef870b3f95d3ad6428bfe4224ef34908f1b42b0badf858216654452"
+  license "Zlib"
   head "http://hg.code.sf.net/p/optipng/mercurial", using: :hg
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

When installing current `optipng` formula on an Apple ARM it fails with an error from the `libpng` shipped within the package:

```sh

$ brew install -s optipng

[...]

==> ./configure --with-system-zlib --prefix=/opt/homebrew/Cellar/optipng/0.7.7 --mandir=/opt/homebrew/Cellar/optipng/0.7.7/share/man
==> make install
Last 15 lines from /Users/ignic/Library/Logs/Homebrew/optipng/02.make:
clang -c  -O2 -Wall -Wextra  -I../libpng -I../gifread -I../pnmio -I../minitiff -o pngxset.o pngxset.c
ar cru libpngxtern.a pngxread.o pngxrbmp.o pngxrgif.o pngxrjpg.o pngxrpnm.o pngxrtif.o pngxio.o pngxmem.o pngxset.o
ranlib libpngxtern.a
ar cru libopngreduc.a opngreduc.o
ranlib libopngreduc.a
clang -c  -O2 -Wall -Wextra -I../cexcept  -I../libpng -I../opngreduc -I../pngxtern -o optipng.o optipng.c
clang -c  -O2 -Wall -Wextra -I../cexcept  -I../libpng -I../opngreduc -I../pngxtern -o optim.o optim.c
clang -s -o optipng optipng.o optim.o bitset.o ioutil.o ratio.o wildargs.o ../opngreduc/libopngreduc.a ../pngxtern/libpngxtern.a ../libpng/libpng.a  ../gifread/libgifread.a ../pnmio/libpnmio.a ../minitiff/libminitiff.a  -lz -lm
Undefined symbols for architecture arm64:
  "_png_init_filter_functions_neon", referenced from:
      _png_read_filter_row in libpng.a(pngrutil.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [optipng] Error 1
make: *** [install] Error 2
```

Homebrew has a more recent version of libpng (1.6.37 vs 1.6.34) that now even has an arm64 bottle, so maybe we can use it.

`--with-system-libpng` implies `--with-system-zlib`, but I have not removed the latter for clarity.

Just my humble contribution, sorry for any mistakes or breaking a guideline 🙏🏻