### PR TITLE
aws-google-auth: switch to pypi source and update livecheck

### DIFF
--- a/Formula/aws-google-auth.rb
+++ b/Formula/aws-google-auth.rb
@@ -3,8 +3,8 @@ class AwsGoogleAuth < Formula
 
   desc "Acquire AWS credentials using Google Apps"
   homepage "https://github.com/cevoaustralia/aws-google-auth"
-  url "https://github.com/cevoaustralia/aws-google-auth/archive/0.0.36.tar.gz"
-  sha256 "c880633b2813b3fd2312fd1301a8927ebc7b13c3405932bd0ec760cecfb7c780"
+  url "https://files.pythonhosted.org/packages/6c/cc/f4c6e51c6dfa2800f9c89c639786b61e766c07752385333374c5291510fe/aws-google-auth-0.0.36.tar.gz"
+  sha256 "2fae0f2f9963e0e3e99007adc23d679eb1f92f834da05ebf27435f48a8ae3765"
   license "MIT"
   revision 2
   head "https://github.com/cevoaustralia/aws-google-auth.git"

--- a/Formula/aws-google-auth.rb
+++ b/Formula/aws-google-auth.rb
@@ -9,6 +9,10 @@ class AwsGoogleAuth < Formula
   revision 2
   head "https://github.com/cevoaustralia/aws-google-auth.git"
 
+  livecheck do
+    url :stable
+  end
+
   bottle do
     cellar :any
     sha256 "67eb5983db407f9a4b8565a1e34837b0c8c3490b2e0d2d14f6154db86fd34c55" => :big_sur


### PR DESCRIPTION
aws-google-auth: switch to pypi source