### PR TITLE
vim: remove now unnecessary -fdeclspec flag

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -37,9 +37,6 @@ class Vim < Formula
   end
 
   def install
-    # Fix error: '__declspec' attributes are not enabled
-    ENV.append_to_cflags "-fdeclspec"
-
     ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin"
 
     # https://github.com/Homebrew/homebrew-core/pull/1046


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
