### PR TITLE
ansible: fix ansible-base url

### DIFF
--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -113,8 +113,8 @@ class Ansible < Formula
   end
 
   resource "ansible-base" do
-    url "https://files.pythonhosted.org/packages/2e/d1/92422f8f53ae2d4e75ebdc2be2186a9ca2796b5d9679f20ed0239e86d8cf/ansible-base-2.10.3.tar.gz"
-    sha256 "35a208726b10fecbcf00c263ae4572b48f505b5796fb77a85c3e9c1036ea5e4f"
+    url "https://files.pythonhosted.org/packages/2d/e0/3eabf1be1211f653c73bc7827084c301aaefc6d8fc73e33572172cf0306b/ansible-base-2.10.4.tar.gz"
+    sha256 "d4dad569864c08d8efb6ad99acf48ec46d7d118f8ced64f1185f8eac2c280ec3"
   end
 
   resource "apache-libcloud" do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The update from 2.10.3 to 2.10.4 in https://github.com/Homebrew/homebrew-core/commit/d443773807174224099487cc0628b7d9a76e47d6 didn't update the URL in the _ansible-base_ resource. As a result, `ansible --version` would show 2.10.3 was actually installed, while `brew info ansible` thought 2.10.4 was installed:
```sh
% ansible --version     
ansible 2.10.3
  config file = None
  configured module search path = ['/Users/paul/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.10.4/libexec/lib/python3.9/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.9.1 (default, Dec 28 2020, 11:25:16) [Clang 12.0.0 (clang-1200.0.32.28)]

% brew info ansible
ansible: stable 2.10.4 (bottled), HEAD
Automate deployment, configuration, and upgrading
https://www.ansible.com/
/usr/local/Cellar/ansible/2.10.4 (37,780 files, 350.6MB) *
  Poured from bottle on 2020-12-29 at 12:59:31
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/ansible.rb
License: GPL-3.0-or-later
```

This fix resolves the problem and installs 2.10.4 when installed with `brew install --build-from-source ansible`:
```sh
% ansible --version
ansible 2.10.4
  config file = None
  configured module search path = ['/Users/paul/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.10.4/libexec/lib/python3.9/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.9.1 (default, Dec 28 2020, 11:25:16) [Clang 12.0.0 (clang-1200.0.32.28)]
```