### PR TITLE
tectonic: add livecheck

### DIFF
--- a/Formula/tectonic.rb
+++ b/Formula/tectonic.rb
@@ -5,6 +5,14 @@ class Tectonic < Formula
   sha256 "5a2c910f822d59ddaf9d32a0e5f7f34ce30f44e4129513b3a0c50425cf48ac8f"
   license "MIT"
 
+  # As of writing, only the tags starting with `tectonic@` are release versions.
+  # NOTE: The `GithubLatest` strategy cannot be used here because the "latest"
+  # release on GitHub sometimes points to a tag that isn't a release version.
+  livecheck do
+    url :stable
+    regex(/^tectonic@v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any
     sha256 "98a8197e79a15cbb27f29f871d78ef1ee3a5bff4292afd0aa030b12bc8d6e7bb" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The GitHub repository for `tectonic` contains various tags that aren't related to release versions. The latest version reported by livecheck is currently `2@0.1.0`, from a `tectonic_bridge_graphite2@0.1.0` tag, instead of `0.4.1`.

This PR adds a `livecheck` block containing a regex that restricts matching to tags like `tectonic@1.2.3`, as these are the release versions that we use in this formula. We can't use the `GithubLatest` strategy here because the "latest" release on GitHub points to one of the non-release tags (`tectonic_dep_support@0.1.0`), so it's not correct.