### PR TITLE
partial-emlx-converter 3.0.2 (new formula)

### DIFF
--- a/Formula/partial-emlx-converter.rb
+++ b/Formula/partial-emlx-converter.rb
@@ -1,0 +1,27 @@
+require "language/node"
+
+class PartialEmlxConverter < Formula
+  desc "Convert .emlx and .partial.emlx files created by Apple’s Mail.app to .eml"
+  homepage "https://github.com/qqilihq/partial-emlx-converter#readme"
+  url "https://registry.npmjs.org/partial-emlx-converter/-/partial-emlx-converter-3.0.2.tgz"
+  sha256 "1901218bbb96b42e710c31e8524ca746354cd0c940639d18bc1aeab3beff0c0f"
+  license "MIT"
+
+  livecheck do
+    url :stable
+  end
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    # expect exit code 1
+    output = shell_output("#{bin}/partial-emlx-converter", 1).strip
+    expected = "partial-emlx-converter input_directory output_directory [--ignoreErrors]"
+    assert_equal expected, output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

partial-emlx-converter is a CLI tool to convert/recover .emlx and .partial.emlx files with separate attachments which are created by Apple Mail.app to proper self-contained .eml files.