### PR TITLE
serialosc: replace dead homepage

### DIFF
--- a/Formula/serialosc.rb
+++ b/Formula/serialosc.rb
@@ -1,6 +1,6 @@
 class Serialosc < Formula
   desc "Opensound control server for monome devices"
-  homepage "https://monome.org/docs/osc/"
+  homepage "https://github.com/monome/docs/blob/gh-pages/serialosc/osc.md"
   url "https://github.com/monome/serialosc.git",
       tag:      "v1.4.1",
       revision: "4fec6f11276dd302faf9ca8e0a8e126f273cf954"


### PR DESCRIPTION
Old link was 404 which probably was causing rebottling to fail.

Please let this PR get a full CI so we hopefully can get a Big Sur bottle created.