### PR TITLE
Fix num-utils, update links, remove 'unmaintained'

### DIFF
--- a/Formula/num-utils.rb
+++ b/Formula/num-utils.rb
@@ -4,6 +4,7 @@ class NumUtils < Formula
   url "https://suso.suso.org/programs/num-utils/downloads/num-utils-0.5.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/n/num-utils/num-utils_0.5.orig.tar.gz"
   sha256 "03592760fc7844492163b14ddc9bb4e4d6526e17b468b5317b4a702ea7f6c64e"
+  license "GPL-2.0-or-later"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/num-utils.rb
+++ b/Formula/num-utils.rb
@@ -1,6 +1,6 @@
 class NumUtils < Formula
   desc "Programs for dealing with numbers from the command-line"
-  homepage "https://suso.suso.org/programs/num-utils/"
+  homepage "https://suso.suso.org/xulu/Num-utils"
   url "https://suso.suso.org/programs/num-utils/downloads/num-utils-0.5.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/n/num-utils/num-utils_0.5.orig.tar.gz"
   sha256 "03592760fc7844492163b14ddc9bb4e4d6526e17b468b5317b4a702ea7f6c64e"
@@ -15,8 +15,6 @@ class NumUtils < Formula
     sha256 "41a55ac6c46aca45473ca365443fb1fd2d77fdb6e4540edbe849d723d31ba0e0" => :yosemite
     sha256 "188ff1f94691f8bf5099ec1012d4732be8fa385bf738671f86780376dd2597b9" => :mavericks
   end
-
-  disable! date: "2020-12-08", because: :unmaintained
 
   conflicts_with "normalize", because: "both install `normalize` binaries"
   conflicts_with "crush-tools", because: "both install an `range` binary"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There have been no updates to this useful popular package of small tools in years, but it is still alive. I've updated the links, removed the 'unmaintained' tag, and added the license metadata.