### PR TITLE
workflows/triage: update no ARM bottle label regex

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -37,8 +37,8 @@ jobs:
                 }, {
                     "label": "no ARM bottle",
                     "path": "Formula/.+",
-                    "content": "\n    sha256 \"[a-fA-F0-9]+\" => :big_sur\n",
-                    "missing_content": "\n    sha256 \"[a-fA-F0-9]+\" => :arm64_big_sur\n"
+                    "content": "\n    sha256 .* big_sur:\s+\"[a-fA-F0-9]+\"\n",
+                    "missing_content": "\n    sha256 .* arm64_big_sur:\s+\"[a-fA-F0-9]+\"\n"
                 }, {
                     "label": "formula deprecated",
                     "path": "Formula/.+",


### PR DESCRIPTION
This updates the workflow so that the `no ARM bottle` label is correctly applied given the new bottle block syntax.
