### PR TITLE
Document livecheck blocks using :head

### DIFF
--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -6,6 +6,8 @@ class Ghostscript < Formula
   license "AGPL-3.0-or-later"
   revision 1
 
+  # We check the tags from the `head` repository because the GitHub tags are
+  # formatted ambiguously, like `gs9533` (corresponding to version 9.53.3).
   livecheck do
     url :head
     regex(/^ghostpdl[._-]v?(\d+(?:\.\d+)+)$/i)

--- a/Formula/kde-extra-cmake-modules.rb
+++ b/Formula/kde-extra-cmake-modules.rb
@@ -6,6 +6,8 @@ class KdeExtraCmakeModules < Formula
   license all_of: ["BSD-2-Clause", "BSD-3-Clause", "MIT"]
   head "https://invent.kde.org/frameworks/extra-cmake-modules.git"
 
+  # We check the tags from the `head` repository because the latest stable
+  # version doesn't seem to be easily available elsewhere.
   livecheck do
     url :head
     regex(/^v?(\d+(?:\.\d+)+)$/i)

--- a/Formula/mpw.rb
+++ b/Formula/mpw.rb
@@ -8,6 +8,8 @@ class Mpw < Formula
   revision 2
   head "https://gitlab.com/MasterPassword/MasterPassword.git"
 
+  # The first-party site doesn't seem to list version information, so it's
+  # necessary to check the tags from the `head` repository instead.
   livecheck do
     url :head
     regex(/^v?(\d+(?:\.\d+)+[._-]cli[._-]?\d+)$/i)

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -8,9 +8,10 @@ class Qt < Formula
   mirror "https://mirrors.ocf.berkeley.edu/qt/archive/qt/5.15/5.15.2/single/qt-everywhere-src-5.15.2.tar.xz"
   sha256 "3a530d1b243b5dec00bc54937455471aaa3e56849d2593edb8ded07228202240"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
-
   head "https://code.qt.io/qt/qt5.git", branch: "dev", shallow: false
 
+  # The first-party website doesn't make version information readily available,
+  # so we check the `head` repository tags instead.
   livecheck do
     url :head
     regex(/^v?(\d+(?:\.\d+)+)$/i)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds explanatory comments before `livecheck` blocks using `url :head`, as these are exceptions and we prefer to align checks with the `stable` source whenever possible. Other instances already have an explanatory comment or are self-explanatory (i.e., `stable` and `head` are the same source but the `stable` URL can't be processed into the `head` URL, so we use `url :head`). This is part of the ongoing work to minimize usage of `url :head` in `livecheck` blocks.

~Due to the nature of these changes, I've simply formatted this as one commit but I can rework this as one-commit-per-formula if necessary.~ I've reworked this as one-commit-per-formula, as requested.