### PR TITLE
igraph 0.8.5 add --enable-tls

### DIFF
--- a/Formula/igraph.rb
+++ b/Formula/igraph.rb
@@ -4,6 +4,7 @@ class Igraph < Formula
   url "https://github.com/igraph/igraph/releases/download/0.8.5/igraph-0.8.5.tar.gz"
   sha256 "2e5da63a2b8e9bb497893a17cf77c691df1739c298664f8adb1310a01218f95b"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     cellar :any
@@ -26,7 +27,8 @@ class Igraph < Formula
                           "--prefix=#{prefix}",
                           "--with-external-blas",
                           "--with-external-lapack",
-                          "--with-external-glpk"
+                          "--with-external-glpk",
+                          "--enable-tls"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Hi,

The default igraph build process doesn't enable TLS which make igraph not thread safe.
This pull request adds --enable-tls to the configure script.

Thanks for