### PR TITLE
Fix remaining Boost packages  on Apple silicon

### DIFF
--- a/Formula/boost-build.rb
+++ b/Formula/boost-build.rb
@@ -22,6 +22,13 @@ class BoostBuild < Formula
 
   conflicts_with "b2-tools", because: "both install `b2` binaries"
 
+  # Fix build system issues on Apple silicon. This change has aleady
+  # been merged upstream, remove this patch once it lands in a release.
+  patch do
+    url "https://github.com/boostorg/build/commit/456be0b7ecca065fbccf380c2f51e0985e608ba0.patch?full_index=1"
+    sha256 "e7a78145452fc145ea5d6e5f61e72df7dcab3a6eebb2cade6b4cfae815687f3a"
+  end
+
   def install
     system "./bootstrap.sh"
     system "./b2", "--prefix=#{prefix}", "install"

--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -19,6 +19,14 @@ class BoostMpi < Formula
   depends_on "boost"
   depends_on "open-mpi"
 
+  # Fix build system issues on Apple silicon. This change has aleady
+  # been merged upstream, remove this patch once it lands in a release.
+  patch do
+    url "https://github.com/boostorg/build/commit/456be0b7ecca065fbccf380c2f51e0985e608ba0.patch?full_index=1"
+    sha256 "e7a78145452fc145ea5d6e5f61e72df7dcab3a6eebb2cade6b4cfae815687f3a"
+    directory "tools/build"
+  end
+
   def install
     # "layout" should be synchronized with boost
     args = %W[

--- a/Formula/boost-python3.rb
+++ b/Formula/boost-python3.rb
@@ -18,6 +18,14 @@ class BoostPython3 < Formula
   depends_on "boost"
   depends_on "python@3.9"
 
+  # Fix build system issues on Apple silicon. This change has aleady
+  # been merged upstream, remove this patch once it lands in a release.
+  patch do
+    url "https://github.com/boostorg/build/commit/456be0b7ecca065fbccf380c2f51e0985e608ba0.patch?full_index=1"
+    sha256 "e7a78145452fc145ea5d6e5f61e72df7dcab3a6eebb2cade6b4cfae815687f3a"
+    directory "tools/build"
+  end
+
   def install
     # "layout" should be synchronized with boost
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Patch Boost's build system to build cleanly on Apple Silicon. This ports PR #59257 to the remaining boost packages.
