### PR TITLE
rbw 0.5.2 (new formula)

### DIFF
--- a/Formula/rbw.rb
+++ b/Formula/rbw.rb
@@ -1,0 +1,19 @@
+class Rbw < Formula
+  desc "Unofficial command-line client for Bitwarden"
+  homepage "https://github.com/doy/rbw"
+  url "https://github.com/doy/rbw/archive/0.5.2.tar.gz"
+  sha256 "5ab3c569ea55eeee6e70130c3d1a3399ac0529b666e2ba12264c1a7b0b5dbc3c"
+  license "MIT"
+
+  depends_on "rust" => :build
+  depends_on "openssl@1.1"
+  depends_on "pinentry"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    system "#{bin}/rbw", "--version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The audit with `--new` doesn't pass on "popularity" check, but 45 stars is still something i guess, i use it since many months and it works fine, it is maintained. And this is the only usable CLI for Bitwarden, so it would be very nice to have as a Formula.