### PR TITLE
yarn: update livecheck

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -7,8 +7,7 @@ class Yarn < Formula
   license "BSD-2-Clause"
 
   livecheck do
-    url "https://yarnpkg.com/en/"
-    regex(/Stable:.*?v?(\d+(?:\.\d+)+)/im)
+    skip("1.x line is frozen and features/bugfixes only happen on 2.x")
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `yarn` to skip checking until the formula is updated to use a release beyond 1.x.

The [`yarn` GitHub repository](https://github.com/yarnpkg/yarn) description states "The 1.x line is frozen - features and bugfixes now happen on https://github.com/yarnpkg/berry". The `berry` repository is described as `Active development trunk for Yarn` and the latest version listed in the `README` is `2.4.0` (from the [`@yarnpkg/cli` npm package](https://www.npmjs.com/package/@yarnpkg/cli)).