### PR TITLE
orbit: fix build, but also deprecate

### DIFF
--- a/Formula/orbit.rb
+++ b/Formula/orbit.rb
@@ -1,9 +1,11 @@
 class Orbit < Formula
   desc "CORBA 2.4-compliant object request broker (ORB)"
-  homepage "https://projects.gnome.org/ORBit2"
+  homepage "https://web.archive.org/web/20191222075841/projects-old.gnome.org/ORBit2/"
   url "https://download.gnome.org/sources/ORBit2/2.14/ORBit2-2.14.19.tar.bz2"
   sha256 "55c900a905482992730f575f3eef34d50bda717c197c97c08fa5a6eafd857550"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.0-only"]
   revision 1
+  head "https://gitlab.gnome.org/Archive/orbit2.git"
 
   livecheck do
     url :stable
@@ -15,6 +17,9 @@ class Orbit < Formula
     sha256 "367cb438ac5ee8c44cd932d259f82b43458af90df8df28803e2248ad75952800" => :mojave
     sha256 "50487080b7e4614d077b4cbb818a726a7bae7a7a281fc85fabd6ff88ed848016" => :high_sierra
   end
+
+  # GNOME 2.19 deprecated Orbit2 in 2007; now even their webpage for it is gone as of 2020
+  deprecate! date: "2020-12-25", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "glib"
@@ -32,6 +37,7 @@ class Orbit < Formula
   end
 
   def install
+    ENV.deparallelize
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
The IDL compiler was dying with a Segmentation Fault, but it seemed to be happening at the same time some of its input files were being written to.  Compiles fine for me once I disable parallel building.

However, further research shows that this is very deprecated.. in  fact the deprecation process started in 2007 on the GNOME side meaning  that when this formula was added in 2012 it was already well past its sell-by date.  Now even the upstream web page is gone, so it's probably safe to start the long goodbye from Homebrew.

Just as a reference point, Gentoo removed it completely from their repo earlier this month: https://bugs.gentoo.org/751004