### PR TITLE
qt: bump version 6.0.1

### DIFF
--- a/Aliases/pyside@6
+++ b/Aliases/pyside@6
@@ -1,0 +1,1 @@
+../Formula/pyside.rb

--- a/Aliases/qt5
+++ b/Aliases/qt5
@@ -1,1 +1,1 @@
-../Formula/qt.rb
+../Formula/qt@5.rb

--- a/Aliases/qt6
+++ b/Aliases/qt6
@@ -1,0 +1,1 @@
+../Formula/qt.rb

--- a/Aliases/qt@5
+++ b/Aliases/qt@5
@@ -1,1 +1,0 @@
-../Formula/qt.rb

--- a/Aliases/qt@6
+++ b/Aliases/qt@6
@@ -1,0 +1,1 @@
+../Formula/qt.rb

--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -2,6 +2,7 @@ class Audacious < Formula
   desc "Free and advanced audio player based on GTK+"
   homepage "https://audacious-media-player.org/"
   license "BSD-2-Clause"
+  revision 1
 
   stable do
     url "https://distfiles.audacious-media-player.org/audacious-4.0.5.tar.bz2"
@@ -52,7 +53,7 @@ class Audacious < Formula
   depends_on :macos # Due to Python 2
   depends_on "mpg123"
   depends_on "neon"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "sdl2"
   depends_on "wavpack"
 

--- a/Formula/carla.rb
+++ b/Formula/carla.rb
@@ -4,7 +4,7 @@ class Carla < Formula
   url "https://github.com/falkTX/Carla/archive/v2.2.0.tar.gz"
   sha256 "4bf08511257db88979eccc002f10c153ff2a14f5143291c2be39cadd69ce10e1"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/falkTX/Carla.git"
 
   livecheck do

--- a/Formula/cgal.rb
+++ b/Formula/cgal.rb
@@ -4,6 +4,7 @@ class Cgal < Formula
   url "https://github.com/CGAL/cgal/releases/download/v5.2/CGAL-5.2.tar.xz"
   sha256 "744c86edb6e020ab0238f95ffeb9cf8363d98cde17ebb897d3ea93dac4145923"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f610594b97b512f9dddbf434c3fa68e6de5d2e45a9a9fe27037fb9f189e76fb3"
@@ -13,7 +14,7 @@ class Cgal < Formula
   end
 
   depends_on "cmake" => [:build, :test]
-  depends_on "qt" => [:build, :test]
+  depends_on "qt@5" => [:build, :test]
   depends_on "boost"
   depends_on "eigen"
   depends_on "gmp"
@@ -32,6 +33,7 @@ class Cgal < Formula
     system "cmake", ".", *args
     system "make", "install"
   end
+
   test do
     # https://doc.cgal.org/latest/Triangulation_2/Triangulation_2_2draw_triangulation_2_8cpp-example.html and  https://doc.cgal.org/latest/Algebraic_foundations/Algebraic_foundations_2interoperable_8cpp-example.html
     (testpath/"surprise.cpp").write <<~EOS
@@ -72,10 +74,13 @@ class Cgal < Formula
       cmake_minimum_required(VERSION 3.1...3.15)
       find_package(CGAL COMPONENTS Qt5)
       add_definitions(-DCGAL_USE_BASIC_VIEWER -DQT_NO_KEYWORDS)
+      include_directories(surprise BEFORE SYSTEM #{Formula["qt@5"].opt_include})
       add_executable(surprise surprise.cpp)
+      target_include_directories(surprise BEFORE PUBLIC #{Formula["qt@5"].opt_include})
       target_link_libraries(surprise PUBLIC CGAL::CGAL_Qt5)
     EOS
-    system "cmake", "-L", "-DQt5_DIR=#{Formula["qt"].opt_lib}/cmake/Qt5",
+    system "cmake", "-L", "-DQt5_DIR=#{Formula["qt@5"].opt_lib}/cmake/Qt5",
+           "-DCMAKE_PREFIX_PATH=#{Formula["qt@5"].opt_lib}",
            "-DCMAKE_BUILD_RPATH=#{HOMEBREW_PREFIX}/lib", "-DCMAKE_PREFIX_PATH=#{prefix}", "."
     system "cmake", "--build", ".", "-v"
     assert_equal "15\n15", shell_output("./surprise").chomp

--- a/Formula/codequery.rb
+++ b/Formula/codequery.rb
@@ -4,6 +4,7 @@ class Codequery < Formula
   url "https://github.com/ruben2020/codequery/archive/v0.24.0.tar.gz"
   sha256 "39afc909eae3b0b044cefbbb0e33d09e8198a3b157cf4175fceb5a22217fe801"
   license "MPL-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "e878297e7d2e9199a0524a9de866b5d98c49746449bd34829cb2df1ad8062466"
@@ -13,7 +14,7 @@ class Codequery < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     args = std_cmake_args

--- a/Formula/coin3d.rb
+++ b/Formula/coin3d.rb
@@ -38,7 +38,7 @@ class Coin3d < Formula
   depends_on "ninja" => :build
   depends_on "swig" => :build
   depends_on "boost"
-  depends_on "pyside"
+  depends_on "pyside@2"
   depends_on "python@3.9"
 
   def install
@@ -83,6 +83,8 @@ class Coin3d < Formula
            "-o", "test"
     system "./test"
 
+    xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
+    ENV.append_path "PYTHONPATH", "#{Formula["pyside@2"].opt_lib}/python#{xy}/site-packages"
     system Formula["python@3.9"].opt_bin/"python3", "-c", <<~EOS
       from pivy.sogui import SoGui
       assert SoGui.init("test") is not None

--- a/Formula/color-code.rb
+++ b/Formula/color-code.rb
@@ -3,7 +3,7 @@ class ColorCode < Formula
   homepage "http://colorcode.laebisch.com/"
   url "http://colorcode.laebisch.com/download/ColorCode-0.8.5.tar.gz"
   sha256 "7c128db12af6ab11439eb710091b4a448100553a4d11d3a7c8dafdfbc57c1a85"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "efd44639662b77ac3216c32c7edfe71c184396daa9ed89cbac2e63411e2a0f90"
@@ -16,10 +16,11 @@ class ColorCode < Formula
     sha256 cellar: :any, yosemite:      "559f6c6ac094ff6d6e5f7157c3042ae819cd4a4233292c36dca21db85b152b90"
   end
 
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
-    system "qmake"
+    qt5 = Formula["qt@5"].opt_prefix
+    system "#{qt5}/bin/qmake"
     system "make"
     prefix.install "ColorCode.app"
     bin.write_exec_script "#{prefix}/ColorCode.app/Contents/MacOS/colorcode"

--- a/Formula/djview4.rb
+++ b/Formula/djview4.rb
@@ -4,6 +4,7 @@ class Djview4 < Formula
   url "https://downloads.sourceforge.net/project/djvu/DjView/4.12/djview-4.12.tar.gz"
   sha256 "5673c6a8b7e195b91a1720b24091915b8145de34879db1158bc936b100eaf3e3"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,7 +22,7 @@ class Djview4 < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "djvulibre"
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     system "autoreconf", "-fiv"
@@ -38,9 +39,14 @@ class Djview4 < Formula
     # Simply copy the application bundle where you want it.
     on_macos do
       prefix.install "src/djview.app"
+      bin.write_exec_script prefix/"djview.app/Contents/MacOS/djview"
     end
     on_linux do
       prefix.install "src/djview"
     end
+  end
+
+  test do
+    assert_predicate prefix/"djview.app", :exist?
   end
 end

--- a/Formula/dspdfviewer.rb
+++ b/Formula/dspdfviewer.rb
@@ -4,7 +4,7 @@ class Dspdfviewer < Formula
   url "https://github.com/dannyedel/dspdfviewer/archive/v1.15.1.tar.gz"
   sha256 "c5b6f8c93d732e65a27810286d49a4b1c6f777d725e26a207b14f6b792307b03"
   license "GPL-2.0"
-  revision 8
+  revision 9
   head "https://github.com/dannyedel/dspdfviewer.git"
 
   bottle do
@@ -29,7 +29,7 @@ class Dspdfviewer < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "openjpeg"
-  depends_on "qt"
+  depends_on "qt@5"
 
   resource "poppler" do
     url "https://poppler.freedesktop.org/poppler-0.65.0.tar.xz"

--- a/Formula/fceux.rb
+++ b/Formula/fceux.rb
@@ -5,6 +5,7 @@ class Fceux < Formula
       tag:      "fceux-2.3.0",
       revision: "65c5b0d2a1c08db75bb41340bfa5534578926944"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/TASVideos/fceux.git"
 
   bottle do
@@ -17,7 +18,7 @@ class Fceux < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "minizip"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "sdl2"
 
   def install

--- a/Formula/gammaray.rb
+++ b/Formula/gammaray.rb
@@ -4,6 +4,7 @@ class Gammaray < Formula
   url "https://github.com/KDAB/GammaRay/releases/download/v2.11.2/gammaray-2.11.2.tar.gz"
   sha256 "bba4f21a2bc81ec8ab50dce5218c7a375b92d64253c690490a6fcb384c2ff9f3"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/KDAB/GammaRay.git"
 
   bottle do
@@ -16,7 +17,7 @@ class Gammaray < Formula
 
   depends_on "cmake" => :build
   depends_on "graphviz"
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     # For Mountain Lion

--- a/Formula/gdcm.rb
+++ b/Formula/gdcm.rb
@@ -4,7 +4,7 @@ class Gdcm < Formula
   url "https://github.com/malaterre/GDCM/archive/v3.0.8.tar.gz"
   sha256 "47b96be345b1611784f9e65fc39367c7450c9a1ef81c21f8acddfb6207098315"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable

--- a/Formula/gnuplot.rb
+++ b/Formula/gnuplot.rb
@@ -4,7 +4,7 @@ class Gnuplot < Formula
   url "https://downloads.sourceforge.net/project/gnuplot/gnuplot/5.4.1/gnuplot-5.4.1.tar.gz"
   sha256 "6b690485567eaeb938c26936e5e0681cf70c856d273cc2c45fabf64d8bc6590e"
   license "gnuplot"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1
@@ -27,7 +27,7 @@ class Gnuplot < Formula
   depends_on "libcerf"
   depends_on "lua"
   depends_on "pango"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "readline"
 
   def install

--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -6,6 +6,7 @@ class Gnuradio < Formula
   url "https://github.com/gnuradio/gnuradio/releases/download/v3.9.0.0/gnuradio-3.9.0.0.tar.xz"
   sha256 "0a2622933c96a4b22405c7656b8af0db32762834317ec2b90bff0a0a5a4f75cb"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/gnuradio/gnuradio.git"
 
   bottle do
@@ -30,7 +31,7 @@ class Gnuradio < Formula
   depends_on "pygobject3"
   depends_on "pyqt"
   depends_on "python@3.9"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "qwt"
   depends_on "uhd"
   depends_on "volk"

--- a/Formula/gpsbabel.rb
+++ b/Formula/gpsbabel.rb
@@ -4,6 +4,7 @@ class Gpsbabel < Formula
   url "https://github.com/gpsbabel/gpsbabel/archive/gpsbabel_1_7_0.tar.gz"
   sha256 "30b186631fb43db576b8177385ed5c31a5a15c02a6bc07bae1e0d7af9058a797"
   license "GPL-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -19,7 +20,7 @@ class Gpsbabel < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libusb"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "shapelib"
 
   uses_from_macos "zlib"

--- a/Formula/icemon.rb
+++ b/Formula/icemon.rb
@@ -4,6 +4,7 @@ class Icemon < Formula
   url "https://github.com/icecc/icemon/archive/v3.3.tar.gz"
   sha256 "3caf14731313c99967f6e4e11ff261b061e4e3d0c7ef7565e89b12e0307814ca"
   license "GPL-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "a975fb1f42d8a4f3b854f435998ea86629f275bce32ec9d66d49554d3677cc8d"
@@ -18,7 +19,7 @@ class Icemon < Formula
   depends_on "sphinx-doc" => :build
   depends_on "icecream"
   depends_on "lzo"
-  depends_on "qt"
+  depends_on "qt@5"
 
   resource "ecm" do
     url "https://github.com/KDE/extra-cmake-modules/archive/v5.62.0.tar.gz"

--- a/Formula/inspectrum.rb
+++ b/Formula/inspectrum.rb
@@ -4,6 +4,7 @@ class Inspectrum < Formula
   url "https://github.com/miek/inspectrum/archive/v0.2.3.tar.gz"
   sha256 "7be5be96f50b0cea5b3dd647f06cc00adfa805a395484aa2ab84cf3e49b7227b"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/miek/inspectrum.git"
 
   bottle do
@@ -17,7 +18,7 @@ class Inspectrum < Formula
   depends_on "pkg-config" => :build
   depends_on "fftw"
   depends_on "liquid-dsp"
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -1,8 +1,8 @@
 class Jack < Formula
   desc "Audio Connection Kit"
   homepage "https://jackaudio.org/"
-  url "https://github.com/jackaudio/jack2/archive/v1.9.16.tar.gz"
-  sha256 "e176d04de94dcaa3f9d32ca1825091e1b938783a78c84e7466abd06af7637d37"
+  url "https://github.com/jackaudio/jack2/archive/v1.9.17.tar.gz"
+  sha256 "38f674bbc57852a8eb3d9faa1f96a0912d26f7d5df14c11005ad499c8ae352f2"
   license "GPL-2.0-or-later"
 
   livecheck do

--- a/Formula/kde-extra-cmake-modules.rb
+++ b/Formula/kde-extra-cmake-modules.rb
@@ -4,6 +4,7 @@ class KdeExtraCmakeModules < Formula
   url "https://download.kde.org/stable/frameworks/5.79/extra-cmake-modules-5.79.0.tar.xz"
   sha256 "b29602db99c566d88fa92106abe114bd57b7ffc6ca20773426f896ffde68bed8"
   license all_of: ["BSD-2-Clause", "BSD-3-Clause", "MIT"]
+  revision 1
   head "https://invent.kde.org/frameworks/extra-cmake-modules.git"
 
   # We check the tags from the `head` repository because the latest stable
@@ -21,7 +22,7 @@ class KdeExtraCmakeModules < Formula
   end
 
   depends_on "cmake" => [:build, :test]
-  depends_on "qt" => :build
+  depends_on "qt@5" => :build
   depends_on "sphinx-doc" => :build
 
   def install

--- a/Formula/kde-karchive.rb
+++ b/Formula/kde-karchive.rb
@@ -9,6 +9,7 @@ class KdeKarchive < Formula
     "LGPL-2.0-or-later",
     any_of: ["LGPL-2.0-only", "LGPL-3.0-only"],
   ]
+  revision 1
   head "https://invent.kde.org/frameworks/karchive.git"
 
   bottle do
@@ -23,7 +24,7 @@ class KdeKarchive < Formula
   depends_on "graphviz" => :build
   depends_on "kde-extra-cmake-modules" => [:build, :test]
 
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "xz"
 
   uses_from_macos "bzip2"
@@ -43,8 +44,9 @@ class KdeKarchive < Formula
   end
 
   test do
+    ENV.delete "CPATH"
     args = std_cmake_args
-    args << "-DQt5Core_DIR=#{Formula["qt"].opt_prefix/"lib/cmake/Qt5Core"}"
+    args << "-DQt5Core_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5Core"}"
 
     %w[bzip2gzip
        helloworld

--- a/Formula/kde-kdoctools.rb
+++ b/Formula/kde-kdoctools.rb
@@ -9,6 +9,7 @@ class KdeKdoctools < Formula
     "LGPL-2.1-or-later",
     any_of: ["LGPL-2.1-only", "LGPL-3.0-only"],
   ]
+  revision 1
   head "https://invent.kde.org/frameworks/kdoctools.git"
 
   bottle do
@@ -95,7 +96,7 @@ class KdeKdoctools < Formula
     cp_r (pkgshare/"tests"), testpath
 
     args = std_cmake_args
-    args << "-DQt5_DIR=#{Formula["qt"].opt_prefix/"lib/cmake/Qt5"}"
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
 
     system "cmake", testpath.to_s, *args
     system "make"

--- a/Formula/kde-ki18n.rb
+++ b/Formula/kde-ki18n.rb
@@ -8,6 +8,7 @@ class KdeKi18n < Formula
     "LGPL-2.0-or-later",
     any_of: ["LGPL-2.1-only", "LGPL-3.0-only"],
   ]
+  revision 1
   head "https://invent.kde.org/frameworks/ki18n.git"
 
   bottle do
@@ -22,7 +23,7 @@ class KdeKi18n < Formula
   depends_on "graphviz" => :build
   depends_on "kde-extra-cmake-modules" => [:build, :test]
   depends_on "gettext"
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     args = std_cmake_args
@@ -56,7 +57,7 @@ class KdeKi18n < Formula
     cp_r (pkgshare/"autotests"), testpath
 
     args = std_cmake_args
-    args << "-DQt5_DIR=#{Formula["qt"].opt_prefix/"lib/cmake/Qt5"}"
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
     args << "-DLibIntl_INCLUDE_DIRS=#{Formula["gettext"].include}"
     args << "-DLibIntl_LIBRARIES=#{Formula["gettext"].lib/"libintl.dylib"}"
 

--- a/Formula/kde-threadweaver.rb
+++ b/Formula/kde-threadweaver.rb
@@ -4,6 +4,7 @@ class KdeThreadweaver < Formula
   url "https://download.kde.org/stable/frameworks/5.79/threadweaver-5.79.0.tar.xz"
   sha256 "297ca4454e9dc526af8033ee47932a63e3ef3d76868a75dfa66df0f7a04d5918"
   license "LGPL-2.0-or-later"
+  revision 1
   head "https://invent.kde.org/frameworks/threadweaver.git"
 
   bottle do
@@ -17,7 +18,7 @@ class KdeThreadweaver < Formula
   depends_on "doxygen" => :build
   depends_on "graphviz" => :build
   depends_on "kde-extra-cmake-modules" => [:build, :test]
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     args = std_cmake_args
@@ -33,7 +34,8 @@ class KdeThreadweaver < Formula
   end
 
   test do
-    qt5_arg = "-DQt5Core_DIR=#{Formula["qt"].opt_prefix/"lib/cmake/Qt5Core"}"
+    ENV.delete "CPATH"
+    qt5_arg = "-DQt5Core_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5Core"}"
     system "cmake", (pkgshare/"examples/HelloWorld"), *std_cmake_args, qt5_arg
     system "make"
 

--- a/Formula/libgr.rb
+++ b/Formula/libgr.rb
@@ -4,6 +4,7 @@ class Libgr < Formula
   url "https://github.com/sciapp/gr/archive/v0.55.0.tar.gz"
   sha256 "070ca1cb0a54f90446e2cc0a0b331a112e0842e32a000bad2135e26ce09f5787"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "ac99069ce1dea838922beedb4a9bc6cc3c7e9aa2fc77b6e613aba07a7aa22283"
@@ -17,7 +18,7 @@ class Libgr < Formula
   depends_on "glfw"
   depends_on "libtiff"
   depends_on "qhull"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "zeromq"
 
   def install

--- a/Formula/mgba.rb
+++ b/Formula/mgba.rb
@@ -4,7 +4,7 @@ class Mgba < Formula
   url "https://github.com/mgba-emu/mgba/archive/0.8.4.tar.gz"
   sha256 "6b94873dac9040fd6fd9f13f76dc48f342e954f3b4cf82717b59601c3a32b72c"
   license "MPL-2.0"
-  revision 2
+  revision 3
   head "https://github.com/mgba-emu/mgba.git"
 
   livecheck do
@@ -25,7 +25,7 @@ class Mgba < Formula
   depends_on "libepoxy"
   depends_on "libpng"
   depends_on "libzip"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "sdl2"
 
   def install

--- a/Formula/mlt.rb
+++ b/Formula/mlt.rb
@@ -4,7 +4,7 @@ class Mlt < Formula
   url "https://github.com/mltframework/mlt/releases/download/v6.24.0/mlt-6.24.0.tar.gz"
   sha256 "3b977c5632329fca7634d0034162df6d5b79cde3256bac43e7ba8353acced61e"
   license "LGPL-2.1-only"
-  revision 1
+  revision 2
   head "https://github.com/mltframework/mlt.git"
 
   bottle do
@@ -24,7 +24,7 @@ class Mlt < Formula
   depends_on "libvorbis"
   depends_on "opencv@3"
   depends_on "pango"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "sdl2"
   depends_on "sox"
 

--- a/Formula/mruby.rb
+++ b/Formula/mruby.rb
@@ -4,6 +4,7 @@ class Mruby < Formula
   url "https://github.com/mruby/mruby/archive/2.1.2.tar.gz"
   sha256 "4dc0017e36d15e81dc85953afb2a643ba2571574748db0d8ede002cefbba053b"
   license "MIT"
+  revision 1
   head "https://github.com/mruby/mruby.git"
 
   bottle do
@@ -19,6 +20,7 @@ class Mruby < Formula
   uses_from_macos "ruby"
 
   def install
+    inreplace "build_config.rb", /default/, "full-core"
     system "make"
 
     cd "build/host/" do

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -5,6 +5,7 @@ class Octave < Formula
   mirror "https://ftpmirror.gnu.org/octave/octave-6.2.0.tar.xz"
   sha256 "7b721324cccb3eaeb4efb455508201ac8ccbd200f77106f52342f9ab7f022d1a"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "50a36fca58813ff8616c80706d4b00755e88c045ac56618624e2b64eee17fc22"
@@ -50,7 +51,7 @@ class Octave < Formula
   depends_on "qhull"
   depends_on "qrupdate"
   depends_on "qscintilla2"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "readline"
   depends_on "suite-sparse"
   depends_on "sundials"
@@ -74,10 +75,10 @@ class Octave < Formula
     ENV["QCOLLECTIONGENERATOR"] = "qhelpgenerator"
     # These "shouldn't" be necessary, but the build breaks without them.
     # https://savannah.gnu.org/bugs/?55883
-    ENV["QT_CPPFLAGS"]="-I#{Formula["qt"].opt_include}"
-    ENV.append "CPPFLAGS", "-I#{Formula["qt"].opt_include}"
-    ENV["QT_LDFLAGS"]="-F#{Formula["qt"].opt_lib}"
-    ENV.append "LDFLAGS", "-F#{Formula["qt"].opt_lib}"
+    ENV["QT_CPPFLAGS"]="-I#{Formula["qt@5"].opt_include}"
+    ENV.append "CPPFLAGS", "-I#{Formula["qt@5"].opt_include}"
+    ENV["QT_LDFLAGS"]="-F#{Formula["qt@5"].opt_lib}"
+    ENV.append "LDFLAGS", "-F#{Formula["qt@5"].opt_lib}"
 
     system "./bootstrap" if build.head?
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -3,7 +3,7 @@ class Opencsg < Formula
   homepage "http://www.opencsg.org"
   url "http://www.opencsg.org/OpenCSG-1.4.2.tar.gz"
   sha256 "d952ec5d3a2e46a30019c210963fcddff66813efc9c29603b72f9553adff4afb"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "441628c8cb74c7bf2eb12999c0d6befd2f94e11597c6707df86512eed2efefa2"
@@ -13,7 +13,7 @@ class Opencsg < Formula
     sha256 cellar: :any, high_sierra:   "67d059404b3a950b73ac4ab6096727c90f24fc1309871969c0d46a7df429de5b"
   end
 
-  depends_on "qt" => :build
+  depends_on "qt@5" => :build
   depends_on "glew"
 
   # This patch disabling building examples
@@ -23,7 +23,8 @@ class Opencsg < Formula
   end
 
   def install
-    system "qmake", "-r", "INSTALLDIR=#{prefix}",
+    qt5 = Formula["qt@5"].opt_prefix
+    system "#{qt5}/bin/qmake", "-r", "INSTALLDIR=#{prefix}",
       "INCLUDEPATH+=#{Formula["glew"].opt_include}",
       "LIBS+=-L#{Formula["glew"].opt_lib} -lGLEW"
     system "make", "install"

--- a/Formula/pc6001vx.rb
+++ b/Formula/pc6001vx.rb
@@ -4,6 +4,7 @@ class Pc6001vx < Formula
   url "https://eighttails.up.seesaa.net/bin/PC6001VX_3.7.0_src.tar.gz"
   sha256 "8a735fa6769b1a268fc64c0ed92d7e27c5990b120f53ad50be255024db35b2b8"
   license "LGPL-2.1-or-later"
+  revision 1
   head "https://github.com/eighttails/PC6001VX.git"
 
   bottle do
@@ -15,7 +16,7 @@ class Pc6001vx < Formula
 
   depends_on "pkg-config" => :build
   depends_on "ffmpeg"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "sdl2"
 
   def install
@@ -27,7 +28,8 @@ class Pc6001vx < Formula
     # Use libc++ explicitly, otherwise build fails
     ENV.append_to_cflags "-stdlib=libc++" if ENV.compiler == :clang
 
-    system "qmake", "PREFIX=#{prefix}", "QMAKE_CXXFLAGS=#{ENV.cxxflags}", "CONFIG+=c++11"
+    qt5 = Formula["qt@5"].opt_prefix
+    system "#{qt5}/bin/qmake", "PREFIX=#{prefix}", "QMAKE_CXXFLAGS=#{ENV.cxxflags}", "CONFIG+=c++11"
     system "make"
     prefix.install "PC6001VX.app"
     bin.write_exec_script "#{prefix}/PC6001VX.app/Contents/MacOS/PC6001VX"

--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -4,6 +4,7 @@ class Poppler < Formula
   url "https://poppler.freedesktop.org/poppler-21.02.0.tar.xz"
   sha256 "5c14759c99891e6e472aced6d5f0ff1dacf85d80cd9026d365c55c653edf792c"
   license "GPL-2.0-only"
+  revision 1
   head "https://gitlab.freedesktop.org/poppler/poppler.git"
 
   livecheck do
@@ -52,7 +53,8 @@ class Poppler < Formula
       -DBUILD_GTK_TESTS=OFF
       -DENABLE_CMS=lcms2
       -DENABLE_GLIB=ON
-      -DENABLE_QT5=ON
+      -DENABLE_QT5=OFF
+      -DENABLE_QT6=ON
       -DENABLE_UNSTABLE_API_ABI_HEADERS=ON
       -DWITH_GObjectIntrospection=ON
     ]
@@ -73,7 +75,7 @@ class Poppler < Formula
     [
       "#{lib}/libpoppler-cpp.dylib",
       "#{lib}/libpoppler-glib.dylib",
-      "#{lib}/libpoppler-qt5.dylib",
+      "#{lib}/libpoppler-qt6.dylib",
       *Dir["#{bin}/*"],
     ].each do |f|
       macho = MachO.open(f)

--- a/Formula/pushpin.rb
+++ b/Formula/pushpin.rb
@@ -4,6 +4,7 @@ class Pushpin < Formula
   url "https://dl.bintray.com/fanout/source/pushpin-1.31.0.tar.bz2"
   sha256 "62504863297a8ec1833486affaff91fade7a970dd43b9c8c2add5944603481ac"
   license "AGPL-3.0-or-later"
+  revision 1
   head "https://github.com/fanout/pushpin.git"
 
   bottle do
@@ -17,7 +18,7 @@ class Pushpin < Formula
   depends_on "condure"
   depends_on "mongrel2"
   depends_on "python@3.9"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "zeromq"
   depends_on "zurl"
 

--- a/Formula/pyqt.rb
+++ b/Formula/pyqt.rb
@@ -4,6 +4,7 @@ class Pyqt < Formula
   url "https://files.pythonhosted.org/packages/28/6c/640e3f5c734c296a7193079a86842a789edb7988dca39eab44579088a1d1/PyQt5-5.15.2.tar.gz"
   sha256 "372b08dc9321d1201e4690182697c5e7ffb2e0770e6b4a45519025134b12e4fc"
   license "GPL-3.0-only"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "8ccb745e9c567b384ca31f8e3f4b4943240d44b6c51e8e49b38073eb2fd7a835"
@@ -13,7 +14,7 @@ class Pyqt < Formula
   end
 
   depends_on "python@3.9"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "sip"
 
   resource "PyQt5-sip" do
@@ -30,7 +31,7 @@ class Pyqt < Formula
             "--sipdir=#{share}/sip/Qt5",
             # sip.h could not be found automatically
             "--sip-incdir=#{Formula["sip"].opt_include}",
-            "--qmake=#{Formula["qt"].bin}/qmake",
+            "--qmake=#{Formula["qt@5"].bin}/qmake",
             # Force deployment target to avoid libc++ issues
             "QMAKE_MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}",
             "--designer-plugindir=#{pkgshare}/plugins",

--- a/Formula/pyside.rb
+++ b/Formula/pyside.rb
@@ -1,13 +1,13 @@
 class Pyside < Formula
   desc "Official Python bindings for Qt"
   homepage "https://wiki.qt.io/Qt_for_Python"
-  url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.2-src/pyside-setup-opensource-src-5.15.2.tar.xz"
-  sha256 "b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418"
+  url "https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-6.0.1-src/pyside-setup-opensource-src-6.0.1.tar.xz"
+  sha256 "baac59a71d5d8d28badd4b484b3722500a6616684f932f0652b33a5b5feaf365"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-3.0-only"]
 
   livecheck do
-    url "https://download.qt.io/official_releases/QtForPython/pyside2/"
-    regex(%r{href=.*?PySide2[._-]v?(\d+(?:\.\d+)+)-src/}i)
+    url "https://download.qt.io/official_releases/QtForPython/pyside6/"
+    regex(%r{href=.*?PySide6[._-]v?(\d+(?:\.\d+)+)-src/}i)
   end
 
   bottle do
@@ -40,14 +40,14 @@ class Pyside < Formula
   end
 
   test do
-    system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2"
-    system Formula["python@3.9"].opt_bin/"python3", "-c", "import shiboken2"
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide6"
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "import shiboken6"
 
+    # TODO: add modules `Position`, `Multimedia`and `WebEngineWidgets` when qt6.2 is released
+    # arm support will finish in qt6.1
     modules = %w[
       Core
       Gui
-      Location
-      Multimedia
       Network
       Quick
       Svg
@@ -55,11 +55,7 @@ class Pyside < Formula
       Xml
     ]
 
-    # QT web engine is currently not supported on Apple
-    # silicon. Re-enable it once it has been enabled in the qt.rb.
-    modules << "WebEngineWidgets" unless Hardware::CPU.arm?
-
-    modules.each { |mod| system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2.Qt#{mod}" }
+    modules.each { |mod| system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide6.Qt#{mod}" }
 
     pyincludes = shell_output("#{Formula["python@3.9"].opt_bin}/python3-config --includes").chomp.split
     pylib = shell_output("#{Formula["python@3.9"].opt_bin}/python3-config --ldflags --embed").chomp.split
@@ -70,13 +66,13 @@ class Pyside < Formula
       int main()
       {
         Py_Initialize();
-        Shiboken::AutoDecRef module(Shiboken::Module::import("shiboken2"));
+        Shiboken::AutoDecRef module(Shiboken::Module::import("shiboken6"));
         assert(!module.isNull());
         return 0;
       }
     EOS
     system ENV.cxx, "-std=c++11", "test.cpp",
-           "-I#{include}/shiboken2", "-L#{lib}", "-lshiboken2.cpython-#{pyver}-darwin",
+           "-I#{include}/shiboken6", "-L#{lib}", "-lshiboken6.cpython-#{pyver}-darwin",
            *pyincludes, *pylib, "-o", "test"
     system "./test"
   end

--- a/Formula/pyside@2.rb
+++ b/Formula/pyside@2.rb
@@ -1,0 +1,76 @@
+class PysideAT2 < Formula
+  desc "Official Python bindings for Qt"
+  homepage "https://wiki.qt.io/Qt_for_Python"
+  url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.2-src/pyside-setup-opensource-src-5.15.2.tar.xz"
+  sha256 "b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-3.0-only"]
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  depends_on "llvm"
+  depends_on "python@3.9"
+  depends_on "qt@5"
+
+  def install
+    xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
+
+    args = std_cmake_args + %W[
+      -DCMAKE_PREFIX_PATH=#{Formula["qt@5"].opt_lib}
+      -GNinja
+      -DPYTHON_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python#{xy}
+      -DCMAKE_INSTALL_RPATH=#{lib}
+    ]
+
+    mkdir "build" do
+      system "cmake", *args, ".."
+      system "ninja", "install"
+    end
+  end
+
+  test do
+    xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
+    ENV.append_path "PYTHONPATH", "#{lib}/python#{xy}/site-packages"
+
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2"
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "import shiboken2"
+
+    modules = %w[
+      Core
+      Gui
+      Location
+      Multimedia
+      Network
+      Quick
+      Svg
+      Widgets
+      Xml
+    ]
+
+    # QT web engine is currently not supported on Apple
+    # silicon. Re-enable it once it has been enabled in the qt.rb.
+    modules << "WebEngineWidgets" unless Hardware::CPU.arm?
+
+    modules.each { |mod| system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2.Qt#{mod}" }
+
+    pyincludes = shell_output("#{Formula["python@3.9"].opt_bin}/python3-config --includes").chomp.split
+    pylib = shell_output("#{Formula["python@3.9"].opt_bin}/python3-config --ldflags --embed").chomp.split
+    pyver = Language::Python.major_minor_version(Formula["python@3.9"].opt_bin/"python3").to_s.delete(".")
+
+    (testpath/"test.cpp").write <<~EOS
+      #include <shiboken.h>
+      int main()
+      {
+        Py_Initialize();
+        Shiboken::AutoDecRef module(Shiboken::Module::import("shiboken2"));
+        assert(!module.isNull());
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "test.cpp",
+           "-I#{include}/shiboken2", "-L#{lib}", "-lshiboken2.cpython-#{pyver}-darwin",
+           *pyincludes, *pylib, "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/qbs.rb
+++ b/Formula/qbs.rb
@@ -4,6 +4,7 @@ class Qbs < Formula
   url "https://download.qt.io/official_releases/qbs/1.18.0/qbs-src-1.18.0.tar.gz"
   sha256 "3d0211e021bea3e56c4d5a65c789d11543cc0b6e88f1bfe23c2f8ebf0f89f8d4"
   license :cannot_represent
+  revision 1
   head "git://code.qt.io/qbs/qbs.git"
 
   bottle do
@@ -14,10 +15,14 @@ class Qbs < Formula
     sha256 cellar: :any, mojave:        "9ebe2cac24aa15e5cfe8411e00286a8ee9fdfaa2de5851fa54036625deb775b4"
   end
 
-  depends_on "qt"
+  # https://www.qt.io/blog/2018/10/29/deprecation-of-qbs
+  deprecate! because: :deprecated_upstream
+
+  depends_on "qt@5"
 
   def install
-    system "qmake", "qbs.pro", "QBS_INSTALL_PREFIX=#{prefix}", "CONFIG+=qbs_disable_rpath"
+    qt5 = Formula["qt@5"].opt_prefix
+    system "#{qt5}/bin/qmake", "qbs.pro", "QBS_INSTALL_PREFIX=#{prefix}", "CONFIG+=qbs_disable_rpath"
     system "make"
     system "make", "install", "INSTALL_ROOT=/"
   end

--- a/Formula/qca.rb
+++ b/Formula/qca.rb
@@ -4,6 +4,7 @@ class Qca < Formula
   url "https://download.kde.org/stable/qca/2.3.2/qca-2.3.2.tar.xz"
   sha256 "4697600237c4bc3a979e87d2cc80624f27b06280e635f5d90ec7dd4d2a9f606d"
   license "LGPL-2.1-or-later"
+  revision 1
   head "https://invent.kde.org/libraries/qca.git"
 
   livecheck do
@@ -26,7 +27,7 @@ class Qca < Formula
   depends_on "nss"
   depends_on "openssl@1.1"
   depends_on "pkcs11-helper"
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     args = std_cmake_args

--- a/Formula/qcachegrind.rb
+++ b/Formula/qcachegrind.rb
@@ -4,6 +4,7 @@ class Qcachegrind < Formula
   url "https://download.kde.org/Attic/applications/19.08.3/src/kcachegrind-19.08.3.tar.xz"
   sha256 "8fc5e0643bb826b07cb5d283b8bd6fd5da4979f6125b43b1db3a9db60b02a36a"
   license "GPL-2.0-or-later"
+  revision 1
 
   # We don't match versions like 19.07.80 or 19.07.90 where the patch number
   # is 80+ (beta) or 90+ (RC), as these aren't stable releases.
@@ -21,13 +22,13 @@ class Qcachegrind < Formula
   end
 
   depends_on "graphviz"
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     spec = (ENV.compiler == :clang) ? "macx-clang" : "macx-g++"
     spec << "-arm64" if Hardware::CPU.arm?
     cd "qcachegrind" do
-      system "#{Formula["qt"].opt_bin}/qmake", "-spec", spec,
+      system "#{Formula["qt@5"].opt_bin}/qmake", "-spec", spec,
                                                "-config", "release"
       system "make"
       prefix.install "qcachegrind.app"

--- a/Formula/qcli.rb
+++ b/Formula/qcli.rb
@@ -4,7 +4,7 @@ class Qcli < Formula
   url "https://github.com/bavc/qctools/archive/v1.2.tar.gz"
   sha256 "d648a5fb6076c6367e4eac320018ccbd1eddcb2160ce175b361b46fcf0d4a710"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/bavc/qctools.git"
 
   bottle do
@@ -15,18 +15,19 @@ class Qcli < Formula
 
   depends_on "pkg-config" => :build
   depends_on "ffmpeg"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "qwt"
 
   def install
+    qt5 = Formula["qt@5"].opt_prefix
     ENV["QCTOOLS_USE_BREW"]="true"
 
     cd "Project/QtCreator/qctools-lib" do
-      system "qmake", "qctools-lib.pro"
+      system "#{qt5}/bin/qmake", "qctools-lib.pro"
       system "make"
     end
     cd "Project/QtCreator/qctools-cli" do
-      system "qmake", "qctools-cli.pro"
+      system "#{qt5}/bin/qmake", "qctools-cli.pro"
       system "make"
       bin.install "qcli"
     end

--- a/Formula/qjackctl.rb
+++ b/Formula/qjackctl.rb
@@ -19,7 +19,7 @@ class Qjackctl < Formula
 
   depends_on "pkg-config" => :build
   depends_on "jack"
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     ENV.cxx11
@@ -29,7 +29,7 @@ class Qjackctl < Formula
                           "--disable-xunique",
                           "--prefix=#{prefix}",
                           "--with-jack=#{Formula["jack"].opt_prefix}",
-                          "--with-qt=#{Formula["qt"].opt_prefix}"
+                          "--with-qt=#{Formula["qt@5"].opt_prefix}"
 
     system "make", "install"
     prefix.install bin/"qjackctl.app"

--- a/Formula/qjson.rb
+++ b/Formula/qjson.rb
@@ -4,7 +4,7 @@ class Qjson < Formula
   url "https://github.com/flavio/qjson/archive/0.9.0.tar.gz"
   sha256 "e812617477f3c2bb990561767a4cd8b1d3803a52018d4878da302529552610d4"
   license "LGPL-2.1"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "c1801c1ef5510834f151d8fb998153c6b1c3e66cb169f007884e8086ba5b62d4"
@@ -18,7 +18,7 @@ class Qjson < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     system "cmake", ".", *std_cmake_args
@@ -35,8 +35,8 @@ class Qjson < Formula
     EOS
     system ENV.cxx, "test.cpp", "-o", "test", "-std=c++11", "-I#{include}",
                     "-L#{lib}", "-lqjson-qt5",
-                    "-I#{Formula["qt"].opt_include}",
-                    "-F#{Formula["qt"].opt_lib}", "-framework", "QtCore"
+                    "-I#{Formula["qt@5"].opt_include}",
+                    "-F#{Formula["qt@5"].opt_lib}", "-framework", "QtCore"
     system "./test"
   end
 end

--- a/Formula/qmmp.rb
+++ b/Formula/qmmp.rb
@@ -4,6 +4,7 @@ class Qmmp < Formula
   url "https://downloads.sourceforge.net/project/qmmp-dev/qmmp/qmmp-1.4.4.tar.bz2"
   sha256 "b1945956109fd9c7844ee5780142c0d24564b88327dc2f9a61d29386abcf9d54"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://svn.code.sf.net/p/qmmp-dev/code/branches/qmmp-1.4/"
 
   livecheck do
@@ -33,7 +34,7 @@ class Qmmp < Formula
   depends_on "musepack"
   depends_on "opus"
   depends_on "opusfile"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "taglib"
 
   def install

--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -4,7 +4,7 @@ class Qscintilla2 < Formula
   url "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.6/QScintilla-2.11.6.tar.gz"
   sha256 "e7346057db47d2fb384467fafccfcb13aa0741373c5d593bc72b55b2f0dd20a7"
   license "GPL-3.0-only"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://www.riverbankcomputing.com/software/qscintilla/download"
@@ -20,7 +20,7 @@ class Qscintilla2 < Formula
 
   depends_on "pyqt"
   depends_on "python@3.9"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "sip"
 
   # Fix for rpath in library install name. Taken from
@@ -47,7 +47,8 @@ class Qscintilla2 < Formula
         s.gsub! "$$[QT_INSTALL_HEADERS]", include
       end
 
-      system "qmake", "qscintilla.pro", *args
+      qt5 = Formula["qt@5"].opt_prefix
+      system "#{qt5}/bin/qmake", "qscintilla.pro", *args
       system "make"
       system "make", "install"
     end

--- a/Formula/qsoas.rb
+++ b/Formula/qsoas.rb
@@ -1,14 +1,13 @@
 class Qsoas < Formula
   desc "Versatile software for data analysis"
-  homepage "http://bip.cnrs-mrs.fr/bip06/qsoas/"
-  url "http://bip.cnrs-mrs.fr/bip06/qsoas/downloads/qsoas-2.2.0.tar.gz"
-  sha256 "acefcbb4286a6e0bf96353f924115d04a77d241962ceda890508bca19ee3b4f6"
-  license "GPL-2.0"
-  revision 1
+  homepage "https://bip.cnrs.fr/groups/bip06/software/"
+  url "https://bip.cnrs.fr/wp-content/uploads/qsoas/qsoas-3.0.tar.gz"
+  sha256 "54b54f54363f69a9845b3e9aa4da7dae9ceb7bb0f3ed59ba92ffa3b408163850"
+  license "GPL-2.0-only"
 
   livecheck do
-    url "http://bip.cnrs-mrs.fr/bip06/qsoas/downloads.html"
-    regex(/href=.*?qsoas[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://github.com/fourmond/QSoas.git"
+    regex(/(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do
@@ -20,18 +19,14 @@ class Qsoas < Formula
 
   depends_on "gsl"
   depends_on "mruby"
-  depends_on "qt"
-
-  patch do
-    url "https://github.com/fourmond/QSoas/compare/2.2.0...release.diff?full_index=1"
-    sha256 "06b122580b6da169730ded812290eb53e1a6ff36d6c20ab9930c3e50b7a79b60"
-  end
+  depends_on "qt@5"
 
   def install
     gsl = Formula["gsl"].opt_prefix
     mruby = Formula["mruby"].opt_prefix
+    qt5 = Formula["qt@5"].opt_prefix
 
-    system "qmake", "MRUBY_DIR=#{mruby}", "GSL_DIR=#{gsl}/include",
+    system "#{qt5}/bin/qmake", "MRUBY_DIR=#{mruby}", "GSL_DIR=#{gsl}/include",
                     "QMAKE_LFLAGS=-L#{mruby}/lib -L#{gsl}/lib"
     system "make"
 

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -1,12 +1,12 @@
-# Patches for Qt must be at the very least submitted to Qt's Gerrit codereview
-# rather than their bug-report Jira. The latter is rarely reviewed by Qt.
 class Qt < Formula
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
-  url "https://download.qt.io/official_releases/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
-  mirror "https://mirrors.dotsrc.org/qtproject/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/qt/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
-  sha256 "3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240"
+  url "https://download.qt.io/official_releases/qt/6.0/6.0.1/single/qt-everywhere-src-6.0.1.tar.xz"
+  mirror "http://mirror.bit.edu.cn/qtproject/official_releases/qt/6.0/6.0.1/single/qt-everywhere-src-6.0.1.tar.xz"
+  mirror "http://ftp.jaist.ac.jp/pub/qtproject/official_releases/qt/6.0/6.0.1/single/qt-everywhere-src-6.0.1.tar.xz"
+  mirror "https://mirrors.dotsrc.org/qtproject/official_releases/qt/6.0/6.0.1/single/qt-everywhere-src-6.0.1.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/qt/official_releases/qt/6.0/6.0.1/single/qt-everywhere-src-6.0.1.tar.xz"
+  sha256 "d13cfac103cd80b216cd2f73d0211dd6b1a1de2516911c89ce9c5ed14d9631a8"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
   head "https://code.qt.io/qt/qt5.git", branch: "dev", shallow: false
 
@@ -24,72 +24,107 @@ class Qt < Formula
     sha256 cellar: :any, mojave:        "25c4a693c787860b090685ac5cbeea18128d4d6361eed5b1bfed1b16ff6e4494"
   end
 
-  keg_only "Qt 5 has CMake issues when linked"
-
+  depends_on "cmake" => [:build, :test]
+  depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on xcode: :build
-  depends_on macos: :sierra
 
-  uses_from_macos "gperf" => :build
-  uses_from_macos "bison"
-  uses_from_macos "flex"
+  depends_on "assimp"
+  depends_on "dbus"
+  depends_on "double-conversion"
+  depends_on "freetype"
+  depends_on "glib"
+  depends_on "icu4c"
+  depends_on "jasper"
+  depends_on "jpeg"
+  depends_on "libb2"
+  depends_on "libpng"
+  depends_on "libproxy"
+  depends_on "libtiff"
+  depends_on "pcre2"
+  depends_on "python@3.9"
+  depends_on "webp"
+  depends_on "zstd"
+
+  uses_from_macos "cups"
+  uses_from_macos "krb5"
+  uses_from_macos "perl"
   uses_from_macos "sqlite"
+  uses_from_macos "zlib"
 
-  # Find SDK for 11.x macOS
-  # Upstreamed, remove when Qt updates Chromium
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/92d4cf/qt/5.15.2.diff"
-    sha256 "fa99c7ffb8a510d140c02694a11e6c321930f43797dbf2fe8f2476680db4c2b2"
+  resource "qtimageformats" do
+    url "https://download.qt.io/official_releases/additional_libraries/qtimageformats/6.0/6.0.1/qtimageformats-everywhere-src-6.0.1.tar.xz"
+    mirror "http://mirror.bit.edu.cn/qtproject/official_releases/additional_libraries/qtimageformats/6.0/6.0.1/qtimageformats-everywhere-src-6.0.1.tar.xz"
+    mirror "http://ftp.jaist.ac.jp/pub/qtproject/official_releases/additional_libraries/qtimageformats/6.0/6.0.1/qtimageformats-everywhere-src-6.0.1.tar.xz"
+    mirror "https://mirrors.dotsrc.org/qtproject/official_releases/additional_libraries/qtimageformats/6.0/6.0.1/qtimageformats-everywhere-src-6.0.1.tar.xz"
+    mirror "https://mirrors.ocf.berkeley.edu/qt/official_releases/additional_libraries/qtimageformats/6.0/6.0.1/qtimageformats-everywhere-src-6.0.1.tar.xz"
+    sha256 "27a9d6e85dcd56ad981ef2aac27844e782f8cce0598f83283e6fbbd2a3810105"
   end
 
-  # Patch for qmake on ARM
-  # https://codereview.qt-project.org/c/qt/qtbase/+/327649
-  if Hardware::CPU.arm?
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/9dc732/qt/qt-split-arch.patch"
-      sha256 "36915fde68093af9a147d76f88a4e205b789eec38c0c6f422c21ae1e576d45c0"
-      directory "qtbase"
-    end
+  resource "qt3d" do
+    url "https://download.qt.io/official_releases/additional_libraries/qt3d/6.0/6.0.1/qt3d-everywhere-src-6.0.1.tar.xz"
+    mirror "http://mirror.bit.edu.cn/qtproject/official_releases/additional_libraries/qt3d/6.0/6.0.1/qt3d-everywhere-src-6.0.1.tar.xz"
+    mirror "http://ftp.jaist.ac.jp/pub/qtproject/official_releases/additional_libraries/qt3d/6.0/6.0.1/qt3d-everywhere-src-6.0.1.tar.xz"
+    mirror "https://mirrors.dotsrc.org/qtproject/official_releases/additional_libraries/qt3d/6.0/6.0.1/qt3d-everywhere-src-6.0.1.tar.xz"
+    mirror "https://mirrors.ocf.berkeley.edu/qt/official_releases/additional_libraries/qt3d/6.0/6.0.1/qt3d-everywhere-src-6.0.1.tar.xz"
+    sha256 "1234c6904ad13894fb1a798a5540317d241b5cbded70e980e929f477bc060f34"
+  end
+
+  resource "qtnetworkauth" do
+    url "https://download.qt.io/official_releases/additional_libraries/qtnetworkauth/6.0/6.0.1/qtnetworkauth-everywhere-src-6.0.1.tar.xz"
+    mirror "http://mirror.bit.edu.cn/qtproject/official_releases/additional_libraries/qtnetworkauth/6.0/6.0.1/qtnetworkauth-everywhere-src-6.0.1.tar.xz"
+    mirror "http://ftp.jaist.ac.jp/pub/qtproject/official_releases/additional_libraries/qtnetworkauth/6.0/6.0.1/qtnetworkauth-everywhere-src-6.0.1.tar.xz"
+    mirror "https://mirrors.dotsrc.org/qtproject/official_releases/additional_libraries/qtnetworkauth/6.0/6.0.1/qtnetworkauth-everywhere-src-6.0.1.tar.xz"
+    mirror "https://mirrors.ocf.berkeley.edu/qt/official_releases/additional_libraries/qtnetworkauth/6.0/6.0.1/qtnetworkauth-everywhere-src-6.0.1.tar.xz"
+    sha256 "7f348acedb24e7c33927bd475b87b3c0c9901122f2e11f8c8209de4497e36122"
   end
 
   def install
-    args = %W[
-      -verbose
-      -prefix #{prefix}
+    resources.each { |addition| addition.stage buildpath/addition.name }
+
+    config_args = %W[
       -release
-      -opensource -confirm-license
-      -system-zlib
-      -qt-libpng
-      -qt-libjpeg
-      -qt-freetype
-      -qt-pcre
-      -nomake examples
-      -nomake tests
-      -no-rpath
-      -pkg-config
-      -dbus-runtime
+
+      -prefix #{HOMEBREW_PREFIX}
+      -extprefix #{prefix}
+
+      -libexecdir share/qt/libexec
+      -plugindir share/qt/plugins
+      -qmldir share/qt/qml
+      -docdir share/doc/qt
+      -examplesdir share/qt/examples
+      -testsdir share/qt/tests
+
+      -libproxy
+      -no-feature-relocatable
+      -system-sqlite
     ]
 
-    if Hardware::CPU.arm?
-      # Temporarily fixes for Apple Silicon
-      args << "-skip" << "qtwebengine" << "-no-assimp"
-    else
-      # Should be reenabled unconditionnaly once it is fixed on Apple Silicon
-      args << "-proprietary-codecs"
-    end
+    cmake_args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"]||s["CMAKE_FIND_FRAMEWORK"] } + %W[
+      -DICU_ROOT=#{Formula["icu4c"].opt_prefix}
 
-    system "./configure", *args
+      -DCMAKE_OSX_DEPLOYMENT_TARGET=#{MacOS.version}
+      -DCMAKE_FIND_FRAMEWORK=FIRST
 
-    # Remove reference to shims directory
-    inreplace "qtbase/mkspecs/qmodule.pri",
-              /^PKG_CONFIG_EXECUTABLE = .*$/,
-              "PKG_CONFIG_EXECUTABLE = #{Formula["pkg-config"].opt_bin/"pkg-config"}"
-    system "make"
-    ENV.deparallelize
-    system "make", "install"
+      -DINSTALL_MKSPECSDIR=share/qt/mkspecs
+      -DINSTALL_DESCRIPTIONSDIR=share/qt/modules
+      -DINSTALL_TRANSLATIONSDIR=share/qt/translations
+
+      -DFEATURE_pkg_config=ON
+      -DFEATURE_qt3d_system_assimp=ON
+      -DTEST_assimp=ON
+    ]
+
+    system "./configure", *config_args, "--", *cmake_args
+    system "ninja"
+    system "ninja", "install"
+
+    rm bin/"qt-cmake-private-install.cmake"
 
     # Some config scripts will only find Qt in a "Frameworks" folder
     frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    inreplace lib/"cmake/Qt6/qt.toolchain.cmake", /.*set.__qt_initial_.*/, ""
 
     # The pkg-config files installed suggest that headers can be found in the
     # `include` directory. Make this so by creating symlinks from `include` to
@@ -98,35 +133,43 @@ class Qt < Formula
       include.install_symlink path => path.parent.basename(".framework")
     end
 
-    # Move `*.app` bundles into `libexec` to expose them to `brew linkapps` and
-    # because we don't like having them in `bin`.
-    # (Note: This move breaks invocation of Assistant via the Help menu
-    # of both Designer and Linguist as that relies on Assistant being in `bin`.)
-    libexec.mkpath
-    Pathname.glob("#{bin}/*.app") { |app| mv app, libexec }
-  end
-
-  def caveats
-    s = <<~EOS
-      We agreed to the Qt open source license for you.
-      If this is unacceptable you should uninstall.
-    EOS
-
-    if Hardware::CPU.arm?
-      s += <<~EOS
-
-        This version of Qt on Apple Silicon does not include QtWebEngine
-      EOS
+    mkdir libexec
+    Pathname.glob("#{bin}/*.app") do |app|
+      mv app, libexec
+      bin.write_exec_script "#{libexec/app.stem}.app/Contents/MacOS/#{app.stem}"
     end
-
-    s
   end
 
   test do
-    (testpath/"hello.pro").write <<~EOS
-      QT       += core
-      QT       -= gui
-      TARGET = hello
+    (testpath/"CMakeLists.txt").write <<~EOS
+      cmake_minimum_required(VERSION 3.19.0)
+
+      project(test VERSION 1.0.0 LANGUAGES CXX)
+
+      set(CMAKE_CXX_STANDARD 17)
+      set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+      set(CMAKE_AUTOMOC ON)
+      set(CMAKE_AUTORCC ON)
+      set(CMAKE_AUTOUIC ON)
+
+      find_package(Qt6 COMPONENTS Core Widgets Sql Concurrent
+        3DCore Svg Quick3D Network NetworkAuth REQUIRED)
+
+      add_executable(test
+          main.cpp
+      )
+
+      target_link_libraries(test PRIVATE Qt6::Core Qt6::Widgets
+        Qt6::Sql Qt6::Concurrent Qt6::3DCore Qt6::Svg Qt6::Quick3D
+        Qt6::Network Qt6::NetworkAuth
+      )
+    EOS
+
+    (testpath/"test.pro").write <<~EOS
+      QT       += core svg 3dcore network networkauth quick3d \
+        sql
+      TARGET = test
       CONFIG   += console
       CONFIG   -= app_bundle
       TEMPLATE = app
@@ -134,24 +177,45 @@ class Qt < Formula
     EOS
 
     (testpath/"main.cpp").write <<~EOS
+      #undef QT_NO_DEBUG
       #include <QCoreApplication>
+      #include <Qt3DCore>
+      #include <QtQuick3D>
+      #include <QImageReader>
+      #include <QtNetworkAuth>
+      #include <QtSql>
+      #include <QtSvg>
       #include <QDebug>
+      #include <iostream>
 
       int main(int argc, char *argv[])
       {
         QCoreApplication a(argc, argv);
-        qDebug() << "Hello World!";
+        QSvgGenerator generator;
+        auto *handler = new QOAuthHttpServerReplyHandler();
+        delete handler; handler = nullptr;
+        auto *root = new Qt3DCore::QEntity();
+        delete root; root = nullptr;
+        Q_ASSERT(QSqlDatabase::isDriverAvailable("QSQLITE"));
+        const auto &list = QImageReader::supportedImageFormats();
+        for(const char* fmt:{"bmp", "cur", "gif", "heic", "heif",
+          "icns", "ico", "jp2", "jpeg", "jpg", "pbm", "pgm", "png",
+          "ppm", "svg", "svgz", "tga", "tif", "tiff", "wbmp", "webp",
+          "xbm", "xpm"}) {
+          Q_ASSERT(list.contains(fmt));
+        }
         return 0;
       }
     EOS
 
+    system "cmake", testpath
+    system "make"
+    system "./test"
+
     # Work around "error: no member named 'signbit' in the global namespace"
     ENV.delete "CPATH"
-
-    system bin/"qmake", testpath/"hello.pro"
+    system bin/"qmake", testpath/"test.pro"
     system "make"
-    assert_predicate testpath/"hello", :exist?
-    assert_predicate testpath/"main.o", :exist?
-    system "./hello"
+    system "./test"
   end
 end

--- a/Formula/qt@5.rb
+++ b/Formula/qt@5.rb
@@ -1,0 +1,142 @@
+# Patches for Qt must be at the very least submitted to Qt's Gerrit codereview
+# rather than their bug-report Jira. The latter is rarely reviewed by Qt.
+class QtAT5 < Formula
+  desc "Cross-platform application and UI framework"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
+  mirror "https://mirrors.dotsrc.org/qtproject/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/qt/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
+  sha256 "3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240"
+  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+
+  keg_only :versioned_formula
+
+  depends_on "pkg-config" => :build
+  depends_on xcode: :build
+  depends_on macos: :sierra
+
+  uses_from_macos "gperf" => :build
+  uses_from_macos "bison"
+  uses_from_macos "flex"
+  uses_from_macos "sqlite"
+
+  # Find SDK for 11.x macOS
+  # Upstreamed, remove when Qt updates Chromium
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/92d4cf/qt/5.15.2.diff"
+    sha256 "fa99c7ffb8a510d140c02694a11e6c321930f43797dbf2fe8f2476680db4c2b2"
+  end
+
+  # Patch for qmake on ARM
+  # https://codereview.qt-project.org/c/qt/qtbase/+/327649
+  if Hardware::CPU.arm?
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/9dc732/qt/qt-split-arch.patch"
+      sha256 "36915fde68093af9a147d76f88a4e205b789eec38c0c6f422c21ae1e576d45c0"
+      directory "qtbase"
+    end
+  end
+
+  def install
+    args = %W[
+      -verbose
+      -prefix #{prefix}
+      -release
+      -opensource -confirm-license
+      -system-zlib
+      -qt-libpng
+      -qt-libjpeg
+      -qt-freetype
+      -qt-pcre
+      -nomake examples
+      -nomake tests
+      -no-rpath
+      -pkg-config
+      -dbus-runtime
+    ]
+
+    if Hardware::CPU.arm?
+      # Temporarily fixes for Apple Silicon
+      args << "-skip" << "qtwebengine" << "-no-assimp"
+    else
+      # Should be reenabled unconditionnaly once it is fixed on Apple Silicon
+      args << "-proprietary-codecs"
+    end
+
+    system "./configure", *args
+
+    # Remove reference to shims directory
+    inreplace "qtbase/mkspecs/qmodule.pri",
+              /^PKG_CONFIG_EXECUTABLE = .*$/,
+              "PKG_CONFIG_EXECUTABLE = #{Formula["pkg-config"].opt_bin/"pkg-config"}"
+    system "make"
+    ENV.deparallelize
+    system "make", "install"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink Dir["#{lib}/*.framework"]
+
+    # The pkg-config files installed suggest that headers can be found in the
+    # `include` directory. Make this so by creating symlinks from `include` to
+    # the Frameworks' Headers folders.
+    Pathname.glob("#{lib}/*.framework/Headers") do |path|
+      include.install_symlink path => path.parent.basename(".framework")
+    end
+
+    # Move `*.app` bundles into `libexec` to expose them to `brew linkapps` and
+    # because we don't like having them in `bin`.
+    # (Note: This move breaks invocation of Assistant via the Help menu
+    # of both Designer and Linguist as that relies on Assistant being in `bin`.)
+    libexec.mkpath
+    Pathname.glob("#{bin}/*.app") { |app| mv app, libexec }
+  end
+
+  def caveats
+    s = <<~EOS
+      We agreed to the Qt open source license for you.
+      If this is unacceptable you should uninstall.
+    EOS
+
+    if Hardware::CPU.arm?
+      s += <<~EOS
+
+        This version of Qt on Apple Silicon does not include QtWebEngine
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    (testpath/"hello.pro").write <<~EOS
+      QT       += core
+      QT       -= gui
+      TARGET = hello
+      CONFIG   += console
+      CONFIG   -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    EOS
+
+    (testpath/"main.cpp").write <<~EOS
+      #include <QCoreApplication>
+      #include <QDebug>
+
+      int main(int argc, char *argv[])
+      {
+        QCoreApplication a(argc, argv);
+        qDebug() << "Hello World!";
+        return 0;
+      }
+    EOS
+
+    # Work around "error: no member named 'signbit' in the global namespace"
+    ENV.delete "CPATH"
+
+    system bin/"qmake", testpath/"hello.pro"
+    system "make"
+    assert_predicate testpath/"hello", :exist?
+    assert_predicate testpath/"main.o", :exist?
+    system "./hello"
+  end
+end

--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -2,7 +2,7 @@ class Qtads < Formula
   desc "TADS multimedia interpreter"
   homepage "https://qtads.sourceforge.io/"
   license "GPL-3.0"
-  revision 1
+  revision 2
   head "https://github.com/realnc/qtads.git"
 
   stable do
@@ -53,7 +53,7 @@ class Qtads < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "sdl2"
   depends_on "sdl2_mixer"
   depends_on "sdl_sound"
@@ -64,7 +64,8 @@ class Qtads < Formula
       "INCLUDEPATH += src $$T2DIR $$T3DIR $$HTDIR",
       "INCLUDEPATH += src $$T2DIR $$T3DIR $$HTDIR #{sdl_sound_include}/SDL"
 
-    system "qmake", "DEFINES+=NO_STATIC_TEXTCODEC_PLUGINS"
+    qt5 = Formula["qt@5"].opt_prefix
+    system "#{qt5}/bin/qmake", "DEFINES+=NO_STATIC_TEXTCODEC_PLUGINS"
     system "make"
     prefix.install "QTads.app"
     bin.write_exec_script "#{prefix}/QTads.app/Contents/MacOS/QTads"

--- a/Formula/qtkeychain.rb
+++ b/Formula/qtkeychain.rb
@@ -4,6 +4,7 @@ class Qtkeychain < Formula
   url "https://github.com/frankosterfeld/qtkeychain/archive/v0.12.0.tar.gz"
   sha256 "cc547d58c1402f6724d3ff89e4ca83389d9e2bdcfd9ae3d695fcdffa50a625a8"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "61f29925d6d5e1bf782025c65973a2ee5f9fcb05d5a9d6dc72c5bb409a335d10"
@@ -13,7 +14,7 @@ class Qtkeychain < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     system "cmake", ".", "-DBUILD_TRANSLATIONS=OFF", *std_cmake_args
@@ -30,8 +31,8 @@ class Qtkeychain < Formula
     EOS
     system ENV.cxx, "test.cpp", "-o", "test", "-std=c++11", "-I#{include}",
                     "-L#{lib}", "-lqt5keychain",
-                    "-I#{Formula["qt"].opt_include}",
-                    "-F#{Formula["qt"].opt_lib}", "-framework", "QtCore"
+                    "-I#{Formula["qt@5"].opt_include}",
+                    "-F#{Formula["qt@5"].opt_lib}", "-framework", "QtCore"
     system "./test"
   end
 end

--- a/Formula/quazip.rb
+++ b/Formula/quazip.rb
@@ -1,9 +1,9 @@
 class Quazip < Formula
   desc "C++ wrapper over Gilles Vollant's ZIP/UNZIP package"
   homepage "https://github.com/stachenov/quazip/"
-  url "https://github.com/stachenov/quazip/archive/v0.9.1.tar.gz"
-  sha256 "5d36b745cb94da440432690050e6db45b99b477cfe9bc3b82fd1a9d36fff95f5"
-  license "LGPL-2.1"
+  url "https://github.com/stachenov/quazip/archive/v1.1.tar.gz"
+  sha256 "54edce9c11371762bd4f0003c2937b5d8806a2752dd9c0fd9085e90792612ad0"
+  license "LGPL-2.1-only"
 
   bottle do
     sha256 cellar: :any, catalina:    "fcc3c28686a10a6e8d0e95ac978c0499400e5af3364c015f6ee128d9c0fd878e"
@@ -11,16 +11,22 @@ class Quazip < Formula
     sha256 cellar: :any, high_sierra: "632c10f191326e2afc006c9a065f40af0f5ab8d6b562b4013ecdf77e79ed1eaf"
   end
 
+  depends_on "cmake" => :build
   depends_on xcode: :build
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
-    system "qmake", "quazip.pro", "-config", "release",
-                    "PREFIX=#{prefix}", "LIBS+=-lz"
+    system "cmake", ".", "-DCMAKE_PREFIX_PATH=#{Formula["qt@5"].opt_lib}", *std_cmake_args
+    system "make"
     system "make", "install"
+
+    cd include do
+      include.install_symlink "QuaZip-Qt#{Formula["qt@5"].version.major}-#{version}/quazip" => "quazip"
+    end
   end
 
   test do
+    ENV.delete "CPATH"
     (testpath/"test.pro").write <<~EOS
       TEMPLATE     = app
       CONFIG      += console
@@ -29,7 +35,7 @@ class Quazip < Formula
       SOURCES     += test.cpp
       INCLUDEPATH += #{include}
       LIBPATH     += #{lib}
-      LIBS        += -lquazip
+      LIBS        += -lquazip#{version.major}-qt#{Formula["qt@5"].version.major}
     EOS
 
     (testpath/"test.cpp").write <<~EOS
@@ -40,7 +46,7 @@ class Quazip < Formula
       }
     EOS
 
-    system "#{Formula["qt"].bin}/qmake", "test.pro"
+    system "#{Formula["qt@5"].bin}/qmake", "test.pro"
     system "make"
     assert_predicate testpath/"test", :exist?, "test output file does not exist!"
     system "./test"

--- a/Formula/qwt.rb
+++ b/Formula/qwt.rb
@@ -3,8 +3,8 @@ class Qwt < Formula
   homepage "https://qwt.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.6/qwt-6.1.6.tar.bz2"
   sha256 "99460d31c115ee4117b0175d885f47c2c590d784206f09815dc058fbe5ede1f6"
-
   license "LGPL-2.1-only" => { with: "Qwt-exception-1.0" }
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "a3ebfd4004fec1a451a9af3764b92932ac03f9c0f62ecf2d2c38087a8968aaa3"
@@ -13,7 +13,7 @@ class Qwt < Formula
     sha256 mojave:        "6dffaa9d451b82e5bdd78ae6dea239b3f0e5338677085babe3b2185724b46580"
   end
 
-  depends_on "qt"
+  depends_on "qt@5"
 
   # Update designer plugin linking back to qwt framework/lib after install
   # See: https://sourceforge.net/p/qwt/patches/45/
@@ -37,7 +37,8 @@ class Qwt < Formula
     spec << "-arm64" if Hardware::CPU.arm?
     args << spec
 
-    system "qmake", *args
+    qt5 = Formula["qt@5"].opt_prefix
+    system "#{qt5}/bin/qmake", *args
     system "make"
     system "make", "install"
   end
@@ -53,10 +54,10 @@ class Qwt < Formula
     system ENV.cxx, "test.cpp", "-o", "out",
       "-std=c++11",
       "-framework", "qwt", "-framework", "QtCore",
-      "-F#{lib}", "-F#{Formula["qt"].opt_lib}",
+      "-F#{lib}", "-F#{Formula["qt@5"].opt_lib}",
       "-I#{lib}/qwt.framework/Headers",
-      "-I#{Formula["qt"].opt_lib}/QtCore.framework/Versions/5/Headers",
-      "-I#{Formula["qt"].opt_lib}/QtGui.framework/Versions/5/Headers"
+      "-I#{Formula["qt@5"].opt_lib}/QtCore.framework/Versions/5/Headers",
+      "-I#{Formula["qt@5"].opt_lib}/QtGui.framework/Versions/5/Headers"
     system "./out"
   end
 end

--- a/Formula/qwtpolar.rb
+++ b/Formula/qwtpolar.rb
@@ -3,7 +3,7 @@ class Qwtpolar < Formula
   homepage "https://qwtpolar.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/qwtpolar/qwtpolar/1.1.1/qwtpolar-1.1.1.tar.bz2"
   sha256 "6168baa9dbc8d527ae1ebf2631313291a1d545da268a05f4caa52ceadbe8b295"
-  revision 4
+  revision 5
 
   bottle do
     sha256 arm64_big_sur: "9e69907710588144c7d42992d475bb4dee85b2c5d65f7516148139bee378b1b8"
@@ -14,7 +14,7 @@ class Qwtpolar < Formula
 
   depends_on xcode: :build
 
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "qwt"
 
   # Update designer plugin linking back to qwtpolar framework/lib after install
@@ -37,7 +37,8 @@ class Qwtpolar < Formula
     end
 
     ENV["QMAKEFEATURES"] = "#{Formula["qwt"].opt_prefix}/features"
-    system "qmake", "-config", "release"
+    qt5 = Formula["qt@5"].opt_prefix
+    system "#{qt5}/bin/qmake", "-config", "release"
     system "make"
     system "make", "install"
     pkgshare.install "examples"
@@ -58,7 +59,7 @@ class Qwtpolar < Formula
       s.gsub! "qwtPolarAddLibrary(qwtpolar)", "qwtPolarAddLibrary(qwtpolar)\nqwtPolarAddLibrary(qwt)"
     end
     cd "examples" do
-      system Formula["qt"].opt_bin/"qmake"
+      system Formula["qt@5"].opt_bin/"qmake"
       rm_rf "bin" # just in case
       system "make"
       assert_predicate Pathname.pwd/"bin/polardemo.app/Contents/MacOS/polardemo",

--- a/Formula/qxmpp.rb
+++ b/Formula/qxmpp.rb
@@ -4,6 +4,7 @@ class Qxmpp < Formula
   url "https://github.com/qxmpp-project/qxmpp/archive/v1.3.1.tar.gz"
   sha256 "812e718a2dd762ec501a9012a1281b9b6c6d46ec38adbc6eec242309144e1c55"
   license "LGPL-2.1"
+  revision 1
 
   bottle do
     sha256 cellar: :any, big_sur:     "98e9f506c62ab3b25d0de4fff745309eb36f99230910e83f8258a4853b8c99f9"
@@ -14,7 +15,7 @@ class Qxmpp < Formula
 
   depends_on "cmake" => :build
   depends_on xcode: :build
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     mkdir "build" do
@@ -24,6 +25,7 @@ class Qxmpp < Formula
   end
 
   test do
+    ENV.delete "CPATH"
     (testpath/"test.pro").write <<~EOS
       TEMPLATE     = app
       CONFIG      += console
@@ -44,7 +46,7 @@ class Qxmpp < Formula
       }
     EOS
 
-    system "#{Formula["qt"].bin}/qmake", "test.pro"
+    system "#{Formula["qt@5"].bin}/qmake", "test.pro"
     system "make"
     assert_predicate testpath/"test", :exist?, "test output file does not exist!"
     system "./test"

--- a/Formula/treefrog.rb
+++ b/Formula/treefrog.rb
@@ -1,10 +1,15 @@
 class Treefrog < Formula
   desc "High-speed C++ MVC Framework for Web Application"
   homepage "https://www.treefrogframework.org/"
-  url "https://github.com/treefrogframework/treefrog-framework/archive/v1.30.0.tar.gz"
-  sha256 "e91384f5ed6c14e0a0eccec5467425d598d58dfa4909cf7619bda0f85e6c6aee"
+  url "https://github.com/treefrogframework/treefrog-framework/archive/v1.31.1.tar.gz"
+  sha256 "282197f1735f7766a804e1f06e29b45754e082db2eb596edcd929f8e308b2887"
   license "BSD-3-Clause"
   head "https://github.com/treefrogframework/treefrog-framework.git"
+
+  livecheck do
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 big_sur:     "8af96d330e176d4cc0cc842ac4773ffb65259ab3e5bdab4d9c7130a185978c52"
@@ -13,9 +18,9 @@ class Treefrog < Formula
     sha256 high_sierra: "0c31aaf7a5199f8b409288fc3e5fd5d4e154b23e8be83354e1ed8e0fd4bb13ec"
   end
 
-  depends_on xcode: ["8.0", :build]
+  depends_on xcode: :build
   depends_on "mongo-c-driver"
-  depends_on "qt"
+  depends_on "qt@5"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--enable-shared-mongoc"
@@ -32,11 +37,12 @@ class Treefrog < Formula
   end
 
   test do
+    ENV.delete "CPATH"
     system bin/"tspawn", "new", "hello"
     assert_predicate testpath/"hello", :exist?
     cd "hello" do
       assert_predicate Pathname.pwd/"hello.pro", :exist?
-      system HOMEBREW_PREFIX/"opt/qt/bin/qmake"
+      system Formula["qt@5"].opt_bin/"qmake"
       assert_predicate Pathname.pwd/"Makefile", :exist?
       system "make"
       system bin/"treefrog", "-v"

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -32,7 +32,7 @@ class Vtk < Formula
   depends_on "pugixml"
   depends_on "pyqt"
   depends_on "python@3.9"
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "sqlite"
   depends_on "theora"
   depends_on "utf8cpp"

--- a/Formula/vtk@8.2.rb
+++ b/Formula/vtk@8.2.rb
@@ -4,7 +4,7 @@ class VtkAT82 < Formula
   url "https://www.vtk.org/files/release/8.2/VTK-8.2.0.tar.gz"
   sha256 "34c3dc775261be5e45a8049155f7228b6bd668106c72a3c435d95730d17d57bb"
   license "BSD-3-Clause"
-  revision 2
+  revision 3
 
   bottle do
     sha256 arm64_big_sur: "8dd6077679c9a51dc7f874f421bf1cfbe9792e6232bf03675ca79c0e7472045b"
@@ -27,24 +27,25 @@ class VtkAT82 < Formula
   depends_on "netcdf"
   depends_on "pyqt"
   depends_on "python@3.9"
-  depends_on "qt"
+  depends_on "qt@5"
 
+  # TODO: use diff
   # Fix compile issues on Mojave and later
   patch do
     url "https://gitlab.kitware.com/vtk/vtk/commit/ca3b5a50d945b6e65f0e764b3138cad17bd7eb8d.patch"
-    sha256 "4e59d1b8b2c672ae571966f3f7ce8d0c66dd3844d6eb3727012dd98c9e897a25"
+    sha256 "49574bb914e2564b21ab0fb23cadcccd7dd323ae7f0f26f64fd6346c3db14cd7"
   end
 
   # Python 3.8 compatibility
   patch do
     url "https://gitlab.kitware.com/vtk/vtk/commit/257b9d7b18d5f3db3fe099dc18f230e23f7dfbab.patch"
-    sha256 "d5eef4a022d7d18087c9267c632c79bd6ef312fc6a287aeacfc44e9d47a5ec91"
+    sha256 "41914057adc511527167b812f9604f1ff0aed74e12dc20c98bbc5c52ccab9cda"
   end
 
   # Qt 5.15 support
   patch do
     url "https://gitlab.kitware.com/vtk/vtk/-/commit/797f28697d5ba50c1fa2bc5596af626a3c277826.patch"
-    sha256 "57618e316e7c3c3ade8d64c472b0ab77ebb0584d34b79c1f8dd3637d023461ff"
+    sha256 "01e870a943edea2a096c7bc9e43d2a70e10a5a80d1cd89b08868ab0f746c1c1c"
   end
 
   def install

--- a/Formula/xpdf.rb
+++ b/Formula/xpdf.rb
@@ -4,6 +4,7 @@ class Xpdf < Formula
   url "https://dl.xpdfreader.com/xpdf-4.03.tar.gz"
   sha256 "0fe4274374c330feaadcebb7bd7700cb91203e153b26aa95952f02bf130be846"
   license "GPL-2.0"
+  revision 1
 
   livecheck do
     url "https://www.xpdfreader.com/download.html"
@@ -20,7 +21,7 @@ class Xpdf < Formula
   depends_on "cmake" => :build
   depends_on "fontconfig"
   depends_on "freetype"
-  depends_on "qt"
+  depends_on "qt@5"
 
   conflicts_with "pdf2image", "pdftohtml", "poppler",
     because: "poppler, pdftohtml, pdf2image, and xpdf install conflicting executables"

--- a/Formula/zurl.rb
+++ b/Formula/zurl.rb
@@ -4,7 +4,7 @@ class Zurl < Formula
   url "https://dl.bintray.com/fanout/source/zurl-1.11.0.tar.bz2"
   sha256 "18aa3b077aefdba47cc46c5bca513ca2e20f2564715be743f70e4efa4fdccd7a"
   license "GPL-3.0-or-later"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "2a1b3d58c7788be71b497f056d11a899a01718f903548a8460cb3986db47c4a8"
@@ -16,7 +16,7 @@ class Zurl < Formula
 
   depends_on "pkg-config" => :build
   depends_on "python@3.9" => :test
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "zeromq"
 
   uses_from_macos "curl"


### PR DESCRIPTION
Create qt@5 for compability, because qt@6 is a breaking change.
Now formulae depend on Qt 5.X should be `depends_on "qt@5"`.

## **WARNING**: Qt [ARM support](https://www.qt.io/blog/qt6-development-hosts-and-targets) is not guaranteed untill [6.1](https://wiki.qt.io/Qt_6.1_Release)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Continue #70302.
All formulae depend on qt now should depend on qt@5 unless they declare they are compatible with qt6!

Head repository still named [qt5](https://wiki.qt.io/Building_Qt_6_from_Git).

Qt6 changes distribution policy, which means the qt-everywhere tarball will not contains all the submodule in qt5,  some reduced modules now belong to [Qt additional libraries](https://download.qt.io/official_releases/additional_libraries/), and in future, [more libraries](https://www.qt.io/blog/add-on-support-in-qt-6.0-and-beyond) will be added into additional libraries
Qt6 introduces more dependencies, some dependencies are inherit from qt@5, some dependencies just let qt don't build the qt bundled version, [see here](https://github.com/qt/qtbase/tree/dev/src/3rdparty).

The dependencies just copied from [qt CI config](https://wiki.qt.io/Qt_6.0_Tools_and_Versions) but with some differences:
- use `unixodbc` (plugin only, and compatible with `libiodbc`)
- build configuration is Release not RelWithDebInfo and not distribute the debug file.
- more plugin-only dependencies
- drop QNX, WASM, IOS support
- not use openssl, because it conflict with libressl's feature
- not use libiconv for qt5 compatible layer

These dependencies are plugin-dependencies:
- `jasper`
- `jpeg`
- `libtiff`
- `webp`
- ~~`mysql` (compatible with `mariadb` and `percona-server`)~~
- ~~`unixodbc`(compatible with `libiodbc`)~~
- ~~`postgresql`~~

Picture formats support dependencies are more than `qt@5` because in this new formula `qt@6`  doesn't use Qt6 bundled version,  if omit these dependencies, qt will still build them for internal use.

~~`qdoc` need llvm related `cmake` file to determine the dependencies, bug macOS's llvm doesn't offer the `cmake` files.~~

Because all dependencies now live in one formula, the patch for `qmake` is meanless here, unless user want install other qt components.

Find framework first because of undefined symbols error from `krb5`, `qt` use some internal symbols which are not provided by `krb5.dylib`

-------

## need help
- [`orc`](https://gstreamer.freedesktop.org/projects/orc.html)(not support AArch64) -> `volk` -> `gnuradio`
- `shapelib` no artifact -> `gpsbabel`
- [`geant4`](https://geant4-forum.web.cern.ch/t/multithreading-on-new-m1-macbook-and-macos-11-0-1/4003)
- formulae depend on `mbedtls`(with `havege`)->[`mongrel2`](https://github.com/Homebrew/homebrew-core/pull/41025) -> `pushpin`
- some formulae use `qmake`: `tarsnap-gui`, `treefrog`, `djview4`
- `mplayer` on arm need help -> `qmmp` there is AArch64 version `mplayer`
- `mlt` test failed, need more info
- `gdal` will use Qt6's files when test, may can update on another pull request

-------

`pyside` bumped version 6.0.1, the old `pyside` named `pyside@2`, and `pyside` has alias `pyside@6` (follow `pyside` official version policy).

`pyqt` support Qt5 and Qt6, but `pyqt6` change the build system, need some new formulae
`qwt` trunk version support Qt6
`quazip` support Qt6 but need `qt5-core-compat`

-------
put the patch here if it is needed in future
```
diff --git a/src/corelib/global/qlibraryinfo.cpp b/src/corelib/global/qlibraryinfo.cpp
index 301c3ab..fbd6adf 100644
--- a/qtbase/src/corelib/global/qlibraryinfo.cpp
+++ b/qtbase/src/corelib/global/qlibraryinfo.cpp
@@ -597,7 +597,7 @@ QString qmake_abslocation();
 
 static QString getPrefixFromHostBinDir(const char *hostBinDirToPrefixPath)
 {
-    const QString canonicalQMakePath = QFileInfo(qmake_abslocation()).canonicalPath();
+    const QString canonicalQMakePath = QFileInfo(qmake_abslocation()).absolutePath();
     return QDir::cleanPath(canonicalQMakePath + QLatin1Char('/')
                            + QLatin1String(hostBinDirToPrefixPath));
 }
```