### PR TITLE
msitools: update livecheck

### DIFF
--- a/Formula/msitools.rb
+++ b/Formula/msitools.rb
@@ -5,8 +5,11 @@ class Msitools < Formula
   sha256 "0cc4d2e0d108fa6f2b4085b9a97dd5bc6d9fcadecdd933f2094f86bafdbe85fe"
   license "LGPL-2.1-or-later"
 
+  # msitools doesn't seem to use the GNOME version scheme, so we have to
+  # loosen the default `Gnome` strategy regex to match the latest version.
   livecheck do
     url :stable
+    regex(/msitools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `msitools` uses the `Gnome` strategy but it seems like `msitools` doesn't use the GNOME version scheme (i.e., even-numbered minor versions are stable but 90+ is unstable). The `Gnome` strategy's default regex assumes the GNOME version scheme is used, so it's necessary to provide a looser regex for this formula.

This became apparent because the latest version is now `0.101` but the default `Gnome` strategy regex doesn't match this version because the minor version is odd. This PR adds a regex to the `livecheck` block that allows it to match any versions, which seems to align with how this formula has been updated in previous PRs.

[For what it's worth, the reason why this regex doesn't start with the typical `href=.*?` is because the `Gnome` formula is checking a JSON file, not an HTML page.]