### PR TITLE
workflows: add remove-disabled-formulae workflow

### DIFF
--- a/.github/workflows/remove-disabled-formulae.yml
+++ b/.github/workflows/remove-disabled-formulae.yml
@@ -1,0 +1,39 @@
+name: Remove disabled formulae
+
+on:
+  push:
+    paths:
+    - .github/workflows/remove-disabled-formulae.yml
+  schedule:
+    # Once every day at midnight UTC
+    - cron: "0 0 * * *"
+
+jobs:
+  remove-disabled-formulae:
+    if: startsWith(github.repository, 'Homebrew/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Configure Git user
+        uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
+
+      - name: Remove disabled formulae
+        id: remove_disabled
+        uses: Homebrew/actions/remove-disabled-formulae@master
+
+      - name: Create pull request
+        if: ${{ steps.remove_disabled.outputs.formulae-removed == 'true' }}
+        uses: peter-evans/create-pull-request@45c510e1f68ba052e3cd911f661a799cfb9ba3a3
+        with:
+          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          branch: remove-disabled-formulae
+          title: Remove disabled formulae
+          body: >
+            This pull request was created automatically by the
+            [`remove-disabled-formulae`](https://github.com/Homebrew/homebrew-core/blob/HEAD/.github/workflows/remove-disabled-formulae.yml)
+            workflow.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds a workflow that will automatically remove formulae that have a disable date of more than one year ago. See discussion in #66360. I haven't really tested the actual PR-creation part of this (although I've tested the old-formula-detection part locally), so if it seems okay I'd suggest merging and seeing what happens.
