### PR TITLE
zile: add link to NEWS file in comment

### DIFF
--- a/Formula/zile.rb
+++ b/Formula/zile.rb
@@ -1,9 +1,9 @@
 class Zile < Formula
   desc "Text editor development kit"
   homepage "https://www.gnu.org/software/zile/"
-  # For version bumps, check the NEWS file in the tarball to
-  # make sure that this is a stable release. For context, see
-  # https://github.com/Homebrew/homebrew-core/issues/67379
+  # Before bumping to a new version, check the NEWS file to make sure it is a
+  # stable release: https://git.savannah.gnu.org/cgit/zile.git/plain/NEWS
+  # For context, see: https://github.com/Homebrew/homebrew-core/issues/67379
   url "https://ftp.gnu.org/gnu/zile/zile-2.4.15.tar.gz"
   mirror "https://ftpmirror.gnu.org/zile/zile-2.4.15.tar.gz"
   sha256 "39c300a34f78c37ba67793cf74685935a15568e14237a3a66fda8fcf40e3035e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a follow-up to #67380 (and #67444), where a comment was added above the stable `url` to explain that it's necessary to check the `NEWS` file to confirm a version is stable before using it in a version bump.

This PR updates the comment to link to the `NEWS` file in the upstream Git repository for Zile, as this may be easier for folks to check compared to downloading/extracting a release tarball. If livecheck is picking up a new version (from the tarballs on the GNU directory listing page), then the `NEWS` file in the Git repository should contain information on the release at that point.

Thoughts @carlocab, @Rylan12?