### PR TITLE
curl: don't hardcode path to certificate bundles

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -42,15 +42,15 @@ class Curl < Formula
   def install
     system "./buildconf" if build.head?
 
-    openssl = Formula["openssl@1.1"]
     args = %W[
       --disable-debug
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
-      --with-ssl=#{openssl.opt_prefix}
-      --with-ca-bundle=#{openssl.pkgetc}/cert.pem
-      --with-ca-path=#{openssl.pkgetc}/certs
+      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
+      --without-ca-bundle
+      --without-ca-path
+      --with-ca-fallback
       --with-secure-transport
       --with-default-ssl-backend=openssl
       --with-gssapi


### PR DESCRIPTION
Instead, rely on OpenSSL's certificate store. Since curl's default backend is already OpenSSL, this should result in no user-visible changes, but will also permit relocatable bottles, which are needed on Linux.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----