### PR TITLE
workflows: add dispatch-rebottle

### DIFF
--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -1,0 +1,161 @@
+name: Dispatch rebottle
+
+on:
+  workflow_dispatch:
+    inputs:
+      formula:
+        description: Formula name
+        required: true
+      issue:
+        description: Issue number, where comment on failure would be posted
+        required: false
+      upload:
+        description: Whether to upload built bottles to Bintray or not
+        required: false
+
+env:
+  HOMEBREW_DEVELOPER: 1
+  HOMEBREW_GITHUB_ACTIONS: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_CHANGE_ARCH_TO_ARM: 1
+
+jobs:
+  bottle:
+    strategy:
+      matrix:
+        version: ['11-arm', '11.0', '10.15', '10.14']
+      fail-fast: false
+    runs-on: ${{ matrix.version }}
+    timeout-minutes: 4320
+    env:
+      PATH: '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+      GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED: 1
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: 1
+    steps:
+      - name: ${{github.event.inputs.formula}}
+        id: print_details
+        run: |
+          echo sender=${{github.event.sender.login}}
+          echo formula=${{github.event.inputs.formula}}
+          echo issue=${{github.event.inputs.issue}}
+          echo upload=${{github.event.inputs.upload}}
+
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - run: brew test-bot --only-cleanup-before
+
+      - run: brew test-bot --only-setup
+
+      - name: Run brew test-bot --only-formulae
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          mkdir bottles
+          cd bottles
+          brew test-bot --only-formulae ${{github.event.inputs.formula}}
+
+      - name: Output brew test-bot --only-formulae failures
+        if: always()
+        run: |
+          cat bottles/steps_output.txt
+          rm bottles/steps_output.txt
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name: logs
+          path: bottles/logs
+
+      - name: Delete logs and home
+        if: always()
+        run: |
+          rm -rvf bottles/logs
+          rm -rvf bottles/home
+
+      - name: Count bottles
+        id: bottles
+        if: always()
+        run: |
+          cd bottles
+          count=$(ls *.json | wc -l | xargs echo -n)
+          echo "$count bottles"
+          echo "::set-output name=count::$count"
+
+      - name: Upload bottles to GitHub Actions
+        if: always() && steps.bottles.outputs.count > 0
+        uses: actions/upload-artifact@main
+        with:
+          name: bottles
+          path: bottles
+
+      - run: brew test-bot --only-cleanup-after
+        if: always()
+
+      - name: Post Cleanup
+        if: always()
+        run: rm -rvf bottles
+
+      - name: Post comment on failure
+        if: ${{!success() && github.event.inputs.issue > 0}}
+        uses: Homebrew/actions/post-comment@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          issue: ${{github.event.inputs.issue}}
+          body: ':x: @${{github.actor}} bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}).'
+          bot_body: ':x: Bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}).'
+          bot: BrewTestBot
+  upload:
+    runs-on: ubuntu-latest
+    needs: bottle
+    if: github.event.inputs.upload
+    env:
+      HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
+    steps:
+      - name: ${{github.event.inputs.formula}}
+        id: print_details
+        run: |
+          echo sender=${{github.event.sender.login}}
+          echo formula=${{github.event.inputs.formula}}
+          echo version=${{github.event.inputs.macos}}
+          echo issue=${{github.event.inputs.issue}}
+          echo upload=${{github.event.inputs.upload}}
+
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Download bottles from GitHub Actions
+        uses: actions/download-artifact@main
+        with:
+          name: bottles
+          path: ~/bottles/
+
+      - name: Setup git
+        uses: Homebrew/actions/git-user-config@master
+
+      - name: Upload and publish bottles on Bintray
+        env:
+          HOMEBREW_BINTRAY_USER: brewtestbot
+          HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
+        run: |
+          cd ~/bottles
+          brew pr-upload --verbose
+
+      - name: Push commits
+        uses: Homebrew/actions/git-try-push@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+
+      - name: Post comment on failure
+        if: ${{!success() && github.event.inputs.issue > 0}}
+        uses: Homebrew/actions/post-comment@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          issue: ${{github.event.inputs.issue}}
+          body: ':x: @${{github.actor}} bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}).'
+          bot_body: ':x: Bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}).'
+          bot: BrewTestBot


### PR DESCRIPTION
Supporting https://github.com/Homebrew/homebrew-core/issues/67713.

The difference between this and `dispatch-build-bottle` is that this will rebottle the entire bottle block, rather than do a `--keep-old` for a single macOS version.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----