### PR TITLE
gost: fix test

### DIFF
--- a/Formula/gost.rb
+++ b/Formula/gost.rb
@@ -27,6 +27,6 @@ class Gost < Formula
       exec "#{bin}/gost -L #{bind_address}"
     end
     sleep 1
-    assert_match "200 OK", shell_output("curl -I -x #{bind_address} https://github.com")
+    assert_match "HTTP/2 200", shell_output("curl -I -x #{bind_address} https://github.com")
   end
 end


### PR DESCRIPTION
Addresses https://github.com/Homebrew/homebrew-core/pull/70446#issuecomment-774334533

For future reference, this is what `curl` actually dumps during the test:
```
HTTP/1.1 200 Connection established
Proxy-Agent: gost/2.11.1

HTTP/2 200
content-type: text/html
content-length: 123345
date: Sat, 06 Feb 2021 03:43:03 GMT
last-modified: Sat, 06 Feb 2021 03:40:54 GMT
etag: "c5586663e2daefdbbd076e1e7faa4b2e"
server: AmazonS3
vary: Accept-Encoding
x-cache: Hit from cloudfront
via: 1.1 cc2beda7b70d44b6ed40dda2c22f45e5.cloudfront.net (CloudFront)
x-amz-cf-pop: SIN52-C3
x-amz-cf-id: QmqjFnkODEcFmdgropHcMGkdVXgFDmLzfqq78zoZkr6g77oIBtSlCQ==
age: 24848
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? *(Only the test is changed.)*
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
