### PR TITLE
ssh-copy-id: backport upstream patch

### DIFF
--- a/Formula/ssh-copy-id.rb
+++ b/Formula/ssh-copy-id.rb
@@ -6,11 +6,20 @@ class SshCopyId < Formula
   version "8.4p1"
   sha256 "5a01d22e407eb1c05ba8a8f7c654d388a13e9f226e4ed33bd38748dafa1d2b24"
   license "SSH-OpenSSH"
+  revision 1
   head "https://github.com/openssh/openssh-portable.git"
 
   bottle :unneeded
 
   keg_only :provided_by_macos
+
+  # Fixes an invalid heredoc within a multiline `$()` block.
+  # Fixed upstream; will be in the next release.
+  # https://github.com/openssh/openssh-portable/pull/206
+  patch do
+    url "https://github.com/openssh/openssh-portable/commit/d9e727dcc04a52caaac87543ea1d230e9e6b5604.patch?full_index=1"
+    sha256 "fbca48deeaf0e51ddf220fa18088142ade2d406ad06bb03720389313df282651"
+  end
 
   def install
     bin.install "contrib/ssh-copy-id"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Without this, certain situations will lead to the error `EOF: command not found`. This is an upstream bug which has been [fixed already](https://github.com/openssh/openssh-portable/pull/206), but which hasn't made it into the version of openssh we ship. I checked the rest of the `ssh-copy-id` history and it doesn't look like there's anything else we'd want to backport, but this bug is user-facing so it's worth fixing.