### PR TITLE
grokj2k: add livecheck

### DIFF
--- a/Formula/grokj2k.rb
+++ b/Formula/grokj2k.rb
@@ -6,6 +6,11 @@ class Grokj2k < Formula
   license "AGPL-3.0-or-later"
   head "https://github.com/GrokImageCompression/grok.git"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     cellar :any
     sha256 "034b2c793f856d59049c4d7881e2a103b3cbf9b8eac4bfd9becb48791a3cefc0" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Livecheck currently reports `7.6.5.debian` as the latest version, presumably because it views the `.debian` suffix as part of the version, similar to OpenSSL's letter suffixes. This PR adds a `livecheck` block to `grokj2k` so that only versions of the format `vX.Y.Z` are used when checking for the latest version