### PR TITLE
gel: fix build on Big Sur

### DIFF
--- a/Formula/gel.rb
+++ b/Formula/gel.rb
@@ -4,6 +4,7 @@ class Gel < Formula
   url "https://github.com/gel-rb/gel/archive/v0.3.0.tar.gz"
   sha256 "fe7c4bd67a2ea857b85b754f5b4d336e26640eda7199bc99b9a1570043362551"
   license "MIT"
+  revision 1
   head "https://github.com/gel-rb/gel.git"
 
   bottle do
@@ -15,6 +16,7 @@ class Gel < Formula
 
   def install
     ENV["PATH"] = "bin:#{ENV["HOME"]}/.local/gel/bin:#{ENV["PATH"]}"
+    inreplace "Gemfile.lock", "rdiscount (2.2.0.1)", "rdiscount (2.2.0.2)"
     system "gel", "install"
     system "rake", "man"
     bin.install "exe/gel"


### PR DESCRIPTION
The `rdiscount` dependency doesn't build on Big Sur; this was fixed in its 2.2.0.2 version: https://github.com/davidfstr/rdiscount/commit/48cf5d5b3818943adc76728aaaf5b40b6ab9825b

The upstream `gel` package has already switched to using rdiscount 2.2.0.2 so this can be removed in the next update: https://github.com/gel-rb/gel/commit/4a404cabba66b040087964216d9f8ecbf4a7cf16
