### PR TITLE
gcc: bump revision (Mojave SDK)

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -14,7 +14,7 @@ class Gcc < Formula
     sha256 "b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c"
   end
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
-  revision 3
+  revision 4
   head "https://gcc.gnu.org/git/gcc.git"
 
   livecheck do
@@ -105,10 +105,6 @@ class Gcc < Formula
       args << "--with-native-system-header-dir=/usr/include"
       args << "--with-sysroot=#{sdk}"
     end
-
-    # Mojave uses the Catalina SDK which causes issues like
-    # https://github.com/Homebrew/homebrew-core/issues/46393
-    ENV["ac_cv_func_aligned_alloc"] = "no" if MacOS.version == :mojave
 
     # Avoid reference to sed shim
     args << "SED=/usr/bin/sed"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The Mojave SDK fix requires gcc to be rebuilt against the fixed SDK.

This should address CI failures seen in #70907, #70923, #71003, #71004.

Context: https://github.com/Homebrew/brew/pull/10552