### PR TITLE
libpst: update sha256 to match upstream

### DIFF
--- a/Formula/libpst.rb
+++ b/Formula/libpst.rb
@@ -2,8 +2,8 @@ class Libpst < Formula
   desc "Utilities for the PST file format"
   homepage "https://www.five-ten-sg.com/libpst/"
   url "https://www.five-ten-sg.com/libpst/packages/libpst-0.6.75.tar.gz"
-  sha256 "4ca98fed8ba208d902c954d82eaf2bf5e071c609df695ec4eb34af110f719987"
-  license "GPL-2.0"
+  sha256 "2f9ddc4727af8e058e07bcedfa108e4555a9519405a47a1fce01e6420dc90c88"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://www.five-ten-sg.com/libpst/packages/"


### PR DESCRIPTION
I verified by email with the package author (Carl Byington) that they repackaged the 0.6.75 tarball with some linux build tweaks.

Note that this will cause the automatic PR checks to fail for this; someone will need to override that just like on ncompress a couple weeks back: https://github.com/Homebrew/homebrew-core/pull/66305#issuecomment-739435390

For posterity, here is the email I sent Carl:
> Hello.
>
> Back in April, Homebrew updated its libpst version 0.6.75.  At the
> time the source tarball had sha256 "`4ca98f...`":
>   `https://github.com/Homebrew/homebrew-core/pull/52672/commits/570cc82f1cb1d697ea124c0b580b258c10eb4545`
>
> Now, however, when I try to re-build this package I see:
> 
>  `==> Downloading`
> `https://www.five-ten-sg.com/libpst/packages/libpst-0.6.75.tar.gz`
>  `Error: SHA256 mismatch`
>  `Expected: 4ca98fed8ba208d902c954d82eaf2bf5e071c609df695ec4eb34af110f719987`
>  `  Actual: 2f9ddc4727af8e058e07bcedfa108e4555a9519405a47a1fce01e6420dc90c88`
> 
> Looking at the download page it seems that there is a "new" 0.6.75
> tarball dated June 16th:
>   https://www.five-ten-sg.com/libpst/packages/
> And looking at the mercurial history it seems that "stable-0-6-75" has
> been tagged multiple times:
>   http://hg.five-ten-sg.com/libpst/
>
> Is this history correct -- i.e. the "new" 0.6.75 tarball is now the
> official version of the package?
>
> Homebrew is very careful about source tarballs matching expected
> values to avoid any nefarious backdoors -- all external resources
> (tarballs, patches, etc) are matched against known-good sha256 sums
> before the build system will use them)  Therefore I want to be
> completely sure that nothing has changed unexpectedly.
> 
> Thanks.
>
> -Mitch

And here is his response:
> > Is this history correct -- i.e. the "new" 0.6.75 tarball is now the
> > official version of the package?
>
> Yes. The only change was to the build packaging to allow builds on EL8.
>
> > Homebrew is very careful about source tarballs matching expected
> > values to avoid any nefarious backdoors
>
> It is good to be cautious. Thanks for checking.