### PR TITLE
libgaiagraphics: add livecheck

### DIFF
--- a/Formula/libgaiagraphics.rb
+++ b/Formula/libgaiagraphics.rb
@@ -5,6 +5,11 @@ class Libgaiagraphics < Formula
   sha256 "ccab293319eef1e77d18c41ba75bc0b6328d0fc3c045bb1d1c4f9d403676ca1c"
   revision 7
 
+  livecheck do
+    url "https://www.gaia-gis.it/gaia-sins/gaiagraphics-sources/"
+    regex(/href=.*?libgaiagraphics[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "71019ebb245fbf75794ffc377be75d4a9731a7cc842a458d630ef7fb9d824741" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `libgaiagraphics`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.