### PR TITLE
workflows/triage: fix `no ARM bottle` regex

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -37,8 +37,8 @@ jobs:
                 }, {
                     "label": "no ARM bottle",
                     "path": "Formula/.+",
-                    "content": "\n    sha256 .* big_sur: +\"[a-fA-F0-9]+\"\n",
-                    "missing_content": "\n    sha256 .* arm64_big_sur: +\"[a-fA-F0-9]+\"\n"
+                    "content": "\n    sha256.* big_sur: +\"[a-fA-F0-9]+\"\n",
+                    "missing_content": "\n    sha256.* arm64_big_sur: +\"[a-fA-F0-9]+\"\n"
                 }, {
                     "label": "formula deprecated",
                     "path": "Formula/.+",


### PR DESCRIPTION
Occasionally there is only one space between `sha256` and the version
symbol.