### PR TITLE
libav: remove livecheck, add deprecation reference

### DIFF
--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -7,11 +7,6 @@ class Libav < Formula
   revision 8
   head "https://git.libav.org/libav.git"
 
-  livecheck do
-    url "https://libav.org/releases/"
-    regex(/href=.*?libav[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     cellar :any
     sha256 "0bd97c8c39f11b5b29d5c271a28eb4ea4a40b4062a4331f8d97f738c9a82fb05" => :big_sur
@@ -20,6 +15,7 @@ class Libav < Formula
     sha256 "f71b7acc7dd972d60176b7d6c9bfe247181867d98ff991d771dcff54a6beace5" => :mojave
   end
 
+  # See: https://lists.libav.org/pipermail/libav-devel/2020-April/086589.html
   deprecate! date: "2019-04-16", because: :unmaintained
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a reference to an upstream comment explaining that `libav` "is dead", to support the deprecation. As such, I'm also removing the `livecheck` block, so this will be automatically skipped due to being deprecated.