### PR TITLE
openstackclient: Add heatclient

### DIFF
--- a/Formula/openstackclient.rb
+++ b/Formula/openstackclient.rb
@@ -6,7 +6,7 @@ class Openstackclient < Formula
   url "https://files.pythonhosted.org/packages/02/0d/18025e48934e59768a085cb4393bebd385be2c4da1d39b4095ab48a321bf/python-openstackclient-5.4.0.tar.gz"
   sha256 "21d228d600421ad5145f31178cdc8578df7d2e569f43381c654caae5a1993b67"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -32,6 +32,11 @@ class Openstackclient < Formula
     sha256 "832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
   end
 
+  resource "Babel" do
+    url "https://files.pythonhosted.org/packages/41/1b/5ed6e564b9ca54318df20ebe5d642ab25da4118df3c178247b8c4b26fa13/Babel-2.9.0.tar.gz"
+    sha256 "da031ab54472314f210b0adcff1588ee5d1d1d0ba4dbd07b94dba82bde791e05"
+  end
+
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/06/a9/cd1fd8ee13f73a4d4f491ee219deeeae20afefa914dfb4c130cfc9dc397a/certifi-2020.12.5.tar.gz"
     sha256 "1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"
@@ -48,8 +53,8 @@ class Openstackclient < Formula
   end
 
   resource "cliff" do
-    url "https://files.pythonhosted.org/packages/eb/ac/f4a5fd1845521e64a0d2224ceb65d81d8dccfb845ed1ccb3918f67836b44/cliff-3.5.0.tar.gz"
-    sha256 "5bfb684b5fcdff0afaaccd1298a376c0e62e644c46b7e9abc034595b41fe1759"
+    url "https://files.pythonhosted.org/packages/6e/82/97ae0291e339eb6992a8d58aca5caa337ee9e6c465e909cdd8fb8015d835/cliff-3.6.0.tar.gz"
+    sha256 "a3f4fa67eeafbcfa7cf9fe4b1755d410876528e1d0d115740db00b50a1250272"
   end
 
   resource "cmd2" do
@@ -133,8 +138,8 @@ class Openstackclient < Formula
   end
 
   resource "openstacksdk" do
-    url "https://files.pythonhosted.org/packages/84/19/f1bc34691a0db5d5072d389f114d0b99080c8a418912ee8690f825760dbf/openstacksdk-0.52.0.tar.gz"
-    sha256 "c9a2dd8c9d2cf44d7ba2075c7963f8fc79adf98f44af6aac2f4b612c12b798b3"
+    url "https://files.pythonhosted.org/packages/1a/dc/b5099bdb4e280b922b7fd0c46d8549387ca96a8e64eefa7449fca0a2758d/openstacksdk-0.53.0.tar.gz"
+    sha256 "3500f2a7b3c317db255510dea6ff59500b4525899f4a083acf764546ea427402"
   end
 
   resource "os-service-types" do
@@ -143,8 +148,8 @@ class Openstackclient < Formula
   end
 
   resource "osc-lib" do
-    url "https://files.pythonhosted.org/packages/2e/99/7d0c86e6b153a4946e0b3ba0c09c065a699244a76c18538d57bfee88f6a3/osc-lib-2.3.0.tar.gz"
-    sha256 "ee4f8b6989d3a3fb1021a6a32665000b1db27e615a0ab5c86c35eb59c90003f1"
+    url "https://files.pythonhosted.org/packages/f4/70/a92bb13b8eaf13be71e72d5137c338279eb139dddc8b146b9849f5e20259/osc-lib-2.3.1.tar.gz"
+    sha256 "f7d178dc6fcf5e5c069206e4fcf7206bf6369e3c855ec5b8498c7f6bb28be75e"
   end
 
   resource "oslo.config" do
@@ -198,8 +203,13 @@ class Openstackclient < Formula
   end
 
   resource "python-cinderclient" do
-    url "https://files.pythonhosted.org/packages/3c/1e/639dc4474dbc5230750132228fa61c50d94dacf1705b9ad5400f14d57b14/python-cinderclient-7.2.0.tar.gz"
-    sha256 "b8f756598c629ebee1924d9357b5a560f40708bc30de19dd088abeac2f71dc56"
+    url "https://files.pythonhosted.org/packages/b0/d1/3cd271a0e9a0b4b5e7d8582d8de976454a5eb799089870a675019790f6a9/python-cinderclient-7.3.0.tar.gz"
+    sha256 "928eb45616eb4146e3ab21534b2c87723298fbf02957bcf219408abfe7f4fc67"
+  end
+
+  resource "python-heatclient" do
+    url "https://files.pythonhosted.org/packages/21/3e/9b8291832fa40bb39d46e13a8327705460ab3fb25c46c950f0fafec9ceaf/python-heatclient-2.3.0.tar.gz"
+    sha256 "d6fe15e610523f96e1ee26e84e9d5fd06846a3fa72d352c38f1fc79abe7eb44a"
   end
 
   resource "python-keystoneclient" do
@@ -208,8 +218,13 @@ class Openstackclient < Formula
   end
 
   resource "python-novaclient" do
-    url "https://files.pythonhosted.org/packages/df/cb/a87d504d62d9987de4b0e69ea98d96004f0c12ea0fed5c7901fead0ee8e9/python-novaclient-17.2.1.tar.gz"
-    sha256 "3f5ced712235f069d4d9fcde994c71a37916b7c307a1c1332b832be1493930bf"
+    url "https://files.pythonhosted.org/packages/3b/58/03c306eb957e4c428484ba10d8a14696e03fae2a1cae8579f8aa8acf3f89/python-novaclient-17.3.0.tar.gz"
+    sha256 "718e37d39739e9f3f504bf80875c883f1dafe653a08f3581bd21d3c0e83c7df0"
+  end
+
+  resource "python-swiftclient" do
+    url "https://files.pythonhosted.org/packages/87/59/5f0657c8fa0f142d43a82cf4c69842eb578ad785b412e9e1b717a777afc4/python-swiftclient-3.11.0.tar.gz"
+    sha256 "3972f8b1986e60ea786ad01697e6882f331209ae947ef8b795531940f1e0732b"
   end
 
   resource "pytz" do
@@ -218,8 +233,8 @@ class Openstackclient < Formula
   end
 
   resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz"
-    sha256 "b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"
+    url "https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz"
+    sha256 "607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"
   end
 
   resource "requests" do
@@ -273,7 +288,13 @@ class Openstackclient < Formula
 
   test do
     system bin/"openstack", "-h"
-    output = shell_output("#{bin}/openstack server list 2>&1", 1)
-    assert_match "Missing value auth-url required", output
+    openstack_subcommands = [
+      "server list",
+      "stack list",
+    ]
+    openstack_subcommands.each do |subcommand|
+      output = shell_output("#{bin}/openstack #{subcommand} 2>&1", 1)
+      assert_match "Missing value auth-url required", output
+    end
   end
 end

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -9,6 +9,9 @@
     "extra_packages": ["ipykernel"]
   },
   "molecule": false,
+  "openstackclient": {
+    "extra_packages": ["python-heatclient"]
+  },
   "pdm": {
     "extra_packages": ["wheel"]
   },


### PR DESCRIPTION
Including all of its dependencies and updates to the rest of the
packages.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

For me the openstack client needs to have the `stack` subcommand which allows for "launching stacks from templates, views details of running stacks including events and resources, and updates and deletes stacks".
I've added the heatclient package which is necessary for running `openstack stack` commands.