### PR TITLE
goaccess: add livecheck

### DIFF
--- a/Formula/goaccess.rb
+++ b/Formula/goaccess.rb
@@ -6,6 +6,11 @@ class Goaccess < Formula
   license "MIT"
   head "https://github.com/allinurl/goaccess.git"
 
+  livecheck do
+    url "https://goaccess.io/download"
+    regex(/href=.*?goaccess[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 "52b359d311d28cb204d7a7cb3ab57e2290749884561a3969aa0905d70a6be533" => :big_sur
     sha256 "86ac282b906c3e61ba7c9992d1078f7cd4ded1f6fd9873067b1b2d537e53a18e" => :arm64_big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `goaccess` but it's reporting `1.4.4` as newest instead of `1.4.5` (as there is no `1.4.5` tag in the Git repository). This PR resolves this issue by adding a `livecheck` block that checks the first-party download page, which links to the `stable` tarball.