### PR TITLE
mysql@5.6: deprecate

### DIFF
--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -5,11 +5,6 @@ class MysqlAT56 < Formula
   sha256 "262ccaf2930fca1f33787505dd125a7a04844f40d3421289a51974b5935d9abc"
   license "GPL-2.0-only"
 
-  livecheck do
-    url "https://dev.mysql.com/downloads/mysql/5.6.html?tpl=files&os=src&version=5.6"
-    regex(/href=.*?mysql[._-]v?(5\.6(?:\.\d+)*)\.t/i)
-  end
-
   bottle do
     sha256 "f11cd8885dc59020425bbdad88911471bc24de21810cbfbbcb6d9dd936473a85" => :big_sur
     sha256 "bbdc569f29b12fbcf5e877b15598b6adbbfa551df4ffdf8047832335b6dc829f" => :catalina
@@ -17,6 +12,8 @@ class MysqlAT56 < Formula
   end
 
   keg_only :versioned_formula
+
+  deprecate! date: "2021-02-01", because: :unsupported
 
   depends_on "cmake" => :build
   depends_on "openssl@1.1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

MySQL 5.6 appears to be unsupported as of 2021-02-01 according to the ["MySQL Product Support EOL Announcements" page](https://www.mysql.com/support/eol-notice.html), so this deprecates the formula and removes the `livecheck` block (which doesn't work anymore due to the EOL anyway).