### PR TITLE
libtasn1: Avoid UB on clang 12

### DIFF
--- a/Formula/libtasn1.rb
+++ b/Formula/libtasn1.rb
@@ -5,6 +5,7 @@ class Libtasn1 < Formula
   mirror "https://ftpmirror.gnu.org/libtasn1/libtasn1-4.16.0.tar.gz"
   sha256 "0e0fb0903839117cb6e3b56e68222771bebf22ad7fc2295a0ed7d576e8d4329d"
   license "LGPL-2.1"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "e5ff2498ab8bcc108dd6797fede68929ae3fd2796c39e349ff3f8e0a87abb7a0"
@@ -12,6 +13,13 @@ class Libtasn1 < Formula
     sha256 cellar: :any, catalina:      "00bd968b6a110c5cb497cf0e3b14800ed5e67a2476d0d544aeb1c0c2c1f3f332"
     sha256 cellar: :any, mojave:        "3c2e9cdfec0ccec899847a3ab69b88967b6cbc0b3e406fa1938a4ca6f277b674"
     sha256 cellar: :any, high_sierra:   "c3cf713b5bb29fcac1381b7242e557b7920cb327c77170a6dd038a477d6021cd"
+  end
+
+  # Remove the patch when the issue is resolved:
+  # https://gitlab.com/gnutls/libtasn1/-/issues/30
+  patch do
+    url "https://gitlab.com/gnutls/libtasn1/-/commit/088c9f3e946cb8a15867f6f09f0ef503a7551961.patch"
+    sha256 "0791ee7d9e0f231018956a0a5eac80165ede1ec7732490d7d8bea7dc83022d3a"
   end
 
   def install

--- a/Formula/libtasn1.rb
+++ b/Formula/libtasn1.rb
@@ -4,7 +4,7 @@ class Libtasn1 < Formula
   url "https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.16.0.tar.gz"
   mirror "https://ftpmirror.gnu.org/libtasn1/libtasn1-4.16.0.tar.gz"
   sha256 "0e0fb0903839117cb6e3b56e68222771bebf22ad7fc2295a0ed7d576e8d4329d"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
   revision 1
 
   bottle do


### PR DESCRIPTION
libtasn1 doesn't work properly if built with clang 12 and -O2.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
