### PR TITLE
vlang: update livecheck

### DIFF
--- a/Formula/vlang.rb
+++ b/Formula/vlang.rb
@@ -8,7 +8,7 @@ class Vlang < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `vlang` was checking the "latest" release on GitHub but this is currently broken because it's a weekly snapshot (`weekly.2021.5`) instead of a proper release (e.g., `0.2.2`). As such, the "latest" release on GitHub isn't a reliable indicator of the latest stable release.

This updates the `livecheck` block to check the Git tags, using the standard regex for Git tags like `1.2.3`/`v1.2.3`, which will only match release versions (not the `weekly` tags). [For what it's worth, checking the first-party website isn't an option, as it simply links to the "latest" release on GitHub instead of pointing to a specific version.]