### PR TITLE
spidermonkey: depends on macos due to Python 2

### DIFF
--- a/Formula/spidermonkey.rb
+++ b/Formula/spidermonkey.rb
@@ -20,6 +20,7 @@ class Spidermonkey < Formula
     sha256 "8cda55126be55fce01a82cf60e10522e211e7d8d384a0935c74a9d524256127f" => :mojave
   end
 
+  depends_on :macos # Due to Python 2
   depends_on "nspr"
   depends_on "readline"
 


### PR DESCRIPTION
Tried to build with Python3, which is not allowed:
checking for Python version >= 2.5 but not 3.x... configure: error: Python 2.5 or higher (but not Python 3.x) is required.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
