### PR TITLE
svg2png: add livecheck

### DIFF
--- a/Formula/svg2png.rb
+++ b/Formula/svg2png.rb
@@ -6,6 +6,11 @@ class Svg2png < Formula
   license "LGPL-2.1"
   revision 1
 
+  livecheck do
+    url "https://cairographics.org/snapshots/"
+    regex(/href=.*?svg2png[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "91ea80e51edffa9ff0f1b75637eb2eb89ebda2ab9b8fcfd94242d113dd6fff99" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `svg2png`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.