### PR TITLE
ncp: rebuild against new libowfat library

### DIFF
--- a/Formula/ncp.rb
+++ b/Formula/ncp.rb
@@ -3,7 +3,13 @@ class Ncp < Formula
   homepage "https://www.fefe.de/ncp/"
   url "https://dl.fefe.de/ncp-1.2.4.tar.bz2"
   sha256 "6cfa72edd5f7717bf7a4a93ccc74c4abd89892360e2e0bb095a73c24b9359b88"
+  revision 1
   head ":pserver:cvs:@cvs.fefe.de:/cvs", using: :cvs
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?ncp[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
Now that the `libowfat` dependency is building correctly again (see #71156), we need to rebottle its dependent `ncp` against it

This should fix the lack of a Big Sur bundle of this formula