### PR TITLE
qt@5: create qt@5 alias and update qt alias

### DIFF
--- a/Aliases/qt@5
+++ b/Aliases/qt@5
@@ -1,0 +1,1 @@
+../Formula/qt.rb

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -98,7 +98,7 @@
   "postgresql95": "postgresql@9.5",
   "presto": "prestodb",
   "pyqt5": "pyqt",
-  "qt5": "qt",
+  "qt5": "qt@5",
   "racket": "minimal-racket",
   "rebar@3": "rebar3",
   "recipes": "gnome-recipes",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There are several pull requests open to add qt 6.0.0 (#68134, #67536), and they are renaming the current `qt` formula to `qt@5`, so this adds a `qt@5` alias separately to ease migration of formulae in 3rd-party taps that depend on qt 5.x. This way they can change their dependencies now to `qt@5` instead of waiting for the big qt 6.0.0 update to land.

It also updates `formula_renames.json` to recommend changing any references to `qt5` to `qt@5` instead of changing them to `qt`, which will soon point to version 6.

cc @fxcoudert 