### PR TITLE
Use a valid HEAD for grc

### DIFF
--- a/Formula/grc.rb
+++ b/Formula/grc.rb
@@ -7,7 +7,7 @@ class Grc < Formula
   sha256 "b167babd8f073a68f5a3091f833e4036fb8d86504e746694747a3ee5048fa7a9"
   license "GPL-2.0"
   revision 2
-  head "https://github.com/garabik/grc.git"
+  head "https://github.com/garabik/grc.git", branch: "devel"
 
   bottle :unneeded
 

--- a/Formula/grc.rb
+++ b/Formula/grc.rb
@@ -5,7 +5,7 @@ class Grc < Formula
   homepage "https://korpus.juls.savba.sk/~garabik/software/grc.html"
   url "https://github.com/garabik/grc/archive/v1.11.3.tar.gz"
   sha256 "b167babd8f073a68f5a3091f833e4036fb8d86504e746694747a3ee5048fa7a9"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 2
   head "https://github.com/garabik/grc.git", branch: "devel"
 


### PR DESCRIPTION
`devel` branch is used in [garabik/grc][] for developing.

[garabik/grc]: https://github.com/garabik/grc

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

hmm... `brew audit --strict grc` reported this.

```
brew audit --strict grc
grc:
  * Formula grc contains deprecated SPDX licenses: ["GPL-2.0"].
    You may need to add `-only` or `-or-later` for GNU licenses (e.g. `GPL`, `LGPL`, `AGPL`, `GFDL`).
    For a list of valid licenses check: https://spdx.org/licenses/
Error: 1 problem in 1 formula detected
```

grc have been using this license from ago. Should change this?