### PR TITLE
neovim: depend on luv, luajit-openresty

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -4,6 +4,7 @@ class Neovim < Formula
   url "https://github.com/neovim/neovim/archive/v0.4.4.tar.gz"
   sha256 "2f76aac59363677f37592e853ab2c06151cca8830d4b3fe4675b4a52d41fc42c"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     rebuild 1
@@ -20,12 +21,13 @@ class Neovim < Formula
 
   depends_on "cmake" => :build
   depends_on "luarocks" => :build
+  depends_on "luv" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "libtermkey"
   depends_on "libuv"
   depends_on "libvterm"
-  depends_on "luajit"
+  depends_on "luajit-openresty"
   depends_on "msgpack"
   depends_on "unibilium"
 
@@ -54,15 +56,9 @@ class Neovim < Formula
     sha256 "ea1f347663cebb523e88622b1d6fe38126c79436da4dbf442674208aa14a8f4c"
   end
 
-  resource "lua-compat-5.3" do
-    url "https://github.com/keplerproject/lua-compat-5.3/archive/v0.7.tar.gz"
-    sha256 "bec3a23114a3d9b3218038309657f0f506ad10dfbc03bb54e91da7e5ffdba0a2"
-  end
-
-  resource "luv" do
-    url "https://github.com/luvit/luv/releases/download/1.30.0-0/luv-1.30.0-0.tar.gz"
-    sha256 "5cc75a012bfa9a5a1543d0167952676474f31c2d7fd8d450b56d8929dbebb5ef"
-  end
+  # Patch for Apple Silicon. Backported from
+  # https://github.com/neovim/neovim/pull/12624
+  patch :DATA
 
   def install
     resources.each do |r|
@@ -71,7 +67,7 @@ class Neovim < Formula
 
     ENV.prepend_path "LUA_PATH", "#{buildpath}/deps-build/share/lua/5.1/?.lua"
     ENV.prepend_path "LUA_CPATH", "#{buildpath}/deps-build/lib/lua/5.1/?.so"
-    lua_path = "--lua-dir=#{Formula["luajit"].opt_prefix}"
+    lua_path = "--lua-dir=#{Formula["luajit-openresty"].opt_prefix}"
 
     cmake_compiler_args = []
     on_macos do
@@ -94,29 +90,14 @@ class Neovim < Formula
           end
         end
       end
-
-      cd "build/src/luv" do
-        cmake_args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] }
-        cmake_args += cmake_compiler_args
-        cmake_args += %W[
-          -DCMAKE_INSTALL_PREFIX=#{buildpath}/deps-build
-          -DLUA_BUILD_TYPE=System
-          -DWITH_SHARED_LIBUV=ON
-          -DBUILD_SHARED_LIBS=OFF
-          -DBUILD_MODULE=OFF
-          -DLUA_COMPAT53_DIR=#{buildpath}/deps-build/build/src/lua-compat-5.3
-        ]
-        system "cmake", ".", *cmake_args
-        system "make", "install"
-      end
     end
 
     mkdir "build" do
       cmake_args = std_cmake_args
       cmake_args += cmake_compiler_args
       cmake_args += %W[
-        -DLIBLUV_INCLUDE_DIR=#{buildpath}/deps-build/include
-        -DLIBLUV_LIBRARY=#{buildpath}/deps-build/lib/libluv.a
+        -DLIBLUV_INCLUDE_DIR=#{Formula["luv"].opt_include}
+        -DLIBLUV_LIBRARY=#{Formula["luv"].opt_lib}/libluv_a.a
       ]
       system "cmake", "..", *cmake_args
       system "make", "install"
@@ -130,3 +111,26 @@ class Neovim < Formula
     assert_equal "Hello World from Neovim!!", (testpath/"test.txt").read.chomp
   end
 end
+
+__END__
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6b3a8dc..f3370e3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -358,16 +358,6 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+   add_definitions(-D_GNU_SOURCE)
+ endif()
+ 
+-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+-  # Required for luajit.
+-  set(CMAKE_EXE_LINKER_FLAGS
+-    "${CMAKE_EXE_LINKER_FLAGS} -pagezero_size 10000 -image_base 100000000")
+-  set(CMAKE_SHARED_LINKER_FLAGS
+-    "${CMAKE_SHARED_LINKER_FLAGS} -image_base 100000000")
+-  set(CMAKE_MODULE_LINKER_FLAGS
+-    "${CMAKE_MODULE_LINKER_FLAGS} -image_base 100000000")
+-endif()
+-
+ include_directories("${PROJECT_BINARY_DIR}/config")
+ include_directories("${PROJECT_SOURCE_DIR}/src")
+ 


### PR DESCRIPTION
~This doesn't quite enable an ARM bottle, but it simplifies and
(marginally) speeds up installation for ARM users who build from HEAD.~

Now builds on ARM.

This also updates the relevant dependencies to newer versions.

Follow up to #68787, #69321.

Related: https://github.com/neovim/neovim/pull/13741

CC @clason 

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?