### PR TITLE
sng: fix compile

### DIFF
--- a/Formula/sng.rb
+++ b/Formula/sng.rb
@@ -21,7 +21,7 @@ class Sng < Formula
   depends_on "xorgrgb"
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}", "--with-rgbtxt=#{Formula["xorgrgb"].share}/X11/rgb.txt"
     system "make", "install"
   end
 


### PR DESCRIPTION
This formula wasn't buildable from source.  It had the correct dependency on xorgrgb but `./configure` wasn't finding it.
