### PR TITLE
zenith 0.12.0

### DIFF
--- a/Formula/zenith.rb
+++ b/Formula/zenith.rb
@@ -1,10 +1,10 @@
 class Zenith < Formula
   desc "In terminal graphical metrics for your *nix system"
   homepage "https://github.com/bvaisvil/zenith/"
-  url "https://github.com/bvaisvil/zenith/archive/0.12.0b.tar.gz"
-  version "0.12.0b"
-  sha256 "ba4896d3018264804192daf1e7aa979d31c3acd5d05a8d966301fe3993f3916d"
+  url "https://github.com/bvaisvil/zenith/archive/0.12.0.tar.gz"
+  sha256 "2b33892be95149550c84179b341e304c4222e3489bc121ea8c8346e075433aa6"
   license "MIT"
+  version_scheme 1
   head "https://github.com/bvaisvil/zenith.git"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

zenith 0.12.0, with patched support for Apple Silicon (output is correctly formatted now vs 0.12.0b). Stable release.

Weirdly, `brew bump-formula-pr` was not able to auto-update the formula, and it thought that `0.12.0b == 0.12.0`.