### PR TITLE
mono-libgdiplus: enable pango support

### DIFF
--- a/Formula/mono-libgdiplus.rb
+++ b/Formula/mono-libgdiplus.rb
@@ -28,7 +28,16 @@ class MonoLibgdiplus < Formula
   depends_on "libexif"
   depends_on "libpng"
   depends_on "libtiff"
+  depends_on "pango"
   depends_on "pixman"
+
+  # Remove at next version bump.
+  # Upstream PR: https://github.com/mono/libgdiplus/pull/605.
+  # Without this patch, it requires pango 1.43 or lower (current available version is 1.48).
+  patch do
+    url "https://github.com/mono/libgdiplus/commit/8f42e17e92c562cc243844b8a004cd03144b1384.patch?full_index=1"
+    sha256 "b38823891ea201588c1edf29f931a0d353a155d7fac36f114482bbe608c5a1c9"
+  end
 
   def install
     system "autoreconf", "-fiv"

--- a/Formula/mono-libgdiplus.rb
+++ b/Formula/mono-libgdiplus.rb
@@ -4,6 +4,7 @@ class MonoLibgdiplus < Formula
   url "https://github.com/mono/libgdiplus/archive/6.0.5.tar.gz"
   sha256 "1fd034f4b636214cc24e94c563cd10b3f3444d9f0660927b60e63fd4131d97fa"
   license "MIT"
+  revision 1
 
   bottle do
     cellar :any


### PR DESCRIPTION
Without pango support, libgdiplus offers basic text rendering and lacks
advanced typography features like emphasis.

Looks like pango@1.42.2 is no longer available, required by
libgdiplus@6.0.5. PR includes a patch from upstream's master branch
which fixes the issue with pango>1.43.