### PR TITLE
tenyr 0.9.8

### DIFF
--- a/Formula/tenyr.rb
+++ b/Formula/tenyr.rb
@@ -1,8 +1,8 @@
 class Tenyr < Formula
   desc "32-bit computing environment (including simulated CPU)"
   homepage "https://tenyr.info/"
-  url "https://github.com/kulp/tenyr/archive/v0.9.7.tar.gz"
-  sha256 "f28e031acb14a0e4ff924479a0fd0087d9a15948a440f03b2dcf002723ccfdfa"
+  url "https://github.com/kulp/tenyr/archive/v0.9.8.tar.gz"
+  sha256 "08dd2e5380de5ba23703f92621a0bc249d0f1fac8e581158572ed039dca72309"
   license "MIT"
   head "https://github.com/kulp/tenyr.git", branch: "develop"
 


### PR DESCRIPTION
~~Looking at Big Sur rebottling failures:~~
```
$ brew audit --strict --online tenyr
tenyr:
  * v0.9.7 is a GitHub pre-release.
Error: 1 problem in 1 formula detected
```
~~Not ideal, but it looks like we've been tracking this project's prereleases for years.  Probably easiest to whitelist it for now.~~

Switched PR to be an update to the non-"prerelease" 0.9.8 per discussion below
