### PR TITLE
Revert ".github/ISSUE_TEMPLATE/bug.yml: update syntax."

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,38 +2,33 @@ name: New issue for Reproducible Bug
 about: "If you're sure it's reproducible and not just your machine: submit an issue so we can investigate."
 labels: bug
 issue_body: false
-body:
-  - type: markdown
+inputs:
+  - type: description
     attributes:
       value: Please note we will close your issue without comment if you do not fill out the issue checklist below and provide ALL the requested information. If you repeatedly fail to use the issue template, we will block you from ever submitting issues to Homebrew again.
   - type: textarea
     attributes:
       label: "`brew gist-logs <formula>` link OR `brew config` AND `brew doctor` output"
-    validations:
       required: true
   - type: checkboxes
     attributes:
       description: Please verify that you've followed these steps
-      options:
+      choices:
         - label: The `brew doctor` above contains no "Warning" lines.
           required: true
   - type: textarea
     attributes:
       label: What were you trying to do (and why)?
-    validations:
       required: true
   - type: textarea
     attributes:
       label: What happened (include all command output)?
-    validations:
       required: true
   - type: textarea
     attributes:
       label: What did you expect to happen?
-    validations:
       required: true
   - type: textarea
     attributes:
       label: Step-by-step reproduction instructions (by running `brew` commands)
-    validations:
       required: true


### PR DESCRIPTION
This shouldn't have been merged until Friday.

Reverts Homebrew/homebrew-core#70976