### PR TITLE
ecl: set library paths explicitly

### DIFF
--- a/Formula/ecl.rb
+++ b/Formula/ecl.rb
@@ -27,7 +27,10 @@ class Ecl < Formula
     system "./configure", "--prefix=#{prefix}",
                           "--enable-threads=yes",
                           "--enable-boehm=system",
-                          "--enable-gmp=system"
+                          "--enable-gmp=system",
+                          "--with-gmp-prefix=#{Formula["gmp"].opt_prefix}",
+                          "--with-libffi-prefix=#{Formula["libffi"].opt_prefix}",
+                          "--with-libgc-prefix=#{Formula["bdw-gc"].opt_prefix}"
     system "make"
     system "make", "install"
   end

--- a/Formula/ecl.rb
+++ b/Formula/ecl.rb
@@ -3,6 +3,7 @@ class Ecl < Formula
   homepage "https://common-lisp.net/project/ecl/"
   url "https://common-lisp.net/project/ecl/static/files/release/ecl-20.4.24.tgz"
   sha256 "670838edf258a936b522fdb620da336de7e575aa0d27e34841727252726d0f07"
+  license "GPL-2.0-or-later"
   head "https://gitlab.com/embeddable-common-lisp/ecl.git", branch: "develop"
 
   bottle do

--- a/Formula/ecl.rb
+++ b/Formula/ecl.rb
@@ -3,7 +3,7 @@ class Ecl < Formula
   homepage "https://common-lisp.net/project/ecl/"
   url "https://common-lisp.net/project/ecl/static/files/release/ecl-20.4.24.tgz"
   sha256 "670838edf258a936b522fdb620da336de7e575aa0d27e34841727252726d0f07"
-  license "GPL-2.0-or-later"
+  license "LGPL-2.1-or-later"
   head "https://gitlab.com/embeddable-common-lisp/ecl.git", branch: "develop"
 
   bottle do


### PR DESCRIPTION
ECL is a Common Lisp to C compiler. When ECL invokes the C compiler, it uses the library directories configured at ECL's build time to set the include path. On Apple Silicon, homebrew has moved to /opt/homebrew, which is not in the default include path of the C compiler. This change makes ECL work when installed in /opt/homebrew by passing those library directories to ./configure.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
