### PR TITLE
Remove GOPATH from formulae that already have :arm64_big_sur bottle

### DIFF
--- a/Formula/darksky-weather.rb
+++ b/Formula/darksky-weather.rb
@@ -17,16 +17,12 @@ class DarkskyWeather < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
-    (buildpath/"src/github.com/genuinetools/weather").install buildpath.children
-
-    cd "src/github.com/genuinetools/weather" do
-      project = "github.com/genuinetools/weather"
-      ldflags = ["-X #{project}/version.GITCOMMIT=homebrew",
-                 "-X #{project}/version.VERSION=v#{version}"]
-      system "go", "build", "-o", bin/"weather", "-ldflags", ldflags.join(" ")
-      prefix.install_metafiles
-    end
+    project = "github.com/genuinetools/weather"
+    ldflags = ["-s -w",
+               "-X #{project}/version.GITCOMMIT=homebrew",
+               "-X #{project}/version.VERSION=v#{version}"]
+    system "go", "build", *std_go_args, "-ldflags", ldflags.join(" ")
+    mv bin/"darksky-weather", bin/"weather"
   end
 
   test do

--- a/Formula/dehydrated.rb
+++ b/Formula/dehydrated.rb
@@ -1,25 +1,15 @@
 class Dehydrated < Formula
   desc "LetsEncrypt/acme client implemented as a shell-script"
   homepage "https://dehydrated.io"
-  url "https://github.com/lukas2511/dehydrated/archive/v0.7.0.tar.gz"
+  url "https://github.com/dehydrated-io/dehydrated/archive/v0.7.0.tar.gz"
   sha256 "1c5f12c2e57e64b1762803f82f0f7e767a72e65a6ce68e4d1ec197e61b9dc4f9"
   license "MIT"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "4b9332dca6c3e4d9b480836fa0655fa6982f516e55578ce73d7628560da90ade" => :big_sur
-    sha256 "28a03e3c28568d6d71869669a5902d67c62466f1c7e38ec4348b825a8e0b615e" => :arm64_big_sur
-    sha256 "9dd59ec022c69ea48b0ffc7bc04ee3104cc7138a69d62f4cd0f39e8f8e511cc1" => :catalina
-    sha256 "aee673b9f0911f72f685cc2cd55018b0d0d1db9a87e9896c4c488f434eda6449" => :mojave
-  end
+  bottle :unneeded
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/lukas2511/dehydrated").install buildpath.children
-    cd "src/github.com/lukas2511/dehydrated" do
-      bin.install "dehydrated"
-      prefix.install_metafiles
-    end
+    bin.install "dehydrated"
+    man1.install "docs/man/dehydrated.1"
   end
 
   test do

--- a/Formula/docker-ls.rb
+++ b/Formula/docker-ls.rb
@@ -17,16 +17,10 @@ class DockerLs < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
+    system "go", "generate", "./lib"
 
-    (buildpath/"src/github.com/mayflower/docker-ls").install buildpath.children
-
-    system "go", "generate", "github.com/mayflower/docker-ls/lib"
-
-    cd "src/github.com/mayflower/docker-ls" do
-      system "go", "build", "-o", bin/"docker-ls", "./cli/docker-ls"
-      system "go", "build", "-o", bin/"docker-rm", "./cli/docker-rm"
-      prefix.install_metafiles
+    %w[docker-ls docker-rm].each do |name|
+      system "go", "build", "-trimpath", "-o", bin/name, "-ldflags", "-s -w", "./cli/#{name}"
     end
   end
 

--- a/Formula/docker-machine-parallels.rb
+++ b/Formula/docker-machine-parallels.rb
@@ -1,8 +1,9 @@
 class DockerMachineParallels < Formula
   desc "Parallels Driver for Docker Machine"
   homepage "https://github.com/Parallels/docker-machine-parallels"
-  url "https://github.com/Parallels/docker-machine-parallels/archive/v2.0.1.tar.gz"
-  sha256 "af52903482bff0f13200cc5aca39037cd8625cc663120e1e4d3be13aeda2720d"
+  url "https://github.com/Parallels/docker-machine-parallels.git",
+      tag:      "v2.0.1",
+      revision: "a1c3d495487413bdd24a562c0edee1af1cfc2f0f"
   license "MIT"
   head "https://github.com/Parallels/docker-machine-parallels.git"
 
@@ -19,17 +20,8 @@ class DockerMachineParallels < Formula
   depends_on "docker-machine"
 
   def install
-    ENV["GOPATH"] = buildpath
-
-    path = buildpath/"src/github.com/Parallels/docker-machine-parallels"
-    path.install Dir["*"]
-
-    cd path do
-      system "make", "build"
-      bin.install "bin/docker-machine-driver-parallels"
-    end
-
-    prefix.install_metafiles path
+    system "make", "build"
+    bin.install "bin/docker-machine-driver-parallels"
   end
 
   test do

--- a/Formula/fzf.rb
+++ b/Formula/fzf.rb
@@ -19,8 +19,7 @@ class Fzf < Formula
   uses_from_macos "ncurses"
 
   def install
-    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
-    system "go", "build", "-o", bin/"fzf", "-ldflags", "-X main.version=#{version} -X main.revision=brew"
+    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.version=#{version} -X main.revision=brew"
 
     prefix.install "install", "uninstall"
     (prefix/"shell").install %w[bash zsh fish].map { |s| "shell/key-bindings.#{s}" }

--- a/Formula/go-statik.rb
+++ b/Formula/go-statik.rb
@@ -19,13 +19,8 @@ class GoStatik < Formula
   conflicts_with "statik", because: "both install `statik` binaries"
 
   def install
-    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
-    (buildpath/"src/github.com/rakyll/statik").install buildpath.children
-
-    cd "src/github.com/rakyll/statik" do
-      system "go", "build", "-o", bin/"statik"
-      prefix.install_metafiles
-    end
+    system "go", "build", *std_go_args, "-ldflags", "-s -w"
+    mv bin/"go-statik", bin/"statik"
   end
 
   test do

--- a/Formula/hcloud.rb
+++ b/Formula/hcloud.rb
@@ -17,15 +17,8 @@ class Hcloud < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
-    (buildpath/"src/github.com/hetznercloud/cli").install buildpath.children
-
-    cd "src/github.com/hetznercloud/cli" do
-      ldflags = "-w -X github.com/hetznercloud/cli/cli.Version=v#{version}"
-      system "go", "build", "-o", bin/"hcloud", "-ldflags", ldflags,
-                   "./cmd/hcloud"
-      prefix.install_metafiles
-    end
+    ldflags = "-s -w -X github.com/hetznercloud/cli/cli.Version=v#{version}"
+    system "go", "build", *std_go_args, "-ldflags", ldflags, "./cmd/hcloud"
 
     output = Utils.safe_popen_read("#{bin}/hcloud", "completion", "bash")
     (bash_completion/"hcloud").write output

--- a/Formula/iamy.rb
+++ b/Formula/iamy.rb
@@ -20,14 +20,8 @@ class Iamy < Formula
   depends_on "awscli"
 
   def install
-    ENV["GOPATH"] = buildpath
-    src = buildpath/"src/github.com/99designs/iamy"
-    src.install buildpath.children
-    src.cd do
-      system "go", "build", "-o", bin/"iamy", "-ldflags",
-             "-X main.Version=v#{version}"
-      prefix.install_metafiles
-    end
+    system "go", "build", *std_go_args, "-ldflags",
+            "-s -w -X main.Version=v#{version}"
   end
 
   test do

--- a/Formula/jd.rb
+++ b/Formula/jd.rb
@@ -16,14 +16,7 @@ class Jd < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    dir = buildpath/"src/github.com/josephburnett/jd"
-    dir.install buildpath.children
-
-    cd dir do
-      system "go", "build", "-o", bin/"jd"
-      prefix.install_metafiles
-    end
+    system "go", "build", *std_go_args, "-ldflags", "-s -w"
   end
 
   test do

--- a/Formula/megacmd.rb
+++ b/Formula/megacmd.rb
@@ -19,12 +19,7 @@ class Megacmd < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/t3rm1n4l/megacmd").install buildpath.children
-    cd "src/github.com/t3rm1n4l/megacmd" do
-      system "go", "build", "-o", bin/"megacmd"
-      prefix.install_metafiles
-    end
+    system "go", "build", *std_go_args, "-ldflags", "-s -w"
   end
 
   test do

--- a/Formula/mkcert.rb
+++ b/Formula/mkcert.rb
@@ -16,13 +16,7 @@ class Mkcert < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
-    (buildpath/"src/github.com/FiloSottile/mkcert").install buildpath.children
-
-    cd "src/github.com/FiloSottile/mkcert" do
-      system "go", "build", "-o", bin/"mkcert", "-ldflags", "-X main.Version=v#{version}"
-      prefix.install_metafiles
-    end
+    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.Version=v#{version}"
   end
 
   test do

--- a/Formula/scmpuff.rb
+++ b/Formula/scmpuff.rb
@@ -18,13 +18,7 @@ class Scmpuff < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
-    (buildpath/"src/github.com/mroth/scmpuff").install buildpath.children
-    cd "src/github.com/mroth/scmpuff" do
-      system "go", "build", "-ldflags", "-X main.VERSION=#{version}",
-                   "-o", bin/"scmpuff"
-      prefix.install_metafiles
-    end
+    system "go", "build", *std_go_args, "-ldflags", "-s -v -X main.VERSION=#{version}"
   end
 
   test do

--- a/Formula/slackcat.rb
+++ b/Formula/slackcat.rb
@@ -18,14 +18,7 @@ class Slackcat < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-
-    src = buildpath/"src/github.com/vektorlab/slackcat"
-    src.install buildpath.children
-    src.cd do
-      system "go", "build", "-o", bin/"slackcat", "-ldflags", "-X main.version=#{version}"
-      prefix.install_metafiles
-    end
+    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.version=#{version}"
   end
 
   test do

--- a/Formula/ssllabs-scan.rb
+++ b/Formula/ssllabs-scan.rb
@@ -18,8 +18,7 @@ class SsllabsScan < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    system "go", "build", "-o", bin/"ssllabs-scan", "ssllabs-scan-v3.go"
+    system "go", "build", *std_go_args, "-ldflags", "-s -w", "ssllabs-scan-v3.go"
   end
 
   def caveats

--- a/Formula/up.rb
+++ b/Formula/up.rb
@@ -17,14 +17,7 @@ class Up < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
-    dir = buildpath/"src/github.com/akavel/up"
-    dir.install buildpath.children
-
-    cd dir do
-      system "go", "build", "-o", bin/"up", "up.go"
-      prefix.install_metafiles
-    end
+    system "go", "build", *std_go_args, "-ldflags", "-s -w", "up.go"
   end
 
   test do

--- a/Formula/velero.rb
+++ b/Formula/velero.rb
@@ -17,26 +17,18 @@ class Velero < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    dir = buildpath/"src/github.com/vmware-tanzu/velero"
-    dir.install buildpath.children - [buildpath/".brew_home"]
+    system "go", "build", *std_go_args, "-installsuffix", "static",
+                  "-ldflags",
+                  "-s -w -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=v#{version}",
+                  "./cmd/velero"
 
-    cd dir do
-      system "go", "build", "-o", bin/"velero", "-installsuffix", "static",
-                   "-ldflags",
-                   "-X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=v#{version}",
-                   "./cmd/velero"
+    # Install bash completion
+    output = Utils.safe_popen_read("#{bin}/velero", "completion", "bash")
+    (bash_completion/"velero").write output
 
-      # Install bash completion
-      output = Utils.safe_popen_read("#{bin}/velero", "completion", "bash")
-      (bash_completion/"velero").write output
-
-      # Install zsh completion
-      output = Utils.safe_popen_read("#{bin}/velero", "completion", "zsh")
-      (zsh_completion/"_velero").write output
-
-      prefix.install_metafiles
-    end
+    # Install zsh completion
+    output = Utils.safe_popen_read("#{bin}/velero", "completion", "zsh")
+    (zsh_completion/"_velero").write output
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This PR removes usage of GOPATH for formulae that already have `arm64_big_sur` bottles (ie. these formulae are buildable using go modules because we use go1.16 for building arm64_big_sur and go1.16 using modules by default)

`dehydrated` doesn't actually use `go` at all 🤷 

I believe it's safe enough to do in a single PR and revision bump is not required. Please let me know if I'm mistaken.

