### PR TITLE
yq@3 - installs v3 of yq for backwards compatability

### DIFF
--- a/Aliases/yq@4
+++ b/Aliases/yq@4
@@ -1,0 +1,1 @@
+../Formula/yq.rb

--- a/Formula/yq3.rb
+++ b/Formula/yq3.rb
@@ -1,0 +1,31 @@
+class Yq3 < Formula
+  desc "Process YAML documents from the CLI - Version 3"
+  homepage "https://github.com/mikefarah/yq"
+  url "https://github.com/mikefarah/yq/archive/3.4.1.tar.gz"
+  sha256 "73259f808d589d11ea7a18e4cd38a2e98b518a6c2c178d1ec57d9c5942277cb1"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  conflicts_with "python-yq", because: "both install `yq` executables"
+  conflicts_with "yq", because: "yq is v4, installs `yq` executable"
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/mikefarah/yq").install buildpath.children
+
+    cd "src/github.com/mikefarah/yq" do
+      system "go", "build", "-o", bin/"yq"
+      prefix.install_metafiles
+
+      (bash_completion/"yq").write Utils.safe_popen_read("#{bin}/yq", "shell-completion", "-V=bash")
+      (zsh_completion/"_yq").write Utils.safe_popen_read("#{bin}/yq", "shell-completion", "-V=zsh")
+      (fish_completion/"yq.fish").write Utils.safe_popen_read("#{bin}/yq", "shell-completion", "-V=fish")
+    end
+  end
+
+  test do
+    assert_equal "key: cat", shell_output("#{bin}/yq n key cat").chomp
+    assert_equal "cat", pipe_output("#{bin}/yq r - key", "key: cat", 0).chomp
+  end
+end

--- a/Formula/yq@3.rb
+++ b/Formula/yq@3.rb
@@ -10,17 +10,7 @@ class YqAT3 < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/mikefarah/yq").install buildpath.children
-
-    cd "src/github.com/mikefarah/yq" do
-      system "go", "build", "-o", bin/"yq"
-      prefix.install_metafiles
-
-      (bash_completion/"yq").write Utils.safe_popen_read("#{bin}/yq", "shell-completion", "-V=bash")
-      (zsh_completion/"_yq").write Utils.safe_popen_read("#{bin}/yq", "shell-completion", "-V=zsh")
-      (fish_completion/"yq.fish").write Utils.safe_popen_read("#{bin}/yq", "shell-completion", "-V=fish")
-    end
+    system "go", "build", "-ldflags", "-s -w", *std_go_args, "-o", bin/"yq"
   end
 
   test do

--- a/Formula/yq@3.rb
+++ b/Formula/yq@3.rb
@@ -1,14 +1,13 @@
-class Yq3 < Formula
+class YqAT3 < Formula
   desc "Process YAML documents from the CLI - Version 3"
   homepage "https://github.com/mikefarah/yq"
   url "https://github.com/mikefarah/yq/archive/3.4.1.tar.gz"
   sha256 "73259f808d589d11ea7a18e4cd38a2e98b518a6c2c178d1ec57d9c5942277cb1"
   license "MIT"
 
-  depends_on "go" => :build
+  keg_only :versioned_formula
 
-  conflicts_with "python-yq", because: "both install `yq` executables"
-  conflicts_with "yq", because: "yq is v4, installs `yq` executable"
+  depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath

--- a/Formula/yq@3.rb
+++ b/Formula/yq@3.rb
@@ -7,6 +7,8 @@ class YqAT3 < Formula
 
   keg_only :versioned_formula
 
+  disable! date: "2021-08-01", because: :unmaintained
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Install version 3 of yq. I've recently release a major (backwards incompatible) upgrade (v4) - this has broken users scripts where they install yq via brew. The purpose of this PR is to allow them to continue using brew and yq v3 until a convenient time for them to upgrade to the latest v4.

Ref: mikefarah/yq#626
