### PR TITLE
scc: fix build with Go 1.16

### DIFF
--- a/Formula/scc.rb
+++ b/Formula/scc.rb
@@ -20,9 +20,7 @@ class Scc < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/boyter/scc/").install Dir["*"]
-    system "go", "build", "-o", "#{bin}/scc", "-v", "github.com/boyter/scc/"
+    system "go", "build", *std_go_args
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#70143 fixes `scc` by adding `GO111MODULE=auto`, but `scc` has a `go.mod`, so it's fixed by just using the default build command instead of copying the module into GOPATH and doing the build from outside the module. This is probably true of a lot of Formulae.

/cc @fxcoudert 