### PR TITLE
easy-tag: fix double forward slash in stable url

### DIFF
--- a/Formula/easy-tag.rb
+++ b/Formula/easy-tag.rb
@@ -1,7 +1,7 @@
 class EasyTag < Formula
   desc "Application for viewing and editing audio file tags"
   homepage "https://projects.gnome.org/easytag"
-  url "https://download.gnome.org//sources/easytag/2.4/easytag-2.4.3.tar.xz"
+  url "https://download.gnome.org/sources/easytag/2.4/easytag-2.4.3.tar.xz"
   sha256 "fc51ee92a705e3c5979dff1655f7496effb68b98f1ada0547e8cbbc033b67dd5"
   revision 5
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm in the process of making the regexes that livecheck strategies use to identify if they apply to a given URL more explicit (see: https://github.com/Homebrew/brew/pull/9519#pullrequestreview-556144560).

My changes in that PR work as expected for existing formulae except `easy-tag`, which includes unnecessary double forward slashes in the URL. The double forward slashes cause the `Gnome` strategy regex not to match, so I'm updating this URL to address the issue before the related brew PR is merged.

Additionally, the existing URL with the double forward slashes redirects to the URL without the double forward slashes, so this is a straightforward change. These URLs are functionally identical, so I've labeled this "CI-syntax-only" but let me know if this needs to run through CI normally.