### PR TITLE
cmake: update livecheck

### DIFF
--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -7,8 +7,8 @@ class Cmake < Formula
   head "https://gitlab.kitware.com/cmake/cmake.git"
 
   livecheck do
-    url "https://cmake.org/download/"
-    regex(/Latest Release \(v?(\d+(?:\.\d+)+)\)/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The URL in the existing `livecheck` block for `cmake` (https://cmake.org/download/) has been giving an "execution expired" error, as the first-party website appears to be unreliable sometimes.

The `stable` archive currently comes from GitHub, so this PR updates the `livecheck` block to use the `GithubLatest` strategy with the `stable` URL. This avoids the issue with the unreliable first-party website while still ensuring that we're only working with release versions (provided the "latest" release remains accurate over time).