### PR TITLE
Deprecate formulae with archived GitHub repository

### DIFF
--- a/Formula/beansdb.rb
+++ b/Formula/beansdb.rb
@@ -16,6 +16,10 @@ class Beansdb < Formula
     sha256 "e3c0bfa02e012ef1b0935fe13be8286dce080e8898b6519f5bf8c886ea77b9bc" => :yosemite
   end
 
+  # Deprecated upstream in favor of `gobeansdb`:
+  # https://github.com/douban/gobeansdb
+  deprecate! date: "2018-06-11", because: :repo_archived
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 

--- a/Formula/bork.rb
+++ b/Formula/bork.rb
@@ -8,6 +8,8 @@ class Bork < Formula
 
   bottle :unneeded
 
+  deprecate! date: "2018-09-11", because: :repo_archived
+
   def install
     prefix.install %w[bin docs lib test types]
   end

--- a/Formula/c14-cli.rb
+++ b/Formula/c14-cli.rb
@@ -14,6 +14,9 @@ class C14Cli < Formula
     sha256 "6b3262c0d209f01dd93a491c541ee7f9fedca9f6ff03203487394e0e4f5cdecf" => :high_sierra
   end
 
+  # "C14 Classic has been discontinued"
+  deprecate! date: "2020-12-01", because: :repo_archived
+
   depends_on "go" => :build
 
   def install

--- a/Formula/cosi.rb
+++ b/Formula/cosi.rb
@@ -14,6 +14,10 @@ class Cosi < Formula
     sha256 "00663999a04ee29f52e334022cc828d7ebe89a442f1e713afb2167112f4ebf75" => :high_sierra
   end
 
+  # Deprecated in favor of the Cothority `blcosi` package.
+  # See: https://github.com/dedis/cothority/tree/master/cosi
+  deprecate! date: "2018-03-01", because: :deprecated_upstream
+
   depends_on "go" => :build
 
   go_resource "github.com/BurntSushi/toml" do

--- a/Formula/docker-swarm.rb
+++ b/Formula/docker-swarm.rb
@@ -6,11 +6,6 @@ class DockerSwarm < Formula
   license "Apache-2.0"
   head "https://github.com/docker/classicswarm.git"
 
-  livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     cellar :any_skip_relocation
     rebuild 1
@@ -18,6 +13,11 @@ class DockerSwarm < Formula
     sha256 "d3cc672187adb5d73dfb2b6a90326de6ad228ccf48141ef3242447ca0416aee3" => :mojave
     sha256 "29e47d799c8e2d2977dd58444095a51c9ac7f261f56eeb5d5b6f71ed299e7533" => :high_sierra
   end
+
+  # "Classic Swarm has been archived and is no longer actively developed. You
+  # may want to use the Swarm mode built into the Docker Engine instead, or
+  # another orchestration system."
+  deprecate! date: "2020-06-11", because: :repo_archived
 
   depends_on "go" => :build
 

--- a/Formula/docker2aci.rb
+++ b/Formula/docker2aci.rb
@@ -14,6 +14,9 @@ class Docker2aci < Formula
     sha256 "b1a61fc4d329ef1e3ad97ea701e2c0be392f29e8d4a8bd2f1934bf7bac620121" => :el_capitan
   end
 
+  # See https://github.com/rkt/rkt/issues/4024
+  deprecate! date: "2020-02-24", because: :repo_archived
+
   depends_on "go" => :build
 
   def install

--- a/Formula/fbi-servefiles.rb
+++ b/Formula/fbi-servefiles.rb
@@ -15,6 +15,8 @@ class FbiServefiles < Formula
     sha256 "d8d8d483abd92d016d8d1a7f0e4535c51233c83914f1c61d1223b72d750f1b8a" => :high_sierra
   end
 
+  deprecate! date: "2020-11-12", because: :repo_archived
+
   depends_on "python@3.9"
 
   def install

--- a/Formula/fleetctl.rb
+++ b/Formula/fleetctl.rb
@@ -16,7 +16,9 @@ class Fleetctl < Formula
     sha256 "578bc15de6d87d53165ff70805388b41388f01d10a7c5d809fafd46c4d9040aa" => :high_sierra
   end
 
-  deprecate! date: "2020-11-15", because: :repo_archived
+  # "CoreOS recommends Kubernetes for all clustering needs":
+  # https://coreos.com/blog/migrating-from-fleet-to-kubernetes.html
+  deprecate! date: "2020-04-15", because: :repo_archived
 
   depends_on "go" => :build
 

--- a/Formula/gdub.rb
+++ b/Formula/gdub.rb
@@ -7,6 +7,10 @@ class Gdub < Formula
 
   bottle :unneeded
 
+  # "This project is obsolete. Please use 'gng' instead.":
+  # https://github.com/gdubw/gng
+  deprecate! date: "2021-01-05", because: :repo_archived
+
   def install
     bin.install "bin/gw"
   end

--- a/Formula/giflossy.rb
+++ b/Formula/giflossy.rb
@@ -3,7 +3,7 @@ class Giflossy < Formula
   homepage "https://pornel.net/lossygif"
   url "https://github.com/kornelski/giflossy/archive/1.91.tar.gz"
   sha256 "b97f6aadf163ff5dd96ad1695738ad3d5aa7f1658baed8665c42882f11d9ab22"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   head "https://github.com/kornelski/giflossy.git"
 
   bottle do
@@ -15,7 +15,9 @@ class Giflossy < Formula
     sha256 "02eeb9a6b44178fdf1df803346dceedda853c7245cd51a1a6166290a73fb51f4" => :mojave
   end
 
-  deprecate! date: "2020-11-27", because: :repo_archived
+  # "This project has now been officially merged upstream into Gifsicle, so
+  # please use that": https://github.com/kohler/gifsicle
+  deprecate! date: "2019-05-27", because: :repo_archived
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/git-credential-manager.rb
+++ b/Formula/git-credential-manager.rb
@@ -8,6 +8,10 @@ class GitCredentialManager < Formula
 
   bottle :unneeded
 
+  # "This project has been superceded by Git Credential Manager Core":
+  # https://github.com/microsoft/Git-Credential-Manager-Core
+  deprecate! date: "2020-10-01", because: :repo_archived
+
   depends_on "openjdk"
 
   def install

--- a/Formula/govendor.rb
+++ b/Formula/govendor.rb
@@ -14,7 +14,7 @@ class Govendor < Formula
     sha256 "28492791ec9b8c58e472a7276c9b86450112ef642e2aa10d025eb623e0921f40" => :mojave
   end
 
-  deprecate! date: "2020-11-15", because: :repo_archived
+  deprecate! date: "2020-03-02", because: :repo_archived
 
   depends_on "go"
 

--- a/Formula/infrakit.rb
+++ b/Formula/infrakit.rb
@@ -16,7 +16,7 @@ class Infrakit < Formula
     sha256 "8db80c4d2d7842486a4cedfa4952ed06e453f2e61f4e6818a08b17fa694d1a1c" => :sierra
   end
 
-  deprecate! date: "2020-10-25", because: :repo_archived
+  deprecate! date: "2020-02-19", because: :repo_archived
 
   depends_on "go" => :build
   depends_on "libvirt" => :build

--- a/Formula/json11.rb
+++ b/Formula/json11.rb
@@ -14,7 +14,7 @@ class Json11 < Formula
     sha256 "e0229fc7e70a26fdd945e3cf666e2608f73d186b20fcc2555d19466e78771d54" => :mojave
   end
 
-  deprecate! date: "2020-11-27", because: :repo_archived
+  deprecate! date: "2020-03-25", because: :repo_archived
 
   depends_on "cmake" => :build
 

--- a/Formula/kube-aws.rb
+++ b/Formula/kube-aws.rb
@@ -1,11 +1,11 @@
 class KubeAws < Formula
   desc "Command-line tool to declaratively manage Kubernetes clusters on AWS"
-  homepage "https://kubernetes-incubator.github.io/kube-aws/"
-  url "https://github.com/kubernetes-incubator/kube-aws.git",
+  homepage "https://kubernetes-retired.github.io/kube-aws/"
+  url "https://github.com/kubernetes-retired/kube-aws.git",
       tag:      "v0.16.4",
       revision: "c74d91ecd6760d33111dc8c7f8f51bf816424310"
   license "Apache-2.0"
-  head "https://github.com/kubernetes-incubator/kube-aws.git"
+  head "https://github.com/kubernetes-retired/kube-aws.git"
 
   bottle do
     cellar :any_skip_relocation
@@ -13,6 +13,9 @@ class KubeAws < Formula
     sha256 "f05e8f3cfbe5f8c17f2cd6d3a854b7c329d7f922f03271bb36ca8497589ef7d4" => :mojave
     sha256 "5172a4ad55d3977c81d405bc67d91a35ead719e24c555d5843529d2489323d79" => :high_sierra
   end
+
+  # Fork can be found at: https://github.com/kube-aws/kube-aws
+  deprecate! date: "2020-09-29", because: :repo_archived
 
   depends_on "go" => :build
   depends_on "packr" => :build

--- a/Formula/landscaper.rb
+++ b/Formula/landscaper.rb
@@ -17,7 +17,7 @@ class Landscaper < Formula
   end
 
   # also depends on helm@2 (which failed to build)
-  deprecate! date: "2020-07-26", because: :repo_archived
+  deprecate! date: "2020-04-22", because: :repo_archived
 
   depends_on "dep" => :build
   depends_on "go" => :build

--- a/Formula/minimesos.rb
+++ b/Formula/minimesos.rb
@@ -8,6 +8,8 @@ class Minimesos < Formula
 
   bottle :unneeded
 
+  deprecate! date: "2018-06-22", because: :repo_archived
+
   def install
     bin.install "bin/minimesos"
   end

--- a/Formula/natalie.rb
+++ b/Formula/natalie.rb
@@ -15,7 +15,7 @@ class Natalie < Formula
     sha256 "dd51e00a1969ffdd478e954bed48bedd1c5a9813b67931aa146711f49cb58223" => :high_sierra
   end
 
-  deprecate! date: "2020-11-21", because: :repo_archived
+  deprecate! date: "2020-09-08", because: :repo_archived
 
   depends_on xcode: ["9.4", :build]
 

--- a/Formula/pdf-redact-tools.rb
+++ b/Formula/pdf-redact-tools.rb
@@ -16,7 +16,9 @@ class PdfRedactTools < Formula
     sha256 "e89303de13975510234c078756470ac529050a93a4e4a7592b94ef5971cea049" => :mojave
   end
 
-  deprecate! date: "2020-11-20", because: :unmaintained
+  # "This project is no longer maintained. A much better tool is dangerzone:
+  # https://dangerzone.rocks"
+  deprecate! date: "2020-05-05", because: :repo_archived
 
   depends_on "exiftool"
   depends_on "ghostscript"

--- a/Formula/plustache.rb
+++ b/Formula/plustache.rb
@@ -15,7 +15,7 @@ class Plustache < Formula
     sha256 "046e756acf6694ae9b8768c62981f807a93aaef52d175bbff7005a29bb23aa00" => :high_sierra
   end
 
-  deprecate! date: "2020-11-15", because: :repo_archived
+  deprecate! date: "2020-08-06", because: :repo_archived
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/pony-stable.rb
+++ b/Formula/pony-stable.rb
@@ -13,8 +13,9 @@ class PonyStable < Formula
     sha256 "caf0c823ba581ab0e669d0372c06d1cb74262f05334814a5f49370659aa030d1" => :high_sierra
   end
 
-  # See https://github.com/ponylang/pony-stable/commit/efd64049752210a71796a125792aa01b74476912
-  deprecate! date: "2021-01-02", because: :repo_archived
+  # "Stable is no longer being developed. It's been replaced by Corral
+  # (https://github.com/ponylang/corral)."
+  deprecate! date: "2020-05-12", because: :repo_archived
 
   depends_on "ponyc"
 

--- a/Formula/rancher-compose.rb
+++ b/Formula/rancher-compose.rb
@@ -15,6 +15,8 @@ class RancherCompose < Formula
     sha256 "23291133a0a775210ae1244ae594931ce04fab8e7c0a37ba90431d61d869317b" => :yosemite
   end
 
+  deprecate! date: "2020-10-18", because: :repo_archived
+
   depends_on "go" => :build
 
   def install

--- a/Formula/rebar.rb
+++ b/Formula/rebar.rb
@@ -15,7 +15,9 @@ class Rebar < Formula
     sha256 "265cfa8851de8a55ff46346167f8670df48d8a731c427d51fe0da16cf2ee8b78" => :mojave
   end
 
-  deprecate! date: "2020-11-24", because: :repo_archived
+  # Deprecated upstream on 2016-04-13 in favor of rebar3:
+  # https://github.com/erlang/rebar3
+  deprecate! date: "2019-03-22", because: :repo_archived
 
   depends_on "erlang"
 

--- a/Formula/rpg.rb
+++ b/Formula/rpg.rb
@@ -15,7 +15,7 @@ class Rpg < Formula
     sha256 "f1c7e5d997a1f0ceb1cca6b1067408912ff8e14522fb411530649f0689f9d042" => :high_sierra
   end
 
-  deprecate! date: "2020-11-11", because: :repo_archived
+  deprecate! date: "2017-11-08", because: :repo_archived
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/skafos.rb
+++ b/Formula/skafos.rb
@@ -13,6 +13,8 @@ class Skafos < Formula
     sha256 "57dc00bd0e8bfc96998c690cbd77a7c4c6486d50655603bfdf65771e340ee6b6" => :high_sierra
   end
 
+  deprecate! date: "2020-12-16", because: :repo_archived
+
   depends_on "cmake" => :build
   depends_on "libarchive"
   depends_on "yaml-cpp"

--- a/Formula/termtosvg.rb
+++ b/Formula/termtosvg.rb
@@ -17,7 +17,7 @@ class Termtosvg < Formula
     sha256 "26a80230af97da8f083d5e3004cb3a000e4cd16e33ce4e733400a9d9d0ade42a" => :high_sierra
   end
 
-  deprecate! date: "2020-10-08", because: :repo_archived
+  deprecate! date: "2020-06-16", because: :repo_archived
 
   depends_on "python@3.9"
 

--- a/Formula/tidyp.rb
+++ b/Formula/tidyp.rb
@@ -14,7 +14,7 @@ class Tidyp < Formula
     sha256 "267b4c383278baa37d4bab8e10aba1ee73d2eba642332414fad77d262b602099" => :high_sierra
   end
 
-  deprecate! date: "2020-11-10", because: :repo_archived
+  deprecate! date: "2020-09-05", because: :repo_archived
 
   uses_from_macos "libxslt" => :build
 

--- a/Formula/vavrdiasm.rb
+++ b/Formula/vavrdiasm.rb
@@ -3,7 +3,7 @@ class Vavrdiasm < Formula
   homepage "https://github.com/vsergeev/vAVRdisasm"
   url "https://github.com/vsergeev/vavrdisasm/archive/v3.1.tar.gz"
   sha256 "4fe5edde40346cb08c280bd6d0399de7a8d2afdf20fb54bf41a8abb126636360"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
 
   bottle do
     cellar :any_skip_relocation
@@ -16,7 +16,7 @@ class Vavrdiasm < Formula
     sha256 "f881c5a6d94581c4fc9efb13118c84c40700f13d130302f6ee4cb16968d1f6b0" => :mavericks
   end
 
-  disable! date: "2020-12-08", because: :unmaintained
+  disable! date: "2020-09-17", because: :unmaintained
 
   # Patch:
   # - BSD `install(1)' does not have a GNU-compatible `-D' (create intermediate

--- a/Formula/ykneomgr.rb
+++ b/Formula/ykneomgr.rb
@@ -23,7 +23,8 @@ class Ykneomgr < Formula
     depends_on "libtool" => :build
   end
 
-  deprecate! date: "2020-12-28", because: :deprecated_upstream  # ... in favor of ykman
+  # Deprecated in favor of YubiKey Manager (ykman)
+  deprecate! date: "2017-01-27", because: :deprecated_upstream
 
   depends_on "help2man" => :build
   depends_on "pkg-config" => :build

--- a/Formula/zinc.rb
+++ b/Formula/zinc.rb
@@ -6,7 +6,7 @@ class Zinc < Formula
 
   bottle :unneeded
 
-  deprecate! date: "2020-08-17", because: :repo_archived
+  deprecate! date: "2018-06-10", because: :repo_archived
 
   def install
     rm_f Dir["bin/ng/{linux,win}*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR deprecates formulae that have an archived GitHub repository and aren't already deprecated or disabled. Let me know if any of these should use `disable!` instead of `deprecate!`.

This also updates the `deprecate!`/`disable!` dates for some formulae that have already been deprecated/disabled. I used upstream deprecation dates (from commits, documentation, etc.) where possible and, in other cases, I used the earliest Wayback Machine snapshot where the repository was archived. This should give us a better idea of how long the software has been deprecated/archived, instead of simply using the date when we first noticed the repository was archived.