### PR TITLE
fio: backport compilation fix, update license to SPDX 3.0 format

### DIFF
--- a/Formula/fio.rb
+++ b/Formula/fio.rb
@@ -16,6 +16,13 @@ class Fio < Formula
 
   uses_from_macos "zlib"
 
+  # Upstream fix for "ld: weak import of symbol '___darwin_check_fd_set_overflow' not supported because of option: -no_weak_imports for architecture x86_64"
+  # https://github.com/axboe/fio/commit/b6a1e63a1.diff
+  patch do
+    url "https://github.com/axboe/fio/commit/b6a1e63a1.diff"
+    sha256 "839cad74c7f5b8b2bb4610643cbf20c833b0b1a65272fa202358ea00ea578d3d"
+  end
+
   def install
     system "./configure"
     # fio's CFLAGS passes vital stuff around, and crushing it will break the build

--- a/Formula/fio.rb
+++ b/Formula/fio.rb
@@ -3,7 +3,7 @@ class Fio < Formula
   homepage "https://github.com/axboe/fio"
   url "https://github.com/axboe/fio/archive/fio-3.19.tar.gz"
   sha256 "809963b1d023dbc9ac7065557af8129aee17b6895e0e8c5ca671b0b14285f404"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Use new SPDX 3.0 license identifier

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
