### PR TITLE
*formulae: `uses_from_macos` more dependencies

### DIFF
--- a/Formula/iftop.rb
+++ b/Formula/iftop.rb
@@ -33,6 +33,8 @@ class Iftop < Formula
     depends_on "automake" => :build
   end
 
+  uses_from_macos "libpcap"
+
   def install
     system "./bootstrap" if build.head?
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/logstash.rb
+++ b/Formula/logstash.rb
@@ -20,6 +20,8 @@ class Logstash < Formula
 
   depends_on "openjdk@8"
 
+  uses_from_macos "ruby" => :build
+
   def install
     # remove non open source files
     rm_rf "x-pack"

--- a/Formula/tcptraceroute.rb
+++ b/Formula/tcptraceroute.rb
@@ -33,6 +33,8 @@ class Tcptraceroute < Formula
 
   depends_on "libnet"
 
+  uses_from_macos "libpcap"
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/testdisk.rb
+++ b/Formula/testdisk.rb
@@ -19,6 +19,8 @@ class Testdisk < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "752a686f8fa7717cbbdef064eefd80503eccdddfc587bd48fd24256e23332470"
   end
 
+  uses_from_macos "ncurses"
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
 
-----

- iftop: uses_from_macos "libpcap"
- testdisk: uses_from_macos "ncurses"
- tcptraceroute: uses_from_macos "libpcap"

These shouldn't need new macOS bottles.
Related issue: https://github.com/Homebrew/linuxbrew-core/issues/22225.
