### PR TITLE
emacs: disable selinux

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -56,6 +56,11 @@ class Emacs < Formula
   end
 
   def install
+    # Mojave uses the Catalina SDK which causes issues like
+    # https://github.com/Homebrew/homebrew-core/issues/46393
+    # https://github.com/Homebrew/homebrew-core/pull/70421
+    ENV["ac_cv_func_aligned_alloc"] = "no" if MacOS.version == :mojave
+
     args = %W[
       --disable-silent-rules
       --enable-locallisppath=#{HOMEBREW_PREFIX}/share/emacs/site-lisp
@@ -68,6 +73,7 @@ class Emacs < Formula
       --with-modules
       --without-ns
       --without-imagemagick
+      --without-selinux
     ]
 
     if build.head?


### PR DESCRIPTION
The flags does nothing on mac, and prevents emacs to build against selinux
on linux (which we do not have a formula for)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
