### PR TITLE
fix: description of massdns

### DIFF
--- a/Formula/massdns.rb
+++ b/Formula/massdns.rb
@@ -1,5 +1,5 @@
 class Massdns < Formula
-  desc "Particle library for 3D graphics"
+  desc "A high-performance DNS stub resolver"
   homepage "https://github.com/blechschmidt/massdns"
   url "https://github.com/blechschmidt/massdns/archive/1.0.0.tar.gz"
   sha256 "0eba00a03e74a02a78628819741c75c2832fb94223d0ff632249f2cc55d0fdbb"

--- a/Formula/massdns.rb
+++ b/Formula/massdns.rb
@@ -1,5 +1,5 @@
 class Massdns < Formula
-  desc "A high-performance DNS stub resolver"
+  desc "High-performance DNS stub resolver"
   homepage "https://github.com/blechschmidt/massdns"
   url "https://github.com/blechschmidt/massdns/archive/1.0.0.tar.gz"
   sha256 "0eba00a03e74a02a78628819741c75c2832fb94223d0ff632249f2cc55d0fdbb"


### PR DESCRIPTION
I don't know why, maybe a Copy&Paste-Error, but the description of `massdns` is potentially wrong.
Referring to the [official repository](https://github.com/blechschmidt/massdns) it is actually a `high-performance DNS stub resolver` instead of `Particle library for 3D graphics`