### PR TITLE
nexus: update livecheck

### DIFF
--- a/Formula/nexus.rb
+++ b/Formula/nexus.rb
@@ -5,10 +5,12 @@ class Nexus < Formula
   sha256 "a1223bbc91ced7b16175b2e872957397b9d58508d08cd7c5d44f5e378c3adeab"
   license "EPL-1.0"
 
+  # As of writing, upstream is publishing both v2 and v3 releases. The "latest"
+  # release on GitHub isn't reliable, as it can point to a release from either
+  # one of these major versions depending on which was published most recently.
   livecheck do
     url :stable
-    strategy :github_latest
-    regex(%r{href=.*?/tag/release[._-]v?(\d+(?:[.-]\d+)+)["' >]}i)
+    regex(/^(?:release[._-])?v?(\d+(?:[.-]\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The upstream GitHub repository for `nexus` is publishing both v2 and v3 releases. As a result, the "latest" release sometimes points to the latest v2 release and sometimes the last v3 release, depending on which was published most recently.

This updates the `livecheck` block to check the Git tags instead, since the "latest" release isn't reliably correct.