### PR TITLE
crystal 0.36.0

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -2,7 +2,6 @@ class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
   license "Apache-2.0"
-  revision 2
 
   stable do
     url "https://github.com/crystal-lang/crystal/archive/0.36.0.tar.gz"

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -5,12 +5,12 @@ class Crystal < Formula
   revision 2
 
   stable do
-    url "https://github.com/crystal-lang/crystal/archive/0.35.1.tar.gz"
-    sha256 "d324c79002b8a871997049e89cac3989fa48083e11bf9b8ec7fe2d1e94b35199"
+    url "https://github.com/crystal-lang/crystal/archive/0.36.0.tar.gz"
+    sha256 "32ad927e78c4cc85e18136f70cfb9f1798edcc734de4d927b28f4de16c1456d3"
 
     resource "shards" do
-      url "https://github.com/crystal-lang/shards/archive/v0.11.1.tar.gz"
-      sha256 "e78095867334b4058f860c6da8dc3892994769ef51795de74ffb708a66c6847d"
+      url "https://github.com/crystal-lang/shards/archive/v0.13.0.tar.gz"
+      sha256 "82a496aa450624afceab79bd9f7e6e1a43de41f61095512d08c3a3063c4da723"
     end
   end
 
@@ -61,14 +61,14 @@ class Crystal < Formula
 
   resource "boot" do
     on_macos do
-      url "https://github.com/crystal-lang/crystal/releases/download/0.34.0/crystal-0.34.0-1-darwin-x86_64.tar.gz"
-      version "0.34.0-1"
-      sha256 "979b3006b03e5c598deb0c5a519b7fc9c5a805c930416b77b492a28af0a3a972"
+      url "https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-darwin-x86_64.tar.gz"
+      version "0.35.1-1"
+      sha256 "7d75f70650900fa9f1ef932779bc23f79a199427c4219204fa9e221c330a1ab6"
     end
     on_linux do
-      url "https://github.com/crystal-lang/crystal/releases/download/0.34.0/crystal-0.34.0-1-linux-x86_64.tar.gz"
-      version "0.34.0-1"
-      sha256 "268ace9073ad073b56c07ac10e3f29927423a8b170d91420b0ca393fb02acfb1"
+      url "https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-linux-x86_64.tar.gz"
+      version "0.35.1-1"
+      sha256 "6c3fd36073b32907301b0a9aeafd7c8d3e9b9ba6e424ae91ba0c5106dc23f7f9"
     end
   end
 
@@ -106,16 +106,10 @@ class Crystal < Formula
 
     # Install shards
     resource("shards").stage do
-      ENV["CRYSTAL_OPTS"] = "--release --no-debug"
-      shards = nil
-      on_macos do
-        shards = buildpath/"boot/embedded/bin/shards"
-      end
-      on_linux do
-        shards = buildpath/"boot/bin/shards"
-      end
       system "make", "bin/shards", "CRYSTAL=#{buildpath/"bin/crystal"}",
-                                   "SHARDS=#{shards}"
+                                   "SHARDS=false",
+                                   "release=true",
+                                   "FLAGS=--no-debug"
 
       # Install shards
       bin.install "bin/shards"


### PR DESCRIPTION
There is a new release of crystal and shards.

Support for llvm@11 is not production ready, so we stick with llvm@9 still.