### PR TITLE
Remove useless CMAKE_BUILD_TYPE=Release

### DIFF
--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -65,7 +65,6 @@ class ClangFormat < Formula
       args << "-DLLVM_ENABLE_LIBCXX=ON"
       args << "-DLLVM_EXTERNAL_PROJECTS=\"clang;libcxx;libcxxabi\""
       args << "-DLLVM_EXTERNAL_LIBCXX_SOURCE_DIR=\"#{buildpath/"projects/libcxx"}\""
-      args << "-DCMAKE_BUILD_TYPE=Release"
       args << ".."
       system "cmake", "-G", "Ninja", *args
       system "ninja", "clang-format"

--- a/Formula/itpp.rb
+++ b/Formula/itpp.rb
@@ -29,10 +29,7 @@ class Itpp < Formula
 
   def install
     mkdir "build" do
-      args = std_cmake_args
-      args.delete "-DCMAKE_BUILD_TYPE=None"
-      args << "-DCMAKE_BUILD_TYPE=Release"
-      system "cmake", "..", *args
+      system "cmake", "..", *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Formula/lasi.rb
+++ b/Formula/lasi.rb
@@ -36,7 +36,7 @@ class Lasi < Formula
     # installed files.  Instead we don't build them at all.
     inreplace "CMakeLists.txt", "add_subdirectory(examples)", ""
 
-    system "cmake", ".", "-DCMAKE_BUILD_TYPE=Release", *args
+    system "cmake", ".", *args
 
     system "make", "install"
   end

--- a/Formula/libstxxl.rb
+++ b/Formula/libstxxl.rb
@@ -24,10 +24,8 @@ class Libstxxl < Formula
   depends_on "cmake" => :build
 
   def install
-    args = std_cmake_args - %w[-DCMAKE_BUILD_TYPE=None]
-    args << "-DCMAKE_BUILD_TYPE=Release"
     mkdir "build" do
-      system "cmake", "..", *args
+      system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
   end

--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -45,8 +45,8 @@ class Minetest < Formula
   def install
     (buildpath/"games/minetest_game").install resource("minetest_game")
 
-    args = std_cmake_args - %w[-DCMAKE_BUILD_TYPE=None]
-    args << "-DCMAKE_BUILD_TYPE=Release" << "-DBUILD_CLIENT=1" << "-DBUILD_SERVER=0"
+    args = std_cmake_args
+    args << "-DBUILD_CLIENT=1" << "-DBUILD_SERVER=0"
     args << "-DENABLE_FREETYPE=1" << "-DCMAKE_EXE_LINKER_FLAGS='-L#{Formula["freetype"].opt_lib}'"
     args << "-DENABLE_GETTEXT=1" << "-DCUSTOM_GETTEXT_PATH=#{Formula["gettext"].opt_prefix}"
 

--- a/Formula/monetdb.rb
+++ b/Formula/monetdb.rb
@@ -27,7 +27,6 @@ class Monetdb < Formula
     mkdir "build" do
       system "cmake", "..", *std_cmake_args,
                       "-DRELEASE_VERSION=ON",
-                      "-DCMAKE_BUILD_TYPE=Release",
                       "-DASSERT=OFF",
                       "-DSTRICT=OFF",
                       "-DTESTING=OFF",

--- a/Formula/onnxruntime.rb
+++ b/Formula/onnxruntime.rb
@@ -29,7 +29,6 @@ class Onnxruntime < Formula
       -DPYTHON_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3
       -Donnxruntime_BUILD_SHARED_LIB=ON
       -Donnxruntime_BUILD_UNIT_TESTS=OFF
-      -DCMAKE_BUILD_TYPE=Release
     ]
 
     mkdir "build" do


### PR DESCRIPTION
`-DCMAKE_BUILD_TYPE=Release` has been part of `std_cmake_args` since April 2015 :) https://github.com/Homebrew/brew/commit/a5c4eb2d3eae9e2fd7b7f0fd431fe763688af82b