### PR TITLE
confuse: update GitHub owner in URLs

### DIFF
--- a/Formula/confuse.rb
+++ b/Formula/confuse.rb
@@ -1,7 +1,7 @@
 class Confuse < Formula
   desc "Configuration file parser library written in C"
-  homepage "https://github.com/martinh/libconfuse"
-  url "https://github.com/martinh/libconfuse/releases/download/v3.3/confuse-3.3.tar.xz"
+  homepage "https://github.com/libconfuse/libconfuse"
+  url "https://github.com/libconfuse/libconfuse/releases/download/v3.3/confuse-3.3.tar.xz"
   sha256 "1dd50a0320e135a55025b23fcdbb3f0a81913b6d0b0a9df8cc2fdf3b3dc67010"
   license "ISC"
 


### PR DESCRIPTION
(The previous URLs redirect to the new URLs.)

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Note that `brew audit --strict confuse` reports a problem even on `master`—i.e., this PR does not _introduce_ any audit failures.