### PR TITLE
librem: fix test for linux

### DIFF
--- a/Formula/librem.rb
+++ b/Formula/librem.rb
@@ -26,6 +26,7 @@ class Librem < Formula
 
   test do
     (testpath/"test.c").write <<~EOS
+      #include <stdint.h>
       #include <re/re.h>
       #include <rem/rem.h>
       int main() {


### PR DESCRIPTION
Fixes:
```
/home/linuxbrew/.linuxbrew/include/re/re_list.h:67:1: error: unknown type name ‘uint32_t’
 uint32_t list_count(const struct list *list);
 ^
In file included from /usr/include/x86_64-linux-gnu/sys/socket.h:38:0,
                 from /home/linuxbrew/.linuxbrew/include/re/re_sa.h:11,
                 from /home/linuxbrew/.linuxbrew/include/re/re.h:20,
                 from test.c:1:
/usr/include/x86_64-linux-gnu/bits/socket.h:33:21: error: conflicting types for ‘socklen_t’
 typedef __socklen_t socklen_t;
                     ^
In file included from /home/linuxbrew/.linuxbrew/include/re/re.h:15:0,
                 from test.c:1:
/home/linuxbrew/.linuxbrew/include/re/re_types.h:57:18: note: previous declaration of ‘socklen_t’ was here
 typedef uint32_t socklen_t;
                  ^
Error: librem: failed
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
