### PR TITLE
urdfdom: update livecheck

### DIFF
--- a/Formula/urdfdom.rb
+++ b/Formula/urdfdom.rb
@@ -7,7 +7,7 @@ class Urdfdom < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As stated in https://github.com/Homebrew/homebrew-core/pull/69356#issuecomment-763801495, the 2.x versions are not official releases, but they are reported as latest by livecheck. This PR changes the livecheck strategy for `urdfdom` to `github_latest` so that only the latest GitHub Release is reported as the latest version