### PR TITLE
MMseqs2: Add support for Apple Silicon

### DIFF
--- a/Formula/mmseqs2.rb
+++ b/Formula/mmseqs2.rb
@@ -5,6 +5,7 @@ class Mmseqs2 < Formula
   version "12-113e3"
   sha256 "81fa0d77eab9d74b429567da00aa7ec2d46049537ce469595d7356b6d8b5458a"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/soedinglab/MMseqs2.git"
 
   bottle do
@@ -16,7 +17,7 @@ class Mmseqs2 < Formula
     sha256 "6a92a84f48542cac881e7bf4de5c7946d8038e8da1c799c98fe0992ed3f4d1a0" => :high_sierra
   end
 
-  depends_on "cmake" => :build
+  depends_on "cmake" => [:build, :test]
   depends_on "libomp"
   depends_on "wget"
 
@@ -28,10 +29,19 @@ class Mmseqs2 < Formula
         revision: "d53d8be3761ee625b0dcddda29b092bbd02244ef"
   end
 
+  resource "testdata" do
+    url "https://github.com/soedinglab/MMseqs2/releases/download/12-113e3/MMseqs2-Regression-Minimal.zip"
+    sha256 "ab0c2953d1c27736c22a57a1ccbb976c1320435fad82b5c579dbd716b7bae4ce"
+  end
+
   def install
     args = *std_cmake_args << "-DHAVE_TESTS=0" << "-DHAVE_MPI=0"
     args << "-DVERSION_OVERRIDE=#{version}"
-    args << "-DHAVE_SSE4_1=1"
+    args << if Hardware::CPU.arm?
+      "-DHAVE_ARM8=1"
+    else
+      "-DHAVE_SSE4_1=1"
+    end
 
     libomp = Formula["libomp"]
     args << "-DOpenMP_C_FLAGS=-Xpreprocessor\ -fopenmp\ -I#{libomp.opt_include}"
@@ -52,14 +62,12 @@ class Mmseqs2 < Formula
   end
 
   def caveats
-    "MMseqs2 requires at least SSE4.1 CPU instruction support." unless Hardware::CPU.sse4?
+    "MMseqs2 requires at least SSE4.1 CPU instruction support." unless Hardware::CPU.sse4? || Hardware::CPU.arm?
   end
 
   test do
-    system "#{bin}/mmseqs", "createdb", "#{pkgshare}/examples/QUERY.fasta", "q"
-    system "#{bin}/mmseqs", "cluster", "q", "res", "tmp", "-s", "1"
-    system "#{bin}/mmseqs", "createtsv", "q", "q", "res", "res.tsv"
-    assert_predicate testpath/"res.tsv", :exist?
-    assert_predicate (testpath/"res.tsv").size, :positive?
+    resource("testdata").stage do
+      system "./run_regression.sh", "#{bin}/mmseqs", "scratch"
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
There wasn't a bot for ARM64 before when I open the previous PR (https://github.com/Homebrew/homebrew-core/pull/65950). I hope that this time it will work. As @fxcoudert added a bottle for ARM64 Big Sur without the corresponding flag I am not quite sure what the latest arm64 bottle is actually doing. I added one small part of our comprehensive regression suite to actually test that MMseqs2 is doing what it is supposed to.