### PR TITLE
patchelf: update livecheck

### DIFF
--- a/Formula/patchelf.rb
+++ b/Formula/patchelf.rb
@@ -8,7 +8,8 @@ class Patchelf < Formula
   head "https://github.com/NixOS/patchelf.git"
 
   livecheck do
-    url :head
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `patchelf` to use `url :stable` instead of `url :head`, as these both use the same source and we prefer to align checks with `stable`. This also preemptively uses the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`), so the check will omit unwanted tags (should they appear in the future).