### PR TITLE
pdftoipe: bump revision

### DIFF
--- a/Formula/pdftoipe.rb
+++ b/Formula/pdftoipe.rb
@@ -4,7 +4,7 @@ class Pdftoipe < Formula
   url "https://github.com/otfried/ipe-tools/archive/v7.2.20.1.tar.gz"
   sha256 "233f5629986ade3d70de6dd1af85d578d6aa0f92f9bcd1ecd4e8e5a94b508376"
   license "GPL-2.0-or-later"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any


### PR DESCRIPTION
I think this may be needed after the most recent poppler update ( a5840b1eedb1c16b628268837aed5f49884734cf )

In any case I want to see if Big Sur is still having bottling issues on this formula (build/test works fine locally)