### PR TITLE
xmake: enable test with root on linux (for docker CI)

### DIFF
--- a/Formula/xmake.rb
+++ b/Formula/xmake.rb
@@ -28,6 +28,9 @@ class Xmake < Formula
   end
 
   test do
+    on_linux do
+      ENV["XMAKE_ROOT"] = "y" if ENV["CI"]
+    end
     system bin/"xmake", "create", "test"
     cd "test" do
       system bin/"xmake"


### PR DESCRIPTION
Fixes:
error: Running xmake as root is extremely dangerous and no longer supported.
As xmake does not drop privileges on installation you would be giving all
build scripts full access to your system.
Or you can add `--root` option or XMAKE_ROOT=y to allow run as root temporarily.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
