### PR TITLE
dust: update livecheck

### DIFF
--- a/Formula/dust.rb
+++ b/Formula/dust.rb
@@ -7,8 +7,8 @@ class Dust < Formula
   head "https://github.com/bootandy/dust.git"
 
   livecheck do
-    url :head
-    regex(/v([\d.]+)/i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR replaces `url :head` with `url :stable` in the existing `livecheck` block for `dust`, as we prefer to align the check with `stable` whenever possible. In this case, `stable` and `head` are both the GitHub repository, so there's no functional difference.

This also updates the regex to replace an older, looser regex format with the standard regex for Git tags like `1.2.3`/`v1.2.3`.