### PR TITLE
OpenOCD - Fix head url

### DIFF
--- a/Formula/open-ocd.rb
+++ b/Formula/open-ocd.rb
@@ -21,7 +21,7 @@ class OpenOcd < Formula
   end
 
   head do
-    url "https://git.code.sf.net/p/openocd/code.git"
+    url "https://github.com/ntfreak/openocd.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/Formula/open-ocd.rb
+++ b/Formula/open-ocd.rb
@@ -3,7 +3,7 @@ class OpenOcd < Formula
   homepage "http://openocd.org/"
   url "https://downloads.sourceforge.net/project/openocd/openocd/0.10.0/openocd-0.10.0.tar.bz2"
   sha256 "7312e7d680752ac088b8b8f2b5ba3ff0d30e0a78139531847be4b75c101316ae"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable


### PR DESCRIPTION
The previous url was having issues when install open-ocd with --HEAD
This commit updates the head url to the official Github mirror

> https://github.com/ntfreak/openocd.git

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
