### PR TITLE
jasper: disable docs and explicitly enable shared library

### DIFF
--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -15,24 +15,33 @@ class Jasper < Formula
   depends_on "cmake" => :build
   depends_on "jpeg"
 
+  on_linux do
+    depends_on "freeglut"
+  end
+
   def install
     mkdir "build" do
-      # Make sure macOS's GLUT.framework is used, not XQuartz or freeglut
-      # Reported to CMake upstream 4 Apr 2016 https://gitlab.kitware.com/cmake/cmake/issues/16045
-      glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework"
+      args = std_cmake_args
+      args << "-DJAS_ENABLE_DOC=OFF"
+
+      on_macos do
+        # Make sure macOS's GLUT.framework is used, not XQuartz or freeglut
+        # Reported to CMake upstream 4 Apr 2016 https://gitlab.kitware.com/cmake/cmake/issues/16045
+        glut_lib = "#{MacOS.sdk_path}/System/Library/Frameworks/GLUT.framework"
+        args << "-DGLUT_glut_LIBRARY=#{glut_lib}"
+      end
 
       system "cmake", "..",
-        "-DGLUT_glut_LIBRARY=#{glut_lib}",
         "-DJAS_ENABLE_AUTOMATIC_DEPENDENCIES=false",
-        *std_cmake_args
+        "-DJAS_ENABLE_SHARED=ON",
+        *args
       system "make"
       system "make", "install"
       system "make", "clean"
 
       system "cmake", "..",
-        "-DGLUT_glut_LIBRARY=#{glut_lib}",
         "-DJAS_ENABLE_SHARED=OFF",
-        *std_cmake_args
+        *args
       system "make"
       lib.install "src/libjasper/libjasper.a"
     end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This disable document generation which tries to run if LaTeX is detected but is likely to fail.  I also needed to explicitly enable building the shared library on Linux.

@jonchang it seems this formula hasn't had all the Linux changes back ported to it.  I tried to backport the fixes for GLUT but the way they are implemented in the Linux formula doesn't pass `brew audit` because it uses `if OS.mac?`/`unless OS.mac?`.  Let me know if I should do anything else for this.  