### PR TITLE
asciiquarium: fix test logic

### DIFF
--- a/Formula/asciiquarium.rb
+++ b/Formula/asciiquarium.rb
@@ -1,10 +1,14 @@
+require "language/perl"
+
 class Asciiquarium < Formula
+  include Language::Perl::Shebang
+
   desc "Aquarium animation in ASCII art"
   homepage "https://robobunny.com/projects/asciiquarium/html/"
   url "https://robobunny.com/projects/asciiquarium/asciiquarium_1.1.tar.gz"
   sha256 "1b08c6613525e75e87546f4e8984ab3b33f1e922080268c749f1777d56c9d361"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://robobunny.com/projects/asciiquarium/"
@@ -47,7 +51,7 @@ class Asciiquarium < Formula
     # Disable dynamic selection of perl which may cause segfault when an
     # incompatible perl is picked up.
     # https://github.com/Homebrew/homebrew-core/issues/4936
-    inreplace "asciiquarium", "#!/usr/bin/env perl", "#!#{Formula["perl"].opt_bin/"perl"}"
+    rewrite_shebang detected_perl_shebang, "asciiquarium"
 
     chmod 0755, "asciiquarium"
     bin.install "asciiquarium"
@@ -67,9 +71,9 @@ class Asciiquarium < Formula
 
     require "pty"
     ENV["TERM"] = "xterm"
-    PTY.spawn(bin/"asciiquarium") do |stdout, _stdin, pid|
-      sleep 0.5
-      Process.kill "TERM", pid
+    PTY.spawn(bin/"asciiquarium") do |stdout, stdin, _pid|
+      sleep 1
+      stdin.write "q"
       output = begin
         stdout.gets
       rescue Errno::EIO


### PR DESCRIPTION
- The stdin/sdtout variable names were inverted
- Fixes: Errno::EIO: Input/output error @ io_fread - /dev/pts/2 on linux

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
