### PR TITLE
matplotplusplus: revision bump (Mojave SDK)

### DIFF
--- a/Formula/matplotplusplus.rb
+++ b/Formula/matplotplusplus.rb
@@ -4,6 +4,7 @@ class Matplotplusplus < Formula
   url "https://github.com/alandefreitas/matplotplusplus/archive/v1.0.1.tar.gz"
   sha256 "19f5f6fe40b56efc49dcda7f6c6de07679f5707254dea6859c3c7b4a8a0759a3"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "979279ad16e5e814b368c88c46cc5d995367c245100b033fade178ef3ab3cbeb"


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The Mojave SDK was fixed recently, so this needs to be rebuilt against
the fixed SDK.

Addresses failures seen in #70907, #70923, #71003.