### PR TITLE
gron: add to github prerelease audit_exceptions

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -2,6 +2,7 @@
   "elm-format": "0.8.3",
   "get-flash-videos": "1.25.99.03",
   "gitless": "0.8.8",
+  "gron": "all",
   "riff": "0.5.0",
   "telegram-cli": "1.3.1",
   "volta": "0.8.6"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Following https://github.com/Homebrew/brew/pull/9427, thir PR adds `gron` the to the Github prerelease allowlist since all its releases are currently tagged as prerelease. After this is merged, I'll trigger a Big Sur bottle build as explained in https://github.com/Homebrew/homebrew-core/issues/64785 since it's the only reason the bottle creation failed.