### PR TITLE
dafny 3.0.0

### DIFF
--- a/Formula/dafny.rb
+++ b/Formula/dafny.rb
@@ -1,10 +1,9 @@
 class Dafny < Formula
   desc "Verification-aware programming language"
   homepage "https://github.com/dafny-lang/dafny/blob/master/README.md"
-  url "https://github.com/dafny-lang/dafny/archive/v2.3.0.tar.gz"
-  sha256 "ea7ae310282c922772a46a9a85e2b4213043283038b74d012047b5294687d168"
+  url "https://github.com/dafny-lang/dafny/archive/v3.0.0.tar.gz"
+  sha256 "5e9af6ca59c3329cd93d792bf9890c55c68c4f656afb19c85d1c44b0c7989fc2"
   license "MIT"
-  revision 3
 
   livecheck do
     url :stable
@@ -17,31 +16,22 @@ class Dafny < Formula
     sha256 cellar: :any_skip_relocation, mojave:   "3a21de05e53a0276a2aaaf3e82f2f8062b02ae9e31ba2a7bd0b2631691d10eca"
   end
 
-  depends_on "mono-libgdiplus" => :build
+  depends_on "gradle" => :build
   depends_on "nuget" => :build
-  depends_on "mono"
-
-  resource "boogie" do
-    url "https://github.com/boogie-org/boogie.git",
-        revision: "9e74c3271f430adb958908400c6f6fce5b59000a"
-  end
+  depends_on "dotnet"
+  depends_on "openjdk"
 
   # Use the following along with the z3 build below, as long as dafny
   # cannot build with latest z3 (https://github.com/dafny-lang/dafny/issues/810)
   resource "z3" do
-    url "https://github.com/Z3Prover/z3/archive/z3-4.8.4.tar.gz"
-    sha256 "5a18fe616c2a30b56e5b2f5b9f03f405cdf2435711517ff70b076a01396ef601"
+    url "https://github.com/Z3Prover/z3/archive/Z3-4.8.5.tar.gz"
+    sha256 "4e8e232887ddfa643adb6a30dcd3743cb2fa6591735fbd302b49f7028cdc0363"
   end
 
   def install
-    (buildpath/"../boogie").install resource("boogie")
-    cd buildpath/"../boogie" do
-      system "nuget", "restore", "Source/Boogie.sln"
-      system "msbuild", "Source/Boogie.sln"
-    end
-    system "msbuild", "Source/Dafny.sln"
+    system "make", "exe", "runtime"
 
-    libexec.install Dir["Binaries/*"]
+    libexec.install Dir["Binaries/*", "Scripts/quicktest.sh"]
 
     dst_z3_bin = libexec/"z3/bin"
     dst_z3_bin.mkpath
@@ -54,7 +44,7 @@ class Dafny < Formula
 
     (bin/"dafny").write <<~EOS
       #!/bin/bash
-      mono #{libexec}/dafny.exe "$@"
+      dotnet #{libexec}/Dafny.dll "$@"
     EOS
   end
 
@@ -67,10 +57,10 @@ class Dafny < Formula
       }
     EOS
     assert_equal "\nDafny program verifier finished with 1 verified, 0 errors\n",
-                  shell_output("#{bin}/dafny /nologo /compile:0 #{testpath}/test.dfy")
+                  shell_output("#{bin}/dafny /compile:0 #{testpath}/test.dfy")
     assert_equal "\nDafny program verifier finished with 1 verified, 0 errors\nRunning...\n\nhello, Dafny\n",
-                  shell_output("#{bin}/dafny /nologo /compile:3 #{testpath}/test.dfy")
-    assert_equal "Z3 version 4.8.4 - 64 bit\n",
+                  shell_output("#{bin}/dafny /compile:3 #{testpath}/test.dfy")
+    assert_equal "Z3 version 4.8.5 - 64 bit\n",
                  shell_output("#{libexec}/z3/bin/z3 -version")
   end
 end


### PR DESCRIPTION
This update to the Dafny formula corresponds to the 3.0.0 release of Dafny. That release uses dotnet 5.0 rather than mono to build and run Dafny.
