### PR TITLE
keepassc: update to python 3.9

### DIFF
--- a/Formula/keepassc.rb
+++ b/Formula/keepassc.rb
@@ -4,7 +4,7 @@ class Keepassc < Formula
   url "https://files.pythonhosted.org/packages/c8/87/a7d40d4a884039e9c967fb2289aa2aefe7165110a425c4fb74ea758e9074/keepassc-1.8.2.tar.gz"
   sha256 "2e1fc6ccd5325c6f745f2d0a3bb2be26851b90d2095402dd1481a5c197a7b24e"
   license "ISC"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -17,7 +17,7 @@ class Keepassc < Formula
     sha256 "6304afecfb788ee22bf327d47ca046fc905db8383b348393eb7907f7b1479ce4" => :high_sierra
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "kppy" do
     url "https://files.pythonhosted.org/packages/c8/d9/6ced04177b4790ccb1ba44e466c5b67f3a1cfe4152fb05ef5f990678f94f/kppy-1.5.2.tar.gz"
@@ -25,8 +25,8 @@ class Keepassc < Formula
   end
 
   resource "pycryptodomex" do
-    url "https://files.pythonhosted.org/packages/7f/3c/80cfaec41c3a9d0f524fe29bca9ab22d02ac84b5bfd6e22ade97d405bdba/pycryptodomex-3.9.7.tar.gz"
-    sha256 "50163324834edd0c9ce3e4512ded3e221c969086e10fdd5d3fdcaadac5e24a78"
+    url "https://files.pythonhosted.org/packages/14/90/f4a934bffae029e16fb33f3bd87014a0a18b4bec591249c4fc01a18d3ab6/pycryptodomex-3.9.9.tar.gz"
+    sha256 "7b5b7c5896f8172ea0beb283f7f9428e0ab88ec248ce0a5b8c98d73e26267d51"
   end
 
   def install
@@ -34,8 +34,13 @@ class Keepassc < Formula
     ENV.prepend_create_path "PYTHONPATH", libexec+"lib/python#{pyver}/site-packages"
     install_args = %W[setup.py install --prefix=#{libexec}]
 
-    resource("pycryptodomex").stage { system "python3", *install_args }
-    resource("kppy").stage { system "python3", *install_args }
+    resource("pycryptodomex").stage do
+      system "python3", *install_args, "--single-version-externally-managed", "--record=installed.txt"
+    end
+
+    resource("kppy").stage do
+      system "python3", *install_args
+    end
 
     system "python3", *install_args
 


### PR DESCRIPTION
There was a previous attempt to do this by @fxcoudert (#62341) but it didn't work and was abandoned.  I did some debugging and found the issue was just that by default `pycryptodomex` installs into an egg-directory which isn't what we want.  Just forcing it to use `--single-version-externally-managed` (like many other formulae with python subresources do) solves the issue.

The kppy subresource doesn't accept this option, but it looks like it installs fine without it.