### PR TITLE
m4: patch fix under Linux/armv7l

### DIFF
--- a/Formula/m4.rb
+++ b/Formula/m4.rb
@@ -30,6 +30,14 @@ class M4 < Formula
     end
   end
 
+  if OS.linux? && Hardware::CPU.arm?
+    # Apply fix for https://askubuntu.com/a/1112101
+    patch do
+      url "https://git.openembedded.org/openembedded-core/plain/meta/recipes-devtools/m4/m4/m4-1.4.18-glibc-change-work-around.patch"
+      sha256 "9e8fc660515be565f26194d3d6124a9483dc15a66ee8ea3f0b409c02d60a62f5"
+    end
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make"


### PR DESCRIPTION
fixes the following error on Linux including the raspberry pi.
```
error "Please port gnulib freadahead.c to your platform! Look at the definition of fflush, fread, 
ungetc on your system, then report this to bug-gnulib."
```