### PR TITLE
dnstracer: add livecheck

### DIFF
--- a/Formula/dnstracer.rb
+++ b/Formula/dnstracer.rb
@@ -5,6 +5,15 @@ class Dnstracer < Formula
   mirror "https://deb.debian.org/debian/pool/main/d/dnstracer/dnstracer_1.9.orig.tar.gz"
   sha256 "2ebc08af9693ba2d9fa0628416f2d8319ca1627e41d64553875d605b352afe9c"
 
+  # It's necessary to check the `/unix/general.php` page, instead of
+  # `/download/`, until a real 1.10 version exists. The file name for version
+  # 1.1 on the `/download/` page is given as 1.10 and this is erroneously
+  # treated as newer than 1.9.
+  livecheck do
+    url "https://www.mavetju.org/unix/general.php"
+    regex(/href=.*?dnstracer[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "c6e0d89127fbc47d2b30cd7d2918279f858a79d87b2e32e63cccfcc4f92f3495" => :big_sur


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `dnstracer`. This PR adds a `livecheck` block that checks the [`/unix/general.php` page](https://www.mavetju.org/unix/general.php) which links to the `stable` archive.

It's necessary to check the `/unix/general.php` page, instead of [`/download/`](https://www.mavetju.org/download/), until a real `1.10` version exists. The file name for version `1.1` on the `/download/` page is given as `1.10` and this is erroneously treated as newer than `1.9` (since 10 is greater than 9). Just to be clear, we can't skip `1.10` (using a `strategy` block) because then we would miss a real `1.10` version.

We can update the `livecheck` block to check the `/download/` page in the future if there's ever a `1.10` version (or later) but this is necessary for now.