### PR TITLE
thrift@0.9: whitelist github prerelease

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -4,5 +4,6 @@
   "gitless": "0.8.8",
   "gron": "all",
   "riff": "0.5.0",
-  "telegram-cli": "1.3.1"
+  "telegram-cli": "1.3.1",
+  "thrift@0.9": "all"
 }


### PR DESCRIPTION
Per https://github.com/apache/thrift/releases/tag/0.9.3.1
> This is marked in GitHub as a pre-release so that it does not become the "latest" release.

Since the upstream project uses "pre-release" for any 0.9.x release we probably should just mark the version as "all"

This should fix the Big Sur bottling issue of this formula