### PR TITLE
tcc: add license

### DIFF
--- a/Formula/tcc.rb
+++ b/Formula/tcc.rb
@@ -3,6 +3,7 @@ class Tcc < Formula
   homepage "https://bellard.org/tcc/"
   url "https://download.savannah.nongnu.org/releases/tinycc/tcc-0.9.27.tar.bz2"
   sha256 "de23af78fca90ce32dff2dd45b3432b2334740bb9bb7b05bf60fdbfc396ceb9c"
+  license "LGPL-2.0-or-later"
   revision 1
 
   livecheck do


### PR DESCRIPTION
tcc: add license

```
/*
 *  TCC - Tiny C Compiler
 * 
 *  Copyright (c) 2001-2004 Fabrice Bellard
 *
 * This library is free software; you can redistribute it and/or
 * modify it under the terms of the GNU Lesser General Public
 * License as published by the Free Software Foundation; either
 * version 2 of the License, or (at your option) any later version.
 *
 * This library is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 * Lesser General Public License for more details.
 *
 * You should have received a copy of the GNU Lesser General Public
 * License along with this library; if not, write to the Free Software
 * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
```