### PR TITLE
maxwell: use OpenJDK 11

### DIFF
--- a/Formula/maxwell.rb
+++ b/Formula/maxwell.rb
@@ -26,9 +26,13 @@ class Maxwell < Formula
 
   test do
     fork do
-      exec "#{bin}/maxwell --help > #{testpath}/maxwell.log 2>/dev/null"
+      # Tell Maxwell to connect to a bogus host name so we don't actually connect to a local instance
+      # The '.invalid' TLD is reserved as never to be installed as a valid TLD.
+      exec "#{bin}/maxwell --host not.real.invalid > #{testpath}/maxwell.log 2>&1"
     end
     sleep 15
-    assert_match "Help for Maxwell:", IO.read("#{testpath}/maxwell.log")
+
+    # Validate that we actually got in to Maxwell far enough to attempt to connect.
+    assert_match "ERROR Maxwell - SQLException: Communications link failure", IO.read("#{testpath}/maxwell.log")
   end
 end

--- a/Formula/maxwell.rb
+++ b/Formula/maxwell.rb
@@ -26,9 +26,9 @@ class Maxwell < Formula
 
   test do
     fork do
-      exec "#{bin}/maxwell --log_level=OFF > #{testpath}/maxwell.log 2>/dev/null"
+      exec "#{bin}/maxwell --help > #{testpath}/maxwell.log 2>/dev/null"
     end
     sleep 15
-    assert_match "Using kafka version", IO.read("#{testpath}/maxwell.log")
+    assert_match "Help for Maxwell:", IO.read("#{testpath}/maxwell.log")
   end
 end

--- a/Formula/maxwell.rb
+++ b/Formula/maxwell.rb
@@ -12,7 +12,7 @@ class Maxwell < Formula
 
   bottle :unneeded
 
-  depends_on "openjdk@8"
+  depends_on "openjdk@11"
 
   def install
     libexec.install Dir["*"]
@@ -21,7 +21,7 @@ class Maxwell < Formula
       bin.install libexec/"bin/#{f}"
     end
 
-    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("11.0"))
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[Maxwell's Daemon](https://maxwells-daemon.io) was [recently updated to require JDK 11+](https://github.com/zendesk/maxwell/releases/tag/v1.30.0). The test wasn't catching this because it was grepping for `Using Kafka Version`, which is actually written by the *shell script* that launches Java.

I updated the test to call `--help` and assert something in that output so the Java app actually launches. It immediately failed because Java wasn't launching and the following error was output:

```
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.UnsupportedClassVersionError: com/zendesk/maxwell/Maxwell has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
        at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
        at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
        at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:601)
```

After updating the formula to now depend on `openjdk@11` and use the `JAVA_HOME` value from that, it works and the new test passes 🎉 .

This is my first formula contribution so let me know if there's something I missed!