### PR TITLE
mplayer: fix improper autodetection of libbs2b availability

### DIFF
--- a/Formula/mplayer.rb
+++ b/Formula/mplayer.rb
@@ -3,7 +3,7 @@ class Mplayer < Formula
   homepage "https://mplayerhq.hu/"
   url "https://mplayerhq.hu/MPlayer/releases/MPlayer-1.4.tar.xz"
   sha256 "82596ed558478d28248c7bc3828eb09e6948c099bbd76bb7ee745a0e3275b548"
-  revision 2
+  revision 3
 
   livecheck do
     url "https://mplayerhq.hu/MPlayer/releases/"
@@ -44,6 +44,7 @@ class Mplayer < Formula
       --disable-x11
       --enable-caca
       --enable-freetype
+      --disable-libbs2b
     ]
     system "./configure", *args
     system "make"

--- a/Formula/mplayer.rb
+++ b/Formula/mplayer.rb
@@ -4,7 +4,7 @@ class Mplayer < Formula
   url "https://mplayerhq.hu/MPlayer/releases/MPlayer-1.4.tar.xz"
   sha256 "82596ed558478d28248c7bc3828eb09e6948c099bbd76bb7ee745a0e3275b548"
   license all_of: ["GPL-2.0-only", "GPL-2.0-or-later"]
-  revision 3
+  revision 2
 
   livecheck do
     url "https://mplayerhq.hu/MPlayer/releases/"

--- a/Formula/mplayer.rb
+++ b/Formula/mplayer.rb
@@ -3,6 +3,7 @@ class Mplayer < Formula
   homepage "https://mplayerhq.hu/"
   url "https://mplayerhq.hu/MPlayer/releases/MPlayer-1.4.tar.xz"
   sha256 "82596ed558478d28248c7bc3828eb09e6948c099bbd76bb7ee745a0e3275b548"
+  license all_of: ["GPL-2.0-only", "GPL-2.0-or-later"]
   revision 3
 
   livecheck do


### PR DESCRIPTION
Issue: When trying to build `mplayer` formula, it fails with the following error:

```
libaf/af_bs2b.c:24:10: fatal error: 'bs2b.h' file not found
#include <bs2b.h>
         ^~~~~~~~
```

I'm using Mac OS X 10.13 (guilty as charged) with XCode 10.1.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

EDIT: added the issue description