### PR TITLE
Update libexif homepage

### DIFF
--- a/Formula/exif.rb
+++ b/Formula/exif.rb
@@ -1,6 +1,6 @@
 class Exif < Formula
   desc "Read, write, modify, and display EXIF data on the command-line"
-  homepage "https://libexif.sourceforge.io/"
+  homepage "https://libexif.github.io/"
   url "https://github.com/libexif/exif/releases/download/exif-0_6_22-release/exif-0.6.22.tar.xz"
   sha256 "0fe268736e0ca0538d4af941022761a438854a64c8024a4175e57bf0418117b9"
   license "LGPL-2.1"


### PR DESCRIPTION
The homepage for this library has moved to github a long time ago, as
can be seen when visiting the current URL [[1]]:

> The libexif C EXIF library
> This site has moved to https://libexif.github.io
> Last update: 2017-11-29

This updates `homepage` to point to the new location [[2]].

[1]: https://libexif.sourceforge.io/
[2]: https://libexif.github.io

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
