### PR TITLE
enigma: fix compile on Big Sur

### DIFF
--- a/Formula/enigma.rb
+++ b/Formula/enigma.rb
@@ -3,7 +3,7 @@ class Enigma < Formula
   homepage "https://www.nongnu.org/enigma/"
   url "https://downloads.sourceforge.net/project/enigma-game/Release%201.21/enigma-1.21.tar.gz"
   sha256 "d872cf067d8eb560d3bb1cb17245814bc56ac3953ae1f12e2229c8eb6f82ce01"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 4
 
   livecheck do
@@ -54,6 +54,7 @@ class Enigma < Formula
       s.gsub! %r{\$\{\w+//\\"/\}/lib(freetype|png|xerces-c)\.a}, '-l\1'
       s.gsub! %r{(LIBINTL)="\$\{with_libintl_prefix\}/lib/lib(intl)\.a"}, '\1=-l\2'
       s.gsub! /^\s+LIBENET_CFLAGS\n.*LIBENET.*\n\s+LIBENET_LIBS\n.*LIBENET.*$/, ""
+      s.gsub! "/usr/lib/libiconv.dylib", "-liconv"
     end
     inreplace "src/Makefile.in" do |s|
       s.gsub! %r{(cp -a /Library/Frameworks/.*)$}, 'echo \1'


### PR DESCRIPTION
This is another failure caused by MacOS 11's weird dynamic library system where the `/usr/lib/*.dylib` aren't physically present on the filesystem but do exist as dynamic libraries which you can link against, `dlopen()`, etc.

The configure.ac for this package includes some hacks that put `/usr/lib/libiconv.dylib` directly onto some command lines and that later causes later test programs to fail.  In this case the end result was that it mis-detected the versions of SDL leading to them being rejected.

This formula already does a bunch of `inreplace` surgery on the configure script (for better or worse) so the easiest fix
I think is to just add one more.  With this the game compiles and runs for me on Big Sur.

I don't know if this is how upstream will want to fix this, but I filed https://github.com/Enigma-Game/Enigma/issues/33
