### PR TITLE
snappystream: build requires C++11

### DIFF
--- a/Formula/snappystream.rb
+++ b/Formula/snappystream.rb
@@ -18,7 +18,7 @@ class Snappystream < Formula
   depends_on "snappy"
 
   def install
-    system "cmake", ".", *std_cmake_args, "-DBUILD_TESTS=ON"
+    system "cmake", ".", *std_cmake_args, "-DBUILD_TESTS=ON", "-DCMAKE_CXX_STANDARD=11"
     system "make", "all", "test", "install"
   end
 


### PR DESCRIPTION
This must have worked at one point, and I think upstream is actually OK.  However `*std_cmake_args` overriding of `CMAKE_CXX_FLAGS_RELEASE` seems to have changed the default C++ dialect that this is building with.

Just tell cmake to default to C++11 for this project and it builds fine again.
