### PR TITLE
yafc: change call to Checksum

### DIFF
--- a/Formula/yafc.rb
+++ b/Formula/yafc.rb
@@ -30,7 +30,7 @@ class Yafc < Formula
 
   test do
     download_file = testpath/"gcc-10.2.0.tar.xz.sig"
-    expected_checksum = Checksum.new("sha256", "8e271266e0e3312bb1c384c48b01374e9c97305df781599760944e0a093fad38")
+    expected_checksum = Checksum.new("8e271266e0e3312bb1c384c48b01374e9c97305df781599760944e0a093fad38")
     output = pipe_output("#{bin}/yafc -W #{testpath} -a ftp://ftp.gnu.org/gnu/gcc/gcc-10.2.0/",
                          "get #{download_file.basename}", 0)
     assert_match version.to_s, output


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
update call to Checksum now that `sha256` is the only type: https://github.com/Homebrew/brew/pull/10247