### PR TITLE
tcptraceroute: add livecheck

### DIFF
--- a/Formula/tcptraceroute.rb
+++ b/Formula/tcptraceroute.rb
@@ -17,6 +17,13 @@ class Tcptraceroute < Formula
     end
   end
 
+  # This regex is open-ended because the newest version is a beta version and
+  # we need to match these versions until there's a new stable release.
+  livecheck do
+    url :stable
+    regex(/^(?:tcptraceroute[._-])?v?(\d+(?:\.\d+)+.*)/i)
+  end
+
   bottle do
     cellar :any
     sha256 "cc82e1da8c8ddfcaf62dbf23fdf0aa76817c8f8c57c822577d82282bb51dbcb3" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `tcptraceroute` and reports the latest version as `1.4`. This is the latest stable version but the version used in the formula is `1.5beta7`, which is unstable.

This adds a `livecheck` block with an open-ended regex that will match and capture unstable versions. This should be updated if/when the next stable release occurs and the formula is updated but this is necessary for the time being.