### PR TITLE
apr: fix IPv6 config failure

### DIFF
--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -5,7 +5,7 @@ class Apr < Formula
   mirror "https://archive.apache.org/dist/apr/apr-1.7.0.tar.bz2"
   sha256 "e2e148f0b2e99b8e5c6caa09f6d4fb4dd3e83f744aa72a952f94f5a14436f7ea"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -32,6 +32,13 @@ class Apr < Formula
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/7e2246542543bbd3111a4ec29f801e6e4d538f88/apr/r1871981-macos11.patch"
     sha256 "8754b8089d0eb53a7c4fd435c9a9300560b675a8ff2c32315a5e9303408447fe"
+  end
+
+  # Apply r1882980+1882981 to fix implicit exit() declaration
+  # Remove with the next release, along with the autoconf call & dependency.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/fa29e2e398c638ece1a72e7a4764de108bd09617/apr/r1882980%2B1882981-configure.patch"
+    sha256 "24189d95ab1e9523d481694859b277c60ca29bfec1300508011794a78dfed127"
   end
 
   def install

--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -5,7 +5,7 @@ class Httpd < Formula
   mirror "https://archive.apache.org/dist/httpd/httpd-2.4.46.tar.bz2"
   sha256 "740eddf6e1c641992b22359cabc66e6325868c3c5e2e3f98faf349b61ecf41ea"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable


### PR DESCRIPTION
Fixes #66165. Also bump `httpd` to force a rebuild, otherwise it's stuck without IPv6 support and its test fails.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
