### PR TITLE
cert_error_allowlist.json: add gnuradio

### DIFF
--- a/audit_exceptions/cert_error_allowlist.json
+++ b/audit_exceptions/cert_error_allowlist.json
@@ -1,4 +1,5 @@
 {
+  "gnuradio": "https://gnuradio.org/",
   "hashcat": "https://hashcat.net/hashcat/",
   "micropython": "https://www.micropython.org/",
   "monero": "https://www.getmonero.org/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

System `curl` doesn't support tlsv1.3:

> ```
> ==> brew audit gnuradio --online --git --skip-style
> ==> FAILED
> gnuradio:
>   * The URL https://gnuradio.org/ is not reachable
> Error: 1 problem in 1 formula detected
> ```


Here's underneath error:
```
$ /usr/bin/curl --disable --globoff --show-error --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36" --header Accept-Language:\ en --retry 3 --dump-header - --output /var/folders/v5/ly_6fqkn1_l7g5w7lmwm_qlh0000gn/T/20210121-5147-cqft6l --location --connect-timeout 15 --max-time 25 --retry-max-time 25  https://gnuradio.org/
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (35) error:1400442E:SSL routines:CONNECT_CR_SRVR_HELLO:tlsv1 alert protocol version
```

Ref: https://github.com/Homebrew/homebrew-core/pull/69326#issuecomment-764555956