### PR TITLE
gnupg: add patch to work with pinentry-mac

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -4,6 +4,7 @@ class Gnupg < Formula
   url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.27.tar.bz2"
   sha256 "34e60009014ea16402069136e0a5f63d9b65f90096244975db5cea74b3d02399"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gnupg/"
@@ -28,6 +29,14 @@ class Gnupg < Formula
   depends_on "libusb"
   depends_on "npth"
   depends_on "pinentry"
+
+  # This patch is a workaround for a bug in gpg-agent when a wrong password from the cache is returned by
+  # pinentry-mac. Without this patch, the agent would let pinentry-mac remove the password from the cache and return
+  # a BAD_PASSPHRASE error. With this patch, the agent asks pinentry-mac again to get a password from the user.
+  patch do
+    url "https://raw.githubusercontent.com/GPGTools/MacGPG2/7770678e923741ca6d9f0f1a4d5cdf3971250754/patches/gnupg/agent-cache-bug-workaround.patch"
+    sha256 "c68158c7f7f1a6bceed9a8e2f429faf3c83d75e6144e16a6c2ed0fdce4a2e17f"
+  end
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As discussed in https://github.com/Homebrew/homebrew-core/pull/68265#issuecomment-760344215 this adds the patch to GnuPG recommended by the GPGTools team to workaround for a bug in gpg-agent when a wrong password from the cache is returned by pinentry-mac.