### PR TITLE
openssh: build for Apple Silicon

### DIFF
--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -6,7 +6,7 @@ class Openssh < Formula
   version "8.4p1"
   sha256 "5a01d22e407eb1c05ba8a8f7c654d388a13e9f226e4ed33bd38748dafa1d2b24"
   license "SSH-OpenSSH"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/"


### PR DESCRIPTION
One of the most-downloaded formula with no Apple Silicon bottle… let's try to fix it