### PR TITLE
alure: remove livecheck

### DIFF
--- a/Formula/alure.rb
+++ b/Formula/alure.rb
@@ -5,11 +5,6 @@ class Alure < Formula
   sha256 "465e6adae68927be3a023903764662d64404e40c4c152d160e3a8838b1d70f71"
   revision 1
 
-  livecheck do
-    url "https://kcat.strangesoft.net/alure-releases/"
-    regex(/alure[._-]v?(\d+(?:\.\d+)+)/i)
-  end
-
   bottle do
     cellar :any
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The first-party website for `alure` (https://kcat.strangesoft.net) has been down for quite some time. According to https://github.com/kcat/alure/issues/47, the `strangesoft.net` domain expired, which may suggest the site won't be coming back.

Seeing as this check is not working and is unlikely to return to a working state, I'm removing this `livecheck` block for now. We can always add a new one if/when this situation changes in the future.