### PR TITLE
xerces-c: fix rpath

### DIFF
--- a/Formula/xerces-c.rb
+++ b/Formula/xerces-c.rb
@@ -26,12 +26,12 @@ class XercesC < Formula
     ENV.cxx11
 
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{lib}"
       system "make"
       system "ctest", "-V"
       system "make", "install"
       system "make", "clean"
-      system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", *std_cmake_args
+      system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{lib}"
       system "make"
       lib.install Dir["src/*.a"]
     end


### PR DESCRIPTION
Should allow ARM build outside `/usr/local`