### PR TITLE
usb.ids 2021.01.22

### DIFF
--- a/Formula/usb.ids.rb
+++ b/Formula/usb.ids.rb
@@ -1,8 +1,8 @@
 class UsbIds < Formula
   desc "Repository of vendor, device, subsystem and device class IDs used in USB devices"
   homepage "http://www.linux-usb.org/usb-ids.html"
-  url "https://deb.debian.org/debian/pool/main/u/usb.ids/usb.ids_2020.08.26.orig.tar.xz"
-  sha256 "de972f2cde2b681f3350273c4cae9985364c1acd99d774bdd82ca7e7408574d6"
+  url "https://deb.debian.org/debian/pool/main/u/usb.ids/usb.ids_2021.01.22.orig.tar.xz"
+  sha256 "024eb1f0a483c7fbad21f73d2aaf475994d827435be3a0c897011d3d90f2519e"
   license any_of: ["GPL-2.0-or-later", "BSD-3-Clause"]
 
   livecheck do
@@ -10,14 +10,7 @@ class UsbIds < Formula
     regex(/href=.*?usb\.ids[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
   end
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "02a17ca9f1852d442ac0b6b41591b547cffb9a104a5466d9e12fb18535b91fcd" => :big_sur
-    sha256 "c4dabe62b2a771db0469b82e90c716271d858b8cee1f9e269ee8ee849b551485" => :arm64_big_sur
-    sha256 "2994769226c7815ef5eee9ba27f729005fd993341dfbca50f413139ef411ac5c" => :catalina
-    sha256 "8b29c5873a395b8bdff9219dcfafb13d05d7428c8f4d050cb776d332dd7aef1f" => :mojave
-    sha256 "18a048550eae20c48c7af4cc0b93f1da748cae52417e364b1aedc154c27613d5" => :high_sierra
-  end
+  bottle :unneeded
 
   def install
     (share/"misc").install "usb.ids"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Switch to `bottle :unneeded`. There's only one file in the archive that we need so really no reason (as far as I can tell) for us to distribute bottles. I know that Debian does sometimes yank old archives, though (see `dpkg` formula), so maybe a `mirror` would be handy.