### PR TITLE
mandoc: add livecheck

### DIFF
--- a/Formula/mandoc.rb
+++ b/Formula/mandoc.rb
@@ -5,6 +5,11 @@ class Mandoc < Formula
   sha256 "8219b42cb56fc07b2aa660574e6211ac38eefdbf21f41b698d3348793ba5d8f7"
   head "anoncvs@mandoc.bsd.lv:/cvs", using: :cvs
 
+  livecheck do
+    url "https://mandoc.bsd.lv/snapshots/"
+    regex(/href=.*?mandoc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 "62085d74ed9eb8c3765e3f187784b0e55842f0ad666de8f8e66463a2db09b791" => :big_sur
     sha256 "1de7d1e05231afb26c450c435c75b1822b98416405930b4c505df07f9ff6a4c3" => :arm64_big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `mandoc`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.