### PR TITLE
pinentry-mac: 1.1.0.3 (with support for Apple Silicon)

### DIFF
--- a/Formula/pinentry-mac.rb
+++ b/Formula/pinentry-mac.rb
@@ -1,10 +1,10 @@
 class PinentryMac < Formula
   desc "Pinentry for GPG on Mac"
-  homepage "https://github.com/GPGTools/pinentry-mac"
-  url "https://github.com/GPGTools/pinentry-mac/archive/v0.9.4.tar.gz"
-  sha256 "037ebb010377d3a3879ae2a832cefc4513f5c397d7d887d7b86b4e5d9a628271"
+  homepage "https://github.com/GPGTools/pinentry"
+  url "https://github.com/GPGTools/pinentry/archive/v1.1.0.3.tar.gz"
+  sha256 "1ac83f1688d02518da5ddce1ceaa7e40893080a8d2f015b759dfaddf1b14545c"
   license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later"]
-  head "https://github.com/GPGTools/pinentry-mac.git"
+  head "https://github.com/GPGTools/pinentry.git", branch: "dev"
 
   bottle do
     cellar :any_skip_relocation
@@ -19,18 +19,19 @@ class PinentryMac < Formula
     sha256 "c2538b57edce2eb7ccc10a32e16ccfbbbe8e61c384c4db8d5a62b04d3815c0ed" => :mavericks
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on xcode: :build
-
-  patch do
-    # patch header locations for macOS 10.14
-    # https://github.com/GPGTools/pinentry-mac/pull/7
-    url "https://github.com/GPGTools/pinentry-mac/commit/62fe9f9a3d21891e87883af2e0e3815155926b20.patch?full_index=1"
-    sha256 "d4bcf2003fa1345ecb1809461140179a3737e8e03eb49d623435beb3c2f09b64"
-  end
+  depends_on "gettext"
+  depends_on "libassuan"
 
   def install
+    system "autoreconf", "-fiv"
+    system "autoconf"
+    system "./configure", "--disable-ncurses", "--enable-maintainer-mode"
     system "make"
-    prefix.install "build/Release/pinentry-mac.app"
+    prefix.install "macosx/pinentry-mac.app"
     bin.write_exec_script "#{prefix}/pinentry-mac.app/Contents/MacOS/pinentry-mac"
   end
 
@@ -44,6 +45,6 @@ class PinentryMac < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/pinentry-mac --version")
+    assert_match version.major_minor_patch.to_s, shell_output("#{bin}/pinentry-mac --version")
   end
 end

--- a/Formula/pinentry-mac.rb
+++ b/Formula/pinentry-mac.rb
@@ -3,7 +3,7 @@ class PinentryMac < Formula
   homepage "https://github.com/GPGTools/pinentry-mac"
   url "https://github.com/GPGTools/pinentry-mac/archive/v0.9.4.tar.gz"
   sha256 "037ebb010377d3a3879ae2a832cefc4513f5c397d7d887d7b86b4e5d9a628271"
-  license "GPL-2.0"
+  license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later"]
   head "https://github.com/GPGTools/pinentry-mac.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This pull request adds to more patches (https://github.com/GPGTools/pinentry-mac/pull/8 and https://github.com/GPGTools/pinentry-mac/pull/9) in order to build a binary that is can run on Apple Silicon.

As it currently is, the bottle for Big Sur ARM64 contains a binary that cannot run on Apple Silicon, which looks like this:

> /opt/homebrew/bin/pinentry-mac: line 2: /opt/homebrew/Cellar/pinentry-mac/0.9.4/pinentry-mac.app/Contents/MacOS/pinentry-mac: Bad CPU type in executable
> /opt/homebrew/bin/pinentry-mac: line 2: /opt/homebrew/Cellar/pinentry-mac/0.9.4/pinentry-mac.app/Contents/MacOS/pinentry-mac: Undefined error: 0

Since the current bottle is broken, I also bumped the `revision` to `1`.

In order to get `brew audit --strict pinentry-mac` to pass, I also had to update the `licence` field which was done in a separate commit. The commit message includes [a link to where I found the license](https://github.com/GPGTools/pinentry-mac/blob/8d811e25d58e88d804f61e2bcba3b0b2ddef402f/Source/main.m#L13-L16).