### PR TITLE
openimageio: update livecheck

### DIFF
--- a/Formula/openimageio.rb
+++ b/Formula/openimageio.rb
@@ -11,7 +11,7 @@ class Openimageio < Formula
   livecheck do
     url :stable
     strategy :github_latest
-    regex(%r{href=.*?/tag/Release[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    regex(%r{href=.*?/tag/(?:Release[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`openimageio` is transitioning to tags like `v1.2.3` instead of `Release-1.2.3`. This updates the regex in the `livecheck` block to make the leading `Release-` part of the tag optional, so it will match either format. Currently the check is broken with `Unable to get versions` but this fixes it.