### PR TITLE
imagesnap: remove explicit SDK setting from xcodebuild

### DIFF
--- a/Formula/imagesnap.rb
+++ b/Formula/imagesnap.rb
@@ -3,6 +3,7 @@ class Imagesnap < Formula
   homepage "https://iharder.sourceforge.io/current/macosx/imagesnap/"
   url "https://github.com/rharder/imagesnap/archive/0.2.6.tar.gz"
   sha256 "e55c9f8c840c407b7441c16279c39e004f6225b96bb64ff0c2734da18a759033"
+  license :public_domain
 
   bottle do
     rebuild 1
@@ -30,7 +31,7 @@ class Imagesnap < Formula
   end
 
   def install
-    xcodebuild "-project", "ImageSnap.xcodeproj", "SYMROOT=build", "-sdk", MacOS.sdk_path
+    xcodebuild "-project", "ImageSnap.xcodeproj", "SYMROOT=build"
     bin.install "build/Release/imagesnap"
   end
 


### PR DESCRIPTION
This `-sdk` flag no longer seems to work; this meant that this formula no longer builds from source and didn't get a Big Sur rebottle.

The flag was originally added to this formula in 2011 to work around some issue with Xcode 4 (3c8f29684e8b0842792d8312090f8bdcf5855a7c) It seems to be the only formula that does this so it seems safe to remove.

Also mark it as explicit public domain per https://github.com/rharder/imagesnap/blob/master/README.md#a-note-about-public-domain