### PR TITLE
libcaca: update stable and livecheck

### DIFF
--- a/Formula/libcaca.rb
+++ b/Formula/libcaca.rb
@@ -1,7 +1,7 @@
 class Libcaca < Formula
   desc "Convert pixel information into colored ASCII art"
   homepage "http://caca.zoy.org/wiki/libcaca"
-  url "http://caca.zoy.org/files/libcaca/libcaca-0.99.beta19.tar.gz"
+  url "http://caca.zoy.org/raw-attachment/wiki/libcaca/libcaca-0.99.beta19.tar.gz"
   mirror "https://www.mirrorservice.org/sites/distfiles.macports.org/libcaca/libcaca-0.99.beta19.tar.gz"
   mirror "https://fossies.org/linux/privat/libcaca-0.99.beta19.tar.gz"
   version "0.99b19"
@@ -9,14 +9,12 @@ class Libcaca < Formula
   license "WTFPL"
   revision 3
 
-  # The regex here matches unstable releases and is loose about it (`.*`), as
-  # there are currently only beta releases and we don't know if there will be
-  # releases candidates, etc. before there's a stable release. Hopefully we can
-  # restrict this to stable releases in the future but it has to be loose for
-  # the moment.
+  # The regex here is looser than usual because it has to match unstable
+  # versions for now. If this software is updated in the future to a stable
+  # version, this regex should be modified to not match unstable versions.
   livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+.*)/i)
+    url :homepage
+    regex(/href=.*?libcaca[._-]v?(\d+(?:\.\d+)+.*?)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `stable` URL for `libcaca` is redirecting from `http://caca.zoy.org/files/libcaca/libcaca-0.99.beta19.tar.gz` to `/attachment/wiki/libcaca/libcaca-0.99.beta19.tar.gz?format=raw`.

The `format=raw` query string parameter is necessary to download the file, otherwise the website will load [an HTML page for the file](http://caca.zoy.org/attachment/wiki/libcaca/libcaca-0.99.beta19.tar.gz). This HTML page states, "*HTML preview not available*, since no preview renderer could handle it. Try [downloading](http://caca.zoy.org/raw-attachment/wiki/libcaca/libcaca-0.99.beta19.tar.gz) the file instead." The "downloading" link points to `http://caca.zoy.org/raw-attachment/wiki/libcaca/libcaca-0.99.beta19.tar.gz`, so the `/raw-attachment/` path is an alternative to the `format=raw` query string parameter. I think this is cleaner than the query string parameter, so I've used it in this PR.

Past that, this updates the existing `livecheck` block to check the homepage, which links to the `stable` archive. This aligns the check with the `stable` source, which we prefer. I also pared down the explanatory comment while I was at it.