### PR TITLE
minbif: deprecate

### DIFF
--- a/Formula/minbif.rb
+++ b/Formula/minbif.rb
@@ -1,9 +1,10 @@
 class Minbif < Formula
   desc "IRC-to-other-IM-networks gateway using Pidgin library"
-  homepage "https://symlink.me/projects/minbif/wiki/"
+  homepage "https://web.archive.org/web/20180831190920/https://symlink.me/projects/minbif/wiki/"
   url "https://deb.debian.org/debian/pool/main/m/minbif/minbif_1.0.5+git20150505.orig.tar.gz"
   version "1.0.5-20150505"
   sha256 "4e264fce518a0281de9fc3d44450677c5fa91097a0597ef7a0d2a688ee66d40b"
+  license "GPL-2.0-only"
   revision 3
 
   bottle do
@@ -12,6 +13,8 @@ class Minbif < Formula
     sha256 "479cfbb3b59f2c0c05b0553188ae2497ee313b02e5850172bb7055231def61b8" => :mojave
     sha256 "5b8a0fd609cda94163f95c7d0b6620c143b3ff127178d37a57b76493231c73cc" => :sierra
   end
+
+  deprecate! date: "2020-12-29", because: :unmaintained
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -44,7 +47,7 @@ class Minbif < Formula
       Minbif must be passed its config as first argument:
           minbif #{etc}/minbif/minbif.conf
 
-      Learn more about minbif: https://symlink.me/projects/minbif/wiki/Quick_start
+      Learn more about minbif: https://web.archive.org/web/20160714124330/https://symlink.me/projects/minbif/wiki/Quick_start
     EOS
   end
 


### PR DESCRIPTION
This formula didn't rebottle for Big Sur, but it does compile once I repointed its `homepage`.  However, the formula seems ripe for deprecation:
* Original project page at http://minbif.im/ is now just a nginx landing page.  Seems it has been like that for a couple years
* The project was hosted at symlink.me which is also gone since ~2018
* There is a github repo at https://github.com/jasuarez/minbif but I don't know how official it is.  (cc @jasuarez )Regardless, it has been static since 2015
* The original author is on github as well (@rbignon) but doesn't have a repo for it there

This seems about as unmaintained as it comes.  Given that the IM world has moved on a lot since 2011 (when 1.0.5 was released) I'm also not sure how much functionality it retains.
