### PR TITLE
util-linux: Fix the formatting of the caveats

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -81,12 +81,14 @@ class UtilLinux < Formula
       wall wdctl
       zramctl
     ]
-    <<~EOS
-      The following tools are not supported under macOS, and are therefore not included:
-      #{Formatter.wrap(Formatter.columns(linux_only_bins), 80)}
-      The following tools are already shipped by macOS, and are therefore not included:
-      #{Formatter.wrap(Formatter.columns(system_bins), 80)}
-    EOS
+    on_macos do
+      <<~EOS
+        The following tools are not supported for macOS, and are therefore not included:
+        #{Formatter.columns(linux_only_bins)}
+        The following tools are shipped by macOS, and are therefore not included:
+        #{Formatter.columns(system_bins)}
+      EOS
+    end
   end
 
   test do

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -3,7 +3,15 @@ class UtilLinux < Formula
   homepage "https://github.com/karelzak/util-linux"
   url "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.36/util-linux-2.36.1.tar.xz"
   sha256 "09fac242172cd8ec27f0739d8d192402c69417617091d8c6e974841568f37eed"
-  license "GPL-2.0"
+  license all_of: [
+    "BSD-3-Clause",
+    "BSD-4-Clause-UC",
+    "GPL-2.0-only",
+    "GPL-2.0-or-later",
+    "GPL-3.0-or-later",
+    "LGPL-2.1-or-later",
+    :public_domain,
+  ]
 
   bottle do
     cellar :any


### PR DESCRIPTION
Fix the formatting of the caveats.
Print the caveats only on macOS.
Update the license. See https://github.com/karelzak/util-linux/blob/master/README.licensing

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

### Before

```
==> Caveats
The following tools are not supported under macOS, and are therefore not include
d:
addpart      dmesg        ipcrm        lsmem        rfkill       umount agetty  
eject        ipcs         lsns         rtcwake      unshare blkdiscard  
fallocate    kill         mount        script       utmpdump blkzone     
fdformat     last         mountpoint   scriptlive   uuidd blockdev     fincore  
ldattach     nsenter      setarch      wall chcpu        findmnt      losetup   
partx        setterm      wdctl chmem        fsck         lsblk       
pivot_root   sulogin      zramctl choom        fsfreeze     lscpu        prlimit
swapoff chrt         fstrim       lsipc        raw          swapon ctrlaltdel  
hwclock      lslocks      readprofile  switch_root delpart      ionice      
lslogins     resizepart   taskset

The following tools are already shipped by macOS, and are therefore not included
:
cal       colcrt    getopt    logger    mesg      nologin   rev       whereis
col       colrm     hexdump   look      more      renice    ul
```

### After

```
==> Caveats
The following tools are not supported for macOS, and are therefore not included:
addpart      dmesg        ipcrm        lsmem        rfkill       umount
agetty       eject        ipcs         lsns         rtcwake      unshare
blkdiscard   fallocate    kill         mount        script       utmpdump
blkzone      fdformat     last         mountpoint   scriptlive   uuidd
blockdev     fincore      ldattach     nsenter      setarch      wall
chcpu        findmnt      losetup      partx        setterm      wdctl
chmem        fsck         lsblk        pivot_root   sulogin      zramctl
choom        fsfreeze     lscpu        prlimit      swapoff
chrt         fstrim       lsipc        raw          swapon
ctrlaltdel   hwclock      lslocks      readprofile  switch_root
delpart      ionice       lslogins     resizepart   taskset

The following tools are shipped by macOS, and are therefore not included:
cal       colcrt    getopt    logger    mesg      nologin   rev       whereis
col       colrm     hexdump   look      more      renice    ul
```