### PR TITLE
torsocks: fix the patch URL

### DIFF
--- a/Formula/torsocks.rb
+++ b/Formula/torsocks.rb
@@ -18,9 +18,9 @@ class Torsocks < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
-  # https://trac.torproject.org/projects/tor/ticket/28538
+  # https://gitlab.torproject.org/legacy/trac/-/issues/28538
   patch do
-    url "https://trac.torproject.org/projects/tor/raw-attachment/ticket/28538/0001-Fix-macros-for-accept4-2.patch"
+    url "https://gitlab.torproject.org/legacy/trac/uploads/9efc1c0c47b3950aa91e886b01f7e87d/0001-Fix-macros-for-accept4-2.patch"
     sha256 "97881f0b59b3512acc4acb58a0d6dfc840d7633ead2f400fad70dda9b2ba30b0"
   end
 


### PR DESCRIPTION
Tor project moved their issues from Trac to Gitlab, and now Trac attachment URLs don't work.
Update the patch URL to Gitlab.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
