### PR TITLE
boost: patch for INTERFACE_LINK_LIBS bug

### DIFF
--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -5,6 +5,7 @@ class Boost < Formula
   mirror "https://dl.bintray.com/homebrew/mirror/boost_1_75_0.tar.bz2"
   sha256 "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb"
   license "BSL-1.0"
+  revision 1
   head "https://github.com/boostorg/boost.git"
 
   livecheck do
@@ -24,6 +25,13 @@ class Boost < Formula
 
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
+
+  # Reduce INTERFACE_LINK_LIBRARIES exposure for shared libraries. Remove with the next release.
+  patch do
+    url "https://github.com/boostorg/boost_install/commit/7b3fc734242eea9af734d6cd8ccb3d8f6b64c5b2.patch?full_index=1"
+    sha256 "cd96f5c51fa510fa6cd194eb011c0a6f9beb377fa2e78821133372f76a3be349"
+    directory "tools/boost_install"
+  end
 
   # Fix build on 64-bit arm
   patch do

--- a/Formula/flann.rb
+++ b/Formula/flann.rb
@@ -4,7 +4,7 @@ class Flann < Formula
   url "https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz"
   sha256 "b23b5f4e71139faa3bcb39e6bbcc76967fbaf308c4ee9d4f5bfbeceaa76cc5d3"
   license "BSD-3-Clause"
-  revision 9
+  revision 10
 
   bottle do
     cellar :any

--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -5,7 +5,7 @@ class Netcdf < Formula
   mirror "https://www.gfd-dennou.org/arch/netcdf/unidata-mirror/netcdf-c-4.7.4.tar.gz"
   sha256 "0e476f00aeed95af8771ff2727b7a15b2de353fb7bb3074a0d340b55c2bd4ea8"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://github.com/Unidata/netcdf-c.git"
 
   livecheck do

--- a/Formula/pcl.rb
+++ b/Formula/pcl.rb
@@ -100,6 +100,10 @@ class Pcl < Formula
       }
     EOS
     mkdir "build" do
+      # the following line is needed to workaround a bug in test-bot
+      # (Homebrew/homebrew-test-bot#544) when bumping the boost
+      # revision without bumping this formula's revision as well
+      ENV.prepend_path "PKG_CONFIG_PATH", Formula["eigen"].opt_share/"pkgconfig"
       system "cmake", "..", *std_cmake_args
       system "make"
       system "./pcd_write"

--- a/Formula/vtk@8.2.rb
+++ b/Formula/vtk@8.2.rb
@@ -4,7 +4,7 @@ class VtkAT82 < Formula
   url "https://www.vtk.org/files/release/8.2/VTK-8.2.0.tar.gz"
   sha256 "34c3dc775261be5e45a8049155f7228b6bd668106c72a3c435d95730d17d57bb"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "961f425ff924bcb05d4968fec2ab3a883b1b079b3547966753ccdd86a05ff81b" => :big_sur


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In boost 1.75.0, the cmake `INTERFACE_LINK_LIBRARIESS` now include non-boost dependencies like `libicudata` from the
keg-only formula `icu4c`. This introduces linking errors for software that previously linked successfully in brew against boost 1.74.0 shared libraries (see #67427 and boostorg/boost_install#47).

This adds a patch to the boost formula that has been merged upstream to limit the expansion of `INTERFACE_LINK_LIBRARIES` to boost's static libraries, so that the linking errors with shared libraries are resolved. I've tested it locally to confirm that it resolves my issues documented in https://github.com/osrf/homebrew-simulation/issues/1235.