### PR TITLE
go on ARM

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_CHANGE_ARCH_TO_ARM: 1
 jobs:
   tap_syntax:
     if: github.repository == 'Homebrew/homebrew-core'
@@ -65,7 +66,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.tap_syntax.outputs.run-tests
     strategy:
       matrix:
-        version: ['11.0', '10.15', '10.14']
+        version: ['11-arm', '11.0', '10.15', '10.14']
       fail-fast: false
     runs-on: ${{ matrix.version }}
     timeout-minutes: 4320

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -4,9 +4,15 @@ class Go < Formula
   license "BSD-3-Clause"
 
   stable do
-    url "https://golang.org/dl/go1.15.6.src.tar.gz"
-    mirror "https://fossies.org/linux/misc/go1.15.6.src.tar.gz"
-    sha256 "890bba73c5e2b19ffb1180e385ea225059eb008eb91b694875dd86ea48675817"
+    if Hardware::CPU.arm?
+      url "https://golang.org/dl/go1.16beta1.src.tar.gz"
+      sha256 "48e032c8cf71af4dc8119a29ee829c4fbd5265e32fd012564d4a70bb207695c1"
+      version "1.15.6"
+    else
+      url "https://golang.org/dl/go1.15.6.src.tar.gz"
+      mirror "https://fossies.org/linux/misc/go1.15.6.src.tar.gz"
+      sha256 "890bba73c5e2b19ffb1180e385ea225059eb008eb91b694875dd86ea48675817"
+    end
 
     go_version = version.major_minor
     resource "gotools" do
@@ -37,8 +43,13 @@ class Go < Formula
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do
     on_macos do
-      url "https://storage.googleapis.com/golang/go1.7.darwin-amd64.tar.gz"
-      sha256 "51d905e0b43b3d0ed41aaf23e19001ab4bc3f96c3ca134b48f7892485fc52961"
+      if Hardware::CPU.arm?
+        url "https://storage.googleapis.com/golang/go1.16beta1.darwin-arm64.tar.gz"
+        sha256 "fd57f47987bb330fd9b438e7b4c8941b63c3807366602d99c1d99e0122ec62f1"
+      else
+        url "https://storage.googleapis.com/golang/go1.7.darwin-amd64.tar.gz"
+        sha256 "51d905e0b43b3d0ed41aaf23e19001ab4bc3f96c3ca134b48f7892485fc52961"
+      end
     end
 
     on_linux do
@@ -72,6 +83,19 @@ class Go < Formula
       (libexec/"bin").install "godoc"
     end
     bin.install_symlink libexec/"bin/godoc"
+  end
+
+  def caveats
+    s = ""
+
+    if Hardware::CPU.arm?
+      s += <<~EOS
+        This is a beta version of the Go compiler for Apple Silicon
+        (go 1.16beta1).
+      EOS
+    end
+
+    s
   end
 
   test do


### PR DESCRIPTION
go 1.16 will be the first version of go to support Apple Silicon. That will be released sometime in February, after a RC (release candidate) that will ship mid-January. A backport of that support to the stable go version (1.15.6) is apparently out of the question.

A beta version is already available for testing, and is what the go project distributes as binaries for Apple Silicon. I think it makes sense, given how widely used go is, to distribute that in Homebrew as well. This is a topic we've already discussed in other PRs for large-scale widely-used projects where the release cycle is not aligned with Apple Silicon availability (openjdk, gcc, and rust) and we have reached that consensus. We already distribute GCC in this state, Rust will be arriving soon, and the openjdk PR is being finalised.

The only questions remaining are:
- what do we want the version to be? same across all architectures (which mean faking the version on ARM, with a caveat)? or something else?
- what caveats do we display?

_Do not merge as-is, as it contains a commit to the workflow to enable testing on ARM._