### PR TITLE
pakchois: switch back to normal homepage

### DIFF
--- a/Formula/pakchois.rb
+++ b/Formula/pakchois.rb
@@ -1,8 +1,14 @@
 class Pakchois < Formula
   desc "PKCS #11 wrapper library"
-  homepage "https://web.archive.org/web/www.manyfish.co.uk/pakchois/"
-  url "https://web.archive.org/web/20161220165909/www.manyfish.co.uk/pakchois/pakchois-0.4.tar.gz"
+  homepage "https://www.manyfish.co.uk/pakchois/"
+  url "https://www.manyfish.co.uk/pakchois/pakchois-0.4.tar.gz"
   sha256 "d73dc5f235fe98e4d1e8c904f40df1cf8af93204769b97dbb7ef7a4b5b958b9a"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?pakchois[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
About 2.5 years ago this formula switched its URLs to archive.org (e313311341d59d7cc33e655d8fcc2fb6920ab3ad). We've been having trouble using archive.org for downloading tarballs (it likes to sometimes decompress them automatically, breaking sha256) However the main webpage seems fine today and is even https now.
