### PR TITLE
predictionio: deprecate

### DIFF
--- a/Formula/predictionio.rb
+++ b/Formula/predictionio.rb
@@ -13,6 +13,8 @@ class Predictionio < Formula
 
   bottle :unneeded
 
+  deprecate! date: "2020-09-01", because: :unmaintained
+
   depends_on "apache-spark"
   depends_on "elasticsearch@6"
   depends_on "hadoop"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Deprecating `predictionio` since its homepage states

> Project Predictionio has retired. For details please refer to its Attic page.

The attic page says

> Apache PredictionIO moved into the Attic in Sep 2020. [...] The website, downloads and issue tracker all remain open, though the issue tracker is read-only.

Related to #65831.