### PR TITLE
mogenerator: fix xcode project file dependencies

### DIFF
--- a/Formula/mogenerator.rb
+++ b/Formula/mogenerator.rb
@@ -16,6 +16,12 @@ class Mogenerator < Formula
 
   depends_on xcode: :build
 
+  # https://github.com/rentzsch/mogenerator/pull/390
+  patch do
+    url "https://github.com/rentzsch/mogenerator/commit/20d9cce6df8380160cac0ce07687688076fddf3d.patch?full_index=1"
+    sha256 "de700f06c32cc0d4fbcb1cdd91e9e97a55931bc047841985d5c0905e65b5e5b0"
+  end
+
   def install
     xcodebuild "-target", "mogenerator", "-configuration", "Release", "SYMROOT=symroot", "OBJROOT=objroot"
     bin.install "symroot/Release/mogenerator"


### PR DESCRIPTION
This formula was no longer building on Xcode 12.  After a lot of investigation I think I narrowed it down to an issue with file
dependencies inside of its xcode project: https://github.com/rentzsch/mogenerator/pull/390
