### PR TITLE
Revert "wheezy_tests: use build from source"

### DIFF
--- a/.github/workflows/wheezy_tests.yml
+++ b/.github/workflows/wheezy_tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -eux
           docker pull homebrew/debian7:latest
-          docker run -v /home/linuxbrew:/home/linuxbrew -v ~/bottles:/home/linuxbrew/bottles -u root --env-file <(env | grep 'HOMEBREW\|GITHUB') homebrew/debian7:latest bash -c 'cd /root && brew test-bot --only-formulae --build-from-source && cp *.bottle.* /home/linuxbrew/bottles'
+          docker run -v /home/linuxbrew:/home/linuxbrew -v ~/bottles:/home/linuxbrew/bottles -u root --env-file <(env | grep 'HOMEBREW\|GITHUB') homebrew/debian7:latest bash -c 'cd /root && brew test-bot --only-formulae && cp *.bottle.* /home/linuxbrew/bottles'
       - name: Count bottles
         if: always()
         run: |


### PR DESCRIPTION
This reverts commit dc391bb04e188c23d183229985c65984d5da1acc.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
