### PR TITLE
physfs: fix for Apple Silicon

### DIFF
--- a/Formula/physfs.rb
+++ b/Formula/physfs.rb
@@ -31,6 +31,7 @@ class Physfs < Formula
     mkdir "macbuild" do
       args = std_cmake_args
       args << "-DPHYSFS_BUILD_TEST=TRUE"
+      args << "-DCMAKE_INSTALL_RPATH=#{lib}"
       args << "-DPHYSFS_BUILD_WX_TEST=FALSE" unless build.head?
       system "cmake", "..", *args
       system "make", "install"


### PR DESCRIPTION
This is a call for help. `physfs` is one of the top blockers on Apple Silicon (https://github.com/Homebrew/brew/issues/10152), and we need to figure out how to fix it.