### PR TITLE
tcpflow: update stable and livecheck

### DIFF
--- a/Formula/tcpflow.rb
+++ b/Formula/tcpflow.rb
@@ -1,15 +1,14 @@
 class Tcpflow < Formula
   desc "TCP/IP packet demultiplexer"
   homepage "https://github.com/simsong/tcpflow"
-  url "https://github.com/simsong/tcpflow/releases/download/tcpflow-1.5.0/tcpflow-1.5.0.tar.gz"
+  url "https://downloads.digitalcorpora.org/downloads/tcpflow/tcpflow-1.5.0.tar.gz"
   sha256 "20abe3353a49a13dcde17ad318d839df6312aa6e958203ea710b37bede33d988"
   license "GPL-3.0"
   revision 1
 
   livecheck do
-    url :stable
-    regex(%r{href=.*?/tag/(?:tcpflow[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
-    strategy :github_latest
+    url "http://downloads.digitalcorpora.org/downloads/tcpflow/"
+    regex(/href=.*?tcpflow[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a follow-up to #70341 to return the formula to using a digitalcorpora.org URL now that the `downloads` directory is available on their new file hosting. The `stable` archive remains the same and there's no change to the `sha256`.

This also reverts the `livecheck` block to the previous setup to align with the current `stable` URL.
