### PR TITLE
dartsim: revision bump for bullet

### DIFF
--- a/Formula/dartsim.rb
+++ b/Formula/dartsim.rb
@@ -4,7 +4,7 @@ class Dartsim < Formula
   url "https://github.com/dartsim/dart/archive/v6.9.5.tar.gz"
   sha256 "624c00b65e3a753cba50de038620860c86e2ac47b1793ae51f9427a4bcb14c32"
   license "BSD-2-Clause"
-  revision 3
+  revision 4
 
   bottle do
     sha256 "f3dd620fb470fff2617357bc8993679c69f38fe77aeba5d50014c45ef6329514" => :catalina

--- a/Formula/libccd.rb
+++ b/Formula/libccd.rb
@@ -4,6 +4,7 @@ class Libccd < Formula
   url "https://github.com/danfis/libccd/archive/v2.1.tar.gz"
   sha256 "542b6c47f522d581fbf39e51df32c7d1256ac0c626e7c2b41f1040d4b9d50d1e"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `bullet` formula switched from single-precision floating point to double precision in #67504, then back to single precision in #68634. The `dartsim` bottle was not rebuilt in #68634, which is causing some `dyld: Symbol not found` errors (details in https://github.com/Homebrew/homebrew-core/issues/68623#issuecomment-758509115). This revision  bump should fix the ABI.

It's possible that `efl` needs to be rebuilt as well, but I have not confirmed, so I am just bumping `dartsim` for now.