### PR TITLE
byteman: add livecheck

### DIFF
--- a/Formula/byteman.rb
+++ b/Formula/byteman.rb
@@ -6,6 +6,11 @@ class Byteman < Formula
   license "LGPL-2.1-or-later"
   head "https://github.com/bytemanproject/byteman"
 
+  livecheck do
+    url "https://byteman.jboss.org/downloads.html"
+    regex(/href=.*?byteman-download[._-]v?(\d+(?:\.\d+)+)-bin\.zip/i)
+  end
+
   bottle :unneeded
 
   depends_on "openjdk"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is checking the Git tags for `byteman` and reporting `4.0.12` as newest. According to the first-party download page, the newest version is `4.0.13`. This adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.