### PR TITLE
ola: Bump protobuf version to 3.14

### DIFF
--- a/Formula/ola.rb
+++ b/Formula/ola.rb
@@ -21,7 +21,7 @@ class Ola < Formula
   depends_on "libmicrohttpd"
   depends_on "libusb"
   depends_on "numpy"
-  depends_on "protobuf@3.14"
+  depends_on "protobuf"
   depends_on "python@3.9"
 
   # remove in version 0.10.9

--- a/Formula/ola.rb
+++ b/Formula/ola.rb
@@ -4,6 +4,7 @@ class Ola < Formula
   url "https://github.com/OpenLightingProject/ola/releases/download/0.10.8/ola-0.10.8.tar.gz"
   sha256 "102aa3114562a2a71dbf7f77d2a0fb9fc47acc35d6248a70b6e831365ca71b13"
   license "GPL-2.0"
+  revision 1
   head "https://github.com/OpenLightingProject/ola.git"
 
   bottle do
@@ -20,7 +21,7 @@ class Ola < Formula
   depends_on "libmicrohttpd"
   depends_on "libusb"
   depends_on "numpy"
-  depends_on "protobuf@3.6"
+  depends_on "protobuf@3.14"
   depends_on "python@3.9"
 
   # remove in version 0.10.9


### PR DESCRIPTION
As discussed in #65415, untested, aside from what CI covers. We were good up to at least 3.11 previously.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? - I don't have an OS X test machine available anymore
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? - I don't have an OS X test machine available anymore
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? - I don't have an OS X test machine available anymore

-----
