### PR TITLE
cert_error_allowlist: add minio, libbladerf

### DIFF
--- a/audit_exceptions/cert_error_allowlist.json
+++ b/audit_exceptions/cert_error_allowlist.json
@@ -1,6 +1,8 @@
 {
   "gnuradio": "https://gnuradio.org/",
   "hashcat": "https://hashcat.net/hashcat/",
+  "libbladerf": "https://nuand.com/",
   "micropython": "https://www.micropython.org/",
+  "minio": "https://min.io",
   "monero": "https://www.getmonero.org/"
 }


### PR DESCRIPTION
Fixes audit failures in #70738, #70577.

Closes #70820.