### PR TITLE
python: build with --enable-optimizations and --with-lto

### DIFF
--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -4,7 +4,7 @@ class PythonAT39 < Formula
   url "https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tar.xz"
   sha256 "991c3f8ac97992f3d308fefeb03a64db462574eadbff34ce8bc5bb583d9903ff"
   license "Python-2.0"
-  revision 7
+  revision 8
 
   livecheck do
     url "https://www.python.org/ftp/python/"
@@ -104,6 +104,11 @@ class PythonAT39 < Formula
     ENV["PYTHONHOME"] = nil
     ENV["PYTHONPATH"] = nil
 
+    # The --enable-optimization and --with-lto flags diverge from what upstream
+    # python does for their macOS binary releases. They have chosen not to apply
+    # these flags because they want one build that will work across many macOS
+    # releases. Homebrew is not so constrained because the bottling
+    # infrastructure specializes for each macOS major release.
     args = %W[
       --prefix=#{prefix}
       --enable-ipv6
@@ -112,11 +117,17 @@ class PythonAT39 < Formula
       --enable-loadable-sqlite-extensions
       --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
       --with-dbmliborder=gdbm:ndbm
+      --enable-optimizations
+      --with-lto
     ]
 
     on_macos do
       args << "--enable-framework=#{frameworks}"
       args << "--with-dtrace"
+
+      # Override LLVM_AR to be plain old system ar.
+      # https://bugs.python.org/issue43109
+      args << "LLVM_AR=/usr/bin/ar"
     end
     on_linux do
       args << "--enable-shared"


### PR DESCRIPTION
- [Y] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [Y] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [Y] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Y] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Y] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Recent python offers flags to enable PGO and LTO which hopefully results in a faster Python interpreter. This PR adds the required flags to the homebrew `configure` invocation. It also papers over a macOS specific issue where the `configure` script believes it needs `llvm-ar` when building `--with-lto`. I don't think that is actually true on macOS, as Xcode doesn't provide `llvm-ar`. I wasn't sure if there was an expansion like `#{MacOS.sdk_path}` that would be a better prefix than `/usr` when applying this override.
