### PR TITLE
vim: patch to fix vimscript bug fixed in later version

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -5,6 +5,7 @@ class Vim < Formula
   url "https://github.com/vim/vim/archive/v8.2.2250.tar.gz"
   sha256 "be1de89b4e41d17a4f27bb70210e9e7d334b80a8f488659617d0742e0cd1bbbd"
   license "Vim"
+  revision 1
   head "https://github.com/vim/vim.git"
 
   bottle do
@@ -27,6 +28,13 @@ class Vim < Formula
 
   conflicts_with "macvim",
     because: "vim and macvim both install vi* binaries"
+
+  # Fix vimscript issue that was fixed upstream in 8.2.2251 (just missed our cutoff of every 50 releases)
+  # Remove the next time vim is updated.
+  patch do
+    url "https://github.com/vim/vim/commit/a04d447d3aaddb5b978dd9a0e0186007fde8e09e.patch?full_index=1"
+    sha256 "ddc00f61dc75e3875ea490c56b9cf843f20292844bc34ad434c566ab30e2335a"
+  end
 
   def install
     # Fix error: '__declspec' attributes are not enabled


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Update `vim` to version 8.2.2251. This will cause `brew audit` to fail because it's not a multiple of 50. However, version 8.2.2250 introduced a bug (see https://github.com/vim-airline/vim-airline/issues/2312) that was fixed in version 8.2.2251.

An alternative to updating the version to a non-multiple of 50 would be to add the change (https://github.com/vim/vim/commit/a04d447d3aaddb5b978dd9a0e0186007fde8e09e) as a patch. Since it's technically a new release, I think changing the version is a better solution as long as it won't break everything.
