### PR TITLE
*formulae: Add `depends_on :macos` to some

### DIFF
--- a/Formula/carthage.rb
+++ b/Formula/carthage.rb
@@ -16,6 +16,7 @@ class Carthage < Formula
   end
 
   depends_on xcode: ["10.0", :build]
+  depends_on :macos
 
   def install
     system "make", "prefix_install", "PREFIX=#{prefix}"

--- a/Formula/ios-deploy.rb
+++ b/Formula/ios-deploy.rb
@@ -15,6 +15,7 @@ class IosDeploy < Formula
   end
 
   depends_on xcode: :build
+  depends_on :macos
 
   def install
     xcodebuild "-configuration", "Release", "SYMROOT=build"

--- a/Formula/macos-trash.rb
+++ b/Formula/macos-trash.rb
@@ -13,6 +13,7 @@ class MacosTrash < Formula
   end
 
   depends_on xcode: ["12.0", :build]
+  depends_on :macos
 
   conflicts_with "trash", because: "both install a `trash` binary"
   conflicts_with "trash-cli", because: "both install a `trash` binary"

--- a/Formula/osx-cpu-temp.rb
+++ b/Formula/osx-cpu-temp.rb
@@ -14,6 +14,8 @@ class OsxCpuTemp < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "d68a47b126eaee8f75d281785322877055187f89540eb2744b9cd4da15ca6a69"
   end
 
+  depends_on :macos
+
   def install
     system "make"
     bin.install "osx-cpu-temp"

--- a/Formula/pinentry-mac.rb
+++ b/Formula/pinentry-mac.rb
@@ -19,6 +19,7 @@ class PinentryMac < Formula
   depends_on xcode: :build
   depends_on "gettext"
   depends_on "libassuan"
+  depends_on :macos
 
   def install
     system "autoreconf", "-fiv"

--- a/Formula/pngpaste.rb
+++ b/Formula/pngpaste.rb
@@ -13,6 +13,8 @@ class Pngpaste < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "eed393d2dbd516f60bdaa445df330a140853bee95cd49b0c3730345f57136676"
   end
 
+  depends_on :macos
+
   def install
     system "make", "all"
     bin.install "pngpaste"

--- a/Formula/reattach-to-user-namespace.rb
+++ b/Formula/reattach-to-user-namespace.rb
@@ -14,6 +14,8 @@ class ReattachToUserNamespace < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "68e1f00743690086fb23ce013767e0a669ef46807ee9f618fe9ea4a25c50d5c0"
   end
 
+  depends_on :macos
+
   def install
     system "make"
     bin.install "reattach-to-user-namespace"

--- a/Formula/rpcgen.rb
+++ b/Formula/rpcgen.rb
@@ -21,6 +21,7 @@ class Rpcgen < Formula
   keg_only :provided_by_macos
 
   depends_on xcode: ["7.3", :build]
+  depends_on :macos
 
   def install
     xcodebuild "-project", "developer_cmds.xcodeproj",

--- a/Formula/telnet.rb
+++ b/Formula/telnet.rb
@@ -19,6 +19,7 @@ class Telnet < Formula
   end
 
   depends_on xcode: :build
+  depends_on :macos
 
   conflicts_with "inetutils", because: "both install 'telnet' binaries"
 

--- a/Formula/trash.rb
+++ b/Formula/trash.rb
@@ -15,6 +15,8 @@ class Trash < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "0ef5ea924ba8d01398686657a839ad270796f3f10eee86d6522980d32038df9a"
   end
 
+  depends_on :macos
+
   conflicts_with "macos-trash", because: "both install a `trash` binary"
   conflicts_with "trash-cli", because: "both install a `trash` binary"
 

--- a/Formula/xhyve.rb
+++ b/Formula/xhyve.rb
@@ -15,6 +15,8 @@ class Xhyve < Formula
     sha256 cellar: :any, yosemite:    "e61ee4b3d2d3b5bba47f4288af54980f5de7991cadf6aa83dc058cb36854c789"
   end
 
+  depends_on :macos
+
   def install
     args = []
     args << "GIT_VERSION=#{version}" if build.stable?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Related issue: https://github.com/Homebrew/linuxbrew-core/issues/22225, section "need to be marked macOS only". I did the ones I was 100% sure about. Marking `telnet` as macOS only feels weird though. :-D

