### PR TITLE
git-interactive-rebase-tool 2.0.0

### DIFF
--- a/Formula/git-interactive-rebase-tool.rb
+++ b/Formula/git-interactive-rebase-tool.rb
@@ -1,8 +1,8 @@
 class GitInteractiveRebaseTool < Formula
   desc "Native sequence editor for Git interactive rebase"
   homepage "https://gitrebasetool.mitmaro.ca/"
-  url "https://github.com/MitMaro/git-interactive-rebase-tool/archive/1.2.1.tar.gz"
-  sha256 "8df32f209d481580c3365a065882e40343ecc42d9e4ed593838092bb6746a197"
+  url "https://github.com/MitMaro/git-interactive-rebase-tool/archive/2.0.0.tar.gz"
+  sha256 "572815b6bf152cae9414635caf9c8c918a575747c3a8885767380da4aeeeb709"
   license "GPL-3.0-or-later"
 
   livecheck do
@@ -19,7 +19,6 @@ class GitInteractiveRebaseTool < Formula
 
   depends_on "rust" => :build
 
-  uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   def install
@@ -27,41 +26,29 @@ class GitInteractiveRebaseTool < Formula
   end
 
   test do
-    require "pty" # required for interactivity
+    require "pty"
+    require "io/console"
+
     mkdir testpath/"repo" do
       system "git", "init"
-      touch "FILE1"
-      system "git", "add", "FILE1"
-      system "git", "commit", "--date='2005-04-07T22:13:13-3:30'",
-                              "--author='Test <test@example.com>'",
-                              "--message='File 1'"
-      touch "FILE2"
-      system "git", "add", "FILE2"
-      system "git", "commit", "--date='2005-04-07T22:13:13-3:30'",
-                              "--author='Test <test@example.com>'",
-                              "--message='File 2'"
     end
 
     (testpath/"repo/.git/rebase-merge/git-rebase-todo").write <<~EOS
-      pick be5eaa0 File 1
-      pick 32bd1bb File 2
+      noop
     EOS
 
     expected_git_rebase_todo = <<~EOS
-      drop be5eaa0 File 1
-      pick 32bd1bb File 2
+      noop
     EOS
 
     env = { "GIT_DIR" => testpath/"repo/.git/" }
     executable = bin/"interactive-rebase-tool"
-    file = testpath/"repo/.git/rebase-merge/git-rebase-todo"
-    PTY.spawn(env, executable, file) do |stdout, stdin, _pid|
-      # simulate user input
-      stdin.putc "d"
-      stdin.putc "W"
-      stdout.read
-    end
+    todo_file = testpath/"repo/.git/rebase-merge/git-rebase-todo"
 
-    assert_equal expected_git_rebase_todo, (testpath/"repo/.git/rebase-merge/git-rebase-todo").read
+    _, _, pid = PTY.spawn(env, executable, todo_file)
+    Process.wait(pid)
+
+    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal expected_git_rebase_todo, todo_file.read
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This update was non-simple as the existing tests were broken by changes in the project. The tests failed because the existing tests depend on reading input from stdin, but this project no longer supports reading from stdin in all cases. To fix this, providing a noop rebase file will allow the application to run and successfully exit, without the need to virtually interact with the program. I think this is due to an [upstream issue in Crossterm](https://github.com/crossterm-rs/crossterm/issues/396), but I can't be sure.

Also, the project no longer depends on ncurses, so that dependency has been removed.


There is also an [existing PR](https://github.com/Homebrew/homebrew-core/pull/70470) but the tests are failing and this should fix them. 