### PR TITLE
zile: re-enable livecheck

### DIFF
--- a/Formula/zile.rb
+++ b/Formula/zile.rb
@@ -1,8 +1,8 @@
 class Zile < Formula
   desc "Text editor development kit"
   homepage "https://www.gnu.org/software/zile/"
-  # For version bumps, check the NEWS file in the tarball to make sure that
-  # this is a stable release. For context, see
+  # For version bumps, check the NEWS file in the tarball to
+  # make sure that this is a stable release. For context, see
   # https://github.com/Homebrew/homebrew-core/issues/67379
   url "https://ftp.gnu.org/gnu/zile/zile-2.4.15.tar.gz"
   mirror "https://ftpmirror.gnu.org/zile/zile-2.4.15.tar.gz"
@@ -11,7 +11,7 @@ class Zile < Formula
   version_scheme 1
 
   livecheck do
-    skip "Version string does not distinguish stable from beta"
+    url :stable
   end
 
   bottle do


### PR DESCRIPTION
`livecheck` can now reliably check for stable releases: https://github.com/Homebrew/homebrew-core/issues/67379#issuecomment-749563138

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?