### PR TITLE
spidermonkey: fix readline linkage

### DIFF
--- a/Formula/spidermonkey.rb
+++ b/Formula/spidermonkey.rb
@@ -1,11 +1,11 @@
 class Spidermonkey < Formula
   desc "JavaScript-C Engine"
-  homepage "https://developer.mozilla.org/en/SpiderMonkey"
+  homepage "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey"
   url "https://archive.mozilla.org/pub/mozilla.org/js/js185-1.0.0.tar.gz"
   version "1.8.5"
   sha256 "5d12f7e1f5b4a99436685d97b9b7b75f094d33580227aa998c406bbae6f2a687"
   license "MPL-1.1"
-  revision 3
+  revision 4
   head "https://hg.mozilla.org/mozilla-central", using: :hg
 
   livecheck do
@@ -32,7 +32,15 @@ class Spidermonkey < Formula
       inreplace "config/rules.mk",
         "-install_name @executable_path/$(SHARED_LIBRARY) ",
         "-install_name #{lib}/$(SHARED_LIBRARY) "
+
+      # The ./configure script assumes that it can find readline
+      # just as "-lreadline", but we want it to look in opt/readline/lib
+      inreplace "configure", "-lreadline", "-L#{Formula["readline"].opt_lib} -lreadline"
     end
+
+    # The ./configure script that comes with spidermonkey 1.8.5 makes some mistakes
+    # with Xcode 12's default setting of -Werror,implicit-function-declaration
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
 
     mkdir "brew-build" do
       system "../js/src/configure", "--prefix=#{prefix}",


### PR DESCRIPTION
This formula wasn't building from source because `-lreadline` wasn't finding the readline library.

There were also Xcode 12 issues involving `./configure`

Note that homebrew has a very old version of spidermonkey.  There seem to have been sporadic attempts to upgrade over the last 5 years (like #820) but none of them seem to have gone anywhere. It's a tricky situation since there are other packages that take it as a dependency and I guess this version works.  Therefore I am just propping up the build of the old 1.8.5 version at this point.
