### PR TITLE
openkim-models: add livecheck

### DIFF
--- a/Formula/openkim-models.rb
+++ b/Formula/openkim-models.rb
@@ -5,6 +5,11 @@ class OpenkimModels < Formula
   sha256 "50338084ece92ec0fb13b0bbdf357b5d7450e26068ba501f23c315f814befc26"
   revision 1
 
+  livecheck do
+    url "https://s3.openkim.org/archives/collection/"
+    regex(/href=.*?openkim-models[._-]v?(\d+(?:-\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 "d8eb0ffb78085bf3d5770d022378d82631e75c8975611bcd4f6b63a33f0ef74c" => :big_sur
     sha256 "9420d4f91176705c43778e8566407d3310924b35dc0e10c3ceaaac86dc5c3713" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `openkim-models`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.