### PR TITLE
tree-sitter: bottle for ARM

### DIFF
--- a/Formula/tree-sitter.rb
+++ b/Formula/tree-sitter.rb
@@ -14,7 +14,6 @@ class TreeSitter < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "emscripten" => :test
   depends_on "node" => :test
 
   def install


### PR DESCRIPTION
The `emscripten` test dependency is not really doing anything, and I suspect it's blocking the bottling of tree-sitter for ARM. So, let's remove it.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?