### PR TITLE
pacparser: fix Big Sur build

### DIFF
--- a/Formula/pacparser.rb
+++ b/Formula/pacparser.rb
@@ -3,7 +3,7 @@ class Pacparser < Formula
   homepage "https://github.com/pacparser/pacparser"
   url "https://github.com/pacparser/pacparser/archive/1.3.7.tar.gz"
   sha256 "575c5d8096b4c842b2af852bbb8bcfde96170b28b49f33249dbe2057a8beea13"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
   head "https://github.com/pacparser/pacparser.git"
 
   bottle do
@@ -14,6 +14,12 @@ class Pacparser < Formula
     sha256 "5a4db686679c753a806fa2e2df5e93263f973f447f9357fcdadc071687c10071" => :mojave
     sha256 "1bb0af844e0cfd58357987f2f9e6f82b0e72a13df961f13ad8b81b3e00a3dff2" => :high_sierra
     sha256 "719e5eadacf71e3a2e863447609322c45f3be3a9d3ee63373c05a9a2ae7f31b8" => :sierra
+  end
+
+  # Fix build for MacOS 11.1
+  patch do
+    url "https://github.com/manugarg/pacparser/commit/28afea85c7578d033132f3817b62d3bb707cc3a3.patch?full_index=1"
+    sha256 "52fc5b276caf6e95a3ae4ac21e75c9751daaf429f344fdc6b62c85de4aa40d48"
   end
 
   def install


### PR DESCRIPTION
The Makefile inside pacparser mis-detected the OS version "11.1" as "10.1" and therefore decided it couldn't have the `va_copy()` macro.

Sent upstream as https://github.com/manugarg/pacparser/pull/104

Interestingly, just assigning va_list's happens to work on arm64 so this formula previously bottled OK on big_sur_arm64 but not intel!
