### PR TITLE
clisp: remove ENV.O0 call

### DIFF
--- a/Formula/clisp.rb
+++ b/Formula/clisp.rb
@@ -38,7 +38,7 @@ class Clisp < Formula
 
   def install
     ENV.deparallelize # This build isn't parallel safe.
-    ENV.O0 # Any optimization breaks the build
+    ENV["HOMEBREW_OPTIMIZATION_LEVEL"] = "O0" # Any optimization breaks the build
 
     # Clisp requires to select word size explicitly this way,
     # set it in CFLAGS won't work.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This method has been disabled, so source builds no longer work.

See #70594.

I hope the comment about the build breaking is no longer true.