### PR TITLE
Updated llvm.rb to use main branch

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -3,7 +3,7 @@ class Llvm < Formula
   homepage "https://llvm.org/"
   # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
   license "Apache-2.0"
-  head "https://github.com/llvm/llvm-project.git"
+  head "https://github.com/llvm/llvm-project.git", branch: "main"
 
   stable do
     url "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.1/llvm-project-11.0.1.src.tar.xz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Hi!

I just noticed that brew install llvm --HEAD is broken, due to it attempting to pull from the master branch.  This is now deprecated in LLVM, and all users should use 'main' instead.

I'm going through the test stages now, but wanted to open this in case you wanted to course-correct the patch.  In particular, I don't want it to break the 'normal' use case of installing LLVM 11, so wanted to give the maintainers a chance to comment.

I'll update it once the tests have completed, but it may be a day or two.

Thanks!

Will Lovett