### PR TITLE
oq: add pcre dependency

### DIFF
--- a/Formula/oq.rb
+++ b/Formula/oq.rb
@@ -4,6 +4,7 @@ class Oq < Formula
   url "https://github.com/Blacksmoke16/oq/archive/v1.1.2.tar.gz"
   sha256 "1bd940a72af556a4e685086ca0d3a363d71e3cfedeffb36f865f38d44386f94a"
   license "MIT"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,6 +17,7 @@ class Oq < Formula
   depends_on "jq"
   depends_on "libevent"
   depends_on "libyaml"
+  depends_on "pcre"
 
   uses_from_macos "libxml2"
 


### PR DESCRIPTION
This hopefully will fix the bottling problem this formula had on Big Sur: https://github.com/Homebrew/homebrew-core/runs/1600486263?check_suite_focus=true
```
==> brew linkage --test oq
==> FAILED
Broken dependencies:
  /usr/local/opt/pcre/lib/libpcre.1.dylib (pcre)

==> brew install --only-dependencies --include-test oq
==> brew test --verbose oq
==> FAILED
==> Testing oq
/usr/bin/sandbox-exec -f /private/tmp/homebrew20201223-57783-8qo4d6.sb ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/oq.rb --verbose
==> /usr/local/Cellar/oq/1.1.2/bin/oq -o xml --indent 0 .
dyld: Library not loaded: /usr/local/opt/pcre/lib/libpcre.1.dylib
  Referenced from: /usr/local/Cellar/oq/1.1.2/bin/oq
  Reason: image not found
Error: oq: failed
```