### PR TITLE
grok: update livecheck

### DIFF
--- a/Formula/grok.rb
+++ b/Formula/grok.rb
@@ -8,8 +8,8 @@ class Grok < Formula
   head "https://github.com/jordansissel/grok.git"
 
   livecheck do
-    url :head
-    regex(/^v?(\d+\.\d{,3}(\.\d+)+)$/i)
+    url :stable
+    regex(/^v?(\d+\.\d{6,8}(\.\d+)*)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR replaces `url :head` with `url :stable` in the existing `livecheck` block for `grok`, as we prefer to align the check with `stable` whenever possible. In this case, `stable` and `head` are both the GitHub repository, so there's no functional difference.

This also updates the regex to use `\d{6,8}` for the date portion of the version (which is typical) and to make the trailing `(\.\d+)` optional, as there are versions that don't include it (e.g., `v1.20110630` instead of `1.20110308.1`).