### PR TITLE
Remove livecheck from deprecated formulae

### DIFF
--- a/Formula/atdtool.rb
+++ b/Formula/atdtool.rb
@@ -8,10 +8,6 @@ class Atdtool < Formula
   license "BSD-3-Clause"
   revision 4
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     cellar :any_skip_relocation
     rebuild 1

--- a/Formula/lesstif.rb
+++ b/Formula/lesstif.rb
@@ -6,10 +6,6 @@ class Lesstif < Formula
   license all_of: ["GPL-2.0-or-later", "LGPL-2.0-or-later"]
   revision 1
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     sha256 "49ec8eeeb266caef90b7fee6151d7292e4b636256863a9a4b67abdf965aba33b" => :big_sur
     sha256 "b21ba8ea2bfc016141ab76a3021c7a941f1a682840cec111bc2bc2b8adc53af6" => :arm64_big_sur

--- a/Formula/orbit.rb
+++ b/Formula/orbit.rb
@@ -7,10 +7,6 @@ class Orbit < Formula
   revision 1
   head "https://gitlab.gnome.org/Archive/orbit2.git"
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     rebuild 3
     sha256 "d39f55257c7d7eff2ecb9bb03c596a23d53abf2c081b87bf06f1b93415dda0b4" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This removes the `livecheck` block from a few formulae that have been deprecated and won't (or aren't likely to) receive updates in the future.

There are other formulae that are deprecated/disabled due to not building but I've left those alone for now (as some may be updated in the future to fix the current issues).