### PR TITLE
bullet: switch back to a single-precision build

### DIFF
--- a/Formula/bullet.rb
+++ b/Formula/bullet.rb
@@ -4,7 +4,7 @@ class Bullet < Formula
   url "https://github.com/bulletphysics/bullet3/archive/3.08.tar.gz"
   sha256 "05826c104b842bcdd1339b86894cb44c84ac2525ac296689d34b38a14bbba0dd"
   license "Zlib"
-  revision 1
+  revision 2
   head "https://github.com/bulletphysics/bullet3.git"
 
   bottle do
@@ -22,7 +22,6 @@ class Bullet < Formula
     args = std_cmake_args + %W[
       -DBUILD_PYBULLET=ON
       -DBUILD_PYBULLET_NUMPY=ON
-      -DUSE_DOUBLE_PRECISION=ON
       -DBT_USE_EGL=ON
       -DBUILD_UNIT_TESTS=OFF
       -DCMAKE_INSTALL_RPATH=#{lib}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The Bullet package was historically built with single-precision and got (most probably unintentionally) changed to double-precision for 3.07. This reverts it back to single-precision, since that's what most C++ software expects. See #68623 for further details.