### PR TITLE
ghostscript: align with Linux formula

### DIFF
--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -30,6 +30,10 @@ class Ghostscript < Formula
   depends_on "pkg-config" => :build
   depends_on "libtiff"
 
+  on_macos do
+    patch :DATA # Uncomment macOS-specific make vars
+  end
+
   on_linux do
     depends_on "fontconfig"
     depends_on "libidn"
@@ -48,9 +52,12 @@ class Ghostscript < Formula
     sha256 "155cf2ee5a498d441c3194ba3d75cb7812beaa3f507a72017174a884bf742862"
   end
 
-  patch :DATA # Uncomment macOS-specific make vars
-
   def install
+    on_linux do
+      # Fixes: ./soobj/dxmainc.o: file not recognized: File truncated
+      ENV.deparallelize
+    end
+
     args = %W[
       --prefix=#{prefix}
       --disable-cups


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Linux formula: https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/ghostscript.rb

Tested on Ubuntu 16.04, still requires `ENV.deparallelize`