### PR TITLE
rt-audio: fix shim pollution

### DIFF
--- a/Formula/rt-audio.rb
+++ b/Formula/rt-audio.rb
@@ -4,6 +4,7 @@ class RtAudio < Formula
   url "https://www.music.mcgill.ca/~gary/rtaudio/release/rtaudio-5.1.0.tar.gz"
   sha256 "ff138b2b6ed2b700b04b406be718df213052d4c952190280cf4e2fab4b61fe09"
   license "MIT"
+  revision 1
   head "https://github.com/thestk/rtaudio.git"
 
   bottle do
@@ -19,8 +20,8 @@ class RtAudio < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"
-    doc.install Dir["doc/*"]
-    pkgshare.install "tests"
+    doc.install %w[doc/release.txt doc/html doc/images]
+    (pkgshare/"tests").install "tests/testall.cpp"
   end
 
   test do


### PR DESCRIPTION
This formula was failing to bottle due to shim-pollution checks becoming stricter since it was last updated:
```
  * Files were found with references to the Homebrew shims directory.
    The offending files are:
      share/doc/rt-audio/Makefile
      share/rt-audio/tests/teststops
      share/rt-audio/tests/record
      share/rt-audio/tests/playsaw
      share/rt-audio/tests/Makefile
      share/rt-audio/tests/testall
      share/rt-audio/tests/duplex
      share/rt-audio/tests/audioprobe
      share/rt-audio/tests/playraw
      share/rt-audio/tests/apinames
```
The package's "make install" actually is fine but the formula then installs extra files:
* For the `doc` directory, things like the `html` and `images` directory are valid, but we don't need the doxygen source or its build infrastructure (The doxygen-produced files are in the upstream tarball, we don't even build them as part of the formula build)
* The `rt-audio/tests` is just installed so that `brew test` can reference these files later.  I don't know if this is a good pattern in general, but the only file it actually uses is testall.cpp so at least limit it to just that file.

cc @dunn @alebcay 
