### PR TITLE
mpw: update livecheck

### DIFF
--- a/Formula/mpw.rb
+++ b/Formula/mpw.rb
@@ -10,7 +10,7 @@ class Mpw < Formula
 
   livecheck do
     url :head
-    regex(/^v?(\d+(?:\.\d+)+.?cli.?\d+)$/i)
+    regex(/^v?(\d+(?:\.\d+)+[._-]cli[._-]?\d+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the regex in the existing `livecheck` block for `mpw` to use `[._-]` (instead of `.`), as this is commonly used for certain delimiters in our regexes. We try to use the "match anything" `.` only when it's truly necessary/beneficial. This is merely a stylistic change and there isn't a functional difference at this time.