### PR TITLE
grokj2k 7.6.6

### DIFF
--- a/Formula/grokj2k.rb
+++ b/Formula/grokj2k.rb
@@ -1,8 +1,8 @@
 class Grokj2k < Formula
   desc "JPEG 2000 Library"
   homepage "https://github.com/GrokImageCompression/grok"
-  url "https://github.com/GrokImageCompression/grok/archive/v7.6.5.tar.gz"
-  sha256 "fc6ffa80af02186828f36a41bcdbd01b11a1e6b44e26b25793eb4476b4fe599b"
+  url "https://github.com/GrokImageCompression/grok/archive/v7.6.6.tar.gz"
+  sha256 "669ca69aa70598ee1c4a1f7239efc0a4bc463275a150019baedd10b8440ec78c"
   license "AGPL-3.0-or-later"
   head "https://github.com/GrokImageCompression/grok.git"
 


### PR DESCRIPTION
This release fixes a severe bug in the encoder, which causes lossy compression of monochrome images to be
completely blank.



- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
