### PR TITLE
orientdb: use don't hardcode homebrew prefix in plist file to fix audit on ARM

### DIFF
--- a/Formula/orientdb.rb
+++ b/Formula/orientdb.rb
@@ -4,6 +4,7 @@ class Orientdb < Formula
   url "https://s3.us-east-2.amazonaws.com/orientdb3/releases/3.1.8/orientdb-3.1.8.zip"
   sha256 "026d3f34ba67d8b5ca805258fa80f2a7c2a23c753b1c185143809d6d541640df"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://orientdb.org/download"
@@ -83,7 +84,7 @@ class Orientdb < Formula
           <string>homebrew.mxcl.orientdb</string>
           <key>ProgramArguments</key>
           <array>
-            <string>/usr/local/opt/orientdb/libexec/bin/server.sh</string>
+            <string>#{HOMEBREW_PREFIX}/opt/orientdb/libexec/bin/server.sh</string>
           </array>
           <key>RunAtLoad</key>
           <true/>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
updates the plist to not hardcode `/usr/local` as the Homebrew prefix