### PR TITLE
workflows/triage: force ARM for new formulae

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -27,6 +27,10 @@ jobs:
                     "status": "added",
                     "path": "Formula/.+"
                 }, {
+                    "label": "CI-force-arm",
+                    "status": "added",
+                    "path": "Formula/.+"
+                }, {
                     "label": "marked for removal/rejection",
                     "status": "removed",
                     "path": "Formula/.+"


### PR DESCRIPTION
This makes @BrewTestBot add the CI-force-arm label to all new formula PRs.