### PR TITLE
mas 1.8.0

### DIFF
--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -2,8 +2,8 @@ class Mas < Formula
   desc "Mac App Store command-line interface"
   homepage "https://github.com/mas-cli/mas"
   url "https://github.com/mas-cli/mas.git",
-      tag:      "v1.7.1",
-      revision: "b8dcb4ce4b1d78ada7556565dd5c73e9913758d8"
+      tag:      "v1.8.0",
+      revision: "9eaf57a5de836ce5e5435a8df14da4aa1b7d7444"
   license "MIT"
   head "https://github.com/mas-cli/mas.git"
 
@@ -14,19 +14,20 @@ class Mas < Formula
   end
 
   depends_on "carthage" => :build
-  depends_on xcode: ["10.2", :build]
+  if Hardware::CPU.arm?
+    depends_on xcode: ["12.2", :build]
+  else
+    depends_on xcode: ["11.4", :build]
+  end
 
   def install
     # Working around build issues in dependencies
     # - Prevent warnings from causing build failures
     # - Prevent linker errors by telling all lib builds to use max size install names
-    # - Ensure dependencies build for the current CPU; otherwise Commandant will
-    #   build for x86_64 when running arm64
     xcconfig = buildpath/"Overrides.xcconfig"
     xcconfig.write <<~EOS
       GCC_TREAT_WARNINGS_AS_ERRORS = NO
       OTHER_LDFLAGS = -headerpad_max_install_names
-      VALID_ARCHS = #{Hardware::CPU.arch}
     EOS
     ENV["XCODE_XCCONFIG_FILE"] = xcconfig
 


### PR DESCRIPTION
[v1.8.0](https://github.com/mas-cli/mas/releases/tag/v1.8.0) introduces support for arm64

- [x] remove workaround for building on Apple Silicon
- [x] add arm64_big_sur bottle
- [x] update minimum build requirements 
