### PR TITLE
md5deep: support for ARM

### DIFF
--- a/Formula/md5deep.rb
+++ b/Formula/md5deep.rb
@@ -4,6 +4,7 @@ class Md5deep < Formula
   url "https://github.com/jessek/hashdeep/archive/release-4.4.tar.gz"
   sha256 "dbda8ab42a9c788d4566adcae980d022d8c3d52ee732f1cbfa126c551c8fcc46"
   license "GPL-2.0"
+  revision 1
   head "https://github.com/jessek/hashdeep.git"
 
   bottle do

--- a/Formula/md5deep.rb
+++ b/Formula/md5deep.rb
@@ -20,6 +20,10 @@ class Md5deep < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
+  # Fix compilation error due to very old GNU config scripts in source repo
+  # reported upstream at https://github.com/jessek/hashdeep/issues/400
+  patch :DATA if Hardware::CPU.arm?
+
   # Fix compilation error due to pointer comparison
   if MacOS.version >= :sierra
     patch do
@@ -41,3 +45,19 @@ class Md5deep < Formula
     shell_output("#{bin}/sha1deep -b testfile.txt").strip
   end
 end
+
+__END__
+diff --git a/config.guess b/config.guess
+index cc726cd..37d7e9d 100755
+--- a/config.guess
++++ b/config.guess
+@@ -1130,6 +1130,9 @@ EOF
+     *:Rhapsody:*:*)
+ 	echo ${UNAME_MACHINE}-apple-rhapsody${UNAME_RELEASE}
+ 	exit 0 ;;
++	arm64:Darwin:*:*)
++	echo arm-apple-darwin"$UNAME_RELEASE"
++	exit ;;
+     *:Darwin:*:*)
+ 	case `uname -p` in
+ 	    *86) UNAME_PROCESSOR=i686 ;;


### PR DESCRIPTION
md5deep currently fails to install on Apple Silicon thanks to an outdated copy of the GNU config scripts in that repo. The issue has been [reported upstream](https://github.com/jessek/hashdeep/issues/400). Until they fix it this pull request adds a minimal patch to get the homebrew formula compiling again.

----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

`brew audit --strict` warns that `GPL-2.0` is not a valid license which is not related to these changes. Not sure if you'd like that fixed in this PR too?