### PR TITLE
tmpreaper: replace 404'ed download link

### DIFF
--- a/Formula/tmpreaper.rb
+++ b/Formula/tmpreaper.rb
@@ -1,9 +1,10 @@
 class Tmpreaper < Formula
   desc "Clean up files in directories based on their age"
   homepage "https://packages.debian.org/sid/tmpreaper"
-  url "https://deb.debian.org/debian/pool/main/t/tmpreaper/tmpreaper_1.6.14.tar.gz"
+  url "https://old-releases.ubuntu.com/ubuntu/pool/universe/t/tmpreaper/tmpreaper_1.6.14.tar.gz"
+  mirror "https://fossies.org/linux/misc/tmpreaper_1.6.14.tar.gz"
   sha256 "4acb93745ceb8b8c5941313bbba78ceb2af0c3914f1afea0e0ae1f7950d6bdae"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Tarball we had been using seems to have disappeared from debian.org, but found it a couple other places.