### PR TITLE
argyll-cms: fix build on Big Sur; various other fixes

### DIFF
--- a/Formula/argyll-cms.rb
+++ b/Formula/argyll-cms.rb
@@ -3,7 +3,8 @@ class ArgyllCms < Formula
   homepage "https://www.argyllcms.com/"
   url "https://www.argyllcms.com/Argyll_V2.1.2_src.zip"
   sha256 "be378ca836b17b8684db05e9feaab138d711835ef00a04a76ac0ceacd386a3e3"
-  license "AGPL-3.0"
+  license "AGPL-3.0-only"
+  revision 1
 
   bottle do
     cellar :any
@@ -16,6 +17,9 @@ class ArgyllCms < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
+  depends_on "openssl@1.1"
+
+  uses_from_macos "zlib"
 
   conflicts_with "num-utils", because: "both install `average` binaries"
 
@@ -25,7 +29,7 @@ class ArgyllCms < Formula
   # https://www.mikeash.com/pyblog/objc_msgsends-new-prototype.html
   # Submitted upstream: https://www.freelists.org/post/argyllcms/Patch-Fix-macOS-build-failures-from-obj-msgSend-definition-change
   patch do
-    url "https://www.freelists.org/archives/argyllcms/02-2020/bin7VecLntD2x.bin"
+    url "https://www.freelists.org/archives/argyllcms/02-2020/binRagOo4qV7a.bin"
     sha256 "fa86f5f21ed38bec6a20a79cefb78ef7254f6185ef33cac23e50bb1de87507a4"
   end
 
@@ -36,10 +40,35 @@ class ArgyllCms < Formula
       inreplace "numlib/numsup.c", "CLOCK_MONOTONIC", "UNDEFINED_GIBBERISH"
     end
 
+    # The JamTop file tries to automatically detect whether its dependencies
+    # are already installed and if not uses its own included copies.  However
+    # its detection of Homebrew-installed libraries isn't reliable so rewrite
+    # it.  Unfortunately it doesn't have anything like autoconf's "--with-X=/path"
+    # to specify them explicitly.
+    force_library_external("TIFF", "libtiff", "-ltiff")
+    force_library_external("JPEG", "jpeg", "-ljpeg")
+    force_library_external("PNG", "libpng", "-lpng")
+    force_library_external("SSL", "openssl@1.1", "-lssl -lcrypto")
+    inreplace "JamTop", /^CheckForLibrary "Z".*;/,
+      ["ZINC = ;\n",
+       "ZLIC = ;\n",
+       "HAVE_ZLIB = true ;\n",
+       "LINKFLAGS += -lz ;\n"].join
+
+    ENV["PREFIX"] = prefix
+    # For some reason, if you don't set DESTDIR it treats PREFIX as
+    # a relative path even wen it starts with "/"!
+    ENV["DESTDIR"] = "/"
+    # By default, the color profiles get instealld in /usr/local/ref but
+    # it's more UNIX-like for them to be under /usr/local/share/argyll
+    # This matches what FreeBSD ports has always done
+    ENV["REFSUBDIR"] = "share/argyll/ref"
     system "sh", "makeall.sh"
-    system "./makeinstall.sh"
-    rm "bin/License.txt"
-    prefix.install "bin", "ref", "doc"
+    system "sh", "makeinstall.sh"
+    # Adjust the location of the license file
+    mv bin/"License.txt", prefix/"License.txt"
+    # Also install documentation files
+    (share/"argyll").install "doc"
   end
 
   test do
@@ -49,5 +78,14 @@ class ArgyllCms < Formula
       assert_predicate testpath/f, :exist?
     end
     assert_match "Calibrate a Display", shell_output("#{bin}/dispcal 2>&1", 1)
+  end
+
+  def force_library_external(name, formula, libflags)
+    inreplace "JamTop", /^CheckForLibrary "#{name}".*;/,
+      ["#{name}INC = ;\n",
+       "#{name}LIC = ;\n",
+       "HAVE_#{name} = true ;\n",
+       "LINKFLAGS += -L#{Formula[formula].opt_lib} #{libflags} ;\n",
+       "HDRS += #{Formula[formula].opt_include} ;\n"].join
   end
 end


### PR DESCRIPTION
* Install was completely failing from source because the URL to @mistydemeo's previous fix changed.  It's possible that freelists.org just doesn't provide long-term stable URLs and we'll need to rehost it, but for now I just updated the existing URL
* Even after it was able to download everything, it still did not build on my Big Sur (Intel) environment.  The immediate issue was compiler errors in the old version of zlib that the project packaged... but the real issue was that it was relying on these included copies of dependencies at all.

Unfortunately there doesn't seem to be any clean way of forcing it to use a particular copy of these dependencies (i.e. a `--with-foo=/...` parameter you'd see with autoconf) and the project's own `CheckForLibrary` function is pretty linux-centric.  The most reliable way to make this work is to  just replace the `CheckForLibrary` calls with direct settings giving the libraries we want it to use.
* The install directory was also pretty messed up since it wants to put some data files  into `/usr/local/ref` by default.  I copied what FreeBSD's ports tree does and move those to `$prefix/share/argyll/ref` instead.
