### PR TITLE
arx-libertatis: update license, stable, livecheck

### DIFF
--- a/Formula/arx-libertatis.rb
+++ b/Formula/arx-libertatis.rb
@@ -1,11 +1,11 @@
 class ArxLibertatis < Formula
   desc "Cross-platform, open source port of Arx Fatalis"
   homepage "https://arx-libertatis.org/"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 2
 
   stable do
-    url "https://arx-libertatis.org/files/arx-libertatis-1.1.2.tar.xz"
+    url "https://arx-libertatis.org/files/arx-libertatis-1.1.2/arx-libertatis-1.1.2.tar.xz"
     sha256 "82adb440a9c86673e74b84abd480cae968e1296d625b6d40c69ca35b35ed4e42"
 
     # Add a missing include to CMakeLists.txt
@@ -16,8 +16,8 @@ class ArxLibertatis < Formula
   end
 
   livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://arx-libertatis.org/files/"
+    regex(%r{href=["']?arx-libertatis[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `arx-libertatis` to check the directory listing page where the version directories are found (containing the archive files we use as `stable`). This aligns the check with the `stable` source, which we prefer.

This also updates the `stable` URL to the current location of the `arx-libertatis-1.1.2.tar.xz` archive, which is now found in an `arx-libertatis-1.1.2` subdirectory. The previous URL was redirecting, so this avoids the redirection.

Lastly, this updates the license to `GPL-3.0-or-later`, referencing the [first-party homepage](https://arx-libertatis.org), which states "Arx Libertatis is based on the publicly released [Arx Fatalis sources](https://web.archive.org/web/20180105233341/https://www.arkane-studios.com/uk/arx_downloads.php) and available under the [GPL 3+ license](https://www.gnu.org/licenses/gpl.html)."