### PR TITLE
gcc: fix mojave build, numpy: revision bump

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -14,6 +14,7 @@ class Gcc < Formula
     sha256 "b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c"
   end
   license "GPL-3.0"
+  revision 1
   head "https://gcc.gnu.org/git/gcc.git"
 
   livecheck do
@@ -105,6 +106,10 @@ class Gcc < Formula
       args << "--with-native-system-header-dir=/usr/include"
       args << "--with-sysroot=#{sdk}"
     end
+
+    # Mojave uses the Catalina SDK which causes issues like
+    # https://github.com/Homebrew/homebrew-core/issues/46393
+    args << "ac_cv_func_aligned_alloc=no" if MacOS.version == :mojave
 
     # Avoid reference to sed shim
     args << "SED=/usr/bin/sed"

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -109,7 +109,7 @@ class Gcc < Formula
 
     # Mojave uses the Catalina SDK which causes issues like
     # https://github.com/Homebrew/homebrew-core/issues/46393
-    args << "ac_cv_func_aligned_alloc=no" if MacOS.version == :mojave
+    ENV["ac_cv_func_aligned_alloc"] = "no" if MacOS.version == :mojave
 
     # Avoid reference to sed shim
     args << "SED=/usr/bin/sed"

--- a/Formula/numpy.rb
+++ b/Formula/numpy.rb
@@ -4,6 +4,7 @@ class Numpy < Formula
   url "https://files.pythonhosted.org/packages/c5/63/a48648ebc57711348420670bb074998f79828291f68aebfff1642be212ec/numpy-1.19.4.zip"
   sha256 "141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/numpy/numpy.git"
 
   livecheck do


### PR DESCRIPTION
Follow up to https://github.com/Homebrew/homebrew-core/pull/67951.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?