### PR TITLE
go-bindata: fix for Apple Silicon

### DIFF
--- a/Formula/go-bindata.rb
+++ b/Formula/go-bindata.rb
@@ -18,6 +18,7 @@ class GoBindata < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/kevinburke").mkpath
     ln_s buildpath, buildpath/"src/github.com/kevinburke/go-bindata"
     system "go", "build", "-o", bin/"go-bindata", "./go-bindata"

--- a/Formula/go-bindata.rb
+++ b/Formula/go-bindata.rb
@@ -4,6 +4,7 @@ class GoBindata < Formula
   url "https://github.com/kevinburke/go-bindata/archive/v3.22.0.tar.gz"
   sha256 "1ad4c1e8db221aadd53c69d4cb4e3ebfeae203ecc61f40dfd4679c2b0d23a932"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
This is a call for help. `go-bindata` is one of the top blockers on Apple Silicon (https://github.com/Homebrew/brew/issues/10152), and we need to figure out how to fix it.