### PR TITLE
numpy: revision bump for gcc

### DIFF
--- a/Formula/numpy.rb
+++ b/Formula/numpy.rb
@@ -4,6 +4,7 @@ class Numpy < Formula
   url "https://files.pythonhosted.org/packages/c5/63/a48648ebc57711348420670bb074998f79828291f68aebfff1642be212ec/numpy-1.19.4.zip"
   sha256 "141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/numpy/numpy.git"
 
   livecheck do


### PR DESCRIPTION
We've been seeing numpy-related issues on Mojave since the last gcc revision bump. See for example here: https://github.com/Homebrew/homebrew-core/pull/67929

This should fix it