### PR TITLE
pypi_formula_mappings: add wheel to pdm

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -9,6 +9,9 @@
     "extra_packages": ["ipykernel"]
   },
   "molecule": false,
+  "pdm": {
+    "extra_packages": ["wheel"]
+  },
   "salt": {
     "extra_packages": ["M2Crypto", "pygit2"]
   },


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`pdm` needs `wheel` to function, but it's in the global exclude list so it's not added. Explicitly specify it so we know not to exclude it. 

Supports https://github.com/Homebrew/homebrew-core/pull/69270

Requires https://github.com/Homebrew/brew/pull/10356