### PR TITLE
git-cal: install correctly on Big Sur

### DIFF
--- a/Formula/git-cal.rb
+++ b/Formula/git-cal.rb
@@ -4,7 +4,13 @@ class GitCal < Formula
   url "https://github.com/k4rthik/git-cal/archive/v0.9.1.tar.gz"
   sha256 "783fa73197b349a51d90670480a750b063c97e5779a5231fe046315af0a946cd"
   license "MIT"
+  revision 1
   head "https://github.com/k4rthik/git-cal.git"
+
+  livecheck do
+    url :head
+    strategy :github_latest
+  end
 
   bottle do
     cellar :any_skip_relocation
@@ -19,7 +25,7 @@ class GitCal < Formula
   end
 
   def install
-    system "perl", "Makefile.PL", "PREFIX=#{prefix}"
+    system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}", "INSTALLSITEMAN1DIR=#{man1}"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
As discussed with https://github.com/Homebrew/homebrew-core/pull/66370#issuecomment-740856994 Big Sur's system perl changed how `PREFIX=` is treated as an install destination.  The more explicit way to control MakeMaker is to set `INSTALL_BASE` instead, which should result in consistent behavior between different OS/X versions.
