### PR TITLE
llvm: fix patch URL

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -40,7 +40,7 @@ class Llvm < Formula
     # Regression in LLDB by D89156 on MacOS, fixed by D95683.
     # https://reviews.llvm.org/D95683
     patch do
-      url "https://reviews.llvm.org/file/data/ud3rpyci65brpi32praa/PHID-FILE-cdiialsygwx24dl7twob/D95683.diff"
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/698a42e95e2c982c1d11f1b7d3293ba3aac677ee/llvm/lldb.patch"
       sha256 "b0dd8153370de8333dc57f950976bc87413c0b053bd30d9b8b10540094923b88"
     end
   end


### PR DESCRIPTION
The current URL of the patch for lldb is not stable.

See also https://github.com/Homebrew/formula-patches/pull/349.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?