### PR TITLE
freeimage: Add head url

### DIFF
--- a/Formula/freeimage.rb
+++ b/Formula/freeimage.rb
@@ -5,6 +5,7 @@ class Freeimage < Formula
   version "3.18.0"
   sha256 "f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd"
   license "FreeImage"
+  head "https://svn.code.sf.net/p/freeimage/svn/FreeImage/trunk/"
 
   livecheck do
     url :stable


### PR DESCRIPTION
Signed-off-by: Andreas Sandberg <andreas@sandberg.uk>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Add the ability to build the head version of FreeImage. The head contains an updated version of libpng which builds cleanly on Apple Silicon. The new version of libpng in the HEAD also fixes a use-after-free bug (CVE-2019-7317) that is present in old versions of libpng.

PR #67708 fixes the build issue on stable. 