### PR TITLE
geph4 4.1.7 (new formula)

### DIFF
--- a/Formula/geph4.rb
+++ b/Formula/geph4.rb
@@ -1,8 +1,8 @@
 class Geph4 < Formula
   desc "Modular Internet censorship circumvention system to deal with national filtering"
   homepage "https://geph.io/"
-  url "https://github.com/geph-official/geph4/archive/v4.1.4.tar.gz"
-  sha256 "bc7cf04a192d0c0e5b4ebab340a98cb193a7a49e7edd77d3c4144b3c9db786b3"
+  url "https://github.com/geph-official/geph4/archive/v4.1.7.tar.gz"
+  sha256 "b0f58e1de7a620033098846b7b9a10371160b0d12faabb15b1b08d015391d268"
   license "GPL-3.0-only"
 
   depends_on "rust" => :build

--- a/Formula/geph4.rb
+++ b/Formula/geph4.rb
@@ -1,0 +1,20 @@
+class Geph4 < Formula
+  desc "Modular Internet censorship circumvention system to deal with national filtering"
+  homepage "https://geph.io/"
+  url "https://github.com/geph-official/geph4/archive/v4.1.2.tar.gz"
+  sha256 "7b2a9a7532cf1780b8b3c7a421ae6def63ad0948570813bd251dd50befb3ff77"
+  license "GPL-3.0-only"
+
+  depends_on "rust" => :build
+
+  def install
+    File.delete("Cross.toml")
+    remove_dir(".cargo")
+    Dir.chdir "geph4-client"
+    system "cargo", "install", "--bin", "geph4-client", *std_cargo_args
+  end
+
+  test do
+    assert_equal "geph4-client #{version}", shell_output("#{bin}/geph4-client -V").strip
+  end
+end

--- a/Formula/geph4.rb
+++ b/Formula/geph4.rb
@@ -15,6 +15,8 @@ class Geph4 < Formula
   end
 
   test do
-    assert_equal "geph4-client #{version}", shell_output("#{bin}/geph4-client -V").strip
+    assert_equal "{\"error\":\"wrong password\"}",
+     shell_output("#{bin}/geph4-client sync --username 'test' --password 'test' --credential-cache ~/test.db")
+       .lines.last.strip
   end
 end

--- a/Formula/geph4.rb
+++ b/Formula/geph4.rb
@@ -1,8 +1,8 @@
 class Geph4 < Formula
   desc "Modular Internet censorship circumvention system to deal with national filtering"
   homepage "https://geph.io/"
-  url "https://github.com/geph-official/geph4/archive/v4.1.2.tar.gz"
-  sha256 "7b2a9a7532cf1780b8b3c7a421ae6def63ad0948570813bd251dd50befb3ff77"
+  url "https://github.com/geph-official/geph4/archive/v4.1.4.tar.gz"
+  sha256 "bc7cf04a192d0c0e5b4ebab340a98cb193a7a49e7edd77d3c4144b3c9db786b3"
   license "GPL-3.0-only"
 
   depends_on "rust" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
- This is a new version of [Geph2](https://github.com/Homebrew/homebrew-core/blob/e2c833d326c45d9aaf4e26af6dd8b2f31564dc04/Formula/geph2.rb), so it should be considered notable enough even though the repository of the new version does not meet the requirements.
- The installation works as expected though `brew audit --new-formula geph4` says `The installation seems to be empty.`