### PR TITLE
rxvt-unicode: add livecheck

### DIFF
--- a/Formula/rxvt-unicode.rb
+++ b/Formula/rxvt-unicode.rb
@@ -6,6 +6,11 @@ class RxvtUnicode < Formula
   license "GPL-3.0-only"
   revision 4
 
+  livecheck do
+    url "http://dist.schmorp.de/rxvt-unicode/"
+    regex(/href=.*?rxvt-unicode[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "13dca2d2c2ca7e160e54a6d839b48fb259b4ae719803c0374c186904f3f9ac0e"
     sha256 big_sur:       "db278d2c19f2b837f1fa44dfa4a72bac3ed8c8359a13732fb7db854ba1c6b450"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `rxvt-unicode`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.