### PR TITLE
Rosetta revision bumps

### DIFF
--- a/Formula/abseil.rb
+++ b/Formula/abseil.rb
@@ -4,7 +4,7 @@ class Abseil < Formula
   url "https://github.com/abseil/abseil-cpp/archive/20200923.2.tar.gz"
   sha256 "bf3f13b13a0095d926b25640e060f7e13881bd8a792705dd9e161f3c2b9aa976"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Formula/broot.rb
+++ b/Formula/broot.rb
@@ -4,6 +4,7 @@ class Broot < Formula
   url "https://github.com/Canop/broot/archive/v1.1.10.tar.gz"
   sha256 "f40e63cf8bcf7d70a42d528696fe0355ff5a4a80cfd654593dabdd866613bc60"
   license "MIT"
+  revision 1
   head "https://github.com/Canop/broot.git"
 
   bottle do

--- a/Formula/bullet.rb
+++ b/Formula/bullet.rb
@@ -4,6 +4,7 @@ class Bullet < Formula
   url "https://github.com/bulletphysics/bullet3/archive/3.08.tar.gz"
   sha256 "05826c104b842bcdd1339b86894cb44c84ac2525ac296689d34b38a14bbba0dd"
   license "Zlib"
+  revision 1
   head "https://github.com/bulletphysics/bullet3.git"
 
   bottle do

--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -8,6 +8,7 @@ class Dpkg < Formula
   mirror "https://deb.debian.org/debian/pool/main/d/dpkg/dpkg_1.20.5.tar.xz"
   sha256 "f2f23f3197957d89e54b87cf8fc42ab00e1b74f3a32090efe9acd08443f3e0dd"
   license "GPL-2.0"
+  revision 1
 
   livecheck do
     url "https://deb.debian.org/debian/pool/main/d/dpkg/"

--- a/Formula/eksctl.rb
+++ b/Formula/eksctl.rb
@@ -5,6 +5,7 @@ class Eksctl < Formula
       tag:      "0.35.0",
       revision: "1eafbc7b3fa3d9c31575b51b8fbac718ec108051"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/weaveworks/eksctl.git"
 
   bottle do

--- a/Formula/freerdp.rb
+++ b/Formula/freerdp.rb
@@ -4,7 +4,7 @@ class Freerdp < Formula
   url "https://github.com/FreeRDP/FreeRDP/archive/2.2.0.tar.gz"
   sha256 "883bc0396c6be9aba6bc07ebc8ff08457125868ada0f06554e62ef072f90cf59"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "dd8fc56553931bdc70efae9305b68b9061092f4f1cf901df4a3f499419de7608" => :big_sur

--- a/Formula/git-delta.rb
+++ b/Formula/git-delta.rb
@@ -4,6 +4,7 @@ class GitDelta < Formula
   url "https://github.com/dandavison/delta/archive/0.4.5.tar.gz"
   sha256 "e19ab2d6a7977a3aa939a2d70b6d007aad8b494a901d47a3e0c2357eedad0c80"
   license "MIT"
+  revision 1
   head "https://github.com/dandavison/delta.git"
 
   bottle do

--- a/Formula/glow.rb
+++ b/Formula/glow.rb
@@ -4,6 +4,7 @@ class Glow < Formula
   url "https://github.com/charmbracelet/glow/archive/v1.3.0.tar.gz"
   sha256 "828d8453f026a24cd7a6dcf8d97213fe713cadcfab7ca969d5f4c8338d88bb86"
   license "MIT"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -6,7 +6,7 @@ class Grpc < Formula
       revision: "ee5b762f33a42170144834f5ab7efda9d76c480b",
       shallow:  false
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/grpc/grpc.git"
 
   livecheck do

--- a/Formula/jupyterlab.rb
+++ b/Formula/jupyterlab.rb
@@ -6,6 +6,7 @@ class Jupyterlab < Formula
   url "https://files.pythonhosted.org/packages/a2/5c/c209190ba2a6dac3937d91f2610f5eee9a29b7f05f5a66bb7058e83e730b/jupyterlab-3.0.0.tar.gz"
   sha256 "15228dff3f77b0bca795fd232cb25f02121510cec83f1d25856b3bc8e585b087"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/lazygit.rb
+++ b/Formula/lazygit.rb
@@ -4,6 +4,7 @@ class Lazygit < Formula
   url "https://github.com/jesseduffield/lazygit/archive/v0.24.2.tar.gz"
   sha256 "95f629d57b459a3414af0582c20835edc970ec83a2c791cff97e5b8aac3b7025"
   license "MIT"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/libarchive.rb
+++ b/Formula/libarchive.rb
@@ -4,6 +4,7 @@ class Libarchive < Formula
   url "https://www.libarchive.org/downloads/libarchive-3.5.1.tar.xz"
   sha256 "0e17d3a8d0b206018693b27f08029b598f6ef03600c2b5d10c94ce58692e299b"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     url "https://libarchive.org/downloads/"

--- a/Formula/libepoxy.rb
+++ b/Formula/libepoxy.rb
@@ -4,6 +4,7 @@ class Libepoxy < Formula
   url "https://download.gnome.org/sources/libepoxy/1.5/libepoxy-1.5.5.tar.xz"
   sha256 "261663db21bcc1cc232b07ea683252ee6992982276536924271535875f5b0556"
   license "MIT"
+  revision 1
 
   # We use a common regex because libepoxy doesn't use GNOME's "even-numbered
   # minor is stable" version scheme.

--- a/Formula/libxslt.rb
+++ b/Formula/libxslt.rb
@@ -4,7 +4,7 @@ class Libxslt < Formula
   url "http://xmlsoft.org/sources/libxslt-1.1.34.tar.gz"
   sha256 "98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f"
   license "X11"
-  revision 1
+  revision 2
 
   livecheck do
     url "http://xmlsoft.org/sources/"

--- a/Formula/mosquitto.rb
+++ b/Formula/mosquitto.rb
@@ -6,6 +6,7 @@ class Mosquitto < Formula
   # dual-licensed under EPL-1.0 and EDL-1.0 (Eclipse Distribution License v1.0),
   # EDL-1.0 is not in the SPDX list
   license "EPL-1.0"
+  revision 1
 
   livecheck do
     url "https://mosquitto.org/download/"

--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -4,6 +4,7 @@ class Notmuch < Formula
   url "https://notmuchmail.org/releases/notmuch-0.31.3.tar.xz"
   sha256 "484041aed08f88f3a528a5b82489b6cda4090764228813bca73678da3a753aca"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://git.notmuchmail.org/git/notmuch", using: :git
 
   livecheck do

--- a/Formula/pugixml.rb
+++ b/Formula/pugixml.rb
@@ -4,7 +4,7 @@ class Pugixml < Formula
   url "https://github.com/zeux/pugixml/releases/download/v1.11.4/pugixml-1.11.4.tar.gz"
   sha256 "8ddf57b65fb860416979a3f0640c2ad45ddddbbafa82508ef0a0af3ce7061716"
   license "MIT"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable

--- a/Formula/pulumi.rb
+++ b/Formula/pulumi.rb
@@ -5,6 +5,7 @@ class Pulumi < Formula
       tag:      "v2.16.2",
       revision: "58c07c52c8d4db037c284b66d432d96db6081ca9"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/pulumi/pulumi.git"
 
   bottle do

--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -4,6 +4,7 @@ class Sdl2 < Formula
   url "https://libsdl.org/release/SDL2-2.0.14.tar.gz"
   sha256 "d8215b571a581be1332d2106f8036fcb03d12a70bae01e20f424976d275432bc"
   license "Zlib"
+  revision 1
 
   livecheck do
     url "https://www.libsdl.org/download-2.0.php"

--- a/Formula/sshuttle.rb
+++ b/Formula/sshuttle.rb
@@ -6,7 +6,7 @@ class Sshuttle < Formula
   url "https://files.pythonhosted.org/packages/ee/5d/8eb1de9ed90732309cc8c64256d2e35de3f269713d707e1074a37d794665/sshuttle-1.0.4.tar.gz"
   sha256 "21a11f3f0f710de92241d8ffca58bebb969f689f650d59e97ba366d7407e16e5"
   license "LGPL-2.1-or-later"
-  revision 1
+  revision 2
   head "https://github.com/sshuttle/sshuttle.git"
 
   livecheck do

--- a/Formula/streamlink.rb
+++ b/Formula/streamlink.rb
@@ -6,6 +6,7 @@ class Streamlink < Formula
   url "https://files.pythonhosted.org/packages/b4/d6/4981231ee8d23a7898d44efb3cf36e3a7820eb485c937f67d02428c6c585/streamlink-2.0.0.tar.gz"
   sha256 "c0ead9e961638d41cab9bd9677cdc701f2313bfd4d23cd8158410932839c62db"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/streamlink/streamlink.git"
 
   livecheck do

--- a/Formula/supervisor.rb
+++ b/Formula/supervisor.rb
@@ -5,6 +5,7 @@ class Supervisor < Formula
   homepage "http://supervisord.org/"
   url "https://files.pythonhosted.org/packages/11/35/eab03782aaf70d87303b21a67c345b953d3b59d4e3971a568c51e523f5c0/supervisor-4.2.1.tar.gz"
   sha256 "c479c875853e9c013d1fa73e529fd2165ff1ecaecc7e82810ba57e7362ae984d"
+  revision 1
   head "https://github.com/Supervisor/supervisor.git"
 
   livecheck do

--- a/Formula/swiftformat.rb
+++ b/Formula/swiftformat.rb
@@ -4,6 +4,7 @@ class Swiftformat < Formula
   url "https://github.com/nicklockwood/SwiftFormat/archive/0.47.9.tar.gz"
   sha256 "29d017bad7b3acc914466260825b0a3ce3b57f4d8dd0971329e6bb90ece449e2"
   license "MIT"
+  revision 1
   head "https://github.com/nicklockwood/SwiftFormat.git", shallow: false
 
   bottle do

--- a/Formula/travis.rb
+++ b/Formula/travis.rb
@@ -4,7 +4,7 @@ class Travis < Formula
   url "https://github.com/travis-ci/travis.rb/archive/v1.10.0.tar.gz"
   sha256 "b63991faebbd5da0e92bf1547775b69a0dbed01dd57e8b469d23a2a7bd79da43"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -4,7 +4,7 @@ class Weechat < Formula
   url "https://weechat.org/files/src/weechat-3.0.tar.xz"
   sha256 "6cb7d25a363b66b835f1b9f29f3580d6f09ac7d38505b46a62c178b618d9f1fb"
   license "GPL-3.0-or-later"
-  revision 2
+  revision 3
   head "https://github.com/weechat/weechat.git"
 
   bottle do


### PR DESCRIPTION
Revision bumps for formulae > 1000 monthly installs per analytics.

https://github.com/Homebrew/homebrew-core/issues/67713

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----