### PR TITLE
imagejs: remove unreachable homepage

### DIFF
--- a/Formula/imagejs.rb
+++ b/Formula/imagejs.rb
@@ -1,10 +1,15 @@
 class Imagejs < Formula
   desc "Tool to hide JavaScript inside valid image files"
-  homepage "https://jklmnn.de/imagejs/"
+  homepage "https://github.com/jklmnn/imagejs"
   url "https://github.com/jklmnn/imagejs/archive/0.7.2.tar.gz"
   sha256 "ba75c7ea549c4afbcb2a516565ba0b762b5fc38a03a48e5b94bec78bac7dab07"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
   head "https://github.com/jklmnn/imagejs.git"
+
+  livecheck do
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
The `jklmnn.de` domain resolves, but isn't reachable over either IPv4 nor IPv6

Author now seems to be using `jkliemann.de` domain, but that doesn't seem to include a homepage for imagejs

cc @jklmnn