### PR TITLE
libffi: restrict patch to ARM

### DIFF
--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -6,7 +6,7 @@ class Libffi < Formula
   mirror "https://github.com/libffi/libffi/releases/download/v3.3/libffi-3.3.tar.gz"
   sha256 "72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any
@@ -26,10 +26,12 @@ class Libffi < Formula
   keg_only :provided_by_macos
 
   on_macos do
-    # Improved aarch64-apple-darwin support. See https://github.com/libffi/libffi/pull/565
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/a4a91e61/libffi/libffi-3.3-arm64.patch"
-      sha256 "ee084f76f69df29ed0fa1bc8957052cadc3bbd8cd11ce13b81ea80323f9cb4a3"
+    if Hardware::CPU.arm?
+      # Improved aarch64-apple-darwin support. See https://github.com/libffi/libffi/pull/565
+      patch do
+        url "https://raw.githubusercontent.com/Homebrew/formula-patches/a4a91e61/libffi/libffi-3.3-arm64.patch"
+        sha256 "ee084f76f69df29ed0fa1bc8957052cadc3bbd8cd11ce13b81ea80323f9cb4a3"
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes https://github.com/Homebrew/homebrew-core/pull/68476#issuecomment-758249624.