### PR TITLE
par: add livecheck

### DIFF
--- a/Formula/par.rb
+++ b/Formula/par.rb
@@ -4,6 +4,11 @@ class Par < Formula
   url "http://www.nicemice.net/par/Par-1.53.0.tar.gz"
   sha256 "c809c620eb82b589553ac54b9898c8da55196d262339d13c046f2be44ac47804"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?Par[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "9af002ed591438fc64cf745df797fdd4c6138a847c6ffe650a8371ef6a2243fa" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `par`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.