### PR TITLE
feedgnuplot: fix big sur build

### DIFF
--- a/Formula/feedgnuplot.rb
+++ b/Formula/feedgnuplot.rb
@@ -3,8 +3,8 @@ class Feedgnuplot < Formula
   homepage "https://github.com/dkogan/feedgnuplot"
   url "https://github.com/dkogan/feedgnuplot/archive/v1.55.tar.gz"
   sha256 "1205afedf8ce79d8531e0d0f8f9565df365a568a0ee6a8e17738602682095303"
-  # licensed under either "GPL-3.0" or "Artistic-1.0"
-  license "GPL-3.0"
+  license any_of: ["GPL-1.0-or-later", "Artistic-1.0"]
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +16,7 @@ class Feedgnuplot < Formula
   depends_on "gnuplot"
 
   def install
-    system "perl", "Makefile.PL", "prefix=#{prefix}"
+    system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}"
     system "make"
     system "make", "install"
 

--- a/Formula/feedgnuplot.rb
+++ b/Formula/feedgnuplot.rb
@@ -18,7 +18,7 @@ class Feedgnuplot < Formula
   uses_from_macos "perl"
 
   def install
-    system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}"
+    system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}", "INSTALLSITEMAN1DIR=#{man1}"
     system "make"
     system "make", "install"
 

--- a/Formula/feedgnuplot.rb
+++ b/Formula/feedgnuplot.rb
@@ -15,6 +15,8 @@ class Feedgnuplot < Formula
 
   depends_on "gnuplot"
 
+  uses_from_macos "perl"
+
   def install
     system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}"
     system "make"

--- a/Formula/feedgnuplot.rb
+++ b/Formula/feedgnuplot.rb
@@ -3,7 +3,7 @@ class Feedgnuplot < Formula
   homepage "https://github.com/dkogan/feedgnuplot"
   url "https://github.com/dkogan/feedgnuplot/archive/v1.55.tar.gz"
   sha256 "1205afedf8ce79d8531e0d0f8f9565df365a568a0ee6a8e17738602682095303"
-  license any_of: ["GPL-1.0-or-later", "Artistic-1.0"]
+  license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   revision 1
 
   bottle do

--- a/Formula/feedgnuplot.rb
+++ b/Formula/feedgnuplot.rb
@@ -20,7 +20,7 @@ class Feedgnuplot < Formula
   def install
     system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}", "INSTALLSITEMAN1DIR=#{man1}"
     system "make"
-    system "make", "install"
+    system "make", "install", "mandir=#{man}"
 
     bash_completion.install "completions/bash/feedgnuplot"
     zsh_completion.install "completions/zsh/_feedgnuplot"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As discussed with https://github.com/Homebrew/homebrew-core/pull/66370#issuecomment-740856994 Big Sur's system perl changed how `PREFIX=` is treated as an install destination.  The more explicit way to control MakeMaker is to set `INSTALL_BASE` instead, which should result in consistent behavior between different OS/X versions.

cc @mitchblank