### PR TITLE
echoprint-codegen: deprecate, fix build on Big Sur

### DIFF
--- a/Formula/echoprint-codegen.rb
+++ b/Formula/echoprint-codegen.rb
@@ -16,6 +16,8 @@ class EchoprintCodegen < Formula
     sha256 cellar: :any, el_capitan:  "06f93b8c6bb025d833ff7757048ea0680b240e3cdd6a51f4dd2fb4e6aad3f7dd"
   end
 
+  deprecate! date: "2021-02-09", because: :unmaintained
+
   depends_on "boost"
   depends_on "ffmpeg"
   depends_on "taglib"
@@ -27,6 +29,9 @@ class EchoprintCodegen < Formula
   end
 
   def install
+    # Further Makefile fixes for https://github.com/spotify/echoprint-codegen/issues/97#issuecomment-776068938
+    inreplace "src/Makefile", "-lSystem", ""
+    inreplace "src/Makefile", "-framework Accelerate", ""
     system "make", "-C", "src", "install", "PREFIX=#{prefix}"
   end
 end


### PR DESCRIPTION
We already are patching this formula to fix issues that @fxcodert hit on 10.13, this just does more of the same: https://github.com/spotify/echoprint-codegen/issues/97

I'm going ahead and marking this formula deprecated:
* Upstream repo has been quiet for over 5 years now
* The last tagged release 4.12 release came out almost 9 years ago (all changes since then have just been build/docs tweaks).
* The original project site is long-gone (but still referenced on github project page)

It really looks like this project has been dead for awhile so probably time to start the long goodbye.
