### PR TITLE
libffi: apply Apple-supplied patches for Apple Silicon

### DIFF
--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -6,6 +6,7 @@ class Libffi < Formula
   mirror "https://github.com/libffi/libffi/releases/download/v3.3/libffi-3.3.tar.gz"
   sha256 "72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056"
   license "MIT"
+  revision 1
 
   bottle do
     cellar :any
@@ -24,6 +25,12 @@ class Libffi < Formula
   end
 
   keg_only :provided_by_macos
+
+  # Improved aarch64-apple-darwin support. See https://github.com/libffi/libffi/pull/565
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/a4a91e61/libffi/libffi-3.3-arm64.patch"
+    sha256 "ee084f76f69df29ed0fa1bc8957052cadc3bbd8cd11ce13b81ea80323f9cb4a3"
+  end
 
   def install
     args = std_configure_args


### PR DESCRIPTION
This PR applies the following patches to libffi-3.3:

Port to iOS/arm64e:
https://github.com/libffi/libffi/commit/4c7bde32ea3af479babdf527d94f241282951cb9

x86: Support building without FFI_GO_CLOSURES (Apple):
https://github.com/jeremyhu/libffi/commit/9f3d2b4eb62168e19962dd62c14fed48a576ee57

arm: Support building without FFI_GO_CLOSURES (Apple):
https://github.com/jeremyhu/libffi/commit/9c939534a278b3d5cb73104e69458bd3c24cb4bd

testsuite: Add a missing include of <inttypes.h> to fix build failure… (Apple):
https://github.com/jeremyhu/libffi/commit/0fa448827b2aabffbf2fdab0418e5e571db27c89

arm64e: use a dedicated dylib for trampolines, so it can be remapped (Apple):
https://github.com/jeremyhu/libffi/commit/a1928d7809c7a8decd85255290f287072b907509

arm64e: libunwind requires that the CFA match the value used to sign LR (Apple):
https://github.com/jeremyhu/libffi/commit/5c91f6048da553ed92984310246a9f804d8bb210

Fix variadic arguments on arm64 darwin ABI (Apple):
https://github.com/jeremyhu/libffi/commit/6aa41bec9bf4b87bfbe70c34d4770bc9962298ca

Set FFI_TRAMPOLINE_WHOLE_DYLIB on aarch64-apple-darwin:
https://github.com/hjelmn/libffi/commit/52b84b7b4b46b9301ca0710128e182f10b410e34

These should improve support of libffi on Apple Silicon. These patches were
verified using ghc 8.10.3. Without these patches ghc's ffi tests crash.

Signed-off-by: Nathan Hjelm <hjelmn@cs.unm.edu>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
