### PR TITLE
abseil: build for Apple Silicon

### DIFF
--- a/Formula/abseil.rb
+++ b/Formula/abseil.rb
@@ -4,7 +4,7 @@ class Abseil < Formula
   url "https://github.com/abseil/abseil-cpp/archive/20200923.2.tar.gz"
   sha256 "bf3f13b13a0095d926b25640e060f7e13881bd8a792705dd9e161f3c2b9aa976"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   bottle do
     cellar :any
@@ -19,6 +19,7 @@ class Abseil < Formula
     mkdir "build" do
       system "cmake", "..",
                       *std_cmake_args,
+                      "-DCMAKE_INSTALL_RPATH=#{lib}",
                       "-DCMAKE_CXX_STANDARD=17",
                       "-DBUILD_SHARED_LIBS=ON"
       system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Fixes test error of
```
dyld: Library not loaded: @rpath/libabsl_strings_internal.dylib
  Referenced from: /opt/homebrew/opt/abseil/lib/libabsl_strings.dylib
  Reason: image not found

Error: abseil: failed
An exception occurred within a child process:
  Test::Unit::AssertionFailedError: <0> expected but was
<nil>.
```