### PR TITLE
gnuradio: update to 3.9

### DIFF
--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -3,10 +3,9 @@ class Gnuradio < Formula
 
   desc "SDK for signal processing blocks to implement software radios"
   homepage "https://gnuradio.org/"
-  url "https://github.com/gnuradio/gnuradio/releases/download/v3.8.2.0/gnuradio-3.8.2.0.tar.gz"
-  sha256 "3e293541a9ac8d78660762bae8b80c0f6195b3494e1c50c01a9fd79cc60bb624"
+  url "https://github.com/gnuradio/gnuradio/releases/download/v3.9.0.0/gnuradio-3.9.0.0.tar.xz"
+  sha256 "0a2622933c96a4b22405c7656b8af0db32762834317ec2b90bff0a0a5a4f75cb"
   license "GPL-3.0-or-later"
-  revision 6
   head "https://github.com/gnuradio/gnuradio.git"
 
   bottle do
@@ -18,7 +17,7 @@ class Gnuradio < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "pkg-config" => :build
-  depends_on "swig" => :build
+  depends_on "pybind11" => :build
   depends_on "adwaita-icon-theme"
   depends_on "boost"
   depends_on "fftw"
@@ -38,8 +37,8 @@ class Gnuradio < Formula
   depends_on "zeromq"
 
   resource "Cheetah" do
-    url "https://files.pythonhosted.org/packages/50/d5/34b30f650e889d0d48e6ea9337f7dcd6045c828b9abaac71da26b6bdc543/Cheetah3-3.2.5.tar.gz"
-    sha256 "ececc9ca7c58b9a86ce71eb95594c4619949e2a058d2a1af74c7ae8222515eb1"
+    url "https://files.pythonhosted.org/packages/ee/6f/29c6d74d8536dede06815eeaebfad53699e3f3df0fb22b7a9801a893b426/Cheetah3-3.2.6.tar.gz"
+    sha256 "f1c2b693cdcac2ded2823d363f8459ae785261e61c128d68464c8781dba0466b"
   end
 
   resource "click" do
@@ -53,8 +52,8 @@ class Gnuradio < Formula
   end
 
   resource "Mako" do
-    url "https://files.pythonhosted.org/packages/72/89/402d2b4589e120ca76a6aed8fee906a0f5ae204b50e455edd36eda6e778d/Mako-1.1.3.tar.gz"
-    sha256 "8195c8c1400ceb53496064314c6736719c6f25e7479cd24c77be3d9361cddc27"
+    url "https://files.pythonhosted.org/packages/5c/db/2d2d88b924aa4674a080aae83b59ea19d593250bfe5ed789947c21736785/Mako-1.1.4.tar.gz"
+    sha256 "17831f0b7087c313c0ffae2bcbbd3c1d5ba9eeac9c38f2eb7b50e8c99fe9d5ab"
   end
 
   resource "six" do
@@ -72,18 +71,11 @@ class Gnuradio < Formula
     sha256 "964031c0944f913933f55ad1610938105a6657a69d1ac5a6dd50e16a679104d5"
   end
 
-  # patch for boost 1.73.0, remove after next release
-  # https://github.com/gnuradio/gnuradio/pull/3566
+  # patch to fix drag-and-drop in gnuradio-companion, remove after next release
+  # https://github.com/gnuradio/gnuradio/issues/2727
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/0d2af1812716a874d1e49268e999ea1a8ca9fc3c/gnuradio/boost-1.73.0.patch"
-    sha256 "7e4abd08210d242d65807b7e2419f163a58b4630027a3beaff0e325d044266d7"
-  end
-
-  # Add -undefined dynamic_lookup linker flag back for macOS
-  # https://github.com/gnuradio/gnuradio/pull/3674
-  patch do
-    url "https://github.com/gnuradio/gnuradio/commit/80ba62cb11cf604495e87a5e302e68eaf441eea9.patch?full_index=1"
-    sha256 "d12640f62b266b244950d84f2deb1544f41574229106a525e693159fb3fc80eb"
+    url "https://github.com/gnuradio/gnuradio/commit/518dc7eda3a2575292dc67374cad62c887f83d12.patch?full_index=1"
+    sha256 "88f28e204615c1893568cf72c3841cf372f7626e4e5aadd6a099fe4a3caa08a9"
   end
 
   def install

--- a/Formula/gr-osmosdr.rb
+++ b/Formula/gr-osmosdr.rb
@@ -13,6 +13,8 @@ class GrOsmosdr < Formula
     sha256 "1316ec1150647972436f96a9d957b5c5b7889f6f962217b181e6185a939aa2e2" => :mojave
   end
 
+  disable! date: "2020-01-17", because: :does_not_build
+
   depends_on "cmake" => :build
   depends_on "swig" => :build
   depends_on "airspy"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](**https://github.com/Homebrew/homebrew-core/pulls**) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Related to #69207.

This change updates the formula to install the recently-released GNU Radio 3.9.

I removed a seemingly unnecessary patch and included one that fixes a long-standing drag-and-drop issue.

I did not update the versions of any Python modules, but they did switch from SWIG to pybind11.

The tests pass (I had to re-run `brew link numpy` first) but I have not had the chance to use this extensively.