### PR TITLE
rename gtk+4 to gtk4

### DIFF
--- a/Aliases/gtk+4
+++ b/Aliases/gtk+4
@@ -1,0 +1,1 @@
+../Formula/gtk4.rb

--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -39,7 +39,7 @@ class Glib < Formula
     sha256 "a57fec9e85758896ff5ec1ad483050651b59b7b77e0217459ea650704b7d422b"
   end
 
-  # required for gtk+4
+  # required for gtk4
   # see discussion at https://gitlab.gnome.org/GNOME/gtk/-/issues/3477
   patch do
     url "https://gitlab.gnome.org/GNOME/glib/-/commit/8c76bec77985be7f4c81a052ec649232341369f6.patch"

--- a/Formula/gtk4.rb
+++ b/Formula/gtk4.rb
@@ -1,4 +1,4 @@
-class Gtkx4 < Formula
+class Gtk4 < Formula
   desc "Toolkit for creating graphical user interfaces"
   homepage "https://gtk.org/"
   url "https://download.gnome.org/sources/gtk/4.0/gtk-4.0.0.tar.xz"
@@ -8,13 +8,6 @@ class Gtkx4 < Formula
   livecheck do
     url :stable
     regex(/gtk[._-](4\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
-  end
-
-  bottle do
-    sha256 "393079a26d13a3bdbfb52a806af74a6a2a677619912549c966dd9eb6d4a151ce" => :big_sur
-    sha256 "22d8d06d4e3ff5e3e300f4b77d899ed3330cb643af5f8a4114fe6b213513115a" => :arm64_big_sur
-    sha256 "0c74e511794ab314900f21300ad9a2c3d93edc83604dbf99ca5c57dc9a81f24c" => :catalina
-    sha256 "320f43ecc1ea6ec38a28cc5e344d2d393318ef5bb661aeab6a34c5211d421259" => :mojave
   end
 
   depends_on "docbook" => :build

--- a/Formula/gtkmm4.rb
+++ b/Formula/gtkmm4.rb
@@ -22,7 +22,7 @@ class Gtkmm4 < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => [:build, :test]
   depends_on "cairomm"
-  depends_on "gtk+4"
+  depends_on "gtk4"
   depends_on "pangomm"
 
   def install

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -52,6 +52,7 @@
   "grunt": "grunt-cli",
   "gst-validate": "gst-devtools",
   "gtef": "tepl",
+  "gtk+4": "gtk4",
   "gtksourceview@4": "gtksourceview4",
   "gutenberg": "zola",
   "hamsterdb": "upscaledb",


### PR DESCRIPTION
The upstream project removed the "+" from the name.

Reference: https://mail.gnome.org/archives/gtk-devel-list/2019-February/msg00000.html

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
