### PR TITLE
terraform-docs: arm64 compatibility

### DIFF
--- a/Formula/terraform-docs.rb
+++ b/Formula/terraform-docs.rb
@@ -16,7 +16,8 @@ class TerraformDocs < Formula
 
   def install
     system "make", "build"
-    bin.install "bin/darwin-amd64/terraform-docs"
+    cpu = Hardware::CPU.arm? ? "arm64" : "amd64"
+    bin.install "bin/darwin-#{cpu}/terraform-docs"
     prefix.install_metafiles
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Adds support for Arm64 architecture to terraform-docs package. It's builder package builds a binary at $(BUILD_DIR)/$(GOOS)-$(GOARCH)/terraform-docs, but this Formula is hardcoded to look for darwin-amd64. This PR adds a conditional to support arm64. Tested that --build-from-source works on both an Intel and ARM Mac.

Only way this PR doesn't pass brew audit --strict locally is that the new bottle SHA256 lines no longer pass linting after the change to the new format; this is unrelated to the changes here.
