### PR TITLE
shntool: update url

### DIFF
--- a/Formula/shntool.rb
+++ b/Formula/shntool.rb
@@ -1,10 +1,10 @@
 class Shntool < Formula
   desc "Multi-purpose tool for manipulating and analyzing WAV files"
-  homepage "https://web.archive.org/web/20180903160820/etree.org/shnutils/shntool/"
-  url "https://web.archive.org/web/20180903160820/etree.org/shnutils/shntool/dist/src/shntool-3.0.10.tar.gz"
+  homepage "http://shnutils.freeshell.org/shntool/"
+  url "http://shnutils.freeshell.org/shntool/dist/src/shntool-3.0.10.tar.gz"
   mirror "https://www.mirrorservice.org/sites/download.salixos.org/x86_64/extra-14.2/source/audio/shntool/shntool-3.0.10.tar.gz"
   sha256 "74302eac477ca08fb2b42b9f154cc870593aec8beab308676e4373a5e4ca2102"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
archive.org likes to auto-gunzip files which breaks sha256.  However it seems that the site is available elsewhere.
