### PR TITLE
formulae: reorder bottle blocks

### DIFF
--- a/Formula/autopep8.rb
+++ b/Formula/autopep8.rb
@@ -12,8 +12,8 @@ class Autopep8 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "0d9286b07276cd78d5fb31ed9bd126b5675ffb9b8509793f17d49a571e44b49b"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "abf487f3114b67ebfe0760421a3df96e948fbcb2ec378cd2fcab08e2d73aaf49"
+    sha256 cellar: :any_skip_relocation, big_sur:       "0d9286b07276cd78d5fb31ed9bd126b5675ffb9b8509793f17d49a571e44b49b"
     sha256 cellar: :any_skip_relocation, catalina:      "7445d78c6c97dad32d841a2afaa2f655d1514b72eca5650460d1d1a8f175e1fe"
     sha256 cellar: :any_skip_relocation, mojave:        "b3ea685a6f92eb1c2b283a38c54a1155fe06fc3f0f7374c8a99ffcbd483286c8"
   end

--- a/Formula/aws-cdk.rb
+++ b/Formula/aws-cdk.rb
@@ -12,8 +12,8 @@ class AwsCdk < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "3c42fe319ba690757281ad68420396425219bc796bf58ccd2830e9be2297deab"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "db4f53ac6f43d594e001419e389e3cb7eaade2b8e55c49c0f77501cdcc55ae4b"
+    sha256 cellar: :any_skip_relocation, big_sur:       "3c42fe319ba690757281ad68420396425219bc796bf58ccd2830e9be2297deab"
     sha256 cellar: :any_skip_relocation, catalina:      "a92171a5f012e5dcf1273e81fb5847ae0fdb26859dbf8fec9a5308d77043f8b4"
     sha256 cellar: :any_skip_relocation, mojave:        "5ba181b093e520e08b06288996176cb83a5b9a18a39b1da5f64befd2262412d3"
   end

--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -14,8 +14,8 @@ class AwscliAT1 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "0f009bbd601899930d73ea944913324de94fadbf26dececebfb1cfd8be997af8"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "28afb478b703052750d2440a4c2ff85f2921533fb394f8a6d8f4c4df6d0d4a9e"
+    sha256 cellar: :any_skip_relocation, big_sur:       "0f009bbd601899930d73ea944913324de94fadbf26dececebfb1cfd8be997af8"
     sha256 cellar: :any_skip_relocation, catalina:      "2227b3582ee66e3d167edcade22cde35d135b2bf50e9ef569fd1a4194079f55c"
     sha256 cellar: :any_skip_relocation, mojave:        "50e11107c8bdbb46d2253efca8132c739f1a17ae7fd4ab3a8c87eedeaa3275c9"
   end

--- a/Formula/bitwarden-cli.rb
+++ b/Formula/bitwarden-cli.rb
@@ -12,8 +12,8 @@ class BitwardenCli < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "d35e2f8abba1c08879ef4f756643b005dc13ced957cabb542ae9fe8ca72eb71c"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "76456ab9cc5aa55791cc6480d771b23370a3ed3ac038efd7841cc3535ecbc1c1"
+    sha256 cellar: :any_skip_relocation, big_sur:       "d35e2f8abba1c08879ef4f756643b005dc13ced957cabb542ae9fe8ca72eb71c"
     sha256 cellar: :any_skip_relocation, catalina:      "7be0a5239e74b4a754730ca1baecb6e2666a7a2c2883ffc61b368989e50dbb4d"
     sha256 cellar: :any_skip_relocation, mojave:        "a55e52d3c9c4fe1fba871182575dceb6b7a415cedeea192062d556b07b61483f"
   end

--- a/Formula/calc.rb
+++ b/Formula/calc.rb
@@ -10,8 +10,8 @@ class Calc < Formula
   end
 
   bottle do
-    sha256 big_sur:       "3d4821d5977cafef210d99e121549c43d0f0afb51302224380e94fc8b92be7b8"
     sha256 arm64_big_sur: "d64c698c14375806dfe5ab6026aac624ccd4156c65ca3587f320415745e528dd"
+    sha256 big_sur:       "3d4821d5977cafef210d99e121549c43d0f0afb51302224380e94fc8b92be7b8"
     sha256 catalina:      "9c0fcfc9f4ae9db884ab809d0385fa6bcc34f86789bbe786a0330ef9b579bf79"
     sha256 mojave:        "02f1b5c6130bcb6bcacc6993997f8096c0dd5ef912822b52ed814b5e0214ed3b"
   end

--- a/Formula/ccache.rb
+++ b/Formula/ccache.rb
@@ -7,8 +7,8 @@ class Ccache < Formula
   head "https://github.com/ccache/ccache.git"
 
   bottle do
-    sha256 cellar: :any, big_sur:       "4323fd450d0e58cb7c4b76d5254e5a5b44d960d5216073dfeeda41e9baf298f3"
     sha256 cellar: :any, arm64_big_sur: "582e21a87c6025f4de138f2a5b47a14a0487f2e6deabf4dd54cfb0d34d27190b"
+    sha256 cellar: :any, big_sur:       "4323fd450d0e58cb7c4b76d5254e5a5b44d960d5216073dfeeda41e9baf298f3"
     sha256 cellar: :any, catalina:      "e84ad1c22e01e75f740c910f562935c2d00058aaf4e8bbd09050dfee18f45324"
     sha256 cellar: :any, mojave:        "143ee0131253764d489ba4ff6569ec565c50d50662d878065bdf44d290d23c2b"
   end

--- a/Formula/certbot.rb
+++ b/Formula/certbot.rb
@@ -9,8 +9,8 @@ class Certbot < Formula
   head "https://github.com/certbot/certbot.git"
 
   bottle do
-    sha256 cellar: :any, big_sur:       "10d99154d4f477f963485fd1e346c652a6719a797ee4392f6d7ea6b17ded8e57"
     sha256 cellar: :any, arm64_big_sur: "57aff9376ffebee8dc496452fa160bcf5fa5b640dc9ac062a94da49262507027"
+    sha256 cellar: :any, big_sur:       "10d99154d4f477f963485fd1e346c652a6719a797ee4392f6d7ea6b17ded8e57"
     sha256 cellar: :any, catalina:      "32a50594c947ede27153dc4eb75653aa66a3ddae546a9d076c782e68b61a0758"
     sha256 cellar: :any, mojave:        "2e6f5d380da787a79c8c817eb3436a1000ba77885fa124075e980e8285a9a95e"
   end

--- a/Formula/cfn-lint.rb
+++ b/Formula/cfn-lint.rb
@@ -12,8 +12,8 @@ class CfnLint < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "743cd92fba908a174df74489cde1540ec07e55da5f8dbfc9a8bd8ac537bb30a2"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "a894ba98163e9a6d82facd05563bbba8a963b322a8a6a3aa349056ab2124c227"
+    sha256 cellar: :any_skip_relocation, big_sur:       "743cd92fba908a174df74489cde1540ec07e55da5f8dbfc9a8bd8ac537bb30a2"
     sha256 cellar: :any_skip_relocation, catalina:      "e2c6d44914b002be71f02299d987077d736d6053177e65d4c882f34463bc4012"
     sha256 cellar: :any_skip_relocation, mojave:        "74246247d136dab665f24cb086f4eebd990717d6527097096b2407bcf271cb53"
   end

--- a/Formula/checkov.rb
+++ b/Formula/checkov.rb
@@ -9,8 +9,8 @@ class Checkov < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "33a3dec943fce8526ce4450b9fc4847f67bd2c8a5acbc38e207ce9ffa3a2a22e"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e9cced0eb4d5dbfe7451a41eeaf44b4c9d4b21158304582c26e0754cc2503eec"
+    sha256 cellar: :any_skip_relocation, big_sur:       "33a3dec943fce8526ce4450b9fc4847f67bd2c8a5acbc38e207ce9ffa3a2a22e"
     sha256 cellar: :any_skip_relocation, catalina:      "8fda2855f2a15e48dc178f58b6a27a950e3d70a59b4dd4f751ef372080f9e6a8"
     sha256 cellar: :any_skip_relocation, mojave:        "8f1dff7758e0bc36a259bc6c8bd88fb9b2b4e30d560c923c8342abd6b7a82512"
   end

--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -12,8 +12,8 @@ class Clamav < Formula
   end
 
   bottle do
-    sha256 big_sur:       "ef79742b675d0b07d1cef974996a4647848ba2d2508c3f7a011d93090ae52e3a"
     sha256 arm64_big_sur: "819a822b63f106657c8e0374eddad592eda5aebaa608a16111578b8e5dac390c"
+    sha256 big_sur:       "ef79742b675d0b07d1cef974996a4647848ba2d2508c3f7a011d93090ae52e3a"
     sha256 catalina:      "aeb895673034b67934ec56ab7bc91c49e6034c80c54c699966f2ed6064b0aba8"
     sha256 mojave:        "d5e992c19a4104eea8a8cf17cd13f71e18a0484a35939a30f2aec534603bb5ac"
   end

--- a/Formula/coin3d.rb
+++ b/Formula/coin3d.rb
@@ -19,8 +19,8 @@ class Coin3d < Formula
   end
 
   bottle do
-    sha256 big_sur:       "509b6d290e63f31756b1040b46366e8c0cafe173b098544caf7e8c61cd8a9b7e"
     sha256 arm64_big_sur: "df8e2e369aad234bc940bfc8e64d3956ba9a0e1896ab68214a7fff82c14e05d7"
+    sha256 big_sur:       "509b6d290e63f31756b1040b46366e8c0cafe173b098544caf7e8c61cd8a9b7e"
     sha256 catalina:      "7ff9151841889454aea31e68576541e0f8b2e2021fd7133abf3e596ac2ae9de8"
     sha256 mojave:        "a791ec37b8aa81bd249cdb2837753ca4419c38957f60c60e249e6c8274976ab6"
   end

--- a/Formula/copilot.rb
+++ b/Formula/copilot.rb
@@ -10,8 +10,8 @@ class Copilot < Formula
   head "https://github.com/aws/copilot-cli.git"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "c4e65bb0077dcf34dca1c7bbabdbc1b34b37660f89f3028321fa30ac13e5f94d"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "78fa7a1243e788c42e47ee8a41bd6a657a78bbe6feec0351f4ac2cb45ccf2a32"
+    sha256 cellar: :any_skip_relocation, big_sur:       "c4e65bb0077dcf34dca1c7bbabdbc1b34b37660f89f3028321fa30ac13e5f94d"
     sha256 cellar: :any_skip_relocation, catalina:      "0430526ab8a2bf8b3944971d1d69f986ca2e3c2c0881bacb18635b01573b17c1"
     sha256 cellar: :any_skip_relocation, mojave:        "d79031b40ca64ab97a9f885b3c9a81f7174f91f1e7896d3b304d3059994a1bc9"
   end

--- a/Formula/cppad.rb
+++ b/Formula/cppad.rb
@@ -14,8 +14,8 @@ class Cppad < Formula
   end
 
   bottle do
-    sha256 cellar: :any, big_sur:       "bbd9d0e16ee51ec4f9d1b031ee459b815bd1fc059c36246b7cbe69e6177750ca"
     sha256 cellar: :any, arm64_big_sur: "577118fabf3804c109fa22d2f995c3170ae9e319e9d50bd810ba98a38ff285bd"
+    sha256 cellar: :any, big_sur:       "bbd9d0e16ee51ec4f9d1b031ee459b815bd1fc059c36246b7cbe69e6177750ca"
     sha256 cellar: :any, catalina:      "dba78015166853249a2ff6467f9dd7fd4e45c7914706ed174e94f31536294549"
     sha256 cellar: :any, mojave:        "28cbc31c7971a99a55d73af33159ccdb6ff0e4902dba0a512065704a30bf5c47"
   end

--- a/Formula/cpprestsdk.rb
+++ b/Formula/cpprestsdk.rb
@@ -9,8 +9,8 @@ class Cpprestsdk < Formula
   head "https://github.com/Microsoft/cpprestsdk.git", branch: "development"
 
   bottle do
-    sha256 cellar: :any, big_sur:       "c65b7f42fed4091750be219a60774854de46903c74ef99def1b73f905bb0728f"
     sha256 cellar: :any, arm64_big_sur: "ac66587bc353b3358ff11606ca3952fa57f7dc57a5f59414ed8bfa62e90ff858"
+    sha256 cellar: :any, big_sur:       "c65b7f42fed4091750be219a60774854de46903c74ef99def1b73f905bb0728f"
     sha256 cellar: :any, catalina:      "f89613fba00d0feaa3e55508f3fb122dc8f4126b679e55c22fd228ed44d0c1c4"
     sha256 cellar: :any, mojave:        "6805fd31638651ef090d68e07cdea155d70b23365828cd1adbfd60fc132eedc3"
   end

--- a/Formula/doctest.rb
+++ b/Formula/doctest.rb
@@ -6,8 +6,8 @@ class Doctest < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "9953fc6b8a5f7c7b367f80ee18da68b866cf98cbd173f7d9e28cabc78f8cc7fb"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d9dc2fad76656c4da31728b79061374da37010829110a2c2f0a97763c2060a6b"
+    sha256 cellar: :any_skip_relocation, big_sur:       "9953fc6b8a5f7c7b367f80ee18da68b866cf98cbd173f7d9e28cabc78f8cc7fb"
     sha256 cellar: :any_skip_relocation, catalina:      "b3b12c49b233e756e7cb8dc06befa73324c5b55692ea0adaf0b0635156a820b5"
     sha256 cellar: :any_skip_relocation, mojave:        "9b2183c34b14c5ecfc1fab142cf68d02454a39bd85d639e59caabd1df65e0fc8"
   end

--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -30,8 +30,8 @@ class Emacs < Formula
 
   bottle do
     rebuild 1
-    sha256 big_sur:       "c4d216163623ccb65f21964df378f1c96871657cbc8ffa702dd3812e7d0e76d8"
     sha256 arm64_big_sur: "66c4fc4a6f21c3303ac39939e8971894560fd4d8e632539e72436bd05a203816"
+    sha256 big_sur:       "c4d216163623ccb65f21964df378f1c96871657cbc8ffa702dd3812e7d0e76d8"
     sha256 catalina:      "86274cfc78b97cf6b5e2e942b9283c2da926b8fa4a9a0400515661a9dccc7c24"
     sha256 mojave:        "8ed16db6ab57f13c9ec1104caf06388829118c8e94b13974f39d4c59d0faf612"
   end

--- a/Formula/faudio.rb
+++ b/Formula/faudio.rb
@@ -7,8 +7,8 @@ class Faudio < Formula
   head "https://github.com/FNA-XNA/FAudio.git"
 
   bottle do
-    sha256 cellar: :any, big_sur:       "1d17eb20201576e754b8d3bded2f3d5c404434f0c7761218417eb67b98e37b75"
     sha256 cellar: :any, arm64_big_sur: "1b04245fc96837e76295de550b71a6726363c1fefc9e51dcf0e37f302dac02b5"
+    sha256 cellar: :any, big_sur:       "1d17eb20201576e754b8d3bded2f3d5c404434f0c7761218417eb67b98e37b75"
     sha256 cellar: :any, catalina:      "c570c1187b5fb6d6bddc23965d18742598947709825d97751770ff0258b20e17"
     sha256 cellar: :any, mojave:        "b087e8546f0979625a76822fd89b3c2e3162eadc4db0ac8ad312a2cc1ede2423"
   end

--- a/Formula/fcct.rb
+++ b/Formula/fcct.rb
@@ -12,8 +12,8 @@ class Fcct < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "ad3be57c5b5be44baebf9b65b58707dc6ae42d8ec88694ecf212ef48b1ec6f71"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "168e14f5c7e7843342a66bd5073e198ee1f63c614b84803f9c9a83d6932b33c2"
+    sha256 cellar: :any_skip_relocation, big_sur:       "ad3be57c5b5be44baebf9b65b58707dc6ae42d8ec88694ecf212ef48b1ec6f71"
     sha256 cellar: :any_skip_relocation, catalina:      "bfa9271ef810cdaa856fe7f77a1bedebda49156a62ffedbadac2a7b3dff762ee"
     sha256 cellar: :any_skip_relocation, mojave:        "01a0424af0d9e118de1f247fee0c9b0cde198364860c818b55259e9c8884ae5b"
   end

--- a/Formula/flow-cli.rb
+++ b/Formula/flow-cli.rb
@@ -7,8 +7,8 @@ class FlowCli < Formula
   head "https://github.com/onflow/flow-cli.git"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "26f2ff6a2154d71d2268bd9a232aa9ecc3081c671c57ae7cefad8d800ee930d0"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e8f039b06734c3ea3e6e083d71956333ab62f8e9c75b826006442136e83800d7"
+    sha256 cellar: :any_skip_relocation, big_sur:       "26f2ff6a2154d71d2268bd9a232aa9ecc3081c671c57ae7cefad8d800ee930d0"
     sha256 cellar: :any_skip_relocation, catalina:      "d99a2857dca3ef9095b0fd7fbfeafedf8675475d8bbfdb9b9afb372e59b23591"
     sha256 cellar: :any_skip_relocation, mojave:        "48b8177bca20f2504c20389f2c15031e4e0ab2d675545710c199ef36ff618916"
   end

--- a/Formula/flux.rb
+++ b/Formula/flux.rb
@@ -13,8 +13,8 @@ class Flux < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 big_sur:       "791262d2de5b0a1aff11f81aa8ac4efa853ede77460aa7cd9f45c310f4ec14c8"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "02d660830c1cb32f100f7eb32231ca2e6f2d94a4a506a2e2da10af8abedc57b2"
+    sha256 cellar: :any,                 big_sur:       "791262d2de5b0a1aff11f81aa8ac4efa853ede77460aa7cd9f45c310f4ec14c8"
     sha256 cellar: :any,                 catalina:      "b1b4742477826eaf7e034d1478b6855008b10557ec690259ba87e97e1c559b48"
     sha256 cellar: :any,                 mojave:        "90cb211a2adeaeae9497ab6d9dc409d1438e49b902560a45eae507f413cc87a8"
   end

--- a/Formula/gitleaks.rb
+++ b/Formula/gitleaks.rb
@@ -6,8 +6,8 @@ class Gitleaks < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "12b782a67f02fdf5544fa5b4fc8ab40243848e40f2254da0f12c9e473aebce7b"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "92f4ea25d97089e136f0ed5fd5d6e696f2da6e6d90f35cae30cf0047a11daac3"
+    sha256 cellar: :any_skip_relocation, big_sur:       "12b782a67f02fdf5544fa5b4fc8ab40243848e40f2254da0f12c9e473aebce7b"
     sha256 cellar: :any_skip_relocation, catalina:      "54f4dcacd3943a063711db03610063b21301122ef57b096a31a4147e547b0f29"
     sha256 cellar: :any_skip_relocation, mojave:        "49f130b583e05eebbf6f980ec606f40360451b38d4f10c1cb98f1f1252d66fbc"
   end

--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -12,8 +12,8 @@ class Glib < Formula
   end
 
   bottle do
-    sha256 big_sur:       "dd09e283eba3f1f69f3ac20b53ade893ff4b4f1232266aa908446bf9607f0237"
     sha256 arm64_big_sur: "7096f09b1f98a1697952e3328f1c4efbe010d2221a984d4f67b739de36ae65e5"
+    sha256 big_sur:       "dd09e283eba3f1f69f3ac20b53ade893ff4b4f1232266aa908446bf9607f0237"
     sha256 catalina:      "44af356038445be37b8c4698760edb1c66d537736872557d816dc30a6d710ddf"
     sha256 mojave:        "1a9c28782aa0fad6cf5a9d945c87d736eae53cd4de333a3aa10d2bc06d80ebf5"
   end

--- a/Formula/gopls.rb
+++ b/Formula/gopls.rb
@@ -12,8 +12,8 @@ class Gopls < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "640b2abf7bb34c3b7b233def57801e82b03e0eb2ccd1be47e58562dce5f23720"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "161d6d2a55f52fbff6beb547649ca659d0faeb0274f21384b219712c407871bc"
+    sha256 cellar: :any_skip_relocation, big_sur:       "640b2abf7bb34c3b7b233def57801e82b03e0eb2ccd1be47e58562dce5f23720"
     sha256 cellar: :any_skip_relocation, catalina:      "c23255983fc3f6472105b7e1fc3d589d1c97fb64b3a3a19d2d922f7359b3dbde"
     sha256 cellar: :any_skip_relocation, mojave:        "b5db2727170427b5f77ebd44ff6c2832c06c9a043e80542329bcfb6985b200e2"
   end

--- a/Formula/helmfile.rb
+++ b/Formula/helmfile.rb
@@ -6,8 +6,8 @@ class Helmfile < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "e346b2062d4eeefc4ce572034ff5786d685ff0e7afae1e22a67675f173779162"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e638118710ee6b1dbd35d68a5d69ddd6173fc74dc6399e0ccfab227de84ea8a0"
+    sha256 cellar: :any_skip_relocation, big_sur:       "e346b2062d4eeefc4ce572034ff5786d685ff0e7afae1e22a67675f173779162"
     sha256 cellar: :any_skip_relocation, catalina:      "8da57f526fc2a750b2c0ffc2188f2e85dea0075e3f905a84a31df3cd598763ff"
     sha256 cellar: :any_skip_relocation, mojave:        "f77168617bd88f9280f3a1de5299bcf7b2c3b3350c85066878cfd4a6ec36b44d"
   end

--- a/Formula/jql.rb
+++ b/Formula/jql.rb
@@ -7,8 +7,8 @@ class Jql < Formula
   head "https://github.com/yamafaktory/jql.git"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "1f5948e6b22235f43c23bfcdeaa8bfcb9ab238b1ce7050f455f6416c4d9b5b67"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "5ac4ee4d58c7c60ca260f9ed69f210f6e73149be8b8b9d571f01986c6fae2d60"
+    sha256 cellar: :any_skip_relocation, big_sur:       "1f5948e6b22235f43c23bfcdeaa8bfcb9ab238b1ce7050f455f6416c4d9b5b67"
     sha256 cellar: :any_skip_relocation, catalina:      "d95e93bea9dc17026e5033482916686a87e22a80035c387efeb17bcc8af48c2b"
     sha256 cellar: :any_skip_relocation, mojave:        "b0e27ddd36efe3fa14caac8b3096e3408b4406af2cda72a7b0bb66a1f062d060"
   end

--- a/Formula/kamel.rb
+++ b/Formula/kamel.rb
@@ -13,8 +13,8 @@ class Kamel < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "5e07672ad25869206e8d43c1959426411b6f1a410e44e4e2279271e07c542684"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c52e7f5e007e12e4c191db92ed779e7aded3e09a42284871a50c52fec108c311"
+    sha256 cellar: :any_skip_relocation, big_sur:       "5e07672ad25869206e8d43c1959426411b6f1a410e44e4e2279271e07c542684"
     sha256 cellar: :any_skip_relocation, catalina:      "982c51e01f8e5bf9fb867c5107428ffe3ef000400c1d9cdc9c5710d50d4f194d"
     sha256 cellar: :any_skip_relocation, mojave:        "356cffa21363864841e10ef0073c6a6ce25d215a7cc728d246e0953c896dfebf"
   end

--- a/Formula/kubeaudit.rb
+++ b/Formula/kubeaudit.rb
@@ -7,8 +7,8 @@ class Kubeaudit < Formula
   head "https://github.com/Shopify/kubeaudit.git"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "6b3dd8f651bf05d1dbf3a026e0882aed226e96e1fed043b625494c20f021fabf"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "08f2c8540db0020a5f88a9b5d4fa2d3f53558766587b3f68891ee8d454e7e401"
+    sha256 cellar: :any_skip_relocation, big_sur:       "6b3dd8f651bf05d1dbf3a026e0882aed226e96e1fed043b625494c20f021fabf"
     sha256 cellar: :any_skip_relocation, catalina:      "7aa43b94f9544018f5d5af233146e843f35deb9b76c6a01d8fe86ede1f13dcf1"
     sha256 cellar: :any_skip_relocation, mojave:        "dc93207e1808fad38e06a08b11a35fc9bf4dd381cacccc525ade4534ee44287e"
   end

--- a/Formula/kubecm.rb
+++ b/Formula/kubecm.rb
@@ -6,8 +6,8 @@ class Kubecm < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "30d33110dd11731e16a97cd0051da789097693b776a6840d9ace343641416f9d"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "9c063e2246b4b2a33ca1289fa2f425e426d59371d306dba91c3aad3df65bae69"
+    sha256 cellar: :any_skip_relocation, big_sur:       "30d33110dd11731e16a97cd0051da789097693b776a6840d9ace343641416f9d"
     sha256 cellar: :any_skip_relocation, catalina:      "8d06b3ea72107fd7577048d5490aeaf35f6fa570ee84e18cfe95ac3ea5c7a822"
     sha256 cellar: :any_skip_relocation, mojave:        "89760c4372178e1cc4d59380ca90e76e4c9d43d037869d8420cc55ad03540887"
   end

--- a/Formula/libebur128.rb
+++ b/Formula/libebur128.rb
@@ -6,8 +6,8 @@ class Libebur128 < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any, big_sur:       "1aed37e815f1444c986736110c62edde85e84149774cdb3e7b6bf0733d8f7379"
     sha256 cellar: :any, arm64_big_sur: "fe625ca313b4c3a0b721601a0f43fc462e425201416a5c0260f362da2a497d6c"
+    sha256 cellar: :any, big_sur:       "1aed37e815f1444c986736110c62edde85e84149774cdb3e7b6bf0733d8f7379"
     sha256 cellar: :any, catalina:      "b17e9a6525ea554b665e6f382a6077eeeb21b944c849f9c931e7cf81487729a6"
     sha256 cellar: :any, mojave:        "f019a2618097ca7169c34756f63cfc0fafabac9d5b3b888d51d7d5dbe8c846e1"
   end

--- a/Formula/libosinfo.rb
+++ b/Formula/libosinfo.rb
@@ -11,8 +11,8 @@ class Libosinfo < Formula
   end
 
   bottle do
-    sha256 big_sur:       "c1eeea184883a96849938c8b71908bb8e5ebc4985c9b958f9671205a11199928"
     sha256 arm64_big_sur: "628d18923f168d2ed454a5a6c3aacc9408f2f009046cee2c84ac7a872b66e428"
+    sha256 big_sur:       "c1eeea184883a96849938c8b71908bb8e5ebc4985c9b958f9671205a11199928"
     sha256 catalina:      "c6423c62d06368ee03080aafaabefced7ddfd6c014c00ffddfab738e8aa76fad"
     sha256 mojave:        "a0ecd6371b9940ee2c73b818cbeb1df7a001c4a4dea0508df2e4e2e885412881"
   end

--- a/Formula/libprelude.rb
+++ b/Formula/libprelude.rb
@@ -6,8 +6,8 @@ class Libprelude < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    sha256 big_sur:       "6917b8d5d3ff58f90327fb818d920de6aea2b5ae78043f00368e3b927fd6ddcd"
     sha256 arm64_big_sur: "7b7bd68152744ba511e577cbba513e86155f0b9734ed54591a462482d94c5679"
+    sha256 big_sur:       "6917b8d5d3ff58f90327fb818d920de6aea2b5ae78043f00368e3b927fd6ddcd"
     sha256 catalina:      "6e8f95a1d163f021c7f6a7e09b92b9f695edd8de41e787dcbcafc87781380980"
     sha256 mojave:        "0bb4d2090cb2f2aa0acb868402232a725e1ad51ead0786988bf1628a94491dde"
   end

--- a/Formula/lighttpd.rb
+++ b/Formula/lighttpd.rb
@@ -11,8 +11,8 @@ class Lighttpd < Formula
   end
 
   bottle do
-    sha256 big_sur:       "71ac008d18b324a770a9f39a5c8194d0526ab85e4491336f059206531f7f0868"
     sha256 arm64_big_sur: "83be5fc9ff54264e3a2ec2633259eb9121fc5fdc7bdd3f43c3319971bc9a6e97"
+    sha256 big_sur:       "71ac008d18b324a770a9f39a5c8194d0526ab85e4491336f059206531f7f0868"
     sha256 catalina:      "bcc720caef8110766bad93f27016cac6443a000ab5de0cb7b231e8f01d3f1129"
     sha256 mojave:        "243daa151b9d0bc1fb6ac914eb807a78f219bbced3ed76f1cfbe1c319189bcbc"
   end

--- a/Formula/logcheck.rb
+++ b/Formula/logcheck.rb
@@ -11,8 +11,8 @@ class Logcheck < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "f2bfaccdb1a53aec3701d8f35c960b3d253395f648ff32602adcc355741b5c36"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "93c3137e2f64093bbd04d83e291b6703c438c2f54624c48b66812dbe59e3e554"
+    sha256 cellar: :any_skip_relocation, big_sur:       "f2bfaccdb1a53aec3701d8f35c960b3d253395f648ff32602adcc355741b5c36"
     sha256 cellar: :any_skip_relocation, catalina:      "aa5bf95cb6fe848f0577be456ee84fd3ea2e5f5e7c00ecab57d6bbc85bf2d218"
     sha256 cellar: :any_skip_relocation, mojave:        "5d88f3e85dd26050d6e65c4e980de25e7168bf6c254ac7e141c10360c41d8c28"
   end

--- a/Formula/lxc.rb
+++ b/Formula/lxc.rb
@@ -11,8 +11,8 @@ class Lxc < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "7883dea752070fbeeafefca87ec599f57bd1cb56884083c727582a65b7ace74d"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "7587be383f80df06098c27228a321bfa80aa1263410121b6f5724fbb72131c87"
+    sha256 cellar: :any_skip_relocation, big_sur:       "7883dea752070fbeeafefca87ec599f57bd1cb56884083c727582a65b7ace74d"
     sha256 cellar: :any_skip_relocation, catalina:      "930ef7166268f2a1f3ac23b5983e5e96b59e9992b68ff87a837fe92c7bd54db5"
     sha256 cellar: :any_skip_relocation, mojave:        "86c31e43fb5cf1976bf5c0d1d220cb1265a8e0848b461c402330601d220a35f0"
   end

--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -12,8 +12,8 @@ class Mariadb < Formula
 
   bottle do
     rebuild 3
-    sha256 big_sur:       "802d047b15b594c3170d90e355f44a6585cd5cd255788ee4922b6e757b216bd0"
     sha256 arm64_big_sur: "1e168542dc43d8c2d88153ee7bfcbbac167de161599a257ef82e8c2ebc094fd5"
+    sha256 big_sur:       "802d047b15b594c3170d90e355f44a6585cd5cd255788ee4922b6e757b216bd0"
     sha256 catalina:      "abd58d85de7c08ed22f82331b09afe3f90bab796fc4bfe318a952826b7c1498e"
     sha256 mojave:        "a0c0f4cb430cf7b462be33c94f34e840f6d0510b1c78c50e596bb36bf0536761"
   end

--- a/Formula/marked.rb
+++ b/Formula/marked.rb
@@ -12,8 +12,8 @@ class Marked < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "94fc83c11e93166522fb2d56f8a96d3627e622d30f37753106819dce812305d9"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "a5d888a79d72e2783f56be1f1c280edf4bed83927831c6c4d673974f722d451f"
+    sha256 cellar: :any_skip_relocation, big_sur:       "94fc83c11e93166522fb2d56f8a96d3627e622d30f37753106819dce812305d9"
     sha256 cellar: :any_skip_relocation, catalina:      "82f09a4efabd0bfcf70a8b1a4f9cfc8f96cba83eb3088b6708b0bf26975130eb"
     sha256 cellar: :any_skip_relocation, mojave:        "8b68e0bf74c3da4b3b35476ca2577d6d076ee375c02f6eb74c18ede54c9918de"
   end

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -12,8 +12,8 @@ class Octave < Formula
   end
 
   bottle do
-    sha256 big_sur:       "364eefc2bd38db495795f8815f234031b00dec5a9a1f45cd9e667d1641ececf8"
     sha256 arm64_big_sur: "0ffe32cfaeb313b49a4f6b1dd1663dbf313156682492c126cfa32bac542bcb1c"
+    sha256 big_sur:       "364eefc2bd38db495795f8815f234031b00dec5a9a1f45cd9e667d1641ececf8"
     sha256 catalina:      "01140e3fafbe5062e299f372959a7e59c7a49031097ab26a3a34bf582b7016a6"
     sha256 mojave:        "0cf560a9f9c32bd5f0155ca27c38047205bdc53009c0540017dac10c99f6ff4c"
   end

--- a/Formula/openlibm.rb
+++ b/Formula/openlibm.rb
@@ -5,8 +5,8 @@ class Openlibm < Formula
   sha256 "eb585204d6c995691e5545ea4ffcb887c159bf05cc5ee1bbf92a6fcdde2fccae"
 
   bottle do
-    sha256 cellar: :any, big_sur:       "efd441cb260e064ee213c0c7008c02baf6c552d4ea45afc11c6df26371032131"
     sha256 cellar: :any, arm64_big_sur: "2046c2a9f7874150036e25091ea934377c7579f0396ae7570f4c2ff350bb6094"
+    sha256 cellar: :any, big_sur:       "efd441cb260e064ee213c0c7008c02baf6c552d4ea45afc11c6df26371032131"
     sha256 cellar: :any, catalina:      "23ae6cbf040c349d0bab99cfe267f2a416c1a24a804724543687d748ab55cfaa"
     sha256 cellar: :any, mojave:        "42e992c9bee0975fa22df4313c80180c08a772fe7b1345808a61c469b00e2044"
   end

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -13,8 +13,8 @@ class Php < Formula
   end
 
   bottle do
-    sha256 big_sur:       "6857142e12254b15da4e74c2986dd24faca57dac8d467b04621db349e277dd63"
     sha256 arm64_big_sur: "cbefa1db73d08b9af4593a44512b8d727e43033ee8517736bae5f16315501b12"
+    sha256 big_sur:       "6857142e12254b15da4e74c2986dd24faca57dac8d467b04621db349e277dd63"
     sha256 catalina:      "b651611134c18f93fdf121a4277b51b197a896a19ccb8020289b4e19e0638349"
     sha256 mojave:        "9583a51fcc6f804aadbb14e18f770d4fb4973deaed6ddc4770342e62974ffbca"
   end

--- a/Formula/php@7.4.rb
+++ b/Formula/php@7.4.rb
@@ -8,8 +8,8 @@ class PhpAT74 < Formula
   license "PHP-3.01"
 
   bottle do
-    sha256 big_sur:       "11cbe697525464636f1e1ecc9de2900b341e8566a0b66239ab05d57271f85076"
     sha256 arm64_big_sur: "3120baa405c79acaae9622e4c99599d8fe09ccdbaeecb8965d131c9559c257f1"
+    sha256 big_sur:       "11cbe697525464636f1e1ecc9de2900b341e8566a0b66239ab05d57271f85076"
     sha256 catalina:      "09d8e3bd11eea8df1020621ba7e9d5e7d540a7042372879893a070ab09c3ca37"
     sha256 mojave:        "9e023ddc63e4269895fb520acc3b21e6619028a94e55706f52d3e998978e57ec"
   end

--- a/Formula/pioneer.rb
+++ b/Formula/pioneer.rb
@@ -7,8 +7,8 @@ class Pioneer < Formula
   head "https://github.com/pioneerspacesim/pioneer.git"
 
   bottle do
-    sha256 big_sur:       "8b59ff2ff180ccdd5485d063d8a46038bc7ae2fb77c70a9a6aec891aba40c7b7"
     sha256 arm64_big_sur: "a3151605aa2a2b4a8a5ac8266105d2293a7f06f594791fed4629340b8f819a71"
+    sha256 big_sur:       "8b59ff2ff180ccdd5485d063d8a46038bc7ae2fb77c70a9a6aec891aba40c7b7"
     sha256 catalina:      "abeb86c374fa69e433e548cd1189105206cfd3859a1dd06d0ea2b45a15092b9f"
     sha256 mojave:        "bd448dc95f9f104637263a4e9aea398177b502938a969b766db8229ddc89860a"
   end

--- a/Formula/pnpm.rb
+++ b/Formula/pnpm.rb
@@ -12,8 +12,8 @@ class Pnpm < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "38f0857cdfcd85de81608412e85b20ea87ec8b3c55e673b327b36efe34a92f25"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "af7cde2aac12ee4eb55dd1c70abcb34e528a042a6402ec8215c0bb589278b91c"
+    sha256 cellar: :any_skip_relocation, big_sur:       "38f0857cdfcd85de81608412e85b20ea87ec8b3c55e673b327b36efe34a92f25"
     sha256 cellar: :any_skip_relocation, catalina:      "1edef5556774b4e87c7750aaca79a06d50ca19599be719c2aaa4dcf8f4ece724"
     sha256 cellar: :any_skip_relocation, mojave:        "62e08ef5ce53395848b839f36a5eb921344cd63813619a3adc6289baa1175b05"
   end

--- a/Formula/pulumi.rb
+++ b/Formula/pulumi.rb
@@ -8,8 +8,8 @@ class Pulumi < Formula
   head "https://github.com/pulumi/pulumi.git"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "c168916bf1b35b0e584496ed691d535462e86c02c943f871010acf76b4e0247b"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d48aa16f8c0762236301f4870a7aacd46f5c6835d9f2baef9583c5104ab05c85"
+    sha256 cellar: :any_skip_relocation, big_sur:       "c168916bf1b35b0e584496ed691d535462e86c02c943f871010acf76b4e0247b"
     sha256 cellar: :any_skip_relocation, catalina:      "7478d5d6cb160d811b44b1fe577966b1f4767618a00560c489c270340b15a3cc"
     sha256 cellar: :any_skip_relocation, mojave:        "9443232b76c444c73963cbe04abf1107f9435c451f3593080b7ddf6e98e1e25e"
   end

--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -12,8 +12,8 @@ class PythonAT39 < Formula
   end
 
   bottle do
-    sha256 big_sur:       "621814095e93c2d8d996365513576604cfc58f17534c1f4ff303cd51028849ab"
     sha256 arm64_big_sur: "9603bfefbb5b29bbbdab37b7b7ce26e27c36f2ecdfcc6a8d1976764bd0508e80"
+    sha256 big_sur:       "621814095e93c2d8d996365513576604cfc58f17534c1f4ff303cd51028849ab"
     sha256 catalina:      "9025d2e4f3aa72b7a1c46c2729bb935a5d9f7a5d34f60c381c43a90e178d3b08"
     sha256 mojave:        "a6c7451d86298f8db98b71c0923a3c2694da1694a4ab51d5bee9c0601f25e200"
   end

--- a/Formula/serverless.rb
+++ b/Formula/serverless.rb
@@ -8,8 +8,8 @@ class Serverless < Formula
   license "MIT"
 
   bottle do
-    sha256 big_sur:       "6655bc381b9800459061209348fad1a84795a9f88364481365ca5a01125ece77"
     sha256 arm64_big_sur: "d69b1214efdd59a64de79087ce7e88848d95dbbcd9cfbd9d53552232f60061e5"
+    sha256 big_sur:       "6655bc381b9800459061209348fad1a84795a9f88364481365ca5a01125ece77"
     sha256 catalina:      "2ec4b92e20f646e38695e7448d537885e6df52c031f7d3e4fb24dce2f8e3e3d4"
     sha256 mojave:        "f5ac50d77b1bd2ff657eeb1a089fa8e9541d07a4ef36d25452833991aeab19fb"
   end

--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -7,8 +7,8 @@ class Sile < Formula
   head "https://github.com/sile-typesetter/sile.git", shallow: false
 
   bottle do
-    sha256 cellar: :any, big_sur:       "96fa8729e8a5a329e31ba0a72401e37f555cb1b901fe40bdaf86ff212f40d873"
     sha256 cellar: :any, arm64_big_sur: "7aacf1722fd5edb35edbafed39a5135ee9dbfc614d5c2af6a78a10a4e72b58ae"
+    sha256 cellar: :any, big_sur:       "96fa8729e8a5a329e31ba0a72401e37f555cb1b901fe40bdaf86ff212f40d873"
     sha256               catalina:      "63164873fb734c31bef4f15dbe1c4b7825f8f4493188be75ebf3930c7a2c6e91"
     sha256               mojave:        "9da40bac62aa9a45c9f0c3b0bcd06de5c6f7da79240b69b21e13c7af52b9885f"
   end

--- a/Formula/sundials.rb
+++ b/Formula/sundials.rb
@@ -11,8 +11,8 @@ class Sundials < Formula
   end
 
   bottle do
-    sha256 big_sur:       "eca818ac9876c5f784483f49eaeb6b8bb2a4a7950520f13e7dd99f43ad06d223"
     sha256 arm64_big_sur: "0fde980804a45806673fce03d868a090d38b8d1615b152dc8da3797f1d59054d"
+    sha256 big_sur:       "eca818ac9876c5f784483f49eaeb6b8bb2a4a7950520f13e7dd99f43ad06d223"
     sha256 catalina:      "bacddf8c38b9c1236cd0aa2dc85273f7ffff6726418781f5a0e223bf132e3e07"
     sha256 mojave:        "9ad76e3dbc09c9d9cb4af9e600376fcae287c63128a100959871ddfe8dba438e"
   end

--- a/Formula/syncthing.rb
+++ b/Formula/syncthing.rb
@@ -12,8 +12,8 @@ class Syncthing < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "aae6580eb1c320c50edba6d735da4dd32301c064d8099d32a611b271e6d7353d"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "1925e1bd9829e7364f2cdde85bb28137eb6cf5e726f79a8d88e99f2547ce19a4"
+    sha256 cellar: :any_skip_relocation, big_sur:       "aae6580eb1c320c50edba6d735da4dd32301c064d8099d32a611b271e6d7353d"
     sha256 cellar: :any_skip_relocation, catalina:      "d4df558cf63abf8fcd401aa2b3011b951353d293d9186ec3493dab1328b48769"
     sha256 cellar: :any_skip_relocation, mojave:        "30b16fcbc6e2307de99bc8749719c67ffbc5231113cdaee711e3371a81ab8545"
   end

--- a/Formula/taskwarrior-tui.rb
+++ b/Formula/taskwarrior-tui.rb
@@ -12,8 +12,8 @@ class TaskwarriorTui < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "cdf2977545ecedbff3661d1995fac4df8acf60124ef8ab59af0ae39e101c28f5"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f1ab1b590ef5216b40d9a905f4329d33b07d23d2a8726afbcd8fffed8872df30"
+    sha256 cellar: :any_skip_relocation, big_sur:       "cdf2977545ecedbff3661d1995fac4df8acf60124ef8ab59af0ae39e101c28f5"
     sha256 cellar: :any_skip_relocation, catalina:      "b9f7eeea5f8036e959d5bf2b1384c2a3b969c364cb61199ab9d16ece62bb8fe9"
     sha256 cellar: :any_skip_relocation, mojave:        "ede876bda28c9866c13af458b799523c16718fb7bb5a926da693e21bba9c8a5b"
   end

--- a/Formula/terrascan.rb
+++ b/Formula/terrascan.rb
@@ -7,8 +7,8 @@ class Terrascan < Formula
   head "https://github.com/accurics/terrascan.git"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "430c828231b47110e56192e22359e52c0b2be9608b835750d6c2e8e7f9437e75"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "22856f97720230a2db38399bca2ea948981abbcfab712cd92cc09107c042da74"
+    sha256 cellar: :any_skip_relocation, big_sur:       "430c828231b47110e56192e22359e52c0b2be9608b835750d6c2e8e7f9437e75"
     sha256 cellar: :any_skip_relocation, catalina:      "3f8196d147f1a96e019272098e369baa73fa0904a490a310454042eba9f01ac2"
     sha256 cellar: :any_skip_relocation, mojave:        "1687e46163119a6cb506a80591b905c5ebcf6b34a8a31294de1a977d190ac19f"
   end

--- a/Formula/tfsec.rb
+++ b/Formula/tfsec.rb
@@ -11,8 +11,8 @@ class Tfsec < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "c9e67d0e9d76160de2971478eb8335a66f7b3d12fab450efacf0f123ebef7476"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "a347948cee69ad7bba4227bdfa36376974747f60580ac59d2281c16868b062df"
+    sha256 cellar: :any_skip_relocation, big_sur:       "c9e67d0e9d76160de2971478eb8335a66f7b3d12fab450efacf0f123ebef7476"
     sha256 cellar: :any_skip_relocation, catalina:      "d633f936964fb737c1fa7bd1b4f54916d5ae9edf4e73aefc1f6e1c9861b42382"
     sha256 cellar: :any_skip_relocation, mojave:        "376ffc12ae740bb9b8f0ed83f1f471b5a701f1b5dd0130f9537f8dcfec3e22c9"
   end

--- a/Formula/tor.rb
+++ b/Formula/tor.rb
@@ -11,8 +11,8 @@ class Tor < Formula
   end
 
   bottle do
-    sha256 big_sur:       "a757e5ff16ae66933aa729fb2f022e62564dd4007daccda31e1d415fdf600e09"
     sha256 arm64_big_sur: "707a87a267fcb0a4186415a9eee85eee62509747a61a31530813146409602d00"
+    sha256 big_sur:       "a757e5ff16ae66933aa729fb2f022e62564dd4007daccda31e1d415fdf600e09"
     sha256 catalina:      "203af4c3f78c82d07e75775bf14c767ed7082d69ecd2126db5a8ebb6a48e51ee"
     sha256 mojave:        "14774e8f2e1ba72edf08d773e66ff7a819c9bde7fb9d6e6c1165d6570f0b8c88"
   end

--- a/Formula/trunk.rb
+++ b/Formula/trunk.rb
@@ -7,8 +7,8 @@ class Trunk < Formula
   head "https://github.com/thedodd/trunk.git"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "6048e4ac198b442011f29daab363a5ad0e63cf0e2c0bdbc55393a74eba7aa8ec"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "fd4c0e014e8bc1c92b50b66971051a47c9545b17b1f0e49c39ea9f6bc56034af"
+    sha256 cellar: :any_skip_relocation, big_sur:       "6048e4ac198b442011f29daab363a5ad0e63cf0e2c0bdbc55393a74eba7aa8ec"
     sha256 cellar: :any_skip_relocation, catalina:      "eb6f94ad5c40e7a6d93887a3b7379643592f5ccead01874a2be775fb6936b43f"
     sha256 cellar: :any_skip_relocation, mojave:        "0e9519ffc6995c91a89e7a2fe103778cf6be65ca036070d2afef9670db648656"
   end

--- a/Formula/unoconv.rb
+++ b/Formula/unoconv.rb
@@ -15,8 +15,8 @@ class Unoconv < Formula
 
   bottle do
     rebuild 1
-    sha256 cellar: :any_skip_relocation, big_sur:       "34695d78b10bb265c9164e262dca4d3321c18bf8f9622c59377f3b8f1e7771d0"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "be1cd33331c14eca168e7667eb571f23ebd5c8023cda1a388405d7f88991e94f"
+    sha256 cellar: :any_skip_relocation, big_sur:       "34695d78b10bb265c9164e262dca4d3321c18bf8f9622c59377f3b8f1e7771d0"
     sha256 cellar: :any_skip_relocation, catalina:      "21013d55757dbd1d67143f3a3d44dfad73a948a84bcbc323a9be2770d103702b"
     sha256 cellar: :any_skip_relocation, mojave:        "8f9de5f5019bfae60563a842de0894f8436bc6a988c87ab407eac02eee99188d"
   end

--- a/Formula/webpack.rb
+++ b/Formula/webpack.rb
@@ -14,8 +14,8 @@ class Webpack < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "ca3629cd7080175278fe738d459f150c523070afff6052bdb984438ce4d941eb"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e35a4c01e13e0094e0ea5bd8e1e74b0fc59db45a1d24bbc13568c64d1e7ca3f1"
+    sha256 cellar: :any_skip_relocation, big_sur:       "ca3629cd7080175278fe738d459f150c523070afff6052bdb984438ce4d941eb"
     sha256 cellar: :any_skip_relocation, catalina:      "104a2250436c654d98f254e6f160b6a1c0e0a8a577937e1f7390ae898b387bfb"
     sha256 cellar: :any_skip_relocation, mojave:        "782f669eea7503559cd60dcba9021412234d4cb9b4121761da3bdd757ca613a7"
   end

--- a/Formula/whistle.rb
+++ b/Formula/whistle.rb
@@ -12,8 +12,8 @@ class Whistle < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "55c1a3c814402fd3b3eb7c9e55a85fc34f2f4ec6d7c690550921516f2fb30c41"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d25cfd686f466915d102aa6dbed3a981bf8590175336c58a6ec9bda67c92d9c6"
+    sha256 cellar: :any_skip_relocation, big_sur:       "55c1a3c814402fd3b3eb7c9e55a85fc34f2f4ec6d7c690550921516f2fb30c41"
     sha256 cellar: :any_skip_relocation, catalina:      "3b2443d360313ddcf9007e41c7dbcf61d3d61f8b2b0b47a63d2aa274b30af258"
     sha256 cellar: :any_skip_relocation, mojave:        "acca70eda23b746e429ba07e79504df55e9c877da950b017c8094224bc31e101"
   end

--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -12,8 +12,8 @@ class Xmrig < Formula
   end
 
   bottle do
-    sha256 big_sur:       "f965e5da7b63cafcf268a16299bf10c50eacf356732d7ecdbd360924a81c9f47"
     sha256 arm64_big_sur: "66e99e58abc037ad83e04cd1e48624c5e482acdf4127c3ba42c40d4a4e1f523e"
+    sha256 big_sur:       "f965e5da7b63cafcf268a16299bf10c50eacf356732d7ecdbd360924a81c9f47"
     sha256 catalina:      "87c958b7178bce25fbd8f4c7d932817d9401f84622dd18d667b1d5a823744892"
     sha256 mojave:        "2ad4ed36ae89682a7f7191d66fd4fd3cdb4f85684757363c1a96561149b57328"
   end

--- a/Formula/xterm.rb
+++ b/Formula/xterm.rb
@@ -12,8 +12,8 @@ class Xterm < Formula
   end
 
   bottle do
-    sha256 big_sur:       "c60885eba8c6f0cf1197793dd0fb82ec3cfec9aa7e234e90920cf4cf3fe62b7b"
     sha256 arm64_big_sur: "feedc30fa7545317fcd21891a8107287d3141454266b316ae3316874e545a3de"
+    sha256 big_sur:       "c60885eba8c6f0cf1197793dd0fb82ec3cfec9aa7e234e90920cf4cf3fe62b7b"
     sha256 catalina:      "5d74ee6b4b620a1d7193686d1050c901f65219ecd0e36abcabdabd9c2959268f"
     sha256 mojave:        "ab6cf49a29e28028be468d0a1dc9bae2e832f9547b4d489aebe6eef5ede2ee60"
   end

--- a/Formula/yaegi.rb
+++ b/Formula/yaegi.rb
@@ -7,8 +7,8 @@ class Yaegi < Formula
   head "https://github.com/containous/yaegi.git"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "a0e1dc410e2a913a7951904ce7de54b1777b97fd452be45f16153079686037b9"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "820c4b465b1dde8ee2d39869b6642fd2be39836bf026737b37eb93e9bd67545c"
+    sha256 cellar: :any_skip_relocation, big_sur:       "a0e1dc410e2a913a7951904ce7de54b1777b97fd452be45f16153079686037b9"
     sha256 cellar: :any_skip_relocation, catalina:      "9e0e585e13b1c4753904ff8ff96cefcfb9589c8a85b05a6bb1e553875d4ab1ef"
     sha256 cellar: :any_skip_relocation, mojave:        "6426147ee6ccb129167c1895119fa20d54e90a0b856ab586a87acd2a8a53c176"
   end

--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -8,8 +8,8 @@ class YoutubeDl < Formula
   license "Unlicense"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "f3162b3444b1a97e3f5ea669726695e1533f603b6ac6840f0e8541a2c89b95fe"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "ae4d3339e865293d91492f340945c65f959bf48f843410e1f4d02a77be023633"
+    sha256 cellar: :any_skip_relocation, big_sur:       "f3162b3444b1a97e3f5ea669726695e1533f603b6ac6840f0e8541a2c89b95fe"
     sha256 cellar: :any_skip_relocation, catalina:      "b466d68fa69917f9389c1740f09a0f234873638151e446731c2c601fa87ee09d"
     sha256 cellar: :any_skip_relocation, mojave:        "496bfe25e6ed8585ce475edfef0f23f17a34e1fd63cee418bdb512fdb93a4bbd"
   end

--- a/Formula/youtubedr.rb
+++ b/Formula/youtubedr.rb
@@ -6,8 +6,8 @@ class Youtubedr < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "4e3faa7172ab8eb87e2215617a9d1212b5671861a05090c8a815b3ced8a5c0d6"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "35d48c7565c357ccfba86abac56278dfa957601e8a904c0131224a40fd228298"
+    sha256 cellar: :any_skip_relocation, big_sur:       "4e3faa7172ab8eb87e2215617a9d1212b5671861a05090c8a815b3ced8a5c0d6"
     sha256 cellar: :any_skip_relocation, catalina:      "260c1b2d84bc38f122c9d4767a42b72e5f75a9de94dcd304ab2ee53bd02c960f"
     sha256 cellar: :any_skip_relocation, mojave:        "9a9f5087f884c4f758bd3a948e4f697a7ce7220e79bfcea14df38eb285c1cace"
   end

--- a/Formula/yq.rb
+++ b/Formula/yq.rb
@@ -6,8 +6,8 @@ class Yq < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:       "6c2a34c77ddfe2037bd142721fed1768070c56962247c569230a985e92fa56ef"
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "26ef0404bd26d64500a49320244ac4b9825bf3e689672b254bb9aebb2a090120"
+    sha256 cellar: :any_skip_relocation, big_sur:       "6c2a34c77ddfe2037bd142721fed1768070c56962247c569230a985e92fa56ef"
     sha256 cellar: :any_skip_relocation, catalina:      "9622d1329b15e4614888d069bc764fef8ad6e23e17ce19fa325b2d5fb91c261a"
     sha256 cellar: :any_skip_relocation, mojave:        "22b786f6edba1a57e334bf8630469791e458ffb6538a9d66cb1897565702a264"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Now that https://github.com/Homebrew/brew/pull/10522 is merged, `brew bottle` will write bottle blocks in the correct order (i.e. ARM bottles, then Intel bottles, then non-macOS bottles). However, in the time between that PR and yesterday's mass-migration, several (62) formulae were updated with bottle blocks in the wrong order. This PR fixes that order by simply swapping the `arm64_big_sur` and `big_sur` bottle tags.

@iMichka or @jonchang: let me know what the best way to handle this from a linuxbrew/core merge perspective is. For now, I went with one commit as that's what was done last time. I'm happy to split them up into smaller chunks or one-commit-per-formula if desired. I figured that this could be handled without a linuxbrew/core PR making the same changes (because it's just reordering lines) but I'm happy to open a PR over in linuxbrew/core if desired. I won't merge this until I get confirmation from someone about this.
