### PR TITLE
libxml++*: restrict livecheck versions

### DIFF
--- a/Formula/libxml++3.rb
+++ b/Formula/libxml++3.rb
@@ -6,6 +6,11 @@ class Libxmlxx3 < Formula
   license "LGPL-2.1-or-later"
   revision 2
 
+  livecheck do
+    url :stable
+    regex(/libxml\+\+[._-]v?(3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "031e2c0f7344a8dca24441939a6770c5f65d2f6aa6525b9fc033e71161ea07c8"
     sha256 cellar: :any, big_sur:       "f0c270ebd865837c345f5299c221d6053dafcc836df83c6a4e07b3efab0b4847"

--- a/Formula/libxml++@4.rb
+++ b/Formula/libxml++@4.rb
@@ -7,6 +7,7 @@ class LibxmlxxAT4 < Formula
 
   livecheck do
     url :stable
+    regex(/libxml\+\+[._-]v?(4\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 
   bottle do

--- a/Formula/libxml++@5.rb
+++ b/Formula/libxml++@5.rb
@@ -7,6 +7,7 @@ class LibxmlxxAT5 < Formula
 
   livecheck do
     url :stable
+    regex(/libxml\+\+[._-]v?(5\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a `livecheck` block for `libxml++3` and updates the `livecheck` blocks for `libxml++@4` and `libxml++@5` to restrict matching to versions with the related major version. This aligns these formulae with the check for `libxml++`, which restricts matching to versions with a major of `2`.