### PR TITLE
freeimage: Update formula to build on M1 machines

### DIFF
--- a/Formula/freeimage.rb
+++ b/Formula/freeimage.rb
@@ -26,6 +26,7 @@ class Freeimage < Formula
 
   def install
     # Temporary workaround for ARM. Upstream tracking issue:
+    # https://sourceforge.net/p/freeimage/bugs/325/
     # https://sourceforge.net/p/freeimage/discussion/36111/thread/cc4cd71c6e/
     if Hardware::CPU.arm?
       ENV.append "CFLAGS", "-DPNG_ARM_NEON_OPT=0"

--- a/Formula/freeimage.rb
+++ b/Formula/freeimage.rb
@@ -28,11 +28,7 @@ class Freeimage < Formula
     # Temporary workaround for ARM. Upstream tracking issue:
     # https://sourceforge.net/p/freeimage/bugs/325/
     # https://sourceforge.net/p/freeimage/discussion/36111/thread/cc4cd71c6e/
-    if Hardware::CPU.arm?
-    ENV["CFLAGS"] = "-O3 -fPIC -fexceptions -fvisibility=hidden -DPNG_ARM_NEON_OPT=0" \
-      if build.stable?
-      ENV.append "CXXFLAGS", "-DPNG_ARM_NEON_OPT=0"
-    end
+    ENV["CFLAGS"] = "-O3 -fPIC -fexceptions -fvisibility=hidden -DPNG_ARM_NEON_OPT=0" if Hardware::CPU.arm?
     system "make", "-f", "Makefile.gnu"
     system "make", "-f", "Makefile.gnu", "install", "PREFIX=#{prefix}"
     system "make", "-f", "Makefile.fip"

--- a/Formula/freeimage.rb
+++ b/Formula/freeimage.rb
@@ -25,6 +25,10 @@ class Freeimage < Formula
   end
 
   def install
+    if Hardware::CPU.arch == :arm64
+      ENV.append "CFLAGS", "-DPNG_ARM_NEON_OPT=0"
+      ENV.append "CXXFLAGS", "-DPNG_ARM_NEON_OPT=0"
+    end
     system "make", "-f", "Makefile.gnu"
     system "make", "-f", "Makefile.gnu", "install", "PREFIX=#{prefix}"
     system "make", "-f", "Makefile.fip"

--- a/Formula/freeimage.rb
+++ b/Formula/freeimage.rb
@@ -25,7 +25,7 @@ class Freeimage < Formula
   end
 
   def install
-    if Hardware::CPU.arch == :arm64
+    if Hardware::CPU.arm?
       ENV.append "CFLAGS", "-DPNG_ARM_NEON_OPT=0"
       ENV.append "CXXFLAGS", "-DPNG_ARM_NEON_OPT=0"
     end

--- a/Formula/freeimage.rb
+++ b/Formula/freeimage.rb
@@ -25,6 +25,8 @@ class Freeimage < Formula
   end
 
   def install
+    # Temporary workaround for ARM. Upstream tracking issue:
+    # https://sourceforge.net/p/freeimage/discussion/36111/thread/cc4cd71c6e/
     if Hardware::CPU.arm?
       ENV.append "CFLAGS", "-DPNG_ARM_NEON_OPT=0"
       ENV.append "CXXFLAGS", "-DPNG_ARM_NEON_OPT=0"

--- a/Formula/freeimage.rb
+++ b/Formula/freeimage.rb
@@ -29,7 +29,8 @@ class Freeimage < Formula
     # https://sourceforge.net/p/freeimage/bugs/325/
     # https://sourceforge.net/p/freeimage/discussion/36111/thread/cc4cd71c6e/
     if Hardware::CPU.arm?
-      ENV.append "CFLAGS", "-DPNG_ARM_NEON_OPT=0"
+    ENV["CFLAGS"] = "-O3 -fPIC -fexceptions -fvisibility=hidden -DPNG_ARM_NEON_OPT=0" \
+      if build.stable?
       ENV.append "CXXFLAGS", "-DPNG_ARM_NEON_OPT=0"
     end
     system "make", "-f", "Makefile.gnu"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

freeimage will fail to build for device with NEON support.

The [issue](https://sourceforge.net/p/freeimage/bugs/325/) has been created to fix this bug, but it has not been resolved yet.

Therefore, I disable NEON optimization until this issue fixed.