### PR TITLE
ec2-api-tools: deprecate

### DIFF
--- a/Formula/ec2-api-tools.rb
+++ b/Formula/ec2-api-tools.rb
@@ -11,6 +11,11 @@ class Ec2ApiTools < Formula
 
   bottle :unneeded
 
+  # Deprecated upstream somewhere between 2017-12-24 and 2018-09-09 here:
+  # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html
+  # The current version (1.7.5.1) is from 2015-09-08.
+  deprecate! date: "2020-02-03", because: :deprecated_upstream
+
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`ec2-api-tools` was marked as deprecated on the Amazon Elastic Compute Cloud API Reference [Welcome page](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html) somewhere between 2017-12-24 and 2018-09-09, according to the available Wayback Machine snapshots.

This was originally brought to my attention on 2020-06-23 by @nandahkrishna (https://github.com/Homebrew/homebrew-livecheck/pull/989#issuecomment-648545281) but I'm just now getting around to creating a PR for this 😅

The current version (`1.7.5.1`) is from 2015-09-08 but this still seems to get installed with some regularity:

* Installs (30 days): 127
* Installs (90 days): 390
* Installs (365 days): 2335