### PR TITLE
dyld-headers: update livecheck

### DIFF
--- a/Formula/dyld-headers.rb
+++ b/Formula/dyld-headers.rb
@@ -7,7 +7,7 @@ class DyldHeaders < Formula
 
   livecheck do
     url "https://opensource.apple.com/tarballs/dyld/"
-    regex(/href=.*?dyld[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?dyld[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the regex in the `livecheck` block to align with the regexes for the other opensource.apple.com formulae.

This uses the common pattern for identifying the version from a tarball in a URL and the only difference is that we've modified the standard regex for versions like `1.2.3` to also match versions like `1`. Some software on opensource.apple.com will alternate between only using a major version and using major/minor/patch, so this is contextually appropriate.