### PR TITLE
libxml++5 5.0.0 (new formula)

### DIFF
--- a/Formula/libxml++5.rb
+++ b/Formula/libxml++5.rb
@@ -1,0 +1,45 @@
+class Libxmlxx5 < Formula
+  desc "C++ wrapper for libxml"
+  homepage "https://libxmlplusplus.sourceforge.io/"
+  url "https://download.gnome.org/sources/libxml++/5.0/libxml++-5.0.0.tar.xz"
+  sha256 "3d716f522d380ba3a78458d8994cb1ce2b618f6a2026bce63ca5c86baef3b874"
+  license "LGPL-2.1-or-later"
+
+  livecheck do
+    url :stable
+  end
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => [:build, :test]
+  depends_on "python" => :build
+
+  uses_from_macos "libxml2"
+
+  def install
+    ENV.cxx11
+    mkdir "build" do
+      system "meson", *std_meson_args, ".."
+      system "ninja"
+      system "ninja", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <libxml++/libxml++.h>
+
+      int main(int argc, char *argv[])
+      {
+         xmlpp::Document document;
+         document.set_internal_subset("homebrew", "", "https://www.brew.sh/xml/test.dtd");
+         xmlpp::Element *rootnode = document.create_root_node("homebrew");
+         return 0;
+      }
+    EOS
+    command = "#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs libxml++-5.0"
+    flags = shell_output(command).strip.split
+    system ENV.cxx, "-std=c++17", "test.cpp", "-o", "test", *flags
+    system "./test"
+  end
+end


### PR DESCRIPTION
This submission might seem strange seeing as I also have a PR open for libxml++4.
Read https://github.com/libxmlplusplus/libxmlplusplus/issues/20#issuecomment-749562164 for the rationale behind simultaneously starting two ABI incompatible series of the same package.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----