### PR TITLE
mysqltuner: contains deprecated SPDX licenses

### DIFF
--- a/Formula/mysqltuner.rb
+++ b/Formula/mysqltuner.rb
@@ -3,7 +3,7 @@ class Mysqltuner < Formula
   homepage "https://raw.github.com/major/MySQLTuner-perl/master/mysqltuner.pl"
   url "https://github.com/major/MySQLTuner-perl/archive/1.7.17.tar.gz"
   sha256 "c82f29aa017360ab8888808393bd06e79af6fa447a62908a3b3dddea92b768b5"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/major/MySQLTuner-perl.git"
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
