### PR TITLE
sourcery: fix build on ARM64

### DIFF
--- a/Formula/sourcery.rb
+++ b/Formula/sourcery.rb
@@ -20,6 +20,10 @@ class Sourcery < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/sourcery --version").chomp
+    (testpath/"a.swift").write "class A {}"
+    (testpath/"a.stencil").write "{% for type in types.all %}{{ type.name }}{% endfor %}"
+    system "#{bin}/sourcery", "--disableCache", "--sources", "#{testpath}/a.swift", "--templates",
+      "#{testpath}/a.stencil", "--output", "#{testpath}/b.swift"
+    assert_match "A", (testpath/"b.swift").read.chomp
   end
 end

--- a/Formula/sourcery.rb
+++ b/Formula/sourcery.rb
@@ -20,10 +20,7 @@ class Sourcery < Formula
   end
 
   test do
-    (testpath/"a.swift").write "class A {}"
-    (testpath/"a.stencil").write "{% for type in types.all %}{{ type.name }}{% endfor %}"
-    system "#{bin}/sourcery", "--disableCache", "--sources", "#{testpath}/a.swift", "--templates",
-      "#{testpath}/a.stencil", "--output", "#{testpath}/b.swift"
-    assert_match "A", (testpath/"b.swift").read.chomp
+    # Regular functionality requires a non-sandboxed environment, so we can only test version/help here.
+    assert_match version.to_s, shell_output("#{bin}/sourcery --version").chomp
   end
 end

--- a/Formula/sourcery.rb
+++ b/Formula/sourcery.rb
@@ -15,10 +15,8 @@ class Sourcery < Formula
   depends_on xcode: "12.0"
 
   def install
-    system "swift", "build", "--disable-sandbox", "-c", "release", "-Xswiftc",
-                             "-target", "-Xswiftc", "x86_64-apple-macosx10.11"
+    system "swift", "build", "--disable-sandbox", "-c", "release"
     bin.install ".build/release/sourcery"
-    lib.install Dir[".build/release/*.dylib"]
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Original formula gave me this error:
```
==> Downloading https://github.com/krzysztofzablocki/Sourcery/archive/1.0.2.tar.gz
Already downloaded: /Users/benedek.kozma/Library/Caches/Homebrew/downloads/c961a8ddc57c9eb67296333a95ffcf967b009e0f9034b6285c63c63ac2e3162d--Sourcery-1.0.2.tar.gz
==> swift build --disable-sandbox -c release -Xswiftc -target -Xswiftc x86_64-apple-macosx10.11
Last 15 lines from /Users/benedek.kozma/Library/Logs/Homebrew/sourcery/01.swift:
  "_yaml_parser_set_input_string", referenced from:
      _$s4Yams6ParserC4yaml8resolver11constructor8encodingACSS_AA8ResolverCAA11ConstructorCAC8EncodingOtKcfc in Parser.swift.o
  "_yaml_scalar_event_initialize", referenced from:
      _$s4Yams7EmitterC15serializeScalar33_ED6AA6759560A6062E809BF7E6589292LLyyAA4NodeO0D0VKF in Emitter.swift.o
  "_yaml_sequence_end_event_initialize", referenced from:
      _$s4Yams7EmitterC17serializeSequence33_ED6AA6759560A6062E809BF7E6589292LLyyAA4NodeO0D0VKF in Emitter.swift.o
  "_yaml_sequence_start_event_initialize", referenced from:
      _$s4Yams7EmitterC17serializeSequence33_ED6AA6759560A6062E809BF7E6589292LLyyAA4NodeO0D0VKF in Emitter.swift.o
  "_yaml_stream_end_event_initialize", referenced from:
      _$s4Yams7EmitterC5closeyyKF in Emitter.swift.o
  "_yaml_stream_start_event_initialize", referenced from:
      _$s4Yams7EmitterC4openyyKF in Emitter.swift.o
ld: symbol(s) not found for architecture x86_64
<unknown>:0: error: link command failed with exit code 1 (use -v to see invocation)
[24/25] Linking sourcery

Do not report this issue to Homebrew/brew or Homebrew/core!
```

Then I removed the bad argumens from install, then I still got this warning:
```
Warning: tried to install empty array to /opt/homebrew/Cellar/sourcery/1.0.2/lib
``` 

So I removed the dylib copy too