### PR TITLE
ctags: revision to restore +regex feature

### DIFF
--- a/Formula/ctags.rb
+++ b/Formula/ctags.rb
@@ -1,7 +1,8 @@
 class Ctags < Formula
   desc "Reimplementation of ctags(1)"
   homepage "https://ctags.sourceforge.io/"
-  revision 1
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
+  revision 2
 
   stable do
     url "https://downloads.sourceforge.net/project/ctags/ctags/5.8/ctags-5.8.tar.gz"
@@ -46,6 +47,9 @@ class Ctags < Formula
       system "autoheader"
       system "autoconf"
     end
+
+    # Work around configure issues with Xcode 12
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
     system "./configure", "--prefix=#{prefix}",
                           "--enable-macro-patterns",
                           "--mandir=#{man}",
@@ -80,5 +84,6 @@ class Ctags < Formula
     EOS
     system "#{bin}/ctags", "-R", "."
     assert_match /func.*test\.c/, File.read("tags")
+    assert_match "+regex", shell_output("ctags --version")
   end
 end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/issues/69624.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----