### PR TITLE
gdb: install gdbserver

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -5,6 +5,7 @@ class Gdb < Formula
   mirror "https://ftpmirror.gnu.org/gdb/gdb-10.1.tar.xz"
   sha256 "f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://sourceware.org/git/binutils-gdb.git"
 
   livecheck do
@@ -56,7 +57,7 @@ class Gdb < Formula
       system "make"
 
       # Don't install bfd or opcodes, as they are provided by binutils
-      system "make", "install-gdb"
+      system "make", "install-gdb", "maybe-install-gdbserver"
     end
   end
 


### PR DESCRIPTION
`gdbserver` is actually being built by default on Linux, but not being installed. (`gdbserver` on macOS is not supported.)

I'm using the `maybe-install-gdbserver` install target to avoid platform-specific instructions. It's a no-op on macOS, but installs the built `gdbserver` on Linux.

Addresses https://github.com/Homebrew/discussions/discussions/659

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
