### PR TITLE
gperf: make keg_only, is provided by macos since Yosemite

### DIFF
--- a/Formula/gperf.rb
+++ b/Formula/gperf.rb
@@ -5,6 +5,7 @@ class Gperf < Formula
   mirror "https://ftpmirror.gnu.org/gperf/gperf-3.1.tar.gz"
   sha256 "588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
   license "GPL-3.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,6 +22,8 @@ class Gperf < Formula
     sha256 "27f661ef9546ff113279654e92c08bb8d8ab837f7dc8b308c1a2beeafdcebc76" => :el_capitan
     sha256 "263440c302dddec69c2140e8df2e4c00a76b76137243e712e8e8756140e0eaf5" => :yosemite
   end
+
+  keg_only :provided_by_macos
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
