### PR TITLE
lammps: update livecheck

### DIFF
--- a/Formula/lammps.rb
+++ b/Formula/lammps.rb
@@ -9,10 +9,16 @@ class Lammps < Formula
   sha256 "759705e16c1fedd6aa6e07d028cc0c78d73c76b76736668420946a74050c3726"
   license "GPL-2.0-only"
 
+  # The `strategy` block below is used to massage upstream tags into the
+  # YYYY-MM-DD format we use in the `version`. This is necessary for livecheck
+  # to be able to do proper `Version` comparison.
   livecheck do
     url :stable
-    strategy :github_latest
-    regex(%r{href=.*?/tag/stable[._-](\d+\w+\d+)["' >]}i)
+    regex(%r{href=.*?/tag/stable[._-](\d{1,2}\w+\d{2,4})["' >]}i)
+    strategy :github_latest do |page, regex|
+      date_str = page[regex, 1]
+      date_str.present? ? Date.parse(date_str).to_s : []
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This finishes the work I started when I created the existing `livecheck` block for `lammps`. We now have the technical flexibility to be able to modify upstream version information so that it matches the version in the formula.

With that in mind, this updates the `livecheck` block to add a `strategy` block that formats a tag like `29Oct2020` into YYYY-MM-DD format (e.g., `2020-10-29`), as used in this formula's `version`. This allows livecheck to properly compare the formula and upstream versions now, whereas before the formula version was always reported as being newer.