### PR TITLE
qbs: add license and update head

### DIFF
--- a/Formula/qbs.rb
+++ b/Formula/qbs.rb
@@ -3,7 +3,8 @@ class Qbs < Formula
   homepage "https://wiki.qt.io/Qbs"
   url "https://download.qt.io/official_releases/qbs/1.18.0/qbs-src-1.18.0.tar.gz"
   sha256 "3d0211e021bea3e56c4d5a65c789d11543cc0b6e88f1bfe23c2f8ebf0f89f8d4"
-  head "https://code.qt.io/qbs/qbs.git"
+  license :cannot_represent
+  head "git://code.qt.io/qbs/qbs.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

From https://doc.qt.io/qbs/attributions.html

> The Qbs library and tools are available under commercial licenses from The Qt Company. In addition, they are available under GNU Lesser General Public License, Version 3 (LGPL version 3) and GNU General Public License, version 2 (GPL version 2).
> 
> Shared functionality, which might be pulled in by user build scripts, is available under commercial licenses, GNU Lesser General Public License, Version 2.1 (LGPL version 2.1) with The Qt Company LGPL Exception version 1.1, and LGPL version 3.
> 
> Autotests are available under commercial licenses and GNU General Public License Version 3, Annotated with The Qt Company GPL Exception 1.0.
> 
> Examples are available under commercial licenses and BSD.