### PR TITLE
charm-tools: add missing dep wheel, update license

### DIFF
--- a/Formula/charm-tools.rb
+++ b/Formula/charm-tools.rb
@@ -5,7 +5,7 @@ class CharmTools < Formula
   homepage "https://github.com/juju/charm-tools"
   url "https://files.pythonhosted.org/packages/1a/77/552dbd44cfc28daa6db06436cce906bbdf452ba6de0059b58b5d892b3317/charm-tools-2.7.8.tar.gz"
   sha256 "f16b3f8b1033451cc6503f2a2eca83e746dac548506ecf547c495cd83784f9f2"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
 
   bottle do
     sha256 cellar: :any, big_sur:     "6404dbae2164f20d435899289d4c65b798edf7f11feb8329dfb442fc596f6e6a"
@@ -99,6 +99,11 @@ class CharmTools < Formula
   resource "iso8601" do
     url "https://files.pythonhosted.org/packages/45/13/3db24895497345fb44c4248c08b16da34a9eb02643cea2754b21b5ed08b0/iso8601-0.1.12.tar.gz"
     sha256 "49c4b20e1f38aa5cf109ddcd39647ac419f928512c869dc01d5c7098eddede82"
+  end
+
+  resource "wheel" do
+    url "https://files.pythonhosted.org/packages/ed/46/e298a50dde405e1c202e316fa6a3015ff9288423661d7ea5e8f22f589071/wheel-0.36.2.tar.gz"
+    sha256 "e11eefd162658ea59a60a0f6c7d493a7190ea4b9a85e335b33489d9f17e0245e"
   end
 
   resource "jsonschema" do


### PR DESCRIPTION
`brew install --build-from-source charm-tools` failled to build.  
Further investigation showed that dependency `jsonschema` needed `wheel` pkg installed.  

```
Processing /private/tmp/charm-tools--jsonschema-20210211-36312-hkfrc1/jsonschema-2.5.1
[...]
      ERROR: Command errored out with exit status 1:
       command: /usr/local/Cellar/charm-tools/2.7.8/libexec/bin/python3.8 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/tmp/pip-wheel-2ie24vr6/vcversioner/setup.py'"'"'; __file__='"'"'/private/tmp/pip-wheel-2ie24vr6/vcversioner/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /private/tmp/pip-wheel-yc1xtp0n
           cwd: /private/tmp/pip-wheel-2ie24vr6/vcversioner/
      Complete output (6 lines):
      usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
         or: setup.py --help [cmd1 cmd2 ...]
         or: setup.py --help-commands
         or: setup.py cmd --help

      error: invalid command 'bdist_wheel'
```

I don't know why this did build before but I suspect `wheel` was by default installed into the virtualenv alongside setuptools etc.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
