### PR TITLE
syncthing: update livecheck block

### DIFF
--- a/Formula/syncthing.rb
+++ b/Formula/syncthing.rb
@@ -7,8 +7,8 @@ class Syncthing < Formula
   head "https://github.com/syncthing/syncthing.git", branch: "main"
 
   livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
The current livecheck block detects version bumps prematurely. v1.13 was
released only officially released [two hours ago](https://github.com/syncthing/syncthing/releases/tag/v1.13.0), but was bumped
yesterday in #70160.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?