### PR TITLE
docbook-xsl: add mirror for patch

### DIFF
--- a/Formula/docbook-xsl.rb
+++ b/Formula/docbook-xsl.rb
@@ -37,6 +37,7 @@ class DocbookXsl < Formula
   # see http://www.linuxfromscratch.org/blfs/view/9.1/pst/docbook-xsl.html for this patch
   patch do
     url "http://www.linuxfromscratch.org/patches/blfs/9.1/docbook-xsl-nons-1.79.2-stack_fix-1.patch"
+    mirror "https://raw.githubusercontent.com/Homebrew/formula-patches/5f2d6c1/docbook-xsl/docbook-xsl-nons-1.79.2-stack_fix-1.patch"
     sha256 "a92c39715c54949ba9369add1809527b8f155b7e2a2b2e30cb4b39ee715f2e30"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`curl` is unable to download the patch for `docbook-xsl` from linuxfromscratch.org

Related:
- https://github.com/Homebrew/formula-patches/pull/331
- https://github.com/Homebrew/homebrew-core/issues/67283

Indirectly related:
- https://github.com/Homebrew/homebrew-core/pull/64175#issuecomment-749379898
- https://github.com/Homebrew/homebrew-core/pull/67385