### PR TITLE
hive: add note regarding Java 11 support

### DIFF
--- a/Formula/hive.rb
+++ b/Formula/hive.rb
@@ -14,6 +14,9 @@ class Hive < Formula
   bottle :unneeded
 
   depends_on "hadoop"
+
+  # hive requires Java 8. Java 11 support ticket:
+  # https://issues.apache.org/jira/browse/HIVE-22415
   depends_on "openjdk@8"
 
   def install


### PR DESCRIPTION
A link to the support ticket should make it easier to ascertain when the
dependency can be switched to openjdk@11.

Follow up to #69686.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?