### PR TITLE
Update netcat.rb

### DIFF
--- a/Formula/netcat.rb
+++ b/Formula/netcat.rb
@@ -1,8 +1,8 @@
 class Netcat < Formula
   desc "Utility for managing network connections"
-  homepage "https://netcat.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/netcat/netcat/0.7.1/netcat-0.7.1.tar.bz2"
-  sha256 "b55af0bbdf5acc02d1eb6ab18da2acd77a400bafd074489003f3df09676332bb"
+  homepage "https://nc110.sourceforge.io/"
+  url "https://sourceforge.net/projects/nc110/files/community%20releases/nc110.20180111.tar.xz"
+  sha256 "9c223f2472fc5b0d77c29a88536913e6573217cbc028dd276c30e689feeb182d"
   license "GPL-2.0"
 
   livecheck do


### PR DESCRIPTION
Netcat is currently set to the old repository from 2004 using version 0.7.1
The modern netcat is updated in 2018 using version 1.10

I've modified the homepage, url and shasum at the top.
Not sure if the rest is working properly as is.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
