### PR TITLE
mlpack: add livecheck

### DIFF
--- a/Formula/mlpack.rb
+++ b/Formula/mlpack.rb
@@ -5,6 +5,11 @@ class Mlpack < Formula
   sha256 "9e5c4af5c276c86a0dcc553289f6fe7b1b340d61c1e59844b53da0debedbb171"
   license all_of: ["BSD-3-Clause", "MPL-2.0", "BSL-1.0", "MIT"]
 
+  livecheck do
+    url "https://mlpack.org/files/"
+    regex(/href=.*?mlpack[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any
     sha256 "55819c54944eabc313874577f91e448decc0e28edb029f66417a900b7f9aba78" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `mlpack`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.