### PR TITLE
kim-api (2.2.1_1) and openkim-models (2019-07-25_2)

### DIFF
--- a/Formula/kim-api.rb
+++ b/Formula/kim-api.rb
@@ -4,6 +4,7 @@ class KimApi < Formula
   url "https://s3.openkim.org/kim-api/kim-api-2.2.1.txz"
   sha256 "1d5a12928f7e885ebe74759222091e48a7e46f77e98d9147e26638c955efbc8e"
   license "CDDL-1.0"
+  revision 1
 
   livecheck do
     url "https://openkim.org/kim-api/previous-versions/"
@@ -21,10 +22,16 @@ class KimApi < Formula
   depends_on "gcc" # for gfortran
 
   def install
+    # change file(COPY) to configure_file() to avoid symlink issue; will be fixed in 2.2.2
+    inreplace "cmake/items-macros.cmake.in" do |s|
+      s.gsub! /file\(COPY ([^ ]+) DESTINATION ([^ ]*)\)/, 'configure_file(\1 \2 COPYONLY)'
+    end
     args = std_cmake_args
     # adjust compiler settings for package
     args << "-DKIM_API_CMAKE_C_COMPILER=/usr/bin/clang"
     args << "-DKIM_API_CMAKE_CXX_COMPILER=/usr/bin/clang++"
+    # adjust libexec dir
+    args << "-DCMAKE_INSTALL_LIBEXECDIR=lib"
     # adjust directories for system collection
     args << "-DKIM_API_SYSTEM_MODEL_DRIVERS_DIR=:#{HOMEBREW_PREFIX}/lib/openkim-models/model-drivers"
     args << "-DKIM_API_SYSTEM_PORTABLE_MODELS_DIR=:#{HOMEBREW_PREFIX}/lib/openkim-models/portable-models"

--- a/Formula/openkim-models.rb
+++ b/Formula/openkim-models.rb
@@ -1,9 +1,8 @@
 class OpenkimModels < Formula
   desc "All OpenKIM Models compatible with kim-api"
   homepage "https://openkim.org"
-  url "https://s3.openkim.org/archives/collection/openkim-models-2019-07-25.txz"
-  sha256 "50338084ece92ec0fb13b0bbdf357b5d7450e26068ba501f23c315f814befc26"
-  revision 1
+  url "https://s3.openkim.org/archives/collection/openkim-models-2021-01-28.txz"
+  sha256 "8824adee02ae4583bd378cc81140fbb49515c5965708ee98d856d122d48dd95f"
 
   livecheck do
     url "https://s3.openkim.org/archives/collection/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Incorrect behavior was resently observed with existing build of `kim-api` and `openkim-models`.  This behavior disappears when the packages are built with (`gcc`,`g++`, and `gfortan`) instead of (`clang`, `clang++`, and `gfortran`).