### PR TITLE
aqbanking: fix cmake picking up gwenhywfar's includedir

### DIFF
--- a/Formula/aqbanking.rb
+++ b/Formula/aqbanking.rb
@@ -36,8 +36,8 @@ class Aqbanking < Formula
   depends_on "pkg-config" # aqbanking-config needs pkg-config for execution
 
   patch do
-    url "https://github.com/wrobelda/aqbanking/commit/171dbecb9720b168282126dcf00e741d9b8e912a.patch?full_index=1"
-    sha256 "80ea4d3e8f5221da220f37d3c8383bf8c971c9481b75d6ea58844f42c6ceb58e"
+    url "https://github.com/aqbanking/aqbanking/commit/661fe19ceb351e86d3c684c304be1cd602cc37de.patch?full_index=1"
+    sha256 "c34185b16fa8b261f760e0b7ff38b6d21b6a4ee5593b8362fc0c1f030f0bb1d2"
   end
 
   def install

--- a/Formula/aqbanking.rb
+++ b/Formula/aqbanking.rb
@@ -4,6 +4,7 @@ class Aqbanking < Formula
   url "https://www.aquamaniac.de/rdm/attachments/download/342/aqbanking-6.2.5.tar.gz"
   sha256 "cf5b060e3ec7e3fc925687caf044d4df3dbf9595f23c4fe8ffad78f44af0d6df"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.aquamaniac.de/rdm/projects/aqbanking/files"
@@ -33,6 +34,11 @@ class Aqbanking < Formula
   depends_on "libxmlsec1"
   depends_on "libxslt"
   depends_on "pkg-config" # aqbanking-config needs pkg-config for execution
+
+  patch do
+    url "https://github.com/wrobelda/aqbanking/commit/171dbecb9720b168282126dcf00e741d9b8e912a.patch?full_index=1"
+    sha256 "80ea4d3e8f5221da220f37d3c8383bf8c971c9481b75d6ea58844f42c6ceb58e"
+  end
 
   def install
     ENV.deparallelize


### PR DESCRIPTION
Reported upstream: 
https://www.aquamaniac.de/rdm/issues/229

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

