### PR TITLE
spatialite-gui: add livecheck

### DIFF
--- a/Formula/spatialite-gui.rb
+++ b/Formula/spatialite-gui.rb
@@ -6,6 +6,11 @@ class SpatialiteGui < Formula
   license "GPL-3.0"
   revision 6
 
+  livecheck do
+    url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/"
+    regex(/href=.*?spatialite[._-]gui[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "3656d32601beec4051e857d755da2d83ebd136382ee32bda4492b04ee4eb7b42" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `spatialite-gui`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.