### PR TITLE
x265: fix rpath

### DIFF
--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -24,11 +24,12 @@ class X265 < Formula
 
   def install
     # Build based off the script at ./build/linux/multilib.sh
-    args = std_cmake_args + %w[
+    args = std_cmake_args + %W[
       -DLINKED_10BIT=ON
       -DLINKED_12BIT=ON
       -DEXTRA_LINK_FLAGS=-L.
       -DEXTRA_LIB=x265_main10.a;x265_main12.a
+      -DCMAKE_INSTALL_RPATH=#{lib}
     ]
     high_bit_depth_args = std_cmake_args + %w[
       -DHIGH_BIT_DEPTH=ON -DEXPORT_C_API=OFF


### PR DESCRIPTION
This is necessary to build outside of `/usr/local` (such as on ARM).