### PR TITLE
kotlin: update livecheck

### DIFF
--- a/Formula/kotlin.rb
+++ b/Formula/kotlin.rb
@@ -7,7 +7,7 @@ class Kotlin < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `kotlin` is using the `GithubLatest` strategy but the "latest" release on GitHub is `v1.4.30-RC`, which is a pre-release version. Since the "latest" release can point to a pre-release version, it's necessary to check the Git tags instead.

This updates the `livecheck` block to replace `strategy :github_latest` with the standard regex for Git tags (i.e., `/^v?(\d+(?:\.\d+)+)$/i`). This regex will omit other pre-release versions like `v1.4.30-M1`, `v1.4.21-2`, `v1.2-beta2`, etc. This returns the correct latest version, `1.4.21`.