### PR TITLE
workflows/tests: force brewed curl on Mojave

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Force vendored Ruby on Catalina
         if: matrix.version == '10.15'
         run: echo 'HOMEBREW_FORCE_VENDOR_RUBY=1' >> $GITHUB_ENV
+      - name: Force Homebrew Curl on Mojave
+        if: matrix.version == '10.14'
+        run: echo 'HOMEBREW_FORCE_BREWED_CURL=1' >> $GITHUB_ENV
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master


### PR DESCRIPTION
System curl is causing audit failures in #70738, #70577, #69326, and a
handful of others I'm not remembering at the moment.