### PR TITLE
json-fortran: add Linux-only dependency

### DIFF
--- a/Formula/json-fortran.rb
+++ b/Formula/json-fortran.rb
@@ -18,6 +18,10 @@ class JsonFortran < Formula
   depends_on "ford" => :build
   depends_on "gcc" # for gfortran
 
+  on_linux do
+    depends_on "libx11"
+  end
+
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args,


### PR DESCRIPTION
https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/json-fortran.rb