### PR TITLE
zig: require llvm only at build-time

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -14,7 +14,7 @@ class Zig < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "llvm"
+  depends_on "llvm" => :build
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As of zig 0.7.0, llvm is no longer required at runtime because zig has a self-hosted compiler.

https://kristoff.it/blog/zig-new-relationship-llvm/
https://ziglang.org/download/0.7.0/release-notes.html#Self-Hosted-Compiler

`brew audit --strict zig` fails locally using the current bottle without llvm. I'm not sure how to properly test this, since to build from source it requires llvm and then I won't get this error.

```console
$ brew audit --strict zig
Broken dependencies:
  /usr/local/opt/llvm/lib/libc++.1.dylib (llvm)
zig:
  * zig has broken dynamic library links:
      
    Rebuild this from source with:
      brew reinstall --build-from-source zig
    If that's successful, file an issue here:
      https://github.com/Homebrew/homebrew-core/issues
Error: 1 problem in 1 formula detected
```
