### PR TITLE
fish: set sed path only for mac

### DIFF
--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -43,8 +43,10 @@ class Fish < Formula
       -Dextra_functionsdir=#{HOMEBREW_PREFIX}/share/fish/vendor_functions.d
       -Dextra_completionsdir=#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d
       -Dextra_confdir=#{HOMEBREW_PREFIX}/share/fish/vendor_conf.d
-      -DSED=/usr/bin/sed
     ]
+    on_macos do
+      args << "-DSED=/usr/bin/sed"
+    end
     system "cmake", ".", *std_cmake_args, *args
     system "make", "install"
   end


### PR DESCRIPTION
This path might not exist on linux

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
