### PR TITLE
tcpflow: update stable and livecheck

### DIFF
--- a/Formula/tcpflow.rb
+++ b/Formula/tcpflow.rb
@@ -1,14 +1,15 @@
 class Tcpflow < Formula
   desc "TCP/IP packet demultiplexer"
   homepage "https://github.com/simsong/tcpflow"
-  url "https://digitalcorpora.org/downloads/tcpflow/tcpflow-1.5.0.tar.gz"
+  url "https://github.com/simsong/tcpflow/releases/download/tcpflow-1.5.0/tcpflow-1.5.0.tar.gz"
   sha256 "20abe3353a49a13dcde17ad318d839df6312aa6e958203ea710b37bede33d988"
   license "GPL-3.0"
   revision 1
 
   livecheck do
-    url "http://downloads.digitalcorpora.org/downloads/tcpflow/"
-    regex(/href=.*?tcpflow[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(%r{href=.*?/tag/(?:tcpflow[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://digitalcorpora.org/downloads/ is no longer available and the `stable` URL for `tcpflow` goes through a few redirections before returning a `404 Not Found` response. The GitHub repository `README` links to http://downloads.digitalcorpora.org/downloads/tcpflow/ but this doesn't exist anymore either.

The `tcpflow-1.5.0.tar.gz` release tarball on GitHub is the same as the digitalcorpora.org tarball, so I've simply substituted it here (no change to the `sha256` needed).

I've updated the `livecheck` block to align the check with the new `stable` source. I've set it to check the "latest" release on GitHub (currently 1.5.0), as there are `tcpflow-1.5.1` and `tcpflow-1.5.2` tags that weren't published as releases which we may not want to use.

---

For what it's worth, this same issue affects `bulk_extractor`. Unfortunately, the related simsong/bulk_extractor GitHub repository hasn't created a release since `1.5.3` and the formula version is `1.5.5`.