### PR TITLE
jython: update livecheck

### DIFF
--- a/Formula/jython.rb
+++ b/Formula/jython.rb
@@ -6,8 +6,8 @@ class Jython < Formula
   license "PSF-2.0"
 
   livecheck do
-    url "https://github.com/jython/jython.git"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://search.maven.org/remotecontent?filepath=org/python/jython-installer/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   # This isn't accidental; there is actually a compile process here.

--- a/Formula/jython.rb
+++ b/Formula/jython.rb
@@ -6,7 +6,7 @@ class Jython < Formula
   license "PSF-2.0"
 
   livecheck do
-    url "https://github.com/jythontools/jython.git"
+    url "https://github.com/jython/jython.git"
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
### Reason
https://github.com/jythontools/jython/git redirects to https://github.com/jython/frozen-mirror.git, and as recommended by them:

> A Mirror of hg.python.org (now frozen). Please use jython/jython. 

I have tested [coatl-dev/coatl-dev/coatl-jython](https://github.com/coatl-dev/homebrew-coatl-dev/blob/638486cb99f114240db0cc5c5be44b3b08fc26ff/Formula/coatl-jython.rb), and this is the output:

```bash
$ brew livecheck --debug coatl-dev/coatl-dev/coatl-jython
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::TapLoader): loading /usr/local/Homebrew/Library/Taps/coatl-dev/homebrew-coatl-dev/Formula/coatl-jython.rb

Formula:          coatl-jython
Livecheckable?:   Yes

URL:              https://github.com/jython/jython.git
Strategy:         Git
Regex:            /^v?(\d+(?:\.\d+)+)$/i

Matched Versions:
2.0, 2.1, 2.2, 2.2.1, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.7.0, 2.7.1, 2.7.2
coatl-jython : 2.7.2 ==> 2.7.2
```