### PR TITLE
di 4.48.0.1

### DIFF
--- a/Formula/di.rb
+++ b/Formula/di.rb
@@ -1,13 +1,13 @@
 class Di < Formula
   desc "Advanced df-like disk information utility"
   homepage "https://gentoo.com/di/"
-  url "https://gentoo.com/di/di-4.48.tar.gz"
-  sha256 "19d549feb59ccde7ff1cd2c48fea7b9ba99fa2285da81424603e23d8b5db3b33"
+  url "https://downloads.sourceforge.net/project/diskinfo-di/di-4.48.0.1.tar.gz"
+  sha256 "60508544319eab687f5172a67bf3679c2b8576dc365629ba63749bcad688b467"
   license "Zlib"
 
   livecheck do
-    url :homepage
-    regex(%r{<p>Current Version: v?(\d+(?:\.\d+)+)</p>}i)
+    url :stable
+    regex(%r{url=.*?/di[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `di` [homepage](https://gentoo.com/di/) lists 4.48.0.1 as the newest version and links to the "latest" download on SourceForge. The existing `di-4.48.tar.gz` file from gentoo.com gives a `404 Not Found` response, so it appears that file hosting has moved to SourceForge.

This bumps the formula to version 4.48.0.1 from SourceForge and updates the `livecheck` block accordingly.