### PR TITLE
libssh: fix static libs

### DIFF
--- a/Formula/libssh.rb
+++ b/Formula/libssh.rb
@@ -4,6 +4,7 @@ class Libssh < Formula
   url "https://www.libssh.org/files/0.9/libssh-0.9.5.tar.xz"
   sha256 "acffef2da98e761fc1fd9c4fddde0f3af60ab44c4f5af05cd1b2d60a3fa08718"
   license "LGPL-2.1-or-later"
+  revision 1
   head "https://git.libssh.org/projects/libssh.git"
 
   bottle do
@@ -22,10 +23,11 @@ class Libssh < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", "-DWITH_STATIC_LIB=ON",
+      system "cmake", "..", "-DBUILD_STATIC_LIB=ON",
                             "-DWITH_SYMBOL_VERSIONING=OFF",
                             *std_cmake_args
       system "make", "install"
+      lib.install "src/libssh.a"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I noticed after upgrading that libssh no longer contains a static library. It turns out the `WITH_STATIC_LIB` parameter no longer works. This fixes the bottle again to contain both the shared and static lib.

It was changed in upstream here: https://github.com/libssh/libssh-mirror/commit/729c92606c88b60e7c255d393756d1d3b7e30698