### PR TITLE
gh: enable `--HEAD` install and upgrade notifier

### DIFF
--- a/Formula/gh.rb
+++ b/Formula/gh.rb
@@ -5,6 +5,8 @@ class Gh < Formula
   sha256 "49c42a3b951b67e29bc66e054fedb90ac2519f7e1bfc5c367e82cb173e4bb056"
   license "MIT"
 
+  head "https://github.com/cli/cli.git", branch: "trunk"
+
   livecheck do
     url :stable
     strategy :github_latest
@@ -20,9 +22,12 @@ class Gh < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GH_VERSION"] = version.to_s
-    ENV["GO_LDFLAGS"] = "-s -w"
-    system "make", "bin/gh", "manpages"
+    with_env(
+      "GH_VERSION" => version.to_s,
+      "GO_LDFLAGS" => "-s -w -X main.updaterEnabled=cli/cli",
+    ) do
+      system "make", "bin/gh", "manpages"
+    end
     bin.install "bin/gh"
     man1.install Dir["share/man/man1/gh*.1"]
     (bash_completion/"gh").write `#{bin}/gh completion -s bash`


### PR DESCRIPTION
This enables the following upgrade notifier when `gh` notices that it is out of date:

<img width="476" alt="Screen Shot 2021-02-08 at 13 56 41" src="https://user-images.githubusercontent.com/887/107223562-9d8cb080-6a16-11eb-8e2a-def0d90cfa17.png">

Ref. https://github.com/cli/cli/pull/2929

As a bonus, this also enables `brew install gh --HEAD`.
