### PR TITLE
bulk_extractor: update stable and livecheck

### DIFF
--- a/Formula/bulk_extractor.rb
+++ b/Formula/bulk_extractor.rb
@@ -1,13 +1,13 @@
 class BulkExtractor < Formula
   desc "Stream-based forensics tool"
   homepage "https://github.com/simsong/bulk_extractor/wiki"
-  url "https://digitalcorpora.org/downloads/bulk_extractor/bulk_extractor-1.5.5.tar.gz"
+  url "https://downloads.digitalcorpora.org/downloads/bulk_extractor/bulk_extractor-1.5.5.tar.gz"
   sha256 "297a57808c12b81b8e0d82222cf57245ad988804ab467eb0a70cf8669594e8ed"
   license "MIT"
   revision 3
 
   livecheck do
-    url "https://digitalcorpora.org/downloads/bulk_extractor/"
+    url "https://downloads.digitalcorpora.org/downloads/bulk_extractor/"
     regex(/href=.*?bulk_extractor[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Same as #70585, this updates the `bulk_extractor` `stable` URL and `livecheck` block to check the current digitalcorpora.org URLs, now that the `downloads` directory is available on their new file hosting.