### PR TITLE
vim 8.2.2375 + de-throttle

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -1,9 +1,9 @@
 class Vim < Formula
   desc "Vi 'workalike' with many additional features"
   homepage "https://www.vim.org/"
-  # vim should only be updated every 50 releases on multiples of 50
-  url "https://github.com/vim/vim/archive/v8.2.2350.tar.gz"
-  sha256 "6af358c1614680591218b5fc2dde29441689d499381438a5d3b9484d461e7b23"
+  # vim should only be updated every 25 releases on multiples of 25
+  url "https://github.com/vim/vim/archive/v8.2.2375.tar.gz"
+  sha256 "54d6c1aa46857c734f1a5f9f89414046266d678bd71ad94f7a961a2547ec0eda"
   license "Vim"
   head "https://github.com/vim/vim.git"
 

--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -6,5 +6,5 @@
   "checkov": 15,
   "gatsby-cli": 10,
   "quicktype": 10,
-  "vim": 50
+  "vim": 25
 }


### PR DESCRIPTION
Update Vim to 8.2.2375. This is not on the usual version mod 50
boundary, because 8.2.2363 has an important fix for a regression that
affects plugins' use of the commonly called cursor() VimL function.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The audit fails, because this doesn't align on the expect modulo 50 boundary of Vim versions, but all other checks passed. Is it possible to merge this anyway?