### PR TITLE
libbitcoin: fix for Apple Silicon

### DIFF
--- a/Formula/libbitcoin.rb
+++ b/Formula/libbitcoin.rb
@@ -43,6 +43,7 @@ class Libbitcoin < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
+                          "--with-boost-libdir=#{Formula["boost"].opt_lib}",
                           "--with-png",
                           "--with-qrencode"
     system "make", "install"


### PR DESCRIPTION
This is a call for help. `libbitcoin` is one of the top blockers on Apple Silicon (https://github.com/Homebrew/brew/issues/10152), and we need to figure out how to fix it.