### PR TITLE
tests.yml: add CI-force-arm label

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,13 +8,13 @@ env:
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_CHANGE_ARCH_TO_ARM: 1
-  HOMEBREW_REQUIRE_BOTTLED_ARM: 1
 jobs:
   tap_syntax:
     if: github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
     outputs:
       run-tests: ${{ steps.check-labels.outputs.result }}
+      run-arm-tests: ${{ steps.check-arm-labels.outputs.result }}
     env:
       HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
     steps:
@@ -62,6 +62,24 @@ jobs:
           }
           console.log('CI-syntax-only label found. Skipping tests.')
 
+    - name: Check for CI-force-arm label
+      id: check-arm-labels
+      uses: actions/github-script@v3
+      if: github.event_name == 'pull_request'
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { data: { labels: labels } } = await github.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          })
+          if (labels.map(label => label.name).includes('CI-force-arm')) {
+            console.log('CI-force-arm label found.')
+            return true
+          }
+          console.log('No CI-force-arm label found.')
+
   tests:
     needs: tap_syntax
     if: github.event_name == 'pull_request' && needs.tap_syntax.outputs.run-tests
@@ -78,6 +96,9 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
+      - name: Check whether ARM tests will be forced
+        if: !needs.tap_syntax.outputs.run-arm-tests
+        run: echo 'HOMEBREW_REQUIRE_BOTTLED_ARM=1' >> $GITHUB_ENV
       - name: Force vendored Ruby on Catalina
         if: matrix.version == '10.15'
         run: echo 'HOMEBREW_FORCE_VENDOR_RUBY=1' >> $GITHUB_ENV


### PR DESCRIPTION
Improving https://github.com/Homebrew/homebrew-core/pull/67577 so that ARM CI behaves as follows:

- by default, only test formulas that already have an ARM bottle
- if `CI-force-arm` flag is found, run ARM CI in all cases

The problem with the current approach is that we're not allowing to test new fixes for ARM. Take this PR #67716 or this one #67758, they would need to run on ARM to test the fix being introduced, but they're not. We need a way to opt-in to ARM testing for a given PR.