### PR TITLE
clojure-lsp 2021.01.28-03.03.16

### DIFF
--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -34,7 +34,7 @@ class ClojureLsp < Formula
     pid = wait_thr.pid
     stdin.write <<~EOF
       Content-Length: 58
-    
+      
       {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
     EOF
     assert_match "Content-Length", stdout.gets("\n")

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -19,7 +19,7 @@ class ClojureLsp < Formula
 
   depends_on "leiningen" => :build
   # The Java Runtime version only recognizes class file versions up to 52.0
-  depends_on "openjdk@11"
+  depends_on "openjdk@8"
 
   def install
     system "lein", "uberjar"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -2,7 +2,7 @@ class ClojureLsp < Formula
   desc "Language Server (LSP) for Clojure"
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   # Switch to use git tag/revision as needed by `lein-git-version`
-  url "https://github.com/snoe/clojure-lsp.git",
+  url "https://github.com/clojure-lsp/clojure-lsp.git",
       tag:      "release-20201207T142850",
       revision: "ab32504073688d507b53e47c354733cd6603bc88"
   version "20201207T142850"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -6,6 +6,7 @@ class ClojureLsp < Formula
       tag:      "2021.01.28-03.03.16",
       revision: "fe50704d5e14009d4eeeb5a88a451d0ef4474838"
   version "2021.01.28-03.03.16"
+  version_scheme 1
   license "MIT"
   head "https://github.com/snoe/clojure-lsp.git"
 

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -33,7 +33,7 @@ class ClojureLsp < Formula
 
     _, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp --version")
     pid = wait_thr.pid
-    assert_match "clojure-lsp", stdout.gets("\n")
+    assert_match "clojure-lsp", stdout.gets
     Process.kill "SIGKILL", pid
   end
 end

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -20,10 +20,7 @@ class ClojureLsp < Formula
   depends_on "openjdk@11"
 
   def install
-    system "lein", "uberjar"
-    jar = Dir["target/clojure-lsp-*-standalone.jar"][0]
-    libexec.install jar
-    bin.write_jar_script libexec/File.basename(jar), "clojure-lsp"
+    chmod 0755, "clojure-lsp"
   end
 
   test do

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -39,5 +39,6 @@ class ClojureLsp < Formula
         {"jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "rootUri": null, "capabilities": {}}}
       EOF
       assert_match "Content-Length:", stdout.gets("\n")
+    end
   end
 end

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -3,7 +3,7 @@ class ClojureLsp < Formula
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   # Switch to use git tag/revision as needed by `lein-git-version`
   url "https://github.com/clojure-lsp/clojure-lsp.git",
-      tag:      "foobar",
+      tag:      "2021.02.02-14.02.23",
       revision: "fb7548b0b43c3e4e266a0f10418dcfa54402de97"
   version "2021.02.02-14.02.23"
   license "MIT"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -38,6 +38,8 @@ class ClojureLsp < Formula
 
       {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
     EOF
+    print "stdout.gets: "
+    print stdout.gets("\n")
     assert_match "Content-Length", stdout.gets("\n")
     Process.kill "SIGKILL", pid
   end

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -31,7 +31,7 @@ class ClojureLsp < Formula
   test do
     require "Open3"
 
-    stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp --version")
+    _, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp --version")
     pid = wait_thr.pid
     assert_match "clojure-lsp", stdout.gets("\n")
     Process.kill "SIGKILL", pid

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -3,9 +3,7 @@ class ClojureLsp < Formula
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   # Switch to use git tag/revision as needed by `lein-git-version`
   url "https://github.com/clojure-lsp/clojure-lsp/releases/download/2021.02.02-14.02.23/clojure-lsp",
-      tag:      "2021.02.02-14.02.23",
-      revision: "fb7548b0b43c3e4e266a0f10418dcfa54402de97"
-  version "2021.02.02-14.02.23"
+  sha256 33182e16557abf76af9d6246da99539c12be46703aae6d9f8c9825b371165a02,
   license "MIT"
   version_scheme 1
   head "https://github.com/snoe/clojure-lsp.git"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -3,9 +3,9 @@ class ClojureLsp < Formula
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   # Switch to use git tag/revision as needed by `lein-git-version`
   url "https://github.com/clojure-lsp/clojure-lsp.git",
-      tag:      "release-20201207T142850",
-      revision: "ab32504073688d507b53e47c354733cd6603bc88"
-  version "20201207T142850"
+      tag:      "2021.02.02-14.02.23",
+      revision: "fb7548b0b43c3e4e266a0f10418dcfa54402de97"
+  version "2021.02.02-14.02.23"
   license "MIT"
   head "https://github.com/snoe/clojure-lsp.git"
 

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -18,7 +18,7 @@ class ClojureLsp < Formula
 
   depends_on "leiningen" => :build
   # The Java Runtime version only recognizes class file versions up to 52.0
-  depends_on "openjdk@8"
+  depends_on "openjdk@11"
 
   def install
     system "lein", "uberjar"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -39,8 +39,5 @@ class ClojureLsp < Formula
         {"jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "rootUri": null, "capabilities": {}}}
       EOF
       assert_match "Content-Length:", stdout.gets("\n")
-    ensure
-      Process.kill "SIGKILL", pid
-    end
   end
 end

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -3,11 +3,10 @@ class ClojureLsp < Formula
   homepage "https://github.com/snoe/clojure-lsp"
   # Switch to use git tag/revision as needed by `lein-git-version`
   url "https://github.com/snoe/clojure-lsp.git",
-      tag:      "2021.01.28-03.03.16",
-      revision: "fe50704d5e14009d4eeeb5a88a451d0ef4474838"
-  version "2021.01.28-03.03.16"
+      tag:      "release-20201207T142850",
+      revision: "ab32504073688d507b53e47c354733cd6603bc88"
+  version "20201207T142850"
   license "MIT"
-  version_scheme 1
   head "https://github.com/snoe/clojure-lsp.git"
 
   bottle do
@@ -29,15 +28,15 @@ class ClojureLsp < Formula
   end
 
   test do
-    input =
-      "Content-Length: 152\r\n" \
-      "\r\n" \
-      "{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"initialize\",\"params\":{\"" \
-      "processId\":88075,\"rootUri\":null,\"capabilities\":{},\"trace\":\"ver" \
-      "bose\",\"workspaceFolders\":null}}\r\n"
+    require "Open3"
 
-    output = "Content-Length:"
-
-    assert_match output, pipe_output("#{bin}/clojure-lsp", input, 0)
+    stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
+    pid = wait_thr.pid
+    stdin.write <<~EOF
+      Content-Length: 58
+      {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
+    EOF
+    assert_match "Content-Length", stdout.gets("\n")
+    Process.kill "SIGKILL", pid
   end
 end

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -31,16 +31,9 @@ class ClojureLsp < Formula
   test do
     require "Open3"
 
-    stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
+    stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp --version")
     pid = wait_thr.pid
-    stdin.write <<~EOF
-      Content-Length: 59
-
-      {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
-    EOF
-    print "stdout.gets: "
-    print stdout.gets("\n")
-    assert_match "Content-Length", stdout.gets("\n")
+    assert_match "clojure-lsp", stdout.gets("\n")
     Process.kill "SIGKILL", pid
   end
 end

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -34,6 +34,7 @@ class ClojureLsp < Formula
     pid = wait_thr.pid
     stdin.write <<~EOF
       Content-Length: 58
+    
       {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
     EOF
     assert_match "Content-Length", stdout.gets("\n")

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -3,7 +3,7 @@ class ClojureLsp < Formula
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   # Switch to use git tag/revision as needed by `lein-git-version`
   url "https://github.com/clojure-lsp/clojure-lsp.git",
-      tag:      "2021.02.02-14.02.23",
+      tag:      "foobar",
       revision: "fb7548b0b43c3e4e266a0f10418dcfa54402de97"
   version "2021.02.02-14.02.23"
   license "MIT"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -34,7 +34,7 @@ class ClojureLsp < Formula
     pid = wait_thr.pid
     stdin.write <<~EOF
       Content-Length: 58
-      
+
       {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
     EOF
     assert_match "Content-Length", stdout.gets("\n")

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -2,8 +2,8 @@ class ClojureLsp < Formula
   desc "Language Server (LSP) for Clojure"
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   # Switch to use git tag/revision as needed by `lein-git-version`
-  url "https://github.com/clojure-lsp/clojure-lsp/releases/download/2021.02.02-14.02.23/clojure-lsp",
-  sha256 33182e16557abf76af9d6246da99539c12be46703aae6d9f8c9825b371165a02,
+  url "https://github.com/clojure-lsp/clojure-lsp/releases/download/2021.02.02-14.02.23/clojure-lsp"
+  sha256 "33182e16557abf76af9d6246da99539c12be46703aae6d9f8c9825b371165a02"
   license "MIT"
   version_scheme 1
   head "https://github.com/snoe/clojure-lsp.git"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -29,16 +29,15 @@ class ClojureLsp < Formula
   end
 
   test do
-    require "open3"
+    input =
+      "Content-Length: 152\r\n" \
+      "\r\n" \
+      "{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"initialize\",\"params\":{\"" \
+      "processId\":88075,\"rootUri\":null,\"capabilities\":{},\"trace\":\"ver" \
+      "bose\",\"workspaceFolders\":null}}\r\n"
 
-    begin
-      stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
-      pid = wait_thr.pid
-      stdin.write <<~EOF
-        Content-Length: 103
-        {"jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "rootUri": null, "capabilities": {}}}
-      EOF
-      assert_match "Content-Length:", stdout.gets("\n")
-    end
+    output = "Content-Length:"
+
+    assert_match output, pipe_output("#{bin}/clojure-lsp", input, 0)
   end
 end

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -20,7 +20,7 @@ class ClojureLsp < Formula
   depends_on "openjdk@11"
 
   def install
-    chmod 0755, "clojure-lsp"
+    bin.install "clojure-lsp"
   end
 
   test do

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -34,7 +34,7 @@ class ClojureLsp < Formula
     stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
     pid = wait_thr.pid
     stdin.write <<~EOF
-      Content-Length: 58
+      Content-Length: 59
 
       {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
     EOF

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -1,6 +1,6 @@
 class ClojureLsp < Formula
   desc "Language Server (LSP) for Clojure"
-  homepage "https://github.com/snoe/clojure-lsp"
+  homepage "https://github.com/clojure-lsp/clojure-lsp"
   # Switch to use git tag/revision as needed by `lein-git-version`
   url "https://github.com/snoe/clojure-lsp.git",
       tag:      "release-20201207T142850",

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -29,11 +29,18 @@ class ClojureLsp < Formula
   end
 
   test do
-    require "Open3"
+    require "open3"
 
-    _, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp --version")
-    pid = wait_thr.pid
-    assert_match "clojure-lsp", stdout.gets
-    Process.kill "SIGKILL", pid
+    begin
+      stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
+      pid = wait_thr.pid
+      stdin.write <<~EOF
+        Content-Length: 103
+        {"jsonrpc": "2.0", "id": 0, "method": "initialize", "params": { "rootUri": null, "capabilities": {}}}
+      EOF
+      assert_match "Content-Length:", stdout.gets("\n")
+    ensure
+      Process.kill "SIGKILL", pid
+    end
   end
 end

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -7,6 +7,7 @@ class ClojureLsp < Formula
       revision: "fb7548b0b43c3e4e266a0f10418dcfa54402de97"
   version "2021.02.02-14.02.23"
   license "MIT"
+  version_scheme 1
   head "https://github.com/snoe/clojure-lsp.git"
 
   bottle do
@@ -18,7 +19,7 @@ class ClojureLsp < Formula
 
   depends_on "leiningen" => :build
   # The Java Runtime version only recognizes class file versions up to 52.0
-  depends_on "openjdk@8"
+  depends_on "openjdk@11"
 
   def install
     system "lein", "uberjar"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -7,15 +7,8 @@ class ClojureLsp < Formula
   license "MIT"
   version_scheme 1
   head "https://github.com/snoe/clojure-lsp.git"
+  bottle :unneeded
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "a647293f345eead229f83e2707fb2c542958c9b4e33fb0bf4e63c7217548d392" => :big_sur
-    sha256 "079f2087995cd399f1c99dddc5f1d6d92e55af2facf67b427fb633a80faba842" => :catalina
-    sha256 "fc1b26dc8f000fc728c26bbedff9f9ab0d6f2071ef17eeb4a0f71c9626184cc7" => :mojave
-  end
-
-  depends_on "leiningen" => :build
   # The Java Runtime version only recognizes class file versions up to 52.0
   depends_on "openjdk@11"
 

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -6,8 +6,8 @@ class ClojureLsp < Formula
       tag:      "2021.01.28-03.03.16",
       revision: "fe50704d5e14009d4eeeb5a88a451d0ef4474838"
   version "2021.01.28-03.03.16"
-  version_scheme 1
   license "MIT"
+  version_scheme 1
   head "https://github.com/snoe/clojure-lsp.git"
 
   bottle do

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -3,9 +3,9 @@ class ClojureLsp < Formula
   homepage "https://github.com/snoe/clojure-lsp"
   # Switch to use git tag/revision as needed by `lein-git-version`
   url "https://github.com/snoe/clojure-lsp.git",
-      tag:      "release-20201207T142850",
-      revision: "ab32504073688d507b53e47c354733cd6603bc88"
-  version "20201207T142850"
+      tag:      "2021.01.28-03.03.16",
+      revision: "fe50704d5e14009d4eeeb5a88a451d0ef4474838"
+  version "2021.01.28-03.03.16"
   license "MIT"
   head "https://github.com/snoe/clojure-lsp.git"
 

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -2,7 +2,7 @@ class ClojureLsp < Formula
   desc "Language Server (LSP) for Clojure"
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   # Switch to use git tag/revision as needed by `lein-git-version`
-  url "https://github.com/clojure-lsp/clojure-lsp.git",
+  url "https://github.com/clojure-lsp/clojure-lsp/releases/download/2021.02.02-14.02.23/clojure-lsp",
       tag:      "2021.02.02-14.02.23",
       revision: "fb7548b0b43c3e4e266a0f10418dcfa54402de97"
   version "2021.02.02-14.02.23"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -30,16 +30,17 @@ class ClojureLsp < Formula
 
   test do
     require "Open3"
-    stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp 2>/dev/null")
+    _stdin, _stdout, stderr, wait_thr = Open3.popen3("#{bin}/clojure-lsp --foo 2>/dev/null")
+    print "stedrr gets: " + stderr.gets
     pid = wait_thr.pid
-    stdin.write <<~EOF
-      Content-Length: 59
+    # stdin.write <<~EOF
+    #   Content-Length: 59
 
-      {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
+    #   {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
 
-    EOF
+    # EOF
 
-    assert_match "Content-Length", stdout.gets
+    # assert_match "Content-Length", stdout.gets
     Process.kill "SIGKILL", pid
   end
 end

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -31,7 +31,7 @@ class ClojureLsp < Formula
     require "Open3"
 
     system "file", "#{bin}/clojure-lsp"
-    stdin, stdout, _stderr, wait_thr = Open3.popen3("#{bin}/clojure-lsp 2>&1")
+    stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp 2>/dev/null")
     pid = wait_thr.pid
     stdin.write <<~EOF
       Content-Length: 59
@@ -40,7 +40,6 @@ class ClojureLsp < Formula
 
     EOF
 
-    stdout.gets # will print java options
     assert_match "Content-Length", stdout.gets
     Process.kill "SIGKILL", pid
   end

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -31,7 +31,9 @@ class ClojureLsp < Formula
     require "Open3"
 
     print "testing"
+    system "file", "#{bin}/clojure-lsp"
     stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
+    print Dir.entries("#{bin}")
     print "testing2"
     pid = wait_thr.pid
     print "testing3"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -21,6 +21,7 @@ class ClojureLsp < Formula
   depends_on "openjdk@11"
 
   def install
+    ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix
     system "lein", "uberjar"
     jar = Dir["target/clojure-lsp-*-standalone.jar"][0]
     libexec.install jar
@@ -29,8 +30,6 @@ class ClojureLsp < Formula
 
   test do
     require "Open3"
-
-    system "file", "#{bin}/clojure-lsp"
     stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp 2>/dev/null")
     pid = wait_thr.pid
     stdin.write <<~EOF

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -4,7 +4,7 @@ class ClojureLsp < Formula
   # Switch to use git tag/revision as needed by `lein-git-version`
   url "https://github.com/clojure-lsp/clojure-lsp.git",
       tag:      "2021.02.04-02.08.58",
-      revision: "ab32504073688d507b53e47c354733cd6603bc88"
+      revision: "a88950f4c742460bf4621e776929f1a22c547e6e"
   version "2021.02.04-02.08.58"
   license "MIT"
   version_scheme 1

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -48,4 +48,3 @@ class ClojureLsp < Formula
     print "testing6"
   end
 end
-

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -2,18 +2,29 @@ class ClojureLsp < Formula
   desc "Language Server (LSP) for Clojure"
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   # Switch to use git tag/revision as needed by `lein-git-version`
-  url "https://github.com/clojure-lsp/clojure-lsp/releases/download/2021.02.02-14.02.23/clojure-lsp"
-  sha256 "33182e16557abf76af9d6246da99539c12be46703aae6d9f8c9825b371165a02"
+  url "https://github.com/clojure-lsp/clojure-lsp.git",
+      tag:      "2021.02.04-02.08.58",
+      revision: "ab32504073688d507b53e47c354733cd6603bc88"
+  version "2021.02.04-02.08.58"
   license "MIT"
   version_scheme 1
-  head "https://github.com/snoe/clojure-lsp.git"
-  bottle :unneeded
+  head "https://github.com/clojure/clojure-lsp.git"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, big_sur:  "a647293f345eead229f83e2707fb2c542958c9b4e33fb0bf4e63c7217548d392"
+    sha256 cellar: :any_skip_relocation, catalina: "079f2087995cd399f1c99dddc5f1d6d92e55af2facf67b427fb633a80faba842"
+    sha256 cellar: :any_skip_relocation, mojave:   "fc1b26dc8f000fc728c26bbedff9f9ab0d6f2071ef17eeb4a0f71c9626184cc7"
+  end
+
+  depends_on "leiningen" => :build
   # The Java Runtime version only recognizes class file versions up to 52.0
   depends_on "openjdk@11"
 
   def install
-    bin.install "clojure-lsp"
+    system "lein", "uberjar"
+    jar = Dir["target/clojure-lsp-*-standalone.jar"][0]
+    libexec.install jar
+    bin.write_jar_script libexec/File.basename(jar), "clojure-lsp"
   end
 
   test do

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -32,7 +32,7 @@ class ClojureLsp < Formula
 
     print "testing"
     system "file", "#{bin}/clojure-lsp"
-    stdin, _stdout, strerr, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
+    stdin, _stdout, stderr, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
     print Dir.entries("#{bin}")
     print "testing2"
     pid = wait_thr.pid

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -30,14 +30,22 @@ class ClojureLsp < Formula
   test do
     require "Open3"
 
+    print "testing"
     stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
+    print "testing2"
     pid = wait_thr.pid
+    print "testing3"
     stdin.write <<~EOF
-      Content-Length: 58
+      Content-Length: 59
 
       {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
     EOF
-    assert_match "Content-Length", stdout.gets("\n")
+
+    print "testing4"
+    assert_match "Content-Length", stdout.gets
+    print "testing5"
     Process.kill "SIGKILL", pid
+    print "testing6"
   end
 end
+

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -32,7 +32,7 @@ class ClojureLsp < Formula
 
     print "testing"
     system "file", "#{bin}/clojure-lsp"
-    stdin, stdout, _, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
+    stdin, _stdout, strerr, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
     print Dir.entries("#{bin}")
     print "testing2"
     pid = wait_thr.pid
@@ -45,7 +45,7 @@ class ClojureLsp < Formula
     EOF
 
     print "testing4"
-    assert_match "Content-Length", stdout.gets
+    assert_match "Content-Length", stderr.gets
     print "testing5"
     Process.kill "SIGKILL", pid
     print "testing6"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -31,7 +31,7 @@ class ClojureLsp < Formula
     require "Open3"
 
     system "file", "#{bin}/clojure-lsp"
-    stdin, stdout, stderr, wait_thr = Open3.popen3("#{bin}/clojure-lsp 2>&1")
+    stdin, stdout, _stderr, wait_thr = Open3.popen3("#{bin}/clojure-lsp 2>&1")
     pid = wait_thr.pid
     stdin.write <<~EOF
       Content-Length: 59

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -30,13 +30,9 @@ class ClojureLsp < Formula
   test do
     require "Open3"
 
-    print "testing"
     system "file", "#{bin}/clojure-lsp"
-    stdin, _stdout, stderr, wait_thr = Open3.popen3("#{bin}/clojure-lsp")
-    print Dir.entries("#{bin}")
-    print "testing2"
+    stdin, stdout, stderr, wait_thr = Open3.popen3("#{bin}/clojure-lsp 2>&1")
     pid = wait_thr.pid
-    print "testing3"
     stdin.write <<~EOF
       Content-Length: 59
 
@@ -44,10 +40,8 @@ class ClojureLsp < Formula
 
     EOF
 
-    print "testing4"
-    assert_match "Content-Length", stderr.gets
-    print "testing5"
+    stdout.gets # will print java options
+    assert_match "Content-Length", stdout.gets
     Process.kill "SIGKILL", pid
-    print "testing6"
   end
 end

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -36,9 +36,10 @@ class ClojureLsp < Formula
     pid = wait_thr.pid
     print "testing3"
     stdin.write <<~EOF
-      Content-Length: 59
+      Content-Length: 59
 
-      {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
+      {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
+
     EOF
 
     print "testing4"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -8,7 +8,7 @@ class ClojureLsp < Formula
   version "2021.02.04-02.08.58"
   license "MIT"
   version_scheme 1
-  head "https://github.com/clojure/clojure-lsp.git"
+  head "https://github.com/clojure-lsp/clojure-lsp.git"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:  "a647293f345eead229f83e2707fb2c542958c9b4e33fb0bf4e63c7217548d392"


### PR DESCRIPTION
Since the release name format has been changed, it needs to be manually updated.

```
brew bump-formula-pr clojure-lsp --tag=2021.01.28-03.03.16 --revision=fe50704d5e14009d4eeeb5a88a451d0ef4474838
...
Error: You need to bump this formula manually since the new version and the old version are both 20201207T142850.
```

See https://github.com/clojure-lsp/clojure-lsp/releases/tag/2021.01.28-03.03.16.


- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] [see logs] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

<details>
<summary>Logs</summary>

```
myuser in ~/temp
$ brew install --build-from-source clojure-lsp.rb
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/cask).
==> Updated Casks
Updated 1 cask.

==> Downloading https://homebrew.bintray.com/bottles/leiningen-2.9.5.catalina.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/7c29f1583ec0deb5b873547b3d9366d9d90f00728dd24e52d2538d5131f0dedb?respon
######################################################################## 100.0%
==> Downloading https://homebrew.bintray.com/bottles/openjdk%408-1.8.0%2B282.catalina.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/43314334444466e9540b4193f8313c080af49e6fb6c7ea1b6b2e7c3fde45335c?respon
######################################################################## 100.0%
==> Cloning https://github.com/snoe/clojure-lsp.git
Cloning into '/Users/myuser/Library/Caches/Homebrew/clojure-lsp--git'...
==> Checking out tag 2021.01.28-03.03.16
HEAD is now at fe50704 Deep merge clj-kondo batch analysis
Warning: Your Xcode (12.1) is outdated.
Please update to Xcode 12.3 (or delete it).
Xcode can be updated from the App Store.

Error: clojure-lsp 20201207T142850 is already installed
To install 2021.01.28-03.03.16, first run:
  brew unlink clojure-lsp
==> `brew cleanup` has not been run in 30 days, running now...
Removing: /Users/myuser/Library/Caches/Homebrew/atk--2.36.0.catalina.bottle.tar.gz... (476.3KB)
Removing: /usr/local/Cellar/automake/1.16.1_1... (131 files, 3.4MB)
Removing: /Users/myuser/Library/Caches/Homebrew/awscli--2.1.19.catalina.bottle.tar.gz... (22.1MB)
Removing: /Users/myuser/Library/Caches/Homebrew/babashka--0.2.6.zip... (18.6MB)
Removing: /Users/myuser/Library/Caches/Homebrew/bfg--1.13.1.jar... (13.8MB)
Removing: /Users/myuser/Library/Caches/Homebrew/binutils--2.35.1_1.catalina.bottle.tar.gz... (39.5MB)
Removing: /Users/myuser/Library/Caches/Homebrew/clj-kondo--2020.12.12.zip... (8.6MB)
Removing: /Users/myuser/Library/Caches/Homebrew/clojure--1.10.1.763.tar.gz... (16.7MB)
Removing: /Users/myuser/Library/Caches/Homebrew/dart--2.10.4.zip... (157.8MB)
Removing: /Users/myuser/Library/Caches/Homebrew/dialog--1.3-20201126.catalina.bottle.tar.gz... (330.7KB)
Removing: /Users/myuser/Library/Caches/Homebrew/docbook--5.1_1.catalina.bottle.tar.gz... (1.3MB)
Removing: /Users/myuser/Library/Caches/Homebrew/docbook-xsl--1.79.2_1.catalina.bottle.tar.gz... (46.4MB)
Removing: /Users/myuser/Library/Caches/Homebrew/fribidi--1.0.10.catalina.bottle.tar.gz... (129.6KB)
Removing: /Users/myuser/Library/Caches/Homebrew/gawk--5.1.0.catalina.bottle.tar.gz... (1.3MB)
Removing: /Users/myuser/Library/Caches/Homebrew/gd--2.3.0.catalina.bottle.tar.gz... (288.9KB)
Removing: /Users/myuser/Library/Caches/Homebrew/gettext--0.21.catalina.bottle.tar.gz... (8.5MB)
Removing: /usr/local/Cellar/gmp/6.2.0... (20 files, 3.2MB)
Removing: /Users/myuser/Library/Caches/Homebrew/gnumeric--1.12.48.catalina.bottle.tar.gz... (17.2MB)
Removing: /Users/myuser/Library/Caches/Homebrew/go--1.15.6.catalina.bottle.tar.gz... (153.9MB)
Removing: /Users/myuser/Library/Caches/Homebrew/goffice--0.10.48.catalina.bottle.tar.gz... (3.2MB)
Removing: /Users/myuser/Library/Caches/Homebrew/imagemagick--7.0.10-58.catalina.bottle.tar.gz... (10.0MB)
Removing: /Users/myuser/Library/Caches/Homebrew/imagemagick@6--6.9.11-58.catalina.bottle.tar.gz... (9.1MB)
Removing: /Users/myuser/Library/Caches/Homebrew/kind--0.9.0.catalina.bottle.1.tar.gz... (4.7MB)
Removing: /Users/myuser/Library/Caches/Homebrew/leptonica--1.80.0.catalina.bottle.tar.gz... (2.4MB)
Removing: /Users/myuser/Library/Caches/Homebrew/libevent--2.1.12.catalina.bottle.tar.gz... (681.3KB)
Removing: /Users/myuser/Library/Caches/Homebrew/libgsf--1.14.47.catalina.bottle.tar.gz... (546.0KB)
Removing: /usr/local/Cellar/libheif/1.7.0... (23 files, 2.4MB)
Removing: /Users/myuser/Library/Caches/Homebrew/liblqr--0.4.2_1.catalina.bottle.1.tar.gz... (43.5KB)
Removing: /usr/local/Cellar/libplist/2.1.0... (29 files, 369.6KB)
Removing: /Users/myuser/Library/Caches/Homebrew/librsvg--2.50.2.catalina.bottle.tar.gz... (38.3MB)
Removing: /Users/myuser/Library/Caches/Homebrew/libsndfile--1.0.30_1.catalina.bottle.tar.gz... (579.8KB)
Removing: /usr/local/Cellar/libtiff/4.1.0... (247 files, 3.6MB)
Removing: /Users/myuser/Library/Caches/Homebrew/libtool--2.4.6_2.catalina.bottle.tar.gz... (1012.8KB)
Removing: /usr/local/Cellar/libusb/1.0.23... (29 files, 531.7KB)
Removing: /Users/myuser/Library/Caches/Homebrew/libvorbis--1.3.7.catalina.bottle.tar.gz... (576.8KB)
Removing: /Users/myuser/Library/Caches/Homebrew/libvpx--1.9.0.catalina.bottle.tar.gz... (1MB)
Removing: /Users/myuser/Library/Caches/Homebrew/libvterm--0.1.4.catalina.bottle.tar.gz... (67.2KB)
Removing: /Users/myuser/Library/Caches/Homebrew/libyaml--0.2.5.catalina.bottle.tar.gz... (107.4KB)
Removing: /Users/myuser/Library/Caches/Homebrew/little-cms2--2.11.catalina.bottle.tar.gz... (386.8KB)
Removing: /usr/local/Cellar/lua/5.3.5_1... (28 files, 274.5KB)
Removing: /Users/myuser/Library/Caches/Homebrew/mpfr--4.1.0.catalina.bottle.tar.gz... (1.2MB)
Removing: /Users/myuser/Library/Caches/Homebrew/msgpack--3.3.0.catalina.bottle.tar.gz... (392.7KB)
Removing: /Users/myuser/Library/Caches/Homebrew/ncurses--6.2.catalina.bottle.tar.gz... (2.3MB)
Removing: /Users/myuser/Library/Caches/Homebrew/node--15.6.0.catalina.bottle.tar.gz... (15.2MB)
Removing: /Users/myuser/Library/Caches/Homebrew/nss--3.60.1.catalina.bottle.tar.gz... (13.5MB)
Removing: /Users/myuser/Library/Caches/Homebrew/openjdk--15.0.1.catalina.bottle.tar.gz... (190.9MB)
Removing: /Users/myuser/Library/Caches/Homebrew/openjdk@8--1.8.0+275.catalina.bottle.tar.gz... (98.3MB)
Removing: /Users/myuser/Library/Caches/Homebrew/pandoc--2.11.3.2.catalina.bottle.tar.gz... (27.6MB)
Removing: /Users/myuser/Library/Caches/Homebrew/pango--1.48.0.catalina.bottle.tar.gz... (733.4KB)
Removing: /Users/myuser/Library/Caches/Homebrew/perl--5.32.0.catalina.bottle.tar.gz... (16.6MB)
Removing: /Users/myuser/Library/Caches/Homebrew/ruby-build--20201225.tar.gz... (68.2KB)
Removing: /Users/myuser/Library/Caches/Homebrew/sass--1.32.4.tar.gz... (343.7KB)
Removing: /Users/myuser/Library/Caches/Homebrew/texinfo--6.7.catalina.bottle.tar.gz... (1.6MB)
Removing: /Users/myuser/Library/Caches/Homebrew/vim--8.2.2350.catalina.bottle.tar.gz... (11.6MB)
Removing: /Users/myuser/Library/Caches/Homebrew/wget--1.21.catalina.bottle.tar.gz... (1.4MB)
Removing: /Users/myuser/Library/Caches/Homebrew/ykman--3.1.1_3.catalina.bottle.tar.gz... (3MB)
Removing: /Users/myuser/Library/Caches/Homebrew/youtube-dl--2021.1.16.catalina.bottle.tar.gz... (4.6MB)
Removing: /Users/myuser/Library/Caches/Homebrew/Cask/vlc--3.0.11.1.dmg... (49.6MB)
Removing: /Users/myuser/Library/Logs/Homebrew/libimobiledevice... (8 files, 507.5KB)
Removing: /Users/myuser/Library/Logs/Homebrew/libplist... (64B)
Removing: /Users/myuser/Library/Logs/Homebrew/clingo... (64B)
Removing: /Users/myuser/Library/Logs/Homebrew/readline... (64B)
Removing: /Users/myuser/Library/Logs/Homebrew/sqlite... (64B)
Removing: /Users/myuser/Library/Logs/Homebrew/lua... (64B)
Removing: /Users/myuser/Library/Logs/Homebrew/libusbmuxd... (64B)
Removing: /Users/myuser/Library/Logs/Homebrew/youtube-dl... (64B)
Removing: /Users/myuser/Library/Logs/Homebrew/openssl@1.1... (64B)
Removing: /Users/myuser/Library/Logs/Homebrew/libusb... (64B)
Removing: /Users/myuser/Library/Logs/Homebrew/automake... (64B)
Pruned 5 symbolic links and 13 directories from /usr/local
```

```
$ brew test clojure-lsp.rb
Error: Testing requires the latest version of clojure-lsp
```

After unlinking it:

```
myuser in ~/temp
$ brew unlink clojure-lsp
Unlinking /usr/local/Cellar/clojure-lsp/20201207T142850... 1 symlinks removed.

myuser in ~/temp
$ brew install --build-from-source clojure-lsp.rb
==> Downloading https://homebrew.bintray.com/bottles/leiningen-2.9.5.catalina.bottle.tar.gz
Already downloaded: /Users/myuser/Library/Caches/Homebrew/downloads/492b205256acbc129a9626bbae8a210de21b3e4265a7ffab8964529bee90b17d--leiningen-2.9.5.catalina.bottle.tar.gz
==> Downloading https://homebrew.bintray.com/bottles/openjdk%408-1.8.0%2B282.catalina.bottle.tar.gz
Already downloaded: /Users/myuser/Library/Caches/Homebrew/downloads/e980129685496f2b8589e7b94db475032f4c15f41fb6d6add81e4bde5d1b8c94--openjdk@8-1.8.0+282.catalina.bottle.tar.gz
==> Cloning https://github.com/snoe/clojure-lsp.git
Updating /Users/myuser/Library/Caches/Homebrew/clojure-lsp--git
==> Checking out tag 2021.01.28-03.03.16
HEAD is now at fe50704 Deep merge clj-kondo batch analysis
HEAD is now at fe50704 Deep merge clj-kondo batch analysis
Warning: Your Xcode (12.1) is outdated.
Please update to Xcode 12.3 (or delete it).
Xcode can be updated from the App Store.

Warning: clojure-lsp 20201207T142850 is available and more recent than version 2021.01.28-03.03.16.
==> Installing dependencies for clojure-lsp: leiningen and openjdk@8
==> Installing clojure-lsp dependency: leiningen
==> Pouring leiningen-2.9.5.catalina.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/lein
Target /usr/local/bin/lein
already exists. You may want to remove it:
  rm '/usr/local/bin/lein'

To force the link and overwrite all conflicting files:
  brew link --overwrite leiningen

To list all files that would be deleted:
  brew link --overwrite --dry-run leiningen

Possible conflicting files are:
/usr/local/bin/lein
==> Caveats
Dependencies will be installed to:
  $HOME/.m2/repository
To play around with Clojure run `lein repl` or `lein help`.

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
==> Summary
🍺  /usr/local/Cellar/leiningen/2.9.5: 10 files, 12.3MB
==> Installing clojure-lsp dependency: openjdk@8
==> Pouring openjdk@8-1.8.0+282.catalina.bottle.tar.gz
==> Caveats
For the system Java wrappers to find this JDK, symlink it with
  sudo ln -sfn /usr/local/opt/openjdk@8/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-8.jdk

openjdk@8 is keg-only, which means it was not symlinked into /usr/local,
because this is an alternate version of another formula.

If you need to have openjdk@8 first in your PATH, run:
  echo 'export PATH="/usr/local/opt/openjdk@8/bin:$PATH"' >> /Users/myuser/.bash_profile

For compilers to find openjdk@8 you may need to set:
  export CPPFLAGS="-I/usr/local/opt/openjdk@8/include"

==> Summary
🍺  /usr/local/Cellar/openjdk@8/1.8.0+282: 742 files, 193.0MB
==> Installing clojure-lsp
==> lein uberjar
🍺  /usr/local/Cellar/clojure-lsp/2021.01.28-03.03.16: 7 files, 30.3MB, built in 2 minutes 4 seconds
==> Caveats
==> leiningen
Dependencies will be installed to:
  $HOME/.m2/repository
To play around with Clojure run `lein repl` or `lein help`.

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
==> openjdk@8
For the system Java wrappers to find this JDK, symlink it with
  sudo ln -sfn /usr/local/opt/openjdk@8/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-8.jdk

openjdk@8 is keg-only, which means it was not symlinked into /usr/local,
because this is an alternate version of another formula.

If you need to have openjdk@8 first in your PATH, run:
  echo 'export PATH="/usr/local/opt/openjdk@8/bin:$PATH"' >> /Users/myuser/.bash_profile

For compilers to find openjdk@8 you may need to set:
  export CPPFLAGS="-I/usr/local/opt/openjdk@8/include"
```

Test:

```
$ brew test clojure-lsp.rb
==> Testing clojure-lsp
Killing child processes...
Error: clojure-lsp: failed
An exception occurred within a child process:
  Timeout::Error: execution expired
/Users/myuser/temp/clojure-lsp.rb:39:in `gets'
/Users/myuser/temp/clojure-lsp.rb:39:in `block in <class:ClojureLsp>'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1910:in `block (3 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/utils.rb:530:in `with_env'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1909:in `block (2 levels) in run_test'
/usr/local/Homebrew/Library/Homebrew/formula.rb:899:in `with_logging'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1908:in `block in run_test'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:63:in `block in run'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:63:in `chdir'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:63:in `run'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2156:in `mktemp'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1902:in `run_test'
/usr/local/Homebrew/Library/Homebrew/test.rb:43:in `block in <main>'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/usr/local/Homebrew/Library/Homebrew/test.rb:42:in `<main>'

```

audit:

```
myuser in ~/temp
$ brew audit --strict clojure-lsp.rb
==> Installing 'bundler' gem
Fetching bundler-1.17.3.gem
Fetching gem metadata from https://rubygems.org/.........
Fetching concurrent-ruby 1.1.8
Fetching minitest 5.14.3
Fetching zeitwerk 2.4.2
Installing minitest 5.14.3
Installing zeitwerk 2.4.2
Fetching ast 2.4.2
Fetching bindata 2.4.8
Installing ast 2.4.2
Using bundler 1.17.3
Fetching byebug 11.1.3
Installing bindata 2.4.8
Installing byebug 11.1.3 with native extensions
Installing concurrent-ruby 1.1.8
Fetching docile 1.3.5
Installing docile 1.3.5
Fetching simplecov-html 0.12.3
Installing simplecov-html 0.12.3
Fetching simplecov_json_formatter 0.1.2
Fetching coderay 1.1.3
Installing simplecov_json_formatter 0.1.2
Fetching colorize 0.8.1
Installing colorize 0.8.1
Installing coderay 1.1.3
Fetching highline 2.0.3
Installing highline 2.0.3
Fetching connection_pool 2.2.3
Installing connection_pool 2.2.3
Fetching diff-lcs 1.4.4
Fetching unf_ext 0.0.7.7
Installing diff-lcs 1.4.4
Fetching hpricot 0.8.6
Installing unf_ext 0.0.7.7 with native extensions
Installing hpricot 0.8.6 with native extensions
Fetching mime-types-data 3.2020.1104
Installing mime-types-data 3.2020.1104
Fetching net-http-digest_auth 1.4.1
Installing net-http-digest_auth 1.4.1
Fetching mini_portile2 2.5.0
Installing mini_portile2 2.5.0
Fetching racc 1.5.2
Installing racc 1.5.2 with native extensions
Fetching ntlm-http 0.1.1
Installing ntlm-http 0.1.1
Fetching webrobots 0.1.2
Installing webrobots 0.1.2
Fetching method_source 1.0.0
Installing method_source 1.0.0
Fetching mustache 1.1.1
Installing mustache 1.1.1
Fetching parallel 1.20.1
Installing parallel 1.20.1
Fetching rainbow 3.0.0
Installing rainbow 3.0.0
Fetching sorbet-runtime 0.5.6251
Installing sorbet-runtime 0.5.6251
Fetching plist 3.6.0
Installing plist 3.6.0
Fetching rack 2.2.3
Installing rack 2.2.3
Fetching rdiscount 2.2.0.2
Installing rdiscount 2.2.0.2 with native extensions
Fetching regexp_parser 2.0.3
Installing regexp_parser 2.0.3
Fetching rexml 3.2.4
Installing rexml 3.2.4
Fetching rspec-support 3.10.0
Installing rspec-support 3.10.0
Fetching sorbet-static 0.5.6251 (universal-darwin-14)
Installing sorbet-static 0.5.6251 (universal-darwin-14)
Fetching ruby-progressbar 1.11.0
Installing ruby-progressbar 1.11.0
Fetching unicode-display_width 2.0.0
Installing unicode-display_width 2.0.0
Fetching ruby-macho 2.5.0
Installing ruby-macho 2.5.0
Fetching sorbet-runtime-stub 0.2.0
Installing sorbet-runtime-stub 0.2.0
Fetching thor 1.0.1
Installing thor 1.0.1
Fetching parser 3.0.0.0
Installing parser 3.0.0.0
Fetching elftools 1.1.3
Installing elftools 1.1.3
Fetching i18n 1.8.7
Installing i18n 1.8.7
Fetching tzinfo 2.0.4
Installing tzinfo 2.0.4
Fetching simplecov 0.21.2
Installing simplecov 0.21.2
Fetching commander 4.5.2
Installing commander 4.5.2
Fetching net-http-persistent 4.0.0
Installing net-http-persistent 4.0.0
Fetching mime-types 3.3.1
Installing mime-types 3.3.1
Fetching unf 0.1.4
Installing unf 0.1.4
Fetching pry 0.13.1
Installing pry 0.13.1
Fetching parallel_tests 3.4.0
Installing parallel_tests 3.4.0
Fetching nokogiri 1.11.1 (x86_64-darwin)
Installing nokogiri 1.11.1 (x86_64-darwin)
Fetching rspec-core 3.10.0
Installing rspec-core 3.10.0
Fetching rspec-expectations 3.10.0
Installing rspec-expectations 3.10.0
Fetching rspec-mocks 3.10.0
Installing rspec-mocks 3.10.0
Fetching sorbet 0.5.6251
Installing sorbet 0.5.6251
Fetching rubocop-ast 1.4.1
Installing rubocop-ast 1.4.1
Fetching patchelf 1.3.0
Installing patchelf 1.3.0
Fetching activesupport 6.1.1
Installing activesupport 6.1.1
Fetching codecov 0.4.2
Installing codecov 0.4.2
Fetching parlour 5.0.0
Installing parlour 5.0.0
Fetching domain_name 0.5.20190701
Installing domain_name 0.5.20190701
Fetching rspec-github 2.3.1
Installing rspec-github 2.3.1
Fetching rspec-retry 0.6.2
Installing rspec-retry 0.6.2
Fetching rspec-its 1.3.0
Installing rspec-its 1.3.0
Fetching rspec 3.10.0
Installing rspec 3.10.0
Fetching rspec-sorbet 1.8.0
Installing rspec-sorbet 1.8.0
Fetching spoom 1.0.7
Installing spoom 1.0.7
Fetching rubocop 1.8.1
Installing rubocop 1.8.1
Fetching http-cookie 1.0.3
Installing http-cookie 1.0.3
Fetching rspec-wait 0.0.9
Installing rspec-wait 0.0.9
Fetching tapioca 0.4.13
Installing tapioca 0.4.13
Fetching rubocop-performance 1.9.2
Installing rubocop-performance 1.9.2
Fetching rubocop-rails 2.9.1
Installing rubocop-rails 2.9.1
Fetching rubocop-rspec 2.1.0
Installing rubocop-rspec 2.1.0
Fetching rubocop-sorbet 0.5.1
Installing rubocop-sorbet 0.5.1
Fetching mechanize 2.7.6
Installing mechanize 2.7.6
Fetching ronn 0.7.3
Installing ronn 0.7.3
Bundle complete! 28 Gemfile dependencies, 78 gems now installed.
Bundled gems are installed into `../../../usr/local/Homebrew/Library/Homebrew/vendor/bundle`
Post-install message from i18n:

HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

If you are upgrading your Rails application from an older version of Rails:

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.

If you are starting a NEW Rails application, you can ignore this notice.

For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0

Post-install message from sorbet:

  Thanks for installing Sorbet! To use it in your project, first run:

    bundle exec srb init

  which will get your project ready to use with Sorbet.
  After that whenever you want to typecheck your code, run:

    bundle exec srb tc

  For more docs see: https://sorbet.org/docs/adopting
clojure-lsp:
  * 1: col 1: No Sorbet sigil found in file. Try a `typed: false` to start (you can also use `rubocop -a` to automatically add this).
  * 1: col 1: Missing top-level class documentation comment.
  * 1: col 1: Missing frozen string literal comment.
  * 43: col 1: 1 trailing blank lines detected.
Error: 4 problems in 1 formula detected
```

</details>
