### PR TITLE
Fix PySide when targeting Apple silicon

### DIFF
--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -57,7 +57,7 @@ class Pyside < Formula
 
   test do
     system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2"
-    %w[
+    modules = %w[
       Core
       Gui
       Location
@@ -65,9 +65,14 @@ class Pyside < Formula
       Network
       Quick
       Svg
-      WebEngineWidgets
       Widgets
       Xml
-    ].each { |mod| system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2.Qt#{mod}" }
+    ]
+
+    # QT web engine is currently not supported on Apple
+    # silicon. Re-enable it once it has been enabled in the qt.rb.
+    modules << "WebEngineWidgets" unless Hardware::CPU.arch == :arm64
+
+    modules.each { |mod| system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2.Qt#{mod}" }
   end
 end

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -23,6 +23,15 @@ class Pyside < Formula
 
   def install
     ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
+    if MacOS.version == :big_sur
+      # Sysconfig promotes '11' to an integer which confuses the build
+      # system. See:
+      #  * https://bugreports.qt.io/browse/PYSIDE-1469
+      #  * https://codereview.qt-project.org/c/pyside/pyside-setup/+/328375
+      inreplace "build_scripts/wheel_utils.py",
+                "python_target_split = [int(x) for x in python_target.split('.')]",
+                "python_target_split = [int(x) for x in str(python_target).split('.')]"
+    end
 
     args = %W[
       --ignore-git

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -37,6 +37,7 @@ class Pyside < Formula
       --ignore-git
       --parallel=#{ENV.make_jobs}
       --install-scripts #{bin}
+      --rpath=#{lib}
     ]
 
     xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -38,6 +38,7 @@ class Pyside < Formula
       --parallel=#{ENV.make_jobs}
       --install-scripts #{bin}
       --rpath=#{lib}
+      --macos-sysroot=#{MacOS.sdk_path}
     ]
 
     xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

PySide currently doesn't build on Apple silicon and macOS SDK 11. This PR fixes a several issues related to SDK 11 and Apple silicon:

* Work around a build system issue on macOS SDK 11 caused by an unexpected return type (see https://codereview.qt-project.org/c/pyside/pyside-setup/+/328375 and https://bugreports.qt.io/browse/PYSIDE-1469).
* Set the rpath to avoid surprising runtime linking issues.
* Don't test web engine widgets as they are currently disabled in the main QT package on Apple silicon.