### PR TITLE
libpinyin: fix license

### DIFF
--- a/Formula/libpinyin.rb
+++ b/Formula/libpinyin.rb
@@ -3,7 +3,7 @@ class Libpinyin < Formula
   homepage "https://github.com/libpinyin/libpinyin"
   url "https://github.com/libpinyin/libpinyin/archive/2.6.0.tar.gz"
   sha256 "2b52f617a99567a8ace478ee82ccc62d1761e3d1db2f1e05ba05b416708c35d2"
-  license "GPL-3.0-only"
+  license "GPL-3.0-or-later"
 
   bottle do
     cellar :any


### PR DESCRIPTION
follow up of #67196

---

license header ref:
```
/* 
 *  libpinyin
 *  Library to deal with pinyin.
 *  
 *  Copyright (C) 2017 Peng Wu <alexepico@gmail.com>
 *  
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by
 *  the Free Software Foundation, either version 3 of the License, or
 *  (at your option) any later version.
 *
 *  This program is distributed in the hope that it will be useful,
 *  but WITHOUT ANY WARRANTY; without even the implied warranty of
 *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 *  GNU General Public License for more details.
 *
 *  You should have received a copy of the GNU General Public License
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
```