### PR TITLE
jenkins, jenkins-lts: use HTTPS urls.

### DIFF
--- a/Formula/jenkins-lts.rb
+++ b/Formula/jenkins-lts.rb
@@ -1,12 +1,12 @@
 class JenkinsLts < Formula
   desc "Extendable open-source CI server"
   homepage "https://jenkins.io/index.html#stable"
-  url "http://mirrors.jenkins.io/war-stable/2.263.4/jenkins.war"
+  url "https://get.jenkins.io/war-stable/2.263.4/jenkins.war"
   sha256 "1d4a7409784236a84478b76f3f2139939c0d7a3b4b2e53b1fcef400c14903ab6"
   license "MIT"
 
   livecheck do
-    url "http://mirrors.jenkins-ci.org/war-stable/"
+    url "https://get.jenkins.io/war-stable/"
     regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 

--- a/Formula/jenkins.rb
+++ b/Formula/jenkins.rb
@@ -1,13 +1,13 @@
 class Jenkins < Formula
   desc "Extendable open source continuous integration server"
   homepage "https://jenkins.io/"
-  url "http://mirrors.jenkins.io/war/2.279/jenkins.war"
+  url "https://get.jenkins.io/war/2.279/jenkins.war"
   sha256 "7b40eb93e811e10edbd6c4efb0fa95f687a958d19559e549b5c014a87e6536df"
   license "MIT"
 
   livecheck do
-    url "https://www.jenkins.io/download/"
-    regex(%r{href=.*?/war/v?(\d+(?:\.\d+)+)/jenkins\.war}i)
+    url "https://get.jenkins.io/war/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   head do


### PR DESCRIPTION
Official Jenkins website uses https://get.jenkins.io website
instead of mirrors.jenkins.io. Switch to the new website.

See discussion https://github.com/Homebrew/discussions/discussions/794

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
