### PR TITLE
bundler-completion: add livecheck to skip

### DIFF
--- a/Formula/bundler-completion.rb
+++ b/Formula/bundler-completion.rb
@@ -7,6 +7,10 @@ class BundlerCompletion < Formula
   license "MIT"
   head "https://github.com/mernen/completion-ruby.git"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   bottle :unneeded
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [GitHub repository for `bundler-completion`](https://github.com/mernen/completion-ruby) doesn't report versions in any way (releases, tags, commit messages, changelog, etc), so we can't identify new versions using livecheck. As such, livecheck is unable to identify versions and this adds a `livecheck` block to formally skip the formula.