### PR TITLE
gopass-jsonapi 1.11.1 (new formula)

### DIFF
--- a/Formula/gopass-jsonapi.rb
+++ b/Formula/gopass-jsonapi.rb
@@ -9,8 +9,7 @@ class GopassJsonapi < Formula
   depends_on "gopass"
 
   def install
-    ENV["GOBIN"] = bin
-    system "go", "install", "-ldflags", "-s -w -X main.version=#{version}", "./..."
+    system "go", *std_go_args, "-ldflags", "-s -w -X main.version=#{version}"
   end
 
   test do

--- a/Formula/gopass-jsonapi.rb
+++ b/Formula/gopass-jsonapi.rb
@@ -9,7 +9,7 @@ class GopassJsonapi < Formula
   depends_on "gopass"
 
   def install
-    system "go", *std_go_args, "-ldflags", "-s -w -X main.version=#{version}"
+    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.version=#{version}"
   end
 
   test do

--- a/Formula/gopass-jsonapi.rb
+++ b/Formula/gopass-jsonapi.rb
@@ -1,0 +1,46 @@
+class GopassJsonapi < Formula
+  desc "Gopass Browser Bindings"
+  homepage "https://github.com/gopasspw/gopass-jsonapi"
+  url "https://github.com/gopasspw/gopass-jsonapi/archive/v1.11.1.tar.gz"
+  sha256 "3c1666cdbf78a73736b089c3188c06724de53a96e43cb1d82fedd7e9543c120f"
+  license "MIT"
+
+  depends_on "go" => :build
+  depends_on "gopass"
+
+  def install
+    ENV["GOBIN"] = bin
+    system "go", "install", "-ldflags", "-s -w -X main.version=#{version}", "./..."
+  end
+
+  test do
+    (testpath/"batch.gpg").write <<~EOS
+      Key-Type: RSA
+      Key-Length: 2048
+      Subkey-Type: RSA
+      Subkey-Length: 2048
+      Name-Real: Testing
+      Name-Email: testing@foo.bar
+      Expire-Date: 1d
+      %no-protection
+      %commit
+    EOS
+
+    begin
+      system Formula["gnupg"].opt_bin/"gpg", "--batch", "--gen-key", "batch.gpg"
+
+      system Formula["gopass"].opt_bin/"gopass", "init", "--path", testpath, "noop", "testing@foo.bar"
+      system Formula["gopass"].opt_bin/"gopass", "generate", "Email/other@foo.bar", "15"
+    ensure
+      system Formula["gnupg"].opt_bin/"gpgconf", "--kill", "gpg-agent"
+      system Formula["gnupg"].opt_bin/"gpgconf", "--homedir", "keyrings/live",
+                                                 "--kill", "gpg-agent"
+    end
+
+    assert_match version.to_s, shell_output("#{bin}/gopass-jsonapi --version")
+
+    msg='{"type": "query", "query": "foo.bar"}'
+    out = pipe_output("#{bin}/gopass-jsonapi listen", [msg.length].pack("L<")+msg)
+    assert_match "Email/other@foo.bar", out
+  end
+end

--- a/Formula/gopass-jsonapi.rb
+++ b/Formula/gopass-jsonapi.rb
@@ -36,10 +36,10 @@ class GopassJsonapi < Formula
                                                  "--kill", "gpg-agent"
     end
 
-    assert_match version.to_s, shell_output("#{bin}/gopass-jsonapi --version")
+    assert_match(/^gopass-jsonapi version #{version}$/, shell_output("#{bin}/gopass-jsonapi --version"))
 
-    msg='{"type": "query", "query": "foo.bar"}'
-    out = pipe_output("#{bin}/gopass-jsonapi listen", [msg.length].pack("L<")+msg)
-    assert_match "Email/other@foo.bar", out
+    msg = '{"type": "query", "query": "foo.bar"}'
+    assert_match "Email/other@foo.bar",
+      pipe_output("#{bin}/gopass-jsonapi listen", "#{[msg.length].pack("L<")}#{msg}")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`gopass` developers decided to move `gopass-jsonapi` needed for the browser integration of `gopass` to a separate package. This pull request will add a formula for this package in order to use `gopass` browser integration. 
