### PR TITLE
xterm: add livecheck

### DIFF
--- a/Formula/xterm.rb
+++ b/Formula/xterm.rb
@@ -6,6 +6,11 @@ class Xterm < Formula
   sha256 "1d4ffe226fa8f021859bbc3007788ff63a46a31242d9bd9a7bd7ebe24e81aca2"
   license :cannot_represent
 
+  livecheck do
+    url "https://invisible-mirror.net/archives/xterm/"
+    regex(/href=.*?xterm[._-]v?(\d+(?:\.\d+)*)\.t/i)
+  end
+
   bottle do
     sha256 "3c3eddaf030860352a88988fbaf010dca4b2fd915b4722e655b98ce37c7416a6" => :big_sur
     sha256 "28e883a95daea3c12aa593cabb9f359e54eed2b6d99c80c0d940cfef36f6d154" => :arm64_big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `xterm`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.