### PR TITLE
ec2-api-tools: remove livecheck

### DIFF
--- a/Formula/ec2-api-tools.rb
+++ b/Formula/ec2-api-tools.rb
@@ -5,10 +5,6 @@ class Ec2ApiTools < Formula
   sha256 "851abe30403ee1c86a3ebdddf5b4bffd7ef4b587110530feadf00954d9ae2f3a"
   revision 1
 
-  livecheck do
-    skip "No longer developed/maintained"
-  end
-
   bottle :unneeded
 
   # Deprecated upstream somewhere between 2017-12-24 and 2018-09-09 here:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`ec2-api-tools` was deprecated in #70349 but I forgot to remove the `livecheck` block in that PR. Since this formula is deprecated, it will be automatically skipped without the `livecheck` block, so it's no longer necessary.