### PR TITLE
rust: Update formula to build natively on M1 machines

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_CHANGE_ARCH_TO_ARM: 1
 jobs:
   tap_syntax:
     if: github.repository == 'Homebrew/homebrew-core'
@@ -65,7 +66,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.tap_syntax.outputs.run-tests
     strategy:
       matrix:
-        version: ['11.0', '10.15', '10.14']
+        version: ['11-arm', '11.0', '10.15', '10.14']
       fail-fast: false
     runs-on: ${{ matrix.version }}
     timeout-minutes: 4320

--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -4,8 +4,14 @@ class Rust < Formula
   license any_of: ["Apache-2.0", "MIT"]
 
   stable do
-    url "https://static.rust-lang.org/dist/rustc-1.48.0-src.tar.gz"
-    sha256 "0e763e6db47d5d6f91583284d2f989eacc49b84794d1443355b85c58d67ae43b"
+    if Hardware::CPU.arm?
+      url "https://static.rust-lang.org/dist/rustc-beta-src.tar.gz#1.49.0-beta"
+      sha256 "364fc8350d30f104595e458e51599369ffc5f796bb91b893372ba2631229963e"
+      version "1.48.0"
+    else
+      url "https://static.rust-lang.org/dist/rustc-1.48.0-src.tar.gz"
+      sha256 "0e763e6db47d5d6f91583284d2f989eacc49b84794d1443355b85c58d67ae43b"
+    end
 
     resource "cargo" do
       url "https://github.com/rust-lang/cargo.git",
@@ -42,8 +48,13 @@ class Rust < Formula
   resource "cargobootstrap" do
     on_macos do
       # From https://github.com/rust-lang/rust/blob/#{version}/src/stage0.txt
-      url "https://static.rust-lang.org/dist/2020-11-19/cargo-1.48.0-x86_64-apple-darwin.tar.gz"
-      sha256 "ce00d796cf5a9ac8d88d9df94c408e5d7ccd3541932a829eae833cc8e57efb15"
+      if Hardware::CPU.arch == :arm64
+        url "https://static.rust-lang.org/dist/2020-12-23/cargo-beta-aarch64-apple-darwin.tar.gz"
+        sha256 "efbc0e72533d4ca7def9a985feef4b3e43d24f1f6792815bdba9125af1f8ecdf"
+      else
+        url "https://static.rust-lang.org/dist/2020-11-19/cargo-1.48.0-x86_64-apple-darwin.tar.gz"
+        sha256 "ce00d796cf5a9ac8d88d9df94c408e5d7ccd3541932a829eae833cc8e57efb15"
+      end
     end
 
     on_linux do
@@ -78,17 +89,15 @@ class Rust < Formula
     else
       args << "--release-channel=stable"
     end
-    # Cross-compile arm64 with x86_64 bootstrap compiler.
-    if Hardware::CPU.arch == :arm64
-      args << "--build=x86_64-apple-darwin"
-      args << "--host=aarch64-apple-darwin"
-      args << "--target=aarch64-apple-darwin"
-      system "./configure", *args
-      system "arch", "-x86_64", "make"
-    else
-      system "./configure", *args
-      system "make"
+
+    if Hardware::CPU.arm?
+      # Fix for 1.49.0-beta, remove when the stable version is released
+      inreplace "src/stage0.txt", "1.48.0", "beta"
+      inreplace "src/stage0.txt", "2020-11-19", "2020-12-23"
     end
+
+    system "./configure", *args
+    system "make"
     system "make", "install"
 
     resource("cargobootstrap").stage do
@@ -115,6 +124,19 @@ class Rust < Formula
       MachO::Tools.change_dylib_id(dylib, "@rpath/#{File.basename(dylib)}")
       chmod 0444, dylib
     end
+  end
+
+  def caveats
+    s = ""
+
+    if Hardware::CPU.arm?
+      s += <<~EOS
+        This is a beta version of the Rust compiler for Apple Silicon
+        (rust 1.49.0-beta).
+      EOS
+    end
+
+    s
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As per comments on the apple silicon issue, this pull request enables building natively straight through from the bootstrapping stage on am M1 based machine.

This will probably need to wait until the 31st so that we can set it to use the 1.49 release, as currently it only builds siuccessfully if you set the URL to a beta release, or use the `--HEAD` argument.

Happy to change out the url for one that works without `--HEAD` if required, although it would need to go somewhere else other than "stable".