### PR TITLE
netcdf: update livecheck

### DIFF
--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -9,8 +9,8 @@ class Netcdf < Formula
   head "https://github.com/Unidata/netcdf-c.git"
 
   livecheck do
-    url :head
-    regex(/^(?:netcdf-|v)?(\d+(?:\.\d+)+)$/i)
+    url "https://www.unidata.ucar.edu/downloads/netcdf/"
+    regex(/href=.*?netcdf-c[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `netcdf` to check the [first-party download page](https://www.unidata.ucar.edu/downloads/netcdf/), which links to the `stable` archive. This aligns the check with the `stable` source, which we prefer.