### PR TITLE
librttopo: add head and livecheck

### DIFF
--- a/Formula/librttopo.rb
+++ b/Formula/librttopo.rb
@@ -4,6 +4,12 @@ class Librttopo < Formula
   url "https://git.osgeo.org/gitea/rttopo/librttopo/archive/librttopo-1.1.0.tar.gz"
   sha256 "2e2fcabb48193a712a6c76ac9a9be2a53f82e32f91a2bc834d9f1b4fa9cd879f"
   license "GPL-2.0-or-later"
+  head "https://git.osgeo.org/gitea/rttopo/librttopo.git"
+
+  livecheck do
+    url :head
+    regex(/^(?:librttopo[._-])?v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     cellar :any
@@ -37,6 +43,6 @@ class Librttopo < Formula
       }
     EOS
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lrttopo", "-o", "test"
-    assert_equal version.to_s, shell_output("./test")
+    assert_equal stable.version.to_s, shell_output("./test")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a `head` URL for `librttopo` as well as a `livecheck` block that checks the upstream Git repository tags (since `stable` is an archive file from the same repository). Since the formula is building from a tag archive, the `--HEAD` build works fine without any modifications to the build/install steps.

The `brew test` failed on a `HEAD` build because the test outputs the stable version but `version` is the `HEAD` version (e.g., `HEAD-98a8bdd`). I've worked around this by using `stable.version.to_s` in the test (instead of `version.to_s`) but this only works if the code in the upstream repository still uses the same version. I imagine the test isn't really intended for `HEAD` builds but this tweak may be better than nothing.

I'm labeling this as "CI-syntax-only", since we don't test `HEAD` builds on CI anyway. If this needs to run normally, feel free to remove the label and trigger a new workflow.