### PR TITLE
lilv: add livecheck

### DIFF
--- a/Formula/lilv.rb
+++ b/Formula/lilv.rb
@@ -5,6 +5,11 @@ class Lilv < Formula
   sha256 "d1bba93d6ddacadb5e742fd10ad732727edb743524de229c70cc90ef81ffc594"
   license "ISC"
 
+  livecheck do
+    url "https://download.drobilla.net/"
+    regex(/href=.*?lilv[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "ab87185c1c9276cf74a6c060a6f9d7f32f3012e581da421277d9851d860cc921" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `lilv`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.