### PR TITLE
fragroute: fix compile against newer libpcap versions

### DIFF
--- a/Formula/fragroute.rb
+++ b/Formula/fragroute.rb
@@ -4,7 +4,13 @@ class Fragroute < Formula
   url "https://www.monkey.org/~dugsong/fragroute/fragroute-1.2.tar.gz"
   mirror "https://mirrorservice.org/sites/ftp.wiretapped.net/pub/security/packet-construction/fragroute-1.2.tar.gz"
   sha256 "6899a61ecacba3bb400a65b51b3c0f76d4e591dbf976fba0389434a29efc2003"
+  license "BSD-3-Clause"
   revision 2
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?fragroute[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 "8b5a87b7cae2d578e00075136ceccaca0c29dbcbb1b01e15675bc29b9205e93d" => :catalina
@@ -15,6 +21,8 @@ class Fragroute < Formula
 
   depends_on "libdnet"
   depends_on "libevent"
+
+  uses_from_macos "libpcap"
 
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/2f5cab626/fragroute/configure.patch"
@@ -32,6 +40,10 @@ class Fragroute < Formula
   end
 
   def install
+    # pcaputil.h defines a "pcap_open()" helper function, but that name
+    # conflicts with an unrelated function in newer versions of libpcap
+    inreplace %w[pcaputil.h pcaputil.c tun-loop.c fragtest.c], /pcap_open\b/, "pcap_open_device_named"
+
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}


### PR DESCRIPTION
There isn't really a place to upstream patches for this; there are a some unofficial github repos but I think the last official release from @dugsong was circa 2002.

Still, with a little bit more patching it does compile OK on MacOS 11.

I think an `inreplace` is the simplest workaround in this case.  Afterwards I did some searching and found other places that had done equivalent patches like https://gitweb.gentoo.org/repo/gentoo.git/tree/net-analyzer/fragroute/files/fragroute-1.2.6-pcap_open.patch although Gentoo is tracking the "fragroute-ipv6" upstream which seems to be another fork of the same project (see https://github.com/stsi/fragroute-ipv6 )   Even `fragroute-ipv6` saw its latest tarball release in 2012... the github has some activity as recently as this year but would also need a similar change to work with recent libpcap (cc @stsi )

For reference, the `pcap_open()` API that is causing the conflict was added in 2017 ( https://github.com/the-tcpdump-group/libpcap/commit/a372536befc9b1ee1d355058daa2eb9f66aa0c59 ) but probably only made it to the MacOS system headers with Big Sur