### PR TITLE
deno: fix pre-Mojave SDK minimum version

### DIFF
--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -27,6 +27,9 @@ class Deno < Formula
   end
 
   def install
+    # Overwrite Chromium minimum SDK version of 10.15
+    ENV["FORCE_MAC_SDK_MIN"] = MacOS.version if MacOS.version < :mojave
+
     # env args for building a release build with our clang, ninja and gn
     ENV["GN"] = buildpath/"gn/out/gn"
     ENV["NINJA"] = Formula["ninja"].opt_bin/"ninja"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes https://github.com/denoland/deno/issues/9404.

Marking this as syntax only since this change is a no-op on any of our existing runners, and `deno` takes ages to build. (Four hours on Mojave on the most recent build attempt.)