### PR TITLE
ocaml-zarith 1.11 (new formula)

### DIFF
--- a/Formula/ocaml-zarith.rb
+++ b/Formula/ocaml-zarith.rb
@@ -1,0 +1,42 @@
+class OcamlZarith < Formula
+  desc "OCaml library for arbitrary-precision arithmetic"
+  homepage "https://github.com/ocaml/Zarith"
+  url "https://github.com/ocaml/Zarith/archive/release-1.11.tar.gz"
+  sha256 "f996af120a10fd06a8272ae99b7affd57cef49c57a3a596e2f589147dd183684"
+  license "LGPL-2.0-only"
+
+  depends_on "ocaml-findlib" => :build
+  depends_on "gmp"
+  depends_on "ocaml"
+
+  def install
+    ENV["OCAMLFIND_DESTDIR"] = lib/"ocaml"
+
+    (lib/"ocaml").mkpath
+    cp Formula["ocaml"].opt_lib/"ocaml/Makefile.config", lib/"ocaml"
+
+    # install in #{lib}/ocaml not #{HOMEBREW_PREFIX}/lib/ocaml
+    inreplace lib/"ocaml/Makefile.config" do |s|
+      s.change_make_var! "prefix", prefix
+    end
+
+    ENV.deparallelize
+    system "./configure"
+    system "make"
+    (lib/"ocaml/stublibs").mkpath # `make install` assumes this directory exists
+    system "make", "install", "STDLIBDIR=#{lib}/ocaml"
+
+    pkgshare.install "tests"
+
+    rm lib/"ocaml/Makefile.config" # avoid conflict with ocaml
+  end
+
+  test do
+    cp_r pkgshare/"tests/.", "."
+    system Formula["ocaml"].opt_bin/"ocamlopt", "-I", lib/"ocaml/zarith",
+           "-ccopt", "-L#{lib}/ocaml -L#{Formula["gmp"].opt_lib}",
+           "zarith.cmxa", "-o", "zq.exe", "zq.ml"
+    expected = IO.read("zq.output64", mode: "rb")
+    assert_equal expected, shell_output("./zq.exe")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a dependency for Coq 8.13, which no longer uses the deprecated Num library. See #68469.

The formula is heavily based on ocaml-num. I don't really understand all the manipulation going on in the install block so I'm not sure if it's all still necessary.