### PR TITLE
gcc: fix patch, update license

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -48,6 +48,15 @@ class Gcc < Formula
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
+  
+  if Hardware::CPU.intel?
+    # Patch for Big Sur version numbering, remove with GCC 11
+    # https://github.com/iains/gcc-darwin-arm64/commit/556ab512
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/7baf6e2f/gcc/bigsur.diff"
+      sha256 "42de3bc4889b303258a4075f88ad8624ea19384cab57a98a5270638654b83f41"
+    end
+  end
 
   def version_suffix
     if build.head?

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -13,7 +13,7 @@ class Gcc < Formula
     mirror "https://ftpmirror.gnu.org/gcc/gcc-10.2.0/gcc-10.2.0.tar.xz"
     sha256 "b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c"
   end
-  license "GPL-3.0-or-later => { with: "GCC-exception-3.1" }"
+  license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
   revision 2
   head "https://gcc.gnu.org/git/gcc.git"
 

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -13,7 +13,7 @@ class Gcc < Formula
     mirror "https://ftpmirror.gnu.org/gcc/gcc-10.2.0/gcc-10.2.0.tar.xz"
     sha256 "b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c"
   end
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 2
   head "https://gcc.gnu.org/git/gcc.git"
 
@@ -48,15 +48,6 @@ class Gcc < Formula
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
-
-  if Hardware::CPU.arm?
-    # Patch for Big Sur version numbering, remove with GCC 11
-    # https://github.com/iains/gcc-darwin-arm64/commit/556ab512
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/7baf6e2f/gcc/bigsur.diff"
-      sha256 "42de3bc4889b303258a4075f88ad8624ea19384cab57a98a5270638654b83f41"
-    end
-  end
 
   def version_suffix
     if build.head?

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -13,7 +13,7 @@ class Gcc < Formula
     mirror "https://ftpmirror.gnu.org/gcc/gcc-10.2.0/gcc-10.2.0.tar.xz"
     sha256 "b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c"
   end
-  license "GPL-3.0-or-later"
+  license "GPL-3.0-or-later => { with: "GCC-exception-3.1" }"
   revision 2
   head "https://gcc.gnu.org/git/gcc.git"
 

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -48,7 +48,7 @@ class Gcc < Formula
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
-  
+
   if Hardware::CPU.intel?
     # Patch for Big Sur version numbering, remove with GCC 11
     # https://github.com/iains/gcc-darwin-arm64/commit/556ab512


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-------
- The `bigsur.diff` conflicts with @fxcoudert 's most recent release, so I removed it from the formula. `brew install -s gcc` now succeeds on my M1 Mac.
- Resolved `Formula gcc contains deprecated SPDX licenses: ["GPL-3.0"]` by changing license to `GPL-3.0-or-later`.