### PR TITLE
chamber: update livecheck

### DIFF
--- a/Formula/chamber.rb
+++ b/Formula/chamber.rb
@@ -8,6 +8,7 @@ class Chamber < Formula
 
   livecheck do
     url :stable
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+(?:-ci\d)?)["' >]}i)
     strategy :github_latest
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `chamber` to add a regex that's looser than the default regex for the `GithubLatest` strategy. This is necessary because the "latest" release on GitHub is `v2.9.1-ci2`, so the default regex doesn't match this and we receive an `Unable to get versions` error.

`v2.9.1-ci1` is currently marked as "pre-release", so I'm going to leave this open for feedback as I'm unsure whether `v2.9.1-ci2` is a stable or pre-release version (despite being marked as "latest"). If it's unstable, then I'll update this PR to check the Git tags instead restrict matching to versions like `v1.2.3`, which would report `2.9.0` as the latest version.