### PR TITLE
inko: do not depend on make

### DIFF
--- a/Formula/inko.rb
+++ b/Formula/inko.rb
@@ -16,16 +16,14 @@ class Inko < Formula
   end
 
   depends_on "coreutils" => :build
-  depends_on "make" => :build
   depends_on "rust" => :build
   depends_on "libffi"
 
   uses_from_macos "ruby", since: :sierra
 
   def install
-    make = Formula["make"].opt_bin/"gmake"
-    system make, "build", "PREFIX=#{libexec}", "FEATURES=libinko/libffi-system"
-    system make, "install", "PREFIX=#{libexec}"
+    system "make", "build", "PREFIX=#{libexec}", "FEATURES=libinko/libffi-system"
+    system "make", "install", "PREFIX=#{libexec}"
     bin.install Dir[libexec/"bin/*"]
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
It looks like these 3 formulae (`crosstool-ng`, `inko`, `uutils-coreutils`) do not require special `gmake`