### PR TITLE
grv: deprecate/disable

### DIFF
--- a/Formula/grv.rb
+++ b/Formula/grv.rb
@@ -15,6 +15,10 @@ class Grv < Formula
     sha256 "19f2e8bedb458d0b339160b275e196add00abcca7db92ba141aaccae255bb973" => :sierra
   end
 
+  # Reported upstream at
+  # https://github.com/rgburke/grv/issues/107
+  disable! date: "2021-08-11", because: :does_not_build
+
   depends_on "cmake" => :build
   depends_on "go" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
grv has not built for a while, and this causes CI issues with every go
version bump. (e.g. https://github.com/Homebrew/homebrew-core/pull/69337)

This was reported at https://github.com/rgburke/grv/issues/107.

I've set the disable date for one year from the upstream report.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?