### PR TITLE
osm: fix missing version info

### DIFF
--- a/Formula/osm.rb
+++ b/Formula/osm.rb
@@ -1,9 +1,11 @@
 class Osm < Formula
   desc "Open Service Mesh (OSM)"
   homepage "https://openservicemesh.io/"
-  url "https://github.com/openservicemesh/osm/archive/v0.7.0.tar.gz"
-  sha256 "ab396a2f156e92fb2215905562f062ee92f96abd8a4d979cfb8c63940c8d5f26"
+  url "https://github.com/openservicemesh/osm.git",
+      tag:      "v0.7.0",
+      revision: "75423a0b4a3d5e9114fd93a133d2485171243c4b"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "217cac47e47bcd4d47b5244302681524ad9dfce9943e87c4bdbf6faf547ebdb8"
@@ -15,11 +17,12 @@ class Osm < Formula
   depends_on "go" => :build
 
   def install
+    ENV["VERSION"] = "v"+version
     system "make", "build-osm"
     bin.install "bin/osm"
   end
 
   test do
-    assert_match "Error: Could not list namespaces related to osm", shell_output("#{bin}/osm namespace list 2>&1", 1)
+    assert_match "Version: v#{version};", shell_output("#{bin}/osm version 2>&1")
   end
 end

--- a/Formula/osm.rb
+++ b/Formula/osm.rb
@@ -23,6 +23,7 @@ class Osm < Formula
   end
 
   test do
+    assert_match "Error: Could not list namespaces related to osm", shell_output("#{bin}/osm namespace list 2>&1", 1)
     assert_match "Version: v#{version};", shell_output("#{bin}/osm version 2>&1")
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently when installed via homebrew, the `osm version` command shows missing version information:
```console
$ osm version
Version: dev; Commit: ; Date: 2021-02-05-07:05
```

This change adds a git reference to the OSM repo and sets the `VERSION` environment variable used by `make build-osm`.

ref. https://github.com/openservicemesh/osm/issues/1960