### PR TITLE
autojump: fix caveats

### DIFF
--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -31,12 +31,13 @@ class Autojump < Formula
 
   def caveats
     <<~EOS
-      Add the following line to your ~/.bash_profile or ~/.zshrc file (and remember
-      to source the file to update your current session):
+      Add the following line to your ~/.bash_profile or ~/.zshrc file:
         [ -f #{etc}/profile.d/autojump.sh ] && . #{etc}/profile.d/autojump.sh
 
       If you use the Fish shell then add the following line to your ~/.config/fish/config.fish:
         [ -f #{HOMEBREW_PREFIX}/share/autojump/autojump.fish ]; and source #{HOMEBREW_PREFIX}/share/autojump/autojump.fish
+
+      Restart your terminal for the settings to take effect.
     EOS
   end
 


### PR DESCRIPTION
Shell profiles are usually not written to be idempotent, so sourcing
them multiple times can be a harmful recommendation.

See also #69323.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?