### PR TITLE
include-what-you-use: remove compiler workaround

### DIFF
--- a/Formula/include-what-you-use.rb
+++ b/Formula/include-what-you-use.rb
@@ -35,13 +35,7 @@ class IncludeWhatYouUse < Formula
     args = std_cmake_args + %W[
       -DCMAKE_INSTALL_PREFIX=#{libexec}
       -DCMAKE_PREFIX_PATH=#{Formula["llvm"].opt_lib}
-    ]
-
-    # IWYU does not build with Apple Clang. Upstream issue:
-    # https://github.com/include-what-you-use/include-what-you-use/issues/867
-    args += %W[
-      -DCMAKE_C_COMPILER=#{Formula["llvm"].opt_bin}/clang
-      -DCMAKE_CXX_COMPILER=#{Formula["llvm"].opt_bin}/clang++
+      -DCMAKE_CXX_FLAGS=-std=gnu++14
     ]
 
     mkdir "build" do


### PR DESCRIPTION
iwyu builds with Apple Clang when provided the appropriate compiler
flags. So, there's no more need to build with LLVM Clang instead.

Follow up to https://github.com/Homebrew/homebrew-core/pull/66857.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?