### PR TITLE
nethack: update livecheck

### DIFF
--- a/Formula/nethack.rb
+++ b/Formula/nethack.rb
@@ -9,9 +9,11 @@ class Nethack < Formula
   license "NGPL"
   head "https://github.com/NetHack/NetHack.git"
 
+  # The /download/ page loads the following page in an iframe and this contains
+  # links to version directories which contain the archive files.
   livecheck do
-    url :head
-    regex(/^NetHack[._-]v?(\d+(?:\.\d+)+)_Released?$/i)
+    url "https://www.nethack.org/common/dnldindex.html"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `nethack` to check the first-party [`dnldindex.html` page](https://www.nethack.org/common/dnldindex.html), which is loaded in an `iframe` on the [download page](https://www.nethack.org/download/). This page links to the version directories where the `stable` archive files are located and we obtain the version information from these links. This aligns the check with the `stable` source, which we prefer.