### PR TITLE
ffmpeg: enable zeromq

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -4,7 +4,7 @@ class Ffmpeg < Formula
   # None of these parts are used by default, you have to explicitly pass `--enable-gpl`
   # to configure to activate them. In this case, FFmpeg's license changes to GPL v2+.
   license "GPL-2.0-or-later"
-  revision 4
+  revision 5
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   stable do
@@ -63,6 +63,7 @@ class Ffmpeg < Formula
   depends_on "x265"
   depends_on "xvid"
   depends_on "xz"
+  depends_on "zeromq"
 
   uses_from_macos "bzip2"
   uses_from_macos "libxml2"
@@ -112,6 +113,7 @@ class Ffmpeg < Formula
       --enable-libspeex
       --enable-libsoxr
       --enable-videotoolbox
+      --enable-libzmq
       --disable-libjack
       --disable-indev=jack
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This enables zeromq support for FFmpeg. zeromq can be used to distribute videos to multiple clients, and for other multi-client purposes. zeromq is a lightweight dependency that adds value to FFmpeg.