### PR TITLE
libzzip: fix rpath, don't build tests

### DIFF
--- a/Formula/libzzip.rb
+++ b/Formula/libzzip.rb
@@ -4,6 +4,7 @@ class Libzzip < Formula
   url "https://github.com/gdraheim/zziplib/archive/v0.13.72.tar.gz"
   sha256 "93ef44bf1f1ea24fc66080426a469df82fa631d13ca3b2e4abaeab89538518dc"
   license "LGPL-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any, big_sur:  "da81c94d36933d34fa6b280165d2d2aa3c98521e846f8b62b615373d32fb0fa4"
@@ -17,7 +18,7 @@ class Libzzip < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args, "-DZZIPSDL=OFF"
+      system "cmake", "..", *std_cmake_args, "-DZZIPTEST=OFF", "-DZZIPSDL=OFF", "-DCMAKE_INSTALL_RPATH=#{lib}"
       system "make", "man"
       system "make", "install"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Fixes RPATH so it runs on ARM. Removes tests which download during build stage.
