### PR TITLE
libftdi: enable LibFTDI++

### DIFF
--- a/Formula/libftdi.rb
+++ b/Formula/libftdi.rb
@@ -4,6 +4,7 @@ class Libftdi < Formula
   url "https://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.5.tar.bz2"
   sha256 "7c7091e9c86196148bd41177b4590dccb1510bfe6cea5bf7407ff194482eb049"
   license "LGPL-2.1-only"
+  revision 1
 
   livecheck do
     url "https://www.intra2net.com/en/developer/libftdi/download.php"

--- a/Formula/libftdi.rb
+++ b/Formula/libftdi.rb
@@ -3,6 +3,7 @@ class Libftdi < Formula
   homepage "https://www.intra2net.com/en/developer/libftdi"
   url "https://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.5.tar.bz2"
   sha256 "7c7091e9c86196148bd41177b4590dccb1510bfe6cea5bf7407ff194482eb049"
+  license "LGPL-2.1-only"
 
   livecheck do
     url "https://www.intra2net.com/en/developer/libftdi/download.php"

--- a/Formula/libftdi.rb
+++ b/Formula/libftdi.rb
@@ -21,6 +21,7 @@ class Libftdi < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "swig" => :build
+  depends_on "boost"
   depends_on "confuse"
   depends_on "libusb"
 

--- a/Formula/libftdi.rb
+++ b/Formula/libftdi.rb
@@ -28,6 +28,7 @@ class Libftdi < Formula
     mkdir "libftdi-build" do
       system "cmake", "..", "-DPYTHON_BINDINGS=OFF",
                             "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
+                            "-DFTDIPP=ON",
                             *std_cmake_args
       system "make", "install"
       pkgshare.install "../examples"


### PR DESCRIPTION
This PR should include the C++ bindings in libftdi.

I think they require boost, so maybe the PR is incomplete.  I'm not really familiar with homebrew, I'm afraid.  But if this is sufficient it opens up the use of the library, if anybody is excited about testing to make sure it doesn't break everything.

I must have failed to read something, with the "missing license" tag.  I hereby offer this change to the public domain, to be freely relicensed by anybody. -xloem