### PR TITLE
libcanberra: add livecheck

### DIFF
--- a/Formula/libcanberra.rb
+++ b/Formula/libcanberra.rb
@@ -4,6 +4,11 @@ class Libcanberra < Formula
   url "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz"
   sha256 "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?libcanberra[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `libcanberra` but the `stable` archive comes from the first-party website. This adds a `livecheck` block that checks the homepage, where the `stable` archive is found.