### PR TITLE
appledoc: get build/test working with Xcode 12

### DIFF
--- a/Formula/appledoc.rb
+++ b/Formula/appledoc.rb
@@ -19,10 +19,14 @@ class Appledoc < Formula
   end
 
   depends_on xcode: :build
+  depends_on arch: :x86_64
 
   def install
     xcodebuild "-project", "appledoc.xcodeproj",
                "-target", "appledoc",
+               # The 2.2.1 tarball includes prebuild Library/*.a files which only
+               # are built for intel:
+               "-arch", "x86_64",
                "-configuration", "Release",
                "clean", "install",
                "SYMROOT=build",
@@ -57,9 +61,11 @@ class Appledoc < Formula
     system bin/"appledoc", "--project-name", "Test",
                            "--project-company", "Homebrew",
                            "--create-html",
-                           "--no-install-docset",
+                           # docset tools were removed in Xcode 9.3:
+                           #   https://github.com/tomaz/appledoc/issues/628
+                           # ...so --no-create-docset is essentially required
+                           "--no-create-docset",
                            "--keep-intermediate-files",
-                           "--docset-install-path", testpath,
                            "--output", testpath,
                            testpath/"test.h"
   end


### PR DESCRIPTION
* Current `xcodebuild` wants to make a universal binary by default.  However, this package includes pre-built `*.a `files that are intel only.  This package will probably never be arm64 ready. (cc @tomaz if I'm incorrect about this)
* As documented in https://github.com/tomaz/appledoc/issues/628 running this command without `--no-create-docset` doesn't work on modern Xcode because apple no longer provides the `docsetutil` CLI tool that it depended on.
