### PR TITLE
rustup-init: add linux-only dependency

### DIFF
--- a/Formula/rustup-init.rb
+++ b/Formula/rustup-init.rb
@@ -14,6 +14,14 @@ class RustupInit < Formula
 
   depends_on "rust" => :build
 
+  uses_from_macos "curl"
+  uses_from_macos "xz"
+
+  on_linux do
+    depends_on "pkg-config" => :build
+    depends_on "openssl@1.1"
+  end
+
   def install
     cargo_home = buildpath/"cargo_home"
     cargo_home.mkpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
