### PR TITLE
get-flash-videos: whitelist prerelease

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -1,5 +1,6 @@
 {
   "elm-format": "0.8.3",
+  "get-flash-videos": "1.25.99.03",
   "gitless": "0.8.8",
   "riff": "0.5.0",
   "telegram-cli": "1.3.1",


### PR DESCRIPTION
The Big Sur rebottling of this formula failed with:
```
 ==> brew audit get-flash-videos --online --git --skip-style
 ==> FAILED
  get-flash-videos:
    * 1.25.99.03 is a GitHub pre-release.
  Error: 1 problem in 1 formula detected
```
see https://github.com/Homebrew/homebrew-core/runs/1600486512?check_suite_focus=true

It looks like this project is moribund but when it was active homebrew tracked the prereleases regularly: https://github.com/Homebrew/homebrew-core/issues?q=get-flash-videos

Probably the easiest thing to do for the moment is just whitelist this one so it can keep building.