### PR TITLE
daemontools: update livecheck

### DIFF
--- a/Formula/daemontools.rb
+++ b/Formula/daemontools.rb
@@ -7,7 +7,7 @@ class Daemontools < Formula
 
   livecheck do
     url "https://cr.yp.to/daemontools/install.html"
-    regex(/href=.*?daemontools-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?daemontools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a simple follow-up to #67355 which updates the `livecheck` block regex to adhere to our prevailing standards. This addresses the following areas:

* Use `[._-]` instead of `-` between the software name and numeric version.
* Use the full standard regex for matching versions like `1.2.3`/`v1.2.3`. Namely, this adds the leading `v?`.