### PR TITLE
obfs4proxy 0.0.11 (new formula)

### DIFF
--- a/Formula/obfs4proxy.rb
+++ b/Formula/obfs4proxy.rb
@@ -1,0 +1,19 @@
+class Obfs4proxy < Formula
+  desc "Pluggable transport proxy for Tor, implementing obfs4"
+  homepage "https://gitlab.com/yawning/obfs4"
+  url "https://gitlab.com/yawning/obfs4/-/archive/obfs4proxy-0.0.11/obfs4-obfs4proxy-0.0.11.tar.gz"
+  sha256 "46f621f1d94d244e7b1d0b93dafea7abadb2428f8b1d0463559426362ea98eae"
+  license "BSD-2-Clause"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args, "./obfs4proxy"
+  end
+
+  test do
+    expect = "ENV-ERROR no TOR_PT_STATE_LOCATION environment variable"
+    actual = shell_output("TOR_PT_MANAGED_TRANSPORT_VER=1 TOR_PT_SERVER_TRANSPORTS=obfs4 #{bin}/obfs4proxy", 1)
+    assert_match expect, actual
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren’t other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you’re submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you’re submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a package that is used in conjunction with Tor to run bridges [1]. 

Although it does not meet all of the guidelines in the formula requirements, it does have 700 stars on its Github [mirror](https://github.com/Yawning/obfs4). It’s also packaged on [Debian](https://packages.debian.org/jessie/obfs4proxy), FreeBSD and OpenBSD.

As for the test, I’m not sure how I can put something there as it’s designed to be used in conjunction with Tor. It is _possible_ to use it separately, but that procedure is somewhat nontrivial. Please let me know if this makes it unsuitable for Homebrew. 

[1]: https://community.torproject.org/relay/setup/bridge/