### PR TITLE
ngt: update livecheck

### DIFF
--- a/Formula/ngt.rb
+++ b/Formula/ngt.rb
@@ -7,7 +7,7 @@ class Ngt < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `ngt` is using the `GithubLatest` strategy but the "latest" release on GitHub is an older version (`1.12.3`) instead of the newest version used in the formula (`1.13.1`). Since the "latest" release can point to an older version, it's necessary to check the Git tags instead.

This updates the `livecheck` block to replace `strategy :github_latest` with the standard regex for Git tags (i.e., `/^v?(\d+(?:\.\d+)+)$/i`), which will return the correct latest version.