### PR TITLE
libzdb: remove shim pollution

### DIFF
--- a/Formula/libzdb.rb
+++ b/Formula/libzdb.rb
@@ -27,12 +27,7 @@ class Libzdb < Formula
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make", "install"
-    # The test files that end up in share/libzdb/test/ have @SED@ replaced
-    # with the configure-detected one.  However, install of a homebrew
-    # build that is the build-shim's copy of sed which we definitely don't
-    # want dangling references to!
-    inreplace %w[test/Makefile test/unit test/zdbpp test/select test/pool test/exception], %r{/[^ ]+/sed}, "sed"
-    pkgshare.install "test"
+    (pkgshare/"test").install Dir["test/*.{c,cpp}"]
   end
 
   test do

--- a/Formula/libzdb.rb
+++ b/Formula/libzdb.rb
@@ -3,7 +3,13 @@ class Libzdb < Formula
   homepage "https://tildeslash.com/libzdb/"
   url "https://tildeslash.com/libzdb/dist/libzdb-3.2.2.tar.gz"
   sha256 "d51e4e21ee1ee84ac8763de91bf485360cd76860b951ca998e891824c4f195ae"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
+  revision 1
+
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?dist/libzdb[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
 
   bottle do
     cellar :any
@@ -21,6 +27,11 @@ class Libzdb < Formula
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make", "install"
+    # The test files that end up in share/libzdb/test/ have @SED@ replaced
+    # with the configure-detected one.  However, install of a homebrew
+    # build that is the build-shim's copy of sed which we definitely don't
+    # want dangling references to!
+    inreplace %w[test/Makefile test/unit test/zdbpp test/select test/pool test/exception], %r{/[^ ]+/sed}, "sed"
     pkgshare.install "test"
   end
 


### PR DESCRIPTION
After the build some test files end up installed into `share/` and they end up with reference to the build-shim version of `sed`  This was causing audit and therefore bottling to fail.
