### PR TITLE
Add ARM Big Sur CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_CHANGE_ARCH_TO_ARM: 1
+  HOMEBREW_REQUIRE_BOTTLED_ARM: 1
 jobs:
   tap_syntax:
     if: github.repository == 'Homebrew/homebrew-core'
@@ -65,7 +67,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.tap_syntax.outputs.run-tests
     strategy:
       matrix:
-        version: ['11.0', '10.15', '10.14']
+        version: ['11-arm', '11.0', '10.15', '10.14']
       fail-fast: false
     runs-on: ${{ matrix.version }}
     timeout-minutes: 4320


### PR DESCRIPTION
This will add Apple Silicon to our CI for all homebrew-core pull requests. We currently have 1046 ARM bottles, so at this point we need to enable it in CI.

However, there are also a number of formulas that currently fail to build on ARM, and we don't want that to block everything else. The approach I propose is simple and (I think) efficient: make it so ARM is skipped during testing if `CI-skip-arm` label is applied. This requires maintainer intervention, but allow us to make a conscious decision.

I need help, however, to achieve this: I don't know how to make the `11-arm` entry in the test `matrix` be conditional on `needs.tap_syntax.outputs.skip-arm`.