### PR TITLE
pngcheck 3.0.1

### DIFF
--- a/Formula/pngcheck.rb
+++ b/Formula/pngcheck.rb
@@ -1,13 +1,13 @@
 class Pngcheck < Formula
   desc "Print info and check PNG, JNG, and MNG files"
   homepage "http://www.libpng.org/pub/png/apps/pngcheck.html"
-  url "https://downloads.sourceforge.net/project/png-mng/pngcheck/2.3.0/pngcheck-2.3.0.tar.gz"
-  sha256 "77f0a039ac64df55fbd06af6f872fdbad4f639d009bbb5cd5cbe4db25690f35f"
-  revision 1
+  url "http://www.libpng.org/pub/png/src/pngcheck-3.0.1.tar.gz"
+  sha256 "66bf4cbaa29908984c0d7ba539358ed63c7c2f02a0b2407ac691465b143efbbb"
+  license all_of: ["MIT", "GPL-2.0-or-later"]
 
   livecheck do
-    url :stable
-    regex(%r{url=.*?/pngcheck[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :homepage
+    regex(/href=.*?pngcheck[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The homepage at http://www.libpng.org/pub/png/apps/pngcheck.html indicates that 3.0.1 is now the latest version. Neither 3.0.0 (released in December 2020) nor 3.0.1 (released January 2021) appear to be available via SourceForge.

Upstream also reports that this update addresses a number of vulnerabilities:
> pngcheck versions 2.4.0 and earlier have a number of buffer-overrun bugs, most (but not all) of which are related to the -f option ("force continued parsing after major errors"). As such, the option has been removed altogether in version 3.0.0 (which is the reason for the major-version bump), released on 12 December 2020. All known vulnerabilities are fixed in this version, but the code is pretty crufty, so it would be safest to assume there are still some problems hidden in there. As always, use at your own risk.

> pngcheck versions 3.0.0 and earlier have a pair of buffer-overrun bugs related to the sPLT and PPLT chunks (the latter is a MNG-only chunk, but it gets noticed even in PNG files if the -s option is used). Both bugs are fixed in version 3.0.1, released on 24 January 2021. Again, while all known vulnerabilities are fixed in this version, the code is quite crufty, so it would be safest to assume there are still some problems hidden in there. As always, use at your own risk. 

I removed the `livecheck` block because I don't believe it would be valid anymore after this change. Regarding licensing, the `pngcheck` package contains three executables: `pngcheck`, `pngsplit`, and `png-fix-IDAT-windowsize`. The first is licensed under MIT while the latter two are licensed `GPL-2.0-or-later`.
<details>
<summary>License headers</summary>

`pngcheck.c`:
```
/*============================================================================
 *
 *   Copyright 1995-2021 by Alexander Lehmann <lehmann@usa.net>,
 *                          Andreas Dilger <adilger@enel.ucalgary.ca>,
 *                          Glenn Randers-Pehrson <randeg@alum.rpi.edu>,
 *                          Greg Roelofs <newt@pobox.com>,
 *                          John Bowler <jbowler@acm.org>,
 *                          Tom Lane <tgl@sss.pgh.pa.us>
 *
 *   Permission to use, copy, modify, and distribute this software and its
 *   documentation for any purpose and without fee is hereby granted, provided
 *   that the above copyright notice appear in all copies and that both that
 *   copyright notice and this permission notice appear in supporting
 *   documentation.  This software is provided "as is" without express or
 *   implied warranty.
 *
 *===========================================================================*/
```

`gpl/pngsplit.c`:
```
/* pngsplit.c - split a PNG file into individual chunk-files (and check CRCs)
**
** Downloads:
**
**      http://www.libpng.org/pub/png/apps/pngcheck.html
**
** To compile (assuming zlib path is ../zlib):
**
**      gcc -Wall -O2 -I../zlib pngsplit.c -o pngsplit -L../zlib -lz
**
**
**  Copyright 2005-2020 Greg Roelofs
**
**  This program is free software; you can redistribute it and/or modify
**  it under the terms of the GNU General Public License as published by
**  the Free Software Foundation; either version 2 of the License, or
**  (at your option) any later version.
**
**  This program is distributed in the hope that it will be useful,
**  but WITHOUT ANY WARRANTY; without even the implied warranty of
**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
**  GNU General Public License for more details.
**
**  You should have received a copy of the GNU General Public License
**  along with this program; if not, write to the Free Software
**  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
**
*/
```

`gpl/png-fix-IDAT-windowsize.c`:
```
/* png-fix-IDAT-windowsize.c - simple utility to reset first IDAT's zlib
**                             window-size bytes and fix up CRC to match
**
** Downloads:
**
**      http://gregroelofs.com/greg_software.html
**
** To compile:
**
**	gcc -Wall -O2 -I/path-to-zlib png-fix-IDAT-windowsize.c \
          -o png-fix-IDAT-windowsize -L/path-to-zlib -lz
**
**
**  Copyright 2005-2020 Greg Roelofs
**
**  This program is free software; you can redistribute it and/or modify
**  it under the terms of the GNU General Public License as published by
**  the Free Software Foundation; either version 2 of the License, or
**  (at your option) any later version.
**
**  This program is distributed in the hope that it will be useful,
**  but WITHOUT ANY WARRANTY; without even the implied warranty of
**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
**  GNU General Public License for more details.
**
**  You should have received a copy of the GNU General Public License
**  along with this program; if not, write to the Free Software
**  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
*/
```

</details>