### PR TITLE
flank: don't set JAVA_HOME in test

### DIFF
--- a/Formula/flank.rb
+++ b/Formula/flank.rb
@@ -20,7 +20,6 @@ class Flank < Formula
   end
 
   test do
-    ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
     (testpath/"flank.yml").write <<~EOS
       gcloud:
         device:


### PR DESCRIPTION
This is unnecessary, and could obscure installation problems.

Cf. https://github.com/Homebrew/brew/pull/10479

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?