### PR TITLE
arabica: update livecheck

### DIFF
--- a/Formula/arabica.rb
+++ b/Formula/arabica.rb
@@ -7,10 +7,14 @@ class Arabica < Formula
   license "BSD-3-Clause"
   head "https://github.com/jezhiggins/arabica.git"
 
+  # The `strategy` block below is used to generate a version from the datetime
+  # of the "latest" release on GitHub, so it will match the formula `version`.
   livecheck do
     url :stable
-    strategy :github_latest
-    regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
+    regex(/datetime=["']?(\d{4}-\d{2}-\d{2})T/i)
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map { |match| match&.first&.gsub(/\D/, "") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This finishes the work I started when I created the existing `livecheck` block for `arabica`. We now have the technical flexibility to be able to modify upstream version information so that it matches the version in the formula.

With that in mind, this updates the `livecheck` block to add a `strategy` block that generates a version from the `datetime` attribute of the "latest" release on GitHub, matching the format of the formula `version`. This allows livecheck to properly compare the formula and upstream versions now, whereas before the formula version was always reported as being newer.