### PR TITLE
aalib: remove ncurses_define flag

### DIFF
--- a/Formula/aalib.rb
+++ b/Formula/aalib.rb
@@ -4,7 +4,7 @@ class Aalib < Formula
   url "https://downloads.sourceforge.net/project/aa-project/aa-lib/1.4rc5/aalib-1.4rc5.tar.gz"
   sha256 "fbddda9230cf6ee2a4f5706b4b11e2190ae45f5eda1f0409dc4f99b35e0a70ee"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   # The latest version in the formula is a release candidate, so we have to
   # allow matching of unstable versions.
@@ -33,7 +33,6 @@ class Aalib < Formula
   end
 
   def install
-    ENV.ncurses_define
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
This was only needed on snow leopard, this prepares the
deprecation of the ncurses_define from brew.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
