### PR TITLE
einstein fix for Apple-M1 /opt based installs

### DIFF
--- a/Formula/einstein.rb
+++ b/Formula/einstein.rb
@@ -26,7 +26,7 @@ class Einstein < Formula
   end
 
   def install
-    system "make"
+    system "make", "PREFIX=#{HOMEBREW_PREFIX}"
 
     bin.install "einstein"
     (pkgshare/"res").install "einstein.res"


### PR DESCRIPTION
The main.cpp:67 file looks for resources under $PREFIX.
The PREFIX variable is set in the Makefile to point to /usr/local, but this is not updated to /opt, which is the default on Apple-M1.
This fix overrides the PREFIX variable with HOMEBREW_PREFIX, allowing for proper resources access.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
