### PR TITLE
lemon: remove dead download URL

### DIFF
--- a/Formula/lemon.rb
+++ b/Formula/lemon.rb
@@ -1,9 +1,9 @@
 class Lemon < Formula
   desc "LALR(1) parser generator like yacc or bison"
   homepage "https://www.hwaci.com/sw/lemon/"
-  url "https://tx97.net/pub/distfiles/lemon-1.69.tar.bz2"
-  mirror "https://mirror.amdmi3.ru/distfiles/lemon-1.69.tar.bz2"
+  url "https://mirror.amdmi3.ru/distfiles/lemon-1.69.tar.bz2"
   sha256 "bc7c1cae233b6af48f4b436ee900843106a15bdb1dc810bc463d8c6aad0dd916"
+  license :public_domain
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Just promote the mirror to be the main URL since I can't find a better source for this tarball.

It's not clear what the long-term future for this formula is since looking at the project's webpage ( https://www.hwaci.com/sw/lemon/ ) it seems like they aren't in the business of distributing tarballs but instead just point interested parties at files shipped as part of SQLite.

One possibility is to just switch this formula to downloading the SQLite tarball and building lemon.c from there, but that still leaves the question of what version number to use?

cc @jpschorr who added this formula originally