### PR TITLE
pdftilecut 0.4 (new formula)

### DIFF
--- a/Formula/pdftilecut.rb
+++ b/Formula/pdftilecut.rb
@@ -2,7 +2,7 @@ class Pdftilecut < Formula
   desc "Sub-divide a PDF page(s) into smaller pages so you can print them"
   homepage "https://github.com/oxplot/pdftilecut"
   url "https://github.com/oxplot/pdftilecut.git",
-      tag: "v0.4",
+      tag:      "v0.4",
       revision: "af9ca3bff60eed47026a6e1c40b6ef85e5b36393"
   license "BSD-3-Clause"
 

--- a/Formula/pdftilecut.rb
+++ b/Formula/pdftilecut.rb
@@ -2,6 +2,7 @@ class Pdftilecut < Formula
   desc "Sub-divide a PDF page(s) into smaller pages so you can print them"
   homepage "https://github.com/oxplot/pdftilecut"
   url "https://github.com/oxplot/pdftilecut/archive/v0.4.tar.gz"
+  sha256 "8a75a0d2e196d156bca4dc006f84c9b7730f20be8c0fc2c90521c538aa627188"
   license "BSD-3-Clause"
 
   depends_on "go" => :build

--- a/Formula/pdftilecut.rb
+++ b/Formula/pdftilecut.rb
@@ -1,22 +1,15 @@
 class Pdftilecut < Formula
   desc "Sub-divide a PDF page(s) into smaller pages so you can print them"
   homepage "https://github.com/oxplot/pdftilecut"
-  url "https://github.com/oxplot/pdftilecut.git",
-      tag:      "v0.4",
-      revision: "af9ca3bff60eed47026a6e1c40b6ef85e5b36393"
+  url "https://github.com/oxplot/pdftilecut/archive/v0.4.tar.gz"
   license "BSD-3-Clause"
 
-  depends_on "autoconf" => :build
-  depends_on "autogen" => :build
-  depends_on "automake" => :build
-  depends_on "cmake" => :build
-  depends_on "coreutils" => :build
   depends_on "go" => :build
-  depends_on "yasm" => :build
+  depends_on "jpeg-turbo" => :build
+  depends_on "qpdf" => :build
 
   def install
-    system "make"
-    bin.install "bin/pdftilecut" => "pdftilecut"
+    system "go", "build", *std_go_args
   end
 
   test do

--- a/Formula/pdftilecut.rb
+++ b/Formula/pdftilecut.rb
@@ -22,6 +22,6 @@ class Pdftilecut < Formula
   test do
     testpdf = test_fixtures("test.pdf")
     system "#{bin}/pdftilecut", "-tile-size", "A6", "-in", testpdf, "-out", "split.pdf"
-    assert (testpath/"split.pdf").file?
+    assert_predicate testpath/"split.pdf", :exist?, "Failed to create split.pdf"
   end
 end

--- a/Formula/pdftilecut.rb
+++ b/Formula/pdftilecut.rb
@@ -1,7 +1,9 @@
 class Pdftilecut < Formula
   desc "Sub-divide a PDF page(s) into smaller pages so you can print them"
   homepage "https://github.com/oxplot/pdftilecut"
-  url "git@github.com:oxplot/pdftilecut.git", using: :git, tag: "v0.4", revision: "af9ca3bff60eed47026a6e1c40b6ef85e5b36393"
+  url "https://github.com/oxplot/pdftilecut.git",
+      tag: "v0.4",
+      revision: "af9ca3bff60eed47026a6e1c40b6ef85e5b36393"
   license "BSD-3-Clause"
 
   depends_on "autoconf" => :build

--- a/Formula/pdftilecut.rb
+++ b/Formula/pdftilecut.rb
@@ -20,6 +20,8 @@ class Pdftilecut < Formula
   end
 
   test do
-    system bin/"pdftilecut", "-h"
+    testpdf = test_fixtures("test.pdf")
+    system "#{bin}/pdftilecut", "-tile-size", "A6", "-in", testpdf, "-out", "split.pdf"
+    assert (testpath/"split.pdf").file?
   end
 end

--- a/Formula/pdftilecut.rb
+++ b/Formula/pdftilecut.rb
@@ -6,8 +6,8 @@ class Pdftilecut < Formula
   license "BSD-3-Clause"
 
   depends_on "go" => :build
-  depends_on "jpeg-turbo" => :build
-  depends_on "qpdf" => :build
+  depends_on "jpeg-turbo"
+  depends_on "qpdf"
 
   def install
     system "go", "build", *std_go_args

--- a/Formula/pdftilecut.rb
+++ b/Formula/pdftilecut.rb
@@ -1,7 +1,6 @@
 class Pdftilecut < Formula
   desc "Sub-divide a PDF page(s) into smaller pages so you can print them"
   homepage "https://github.com/oxplot/pdftilecut"
-  # url "https://github.com/oxplot/pdftilecut/archive/v0.4.tar.gz"
   url "git@github.com:oxplot/pdftilecut.git", using: :git, tag: "v0.4", revision: "af9ca3bff60eed47026a6e1c40b6ef85e5b36393"
   license "BSD-3-Clause"
 

--- a/Formula/pdftilecut.rb
+++ b/Formula/pdftilecut.rb
@@ -1,0 +1,24 @@
+class Pdftilecut < Formula
+  desc "Sub-divide a PDF page(s) into smaller pages so you can print them"
+  homepage "https://github.com/oxplot/pdftilecut"
+  # url "https://github.com/oxplot/pdftilecut/archive/v0.4.tar.gz"
+  url "git@github.com:oxplot/pdftilecut.git", using: :git, tag: "v0.4", revision: "af9ca3bff60eed47026a6e1c40b6ef85e5b36393"
+  license "BSD-3-Clause"
+
+  depends_on "autoconf" => :build
+  depends_on "autogen" => :build
+  depends_on "automake" => :build
+  depends_on "cmake" => :build
+  depends_on "coreutils" => :build
+  depends_on "go" => :build
+  depends_on "yasm" => :build
+
+  def install
+    system "make"
+    bin.install "bin/pdftilecut" => "pdftilecut"
+  end
+
+  test do
+    system bin/"pdftilecut", "-h"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

pdftilecut lets you sub-divide a PDF page(s) into smaller pages so you can print them on small form printers. 
This operation is sometimes called posterizing (related to printing large posters on home printers) and tile cropping.