### PR TITLE
rogue: remove ncurses_define flag

### DIFF
--- a/Formula/rogue.rb
+++ b/Formula/rogue.rb
@@ -21,7 +21,8 @@ class Rogue < Formula
   end
 
   def install
-    ENV.ncurses_define
+    # Fix main.c:241:11: error: incomplete definition of type 'struct _win_st'
+    ENV.append "CPPFLAGS", "-DNCURSES_OPAQUE=0"
 
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
This was only needed on snow leopard, this prepares the
deprecation of the ncurses_define from brew.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
