### PR TITLE
llvm: restrict openmp ARM patch to stable version

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -29,6 +29,14 @@ class Llvm < Formula
       url "https://github.com/llvm/llvm-project/commit/c4d7536136b331bada079b2afbb2bd09ad8296bf.patch?full_index=1"
       sha256 "2b894cbaf990510969bf149697882c86a068a1d704e749afa5d7b71b6ee2eb9f"
     end
+
+    # Upstream ARM patch for OpenMP runtime, remove in next version
+    # https://reviews.llvm.org/D91002
+    # https://bugs.llvm.org/show_bug.cgi?id=47609
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/6166a68c/llvm/openmp_arm.patch"
+      sha256 "70fe3836b423e593688cd1cc7a3d76ee6406e64b9909f1a2f780c6f018f89b1e"
+    end
   end
 
   livecheck do
@@ -63,14 +71,6 @@ class Llvm < Formula
   uses_from_macos "libxml2"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
-
-  # Upstream ARM patch for OpenMP runtime, remove in next version
-  # https://reviews.llvm.org/D91002
-  # https://bugs.llvm.org/show_bug.cgi?id=47609
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/6166a68c/llvm/openmp_arm.patch"
-    sha256 "70fe3836b423e593688cd1cc7a3d76ee6406e64b9909f1a2f780c6f018f89b1e"
-  end
 
   def install
     projects = %w[


### PR DESCRIPTION
The relevant upstream patch was subsumed in:
https://reviews.llvm.org/D88252

This patch was landed 2020-11-24:
https://github.com/llvm/llvm-project/commit/7b5254223acbf2ef9cd278070c5a84ab278d7e5f

It had a bug that was fixed 2020-11-25:
https://github.com/llvm/llvm-project/commit/9e3e332d273b80b5167ac35f8dcfa7178e45c5e9

After these commits, the patch won't apply and isn't necessary.
Restricting it to the stable source fixes a build error with `--HEAD`.
I still can't get the `--HEAD` build to complete successfully on either
x86 or ARM because of an unrelated error during compilation, but this
gets much further than before.

Moved up above the livecheck to satisfy the `audit` results.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
