### PR TITLE
openjdk: caveat and keg_only strictly for macOS

### DIFF
--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -26,7 +26,7 @@ class Openjdk < Formula
     sha256 cellar: :any, mojave:        "13c9bf7e3d1ccb71863249ed983fad3b19324b22557bf12247331a693504c235"
   end
 
-  keg_only "it shadows the macOS `java` wrapper"
+  keg_only :shadowed_by_macos
 
   depends_on "autoconf" => :build
   depends_on xcode: :build if Hardware::CPU.arm?
@@ -160,19 +160,21 @@ class Openjdk < Formula
   end
 
   def caveats
-    s = <<~EOS
-      For the system Java wrappers to find this JDK, symlink it with
-        sudo ln -sfn #{opt_libexec}/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
-    EOS
-
-    if Hardware::CPU.arm?
-      s += <<~EOS
-        This is a beta version of openjdk for Apple Silicon
-        (openjdk 16 preview).
+    on_macos do
+      s = <<~EOS
+        For the system Java wrappers to find this JDK, symlink it with
+          sudo ln -sfn #{opt_libexec}/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk.jdk
       EOS
-    end
 
-    s
+      if Hardware::CPU.arm?
+        s += <<~EOS
+          This is a beta version of openjdk for Apple Silicon
+          (openjdk 16 preview).
+        EOS
+      end
+
+      s
+    end
   end
 
   test do


### PR DESCRIPTION
Addresses https://github.com/Homebrew/discussions/discussions/709

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? *(Only `caveats` block was changed.)*
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? *(Only `caveats` block was changed.)*
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
