### PR TITLE
flawfinder: use local test

### DIFF
--- a/Formula/flawfinder.rb
+++ b/Formula/flawfinder.rb
@@ -23,20 +23,18 @@ class Flawfinder < Formula
 
   depends_on "python@3.9"
 
-  resource "flaws" do
-    url "https://dwheeler.com/flawfinder/test.c"
-    sha256 "4a9687a091b87eed864d3e35a864146a85a3467eb2ae0800a72e330496f0aec3"
-  end
-
   def install
     rewrite_shebang detected_python_shebang, "flawfinder"
     system "make", "prefix=#{prefix}", "install"
   end
 
   test do
-    resource("flaws").stage do
-      assert_match "Hits = 36",
-                   shell_output("#{bin}/flawfinder test.c")
-    end
+    (testpath/"test.c").write <<~EOS
+      int demo(char *a, char *b) {
+        strcpy(a, "\n");
+        strcpy(a, gettext("Hello there"));
+      }
+    EOS
+    assert_match("Hits = 2\n", shell_output("#{bin}/flawfinder test.c"))
   end
 end

--- a/Formula/flawfinder.rb
+++ b/Formula/flawfinder.rb
@@ -5,7 +5,7 @@ class Flawfinder < Formula
   homepage "https://www.dwheeler.com/flawfinder/"
   url "https://www.dwheeler.com/flawfinder/flawfinder-2.0.15.tar.gz"
   sha256 "0a65cf93b1d380669476e576abbb04ea0766a557ce2bf75d9e71f387fcd74406"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/david-a-wheeler/flawfinder.git"
 
   livecheck do
@@ -24,7 +24,7 @@ class Flawfinder < Formula
   depends_on "python@3.9"
 
   resource "flaws" do
-    url "https://www.dwheeler.com/flawfinder/test.c"
+    url "https://dwheeler.com/flawfinder/test.c"
     sha256 "4a9687a091b87eed864d3e35a864146a85a3467eb2ae0800a72e330496f0aec3"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The test file moved from https://www.dwheeler.com/flawfinder/test.c to https://dwheeler.com/flawfinder/test.c. ~~It might be worth putting a portion of the test within the formula itself instead of needing to download it each time.~~ This replaces the test with one within the formula.