### PR TITLE
kerl 2.1.0

### DIFF
--- a/Formula/kerl.rb
+++ b/Formula/kerl.rb
@@ -1,8 +1,8 @@
 class Kerl < Formula
   desc "Easy building and installing of Erlang/OTP instances"
   homepage "https://github.com/kerl/kerl"
-  url "https://github.com/kerl/kerl/archive/2.0.2.tar.gz"
-  sha256 "d2addb942489ad96aa73042ed350b06d9add6fb0075fbd28b84b591541e7fac0"
+  url "https://github.com/kerl/kerl/archive/2.1.0.tar.gz"
+  sha256 "fedb123c96d064b1ff1ea386c3c3395e4cac485237edd8bd05aebb442cc46e86"
   license "MIT"
   head "https://github.com/kerl/kerl.git"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 33,108 bytes
- formula fetch time: 0.6 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.