### PR TITLE
kustomize: update livecheck

### DIFF
--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -9,8 +9,8 @@ class Kustomize < Formula
   head "https://github.com/kubernetes-sigs/kustomize.git"
 
   livecheck do
-    url :head
-    regex(%r{kustomize/v?(\d+(?:\.\d+)+)$}i)
+    url :stable
+    regex(%r{^kustomize/v?(\d+(?:\.\d+)+)$}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR replaces `url :head` with `url :stable` in the existing `livecheck` block for `kustomize`, as we prefer to align the check with `stable` whenever possible. In this case, `stable` and `head` are both the GitHub repository, so there's no functional difference.

This also updates the regex to include `^` at the start, as we use both `^` and `$` to restrict the start/end of the regex when matching Git tags.