### PR TITLE
opencascade: Set RPATH when installing binaries

### DIFF
--- a/Formula/opencascade.rb
+++ b/Formula/opencascade.rb
@@ -47,6 +47,7 @@ class Opencascade < Formula
                     "-D3RDPARTY_TK_LIBRARY_DIR:PATH=#{tcltk.opt_lib}",
                     "-D3RDPARTY_TCL_LIBRARY:FILEPATH=#{tcltk.opt_lib}/libtcl#{tcltk.version.major_minor}.dylib",
                     "-D3RDPARTY_TK_LIBRARY:FILEPATH=#{tcltk.opt_lib}/libtk#{tcltk.version.major_minor}.dylib",
+                    "-DCMAKE_INSTALL_RPATH:FILEPATH=#{lib}",
                     *std_cmake_args
     system "make", "install"
 


### PR DESCRIPTION
DRAWEXE in OpenCASCADE needs RPATH to be set to correctly find dynamically loaded modules. Since the modules are installed in installed in a directory that isn't normally searched by the dynamic loader.

This fixes test issues on Big Sur on Apple silicon.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
