### PR TITLE
ficy: switch to gitlab for head

### DIFF
--- a/Formula/ficy.rb
+++ b/Formula/ficy.rb
@@ -3,8 +3,13 @@ class Ficy < Formula
   homepage "https://www.thregr.org/~wavexx/software/fIcy/"
   url "https://www.thregr.org/~wavexx/software/fIcy/releases/fIcy-1.0.21.tar.gz"
   sha256 "8564b16d3a52fa6dc286b02bfcc19e4acdc148c30f1750ca144e2ea47c84fd81"
-  license "LGPL-2.1"
-  head "https://github.com/wavexx/fIcy.git"
+  license "LGPL-2.1-only"
+  head "https://gitlab.com/wavexx/fIcy.git"
+
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?releases/fIcy[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
The github repo is still there but it is now marked "archived" and the project's homepage points to this gitlab repo instead.

cc @wavexx