### PR TITLE
kibana: deprecate

### DIFF
--- a/Formula/kibana.rb
+++ b/Formula/kibana.rb
@@ -1,6 +1,7 @@
 class Kibana < Formula
   desc "Analytics and search dashboard for Elasticsearch"
   homepage "https://www.elastic.co/products/kibana"
+  # NOTE: Do not bump version to one with a non-open-source license
   url "https://github.com/elastic/kibana.git",
       tag:      "v7.10.2",
       revision: "a0b793698735eb1d0ab1038f8e5d7a951524e929"
@@ -13,6 +14,10 @@ class Kibana < Formula
     sha256 "c1ee01e41c34677dba144152142808d469db2855658fdd3e4fcafbae77a10774" => :catalina
     sha256 "fb818924d852b07ab0417e8ff52899400b98f25bd24714f77a8c472224269690" => :mojave
   end
+
+  # elasticsearch will be relicensed before v7.11.
+  # https://www.elastic.co/blog/licensing-change
+  deprecate! date: "2021-01-14", because: "is switching to an incompatible license"
 
   depends_on "python@3.9" => :build
   depends_on "yarn" => :build


### PR DESCRIPTION
It is switching to an incompatible license. See https://www.elastic.co/blog/licensing-change.

Related: #69121

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?