### PR TITLE
plowshare: update licence

### DIFF
--- a/Formula/plowshare.rb
+++ b/Formula/plowshare.rb
@@ -3,7 +3,7 @@ class Plowshare < Formula
   homepage "https://github.com/mcrapet/plowshare"
   url "https://github.com/mcrapet/plowshare/archive/v2.1.7.tar.gz"
   sha256 "c17d0cc1b3323f72b2c1a5b183a9fcef04e8bfc53c9679a4e1523642310d22ad"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 1
 
   bottle do


### PR DESCRIPTION
I'm mostly hoping to get a rebottle attempt since its spidermonkey dependency is now built for Big Sur