### PR TITLE
openjdk: fix version on ARM

### DIFF
--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -6,7 +6,7 @@ class Openjdk < Formula
     # (because it is better than nothing)
     url "https://github.com/openjdk/jdk-sandbox/archive/a56ddad05cf1808342aeff1b1cd2b0568a6cdc3a.tar.gz"
     sha256 "29df31b5eefb5a6c016f50b2518ca29e8e61e3cfc676ed403214e1f13a78efd5"
-    version "15.99.99"
+    version "15.0.1"
   else
     url "https://hg.openjdk.java.net/jdk-updates/jdk15u/archive/jdk-15.0.1-ga.tar.bz2"
     sha256 "9c5be662f5b166b5c82c27de29b71f867cff3ff4570f4c8fa646490c4529135a"


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/homebrew-core/pull/68946, because https://github.com/Homebrew/homebrew-core/runs/1705106711?check_suite_focus=true

```
Error: Bottles are for openjdk 15.99.99 but formula is version 15.0.1!
```

So we actually can't have arch-dependent version.