### PR TITLE
docker-machine: fix building on go 1.16

### DIFF
--- a/Formula/docker-machine.rb
+++ b/Formula/docker-machine.rb
@@ -21,6 +21,7 @@ class DockerMachine < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/docker/machine").install buildpath.children
     cd "src/github.com/docker/machine" do
       system "make", "build"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
In Go 1.16 the new module system is enabled by default (https://tip.golang.org/doc/go1.16#modules). Unfortunately docker-machine does not support building with modules (yet). While Go 1.16 is still in beta, it is the only version available for Apple Silicon. It is possible to opt out of the module system by setting the environment variable `GO111MODULE=auto`. According to the documentation, this reverts to the default behaviour for Go 1.15 and earlier, so it is a no-op on Intel.

I tried to create a machine using the Parallels driver with the Parallels technical preview. This does not work yet because docker-machine downloads an x86 iso for the virtual machine. However, it seems it should work using the driver of a cloud vendor such as docker-machine-driver-vultr. 