### PR TITLE
rav1e: Add option for building the HEAD of git

### DIFF
--- a/Formula/rav1e.rb
+++ b/Formula/rav1e.rb
@@ -1,12 +1,10 @@
 class Rav1e < Formula
   desc "Fastest and safest AV1 video encoder"
   homepage "https://github.com/xiph/rav1e"
+  url "https://github.com/xiph/rav1e/archive/v0.3.4.tar.gz"
+  sha256 "797699359d594c929636ddd54474c99fe0577b545a21384514f864d68f67b98f"
   license "BSD-2-Clause"
-
-  stable do
-    url "https://github.com/xiph/rav1e/archive/v0.3.4.tar.gz"
-    sha256 "797699359d594c929636ddd54474c99fe0577b545a21384514f864d68f67b98f"
-  end
+  head "https://github.com/xiph/rav1e.git"
 
   livecheck do
     url :stable
@@ -19,10 +17,6 @@ class Rav1e < Formula
     sha256 "ee813b17cb949b695b9a199598b87370decbd7b9b2bfa1400aacd5542c2f73de" => :catalina
     sha256 "047aa3d9eb50622a2f8ebf34559393d8d7b276989ef0329ffad94933eaca2060" => :mojave
     sha256 "042c41714f694ce482a1405b0346f14e69607c0cea8285a6563dfbf2f899aba0" => :high_sierra
-  end
-
-  head do
-    url "https://github.com/xiph/rav1e.git"
   end
 
   depends_on "cargo-c" => :build

--- a/Formula/rav1e.rb
+++ b/Formula/rav1e.rb
@@ -1,9 +1,12 @@
 class Rav1e < Formula
   desc "Fastest and safest AV1 video encoder"
   homepage "https://github.com/xiph/rav1e"
-  url "https://github.com/xiph/rav1e/archive/v0.3.4.tar.gz"
-  sha256 "797699359d594c929636ddd54474c99fe0577b545a21384514f864d68f67b98f"
   license "BSD-2-Clause"
+
+  stable do
+    url "https://github.com/xiph/rav1e/archive/v0.3.4.tar.gz"
+    sha256 "797699359d594c929636ddd54474c99fe0577b545a21384514f864d68f67b98f"
+  end
 
   livecheck do
     url :stable
@@ -16,6 +19,10 @@ class Rav1e < Formula
     sha256 "ee813b17cb949b695b9a199598b87370decbd7b9b2bfa1400aacd5542c2f73de" => :catalina
     sha256 "047aa3d9eb50622a2f8ebf34559393d8d7b276989ef0329ffad94933eaca2060" => :mojave
     sha256 "042c41714f694ce482a1405b0346f14e69607c0cea8285a6563dfbf2f899aba0" => :high_sierra
+  end
+
+  head do
+    url "https://github.com/xiph/rav1e.git"
   end
 
   depends_on "cargo-c" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently only the v4.0.0-alpha in git builds successfully for rav1e on M1 macs, as opposed to the v0.3.4 version the recipe pulls currently.

This pull request adds a `--HEAD` argument so that it can be successfully built on such a machine.