### PR TITLE
h2spec: use `Utils#git_short_head`

### DIFF
--- a/Formula/h2spec.rb
+++ b/Formula/h2spec.rb
@@ -19,7 +19,7 @@ class H2spec < Formula
   depends_on "go" => :build
 
   def install
-    commit = Utils.safe_popen_read("git", "rev-parse", "--short", "HEAD").chomp
+    commit = Utils.git_short_head(buildpath)
     ldflags = %W[
       -s -w
       -X main.VERSION=#{version}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR changes `h2spec` to use the newly released `Utils#git_short_head` helper method in `brew` 2.7.3

Related: https://github.com/Homebrew/homebrew-core/pull/67511#pullrequestreview-558836841, https://github.com/Homebrew/brew/pull/10245