### PR TITLE
Update crane test to avoid Docker Hub

### DIFF
--- a/Formula/crane.rb
+++ b/Formula/crane.rb
@@ -22,9 +22,8 @@ class Crane < Formula
   end
 
   test do
-    json_output = shell_output("#{bin}/crane manifest homebrew/brew")
+    json_output = shell_output("#{bin}/crane manifest gcr.io/go-containerregistry/crane")
     manifest = JSON.parse(json_output)
     assert_equal manifest["schemaVersion"], 2
-    assert_equal manifest["config"]["mediaType"], "application/vnd.docker.container.image.v1+json"
   end
 end


### PR DESCRIPTION
Docker Hub has a very low IP-based rate limit:
https://docs.docker.com/docker-hub/download-rate-limit/

To avoid hitting that limit, we'll point this `crane manifest` test at
`gcr.io/go-containerregistry/crane`, as GCR has much more generous rate
limiting. Further, the gcr.io/go-containerregistry/crane repository is
under the control of the authors of crane, so we will be able to
anticipate any issues with this test.

I've removed the mediaType check from this test, as it is likely to
break in the future when we migrate to OCI-based media types. The
schemaVersion MUST be 2 for both docker manifests and OCI manifests, so
this test should continue working for quite a while.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

When I run `brew test crane` and even `brew test --HEAD crane`, it seems to run the old test that talks to Docker Hub. Am I doing something wrong? @carlocab

```
$ git diff HEAD~1
```
```diff
diff --git a/Formula/crane.rb b/Formula/crane.rb
index f02193d2b0..e207933a8a 100644
--- a/Formula/crane.rb
+++ b/Formula/crane.rb
@@ -22,9 +22,8 @@ class Crane < Formula
   end
 
   test do
-    json_output = shell_output("#{bin}/crane manifest homebrew/brew")
+    json_output = shell_output("#{bin}/crane manifest gcr.io/go-containerregistry/crane")
     manifest = JSON.parse(json_output)
     assert_equal manifest["schemaVersion"], 2
-    assert_equal manifest["config"]["mediaType"], "application/vnd.docker.container.image.v1+json"
   end
 end
```
```
$ brew uninstall --force crane
Uninstalling crane... (5 files, 8MB)

$ brew install --build-from-source crane
==> Downloading https://github.com/google/go-containerregistry/archive/v0.4.0.tar.gz
Already downloaded: /home/jonjohnson/.cache/Homebrew/downloads/41d2b239a254d272e3b7f391a20ca8d367cec5ff71376c64d0812382c1af4f27--go-containerregistry-0.4.0.tar.gz
==> go build -ldflags -s -w -X github.com/google/go-containerregistry/cmd/crane/cmd.Version=0.4.0 ./cmd/crane
🍺  /home/jonjohnson/.linuxbrew/Cellar/crane/0.4.0: 5 files, 8MB, built in 9 seconds

$ brew test crane
==> Testing crane
==> /home/jonjohnson/.linuxbrew/Cellar/crane/0.4.0/bin/crane manifest homebrew/brew
2021/01/19 10:21:05 No matching credentials were found for "index.docker.io/homebrew/brew", falling back on anonymous

$ brew test --HEAD crane
==> Testing crane
==> /home/jonjohnson/.linuxbrew/Cellar/crane/0.4.0/bin/crane manifest homebrew/brew
2021/01/19 10:18:25 No matching credentials were found for "index.docker.io/homebrew/brew", falling back on anonymous
```