### PR TITLE
dMagnetic 0.30 release

### DIFF
--- a/Formula/dmagnetic.rb
+++ b/Formula/dmagnetic.rb
@@ -1,8 +1,8 @@
 class Dmagnetic < Formula
   desc "Magnetic Scrolls Interpreter"
   homepage "https://www.dettus.net/dMagnetic/"
-  url "https://www.dettus.net/dMagnetic/dMagnetic_0.29.tar.bz2"
-  sha256 "a980e35f85c9661fe0d98c670f9d6be56000da2bbc8b3e8e78697eac05ae5b47"
+  url "https://www.dettus.net/dMagnetic/dMagnetic_0.30.tar.bz2"
+  sha256 "9eb825290495150b8ae4eeb0ff04aba724c1fd8f6052b0c4cb90865787f922be"
   license "BSD-2-Clause"
 
   bottle do


### PR DESCRIPTION
This patch should enable brew to download the latest release of dMagnetic, which is 0.30. I do not have access to an Apple computer, so somebody else would have to verify it.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
