### PR TITLE
pcre++: fix "brew audit" issues

### DIFF
--- a/Formula/pcre++.rb
+++ b/Formula/pcre++.rb
@@ -2,8 +2,9 @@ class Pcrexx < Formula
   desc "C++ wrapper for the Perl Compatible Regular Expressions"
   homepage "https://www.daemon.de/PCRE"
   url "https://www.daemon.de/idisk/Apps/pcre++/pcre++-0.9.5.tar.gz"
+  mirror "https://distfiles.openadk.org/pcre++-0.9.5.tar.gz"
   sha256 "77ee9fc1afe142e4ba2726416239ced66c3add4295ab1e5ed37ca8a9e7bb638a"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only"
 
   bottle do
     cellar :any
@@ -26,6 +27,10 @@ class Pcrexx < Formula
 
   def install
     pcre = Formula["pcre"]
+    # Don't install "config.log" into doc/ directory.  "brew audit" will complain
+    # about references to the compiler shims that exist there, and there doesn't
+    # seem to be much reason to keep it around
+    inreplace "doc/Makefile.am", "../config.log", ""
     system "autoreconf", "-fvi"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
@@ -47,6 +52,31 @@ class Pcrexx < Formula
       pcre in case-insensitive file system.  Please use "man pcre++"
       instead.
     EOS
+  end
+
+  test do
+    (testpath/"test.cc").write <<~EOS
+      #include <pcre++.h>
+      #include <iostream>
+
+      int main() {
+        pcrepp::Pcre reg("[a-z]+ [0-9]+", "i");
+        if (!reg.search("abc 512")) {
+          std::cerr << "search failed" << std::endl;
+          return 1;
+        }
+        if (reg.search("512 abc")) {
+          std::cerr << "search should not have passed" << std::endl;
+          return 2;
+        }
+        return 0;
+      }
+    EOS
+    flags = ["-I#{include}", "-L#{lib}",
+             "-I#{Formula["pcre"].opt_include}", "-L#{Formula["pcre"].opt_lib}",
+             "-lpcre++", "-lpcre"] + ENV.cflags.to_s.split
+    system ENV.cxx, "-o", "test_pcrepp", "test.cc", *flags
+    system "./test_pcrepp"
   end
 end
 


### PR DESCRIPTION
Try to make `brew audit --strict` pass on this formula.  Also add a mirror since there were problems with CI downloading the tarball previously.

I had to hack doc/Makefile.am to avoid:
```
  * Files were found with references to the Homebrew shims directory.
    The offending files are:
      doc/libpcre++-0.9.5/config.log
```