### PR TITLE
discount: add explanatory comment before livecheck

### DIFF
--- a/Formula/discount.rb
+++ b/Formula/discount.rb
@@ -6,6 +6,10 @@ class Discount < Formula
   license "BSD-3-Clause"
   head "https://github.com/Orc/discount.git"
 
+  # We check the upstream GitHub repository because the homepage doesn't always
+  # update to list the latest version in a timely manner. As of writing, the
+  # homepage has been showing an older version for months, so it doesn't seem
+  # like a reliable source for the latest version information, unfortunately.
   livecheck do
     url :head
     regex(/^v?(\d+(?:\.\d+)+)$/i)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Since the `livecheck` block for `discount` goes against our prevailing guideline to align the check with the `stable` source when possible, this PR adds a comment before the `livecheck` block to explain why we're checking `head` instead.

We like to document weird situations like this with a preceding comment, otherwise someone may come along and introduce an undesirable change without fully understanding the situation.