### PR TITLE
audit_exceptions/unstable_allowlist: remove rust

### DIFF
--- a/audit_exceptions/unstable_allowlist.json
+++ b/audit_exceptions/unstable_allowlist.json
@@ -8,7 +8,6 @@
   "premake": "4.4-beta",
   "pwnat": "0.3-beta",
   "recode": "3.7-beta",
-  "rust": "1.48.",
   "tcptraceroute": "1.5beta",
   "tiny-fugue": "5.0b",
   "vbindiff": "3.0_beta"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`rust` no longer uses a beta version, so we can remove this.