### PR TITLE
kaitai-struct-compiler: add livecheck

### DIFF
--- a/Formula/kaitai-struct-compiler.rb
+++ b/Formula/kaitai-struct-compiler.rb
@@ -5,6 +5,11 @@ class KaitaiStructCompiler < Formula
   sha256 "3038243334fb65bbb264f33b82986facfe1fbad2de1978766899855b40212215"
   license "GPL-3.0-or-later"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?kaitai-struct-compiler[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
   bottle :unneeded
 
   depends_on "openjdk"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `kaitai-struct-compiler`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.