### PR TITLE
minidlna: improve test reliability

### DIFF
--- a/Formula/minidlna.rb
+++ b/Formula/minidlna.rb
@@ -100,6 +100,8 @@ class Minidlna < Formula
   end
 
   test do
+    require "expect"
+
     (testpath/".config/minidlna/media").mkpath
     (testpath/".config/minidlna/cache").mkpath
     (testpath/"minidlna.conf").write <<~EOS
@@ -111,10 +113,9 @@ class Minidlna < Formula
 
     port = free_port
 
-    fork do
-      exec "#{sbin}/minidlnad", "-d", "-f", "minidlna.conf", "-p", port.to_s, "-P", testpath/"minidlna.pid"
-    end
-    sleep 20
+    io = IO.popen("#{sbin}/minidlnad -d -f minidlna.conf -p #{port} -P #{testpath}/minidlna.pid", "r")
+    io.expect("debug: Initial file scan completed", 30)
+    assert_predicate testpath/"minidlna.pid", :exist?
 
     assert_match /MiniDLNA #{version}/, shell_output("curl localhost:#{port}")
   end


### PR DESCRIPTION
Replace hardcoded `sleep` interval (time can be insufficient) with monitoring of daemon's debug output (more deterministic).

-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [N/A] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

