### PR TITLE
languagetool: update livecheck

### DIFF
--- a/Formula/languagetool.rb
+++ b/Formula/languagetool.rb
@@ -8,7 +8,8 @@ class Languagetool < Formula
   head "https://github.com/languagetool-org/languagetool.git"
 
   livecheck do
-    url :head
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `languagetool` to use `url :stable` instead of `url :head`, as these both use the same source and we prefer to align checks with `stable`. This also adds the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`), to preemptively avoid matching tags that we aren't interested in (e.g., unstable versions).