### PR TITLE
hive: fix Java version

### DIFF
--- a/Formula/hive.rb
+++ b/Formula/hive.rb
@@ -5,7 +5,7 @@ class Hive < Formula
   mirror "https://archive.apache.org/dist/hive/hive-3.1.2/apache-hive-3.1.2-bin.tar.gz"
   sha256 "d75dcf36908b4e7b9b0ec9aec57a46a6628b97b276c233cb2c2f1a3e89b13462"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -14,7 +14,7 @@ class Hive < Formula
   bottle :unneeded
 
   depends_on "hadoop"
-  depends_on "openjdk"
+  depends_on "openjdk@8"
 
   def install
     rm_f Dir["bin/*.cmd", "bin/ext/*.cmd", "bin/ext/util/*.cmd"]
@@ -30,14 +30,14 @@ class Hive < Formula
       next if file.directory?
 
       (bin/file.basename).write_env_script file,
-        Language::Java.java_home_env.merge(HIVE_HOME: libexec)
+        JAVA_HOME:   Formula["openjdk@8"].opt_prefix,
+        HADOOP_HOME: "${HADOOP_HOME:-#{Formula["hadoop"].opt_libexec}}",
+        HIVE_HOME:   libexec
     end
   end
 
   def caveats
     <<~EOS
-      Hadoop must be in your path for hive executable to work.
-
       If you want to use HCatalog with Pig, set $HCAT_HOME in your profile:
         export HCAT_HOME=#{opt_libexec}/hcatalog
     EOS
@@ -45,6 +45,6 @@ class Hive < Formula
 
   test do
     system bin/"schematool", "-initSchema", "-dbType", "derby"
-    assert_match "Hive #{version}", shell_output("#{bin}/hive --version")
+    assert_match "123", shell_output("#{bin}/hive -e 'SELECT 123'")
   end
 end

--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -1,6 +1,7 @@
 [
   "anjuta",
   "fdroidserver",
+  "hive",
   "predictionio",
   "sqoop",
   "visp"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hive [requires Java 8](https://github.com/apache/hive#java). Otherwise, it errors with:

```txt
Exception in thread "main" java.lang.ClassCastException: class jdk.internal.loader.ClassLoaders$AppClassLoader cannot be cast to class java.net.URLClassLoader (jdk.internal.loader.ClassLoaders$AppClassLoader and java.net.URLClassLoader are in module java.base of loader 'bootstrap')
```

This PR:

1. Uses Java 8
2. Updates the test case to catch this
3. (unrelated/optional) Removes the Hadoop caveat by setting `HADOOP_HOME` automatically if it's not set by the user

The audit fails with:

```txt
  * hive contains conflicting version recursive dependencies:
      openjdk, openjdk@8
```

Since the Hadoop formula uses the latest version. Hadoop [officially supports](https://cwiki.apache.org/confluence/display/HADOOP/Hadoop+Java+Versions) Java 8 and 11 for runtime, so we could downgrade it and (it's dependent formula) if needed.