### PR TITLE
wxmac 3.1.4

### DIFF
--- a/Formula/diff-pdf.rb
+++ b/Formula/diff-pdf.rb
@@ -4,7 +4,7 @@ class DiffPdf < Formula
   url "https://github.com/vslavik/diff-pdf/releases/download/v0.4.1/diff-pdf-0.4.1.tar.gz"
   sha256 "0eb81af6b06593488acdc5924a199f74fe3df6ecf2a0f1be208823c021682686"
   license "GPL-2.0-only"
-  revision 10
+  revision 11
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "86e670f863f6b811b886a7ae58754a44325ec03b72967e594e07c26f9b2f4e5c"

--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -5,6 +5,7 @@ class Erlang < Formula
   url "https://github.com/erlang/otp/archive/OTP-23.2.3.tar.gz"
   sha256 "3160912856ba734bd9c17075e72f469b9d4b913f3ab9652ee7e0fb406f0f0f2c"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/erlang/otp.git"
 
   livecheck do

--- a/Formula/erlang@21.rb
+++ b/Formula/erlang@21.rb
@@ -5,6 +5,7 @@ class ErlangAT21 < Formula
   url "https://github.com/erlang/otp/archive/OTP-21.3.8.18.tar.gz"
   sha256 "3481a47503e1ac0c0296970b460d1936ee0432600f685a216608e04b2f608367"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/erlang@22.rb
+++ b/Formula/erlang@22.rb
@@ -5,6 +5,7 @@ class ErlangAT22 < Formula
   url "https://github.com/erlang/otp/archive/OTP-22.3.4.14.tar.gz"
   sha256 "0d1e1f1acf542a98248e388b877d34eba92f367fdcc5ee3ebde557dee60ef551"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/gambit.rb
+++ b/Formula/gambit.rb
@@ -4,6 +4,7 @@ class Gambit < Formula
   url "https://github.com/gambitproject/gambit/archive/v16.0.1.tar.gz"
   sha256 "56bb86fd17575827919194e275320a5dd498708fd8bb3b20845243d492c10fef"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any, catalina:    "c1bf628cb87dbed50a0bd5299b3921545a001999af7a061343caf6aa75784cf5"

--- a/Formula/homeworlds.rb
+++ b/Formula/homeworlds.rb
@@ -2,8 +2,8 @@ class Homeworlds < Formula
   desc "C++ framework for the game of Binary Homeworlds"
   homepage "https://github.com/Quuxplusone/Homeworlds/"
   url "https://github.com/Quuxplusone/Homeworlds.git",
-      revision: "917cd7e7e6d0a5cdfcc56cd69b41e3e80b671cde"
-  version "20141022"
+      revision: "8e193a60a0cc59901df1980f3866731d5c1ee15a"
+  version "20200830"
   license "BSD-2-Clause"
 
   bottle do

--- a/Formula/libspatialite.rb
+++ b/Formula/libspatialite.rb
@@ -6,6 +6,7 @@ class Libspatialite < Formula
   mirror "https://www.mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/distfiles/libspatialite-5.0.0.tar.gz"
   sha256 "7b7fd70243f5a0b175696d87c46dde0ace030eacc27f39241c24bac5dfac6dac"
   license any_of: ["MPL-1.1", "GPL-2.0-or-later", "LGPL-2.1-or-later"]
+  revision 1
 
   livecheck do
     url "https://www.gaia-gis.it/gaia-sins/libspatialite-sources/"
@@ -56,6 +57,7 @@ class Libspatialite < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
       --with-sysroot=#{HOMEBREW_PREFIX}
+      --enable-gcp
       --enable-geocallbacks
       --enable-rttopo=yes
     ]

--- a/Formula/scummvm-tools.rb
+++ b/Formula/scummvm-tools.rb
@@ -1,7 +1,7 @@
 class ScummvmTools < Formula
   desc "Collection of tools for ScummVM"
   homepage "https://www.scummvm.org/"
-  url "https://www.scummvm.org/frs/scummvm-tools/2.2.0/scummvm-tools-2.2.0.tar.xz"
+  url "https://downloads.scummvm.org/frs/scummvm-tools/2.2.0/scummvm-tools-2.2.0.tar.xz"
   sha256 "1e72aa8f21009c1f7447c755e7f4cf499fe9b8ba3d53db681ea9295666cb48a4"
   license "GPL-2.0-or-later"
   head "https://github.com/scummvm/scummvm-tools.git"

--- a/Formula/spatialite-gui.rb
+++ b/Formula/spatialite-gui.rb
@@ -22,6 +22,7 @@ class SpatialiteGui < Formula
   depends_on "freexl"
   depends_on "geos"
   depends_on "libgaiagraphics"
+  depends_on "librasterlite"
   depends_on "libspatialite"
   depends_on "lz4"
   depends_on "openjpeg"

--- a/Formula/spatialite-gui.rb
+++ b/Formula/spatialite-gui.rb
@@ -1,14 +1,13 @@
 class SpatialiteGui < Formula
   desc "GUI tool supporting SpatiaLite"
   homepage "https://www.gaia-gis.it/fossil/spatialite_gui/index"
-  url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/spatialite_gui-1.7.1.tar.gz"
-  sha256 "cb9cb1ede7f83a5fc5f52c83437e556ab9cb54d6ace3c545d31b317fd36f05e4"
-  license "GPL-3.0"
-  revision 7
+  url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/spatialite_gui-2.1.0-beta1.tar.gz"
+  sha256 "ba48d96df18cebc3ff23f69797207ae1582cce62f4596b69bae300ca3c23db33"
+  license "GPL-3.0-only"
 
   livecheck do
     url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/"
-    regex(/href=.*?spatialite[._-]gui[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?spatialite[._-]gui[._-]v?(\d+(?:\.\d+)+(-beta\d)*)\.t/i)
   end
 
   bottle do
@@ -28,11 +27,6 @@ class SpatialiteGui < Formula
   depends_on "sqlite"
   depends_on "wxmac"
 
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/85fa66a9/spatialite-gui/1.7.1.patch"
-    sha256 "37f71f3cb2b0b9649eb85a51296187b0adf2972c5a1d3ee0daf3082e2c35025e"
-  end
-
   def install
     # Link flags for sqlite don't seem to get passed to make, which
     # causes builds to fatally error out on linking.
@@ -45,9 +39,6 @@ class SpatialiteGui < Formula
     # https://www.gaia-gis.it/fossil/spatialite_gui/tktview?name=8349866db6
     ENV.append_to_cflags "-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H"
 
-    # Add aui library; reported upstream multiple times:
-    # https://groups.google.com/forum/#!searchin/spatialite-users/aui/spatialite-users/wnkjK9pde2E/hVCpcndUP_wJ
-    inreplace "configure", "WX_LIBS=\"$(wx-config --libs)\"", "WX_LIBS=\"$(wx-config --libs std,aui)\""
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Formula/spatialite-gui.rb
+++ b/Formula/spatialite-gui.rb
@@ -23,9 +23,13 @@ class SpatialiteGui < Formula
   depends_on "geos"
   depends_on "libgaiagraphics"
   depends_on "libspatialite"
+  depends_on "lz4"
+  depends_on "openjpeg"
   depends_on "proj"
   depends_on "sqlite"
+  depends_on "webp"
   depends_on "wxmac"
+  depends_on "zstd"
 
   def install
     # Link flags for sqlite don't seem to get passed to make, which
@@ -35,11 +39,7 @@ class SpatialiteGui < Formula
     ENV.prepend "LDFLAGS", "-L#{sqlite.opt_lib} -lsqlite3"
     ENV.prepend "CFLAGS", "-I#{sqlite.opt_include}"
 
-    # Use Proj 6.0.0 compatibility headers
-    # https://www.gaia-gis.it/fossil/spatialite_gui/tktview?name=8349866db6
-    ENV.append_to_cflags "-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H"
-
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}", "--disable-xlsxwriter"
     system "make", "install"
   end
 end

--- a/Formula/spatialite-gui.rb
+++ b/Formula/spatialite-gui.rb
@@ -4,7 +4,7 @@ class SpatialiteGui < Formula
   url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/spatialite_gui-1.7.1.tar.gz"
   sha256 "cb9cb1ede7f83a5fc5f52c83437e556ab9cb54d6ace3c545d31b317fd36f05e4"
   license "GPL-3.0"
-  revision 6
+  revision 7
 
   livecheck do
     url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/"

--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -31,6 +31,7 @@ class Wxmac < Formula
     args = [
       "--prefix=#{prefix}",
       "--enable-clipboard",
+      "--enable-compat28",
       "--enable-controls",
       "--enable-dataviewctrl",
       "--enable-display",

--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -1,10 +1,9 @@
 class Wxmac < Formula
   desc "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
   homepage "https://www.wxwidgets.org"
-  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5.1/wxWidgets-3.0.5.1.tar.bz2"
-  sha256 "440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807"
-  license "wxWindows"
-  revision 1
+  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.4/wxWidgets-3.1.4.tar.bz2"
+  sha256 "3ca3a19a14b407d0cdda507a7930c2e84ae1c8e74f946e0144d2fa7d881f1a94"
+  license "LGPL-2.0-or-later" => { with: "LGPL-3.0-linking-exception" }
   head "https://github.com/wxWidgets/wxWidgets.git"
 
   livecheck do

--- a/audit_exceptions/unstable_allowlist.json
+++ b/audit_exceptions/unstable_allowlist.json
@@ -8,6 +8,7 @@
   "premake": "4.4-beta",
   "pwnat": "0.3-beta",
   "recode": "3.7-beta",
+  "spatialite-gui": "2.1.0-beta",
   "tcptraceroute": "1.5beta",
   "tiny-fugue": "5.0b",
   "vbindiff": "3.0_beta"


### PR DESCRIPTION
This version update for `wxmac` was closed in the past for the reasons discussed in https://github.com/Homebrew/homebrew-core/pull/58413.

However, an issue has been identified with wxMaxima on Big Sur (see https://github.com/wxMaxima-developers/wxmaxima/issues/1441 for more information) and it seems that this issue may be rectified by bumping `wxmac` to the newest version and then bumping `wxmaxima`.

So for the moment, this is just for testing purposes.

Thanks.