### PR TITLE
wireguard-go: cross-platform test

### DIFF
--- a/Formula/wireguard-go.rb
+++ b/Formula/wireguard-go.rb
@@ -27,6 +27,13 @@ class WireguardGo < Formula
   end
 
   test do
-    assert_match "be utun", pipe_output("WG_PROCESS_FOREGROUND=1 #{bin}/wireguard-go notrealutun")
+    prog = "#{bin}/wireguard-go -f notrealutun 2>&1"
+    on_macos do
+      assert_match "be utun", pipe_output(prog)
+    end
+
+    on_linux do
+      assert_match "operation not permitted", pipe_output(prog)
+    end
   end
 end


### PR DESCRIPTION
Also use cmdline flag instead of env var to keep program in foreground

Addresses https://github.com/Homebrew/linuxbrew-core/issues/22242

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? *(only changed test block)*
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
