### PR TITLE
formulae*: use libarchive instead of gnu-tar, libarchive conflicts with gnu-tar on linux

### DIFF
--- a/Formula/biosig.rb
+++ b/Formula/biosig.rb
@@ -4,6 +4,7 @@ class Biosig < Formula
   url "https://downloads.sourceforge.net/project/biosig/BioSig%20for%20C_C%2B%2B/src/biosig-2.1.2.src.tar.gz"
   sha256 "1b5bf62739faf3caef7cb7fbb14c7f1dea352caa548b08c7bb5adaaef2f4d1b4"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -17,7 +18,7 @@ class Biosig < Formula
   end
 
   depends_on "gawk" => :build
-  depends_on "gnu-tar" => :build
+  depends_on "libarchive" => :build
   depends_on "dcmtk"
   depends_on "libb64"
   depends_on "numpy"

--- a/Formula/diffoscope.rb
+++ b/Formula/diffoscope.rb
@@ -6,6 +6,7 @@ class Diffoscope < Formula
   url "https://files.pythonhosted.org/packages/82/0b/abc82afbcc451271df4bf027a6f9442f4d7a512c48e7f94d5f3e88a4bea8/diffoscope-166.tar.gz"
   sha256 "20d0b4091ae535dc7d094bf5f366e0687e0b4337a268254b11925b8e7c9ea9c4"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "9f653b6e9b2c87e5bd8b7510393ca221ffbb41091ab3d7c845e6bac72702e92b"
@@ -14,7 +15,6 @@ class Diffoscope < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "93271ba0f90255a8a93e2bd4d75701b9e4404fed70c27bb4dd97bcebe6d386a2"
   end
 
-  depends_on "gnu-tar"
   depends_on "libarchive"
   depends_on "libmagic"
   depends_on "python@3.9"

--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -36,7 +36,12 @@ class Dpkg < Formula
   def install
     # We need to specify a recent gnutar, otherwise various dpkg C programs will
     # use the system "tar", which will fail because it lacks certain switches.
-    ENV["TAR"] = Formula["gnu-tar"].opt_bin/"gtar"
+    on_macos do
+      ENV["TAR"] = Formula["gnu-tar"].opt_bin/"gtar"
+    end
+    on_linux do
+      ENV["TAR"] = Formula["gnu-tar"].opt_bin/"tar"
+    end
 
     # Since 1.18.24 dpkg mandates the use of GNU patch to prevent occurrences
     # of the CVE-2017-8283 vulnerability.

--- a/Formula/gnome-recipes.rb
+++ b/Formula/gnome-recipes.rb
@@ -3,7 +3,7 @@ class GnomeRecipes < Formula
   homepage "https://wiki.gnome.org/Apps/Recipes"
   url "https://download.gnome.org/sources/gnome-recipes/2.0/gnome-recipes-2.0.2.tar.xz"
   sha256 "1be9d2fcb7404a97aa029d2409880643f15071c37039247a6a4320e7478cd5fb"
-  revision 14
+  revision 15
 
   bottle do
     sha256 arm64_big_sur: "c2e5d814490f07f330d62591b7848c5b988706c74feeac8deb7a207201235045"
@@ -19,10 +19,10 @@ class GnomeRecipes < Formula
   depends_on "pkg-config" => :build
   depends_on "adwaita-icon-theme"
   depends_on "gnome-autoar"
-  depends_on "gnu-tar"
   depends_on "gspell"
   depends_on "gtk+3"
   depends_on "json-glib" # for goa
+  depends_on "libarchive"
   depends_on "libcanberra"
   depends_on "librest" # for goa
   depends_on "libsoup"

--- a/Formula/gnu-tar.rb
+++ b/Formula/gnu-tar.rb
@@ -21,6 +21,10 @@ class GnuTar < Formula
     depends_on "gettext" => :build
   end
 
+  on_linux do
+    conflicts_with "libarchive", because: "both install `tar` binaries"
+  end
+
   def install
     # Work around unremovable, nested dirs bug that affects lots of
     # GNU projects. See:

--- a/Formula/libarchive.rb
+++ b/Formula/libarchive.rb
@@ -31,6 +31,7 @@ class Libarchive < Formula
 
   on_linux do
     conflicts_with "cpio", because: "both install `cpio` binaries"
+    conflicts_with "gnu-tar", because: "both install `tar` binaries"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
