### PR TITLE
iam-policy-json-to-terraform: deprecate gopath

### DIFF
--- a/Formula/iam-policy-json-to-terraform.rb
+++ b/Formula/iam-policy-json-to-terraform.rb
@@ -4,6 +4,7 @@ class IamPolicyJsonToTerraform < Formula
   url "https://github.com/flosell/iam-policy-json-to-terraform/archive/1.6.0.tar.gz"
   sha256 "714b8aead9bf5a88989a62eb520163565c890f37ee13783a3ae549bb0b8cdead"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/flosell/iam-policy-json-to-terraform.git"
 
   bottle do
@@ -13,19 +14,10 @@ class IamPolicyJsonToTerraform < Formula
     sha256 "01baa53333aa1aeeafc231c6fb985a21cc98bdee8a3b4812700036f3aa81401e" => :mojave
   end
 
-  depends_on "dep" => :build
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-
-    dir = buildpath/"src/github.com/flosell/iam-policy-json-to-terraform"
-    dir.install buildpath.children
-    cd "src/github.com/flosell/iam-policy-json-to-terraform" do
-      system "make", "iam-policy-json-to-terraform_darwin"
-      mv "iam-policy-json-to-terraform_darwin", "iam-policy-json-to-terraform"
-      bin.install "iam-policy-json-to-terraform"
-    end
+    system "go", "build", *std_go_args, "-ldflags", "-s -w"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
