### PR TITLE
Use stable livecheck URL

### DIFF
--- a/Formula/allegro.rb
+++ b/Formula/allegro.rb
@@ -7,7 +7,7 @@ class Allegro < Formula
   head "https://github.com/liballeg/allegro5.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -8,7 +8,7 @@ class ArduinoCli < Formula
   head "https://github.com/arduino/arduino-cli.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -9,7 +9,7 @@ class AzureCli < Formula
   head "https://github.com/Azure/azure-cli.git"
 
   livecheck do
-    url :head
+    url :stable
     strategy :github_latest
     regex(%r{href=.*?/tag/azure-cli[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end

--- a/Formula/beast.rb
+++ b/Formula/beast.rb
@@ -8,7 +8,7 @@ class Beast < Formula
   head "https://github.com/beast-dev/beast-mcmc.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/boost-build.rb
+++ b/Formula/boost-build.rb
@@ -8,7 +8,7 @@ class BoostBuild < Formula
   head "https://github.com/boostorg/build.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^boost[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/buildkit.rb
+++ b/Formula/buildkit.rb
@@ -8,7 +8,7 @@ class Buildkit < Formula
   head "https://github.com/moby/buildkit.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/castxml.rb
+++ b/Formula/castxml.rb
@@ -7,7 +7,7 @@ class Castxml < Formula
   head "https://github.com/CastXML/castxml.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/cgns.rb
+++ b/Formula/cgns.rb
@@ -7,7 +7,7 @@ class Cgns < Formula
   head "https://github.com/CGNS/CGNS.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/chibi-scheme.rb
+++ b/Formula/chibi-scheme.rb
@@ -7,7 +7,7 @@ class ChibiScheme < Formula
   head "https://github.com/ashinn/chibi-scheme.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/clib.rb
+++ b/Formula/clib.rb
@@ -7,7 +7,7 @@ class Clib < Formula
   head "https://github.com/clibs/clib.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/cmockery2.rb
+++ b/Formula/cmockery2.rb
@@ -7,7 +7,7 @@ class Cmockery2 < Formula
   head "https://github.com/lpabon/cmockery2.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/coccinelle.rb
+++ b/Formula/coccinelle.rb
@@ -8,7 +8,7 @@ class Coccinelle < Formula
   head "https://github.com/coccinelle/coccinelle.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -8,7 +8,7 @@ class Consul < Formula
   head "https://github.com/hashicorp/consul.git", shallow: false
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -7,7 +7,7 @@ class Coq < Formula
   head "https://github.com/coq/coq.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/cpanminus.rb
+++ b/Formula/cpanminus.rb
@@ -8,7 +8,7 @@ class Cpanminus < Formula
   head "https://github.com/miyagawa/cpanminus.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/cppad.rb
+++ b/Formula/cppad.rb
@@ -9,7 +9,7 @@ class Cppad < Formula
   head "https://github.com/coin-or/CppAD.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -14,7 +14,7 @@ class Crystal < Formula
   end
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/ddclient.rb
+++ b/Formula/ddclient.rb
@@ -7,7 +7,7 @@ class Ddclient < Formula
   head "https://github.com/wimpunk/ddclient.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/dnscrypt-proxy.rb
+++ b/Formula/dnscrypt-proxy.rb
@@ -7,7 +7,7 @@ class DnscryptProxy < Formula
   head "https://github.com/DNSCrypt/dnscrypt-proxy.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/docker-compose-completion.rb
+++ b/Formula/docker-compose-completion.rb
@@ -7,7 +7,7 @@ class DockerComposeCompletion < Formula
   head "https://github.com/docker/compose.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/dosbox-x.rb
+++ b/Formula/dosbox-x.rb
@@ -8,7 +8,7 @@ class DosboxX < Formula
   head "https://github.com/joncampbell123/dosbox-x.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^dosbox-x[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/dps8m.rb
+++ b/Formula/dps8m.rb
@@ -6,7 +6,7 @@ class Dps8m < Formula
   head "https://gitlab.com/dps8m/dps8m.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^R?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/dub.rb
+++ b/Formula/dub.rb
@@ -8,7 +8,7 @@ class Dub < Formula
   head "https://github.com/dlang/dub.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/duti.rb
+++ b/Formula/duti.rb
@@ -8,7 +8,7 @@ class Duti < Formula
   head "https://github.com/moretension/duti.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^duti[._-]v?(\d+(?:[.-]\d+)+)$/i)
   end
 

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -15,7 +15,7 @@ class Emscripten < Formula
   head "https://github.com/emscripten-core/emscripten.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -6,7 +6,7 @@ class Fish < Formula
   license "GPL-2.0"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/fluent-bit.rb
+++ b/Formula/fluent-bit.rb
@@ -7,7 +7,7 @@ class FluentBit < Formula
   head "https://github.com/fluent/fluent-bit.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/freeradius-server.rb
+++ b/Formula/freeradius-server.rb
@@ -7,7 +7,7 @@ class FreeradiusServer < Formula
   head "https://github.com/FreeRADIUS/freeradius-server.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^release[._-](\d+(?:[._]\d+)+)$/i)
   end
 

--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -39,7 +39,7 @@ class Freeswitch < Formula
   end
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/git-subrepo.rb
+++ b/Formula/git-subrepo.rb
@@ -7,7 +7,7 @@ class GitSubrepo < Formula
   head "https://github.com/ingydotnet/git-subrepo.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/gitlab-runner.rb
+++ b/Formula/gitlab-runner.rb
@@ -8,7 +8,7 @@ class GitlabRunner < Formula
   head "https://gitlab.com/gitlab-org/gitlab-runner.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/goenv.rb
+++ b/Formula/goenv.rb
@@ -8,7 +8,7 @@ class Goenv < Formula
   head "https://github.com/syndbg/goenv.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/htop.rb
+++ b/Formula/htop.rb
@@ -7,7 +7,7 @@ class Htop < Formula
   head "https://github.com/htop-dev/htop.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/hypre.rb
+++ b/Formula/hypre.rb
@@ -7,7 +7,7 @@ class Hypre < Formula
   head "https://github.com/hypre-space/hypre.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/ibex.rb
+++ b/Formula/ibex.rb
@@ -7,7 +7,7 @@ class Ibex < Formula
   head "https://github.com/ibex-team/ibex-lib.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^ibex[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/imagejs.rb
+++ b/Formula/imagejs.rb
@@ -7,7 +7,7 @@ class Imagejs < Formula
   head "https://github.com/jklmnn/imagejs.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -11,7 +11,7 @@ class Ipfs < Formula
   head "https://github.com/ipfs/go-ipfs.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/itk.rb
+++ b/Formula/itk.rb
@@ -7,7 +7,7 @@ class Itk < Formula
   head "https://github.com/InsightSoftwareConsortium/ITK.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/json-c.rb
+++ b/Formula/json-c.rb
@@ -8,7 +8,7 @@ class JsonC < Formula
   head "https://github.com/json-c/json-c.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^json-c[._-](\d+(?:\.\d+)+)(?:[._-]\d{6,8})?$/i)
   end
 

--- a/Formula/kapacitor.rb
+++ b/Formula/kapacitor.rb
@@ -8,7 +8,7 @@ class Kapacitor < Formula
   head "https://github.com/influxdata/kapacitor.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/kitchen-sync.rb
+++ b/Formula/kitchen-sync.rb
@@ -7,7 +7,7 @@ class KitchenSync < Formula
   head "https://github.com/willbryant/kitchen_sync.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/kops.rb
+++ b/Formula/kops.rb
@@ -7,7 +7,7 @@ class Kops < Formula
   head "https://github.com/kubernetes/kops.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -8,7 +8,7 @@ class Ledger < Formula
   head "https://github.com/ledger/ledger.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/libp11.rb
+++ b/Formula/libp11.rb
@@ -6,7 +6,7 @@ class Libp11 < Formula
   license "LGPL-2.1-or-later"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^libp11[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/librdkafka.rb
+++ b/Formula/librdkafka.rb
@@ -7,7 +7,7 @@ class Librdkafka < Formula
   head "https://github.com/edenhill/librdkafka.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/libtorrent-rasterbar.rb
+++ b/Formula/libtorrent-rasterbar.rb
@@ -7,7 +7,7 @@ class LibtorrentRasterbar < Formula
   revision 1
 
   livecheck do
-    url :head
+    url :stable
     regex(/^libtorrent[._-]v?(\d+(?:[-_.]\d+)+)$/i)
   end
 

--- a/Formula/logstash.rb
+++ b/Formula/logstash.rb
@@ -8,7 +8,7 @@ class Logstash < Formula
   head "https://github.com/elastic/logstash.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -12,7 +12,7 @@ class Mu < Formula
   # as an odd-numbered minor version number indicates a development version:
   # https://github.com/djcb/mu/commit/23f4a64bdcdee3f9956a39b9a5a4fd0c5c2370ba
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+\.\d*[02468](?:\.\d+)*)$/i)
   end
 

--- a/Formula/ncompress.rb
+++ b/Formula/ncompress.rb
@@ -7,7 +7,7 @@ class Ncompress < Formula
   head "https://github.com/vapier/ncompress.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/node-build.rb
+++ b/Formula/node-build.rb
@@ -7,7 +7,7 @@ class NodeBuild < Formula
   head "https://github.com/nodenv/node-build.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/node_exporter.rb
+++ b/Formula/node_exporter.rb
@@ -7,7 +7,7 @@ class NodeExporter < Formula
   head "https://github.com/prometheus/node_exporter.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/nomad.rb
+++ b/Formula/nomad.rb
@@ -7,7 +7,7 @@ class Nomad < Formula
   head "https://github.com/hashicorp/nomad.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/nzbget.rb
+++ b/Formula/nzbget.rb
@@ -8,7 +8,7 @@ class Nzbget < Formula
   head "https://github.com/nzbget/nzbget.git", branch: "develop"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/ocproxy.rb
+++ b/Formula/ocproxy.rb
@@ -8,7 +8,7 @@ class Ocproxy < Formula
   head "https://github.com/cernekee/ocproxy.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d{1,3})+)$/i)
   end
 

--- a/Formula/osrm-backend.rb
+++ b/Formula/osrm-backend.rb
@@ -7,7 +7,7 @@ class OsrmBackend < Formula
   head "https://github.com/Project-OSRM/osrm-backend.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/pdftk-java.rb
+++ b/Formula/pdftk-java.rb
@@ -7,7 +7,7 @@ class PdftkJava < Formula
   head "https://gitlab.com/pdftk-java/pdftk.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/pipes-sh.rb
+++ b/Formula/pipes-sh.rb
@@ -7,7 +7,7 @@ class PipesSh < Formula
   head "https://github.com/pipeseroni/pipes.sh.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/pjproject.rb
+++ b/Formula/pjproject.rb
@@ -7,7 +7,7 @@ class Pjproject < Formula
   head "https://github.com/pjsip/pjproject.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/plank.rb
+++ b/Formula/plank.rb
@@ -7,7 +7,7 @@ class Plank < Formula
   head "https://github.com/pinterest/plank.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/rlwrap.rb
+++ b/Formula/rlwrap.rb
@@ -7,7 +7,7 @@ class Rlwrap < Formula
   head "https://github.com/hanslub42/rlwrap.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/spotifyd.rb
+++ b/Formula/spotifyd.rb
@@ -7,7 +7,7 @@ class Spotifyd < Formula
   head "https://github.com/Spotifyd/spotifyd.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/st.rb
+++ b/Formula/st.rb
@@ -8,7 +8,7 @@ class St < Formula
   head "https://github.com/nferraz/st.git"
 
   livecheck do
-    url :head
+    url :stable
     strategy :github_latest
   end
 

--- a/Formula/tcping.rb
+++ b/Formula/tcping.rb
@@ -7,7 +7,7 @@ class Tcping < Formula
   head "https://github.com/mkirchner/tcping.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -7,7 +7,7 @@ class Telegraf < Formula
   head "https://github.com/influxdata/telegraf.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -7,7 +7,7 @@ class Tesseract < Formula
   head "https://github.com/tesseract-ocr/tesseract.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/tfenv.rb
+++ b/Formula/tfenv.rb
@@ -7,7 +7,7 @@ class Tfenv < Formula
   head "https://github.com/tfutils/tfenv.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/tgenv.rb
+++ b/Formula/tgenv.rb
@@ -7,7 +7,7 @@ class Tgenv < Formula
   head "https://github.com/cunymatthieu/tgenv.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/v2ray-plugin.rb
+++ b/Formula/v2ray-plugin.rb
@@ -7,7 +7,7 @@ class V2rayPlugin < Formula
   head "https://github.com/shadowsocks/v2ray-plugin.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/vapoursynth.rb
+++ b/Formula/vapoursynth.rb
@@ -7,7 +7,7 @@ class Vapoursynth < Formula
   head "https://github.com/vapoursynth/vapoursynth.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^R(\d+(?:\.\d+)*?)$/i)
   end
 

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -19,7 +19,7 @@ class Watchman < Formula
   # The Git repo contains a few tags like `2020.05.18.00`, so we have to
   # restrict matching to versions with two to three parts (e.g., 1.2, 1.2.3).
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+){,2})$/i)
   end
 

--- a/Formula/zero-install.rb
+++ b/Formula/zero-install.rb
@@ -8,7 +8,7 @@ class ZeroInstall < Formula
   head "https://github.com/0install/0install.git"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/zeromq.rb
+++ b/Formula/zeromq.rb
@@ -6,7 +6,7 @@ class Zeromq < Formula
   license "LGPL-3.0-or-later" => { with: "LGPL-3.0-linking-exception" }
 
   livecheck do
-    url :head
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR replaces `url :head` with `url :stable` in `livecheck` blocks where the `stable` URL produces the same URL as `head`. We prefer to align the check with `stable` whenever possible, so this is more in line with that guideline.

`url :stable` is a drop-in replacement for all of these checks and I confirmed that they work the same after these changes. There are others that need additional changes to the `livecheck` block and I'm going to create individual PRs for those.