### PR TITLE
pstree: add livecheck

### DIFF
--- a/Formula/pstree.rb
+++ b/Formula/pstree.rb
@@ -8,6 +8,15 @@ class Pstree < Formula
   mirror "https://fossies.org/linux/misc/pstree-2.39.tar.gz"
   sha256 "7c9bc3b43ee6f93a9bc054eeff1e79d30a01cac13df810e2953e3fc24ad8479f"
 
+  # The stable archive is fetched over FTP and there doesn't appear to be a link
+  # to it on the first-party website. As of writing, the homepage lists an older
+  # version than the README, so checking the README is likely our best option
+  # at the moment.
+  livecheck do
+    url "http://www.thp.uni-duisburg.de/pstree/README"
+    regex(/This is pstree V?\s*?(\d+(?:\.\d+)+)/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     rebuild 2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `stable` archive for `pstree` is fetched over FTP and the download link on the homepage is unversioned (i.e., `pstree.tar.gz`). The only places to obtain the version appear to be the homepage (outdated, listing 2.38 as newest instead of 2.39) or the `README` or `pstree.c` files linked from the homepage. I've chosen to use the `README` in this check.

For what it's worth, I have a WIP version of an `Ftp` livecheck strategy implemented locally but I'm not 100% sold that we should be checking the files on FTP servers. It's something that I plan to revisit in the future but this allows us to avoid the issue for now.

Besides that, I'm not sure if we even need to create a check here, as the latest version (2.39) was released 2015-05-13, so there may not be a new version anytime soon (if ever). The `README` is only 1 KB, so I figure it's not a huge burden to have this check in the interim time.