### PR TITLE
mongrel2: set -undefined dynamic_lookup only on mac

### DIFF
--- a/Formula/mongrel2.rb
+++ b/Formula/mongrel2.rb
@@ -43,7 +43,9 @@ class Mongrel2 < Formula
 
     # Mongrel2 pulls from these ENV vars instead
     ENV["OPTFLAGS"] = "#{ENV.cflags} #{ENV.cppflags}"
-    ENV["OPTLIBS"] = "#{ENV.ldflags} -undefined dynamic_lookup"
+    on_macos do
+      ENV["OPTLIBS"] = "#{ENV.ldflags} -undefined dynamic_lookup"
+    end
 
     system "make", "all"
     system "make", "install", "PREFIX=#{prefix}"


### PR DESCRIPTION
This is a mac-only flag

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
