### PR TITLE
nrpe: don't hard-code Homebrew prefix

### DIFF
--- a/Formula/nrpe.rb
+++ b/Formula/nrpe.rb
@@ -40,7 +40,7 @@ class Nrpe < Formula
 
     inreplace "src/Makefile" do |s|
       s.gsub! "$(LIBEXECDIR)", "$(SBINDIR)"
-      s.gsub! "$(DESTDIR)/usr/local/sbin", "$(SBINDIR)"
+      s.gsub! "$(DESTDIR)#{HOMEBREW_PREFIX}/sbin", "$(SBINDIR)"
     end
 
     system "make", "all"


### PR DESCRIPTION
The nrpe formula hard-codes a path under /usr/local,
so fails to build on Apple Silicon where Homebrew
lives under /opt/homebrew instead.
Use #{HOMEBREW_PREFIX} instead of /usr/local.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
