### PR TITLE
kubeseal: add livecheck

### DIFF
--- a/Formula/kubeseal.rb
+++ b/Formula/kubeseal.rb
@@ -6,6 +6,12 @@ class Kubeseal < Formula
       revision: "378897421ef6ef3ba600b48607988f75fa32b528"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(%r{href=.*?/tag/(?:helm[._-])?v?(.+?)["' >]}i)
+    strategy :github_latest
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "33b659b0f8b22a8bafa97325c31fb91401e12c37fa9c79338b039544c76ceab9" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

At the moment, livecheck happens to be reporting the [seemingly] correct latest version of `kubeseal` by default. However, there have been some recent versions on GitHub marked as "pre-release", so it makes sense for us to specifically check for the "latest" release. This will hopefully help us to avoid accidentally updating to a prerelease version.