### PR TITLE
avrdude: Fix SVN URL

### DIFF
--- a/Formula/avrdude.rb
+++ b/Formula/avrdude.rb
@@ -21,7 +21,7 @@ class Avrdude < Formula
   end
 
   head do
-    url "https://svn.savannah.nongnu.org/svn/avrdude/trunk/avrdude"
+    url "http://svn.savannah.nongnu.org/svn/avrdude/trunk/avrdude"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
The SVN repo is not accessible via HTTPS.

Signed-off-by: Sven Schwermer <sven.schwermer@disruptive-technologies.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
