### PR TITLE
kubeseal: update livecheck

### DIFF
--- a/Formula/kubeseal.rb
+++ b/Formula/kubeseal.rb
@@ -8,8 +8,7 @@ class Kubeseal < Formula
 
   livecheck do
     url :stable
-    regex(%r{href=.*?/tag/(?:helm[._-])?v?(.+?)["' >]}i)
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The "latest" release on GitHub for `kubeseal` is `helm-v1.13.2-r2` but this is only for the Helm chart, not the controller used in the formula. The actual latest version is `0.13.1` (from the `v0.13.1` tag), so the "latest" release on GitHub isn't reliable.

This updates the `livecheck` block to check the Git tags, using a regex that omits tags that don't use a format like `1.2.3`/`v1.2.3`/etc.