### PR TITLE
hapi-fhir-cli: add livecheck

### DIFF
--- a/Formula/hapi-fhir-cli.rb
+++ b/Formula/hapi-fhir-cli.rb
@@ -7,7 +7,7 @@ class HapiFhirCli < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle :unneeded

--- a/Formula/hapi-fhir-cli.rb
+++ b/Formula/hapi-fhir-cli.rb
@@ -5,6 +5,11 @@ class HapiFhirCli < Formula
   sha256 "3d26f947aec63d9826a685403268b4db28ede4f6e7ced4026f28c2eb18c3f082"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle :unneeded
 
   depends_on "openjdk"


### PR DESCRIPTION
avoid release tag like `20201117-cql-initial-impl-BEFORE-MERGE`