### PR TITLE
grokj2k 7.6.4 (new formula)

### DIFF
--- a/Formula/grokj2k.rb
+++ b/Formula/grokj2k.rb
@@ -1,0 +1,42 @@
+class Grokj2k < Formula
+  desc "JPEG 2000 Library"
+  homepage "https://github.com/GrokImageCompression/grok"
+  url "https://github.com/GrokImageCompression/grok/archive/v7.6.4.tar.gz"
+  sha256 "caef130949db325184db922b91f5e231d55941676f29604d8c8e70ea79d5d296"
+  license "AGPL-3.0-or-later"
+  head "https://github.com/GrokImageCompression/grok.git"
+
+  depends_on "cmake" => :build
+  depends_on "doxygen" => :build
+  depends_on "exiftool"
+  depends_on "jpeg-turbo"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "little-cms2"
+
+  def install
+    system "cmake", ".", *std_cmake_args, "-DBUILD_DOC=ON"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <grok.h>
+
+      int main () {
+        grk_image_cmptparm cmptparm;
+        const GRK_COLOR_SPACE color_space = GRK_CLRSPC_GRAY;
+
+        grk_image *image;
+        image = grk_image_create(1, &cmptparm, color_space,false);
+
+        grk_image_destroy(image);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{include.children.first}", "-L#{lib}", "-lgrokj2k", "test.c", "-o", "test"
+    # Linux test
+    # system ENV.cc, "test.c", "-I#{include.children.first}", "-L#{lib}", "-lgrokj2k", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
Grok is one of only two actively maintained open source JPEG 2000 toolkits on the planet, the other being OpenJPEG.

Features include:

1. high performance - approaching the performance of commercial toolkits
2. high stability - Grok is part of the oss-fuzz project, and there are currently no active fuzzer issues open
3. comprehensive test suite - Grok has over 1900 unit tests, all currently passing
4. fast random-access reading of sub-regions of Gigapixel images via TLM and PLT markers
5. full read/write support for ICC colour profiles
6. full read/write support for XML, XMP, IPTC and Exif meta data 
7. support reading GML meta data
8. support for new High Throughput JPEG 2000 standard, which promises up to 10x speedup over original Part 1

Grok has been accepted into Debian unstable and is currently awaiting testing:

https://tracker.debian.org/pkg/libgrokj2k

------------------------------------------------------------------------------------------------------------------------------------------

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ]x Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
