### PR TITLE
airshare: fix test

### DIFF
--- a/Formula/airshare.rb
+++ b/Formula/airshare.rb
@@ -138,10 +138,11 @@ class Airshare < Formula
 
   test do
     port = free_port
-    _, _, wait_thr = Open3.popen2 bin/"airshare", "-p", port.to_s, "homebrew-demo", "-t", "Hello Homebrew!"
+    fork do
+      exec bin/"airshare", "-p", port.to_s, "homebrew-demo", "-t", "Hello Homebrew!"
+    end
     sleep 5
-    output = shell_output("#{bin}/airshare -p #{port} homebrew-demo")
-    assert_equal "Received: Hello Homebrew!\n", output.lines.last
-    Process.kill("TERM", wait_thr.pid)
+    output = shell_output("curl -s http://localhost:#{port}/text")
+    assert_equal "Hello Homebrew!", output.lines.first
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `airshare` formula was building correctly and tests were okay locally as per [this comment](https://github.com/Homebrew/homebrew-core/issues/65000#issuecomment-743343848), however the bottle step failed because of ports being inaccessible in the CI environment.

This PR aims to fix this issue and correct a usage inaccuracy in the previous test. The test proposed here is modelled after the one in `ninja`.