### PR TITLE
fastlane: update livecheck

### DIFF
--- a/Formula/fastlane.rb
+++ b/Formula/fastlane.rb
@@ -7,8 +7,8 @@ class Fastlane < Formula
   head "https://github.com/fastlane/fastlane.git"
 
   livecheck do
-    url :head
-    regex(/^([\d.]+)$/i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `fastlane` to use `url :stable` instead of `url :head`, as these both use the same source and we prefer to align checks with `stable`. This also updates the regex to use the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`) instead of the looser `/^([\d.]+)$/i` (which we avoid, as it can match things that we don't want).