### PR TITLE
pueue: Add ZSH completions

### DIFF
--- a/Formula/pueue.rb
+++ b/Formula/pueue.rb
@@ -22,6 +22,7 @@ class Pueue < Formula
     system "./build_completions.sh"
     bash_completion.install "utils/completions/pueue.bash" => "pueue"
     fish_completion.install "utils/completions/pueue.fish" => "pueue.fish"
+    zsh_completion.install "utils/completions/_pueue" => "_pueue"
 
     prefix.install_metafiles
   end


### PR DESCRIPTION
The upstream project [supports the generation of various shell completions including ZSH][ups].

This PR also adds the file generated for ZSH.
Before only completions for Bash and Fish were includes in this Formula.

--- 

##### Contribution Checklist

- [x] Read contribution guidelines.
- [x] Checked open pull requests.
- [x] Built, tested and audited formula locally.

[ups]: https://github.com/Nukesor/pueue/blob/0f3b6892b9d/build_completions.sh#L6