### PR TITLE
nu-smv: fix build from source

### DIFF
--- a/Formula/nu-smv.rb
+++ b/Formula/nu-smv.rb
@@ -1,8 +1,15 @@
 class NuSmv < Formula
   desc "Reimplementation and extension of SMV symbolic model checker"
-  homepage "http://nusmv.fbk.eu"
-  url "http://nusmv.fbk.eu/distrib/NuSMV-2.6.0.tar.gz"
+  homepage "https://nusmv.fbk.eu"
+  url "https://nusmv.fbk.eu/distrib/NuSMV-2.6.0.tar.gz"
   sha256 "dba953ed6e69965a68cd4992f9cdac6c449a3d15bf60d200f704d3a02e4bbcbb"
+  license "LGPL-2.1-or-later"
+  revision 1
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?announce-NuSMV[._-]v?(\d+(?:\.\d+)+)\.txt/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, catalina:    "90dad1b30d80ee7ddba984d6ad2536fff08896e79cf1a26a083a5e9990fc3c43"
@@ -12,10 +19,37 @@ class NuSmv < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "doxygen" => :build
+  depends_on "pkg-config" => :build
+  depends_on "readline"
+
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
+
+  resource "minisat" do
+    # This URL must match what is specified in MiniSat/minisat-default.cmake except
+    # that we download the '.tar.gz' instead of the '.zip' to keep "brew audit" happy
+    url "https://github.com/niklasso/minisat/archive/37dc6c67e2af26379d88ce349eb9c4c6160e8543.tar.gz"
+    sha256 "3db05b02f91c4b097b7962e523225aa5e6fa9a6c0d42704a170b01b069cdfcfe"
+  end
 
   def install
+    # Normally cmake will try to download the minisat source zip itself
+    # but we already got it as a resource.  If we drop it into the build
+    # directory it will use that one.  However, we grabbed the .tar.gz
+    # instead of the .zip above, so we need to name it .zip so it is
+    # in the right place.  It is ultimately unpacked with bsdtar anyway
+    # so the fact that it's the "wrong" format won't matter!
+    r = resource("minisat")
+    r.fetch unless r.downloaded?
+    cp r.cached_download, buildpath/"MiniSat"/(File.basename(r.url, ".tar.gz") + ".zip")
+
     mkdir "NuSMV/build" do
       system "cmake", "..", *std_cmake_args
+      system "make"
+      system "make", "prog-man-html"
       system "make", "install"
     end
   end


### PR DESCRIPTION
* On my machine building from source failed due to problems installing the missing html documentation.  The project's cmake scripts  assume that if doxygen is detected then it must be manually run before `make install`.  To get consistent results, add it as a dependency and run it
* By default, cmake also downloads (but doesn't sha-verify) the  source to minisat from github.  Download this ourselves as a  resource and then copy it into place to avoid this
* Document dependencies more carefully

NOTE: I am not confident about the way I fetch the subresource -- what I need to do is basic (have homebrew download the subresource but *not* extract it since the build wants the tarball) but there doesn't seem to be a well-documented way of doing this without poking at private APIs.  However, there are 18 other formulae that access `.cached_download` directly to do similar things so I guess this is OK?  What is odd, though, is that they also seem to call `.fetch` without checking `.downladed?` first... which appears to always re-download the resource even if it is in cache(?)  So if an explicit `.fetch` *is* required then it's not clear to me that the typical behavior of not calling `.downloaded?` is safe.  (Compare the implementation of `Resource::stage` to see how `unless downloaded?` gets used there) Really it seems like homebrew's `Resource` class should just have a cleaner way of returning an always-populated value of `.cached_download` that requires less private API use but it doesn't seem to have such a thing right now.