### PR TITLE
orc-tools: add livecheck

### DIFF
--- a/Formula/orc-tools.rb
+++ b/Formula/orc-tools.rb
@@ -5,6 +5,11 @@ class OrcTools < Formula
   sha256 "ade496bf92a2a52f6008e18e1431d770801a93c74dfa0f863cb66b7e9f06b44e"
   license "Apache-2.0"
 
+  livecheck do
+    url "https://search.maven.org/remotecontent?filepath=org/apache/orc/orc-tools/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+
   bottle :unneeded
 
   depends_on "openjdk"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `orc-tools`. This PR adds a `livecheck` block that checks the Maven directory listing page where the version directories are found. [These directories contain the jar file that the formula uses as `stable`.]