### PR TITLE
ocrmypdf: depend on brewed libffi

### DIFF
--- a/Formula/ocrmypdf.rb
+++ b/Formula/ocrmypdf.rb
@@ -6,6 +6,7 @@ class Ocrmypdf < Formula
   url "https://files.pythonhosted.org/packages/61/da/c95cdef733b639abcf8f4d93f4e4cd691c052ebafae1200376e100fca27e/ocrmypdf-11.4.5.tar.gz"
   sha256 "416a9c4321bfc844f250694b8c68ebb538f60609bbc8686bd9f84a13c5127d68"
   license "MPL-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -24,6 +25,7 @@ class Ocrmypdf < Formula
   depends_on "jbig2enc"
   depends_on "jpeg"
   depends_on "leptonica"
+  depends_on "libffi"
   depends_on "libpng"
   depends_on "pngquant"
   depends_on "pybind11"
@@ -32,7 +34,6 @@ class Ocrmypdf < Formula
   depends_on "tesseract"
   depends_on "unpaper"
 
-  uses_from_macos "libffi"
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
   uses_from_macos "zlib"


### PR DESCRIPTION
Fixes CI failure from #68476.

Some of its dependencies already depend on Homebrew libffi, so this does
not introduce a new dependency for users who already have it installed.

Plus, CI runs in #68476 suggest that ocrmypdf is already making use of
Homebrew libffi, so may as well make that dependency explicit.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?