### PR TITLE
dotnet: Add caveats

### DIFF
--- a/Formula/dotnet.rb
+++ b/Formula/dotnet.rb
@@ -51,6 +51,13 @@ class Dotnet < Formula
     (bin/"dotnet").write_env_script libexec/"dotnet", DOTNET_ROOT: libexec
   end
 
+  def caveats
+    <<~EOS
+      For other software to find dotnet you may need to set:
+        export DOTNET_ROOT="#{opt_libexec}"
+    EOS
+  end
+
   test do
     target_framework = "net#{version.major_minor}"
     (testpath/"test.cs").write <<~EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Adds `caveats` to the `dotnet` formula.