### PR TITLE
libvpx: enable building the 'vpxenc' tool

### DIFF
--- a/Formula/libvpx.rb
+++ b/Formula/libvpx.rb
@@ -21,7 +21,6 @@ class Libvpx < Formula
     args = %W[
       --prefix=#{prefix}
       --disable-dependency-tracking
-      --disable-examples
       --disable-unit-tests
       --enable-pic
       --enable-vp9-highbitdepth


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

For some reason, the `vpxenc` command line utility isn’t built when the `--disable-examples` compiler option is specified. I figured this out thankfully to [this answer on StackOverflow](https://stackoverflow.com/a/44536331).