### PR TITLE
Update sourcehut checksums

### DIFF
--- a/Formula/aerc.rb
+++ b/Formula/aerc.rb
@@ -2,7 +2,7 @@ class Aerc < Formula
   desc "Email client that runs in your terminal"
   homepage "https://aerc-mail.org/"
   url "https://git.sr.ht/~sircmpwn/aerc/archive/0.5.2.tar.gz"
-  sha256 "87b922440e53b99f260d2332996537decb452c838c774e9340b633296f9f68ee"
+  sha256 "dec6560c1359d1d56124a85692e877e319036f0312ce9b7a31f9828f99b92c61"
   license "MIT"
 
   bottle do

--- a/Formula/asuka.rb
+++ b/Formula/asuka.rb
@@ -1,8 +1,8 @@
 class Asuka < Formula
   desc "Gemini Project client written in Rust with NCurses"
-  homepage "https://git.sr.ht/~julienxx/asuka"
+  homepage "https://sr.ht/~julienxx/Asuka/"
   url "https://git.sr.ht/~julienxx/asuka/archive/0.8.1.tar.gz"
-  sha256 "06b03e9595b5b84e46e860ea2cf1103b244b3908fabf30337fcdf1db2a06281e"
+  sha256 "8b51eecd885be5b32e970d6cc1f4d56515960a08ed860769368859be8bdc083e"
   license "MIT"
 
   livecheck do

--- a/Formula/scdoc.rb
+++ b/Formula/scdoc.rb
@@ -1,8 +1,8 @@
 class Scdoc < Formula
   desc "Small man page generator"
-  homepage "https://git.sr.ht/~sircmpwn/scdoc/"
+  homepage "https://sr.ht/~sircmpwn/scdoc/"
   url "https://git.sr.ht/~sircmpwn/scdoc/archive/1.11.1.tar.gz"
-  sha256 "e529fcb00508e7e4c5025a745591b805b754b3bd5c84c5192acaefabdfa8f700"
+  sha256 "1098a1ed2e087596fc0b3f657c1c8a5e00412267aa4baf3619e36824306645b1"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The sha256 of _every_ sourcehut archive has changed. ~~If they change archive hashes unannounced, then they can't be used as a stable source in a package manager.~~ Found the anouncement (albeit hidden) - they guarantee stability from now on.