### PR TITLE
workflows/triage: don't label as python if build/test dependency

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -102,7 +102,8 @@ jobs:
                 }, {
                     "label": "python",
                     "path": "Formula/.+",
-                    "content": "(?:depends_on|uses_from_macos) \"python@?.+"
+                    "content": "(?:depends_on|uses_from_macos) \"python@?.+",
+                    "missing_content": "(?:depends_on|uses_from_macos) \"python@?.+\" => :(build|test)"
                 }, {
                     "label": "ruby",
                     "path": "Formula/.+",


### PR DESCRIPTION
No formulae require `python` as both a runtime dependency and build/test dependency. This can be checked by running this command:

```bash
brew ruby -e 'regexes = [ 
  /depends_on "python@.*?" => :(build|test)$/,
  /depends_on "python@.*?"$/,
]
Dir["Formula/*.rb"].sort.each do |f|
  f = Pathname(f)
  s = f.read
  puts f.stem if regexes.all? { |r| r.match?(s) }
end'
```