### PR TITLE
git-cal: update livecheck

### DIFF
--- a/Formula/git-cal.rb
+++ b/Formula/git-cal.rb
@@ -8,7 +8,7 @@ class GitCal < Formula
   head "https://github.com/k4rthik/git-cal.git"
 
   livecheck do
-    url :head
+    url :stable
     strategy :github_latest
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a simple follow-up to #67820, to use `url :stable` in the `livecheck` block instead of `:head`. We prefer to align the check with the `stable` source whenever possible, so we only use `head` in a `livecheck` block when it's necessary.