### PR TITLE
tidy-html5: update livecheck

### DIFF
--- a/Formula/tidy-html5.rb
+++ b/Formula/tidy-html5.rb
@@ -7,8 +7,8 @@ class TidyHtml5 < Formula
   head "https://github.com/htacg/tidy-html5.git", branch: "next"
 
   livecheck do
-    url :head
-    regex(/^v?(\d+\.\d*?[02468]\.\d+)$/i)
+    url :stable
+    regex(/^v?(\d+\.\d*?[02468](?:\.\d+)*)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR replaces `url :head` with `url :stable` in the existing `livecheck` block for `tidy-html5`, as we prefer to align the check with `stable` whenever possible. In this case, `stable` and `head` are both the GitHub repository, so there's no functional difference.

This also updates the regex to allow it to match versions with only two parts (e.g., `1.2`), just in case we ever encounter a version like that (instead of the typical `1.2.3` format).