### PR TITLE
pcl: revision bump for SDK path

### DIFF
--- a/Formula/pcl.rb
+++ b/Formula/pcl.rb
@@ -4,7 +4,7 @@ class Pcl < Formula
   url "https://github.com/PointCloudLibrary/pcl/archive/pcl-1.11.1.tar.gz"
   sha256 "a61558e53abafbc909e0996f91cfd2d7a400fcadf6b8cfb0ea3172b78422c74e"
   license "BSD-3-Clause"
-  revision 6
+  revision 7
   head "https://github.com/PointCloudLibrary/pcl.git"
 
   bottle do


### PR DESCRIPTION
`pcl` test fails on Big Sur because it has recorded the old MacOS11.0.sdk path… rebuild
https://github.com/Homebrew/homebrew-core/pull/68091/checks?check_run_id=1631206390