### PR TITLE
moc: add livecheck

### DIFF
--- a/Formula/moc.rb
+++ b/Formula/moc.rb
@@ -36,6 +36,11 @@ class Moc < Formula
     end
   end
 
+  livecheck do
+    url "http://ftp.daper.net/pub/soft/moc/stable/"
+    regex(/href=.*?moc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 "4910b2a48422741e1002b79d2bb985fc470da2e4322d31b862f994709376525a" => :big_sur
     sha256 "c2fce2f2fdc2d5eb7efddf393de7dc3d75ca4e387d84ae10029120eb5e2a4e53" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `moc`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.