### PR TITLE
cern-ndiff: update livecheck

### DIFF
--- a/Formula/cern-ndiff.rb
+++ b/Formula/cern-ndiff.rb
@@ -7,8 +7,8 @@ class CernNdiff < Formula
   head "https://github.com/MethodicalAcceleratorDesign/MAD-X.git"
 
   livecheck do
-    url :head
-    regex(/^(?:mad-?X.)?v?(\d+(?:[._]\d+)+)$/i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR replaces `url :head` with `url :stable` in the existing `cern-ndiff` `livecheck` block, as we prefer to align the check with `stable` whenever possible. In this case, `stable` and `head` are both the GitHub repository, so there's no functional difference.

This also updates the regex to only match tags like `5.06.01`, as that's what's used in the formula.