### PR TITLE
mpd, minidlna: rebuild bottles

### DIFF
--- a/Formula/minidlna.rb
+++ b/Formula/minidlna.rb
@@ -112,7 +112,7 @@ class Minidlna < Formula
     fork do
       exec "#{sbin}/minidlnad", "-d", "-f", "minidlna.conf", "-p", port.to_s, "-P", testpath/"minidlna.pid"
     end
-    sleep 2
+    sleep 20
 
     assert_match /MiniDLNA #{version}/, shell_output("curl localhost:#{port}")
   end

--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -119,7 +119,7 @@ class Mpd < Formula
     pid = fork do
       exec "#{bin}/mpd --stdout --no-daemon #{testpath}/mpd.conf"
     end
-    sleep 5
+    sleep 20
 
     begin
       ohai "Connect to MPD command (localhost:#{port})"


### PR DESCRIPTION
The `mpd` and `minidlna` Catalina and Big Sur bottles have gone missing, causing CI failures in various PRs (e.g. #68937).