### PR TITLE
libffi: add patches only on mac

### DIFF
--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -25,10 +25,12 @@ class Libffi < Formula
 
   keg_only :provided_by_macos
 
-  # Improved aarch64-apple-darwin support. See https://github.com/libffi/libffi/pull/565
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/a4a91e61/libffi/libffi-3.3-arm64.patch"
-    sha256 "ee084f76f69df29ed0fa1bc8957052cadc3bbd8cd11ce13b81ea80323f9cb4a3"
+  on_macos do
+    # Improved aarch64-apple-darwin support. See https://github.com/libffi/libffi/pull/565
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/a4a91e61/libffi/libffi-3.3-arm64.patch"
+      sha256 "ee084f76f69df29ed0fa1bc8957052cadc3bbd8cd11ce13b81ea80323f9cb4a3"
+    end
   end
 
   def install


### PR DESCRIPTION
Fixes (on linux):
ImportError: /tmp/pip-build-env-x324z_cq/overlay/lib/python3.9/site-packages/_cffi_backend.cpython-39-x86_64-linux-gnu.so: undefined symbol: ffi_prep_closure

and some other errors

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
