### PR TITLE
Add composer v1

### DIFF
--- a/Formula/composer@1.rb
+++ b/Formula/composer@1.rb
@@ -1,0 +1,65 @@
+class ComposerAT1 < Formula
+  desc "Dependency Manager for PHP"
+  homepage "https://getcomposer.org/"
+  url "https://getcomposer.org/download/1.10.19/composer.phar"
+  sha256 "688bf8f868643b420dded326614fcdf969572ac8ad7fbbb92c28a631157d39e8"
+  license "MIT"
+
+  livecheck do
+    url "https://github.com/composer/composer.git"
+    regex(/^[\d.]+$/i)
+  end
+
+  bottle :unneeded
+
+  def install
+    bin.install "composer.phar" => "composer"
+  end
+
+  test do
+    (testpath/"composer.json").write <<~EOS
+      {
+        "name": "homebrew/test",
+        "authors": [
+          {
+            "name": "Homebrew"
+          }
+        ],
+        "require": {
+          "php": ">=5.3.4"
+          },
+        "autoload": {
+          "psr-0": {
+            "HelloWorld": "src/"
+          }
+        }
+      }
+    EOS
+
+    (testpath/"src/HelloWorld/greetings.php").write <<~EOS
+      <?php
+
+      namespace HelloWorld;
+
+      class Greetings {
+        public static function sayHelloWorld() {
+          return 'HelloHomebrew';
+        }
+      }
+    EOS
+
+    (testpath/"tests/test.php").write <<~EOS
+      <?php
+
+      // Autoload files using the Composer autoloader.
+      require_once __DIR__ . '/../vendor/autoload.php';
+
+      use HelloWorld\\Greetings;
+
+      echo Greetings::sayHelloWorld();
+    EOS
+
+    system "#{bin}/composer", "install"
+    assert_match /^HelloHomebrew$/, shell_output("php tests/test.php")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Composer v1 is still needed, because there are existing many php packages there are only supporting this version.