### PR TITLE
xcb-proto, libxcb: requirements do not need a build env

### DIFF
--- a/Formula/libxcb.rb
+++ b/Formula/libxcb.rb
@@ -1,6 +1,6 @@
 class Python3Requirement < Requirement
   fatal true
-  satisfy { which "python3" }
+  satisfy(build_env: false) { which "python3" }
   def message
     <<~EOS
       An existing Python 3 installation is required in order to avoid cyclic

--- a/Formula/xcb-proto.rb
+++ b/Formula/xcb-proto.rb
@@ -1,6 +1,6 @@
 class Python3Requirement < Requirement
   fatal true
-  satisfy { which "python3" }
+  satisfy(build_env: false) { which "python3" }
   def message
     <<~EOS
       An existing Python 3 installation is required in order to avoid cyclic


### PR DESCRIPTION
Fixes (on Linux):
```
RuntimeError: The requested Homebrew GCC was not installed. You must:
brew install gcc
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
