### PR TITLE
pyside: Include C development headers and config

### DIFF
--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -19,48 +19,30 @@ class Pyside < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "llvm" => :build
+  depends_on "ninja" => :build
+  depends_on "llvm"
   depends_on "python@3.9"
   depends_on "qt"
 
   def install
-    ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
-    if MacOS.version == :big_sur
-      # Sysconfig promotes '11' to an integer which confuses the build
-      # system. See:
-      #  * https://bugreports.qt.io/browse/PYSIDE-1469
-      #  * https://codereview.qt-project.org/c/pyside/pyside-setup/+/328375
-      inreplace "build_scripts/wheel_utils.py",
-                "python_target_split = [int(x) for x in python_target.split('.')]",
-                "python_target_split = [int(x) for x in str(python_target).split('.')]"
-    end
-
-    args = %W[
-      --ignore-git
-      --parallel=#{ENV.make_jobs}
-      --install-scripts #{bin}
-      --rpath=#{lib}
-      --macos-sysroot=#{MacOS.sdk_path}
-    ]
-
     xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
 
-    system Formula["python@3.9"].opt_bin/"python3",
-           *Language::Python.setup_install_args(prefix),
-           "--install-lib", lib/"python#{xy}/site-packages", *args,
-           "--build-type=shiboken2"
+    args = std_cmake_args + %W[
+      -GNinja
+      -DPYTHON_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python#{xy}
+      -DCMAKE_INSTALL_RPATH=#{lib}
+    ]
 
-    system Formula["python@3.9"].opt_bin/"python3",
-           *Language::Python.setup_install_args(prefix),
-           "--install-lib", lib/"python#{xy}/site-packages", *args,
-           "--build-type=pyside2"
-
-    lib.install_symlink Dir.glob(lib/"python#{xy}/site-packages/PySide2/*.dylib")
-    lib.install_symlink Dir.glob(lib/"python#{xy}/site-packages/shiboken2/*.dylib")
+    mkdir "build" do
+      system "cmake", *args, ".."
+      system "ninja", "install"
+    end
   end
 
   test do
     system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2"
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "import shiboken2"
+
     modules = %w[
       Core
       Gui
@@ -78,5 +60,24 @@ class Pyside < Formula
     modules << "WebEngineWidgets" unless Hardware::CPU.arm?
 
     modules.each { |mod| system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2.Qt#{mod}" }
+
+    pyincludes = shell_output("#{Formula["python@3.9"].opt_bin}/python3-config --includes").chomp.split
+    pylib = shell_output("#{Formula["python@3.9"].opt_bin}/python3-config --ldflags --embed").chomp.split
+    pyver = Language::Python.major_minor_version(Formula["python@3.9"].opt_bin/"python3").to_s.delete(".")
+
+    (testpath/"test.cpp").write <<~EOS
+      #include <shiboken.h>
+      int main()
+      {
+        Py_Initialize();
+        Shiboken::AutoDecRef module(Shiboken::Module::import("shiboken2"));
+        assert(!module.isNull());
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "test.cpp",
+           "-I#{include}/shiboken2", "-L#{lib}", "-lshiboken2.cpython-#{pyver}-darwin",
+           *pyincludes, *pylib, "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
The Python installer doesn't include the necessary headers for C development. Manually include the necessary headers and configuration files. Other distributions such as Ubuntu already do this when they build the -dev packages.

This is a slight change of direction from the original 5.12.2 package (#38180) which tries to be as close as possible to the version in pip. However, there is software out there that depends on the C interfaces. For example, FreeCAD's official tap includes a "private" PySide version that includes these components. Using the modified pyside package, I'm able to build and run FreeCAD without the private PySide copy (which seems to cause weird conflicts with the main version).

It may alternatively be possible, and cleaner, to use CMake directly instead of setup.py.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

