### PR TITLE
austin 2.1.1

### DIFF
--- a/Formula/austin.rb
+++ b/Formula/austin.rb
@@ -1,8 +1,8 @@
 class Austin < Formula
   desc "Python frame stack sampler for CPython"
   homepage "https://github.com/P403n1x87/austin"
-  url "https://github.com/P403n1x87/austin/archive/v2.0.0.tar.gz"
-  sha256 "95d40608bac22b965712dc929143ebc994d44b2eb4782b99ba58a2deb1e38aa1"
+  url "https://github.com/P403n1x87/austin/archive/v2.1.1.tar.gz"
+  sha256 "adc7ce66478142ae0e0922c8ad2031dbf908c6d9fa2c3f6e9793888bd11e67ab"
   license "GPL-3.0-or-later"
   head "https://github.com/P403n1x87/austin.git"
 

--- a/Formula/austin.rb
+++ b/Formula/austin.rb
@@ -26,6 +26,6 @@ class Austin < Formula
   end
 
   test do
-    shell_output("#{bin}/austin #{Formula["python@3.9"].opt_bin}/python3 -c \"print('Test')\"", 33)
+    shell_output("#{bin}/austin #{Formula["python@3.9"].opt_bin}/python3 -c \"from time import sleep; sleep(1)\"", 37)
   end
 end


### PR DESCRIPTION
~~The change in download sha seems to be an artifact of some Travis drama on the upstream: https://github.com/P403n1x87/austin/issues/65#issuecomment-750825727~~

EDIT: while waiting for this to be reviewed, upstream released 2.1.1 so now this PR just updates to that version

I also had to make a quick hack to avoid a symbol name conflict when compiling against the Big Sur SDK.

~~Note that right now I just did it with an `inreplace` hack; once we have a fix upstream I can replace it with a `patch` block, but I want to get a CI run going first.~~