### PR TITLE
mikutter: use ruby@2.7 instead of ruby@2.6

### DIFF
--- a/Formula/mikutter.rb
+++ b/Formula/mikutter.rb
@@ -4,7 +4,7 @@ class Mikutter < Formula
   url "https://mikutter.hachune.net/bin/mikutter-4.1.1.tar.gz"
   sha256 "4cce3a4770a0d9a2691d21e3379fe616797e583a47273d69d1ec44f48b98836d"
   license "MIT"
-  revision 1
+  revision 2
   head "git://mikutter.hachune.net/mikutter.git", branch: "develop"
 
   livecheck do
@@ -23,7 +23,7 @@ class Mikutter < Formula
   depends_on "gobject-introspection"
   depends_on "gtk+"
   depends_on "libidn"
-  depends_on "ruby@2.6"
+  depends_on "ruby@2.7"
 
   uses_from_macos "xz"
 

--- a/Formula/mikutter.rb
+++ b/Formula/mikutter.rb
@@ -234,7 +234,7 @@ class Mikutter < Formula
       GTK_PATH:              HOMEBREW_PREFIX/"lib/gtk-2.0",
     }
 
-    (bin/"mikutter").write_env_script Formula["ruby@2.6"].opt_bin/"ruby", "#{libexec}/mikutter.rb", env
+    (bin/"mikutter").write_env_script Formula["ruby@2.7"].opt_bin/"ruby", "#{libexec}/mikutter.rb", env
     pkgshare.install_symlink libexec/"core/skin"
 
     # enable other formulae to install plugins

--- a/Formula/mikutter.rb
+++ b/Formula/mikutter.rb
@@ -227,7 +227,7 @@ class Mikutter < Formula
     (lib/"mikutter").install "plugin"
     libexec.install Dir["*"]
 
-    ruby_series = Formula["ruby@2.6"].any_installed_version.major_minor
+    ruby_series = Formula["ruby@2.7"].any_installed_version.major_minor
     env = {
       DISABLE_BUNDLER_SETUP: "1",
       GEM_HOME:              HOMEBREW_PREFIX/"lib/mikutter/vendor/ruby/#{ruby_series}.0",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`mikutter` couldn't build with Ruby 3 (#67676), so it was changed to use `ruby@2.6`. Now, `ruby@2.7` has been added to homebrew-core (#67805), so let's use that instead.