### PR TITLE
ethereum: fix build for Linux

### DIFF
--- a/Formula/ethereum.rb
+++ b/Formula/ethereum.rb
@@ -21,6 +21,10 @@ class Ethereum < Formula
   depends_on "go" => :build
 
   def install
+    on_linux do
+      # See https://github.com/golang/go/issues/26487
+      ENV.O0
+    end
     system "make", "all"
     bin.install Dir["build/bin/*"]
   end


### PR DESCRIPTION
Fixes:
cgo-dwarf-inference:2:8: error: enumerator value for '__cgo_enum__0' is not an integer constant
cgo-dwarf-inference:10:2: error: initializer element is not constant
cgo-dwarf-inference:10:2: note: (near initialization for '__cgodebug_ints[0]')

See https://github.com/golang/go/issues/26487, it looks like setting ENV.O0
is the recommended way to fix this.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
