### PR TITLE
luvit: build from source

### DIFF
--- a/Formula/luvit.rb
+++ b/Formula/luvit.rb
@@ -14,14 +14,38 @@ class Luvit < Formula
     sha256 "2c704b1f98b965c0b6010a897a0c951f47cb896bbbf5381e7d4ee80238692033" => :high_sierra
   end
 
+  depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "luajit"
   depends_on "openssl@1.1"
 
+  # To update this resource, check LIT_VERSION in the Makefile.
+  resource "lit" do
+    url "https://github.com/luvit/lit.git",
+        tag:      "3.8.1",
+        revision: "27114d94b9299437b2229eac6a6c3a9ef41fa83a"
+  end
+
+  # To update this resource, check LUVI_VERSION in
+  # https://github.com/luvit/lit/raw/$(LIT_VERSION)/get-lit.sh
+  resource "luvi" do
+    url "https://github.com/luvit/luvi.git",
+        tag:      "v2.11.0",
+        revision: "9da12caaf01337ef0609d07b2af9a5296c13922a"
+  end
+
   def install
-    ENV["USE_SYSTEM_SSL"] = "1"
-    ENV["USE_SYSTEM_LUAJIT"] = "1"
     ENV["PREFIX"] = prefix
+
+    resource("luvi").stage do
+      system "make", "regular-shared"
+      system "make"
+      buildpath.install "build/luvi"
+    end
+
+    resource("lit").stage do
+      system buildpath/"luvi", ".", "--", "make", ".", buildpath/"lit", buildpath/"luvi"
+    end
+
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
As mentioned in #69036, the formula install block downloads:
- un-checksummed files and pipes one of them into `sh`; and,
- binary executables that are installed into its prefix.

This commit fixes that by bypassing the download and building them all
from source.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?