### PR TITLE
rabitmq: revert version bump

### DIFF
--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -1,9 +1,12 @@
 class Rabbitmq < Formula
   desc "Messaging broker"
   homepage "https://www.rabbitmq.com"
-  url "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.10/rabbitmq-server-generic-unix-3.8.10.tar.xz"
-  sha256 "a07e415986f92291ce2316c8d857eb0392adf5afbe35951943932707d79060be"
+  url "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.9/rabbitmq-server-generic-unix-3.8.9.tar.xz"
+  sha256 "fe1f1ef9b1bd8362421d689ec9b73cb33c8aaf96acf990df6549e3c0275b7aa0"
   license "MPL-2.0"
+  # Version reverted because upstream pulled release.
+  # This can probably be removed after 3.8.10.
+  version_scheme 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
Upstream seem to have pulled the release. See https://github.com/Homebrew/homebrew-core/pull/69384#issuecomment-764997452.

Closes #69485.
