### PR TITLE
metabase: update livecheck

### DIFF
--- a/Formula/metabase.rb
+++ b/Formula/metabase.rb
@@ -6,8 +6,8 @@ class Metabase < Formula
   license "AGPL-3.0-only"
 
   livecheck do
-    url :head
-    strategy :github_latest
+    url "https://www.metabase.com/start/oss/jar.html"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/metabase\.jar}i)
   end
 
   head do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `metabase` to check [a page on the first-party website](https://www.metabase.com/start/oss/jar.html) that links to the `stable` jar file. This aligns the check with the `stable` source, which we prefer.