### PR TITLE
kubernetes-cli: Add support for darwin/arm64

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -22,7 +22,7 @@ class KubernetesCli < Formula
   depends_on "go" => :build
 
   uses_from_macos "rsync" => :build
-
+  patch :DATA
   def install
     # Don't dirty the git tree
     rm_rf ".brew_home"
@@ -58,3 +58,16 @@ class KubernetesCli < Formula
     end
   end
 end
+
+__END__
+index bef1d837..154eecfd 100755
+--- a/hack/lib/golang.sh
++++ b/hack/lib/golang.sh
+@@ -49,6 +49,7 @@ readonly KUBE_SUPPORTED_CLIENT_PLATFORMS=(
+   linux/s390x
+   linux/ppc64le
+   darwin/amd64
++  darwin/arm64
+   windows/amd64
+   windows/386
+ )


### PR DESCRIPTION
This adds support for ARM64 on Apple Silicon courtesy of https://jimmyb.ninja/post/1609779188.

Works on my machine.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
