### PR TITLE
pandoc 2.11.3.2

### DIFF
--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -1,8 +1,8 @@
 class Pandoc < Formula
   desc "Swiss-army knife of markup format conversion"
   homepage "https://pandoc.org/"
-  url "https://hackage.haskell.org/package/pandoc-2.11.3.1/pandoc-2.11.3.1.tar.gz"
-  sha256 "e957f94eb9514dbefd806b642e679a735c880e757bc12ba7f50d521b6d0e08e2"
+  url "https://hackage.haskell.org/package/pandoc-2.11.3.2/pandoc-2.11.3.2.tar.gz"
+  sha256 "79c747edc1a229127bcbfb898431e7bc4901b0de9b741effeed8e9cb133494dc"
   license "GPL-2.0-or-later"
   head "https://github.com/jgm/pandoc.git"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 12,927,106 bytes
- formula fetch time: 1.5 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.