### PR TITLE
blast: use libarchive, libarchive conflicts with cpio on linux

### DIFF
--- a/Formula/blast.rb
+++ b/Formula/blast.rb
@@ -20,9 +20,12 @@ class Blast < Formula
 
   depends_on "lmdb"
 
-  uses_from_macos "cpio" => :build
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "libarchive" => :build
+  end
 
   conflicts_with "proj", because: "both install a `libproj.a` library"
 

--- a/Formula/cpio.rb
+++ b/Formula/cpio.rb
@@ -16,6 +16,10 @@ class Cpio < Formula
 
   keg_only :shadowed_by_macos, "macOS provides cpio"
 
+  on_linux do
+    conflicts_with "libarchive", because: "both install `cpio` binaries"
+  end
+
   def install
     system "./configure",
       "--disable-debug",

--- a/Formula/libarchive.rb
+++ b/Formula/libarchive.rb
@@ -29,6 +29,10 @@ class Libarchive < Formula
   uses_from_macos "expat"
   uses_from_macos "zlib"
 
+  on_linux do
+    conflicts_with "cpio", because: "both install `cpio` binaries"
+  end
+
   def install
     system "./configure",
            "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
