### PR TITLE
mockery: fix binary version

### DIFF
--- a/Formula/mockery.rb
+++ b/Formula/mockery.rb
@@ -4,6 +4,7 @@ class Mockery < Formula
   url "https://github.com/vektra/mockery/archive/v2.6.0.tar.gz"
   sha256 "ce5eea62e9d130e3557c11016c306485ccd77919cf85d706a2556bce28d085ed"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/vektra/mockery.git"
 
   bottle do
@@ -16,14 +17,14 @@ class Mockery < Formula
   depends_on "go"
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w"
+    system "go", "build", *std_go_args, "-ldflags", "-s -w -X github.com/vektra/mockery/v2/pkg/config.SemVer=#{version}"
   end
 
   test do
     output = shell_output("#{bin}/mockery --keeptree 2>&1", 1)
-    assert_match "Starting mockery dry-run=false version=0.0.0-dev", output
+    assert_match "Starting mockery dry-run=false version=#{version}", output
 
     output = shell_output("#{bin}/mockery --all --dry-run 2>&1")
-    assert_match "INF Walking dry-run=true version=0.0.0-dev", output
+    assert_match "INF Walking dry-run=true version=#{version}", output
   end
 end


### PR DESCRIPTION
Upstream uses goreleaser for builds, and `.goreleaser.yml` contains:
```
builds:
  - main: ./main.go
    ldflags:
      - -s -w -X github.com/vektra/mockery/v2/pkg/config.SemVer={{.Version}}
```

Closes #70668

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
