### PR TITLE
st: install correctly on Big Sur

### DIFF
--- a/Formula/st.rb
+++ b/Formula/st.rb
@@ -4,6 +4,13 @@ class St < Formula
   url "https://github.com/nferraz/st/archive/v1.1.4.tar.gz"
   sha256 "c02a16f67e4c357690a5438319843149fd700c223128f9ffebecab2849c58bb8"
   license "MIT"
+  revision 1
+  head "https://github.com/nferraz/st.git"
+
+  livecheck do
+    url :head
+    strategy :github_latest
+  end
 
   bottle do
     cellar :any_skip_relocation
@@ -16,15 +23,12 @@ class St < Formula
   end
 
   def install
-    ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5/site_perl/"
+    ENV.prepend_create_path "PERL5LIB", lib/"perl5/"
 
-    system "perl", "Makefile.PL", "PREFIX=#{libexec}"
+    system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}", "INSTALLSITEMAN1DIR=#{man1}", "INSTALLSITEMAN3DIR=#{man3}"
     system "make", "install"
 
-    bin.install Dir[libexec/"bin/*"]
     bin.env_script_all_files libexec/"bin", PERL5LIB: ENV["PERL5LIB"]
-
-    man1.install_symlink Dir[libexec/"share/man/man1/*.1"]
   end
 
   test do


### PR DESCRIPTION
As discussed with https://github.com/Homebrew/homebrew-core/pull/66370#issuecomment-740856994 Big Sur's system perl changed how `PREFIX=` is treated as an install destination.  The more explicit way to control MakeMaker is to set `INSTALL_BASE` instead, which should result in consistent behavior between different OS/X versions.

This also lets us drop some other hacks that this formula had been doing before.