### PR TITLE
workflows/tests: separate failed bottles by OS version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,7 +151,7 @@ jobs:
         if: always() && steps.bottles.outputs.failures > 0
         uses: actions/upload-artifact@main
         with:
-          name: bottles (failed)
+          name: bottles (${{ matrix.version }})
           path: bottles/failed
 
       # Must be run before the `Upload bottles` step so that failed


### PR DESCRIPTION
This PR changes the `GitHub Actions CI` workflow to upload failed bottles to the artifact `bottles (${{ matrix.version }})` instead of `bottles (failed)`. This will reduce download times—especially for bottles that are hundreds of megabytes, or even a few gigabytes—as it will allow us to download the bottles for our installed macOS versions only

(Follow-up to https://github.com/Homebrew/homebrew-core/pull/69733)