### PR TITLE
pokerstove: build against homebrew's copy of googletest

### DIFF
--- a/Formula/pokerstove.rb
+++ b/Formula/pokerstove.rb
@@ -4,6 +4,7 @@ class Pokerstove < Formula
   url "https://github.com/andrewprock/pokerstove/archive/v1.0.tar.gz"
   sha256 "68503e7fc5a5b2bac451c0591309eacecba738d787874d5421c81f59fde2bc74"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any, catalina:    "db03f71aebe4fd46061765ae3659629ee42a5166f2dbb8b225f53b5baf7fbe62"
@@ -13,9 +14,15 @@ class Pokerstove < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "googletest" => :build
   depends_on "boost"
 
+  # Build against our googletest instead of the included one
+  # Works around https://github.com/andrewprock/pokerstove/issues/74
+  patch :DATA
+
   def install
+    rm_rf "src/ext/googletest"
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make"
@@ -27,3 +34,18 @@ class Pokerstove < Formula
     system bin/"peval_tests"
   end
 end
+
+__END__
+--- pokerstove-1.0/CMakeLists.txt.ORIG	2021-02-14 19:26:14.000000000 +0000
++++ pokerstove-1.0/CMakeLists.txt	2021-02-14 19:26:29.000000000 +0000
+@@ -14,8 +14,8 @@
+ 
+ # Set up gtest. This must be set up before any subdirectories are
+ # added which will use gtest.
+-add_subdirectory(src/ext/googletest)
+-find_library(gtest REQUIRED)
++#add_subdirectory(src/ext/googletest)
++find_package(gtest REQUIRED)
+ include_directories(${GTEST_INCLUDE_DIRS})
+ link_directories(${GTEST_LIBS_DIR})
+ add_definitions("-fPIC")


### PR DESCRIPTION
This package stopped building from source at some point.  The problem is that it had trouble finding the copy of `googletest`
that it includes in the tarball, but it's easy to just switch to building against the homebrew copy.

Filed upstream as https://github.com/andrewprock/pokerstove/issues/74

Note that googletest seems to only be a build-time dependency (verified via `otool -L` that there are no dependencies on any related dynamic libraries)
