### PR TITLE
mingw-w64: avoid shim references

### DIFF
--- a/Formula/mingw-w64.rb
+++ b/Formula/mingw-w64.rb
@@ -79,7 +79,7 @@ class MingwW64 < Formula
         --target=#{target}
         --with-sysroot=#{arch_dir}
         --prefix=#{arch_dir}
-        --with-bugurl=https://github.com/Homebrew/homebrew-core/issues
+        --with-bugurl=#{CoreTap.instance.issues_url}
         --enable-languages=c,c++,fortran
         --with-ld=#{arch_dir}/bin/#{target}-ld
         --with-as=#{arch_dir}/bin/#{target}-as
@@ -91,6 +91,8 @@ class MingwW64 < Formula
         --disable-nls
         --enable-threads=posix
       ]
+      # Avoid reference to sed shim
+      args << "SED=/usr/bin/sed"
 
       mkdir "#{buildpath}/gcc/build-#{arch}" do
         system "../configure", *args

--- a/Formula/mingw-w64.rb
+++ b/Formula/mingw-w64.rb
@@ -79,7 +79,7 @@ class MingwW64 < Formula
         --target=#{target}
         --with-sysroot=#{arch_dir}
         --prefix=#{arch_dir}
-        --with-bugurl=#{CoreTap.instance.issues_url}
+        --with-bugurl=#{tap.issues_url}
         --enable-languages=c,c++,fortran
         --with-ld=#{arch_dir}/bin/#{target}-ld
         --with-as=#{arch_dir}/bin/#{target}-as


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR fixes the following audit warnings (in the same way as we do it for `gcc`):
```
mingw-w64:
  * Files were found with references to the Homebrew shims directory.
    The offending files are:
      toolchain-i686/libexec/gcc/i686-w64-mingw32/10.2.0/install-tools/fixincl
      toolchain-x86_64/libexec/gcc/x86_64-w64-mingw32/10.2.0/install-tools/fixincl
```

See https://github.com/Homebrew/homebrew-core/pull/61982#issuecomment-716661080 and https://github.com/Homebrew/homebrew-core/pull/64824#issuecomment-747201493
