### PR TITLE
libgcrypt: Change patch URL to upstream git server

### DIFF
--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -25,7 +25,7 @@ class Libgcrypt < Formula
   # Important on non /usr/local prefixes
   # https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=commit;h=761d12f140b77b907087590646651d9578b68a54
   patch do
-    url "https://github.com/Homebrew/formula-patches/raw/a367916e22d086d683ebed52f99a63bda2fc83a3/libgcrypt/libgcrypt.pc.in.patch"
+    url "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=patch;h=761d12f140b77b907087590646651d9578b68a54"
     sha256 "f4da2d8c93bc52a26efa429a81d32141246d163d752464cd17ac9cce27d1fc64"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Following #67929, the dependent Homebrew/formula-patches#337 change was rejected, so this follows up to change the patch URL to the gnupg project's gitweb patch URL.

I have no idea what I'm doing here, and #67929 was already accepted, I'm just trying to do what I'm told, which is what I was doing in the first place! 🙇🏻‍♀️