### PR TITLE
glide: deprecate in favor of go modules

### DIFF
--- a/Formula/glide.rb
+++ b/Formula/glide.rb
@@ -15,10 +15,10 @@ class Glide < Formula
     sha256 "d665d8221c75985ffde8357c5ebfd53c2cb3398ac699a1afc1ebf8000e5206cc" => :sierra
   end
 
-  depends_on "go"
-
   # See: https://github.com/Masterminds/glide/commit/c64b14592409a83052f7735a01d203ff1bab0983
   deprecate! date: "2021-01-02", because: :deprecated_upstream
+
+  depends_on "go"
 
   def install
     ENV["GOPATH"] = buildpath

--- a/Formula/glide.rb
+++ b/Formula/glide.rb
@@ -17,6 +17,9 @@ class Glide < Formula
 
   depends_on "go"
 
+  # See: https://github.com/Masterminds/glide/commit/c64b14592409a83052f7735a01d203ff1bab0983
+  deprecate! date: "2021-01-02", because: :deprecated_upstream
+
   def install
     ENV["GOPATH"] = buildpath
     glidepath = buildpath/"src/github.com/Masterminds/glide"


### PR DESCRIPTION
go 1.16 would use go modules as default build, deprecate glide (also mostly unmaintained at this phase)

---

relates to https://github.com/Masterminds/glide/commit/c64b14592409a83052f7735a01d203ff1bab0983