### PR TITLE
opensubdiv: add livecheck

### DIFF
--- a/Formula/opensubdiv.rb
+++ b/Formula/opensubdiv.rb
@@ -5,6 +5,11 @@ class Opensubdiv < Formula
   sha256 "7b22eb27d636ab0c1e03722c7a5a5bd4f11664ee65c9b48f341a6d0ce7f36745"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:[._]\d+)+)$/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "5ebfe202d77f6bd92933301787141552e45d3694ceef3187a2f3c7b23edbf9e8"
     sha256 big_sur:       "9c9da8838f7d8a088fae55beec22ff3e7b687994f2b14a37155fd5fafc66ad5a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `opensubdiv` but it's reporting an unstable version as latest (`3_4_4_RC1`). This adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which omits unstable releases, with a small modification to allow underscore delimiters between the numbers.