### PR TITLE
bulk_extractor: add livecheck

### DIFF
--- a/Formula/bulk_extractor.rb
+++ b/Formula/bulk_extractor.rb
@@ -6,6 +6,11 @@ class BulkExtractor < Formula
   license "MIT"
   revision 3
 
+  livecheck do
+    url "https://digitalcorpora.org/downloads/bulk_extractor/"
+    regex(/href=.*?bulk_extractor[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 "4207941ab88e766e1a0fd55031585c52cea1c27ac528b7db1496a714fbeda5c4" => :big_sur
     sha256 "6acada1995761f484993f407f33014260f8c16596381172b405fe84eef206e06" => :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `bulk_extractor` but it's reporting `1.5.3` as newest instead of `1.5.5` (as there is no `1.5.5` tag in the Git repository). This PR resolves this issue by adding a `livecheck` block that checks the directory listing page where the `stable` archive is found.