### PR TITLE
s3-backer 1.6.1

### DIFF
--- a/Formula/s3-backer.rb
+++ b/Formula/s3-backer.rb
@@ -1,8 +1,8 @@
 class S3Backer < Formula
   desc "FUSE-based single file backing store via Amazon S3"
   homepage "https://github.com/archiecobbs/s3backer"
-  url "https://archie-public.s3.amazonaws.com/s3backer/s3backer-1.5.6.tar.gz"
-  sha256 "deea48205347b24d1298fa16bf3252d9348d0fe81dde9cb20f40071b8de60519"
+  url "https://archie-public.s3.amazonaws.com/s3backer/s3backer-1.6.1.tar.gz"
+  sha256 "ec91b1c2ec2eadd945e1745fdeccc49baeb357a4040fd9ea8605a9bcdc96c29f"
   license "GPL-2.0-or-later"
 
   bottle do

--- a/Formula/s3-backer.rb
+++ b/Formula/s3-backer.rb
@@ -12,8 +12,6 @@ class S3Backer < Formula
     sha256 "4d23cfd2c126c5f3efa1023e7c061830de6f1fdda69760bbd3ed70a169def288" => :high_sierra
   end
 
-  deprecate! date: "2020-11-10", because: "requires FUSE"
-
   depends_on "pkg-config" => :build
   depends_on "openssl@1.1"
   depends_on :osxfuse


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

```
s3-backer:
  * 19: col 3: :osxfuse is deprecated in homebrew/core
Error: 1 problem in 1 formula detected
```

Not much I can do about that. But while FUSE is still supported might as well keep this package up-to-date.

-----
