### PR TITLE
curlpp: fix shim pollition in curlpp-config

### DIFF
--- a/Formula/curlpp.rb
+++ b/Formula/curlpp.rb
@@ -4,6 +4,7 @@ class Curlpp < Formula
   url "https://github.com/jpbarrette/curlpp/archive/v0.8.1.tar.gz"
   sha256 "97e3819bdcffc3e4047b6ac57ca14e04af85380bd93afe314bee9dd5c7f46a0a"
   license "MIT"
+  revision 1
 
   bottle do
     cellar :any
@@ -21,6 +22,7 @@ class Curlpp < Formula
     ENV.cxx11
     system "cmake", ".", *std_cmake_args
     system "make", "install"
+    inreplace bin/"curlpp-config", "#{HOMEBREW_LIBRARY}/Homebrew/shims/mac/super/clang", "/usr/bin/clang"
   end
 
   test do


### PR DESCRIPTION
Not sure if this is the most robust fix, but it's what was done in `gmt` to fix a similar issue: 7b63531c1701e2e8f0539b9c998126e0271ecac9
