### PR TITLE
ripgrep-all: update stale lockfile

### DIFF
--- a/Formula/ripgrep-all.rb
+++ b/Formula/ripgrep-all.rb
@@ -1,9 +1,11 @@
 class RipgrepAll < Formula
   desc "Wrapper around ripgrep that adds multiple rich file types"
   homepage "https://github.com/phiresky/ripgrep-all"
+  # Remove "Cargo.lock" resource at version bump!
   url "https://github.com/phiresky/ripgrep-all/archive/v0.9.6.tar.gz"
   sha256 "8cd7c5d13bd90ef0582168cd2bef73ca13ca6e0b1ecf24b9a5cd7cb886259023"
   license "AGPL-3.0"
+  revision 1
   head "https://github.com/phiresky/ripgrep-all.git"
 
   bottle do
@@ -19,7 +21,15 @@ class RipgrepAll < Formula
 
   uses_from_macos "zip" => :test
 
+  # Replace stale lock file. Remove at version bump.
+  resource "Cargo.lock" do
+    url "https://raw.githubusercontent.com/phiresky/ripgrep-all/fb8354ccd9ae4d6d41bd6c1b24f1c351da5ea24c/Cargo.lock"
+    sha256 "6400f855e43228c93909cf1bf70950d44f7cb0b6ab43170bca47d5a7a08142a5"
+  end
+
   def install
+    rm_f "Cargo.lock"
+    resource("Cargo.lock").stage buildpath
     system "cargo", "install", *std_cargo_args
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I tried doing `brew install --build-from-source ripgrep-all` locally, and now the `cc` error is gone, but a new error arose during build:

```
error: failed to select a version for the requirement `cachedir = "^0.1.1"`
candidate versions found which didn't match: 0.3.0, 0.2.0
location searched: crates.io index
required by package `ripgrep_all v0.9.6 (/private/tmp/ripgrep-all-20210110-99943-ocq35w/ripgrep-all-0.9.6)
```

cc @carlocab