### PR TITLE
mysql-sandbox: install correctly on Big Sur

### DIFF
--- a/Formula/mysql-sandbox.rb
+++ b/Formula/mysql-sandbox.rb
@@ -20,6 +20,8 @@ class MysqlSandbox < Formula
     sha256 "1829b23da5960830f426300cac7b4820f21a4f801a1260357394b205bb9340a4" => :sierra
     sha256 "77ab4eb3bbd5d374020081b3505cd7f18de1500019af148f00ebef13a34e4222" => :el_capitan
   end
+  
+  uses_from_macos "perl"
 
   def install
     ENV["PERL_LIBDIR"] = lib/"perl5"

--- a/Formula/mysql-sandbox.rb
+++ b/Formula/mysql-sandbox.rb
@@ -8,7 +8,7 @@ class MysqlSandbox < Formula
   head "https://github.com/datacharmer/mysql-sandbox.git"
 
   livecheck do
-    url :head
+    url :stable
     strategy :github_latest
   end
 

--- a/Formula/mysql-sandbox.rb
+++ b/Formula/mysql-sandbox.rb
@@ -4,7 +4,13 @@ class MysqlSandbox < Formula
   url "https://github.com/datacharmer/mysql-sandbox/archive/3.2.17.tar.gz"
   sha256 "3af4af111536e4e690042bc80834392f46a7e55c7143332d229ff2eb32321e89"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/datacharmer/mysql-sandbox.git"
+
+  livecheck do
+    url :head
+    strategy :github_latest
+  end
 
   bottle do
     cellar :any_skip_relocation
@@ -16,14 +22,18 @@ class MysqlSandbox < Formula
   end
 
   def install
-    ENV["PERL_LIBDIR"] = libexec/"lib/perl5"
-    ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5/site_perl"
+    ENV["PERL_LIBDIR"] = lib/"perl5"
+    ENV.prepend_create_path "PERL5LIB", lib/"perl5"
 
-    system "perl", "Makefile.PL", "PREFIX=#{libexec}"
+    system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}", "INSTALLSITEMAN3DIR=#{man3}"
     system "make", "test", "install"
 
-    bin.install Dir["#{libexec}/bin/*"]
-    bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
+    Pathname.glob("#{bin}/*") do |file|
+      next if file.extname == ".sh"
+
+      libexec.install(file)
+      file.write_env_script(libexec.join(file.basename), PERL5LIB: ENV["PERL5LIB"])
+    end
   end
 
   test do

--- a/Formula/mysql-sandbox.rb
+++ b/Formula/mysql-sandbox.rb
@@ -20,7 +20,7 @@ class MysqlSandbox < Formula
     sha256 "1829b23da5960830f426300cac7b4820f21a4f801a1260357394b205bb9340a4" => :sierra
     sha256 "77ab4eb3bbd5d374020081b3505cd7f18de1500019af148f00ebef13a34e4222" => :el_capitan
   end
-  
+
   uses_from_macos "perl"
 
   def install


### PR DESCRIPTION
As discussed with https://github.com/Homebrew/homebrew-core/pull/66370#issuecomment-740856994 Big Sur's system perl changed how `PREFIX=` is treated as an install destination.  The more explicit way to control MakeMaker is to set `INSTALL_BASE` instead, which should result in consistent behavior between different OS/X versions.

Even on 10.X, this formula wasn't installing manpages in the correct directory; that is now fixed.
