### PR TITLE
pre-commit: improve postinstall, avoid relative paths for bin too

### DIFF
--- a/Formula/pre-commit.rb
+++ b/Formula/pre-commit.rb
@@ -87,13 +87,17 @@ class PreCommit < Formula
 
   # Avoid relative paths
   def post_install
-    lib_python_path = Pathname.glob(libexec/"lib/python*").first
-    lib_python_path.each_child do |f|
-      next unless f.symlink?
+    xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
+    bin_python_path = Pathname(libexec/"bin")
+    lib_python_path = Pathname(libexec/"lib/python#{xy}")
+    [lib_python_path, bin_python_path].each do |folder|
+      folder.each_child do |f|
+        next unless f.symlink?
 
-      realpath = f.realpath
-      rm f
-      ln_s realpath, f
+        realpath = f.realpath
+        rm f
+        ln_s realpath, f
+      end
     end
   end
 


### PR DESCRIPTION
Fixes the test on Linux:
==> /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/scm/git commit -m test
Last 15 lines from /root/.cache/Homebrew/Logs/pre-commit/test.04.git:
2021-01-16 22:10:15 +0000

/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/scm/git
commit
-m
test

Traceback (most recent call last):
  File "/tmp/pre-commit-test-20210116-36123-16m3ri9/.git/hooks/pre-commit", line 14, in <module>
    from shutil import which
ModuleNotFoundError: No module named 'shutil'

See also:
https://github.com/Homebrew/linuxbrew-core/pull/21773

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
