### PR TITLE
fzf: make vim plugin available automatically

### DIFF
--- a/Formula/fzf.rb
+++ b/Formula/fzf.rb
@@ -23,7 +23,7 @@ class Fzf < Formula
     prefix.install "install", "uninstall"
     (prefix/"shell").install %w[bash zsh fish].map { |s| "shell/key-bindings.#{s}" }
     (prefix/"shell").install %w[bash zsh].map { |s| "shell/completion.#{s}" }
-    (prefix/"plugin").install "plugin/fzf.vim"
+    (share/"vim/vimfiles/plugin").install "plugin/fzf.vim"
     man1.install "man/man1/fzf.1", "man/man1/fzf-tmux.1"
     bin.install "bin/fzf-tmux"
   end
@@ -32,9 +32,6 @@ class Fzf < Formula
     <<~EOS
       To install useful keybindings and fuzzy completion:
         #{opt_prefix}/install
-
-      To use fzf in Vim, add the following line to your .vimrc:
-        set rtp+=#{opt_prefix}
     EOS
   end
 


### PR DESCRIPTION
The fzf formula currently requires a manual installation step with vim. Other formulae such as [hub](https://github.com/Homebrew/homebrew-core/blob/master/Formula/hub.rb) avoid this by linking [their vimscript](https://github.com/github/hub/tree/master/share/vim/vimfiles) into the `share/vim/vimfiles` tree. So this adjusts the fzf formula to do the same thing.

For example, my homebrew install currently has:

```
/opt/homebrew/share/vim
├── vim82 -> ../../Cellar/vim/8.2.2425/share/vim/vim82
└── vimfiles
    ├── ftdetect -> ../../../Cellar/hub/2.14.2/share/vim/vimfiles/ftdetect
    ├── indent -> ../../../Cellar/cmake/3.19.4/share/vim/vimfiles/indent
    └── syntax
        ├── cmake.vim -> ../../../../Cellar/cmake/3.19.4/share/vim/vimfiles/syntax/cmake.vim
        └── pullrequest.vim -> ../../../../Cellar/hub/2.14.2/share/vim/vimfiles/syntax/pullrequest.vim

5 directories, 2 files
```

Users who have the suggested configuration already after this change should continue to have a working installation after upgrading, although will have a superfluous entry on their runtime path.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?