### PR TITLE
lv: make workaround mac-only

### DIFF
--- a/Formula/lv.rb
+++ b/Formula/lv.rb
@@ -30,9 +30,11 @@ class Lv < Formula
   patch :DATA
 
   def install
-    # zcat doesn't handle gzip'd data on OSX.
-    # Reported upstream to nrt@ff.iij4u.or.jp
-    inreplace "src/stream.c", 'gz_filter = "zcat"', 'gz_filter = "gzcat"'
+    on_macos do
+      # zcat doesn't handle gzip'd data on OSX.
+      # Reported upstream to nrt@ff.iij4u.or.jp
+      inreplace "src/stream.c", 'gz_filter = "zcat"', 'gz_filter = "gzcat"'
+    end
 
     cd "build" do
       system "../src/configure", "--prefix=#{prefix}"


### PR DESCRIPTION
This breaks the build on linux

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
