### PR TITLE
gdal: revert Mojave workaround

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -4,7 +4,7 @@ class Gdal < Formula
   url "https://download.osgeo.org/gdal/3.2.1/gdal-3.2.1.tar.xz"
   sha256 "6c588b58fcb63ff3f288eb9f02d76791c0955ba9210d98c3abd879c770ae28ea"
   license "MIT"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://download.osgeo.org/gdal/CURRENT/"
@@ -26,9 +26,6 @@ class Gdal < Formula
   depends_on "pkg-config" => :build
 
   depends_on "cfitsio"
-  # Work around "Symbol not found: _curl_mime_addpart"
-  # due to mismatched SDK version in Mojave.
-  depends_on "curl" if MacOS.version == :mojave
   depends_on "epsilon"
   depends_on "expat"
   depends_on "freexl"
@@ -81,6 +78,7 @@ class Gdal < Formula
       "--with-pcraster=internal",
 
       # Homebrew backends
+      "--with-curl=/usr/bin/curl-config",
       "--with-expat=#{Formula["expat"].prefix}",
       "--with-freexl=#{Formula["freexl"].opt_prefix}",
       "--with-geos=#{Formula["geos"].opt_prefix}/bin/geos-config",
@@ -141,14 +139,6 @@ class Gdal < Formula
       "--without-sde",
       "--without-sosi",
     ]
-
-    # Work around "Symbol not found: _curl_mime_addpart"
-    # due to mismatched SDK version in Mojave.
-    args << if MacOS.version == :mojave
-      "--with-curl=#{Formula["curl"].opt_prefix}/bin/curl-config"
-    else
-      "--with-curl=/usr/bin/curl-config"
-    end
 
     system "./configure", *args
     system "make"

--- a/Formula/gmt.rb
+++ b/Formula/gmt.rb
@@ -5,7 +5,7 @@ class Gmt < Formula
   mirror "https://mirrors.ustc.edu.cn/gmt/gmt-6.1.1-src.tar.xz"
   sha256 "d476cba999340648146ef53ab4a3f64858cbd2f5511cdec9f7f06f3fb7896625"
   license "LGPL-3.0-or-later"
-  revision 2
+  revision 3
   head "https://github.com/GenericMappingTools/gmt.git"
 
   bottle do

--- a/Formula/gmt@5.rb
+++ b/Formula/gmt@5.rb
@@ -6,7 +6,7 @@ class GmtAT5 < Formula
   mirror "https://fossies.org/linux/misc/GMT/gmt-5.4.5-src.tar.gz"
   sha256 "225629c7869e204d5f9f1a384c4ada43e243f83e1ed28bdca4f7c2896bf39ef6"
   license "LGPL-3.0"
-  revision 8
+  revision 9
 
   bottle do
     sha256 big_sur:  "e93f97c3d5a207755822613ab93855ccb63632cd8e6a52e92c32572a42ae4392"

--- a/Formula/mapserver.rb
+++ b/Formula/mapserver.rb
@@ -3,7 +3,7 @@ class Mapserver < Formula
   homepage "https://mapserver.org/"
   url "https://download.osgeo.org/mapserver/mapserver-7.6.2.tar.gz"
   sha256 "36768819f28024312f76a791085f3731d2cc451f7f0c9015c91c12b3929fe179"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any, big_sur:  "79e5808f2f4fb786f71e210418a512b75dd17a158d7705b0d3d1f81e2cfceedd"

--- a/Formula/pdal.rb
+++ b/Formula/pdal.rb
@@ -4,7 +4,7 @@ class Pdal < Formula
   url "https://github.com/PDAL/PDAL/releases/download/2.2.0/PDAL-2.2.0-src.tar.gz"
   sha256 "421e94beafbfda6db642e61199bc4605eade5cab5d2e54585e08f4b27438e568"
   license "BSD-3-Clause"
-  revision 2
+  revision 3
   head "https://github.com/PDAL/PDAL.git"
 
   bottle do

--- a/Formula/points2grid.rb
+++ b/Formula/points2grid.rb
@@ -4,7 +4,7 @@ class Points2grid < Formula
   url "https://github.com/CRREL/points2grid/archive/1.3.1.tar.gz"
   sha256 "6e2f2d3bbfd6f0f5c2d0c7d263cbd5453745a6fbe3113a3a2a630a997f4a1807"
   license "BSD-4-Clause"
-  revision 10
+  revision 11
 
   bottle do
     sha256 cellar: :any, big_sur:  "02e7629e9842b057273e411b4b391befb3292ac1d5ade3265583abbe1e5cca63"

--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -4,6 +4,7 @@ class Postgis < Formula
   url "https://download.osgeo.org/postgis/source/postgis-3.1.1.tar.gz"
   sha256 "0e96afef586db6939d48fb22fbfbc9d0de5e6bc1722d6d553d63bb41441a2a7d"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://download.osgeo.org/postgis/source/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This reverts commit f4e69f8701bf87fec37d9ebc24eb5e0b3a2dc523.

It is no longer necessary after the fix to the mismatched Mojave SDK.

Context: https://github.com/Homebrew/brew/pull/10552