### PR TITLE
disable dependents of gf-complete

### DIFF
--- a/Formula/jerasure.rb
+++ b/Formula/jerasure.rb
@@ -18,6 +18,8 @@ class Jerasure < Formula
     sha256 "1db6ef4631512bf3b155d614588689b2bacc911178cedf828db8f810d9e18d43" => :el_capitan
   end
 
+  disable! date: "2020-12-08", because: "Depends on gf-complete which has been disabled"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/liberasurecode.rb
+++ b/Formula/liberasurecode.rb
@@ -12,6 +12,8 @@ class Liberasurecode < Formula
     sha256 "2f0bb8a2f295cff0ba42097db3f31103f2f10637faa66ba2028bc746934b58d0" => :high_sierra
   end
 
+  disable! date: "2020-12-08", because: "Depends on gf-complete which has been disabled"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build


### PR DESCRIPTION
@fxcoudert disabled `gf-complete` on December 8th (dad36540675cd40fe7a16a26b62fa0ab6b522f35)

This rendered `jerasure` and, in turn, `liberasurecode` unbuildable.  We might as well disable them too as-of the same date.