### PR TITLE
mapnik: fix for boost 1.75

### DIFF
--- a/Formula/mapnik.rb
+++ b/Formula/mapnik.rb
@@ -35,10 +35,17 @@ class Mapnik < Formula
   depends_on "webp"
 
   on_macos do
-    patch :p1 do
+    patch do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/57e635431e09fa1b00f3e1fd9574ad516de13308/mapnik/mapnik-2.0.23.patch"
       sha256 "b946071a95a52757e1aabb03ed7768408b864e20f46cbea39bda2cd1499b256c"
     end
+  end
+
+  # Fix for Boost >= 1.75
+  # https://github.com/mapnik/mapnik/issues/4201
+  patch do
+    url "https://github.com/mapnik/mapnik/commit/49e0ef18.patch?full_index=1"
+    sha256 "d8f12a85ad78f95e3cb2b3b5485e586c250fe2230a90874c0a70843189cc42f5"
   end
 
   def install


### PR DESCRIPTION
Trying the upstream fix at https://github.com/mapnik/mapnik/issues/4201#issuecomment-756160976