### PR TITLE
rust: fix building from source by bumping cargo

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -2,7 +2,7 @@ class Rust < Formula
   desc "Safe, concurrent, practical language"
   homepage "https://www.rust-lang.org/"
   license any_of: ["Apache-2.0", "MIT"]
-  revision 1
+  revision 2
 
   stable do
     url "https://static.rust-lang.org/dist/rustc-1.49.0-src.tar.gz"
@@ -10,8 +10,8 @@ class Rust < Formula
 
     resource "cargo" do
       url "https://github.com/rust-lang/cargo.git",
-          tag:      "0.50.0",
-          revision: "d00d64df9f803bf5bba8714ca498d8f9159d07f6"
+          tag:      "0.50.1",
+          revision: "d61c808dda8029721042618f22e8e15d01328af4"
     end
   end
 


### PR DESCRIPTION
For more information about the fix, see upstream’s <https://github.com/rust-lang/cargo/pull/9130>. (And see <https://github.com/rust-lang/cargo/issues/9101> for more about the actual failure.)

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
