### PR TITLE
curl: fix GSSAPI support on Linux

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -40,6 +40,7 @@ class Curl < Formula
   depends_on "rtmpdump"
   depends_on "zstd"
 
+  uses_from_macos "krb5"
   uses_from_macos "zlib"
 
   def install
@@ -63,6 +64,14 @@ class Curl < Formula
       --with-libssh2
       --without-libpsl
     ]
+
+    on_macos do
+      args << "--with-gssapi"
+    end
+
+    on_linux do
+      args << "--with-gssapi=#{Formula["krb5"].opt_prefix}"
+    end
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Backport of https://github.com/Homebrew/linuxbrew-core/pull/21873.

We currently build curl with GSSAPI support using the `--with-gssapi` flag. On macOS this seems to work fine by using the system `krb5` libraries. On Linux if it does not find a system `krb5` installation, it seems to just ignore that flag and build without GSSAPI support. If it does find a system installation though, it fails because it tries to link the system installation. This can be resolved by depending on `krb5` and also modifying the `--with-gssapi` argument to provide the path where it can find `krb5-config`, which it uses to determine how to link to the GSSAPI libraries.