### PR TITLE
asciidoc: add livecheck

### DIFF
--- a/Formula/asciidoc.rb
+++ b/Formula/asciidoc.rb
@@ -8,6 +8,11 @@ class Asciidoc < Formula
   license "GPL-2.0-only"
   head "https://github.com/asciidoc/asciidoc-py3.git"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b1bcbcde0a7c320b6545b860c6970ba4fe3197fd9895bcd7213bc4e1d94e3fc8"
     sha256 cellar: :any_skip_relocation, big_sur:       "fdfe12fdf2042b563bc1a483ffa374af8a66e4cf0ba3016a391dc2fc21900543"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `asciidoc` but it's reporting `10.0.0a2` as newest, which is a pre-release version. This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which also omits unstable versions.