### PR TITLE
node: avoid timing out in test if `cowsay` isn’t cached

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -111,6 +111,6 @@ class Node < Formula
     system "#{HOMEBREW_PREFIX}/bin/npm", *npm_args, "install", "bufferutil" unless head?
     assert_predicate HOMEBREW_PREFIX/"bin/npx", :exist?, "npx must exist"
     assert_predicate HOMEBREW_PREFIX/"bin/npx", :executable?, "npx must be executable"
-    assert_match "< hello >", shell_output("#{HOMEBREW_PREFIX}/bin/npx cowsay hello")
+    assert_match "< hello >", shell_output("#{HOMEBREW_PREFIX}/bin/npx --yes cowsay hello")
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Before this commit, running `brew test node` could result in the test hanging for a bit, eventually printing the following:

```sh-session
$ brew test node
==> Testing node
==> /opt/homebrew/Cellar/node/15.8.0/bin/node /private/tmp/node-test-20210210-85955-b80upx/test.js
==> /opt/homebrew/Cellar/node/15.8.0/bin/node -e 'console.log(new Intl.NumberFormat("en-EN").format(1234.56))'
==> /opt/homebrew/Cellar/node/15.8.0/bin/node -e 'console.log(new Intl.NumberFormat("de-DE").format(1234.56))'
==> /opt/homebrew/bin/npm -ddd --cache=/Users/jtilles/Library/Caches/Homebrew/npm_cache --build-from-source install npm@latest
==> /opt/homebrew/bin/npm -ddd --cache=/Users/jtilles/Library/Caches/Homebrew/npm_cache --build-from-source install bufferutil
==> /opt/homebrew/bin/npx cowsay hello
Killing child processes...
Error: node: failed
An exception occurred within a child process:
  Timeout::Error: execution expired
/opt/homebrew/Library/Homebrew/formula_assertions.rb:18:in ``'
/opt/homebrew/Library/Homebrew/formula_assertions.rb:18:in `shell_output'
/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/node.rb:114:in `block in <class:Node>'
/opt/homebrew/Library/Homebrew/formula.rb:1915:in `block (3 levels) in run_test'
/opt/homebrew/Library/Homebrew/utils.rb:549:in `with_env'
/opt/homebrew/Library/Homebrew/formula.rb:1914:in `block (2 levels) in run_test'
/opt/homebrew/Library/Homebrew/formula.rb:900:in `with_logging'
/opt/homebrew/Library/Homebrew/formula.rb:1913:in `block in run_test'
/opt/homebrew/Library/Homebrew/mktemp.rb:63:in `block in run'
/opt/homebrew/Library/Homebrew/mktemp.rb:63:in `chdir'
/opt/homebrew/Library/Homebrew/mktemp.rb:63:in `run'
/opt/homebrew/Library/Homebrew/formula.rb:2161:in `mktemp'
/opt/homebrew/Library/Homebrew/formula.rb:1907:in `run_test'
/opt/homebrew/Library/Homebrew/test.rb:43:in `block in <main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/opt/homebrew/Library/Homebrew/test.rb:42:in `<main>'
```

If I understand correctly, that behavior relates to npm 7:

> `npx` has been completely rewritten to use the `npm exec` command. There are various changes in functionality, most noticeable being a prompt if the module you are trying to run is not yet installed.

Source: <https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/#user-content-breaking-changes>