### PR TITLE
ioctl 1.1.3 as 1.1.4 was not a valid release

### DIFF
--- a/Formula/ioctl.rb
+++ b/Formula/ioctl.rb
@@ -1,8 +1,8 @@
 class Ioctl < Formula
   desc "Command-line interface for interacting with the IoTeX blockchain"
   homepage "https://docs.iotex.io/developer/get-started/ioctl-install.html"
-  url "https://github.com/iotexproject/iotex-core/archive/v1.1.4.tar.gz"
-  sha256 "8bc4aca80ba4a51d24aa706327600150c7fb632d76f59da0e1633076b75d420a"
+  url "https://github.com/iotexproject/iotex-core/archive/v1.1.3.tar.gz"
+  sha256 "1a9e50a5831d9543489187944b1fc73bdaf3ae87c9cbe8f46810f25a915d0e24"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/ioctl.rb
+++ b/Formula/ioctl.rb
@@ -4,6 +4,7 @@ class Ioctl < Formula
   url "https://github.com/iotexproject/iotex-core/archive/v1.1.3.tar.gz"
   sha256 "1a9e50a5831d9543489187944b1fc73bdaf3ae87c9cbe8f46810f25a915d0e24"
   license "Apache-2.0"
+  version_scheme 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:  "a404957720d81eb86f3d6c987d9892784fae103fc2bd1d190f8aa012e4842fde"


### PR DESCRIPTION
ioctl was [incorrectly bumped to 1.1.4](https://github.com/Homebrew/homebrew-core/pull/70446#issuecomment-774456814) and blocks go version release 1.15.8 #70446.  
This PR downgrades the formular for ioctl to the latest released version 1.1.3.  


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
