### PR TITLE
ghc: update livecheck

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -6,7 +6,8 @@ class Ghc < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url :stable
+    url "https://www.haskell.org/ghc/download.html"
+    regex(/href=.*?download[._-]ghc[._-][^"' >]+?\.html[^>]*?>\s*?v?(\d+(?:\.\d+)+)\s*?</i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the `stable` URL using the `Hackage` strategy but the latest version, `8.10.3`, appears to be missing at this source. As a result livecheck reports `8.10.2` as newest.

This updates the `livecheck` block to check the first-party download page, as this contains the latest release information.