### PR TITLE
libxcb and xcb-proto: depend on system Python 3

### DIFF
--- a/Formula/libxcb.rb
+++ b/Formula/libxcb.rb
@@ -1,9 +1,21 @@
+class Python3Requirement < Requirement
+  fatal true
+  satisfy { which "python3" }
+  def message
+    <<~EOS
+      An existing Python 3 installation is required in order to avoid cyclic
+      dependencies (as Homebrew's Python depends on xcb-proto).
+    EOS
+  end
+end
+
 class Libxcb < Formula
   desc "X.Org: Interface to the X Window System protocol"
   homepage "https://www.x.org/"
   url "https://xcb.freedesktop.org/dist/libxcb-1.14.tar.gz"
   sha256 "2c7fcddd1da34d9b238c9caeda20d3bd7486456fc50b3cc6567185dbd5b0ad02"
   license "MIT"
+  revision 1
 
   bottle do
     cellar :any
@@ -15,7 +27,9 @@ class Libxcb < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  # Use existing Python 3, to avoid a cyclic dependency on Linux:
+  # python3 -> tcl-tk -> libx11 -> libxcb -> python3
+  depends_on Python3Requirement => :build
   depends_on "xcb-proto" => :build
   depends_on "libpthread-stubs"
   depends_on "libxau"

--- a/Formula/xcb-proto.rb
+++ b/Formula/xcb-proto.rb
@@ -1,10 +1,21 @@
+class Python3Requirement < Requirement
+  fatal true
+  satisfy { which "python3" }
+  def message
+    <<~EOS
+      An existing Python 3 installation is required in order to avoid cyclic
+      dependencies (as Homebrew's Python depends on libxcb).
+    EOS
+  end
+end
+
 class XcbProto < Formula
   desc "X.Org: XML-XCB protocol descriptions for libxcb code generation"
   homepage "https://www.x.org/"
   url "https://xcb.freedesktop.org/dist/xcb-proto-1.14.tar.gz"
   sha256 "1c3fa23d091fb5e4f1e9bf145a902161cec00d260fabf880a7a248b02ab27031"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -15,7 +26,9 @@ class XcbProto < Formula
   end
 
   depends_on "pkg-config" => [:build, :test]
-  depends_on "python@3.9" => :build
+  # Use Python 3, to avoid a cyclic dependency on Linux:
+  # python3 -> tcl-tk -> libx11 -> libxcb -> xcb-proto -> python3
+  depends_on Python3Requirement => :build
 
   # Fix for Python 3.9. Use math.gcd() for Python >= 3.5.
   # fractions.gcd() has been deprecated since Python 3.5.


### PR DESCRIPTION
The current python@3.9 formula depends on brewed tcl-tk.
For Linux, this causes an issue, as this brings in 2 new dependencies
for python@3.9: libx11 and libxext.

These both need xcb-proto and libxcb to build.
And these two dependencies already depend on python@3.9, causing
a dependency circle.

xcb-proto installs some plain python files, which are python-agnostic. Nothing is compiled here, and nothing links against xcb-proto.
The files are installed in:
/home/linuxbrew/.linuxbrew/Cellar/xcb-proto/1.13/lib/python3.9/site-packages/xcbgen/

pkg-config --variable=pythondir xcb-proto will output that path.

This path is defined by whatever Python was used to build xcb-proto.
libxcb does not build without these files.

I propose to intoduce a new Python formula which is ket only,
and which is only used to build xcb-proto and libxcb.

For most people this will not change anything as this is a build dependency only.

The formula might present some interest for users wanting a lightweight Python
version without tcl-tk.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
