### PR TITLE
libgcrypt: Backport corrected pkg-config flags

### DIFF
--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -4,6 +4,7 @@ class Libgcrypt < Formula
   url "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.7.tar.bz2"
   sha256 "03b70f028299561b7034b8966d7dd77ef16ed139c43440925fe8782561974748"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libgcrypt/"

--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -21,6 +21,14 @@ class Libgcrypt < Formula
 
   depends_on "libgpg-error"
 
+  # Upstream patch which corrects the pkg-config flags to include the header and library paths
+  # Important on non /usr/local prefixes
+  # https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=commit;h=761d12f140b77b907087590646651d9578b68a54
+  patch do
+    url "https://github.com/Homebrew/formula-patches/raw/a367916e22d086d683ebed52f99a63bda2fc83a3/libgcrypt/libgcrypt.pc.in.patch"
+    sha256 "f4da2d8c93bc52a26efa429a81d32141246d163d752464cd17ac9cce27d1fc64"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This backports [a libgcrypt patch](https://dev.gnupg.org/T4678) which is in master, but not yet released. (homebrew/formula-patches#337)

For our purposes, it fixes `pkg-config` functionality on non `/usr/local` prefixes, (like Apple silicon Macs) as in current versions the `Cflags` and `Libs` are not correctly set, and default to searching the standard location.

See also the original commit: https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=commit;h=761d12f140b77b907087590646651d9578b68a54

`pkg-config` output, before this change:

```
$ pkg-config --cflags libgcrypt
-I/opt/homebrew/Cellar/libgpg-error/1.41/include
$ pkg-config --libs libgcrypt
-L/opt/homebrew/Cellar/libgpg-error/1.41/lib -lgcrypt -lgpg-error
```

and afterwards:

```
$ pkg-config --cflags libgcrypt
-I/opt/homebrew/Cellar/libgcrypt/1.8.7/include -I/opt/homebrew/Cellar/libgpg-error/1.41/include
$ pkg-config --libs libgcrypt
-L/opt/homebrew/Cellar/libgcrypt/1.8.7/lib -L/opt/homebrew/Cellar/libgpg-error/1.41/lib -lgcrypt -lgpg-error
```