### PR TITLE
openrtsp: delete livecheck

### DIFF
--- a/Formula/openrtsp.rb
+++ b/Formula/openrtsp.rb
@@ -7,11 +7,6 @@ class Openrtsp < Formula
   sha256 "89bdfba7fd215e16be2c9d46a797bf85c5f7f7c46b53dc8af2d1171a658da5b7"
   license "LGPL-3.0-or-later"
 
-  livecheck do
-    url "http://www.live555.com/liveMedia/public/"
-    regex(/href=.*?live[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
-  end
-
   bottle do
     cellar :any
     sha256 "fce2e67f55b717cd6889b5f2bc4e21bcde69acc87ed561f5a5bab17dc1aafe8a" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`openrtsp` was deprecated in https://github.com/Homebrew/homebrew-core/pull/69307 with a disable date of 2021-11-22; delete the `livecheck` block so that newer versions aren't reported by `brew livecheck`