### PR TITLE
bagit: update livecheck

### DIFF
--- a/Formula/bagit.rb
+++ b/Formula/bagit.rb
@@ -12,6 +12,7 @@ class Bagit < Formula
 
   livecheck do
     url :stable
+    regex(%r{href=.*?/project/bagit/v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing check for `bagit` uses the `Pypi` strategy but it's unable to identify the latest version (`1.8.0`) from the latest tarball because the filename is like `bagit-1.8.0.macosx-10.15-x86_64.tar.gz` instead of `bagit-1.7.0.tar.gz`.

This PR adds a regex to the `livecheck` block, which checks the versions in the "Release history" section instead of the latest tarball. I may look into updating the `Pypi` strategy to take this approach by default if this becomes a common occurrence beyond this particular formula.