### PR TITLE
re2: add livecheck

### DIFF
--- a/Formula/re2.rb
+++ b/Formula/re2.rb
@@ -7,6 +7,17 @@ class Re2 < Formula
   license "BSD-3-Clause"
   head "https://github.com/google/re2.git"
 
+  # The `strategy` block below is used to massage upstream tags into the
+  # YYYYMMDD format used in the `version`. This is necessary for livecheck
+  # to be able to do proper `Version` comparison.
+  livecheck do
+    url :stable
+    regex(/^(\d{2,4}-\d{2}-\d{2})$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.gsub(/\D/, "") }.compact
+    end
+  end
+
   bottle do
     cellar :any
     sha256 "02fed353151f3d3d936af926e1fcd18cd68ca0e51694eb48acccbc5280316ce2" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a `livecheck` block for `re2` to modify upstream Git tags from a `2020-11-01` format into the `20201101` format used in the formula `version`.

This is necessary for livecheck to properly compare the formula and upstream versions, to determine which is newer. Without this, livecheck will always erroneously report the formula version as newer.