### PR TITLE
Qt 6.0.0 with submodules

### DIFF
--- a/Formula/qt-base.rb
+++ b/Formula/qt-base.rb
@@ -5,12 +5,6 @@ class QtBase < Formula
   sha256 "ae227180272d199cbb15318e3353716afada5c57fd5185b812ae26912c958656"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
-    cellar :any
-    sha256 "d836c8cd5cd9d10b3a00580853cf52db7e88e7fbbad9117e04bdd4aa625215b3" => :big_sur
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
   depends_on xcode: :build # for xcodebuild to get version

--- a/Formula/qt-base.rb
+++ b/Formula/qt-base.rb
@@ -1,0 +1,189 @@
+class QtBase < Formula
+  desc "Base components of Qt framework (Core, Gui, Widgets, Network, ...)"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.0/6.0.0/submodules/qtbase-everywhere-src-6.0.0.tar.xz"
+  sha256 "ae227180272d199cbb15318e3353716afada5c57fd5185b812ae26912c958656"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+   bottle do
+    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
+    cellar :any
+    sha256 "d836c8cd5cd9d10b3a00580853cf52db7e88e7fbbad9117e04bdd4aa625215b3" => :big_sur
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  depends_on xcode: :build # for xcodebuild to get version
+
+  # Apple Advanced Typography need qt bundled harfbuzz
+  # dependency openssl, fontfonfig will cause config error
+  # mapped cmake variables are:
+  #   -DOPENSSL_ROOT_DIR=#{Formula["openssl"].opt_prefix}
+  #   -DDFEATURE_fontconfig:BOOL=ON
+  # Qt SQL supported DBs are:
+  # DB2 (IBM)
+  #   FEATURE_sql_db2:BOOL=OFF
+  # InterBase
+  #   FEATURE_sql_ibase:BOOL=OFF
+  # MySql
+  #   FEATURE_sql_mysql:BOOL=ON
+  # OCI (Oracle)
+  #   FEATURE_sql_oci:BOOL=OFF
+  # ODBC
+  #   FEATURE_sql_odbc:BOOL=ON
+  # PostgreSQL
+  #   FEATURE_sql_psql:BOOL=ON
+  # SQLite
+  #   FEATURE_sql_sqlite:BOOL=ON
+
+  # optional dependencies
+  # zstd
+  # pcre2
+  # libjpeg
+  # libpng
+  # gegl
+  # dbus
+
+  depends_on "double-conversion"
+  depends_on "freetype"
+  depends_on "icu4c" # Qt needs icu's utilities
+  depends_on "jpeg"
+  depends_on "libb2"
+  depends_on "libpng"
+  depends_on "pcre2"
+  depends_on "pkg-config"
+  depends_on "postgresql"
+  depends_on "unixodbc"
+  depends_on "zstd"
+
+  uses_from_macos "cups"
+  uses_from_macos "krb5"
+  uses_from_macos "perl"
+  uses_from_macos "sqlite"
+
+  # HACK: qmake use symlink's canonical path before patching
+  patch :DATA
+
+  def install
+    # use framework, Qt use some symbol not in krb5
+    ENV.append "LDFLAGS", "-framework GSS"
+
+    # Qt support use `CMAKE_STAGING_PREFIX` instead of `CMAKE_INSTALL_PREFIX` to
+    # change the install dir, see
+    # https://cmake.org/cmake/help/latest/variable/CMAKE_STAGING_PREFIX.html
+    args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+      -DCMAKE_INSTALL_PREFIX=/usr/local
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+
+      -DICU_ROOT=#{Formula["icu4c"].opt_prefix}
+
+      -DINSTALL_ARCHDATADIR=share/qt
+      -DINSTALL_DATADIR=share/qt
+
+      -DINSTALL_DESCRIPTIONSDIR=share/qt/modules
+      -DINSTALL_DOCDIR=share/doc/qt
+      -DINSTALL_EXAMPLESDIR=share/qt/examples
+      -DINSTALL_MKSPECSDIR=share/qt/mkspecs
+      -DINSTALL_PLUGINSDIR=share/qt/plugins
+      -DINSTALL_QMLDIR=share/qt/qml
+      -DINSTALL_TESTSDIR=share/qt/tests
+
+      -DFEATURE_appstore_compliant:BOOL=ON
+      -DFEATURE_freetype:BOOL=ON
+      -DFEATURE_pkg_config:BOOL=ON
+      -DFEATURE_relocatable:BOOL=OFF
+      -DFEATURE_zstd:BOOL=ON
+    ]
+
+    system "cmake", "-G", "Ninja", ".", *args
+    system "ninja"
+    system "ninja", "install"
+
+    # This is required to enable installation of all configurations of
+    # a Qt built with Ninja Multi-Config until the following issue is fixed.
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/20713
+    rm bin/"qt-cmake-private-install.cmake"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # FIXME: remove this toolchain file seems not good
+    rm lib/"cmake/Qt6/qt.toolchain.cmake"
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      cmake_minimum_required(VERSION 3.16.0)
+
+      project(hello VERSION 1.0.0 LANGUAGES CXX)
+
+      set(CMAKE_CXX_STANDARD 17)
+      set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+      set(CMAKE_AUTOMOC ON)
+      set(CMAKE_AUTORCC ON)
+      set(CMAKE_AUTOUIC ON)
+
+      find_package(Qt6 COMPONENTS Widgets REQUIRED)
+
+      add_executable(hello
+          main.cpp
+      )
+
+      target_link_libraries(hello PRIVATE Qt6::Widgets)
+    EOS
+
+    (testpath/"hello.pro").write <<~EOS
+      QT       += core
+      QT       -= gui
+      TARGET = hello
+      CONFIG   += console
+      CONFIG   -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    EOS
+
+    (testpath/"main.cpp").write <<~EOS
+      #include <QCoreApplication>
+      #include <QDebug>
+
+      int main(int argc, char *argv[])
+      {
+        QCoreApplication a(argc, argv);
+        qDebug() << "Hello World!";
+        return 0;
+      }
+    EOS
+
+    system "cmake", testpath
+    system "make"
+    system "./hello"
+
+    # Work around "error: no member named 'signbit' in the global namespace"
+    ENV.delete "CPATH"
+    system bin/"qmake", testpath/"hello.pro"
+    system "make"
+    system "./hello"
+  end
+end
+
+__END__
+diff --git a/src/corelib/global/qlibraryinfo.cpp b/src/corelib/global/qlibraryinfo.cpp
+index 301c3ab..fbd6adf 100644
+--- a/src/corelib/global/qlibraryinfo.cpp
++++ b/src/corelib/global/qlibraryinfo.cpp
+@@ -597,7 +597,7 @@ QString qmake_abslocation();
+ 
+ static QString getPrefixFromHostBinDir(const char *hostBinDirToPrefixPath)
+ {
+-    const QString canonicalQMakePath = QFileInfo(qmake_abslocation()).canonicalPath();
++    const QString canonicalQMakePath = QFileInfo(qmake_abslocation()).absolutePath();
+     return QDir::cleanPath(canonicalQMakePath + QLatin1Char('/')
+                            + QLatin1String(hostBinDirToPrefixPath));
+ }

--- a/Formula/qt-base.rb
+++ b/Formula/qt-base.rb
@@ -5,7 +5,7 @@ class QtBase < Formula
   sha256 "ae227180272d199cbb15318e3353716afada5c57fd5185b812ae26912c958656"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-   bottle do
+  bottle do
     root_url "https://dl.bintray.com/paperchalice/dev-bottle"
     cellar :any
     sha256 "d836c8cd5cd9d10b3a00580853cf52db7e88e7fbbad9117e04bdd4aa625215b3" => :big_sur
@@ -109,6 +109,7 @@ class QtBase < Formula
 
     # FIXME: remove this toolchain file seems not good
     rm lib/"cmake/Qt6/qt.toolchain.cmake"
+
     # The pkg-config files installed suggest that headers can be found in the
     # `include` directory. Make this so by creating symlinks from `include` to
     # the Frameworks' Headers folders.

--- a/Formula/qt-core5-compat.rb
+++ b/Formula/qt-core5-compat.rb
@@ -5,12 +5,6 @@ class QtCore5Compat < Formula
   sha256 "13b9d78aa698609d07376e3e9e9d1a82a96084236aba0642f8ac695c181ab25f"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
-    cellar :any
-    sha256 "f67414810be33b2ec67dd48f25e6bc2df82ff0ccdd15916faa3de6a9dbbd1e35" => :big_sur
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 

--- a/Formula/qt-core5-compat.rb
+++ b/Formula/qt-core5-compat.rb
@@ -1,0 +1,94 @@
+class QtCore5Compat < Formula
+  desc "Qt module contains unsupported Qt 5 APIs"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/archive/qt/6.0/6.0.0/submodules/qt5compat-everywhere-src-6.0.0.tar.xz"
+  sha256 "13b9d78aa698609d07376e3e9e9d1a82a96084236aba0642f8ac695c181ab25f"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+  bottle do
+    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
+    cellar :any
+    sha256 "f67414810be33b2ec67dd48f25e6bc2df82ff0ccdd15916faa3de6a9dbbd1e35" => :big_sur
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  depends_on "qt-base"
+
+  def install
+    args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+      -DCMAKE_INSTALL_PREFIX=/usr/local
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+    ]
+    system "cmake", "-G", "Ninja", ".", *args
+    system "ninja"
+    system "ninja", "install"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      cmake_minimum_required(VERSION 3.16.0)
+
+      project(test_project VERSION 1.0.0 LANGUAGES CXX)
+
+      set(CMAKE_CXX_STANDARD 17)
+      set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+      set(CMAKE_AUTOMOC ON)
+      set(CMAKE_AUTORCC ON)
+      set(CMAKE_AUTOUIC ON)
+
+      find_package(Qt6 COMPONENTS Widgets REQUIRED)
+      find_package(Qt6Core5Compat COMPONENTS Widgets REQUIRED)
+
+      add_executable(test
+          main.cpp
+      )
+
+      target_link_libraries(test PRIVATE Qt6::Widgets Qt6::Core5Compat)
+    EOS
+
+    (testpath/"test.pro").write <<~EOS
+      QT       += core core5compat
+      QT       -= gui
+      TARGET = test
+      CONFIG   += console
+      CONFIG   -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    EOS
+
+    (testpath/"main.cpp").write <<~EOS
+      #include <QCoreApplication>
+      #include <QtCore5Compat/QLinkedList>
+      #include <QDebug>
+
+      int main(int argc, char *argv[])
+      {
+        QLinkedList list = {1, 2, 3};
+        return 0;
+      }
+    EOS
+
+    system "cmake", testpath
+    system "make"
+    system "./test"
+
+    # Work around "error: no member named 'signbit' in the global namespace"
+    ENV.delete "CPATH"
+    system "qmake", testpath/"hello.pro"
+    system "make"
+    system "./test"
+  end
+end

--- a/Formula/qt-declarative.rb
+++ b/Formula/qt-declarative.rb
@@ -1,0 +1,67 @@
+class QtDeclarative < Formula
+  desc "Qt Quick2"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/archive/qt/6.0/6.0.0/submodules/qtdeclarative-everywhere-src-6.0.0.tar.xz"
+  sha256 "8535fe31fa3e876b8f2d3954efcdca47b3813adf228c1640608fb9f4c7b2c1a6"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+  bottle do
+    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
+    cellar :any
+    sha256 "8614b55f5cb5a1d3406198a9eef055206dffb0f9917b648e956573690fe27cf4" => :big_sur
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  depends_on "python@3.9"
+  depends_on "qt-base"
+
+  def install
+    args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+      -DCMAKE_INSTALL_PREFIX=/usr/local
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+
+      -DPython_ROOT_DIR=#{Formula["python@3.9"].opt_prefix}
+    ]
+    system "cmake", "-G", "Ninja", ".", *args
+    system "ninja"
+    system "ninja", "install"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+
+    # FIXME: this step just moves `*.app` bundles into `libexec` and create link
+    libexec.mkpath
+    Pathname.glob("#{bin}/*.app") do |app|
+      mv app, libexec
+      bin.install_symlink "#{libexec/app.stem}.app/Contents/MacOS/#{app.stem}"
+    end
+  end
+
+  test do
+    (testpath/"hello.qml").write <<~EOS
+      import QtQuick 2.0
+      Rectangle {
+          id: page
+          width: 320; height: 480
+          color: "lightgray"
+          Text {
+              id: helloText
+              text: "Hello world!"
+              y: 30
+              anchors.horizontalCenter: page.horizontalCenter
+              font.pointSize: 24; font.bold: true
+          }
+      }
+    EOS
+    system bin/"qmlscene", "--quit", testpath/"hello.qml"
+  end
+end

--- a/Formula/qt-declarative.rb
+++ b/Formula/qt-declarative.rb
@@ -5,12 +5,6 @@ class QtDeclarative < Formula
   sha256 "8535fe31fa3e876b8f2d3954efcdca47b3813adf228c1640608fb9f4c7b2c1a6"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
-    cellar :any
-    sha256 "8614b55f5cb5a1d3406198a9eef055206dffb0f9917b648e956573690fe27cf4" => :big_sur
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 

--- a/Formula/qt-doc.rb
+++ b/Formula/qt-doc.rb
@@ -5,12 +5,6 @@ class QtDoc < Formula
   sha256 "476108d92506d93d5df227f275d653abba57b3b1694afbf2965e0c74e8c0a5a8"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://homebrew.bintray.com/bottles-dev"
-    cellar :any_skip_relocation
-    sha256 "54fe0927736427a9f26fa368b0d23bd067e9db13a6d18a949e1234d7f9f25fad" => :big_sur
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
   depends_on "qt-tools" => :build

--- a/Formula/qt-doc.rb
+++ b/Formula/qt-doc.rb
@@ -17,7 +17,7 @@ class QtDoc < Formula
     system "cmake", "-G", "Ninja", ".", *args
     system "ninja", "docs"
     system "ninja", "install_docs"
-    
+
     Pathname.glob("share/qt/doc/*") do |path|
       doc.install path
     end

--- a/Formula/qt-doc.rb
+++ b/Formula/qt-doc.rb
@@ -1,0 +1,35 @@
+class QtDoc < Formula
+  desc "Qt Documentation"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/archive/qt/6.0/6.0.0/submodules/qtdoc-everywhere-src-6.0.0.tar.xz"
+  sha256 "476108d92506d93d5df227f275d653abba57b3b1694afbf2965e0c74e8c0a5a8"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+  bottle do
+    root_url "https://homebrew.bintray.com/bottles-dev"
+    cellar :any_skip_relocation
+    sha256 "54fe0927736427a9f26fa368b0d23bd067e9db13a6d18a949e1234d7f9f25fad" => :big_sur
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  depends_on "qt-tools" => :build
+
+  def install
+    args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+      -DCMAKE_INSTALL_PREFIX=/usr/local
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+    ]
+    system "cmake", "-G", "Ninja", ".", *args
+    system "ninja", "docs"
+    system "ninja", "install_docs"
+    
+    Pathname.glob("share/qt/doc/*") do |path|
+      doc.install path
+    end
+  end
+
+  test do
+    assert_predicate share/"doc/qt", :exist?
+  end
+end

--- a/Formula/qt-quick-controls2.rb
+++ b/Formula/qt-quick-controls2.rb
@@ -1,0 +1,93 @@
+class QtQuickControls2 < Formula
+  desc "Next generation user interface controls based on Qt Quick"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/archive/qt/6.0/6.0.0/submodules/qtquickcontrols2-everywhere-src-6.0.0.tar.xz"
+  sha256 "03fd2dbf030bf859e8069144bb6a282517063589c9d4025293eb89bcc580253b"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+  bottle do
+    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
+    cellar :any
+    sha256 "190599bf51c90dee19c09cc306b10fa52cc5c95d5aa4d59fd706285b6c22587e" => :big_sur
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  depends_on "qt-declarative"
+
+  def install
+    args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+      -DCMAKE_INSTALL_PREFIX=/usr/local
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+    ]
+    system "cmake", "-G", "Ninja", ".", *args
+    system "ninja"
+    system "ninja", "install"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      cmake_minimum_required(VERSION 3.16.0)
+
+      project(test_project VERSION 1.0.0 LANGUAGES CXX)
+
+      set(CMAKE_CXX_STANDARD 17)
+      set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+      set(CMAKE_AUTOMOC ON)
+      set(CMAKE_AUTORCC ON)
+      set(CMAKE_AUTOUIC ON)
+
+      find_package(Qt6 COMPONENTS Widgets REQUIRED)
+      find_package(Qt6QuickControls2 COMPONENTS Widgets REQUIRED)
+
+      add_executable(test
+          main.cpp
+      )
+
+      target_link_libraries(test PRIVATE Qt6::Widgets Qt6::QuickControls2)
+    EOS
+
+    (testpath/"test.pro").write <<~EOS
+      QT       += core quick quickcontrols2
+      QT       -= gui
+      TARGET = test
+      CONFIG   += console
+      CONFIG   -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    EOS
+
+    (testpath/"main.cpp").write <<~EOS
+      #include <QCoreApplication>
+      #include <QtQuickControls2/QtQuickControls2>
+      #include <QDebug>
+
+      int main(int argc, char *argv[])
+      {
+        return 0;
+      }
+    EOS
+
+    system "cmake", testpath
+    system "make"
+    system "./test"
+
+    # Work around "error: no member named 'signbit' in the global namespace"
+    ENV.delete "CPATH"
+    system "qmake", testpath/"test.pro"
+    system "make"
+    system "./test"
+  end
+end

--- a/Formula/qt-quick-controls2.rb
+++ b/Formula/qt-quick-controls2.rb
@@ -5,12 +5,6 @@ class QtQuickControls2 < Formula
   sha256 "03fd2dbf030bf859e8069144bb6a282517063589c9d4025293eb89bcc580253b"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
-    cellar :any
-    sha256 "190599bf51c90dee19c09cc306b10fa52cc5c95d5aa4d59fd706285b6c22587e" => :big_sur
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 

--- a/Formula/qt-quick-timeline.rb
+++ b/Formula/qt-quick-timeline.rb
@@ -1,0 +1,48 @@
+class QtQuickTimeline < Formula
+  desc "Module for keyframe-based timeline construction."
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/archive/qt/6.0/6.0.0/submodules/qtquicktimeline-everywhere-src-6.0.0.tar.xz"
+  sha256 "7a71495c07a98279a852d518bc9ca0f07b49b495ceb65bfdd000c826ee156b0c"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+  bottle do
+    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
+    cellar :any
+    sha256 "ba0a762a018572d784bdf9c91ee68065c7b9568f9d5361ac27d406de2c37164e" => :big_sur
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  depends_on "qt-declarative"
+
+  def install
+    args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+      -DCMAKE_INSTALL_PREFIX=/usr/local
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+    ]
+    system "cmake", "-G", "Ninja", ".", *args
+    system "ninja"
+    system "ninja", "install"
+  end
+
+  test do
+    (testpath/"hello.qml").write <<~EOS
+      import QtQuick 2.0
+      import QtQuick.Timeline 1.0
+      Rectangle {
+          id: page
+          width: 320; height: 480
+          color: "lightgray"
+          Text {
+              id: helloText
+              text: "Hello world!"
+              y: 30
+              anchors.horizontalCenter: page.horizontalCenter
+              font.pointSize: 24; font.bold: true
+          }
+      }
+    EOS
+    system "qmlscene", "--quit", testpath/"hello.qml"
+  end
+end

--- a/Formula/qt-quick-timeline.rb
+++ b/Formula/qt-quick-timeline.rb
@@ -5,12 +5,6 @@ class QtQuickTimeline < Formula
   sha256 "7a71495c07a98279a852d518bc9ca0f07b49b495ceb65bfdd000c826ee156b0c"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
-    cellar :any
-    sha256 "ba0a762a018572d784bdf9c91ee68065c7b9568f9d5361ac27d406de2c37164e" => :big_sur
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 

--- a/Formula/qt-quick-timeline.rb
+++ b/Formula/qt-quick-timeline.rb
@@ -1,5 +1,5 @@
 class QtQuickTimeline < Formula
-  desc "Module for keyframe-based timeline construction."
+  desc "Module for keyframe-based timeline construction"
   homepage "https://www.qt.io/"
   url "https://download.qt.io/archive/qt/6.0/6.0.0/submodules/qtquicktimeline-everywhere-src-6.0.0.tar.xz"
   sha256 "7a71495c07a98279a852d518bc9ca0f07b49b495ceb65bfdd000c826ee156b0c"

--- a/Formula/qt-quick3d.rb
+++ b/Formula/qt-quick3d.rb
@@ -5,12 +5,6 @@ class QtQuick3d < Formula
   sha256 "0a9a3e765c343b55511900b173f9591df88b0787f67b9ecfb8f25203bfdb0aa8"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
-    cellar :any
-    sha256 "01e453f720d1025ebd4fa80cb62a55e45556b039fd7a8453b10ee2b7a1363370" => :big_sur
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 

--- a/Formula/qt-quick3d.rb
+++ b/Formula/qt-quick3d.rb
@@ -1,0 +1,95 @@
+class QtQuick3d < Formula
+  desc "New module and API for defining 3D content in Qt Quick"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/archive/qt/6.0/6.0.0/submodules/qtquick3d-everywhere-src-6.0.0.tar.xz"
+  sha256 "0a9a3e765c343b55511900b173f9591df88b0787f67b9ecfb8f25203bfdb0aa8"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+  bottle do
+    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
+    cellar :any
+    sha256 "01e453f720d1025ebd4fa80cb62a55e45556b039fd7a8453b10ee2b7a1363370" => :big_sur
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  depends_on "assimp"
+  depends_on "qt-declarative"
+  depends_on "qt-shader-tools"
+
+  def install
+    args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+      -DCMAKE_INSTALL_PREFIX=/usr/local
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+    ]
+    system "cmake", "-G", "Ninja", ".", *args
+    system "ninja"
+    system "ninja", "install"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      cmake_minimum_required(VERSION 3.16.0)
+
+      project(test_project VERSION 1.0.0 LANGUAGES CXX)
+
+      set(CMAKE_CXX_STANDARD 17)
+      set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+      set(CMAKE_AUTOMOC ON)
+      set(CMAKE_AUTORCC ON)
+      set(CMAKE_AUTOUIC ON)
+
+      find_package(Qt6 COMPONENTS Widgets REQUIRED)
+      find_package(Qt6Quick3D COMPONENTS Widgets REQUIRED)
+
+      add_executable(test
+          main.cpp
+      )
+
+      target_link_libraries(test PRIVATE Qt6::Widgets Qt6::Quick3D)
+    EOS
+
+    (testpath/"test.pro").write <<~EOS
+      QT       += core quick3d
+      QT       -= gui
+      TARGET = test
+      CONFIG   += console
+      CONFIG   -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    EOS
+
+    (testpath/"main.cpp").write <<~EOS
+      #include <QCoreApplication>
+      #include <QtQuick3D>
+      #include <QDebug>
+
+      int main(int argc, char *argv[])
+      {
+        return 0;
+      }
+    EOS
+
+    system "cmake", testpath
+    system "make"
+    system "./test"
+
+    # Work around "error: no member named 'signbit' in the global namespace"
+    ENV.delete "CPATH"
+    system "qmake", testpath/"test.pro"
+    system "make"
+    system "./test"
+  end
+end

--- a/Formula/qt-shader-tools.rb
+++ b/Formula/qt-shader-tools.rb
@@ -5,12 +5,6 @@ class QtShaderTools < Formula
   sha256 "201b1376b65ef9f7fd19789781e0378ea813385217cd392c5c896699e6108e6c"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
-    cellar :any
-    sha256 "8e0a867ce0857625d81ba690712e1f8ac6789a7c2b2daedc0d720c471eb74bf6" => :big_sur
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 

--- a/Formula/qt-shader-tools.rb
+++ b/Formula/qt-shader-tools.rb
@@ -1,0 +1,61 @@
+class QtShaderTools < Formula
+  desc "Provide the producer functionality for the shader pipeline"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/archive/qt/6.0/6.0.0/submodules/qtshadertools-everywhere-src-6.0.0.tar.xz"
+  sha256 "201b1376b65ef9f7fd19789781e0378ea813385217cd392c5c896699e6108e6c"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+  bottle do
+    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
+    cellar :any
+    sha256 "8e0a867ce0857625d81ba690712e1f8ac6789a7c2b2daedc0d720c471eb74bf6" => :big_sur
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  depends_on "qt-base"
+
+  def install
+    args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+      -DCMAKE_INSTALL_PREFIX=/usr/local
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+    ]
+    system "cmake", "-G", "Ninja", ".", *args
+    system "ninja"
+    system "ninja", "install"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+  end
+
+  test do
+    (testpath/"shader.frag").write <<~EOS
+      #version 440
+
+      layout(location = 0) in vec2 v_texcoord;
+      layout(location = 0) out vec4 fragColor;
+      layout(binding = 1) uniform sampler2D tex;
+
+      layout(std140, binding = 0) uniform buf {
+          float uAlpha;
+      };
+
+      void main()
+      {
+          vec4 c = texture(tex, v_texcoord);
+          fragColor = vec4(c.rgb, uAlpha);
+      }
+    EOS
+
+    system bin/"qsb", "-o", testpath/"shader.frag.qsb", testpath/"shader.frag"
+    assert_predicate testpath/"shader.frag.qsb", :exist?
+  end
+end

--- a/Formula/qt-svg.rb
+++ b/Formula/qt-svg.rb
@@ -1,0 +1,96 @@
+class QtSvg < Formula
+  desc "SVG support library for Qt"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/archive/qt/6.0/6.0.0/submodules/qtsvg-everywhere-src-6.0.0.tar.xz"
+  sha256 "9703c9a69e21ad373fb52d0107338da7ef0a46966f69107b0d879e9c366dd91b"
+  license all_of: ["GPL-2.0-only", "LGPL-3.0-only"]
+
+  bottle do
+    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
+    cellar :any
+    sha256 "f0e1f6b22b1e6b144788132801b51523637306cd46b1a8d479b72adbdd716812" => :big_sur
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  depends_on "qt-base"
+
+  uses_from_macos "zlib"
+
+  def install
+    args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+      -DCMAKE_INSTALL_PREFIX=/usr/local
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+    ]
+    system "cmake", "-G", "Ninja", ".", *args
+    system "ninja"
+    system "ninja", "install"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      cmake_minimum_required(VERSION 3.16.0)
+
+      project(test VERSION 1.0.0 LANGUAGES CXX)
+
+      set(CMAKE_CXX_STANDARD 17)
+      set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+      set(CMAKE_AUTOMOC ON)
+      set(CMAKE_AUTORCC ON)
+      set(CMAKE_AUTOUIC ON)
+
+      find_package(Qt6 COMPONENTS Widgets REQUIRED)
+      find_package(Qt6Svg COMPONENTS Widgets REQUIRED)
+
+      add_executable(test
+          main.cpp
+      )
+
+      target_link_libraries(test PRIVATE Qt6::Widgets Qt6::Svg)
+    EOS
+
+    (testpath/"test.pro").write <<~EOS
+      QT       += core svg
+      QT       -= gui
+      TARGET = test
+      CONFIG   += console
+      CONFIG   -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    EOS
+
+    (testpath/"main.cpp").write <<~EOS
+      #include <QCoreApplication>
+      #include <QtSvg/QtSvg>
+      #include <QDebug>
+
+      int main(int argc, char *argv[])
+      {
+        QSvgGenerator generator;
+        return 0;
+      }
+    EOS
+
+    system "cmake", testpath
+    system "make"
+    system "./test"
+
+    # Work around "error: no member named 'signbit' in the global namespace"
+    ENV.delete "CPATH"
+    system "qmake", testpath/"test.pro"
+    system "make"
+    system "./test"
+  end
+end

--- a/Formula/qt-svg.rb
+++ b/Formula/qt-svg.rb
@@ -5,12 +5,6 @@ class QtSvg < Formula
   sha256 "9703c9a69e21ad373fb52d0107338da7ef0a46966f69107b0d879e9c366dd91b"
   license all_of: ["GPL-2.0-only", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
-    cellar :any
-    sha256 "f0e1f6b22b1e6b144788132801b51523637306cd46b1a8d479b72adbdd716812" => :big_sur
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 

--- a/Formula/qt-tools.rb
+++ b/Formula/qt-tools.rb
@@ -1,0 +1,66 @@
+class QtTools < Formula
+  desc "Qt utilities"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/archive/qt/6.0/6.0.0/submodules/qttools-everywhere-src-6.0.0.tar.xz"
+  sha256 "b6dc559db447bf394d09dfb238d5c09108f834139a183888179e855c6566bfae"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+bottle do
+    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
+    sha256 "13c9c08adf24f5d710a62e2889ad616c4b2db60eba0bac715fbd5e27250aac63" => :big_sur
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  depends_on "llvm"
+  depends_on "qt-base"
+
+  def install
+    # See qt-base
+    args =std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+      -DCMAKE_INSTALL_PREFIX=/usr/local
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+
+      -DLLVM_INSTALL_DIR=#{Formula["llvm"].opt_prefix}
+    ]
+
+    system "cmake", "-G", "Ninja", ".", *args
+    system "ninja"
+    system "ninja", "install"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+
+    # FIXME: this step just moves `*.app` bundles into `libexec` and create link
+    libexec.mkpath
+    Pathname.glob("#{bin}/*.app") do |app|
+      mv app, libexec
+      bin.install_symlink "#{libexec/app.stem}.app/Contents/MacOS/#{app.stem}"
+    end
+  end
+
+  test do
+    # test `qtpaths`
+    assert_equal "/usr/local", `qtpaths --install-prefix`.strip
+
+    # test `qtdoc`
+    (testpath/"test.qdocconf").write <<~EOS
+      project = test
+      outputdir   = html
+      headerdirs  = .
+      sourcedirs  = .
+      exampledirs = .
+      imagedirs   = .
+    EOS
+    system bin/"qdoc", testpath/"test.qdocconf"
+    assert_predicate testpath/"html/test.index", :exist?
+  end
+end

--- a/Formula/qt-tools.rb
+++ b/Formula/qt-tools.rb
@@ -5,11 +5,6 @@ class QtTools < Formula
   sha256 "b6dc559db447bf394d09dfb238d5c09108f834139a183888179e855c6566bfae"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-bottle do
-    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
-    sha256 "13c9c08adf24f5d710a62e2889ad616c4b2db60eba0bac715fbd5e27250aac63" => :big_sur
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 

--- a/Formula/qt-tools.rb
+++ b/Formula/qt-tools.rb
@@ -8,7 +8,7 @@ class QtTools < Formula
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 
-  depends_on "llvm"
+  depends_on "llvm" # need cmake related files
   depends_on "qt-base"
 
   def install

--- a/Formula/qt-translations.rb
+++ b/Formula/qt-translations.rb
@@ -1,0 +1,32 @@
+class QtTranslations < Formula
+  desc "Translations for Qt Tools"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/archive/qt/6.0/6.0.0/submodules/qttranslations-everywhere-src-6.0.0.tar.xz"
+  sha256 "ed6487425c17e88531e825c44820c1f47c9b7dc0918125e5d45ccc36fdc679d5"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+  bottle do
+    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
+    cellar :any_skip_relocation
+    sha256 "2fe3820a0b006147bfa481969d292b7144182a2e6974700edeeba66ed9a080b8" => :big_sur
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  depends_on "qt-tools"
+
+  def install
+    args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+      -DCMAKE_INSTALL_PREFIX=/usr/local
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+    ]
+    system "cmake", "-G", "Ninja", ".", *args
+    system "ninja"
+    system "ninja", "install"
+  end
+
+  test do
+    assert_predicate share/"qt/translations", :exist?
+  end
+end

--- a/Formula/qt-translations.rb
+++ b/Formula/qt-translations.rb
@@ -5,12 +5,6 @@ class QtTranslations < Formula
   sha256 "ed6487425c17e88531e825c44820c1f47c9b7dc0918125e5d45ccc36fdc679d5"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
-    cellar :any_skip_relocation
-    sha256 "2fe3820a0b006147bfa481969d292b7144182a2e6974700edeeba66ed9a080b8" => :big_sur
-  end
-
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 

--- a/Formula/qt6.rb
+++ b/Formula/qt6.rb
@@ -1,0 +1,173 @@
+class Qt6 < Formula
+  desc "Cross-platform application and UI framework"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/archive/qt/6.0/6.0.0/single/qt-everywhere-src-6.0.0.tar.xz"
+  sha256 "d39a1a557a0dc8dc5ea2eaaee0fa015c71dcbb79c25a6aea421c594227565296"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+  bottle do
+    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
+    cellar :any
+    sha256 "7c053c70c30ae040244cf5043a384c6222b47dc1339754d0bb5e82182203d73b" => :big_sur
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  depends_on xcode: :build # for xcodebuild to get version
+
+  # Apple Advanced Typography need qt bundled harfbuzz
+  # dependency openssl, fontfonfig will cause config error
+  # mapped cmake variables are:
+  #   -DOPENSSL_ROOT_DIR=#{Formula["openssl"].opt_prefix}
+  #   -DDFEATURE_fontconfig:BOOL=ON
+  # Qt SQL supported DBs are:
+  # DB2 (IBM)
+  #   FEATURE_sql_db2:BOOL=OFF
+  # InterBase
+  #   FEATURE_sql_ibase:BOOL=OFF
+  # MySql
+  #   FEATURE_sql_mysql:BOOL=ON
+  # OCI (Oracle)
+  #   FEATURE_sql_oci:BOOL=OFF
+  # ODBC
+  #   FEATURE_sql_odbc:BOOL=ON
+  # PostgreSQL
+  #   FEATURE_sql_psql:BOOL=ON
+  # SQLite
+  #   FEATURE_sql_sqlite:BOOL=ON
+
+  depends_on "assimp"
+  depends_on "double-conversion"
+  depends_on "freetype"
+  depends_on "icu4c"
+  depends_on "jpeg"
+  depends_on "libb2"
+  depends_on "libpng"
+  depends_on "llvm"
+  depends_on "pcre2"
+  depends_on "pkg-config"
+  depends_on "postgresql"
+  depends_on "unixodbc"
+  depends_on "zstd"
+
+  uses_from_macos "cups"
+  uses_from_macos "krb5"
+  uses_from_macos "perl"
+  uses_from_macos "sqlite"
+
+  def install
+    # use framework first for framework gss
+    ENV.append "LDFLAGS", "-framework GSS"
+
+    # FIXME: these options causes configure error
+    # -DOPENSSL_ROOT_DIR=#{Formula["openssl"].opt_prefix}
+    # -DDFEATURE_fontconfig:BOOL=ON
+
+    args = %W[
+      -DICU_ROOT=#{Formula["icu4c"].opt_prefix}
+      -DLLVM_INSTALL_DIR=#{Formula["llvm"].opt_prefix}
+
+      -DINSTALL_ARCHDATADIR=share/qt
+      -DINSTALL_DATADIR=share/qt
+
+      -DINSTALL_DESCRIPTIONSDIR=share/qt/modules
+      -DINSTALL_DOCDIR=share/doc/qt
+      -DINSTALL_EXAMPLESDIR=share/qt/examples
+      -DINSTALL_MKSPECSDIR=share/qt/mkspecs
+      -DINSTALL_PLUGINSDIR=share/qt/plugins
+      -DINSTALL_QMLDIR=share/qt/qml
+      -DINSTALL_TESTSDIR=share/qt/tests
+
+      -DFEATURE_appstore_compliant:BOOL=ON
+      -DFEATURE_freetype:BOOL=ON
+      -DFEATURE_pkg_config:BOOL=ON
+      -DFEATURE_zstd:BOOL=ON
+    ]
+
+    system "cmake", "-G", "Ninja", ".", *(std_cmake_args + args)
+    system "ninja"
+    system "ninja", "install"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+
+    # FIXME: this step just moves `*.app` bundles into `libexec` and create link
+    libexec.mkpath
+    Pathname.glob("#{bin}/*.app") do |app|
+      mv app, libexec
+      bin.install_symlink "#{libexec/app.stem}.app/Contents/MacOS/#{app.stem}"
+    end
+
+    # This is required to enable installation of all configurations of
+    # a Qt built with Ninja Multi-Config until the following issue is fixed.
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/20713
+    rm bin/"qt-cmake-private-install.cmake"
+
+    # FIXME: remove this toolchain file seems not good
+    rm lib/"cmake/Qt6/qt.toolchain.cmake"
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      cmake_minimum_required(VERSION 3.16.0)
+
+      project(hello VERSION 1.0.0 LANGUAGES CXX)
+
+      set(CMAKE_CXX_STANDARD 17)
+      set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+      set(CMAKE_AUTOMOC ON)
+      set(CMAKE_AUTORCC ON)
+      set(CMAKE_AUTOUIC ON)
+
+      find_package(Qt6 COMPONENTS Widgets REQUIRED)
+
+      add_executable(hello
+          main.cpp
+      )
+
+      target_link_libraries(hello PRIVATE Qt6::Widgets)
+    EOS
+
+    (testpath/"main.cpp").write <<~EOS
+      #include <QCoreApplication>
+      #include <QDebug>
+
+      int main(int argc, char *argv[])
+      {
+        QCoreApplication a(argc, argv);
+        qDebug() << "Hello World!";
+        return 0;
+      }
+    EOS
+
+    (testpath/"hello.pro").write <<~EOS
+      QT       += core
+      QT       -= gui
+      TARGET = hello
+      CONFIG   += console
+      CONFIG   -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    EOS
+
+    system "cmake", testpath
+    system "make"
+    system "./hello"
+
+    # Work around "error: no member named 'signbit' in the global namespace"
+    ENV.delete "CPATH"
+    system bin/"qmake", testpath/"hello.pro"
+    system "make"
+    system "./hello"
+  end
+end

--- a/Formula/qt6.rb
+++ b/Formula/qt6.rb
@@ -5,12 +5,6 @@ class Qt6 < Formula
   sha256 "d39a1a557a0dc8dc5ea2eaaee0fa015c71dcbb79c25a6aea421c594227565296"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://dl.bintray.com/paperchalice/dev-bottle"
-    cellar :any
-    sha256 "7c053c70c30ae040244cf5043a384c6222b47dc1339754d0bb5e82182203d73b" => :big_sur
-  end
-
   keg_only :versioned_formula
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
 [#68134 ](https://github.com/Homebrew/homebrew-core/pull/68134)
- Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
    Except qt6
- Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
    Except qt6
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The qt6 formula just merge from other qt formulae.
Qt6 introduces a qt6.toolchain.cmake, but it offend homebrew, should I rm it?
Qt6 has so many optional dependencies.
qt-base may build failed because can't find headers, this may be a clang's bug