### PR TITLE
apcupsd: get building on Xcode 12

### DIFF
--- a/Formula/apcupsd.rb
+++ b/Formula/apcupsd.rb
@@ -3,7 +3,7 @@ class Apcupsd < Formula
   homepage "http://www.apcupsd.org"
   url "https://downloads.sourceforge.net/project/apcupsd/apcupsd%20-%20Stable/3.14.14/apcupsd-3.14.14.tar.gz"
   sha256 "db7748559b6b4c3784f9856561ef6ac6199ef7bd019b3edcd7e0a647bf8f9867"
-  license "GPL-2.0"
+  license "GPL-2.0-only" # a few files have "or later", but most do not
 
   livecheck do
     url :stable
@@ -47,7 +47,10 @@ class Apcupsd < Formula
                           "--sbindir=#{sbin}",
                           "--sysconfdir=#{sysconfdir}",
                           "--enable-cgi", "--with-cgi-bin=#{sysconfdir}",
-                          "--enable-usb", "--enable-modbus-usb"
+                          "--enable-usb", "--enable-modbus-usb",
+                          # Detecting the lack of gethostname_r() goes
+                          # wrong on Xcode 12:
+                          "ac_cv_func_which_gethostbyname_r=no"
 
     system "make", "install"
   end


### PR DESCRIPTION
Some of their custom autoconf is fragile around `gethostname_r()` but OS/X doesn't have that function anyway.