### PR TITLE
unison: update livecheck

### DIFF
--- a/Formula/unison.rb
+++ b/Formula/unison.rb
@@ -6,10 +6,11 @@ class Unison < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/bcpierce00/unison.git", branch: "master"
 
+  # The "latest" release on GitHub sometimes points to unstable versions (e.g.,
+  # release candidates), so we check the Git tags instead.
   livecheck do
     url :stable
-    strategy :github_latest
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+(?:v\d+)?)["' >]}i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The "latest" release on the `unison` GitHub is currently pointing to an unstable version, `v2.51.4_rc1`, so we can't rely on the "latest" release being correct. This updates the `livecheck` block to check the Git tags instead, using a regex that will omit unstable versions.