### PR TITLE
lwtools: update homepage and stable urls

### DIFF
--- a/Formula/lwtools.rb
+++ b/Formula/lwtools.rb
@@ -1,7 +1,7 @@
 class Lwtools < Formula
   desc "Cross-development tools for Motorola 6809 and Hitachi 6309"
-  homepage "http://lwtools.projects.l-w.ca/"
-  url "http://lwtools.projects.l-w.ca/releases/lwtools/lwtools-4.17.tar.gz"
+  homepage "http://www.lwtools.ca/"
+  url "http://www.lwtools.ca/releases/lwtools/lwtools-4.17.tar.gz"
   sha256 "a93ab316ca0176901822873dba4bc286d3a5cf86e6a853d3edb7a51ecc96a91c"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `lwtools.projects.l-w.ca` URLs in the `lwtools` formula are redirecting to `www.lwtools.ca`, so this updates the `homepage` and `stable` URLs to avoid the redirections. The `stable` archive is the same and this continues to build from source, audit, and test fine locally with the updated URLs.