### PR TITLE
ompl: update livecheck

### DIFF
--- a/Formula/ompl.rb
+++ b/Formula/ompl.rb
@@ -6,9 +6,11 @@ class Ompl < Formula
   license "BSD-3-Clause"
   head "https://github.com/ompl/ompl.git"
 
+  # We check the first-party download page because the "latest" GitHub release
+  # isn't a reliable indicator of the latest version on this repository.
   livecheck do
-    url :stable
-    strategy :github_latest
+    url "https://ompl.kavrakilab.org/download.html"
+    regex(%r{href=.*?/ompl/ompl/archive/v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `ompl` checks the "latest" release on the GitHub repository. 1.5.0 is listed as "latest" but there's a 1.5.1 tag after it and the first-party website links to the GitHub tag archive file for 1.5.1 as the newest version.

Since the "latest" GitHub release isn't a reliable indicator of the newest version for this particular repository, this PR adds a livecheck block that checks the [first-party download page](https://ompl.kavrakilab.org/download.html) instead. This page points to the same archive file on GitHub that we use in the formula, so we're merely relying on the first-party website to canonically point us to the latest release.