### PR TITLE
Fix grpc_cli missing a library for execution

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -80,6 +80,7 @@ class Grpc < Formula
     EOS
     system ENV.cc, "test.cpp", "-I#{include}", "-L#{lib}", "-lgrpc", "-o", "test"
     system "./test"
-    assert_match "Received an error when querying services endpoint.", shell_output("grpc_cli ls localhost:#{free_port} 2>&1", 1)
+    output = shell_output("grpc_cli ls localhost:#{free_port} 2>&1", 1)
+    assert_match "Received an error when querying services endpoint.", output
   end
 end

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -80,5 +80,6 @@ class Grpc < Formula
     EOS
     system ENV.cc, "test.cpp", "-I#{include}", "-L#{lib}", "-lgrpc", "-o", "test"
     system "./test"
+    system "grpc_cli", "help", "ls"
   end
 end

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -65,7 +65,7 @@ class Grpc < Formula
       system "cmake", *args
       system "make", "grpc_cli"
       bin.install "grpc_cli"
-      lib.install Dir["libgrpc++_test_config*.{dylib,so}.*"]
+      lib.install Dir["libgrpc++_test_config.*.{dylib,so}"]
     end
   end
 

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -80,6 +80,6 @@ class Grpc < Formula
     EOS
     system ENV.cc, "test.cpp", "-I#{include}", "-L#{lib}", "-lgrpc", "-o", "test"
     system "./test"
-    assert_match "Received an error when querying services endpoint." shell_output("grpc_cli ls localhost:#{free_port}", 1)
+    assert_match "Received an error when querying services endpoint.", shell_output("grpc_cli ls localhost:#{free_port} 2>&1", 1)
   end
 end

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -65,7 +65,7 @@ class Grpc < Formula
       system "cmake", *args
       system "make", "grpc_cli"
       bin.install "grpc_cli"
-      lib.install Dir["libgrpc++_test_config.*.{dylib,so}"]
+      lib.install Dir["libgrpc++_test_config.{*.dylib,so.*}"]
     end
   end
 

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -65,7 +65,7 @@ class Grpc < Formula
       system "cmake", *args
       system "make", "grpc_cli"
       bin.install "grpc_cli"
-      lib.install Dir["libgrpc++_test_config.{*.dylib,so.*}"]
+      lib.install Dir["libgrpc++_test_config*.{dylib,so}*"]
     end
   end
 

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -80,6 +80,6 @@ class Grpc < Formula
     EOS
     system ENV.cc, "test.cpp", "-I#{include}", "-L#{lib}", "-lgrpc", "-o", "test"
     system "./test"
-    system "grpc_cli", "help", "ls"
+    assert_match "Received an error when querying services endpoint." shell_output("grpc_cli ls localhost:#{free_port}", 1)
   end
 end

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -6,7 +6,7 @@ class Grpc < Formula
       revision: "ee5b762f33a42170144834f5ab7efda9d76c480b",
       shallow:  false
   license "Apache-2.0"
-  revision 2
+  revision 3
   head "https://github.com/grpc/grpc.git"
 
   livecheck do


### PR DESCRIPTION
This glob pattern doesn't match the actual file on macOS anymore.
On MacOS the file is called `libgrpc++_test_config.1.dylib`. Trying to run `grpc_cli` results in an error:
```sh
$ grpc_cli ls localhost:8080
dyld: Library not loaded: @rpath/libgrpc++_test_config.1.dylib
  Referenced from: /usr/local/bin/grpc_cli
  Reason: image not found
[1]    40338 abort      grpc_cli ls localhost:8080
```

I am not sure if the new pattern also matches in linux. Is there a way I can provide a test which makes sure we do not break it again? It broke during https://github.com/Homebrew/homebrew-core/pull/67474

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
