### PR TITLE
node@10: deprecate

### DIFF
--- a/Formula/node@10.rb
+++ b/Formula/node@10.rb
@@ -19,6 +19,8 @@ class NodeAT10 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2021-04-30", because: :unsupported
+
   depends_on "pkg-config" => :build
   depends_on "icu4c"
   depends_on :macos # Due to Python 2 (Will not work with Python 3 without extensive patching)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
According to [the official](https://nodejs.org/en/about/releases/), node@10 will be unsupported from April 30th, 2021