### PR TITLE
direnv 2.27.0

### DIFF
--- a/Formula/direnv.rb
+++ b/Formula/direnv.rb
@@ -1,8 +1,8 @@
 class Direnv < Formula
   desc "Load/unload environment variables based on $PWD"
   homepage "https://direnv.net/"
-  url "https://github.com/direnv/direnv/archive/v2.26.0.tar.gz"
-  sha256 "b3dbb97f4d2627ec588894f084bfdc76db47ff5e3bec21050bb818608c7835b9"
+  url "https://github.com/direnv/direnv/archive/v2.27.0.tar.gz"
+  sha256 "9dc5ce43c63d9d9ff510c6bcd6ae06f3f2f907347e7cbb2bb6513bfb0f151621"
   license "MIT"
   head "https://github.com/direnv/direnv.git"
 

--- a/Formula/direnv.rb
+++ b/Formula/direnv.rb
@@ -17,7 +17,7 @@ class Direnv < Formula
   depends_on "go" => :build
 
   def install
-    system "make", "install", "DESTDIR=#{prefix}"
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 86,094 bytes
- formula fetch time: 1.5 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.