### PR TITLE
minio: update livecheck

### DIFF
--- a/Formula/minio.rb
+++ b/Formula/minio.rb
@@ -10,8 +10,10 @@ class Minio < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
-    regex(%r{href=.*?/tag/(?:RELEASE[._-]?)?([^"' >]+)["' >]}i)
+    regex(%r{href=.*?/tag/(?:RELEASE[._-]?)?([\d\-TZ]+)["' >]}i)
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map { |match| match&.first&.gsub(/\D/, "") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This finishes the work I started when I created the existing `livecheck` block for `minio`. We now have the technical flexibility to be able to modify upstream version information so that it matches the version in the formula.

With that in mind, this updates the `livecheck` block to add a `strategy` block that removes any non-numeric characters in matched text. This effectively converts an upstream version like `2020-12-29T23-29-29Z` to the `20201229232929` format used in the formula. This allows livecheck to properly compare versions now, whereas before the formula version was always reported as being newer.