### PR TITLE
libmicrohttpd: do not depend on libgcrypt

### DIFF
--- a/Formula/libmicrohttpd.rb
+++ b/Formula/libmicrohttpd.rb
@@ -4,6 +4,7 @@ class Libmicrohttpd < Formula
   url "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.72.tar.gz"
   mirror "https://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-0.9.72.tar.gz"
   sha256 "0ae825f8e0d7f41201fd44a0df1cf454c1cb0bc50fe9d59c26552260264c2ff8"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :stable

--- a/Formula/libmicrohttpd.rb
+++ b/Formula/libmicrohttpd.rb
@@ -22,6 +22,7 @@ class Libmicrohttpd < Formula
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--enable-https",
                           "--prefix=#{prefix}"
     system "make", "install"
     (pkgshare/"examples").install Dir.glob("doc/examples/*.c")

--- a/Formula/libmicrohttpd.rb
+++ b/Formula/libmicrohttpd.rb
@@ -18,7 +18,6 @@ class Libmicrohttpd < Formula
   end
 
   depends_on "gnutls"
-  depends_on "libgcrypt"
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
* Dropped unused for year `libgcrypt` dependency. Is it used only for GnuTLS versions <2.2.5
* Enforced HTTPS-enabled build since `gnutls` is included as dependency. Helps to avoid any accidental `configure` misconfiguration.
* Disabled detection of `libcurl` to speed-up `configure` a bit as curl is only used for testing, but libmicrohttpd test-sute is not used.