### PR TITLE
mtools: fix build errors on Apple Silicon

### DIFF
--- a/Formula/mtools.rb
+++ b/Formula/mtools.rb
@@ -28,7 +28,7 @@ class Mtools < Formula
 
     # The mtools configure script incorrectly detects stat64. This forces it off
     # to fix build errors on Apple Silicon. See stat(6) and pv.rb.
-    ENV["ac_cv_func_stat64"] = "no"
+    ENV["ac_cv_func_stat64"] = "no" if Hardware::CPU.arm?
 
     system "./configure", *args
     system "make"
@@ -55,4 +55,3 @@ index 056218e..ba3677b 100644
  
  #ifdef HAVE_STRING_H
  # include <string.h>
-

--- a/Formula/mtools.rb
+++ b/Formula/mtools.rb
@@ -26,6 +26,10 @@ class Mtools < Formula
       --without-x
     ]
 
+    # The mtools configure script incorrectly detects stat64. This forces it off
+    # to fix build errors on Apple Silicon. See stat(6) and pv.rb.
+    ENV["ac_cv_func_stat64"] = "no"
+
     system "./configure", *args
     system "make"
     ENV.deparallelize


### PR DESCRIPTION
The mtools configure script incorrectly detects the stat64 function, and
this causes build errors. This forces the configure script to assume
that the function doesn't exist.

The pv formula had a similar issue and included the following
information:

  Since macOS 10.6, stat64 variants are equivalent to plain stat, and
  the suffixed versions have been removed in macOS 11 on Apple Silicon.
  See stat(2).

I tested several of the mtools utilities manually to verify the fix and
they seem to work fine.

Signed-off-by: Frank Hunleth <fhunleth@troodon-software.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
