### PR TITLE
libgtop: depend on linux-only dependency

### DIFF
--- a/Formula/libgtop.rb
+++ b/Formula/libgtop.rb
@@ -23,6 +23,10 @@ class Libgtop < Formula
   depends_on "gettext"
   depends_on "glib"
 
+  on_linux do
+    depends_on "libxau"
+  end
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
libgtop links against libxau on linux.
libxau is in the list of dependencies defined by:
https://packages.debian.org/sid/libgtop-2.0-11

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
