### PR TITLE
ruby@2.5: deprecate

### DIFF
--- a/Formula/ruby@2.5.rb
+++ b/Formula/ruby@2.5.rb
@@ -14,6 +14,8 @@ class RubyAT25 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2021-03-31", because: :unsupported
+
   depends_on "pkg-config" => :build
   depends_on "libyaml"
   depends_on "openssl@1.1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
According to [the official](https://www.ruby-lang.org/en/downloads/branches/), Ruby@2.5 will be unsupported from March 31th, 2021