### PR TITLE
workflows/triage: more improvements

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -103,7 +103,7 @@ jobs:
                     "label": "python",
                     "path": "Formula/.+",
                     "content": "(depends_on|uses_from_macos) \"python(@[0-9.]+)?\"",
-                    "missing_content": "(depends_on|uses_from_macos) \"python(@[0-9.]+)?\" => :(build|test)"
+                    "missing_content": "(depends_on|uses_from_macos) \"python(@[0-9.]+)?\" => \[?:(build|test)"
                 }, {
                     "label": "ruby",
                     "path": "Formula/.+",

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -70,11 +70,11 @@ jobs:
                 }, {
                     "label": "haskell",
                     "path": "Formula/.+",
-                    "content": "depends_on \"(ghc@?|haskell-stack).+"
+                    "content": "depends_on \"(ghc|haskell-stack)(@[0-9.]+)?\""
                 }, {
                     "label": "java",
                     "path": "Formula/.+",
-                    "content": "depends_on \"?(java|openjdk@?).+"
+                    "content": "depends_on \"openjdk(@[0-9.]+)?\""
                 }, {
                     "label": "linux-only",
                     "path": "Formula/.+",
@@ -82,36 +82,36 @@ jobs:
                 }, {
                     "label": "lua",
                     "path": "Formula/.+",
-                    "content": "depends_on \"lua(@[0-9.]+|jit)?\""
+                    "content": "depends_on \"lua(jit)?(@[0-9.]+)?\""
                 }, {
                     "label": "nodejs",
                     "path": "Formula/.+",
-                    "content": "depends_on \"node(@\\d+)?\""
+                    "content": "depends_on \"node(@[0-9.]+)?\""
                 }, {
                     "label": "ocaml",
                     "path": "Formula/.+",
-                    "content": "depends_on \"ocaml\""
+                    "content": "depends_on \"ocaml(@[0-9.]+)?\""
                 }, {
                     "label": "perl",
                     "path": "Formula/.+",
-                    "content": "(depends_on|uses_from_macos) \"perl@?.+"
+                    "content": "(depends_on|uses_from_macos) \"perl(@[0-9.]+)?\""
                 }, {
                     "label": "php",
                     "path": "Formula/.+",
-                    "content": "(depends_on|uses_from_macos) \"php@?.+"
+                    "content": "(depends_on|uses_from_macos) \"php(@[0-9.]+)?\""
                 }, {
                     "label": "python",
                     "path": "Formula/.+",
-                    "content": "(depends_on|uses_from_macos) \"python@?.+",
-                    "missing_content": "(depends_on|uses_from_macos) \"python@?.+\" => :(build|test)"
+                    "content": "(depends_on|uses_from_macos) \"python(@[0-9.]+)?\"",
+                    "missing_content": "(depends_on|uses_from_macos) \"python(@[0-9.]+)?\" => :(build|test)"
                 }, {
                     "label": "ruby",
                     "path": "Formula/.+",
-                    "content": "(depends_on|uses_from_macos) \"ruby@?.+"
+                    "content": "(depends_on|uses_from_macos) \"ruby(@[0-9.]+)?\""
                 }, {
                     "label": "rust",
                     "path": "Formula/.+",
-                    "content": "depends_on \"rust\""
+                    "content": "depends_on \"rust(@[0-9.]+)?\""
                 }, {
                     "label": "swift",
                     "path": "Formula/.+",

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -85,7 +85,7 @@ jobs:
                 }, {
                     "label": "lua",
                     "path": "Formula/.+",
-                    "content": "depends_on \"lua(jit)?(@[0-9.]+)?\""
+                    "content": "depends_on \"(lua|luajit|luajit-openresty)(@[0-9.]+)?\""
                 }, {
                     "label": "nodejs",
                     "path": "Formula/.+",

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -66,15 +66,15 @@ jobs:
                 }, {
                     "label": "go",
                     "path": "Formula/.+",
-                    "content": "depends_on \"go(?:@[0-9.]+)?\""
+                    "content": "depends_on \"go(@[0-9.]+)?\""
                 }, {
                     "label": "haskell",
                     "path": "Formula/.+",
-                    "content": "depends_on \"(?:ghc@?|haskell-stack).+"
+                    "content": "depends_on \"(ghc@?|haskell-stack).+"
                 }, {
                     "label": "java",
                     "path": "Formula/.+",
-                    "content": "depends_on \"?(?:java|openjdk@?).+"
+                    "content": "depends_on \"?(java|openjdk@?).+"
                 }, {
                     "label": "linux-only",
                     "path": "Formula/.+",
@@ -82,11 +82,11 @@ jobs:
                 }, {
                     "label": "lua",
                     "path": "Formula/.+",
-                    "content": "depends_on \"lua(?:@[0-9.]+|jit)?\""
+                    "content": "depends_on \"lua(@[0-9.]+|jit)?\""
                 }, {
                     "label": "nodejs",
                     "path": "Formula/.+",
-                    "content": "depends_on \"node(?:@\\d+)?\""
+                    "content": "depends_on \"node(@\\d+)?\""
                 }, {
                     "label": "ocaml",
                     "path": "Formula/.+",
@@ -94,20 +94,20 @@ jobs:
                 }, {
                     "label": "perl",
                     "path": "Formula/.+",
-                    "content": "(?:depends_on|uses_from_macos) \"perl@?.+"
+                    "content": "(depends_on|uses_from_macos) \"perl@?.+"
                 }, {
                     "label": "php",
                     "path": "Formula/.+",
-                    "content": "(?:depends_on|uses_from_macos) \"php@?.+"
+                    "content": "(depends_on|uses_from_macos) \"php@?.+"
                 }, {
                     "label": "python",
                     "path": "Formula/.+",
-                    "content": "(?:depends_on|uses_from_macos) \"python@?.+",
-                    "missing_content": "(?:depends_on|uses_from_macos) \"python@?.+\" => :(build|test)"
+                    "content": "(depends_on|uses_from_macos) \"python@?.+",
+                    "missing_content": "(depends_on|uses_from_macos) \"python@?.+\" => :(build|test)"
                 }, {
                     "label": "ruby",
                     "path": "Formula/.+",
-                    "content": "(?:depends_on|uses_from_macos) \"ruby@?.+"
+                    "content": "(depends_on|uses_from_macos) \"ruby@?.+"
                 }, {
                     "label": "rust",
                     "path": "Formula/.+",

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -15,6 +15,9 @@ jobs:
         if: always()
         with:
           token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+      - name: Sleep for 10 seconds
+        if: always()
+        run: sleep 10
       - name: Label pull request
         uses: Homebrew/actions/label-pull-requests@master
         if: always()


### PR DESCRIPTION
Continuation of https://github.com/Homebrew/homebrew-core/pull/69975

- `?:` is not needed since `Homebrew/actions/label-pull-requests` doesn't do anything with captures.
- Added `(@[0-9.]+)?` to all dependency regexes for consistency. Although some formulae such as `rust` don't have versioned formulae, it doesn't hurt to search for them anyway; this could useful if we ever add them in the future.
- Before labelling, sleep for 10 seconds. I'm not sure why, but it seems CI is not noticing the `automerge-skip` label when it is added during PR creation. In https://github.com/Homebrew/homebrew-core/pull/69994, the initial `triage` job on PR open doesn't list `automerge-skip` as one of the existing labels: https://github.com/Homebrew/homebrew-core/runs/1793465318?check_suite_focus=true#step:4:106 (Notably, `CI-syntax-only` and `do not merge` are listed, but not `automerge-skip`).