### PR TITLE
audacious vlmcsd youtube-dlc: do not depend on make

### DIFF
--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -33,7 +33,6 @@ class Audacious < Formula
   end
 
   depends_on "gettext" => :build
-  depends_on "make" => :build
   depends_on "pkg-config" => :build
   depends_on "faad2"
   depends_on "ffmpeg"

--- a/Formula/vlmcsd.rb
+++ b/Formula/vlmcsd.rb
@@ -21,7 +21,6 @@ class Vlmcsd < Formula
     sha256 "0cb2abe0a85b0ca14602d565b6ef3c69afa1f466123b37503936dfe064581b54" => :high_sierra
   end
 
-  depends_on "make" => :build
   uses_from_macos "llvm" => :build
 
   def install

--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -21,7 +21,6 @@ class YoutubeDlc < Formula
     sha256 "8a375f9a0651590aaf8259be15e84700f25ad6dba4a97dbeb57c74f3fa523e03" => :mojave
   end
 
-  depends_on "make" => :build
   depends_on "pandoc" => :build
   depends_on "python@3.9"
   uses_from_macos "zip" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The following formulae do depend on `make`, but do not use it actually (`make` formula installs `gmake` binary and doesn't link gnubin directory).

Will check remaining `crosstool-ng`, `inko` and `uutils-coreutils` (which does use `gmake`) separately