### PR TITLE
curaengine: update livecheck

### DIFF
--- a/Formula/curaengine.rb
+++ b/Formula/curaengine.rb
@@ -8,13 +8,13 @@ class Curaengine < Formula
   head "https://github.com/Ultimaker/CuraEngine.git"
 
   # Releases like xx.xx or xx.xx.x are older than releases like x.x.x, so we
-  # work around this less-than-ideal situation by restricting the minor version
-  # to one digit. This won't pick up versions where the minor version is 10+
+  # work around this less-than-ideal situation by restricting the major version
+  # to one digit. This won't pick up versions where the major version is 10+
   # but thankfully that hasn't been true yet. This should be handled in a better
   # way in the future, to avoid the possibility of missing good versions.
   livecheck do
-    url :head
-    regex(/^v?(\d+\.\d(?:\.\d+)+)$/i)
+    url :stable
+    regex(/^v?(\d(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR replaces `url :head` with `url :stable` in the existing `livecheck` block for `curaengine`, as we prefer to align the check with `stable` whenever possible. In this case, `stable` and `head` are both the GitHub repository, so there's no functional difference.

This also updates the regex to restrict the major version to one digit instead of the minor version. We were restricting the minor version to one digit to omit the older releases like `15.06.03` but the current version is `4.8.0`, so this may become a problem if it reaches `4.10.0`. We can accomplish the same thing by restricting the major version to one digit and this will only become a problem at version `10.x`, so it buys us a bit more time until we have to worry about avoiding the older versions in a more intelligent manner.