### PR TITLE
embree: build on ARM

### DIFF
--- a/Formula/embree.rb
+++ b/Formula/embree.rb
@@ -19,15 +19,17 @@ class Embree < Formula
   depends_on "tbb"
 
   def install
-    max_isa = MacOS.version.requires_sse42? ? "SSE4.2" : "SSE2"
-
-    args = std_cmake_args + %W[
+    args = std_cmake_args + %w[
       -DBUILD_TESTING=OFF
       -DEMBREE_IGNORE_CMAKE_CXX_FLAGS=OFF
       -DEMBREE_ISPC_SUPPORT=ON
-      -DEMBREE_MAX_ISA=#{max_isa}
       -DEMBREE_TUTORIALS=OFF
     ]
+
+    if Hardware::CPU.intel?
+      max_isa = MacOS.version.requires_sse42? ? "SSE4.2" : "SSE2"
+      args << "-DEMBREE_MAX_ISA=#{max_isa}"
+    end
 
     mkdir "build" do
       system "cmake", *args, ".."

--- a/Formula/ispc.rb
+++ b/Formula/ispc.rb
@@ -2,8 +2,9 @@ class Ispc < Formula
   desc "Compiler for SIMD programming on the CPU"
   homepage "https://ispc.github.io"
   url "https://github.com/ispc/ispc/archive/v1.15.0.tar.gz"
-  sha256 "788f44abefa508644384307c9ea69ef311ce5d4cfcb513b89e56d08f04d0d4be"
+  sha256 "2658ff00dc045ac9fcefbf6bd26dffaf723b059a942a27df91bbb61bc503a285"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
Do not call `MacOS.version.requires_sse42` unless we're on Intel