### PR TITLE
gr-osmosdr: allow for install from HEAD

### DIFF
--- a/Formula/gr-osmosdr.rb
+++ b/Formula/gr-osmosdr.rb
@@ -6,7 +6,6 @@ class GrOsmosdr < Formula
   url "https://github.com/osmocom/gr-osmosdr/archive/v0.2.3.tar.gz"
   sha256 "11b1eb13725ced5ded9121a10aaf7bccf2430c5c69d020791408219968665b71"
   license "GPL-3.0-or-later"
-  head "https://github.com/osmocom/gr-osmosdr.git"
 
   bottle do
     sha256 big_sur:  "54c41d6a6ad6ff508d1a9fb3fcebf1d245ecd50eded905b9ca51f26fb6f4d01a"
@@ -14,11 +13,16 @@ class GrOsmosdr < Formula
     sha256 mojave:   "1316ec1150647972436f96a9d957b5c5b7889f6f962217b181e6185a939aa2e2"
   end
 
+  head do
+    url "https://github.com/osmocom/gr-osmosdr.git"
+
+    depends_on "pybind11" => :build
+  end
+
   # gr-osmosdr does not build with gnuradio 3.9+
   disable! date: "2021-01-17", because: :does_not_build
 
   depends_on "cmake" => :build
-  depends_on "pybind11" => :build
   depends_on "swig" => :build
   depends_on "airspy"
   depends_on "boost"

--- a/Formula/gr-osmosdr.rb
+++ b/Formula/gr-osmosdr.rb
@@ -6,6 +6,7 @@ class GrOsmosdr < Formula
   url "https://github.com/osmocom/gr-osmosdr/archive/v0.2.3.tar.gz"
   sha256 "11b1eb13725ced5ded9121a10aaf7bccf2430c5c69d020791408219968665b71"
   license "GPL-3.0-or-later"
+  head "https://github.com/osmocom/gr-osmosdr.git"
 
   bottle do
     sha256 big_sur:  "54c41d6a6ad6ff508d1a9fb3fcebf1d245ecd50eded905b9ca51f26fb6f4d01a"
@@ -17,6 +18,7 @@ class GrOsmosdr < Formula
   disable! date: "2021-01-17", because: :does_not_build
 
   depends_on "cmake" => :build
+  depends_on "pybind11" => :build
   depends_on "swig" => :build
   depends_on "airspy"
   depends_on "boost"


### PR DESCRIPTION
This commit follows up on the disabling of the gr-osmosdr package as
part of the upgrade to gnuradio 3.9 [1]. By adding the head directive
[2] we faciliate installing a version of this library that works with
the latest gnuradio due to changes to the new pybind11 interface [3] as
a stop-gap measure until a release is put out that allows it to be
enabled again, which there is an issue tracking [4].


NOTE: This commit does not remove the `disable!` statement, but someone can now use `brew edit gr-osmosdr` to comment it out and install the package if they wish.


[1] https://github.com/Homebrew/homebrew-core/pull/69326
[2] https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md#unstable-versions-head
[3] https://github.com/osmocom/gr-osmosdr/commit/0d727b3ef8ea56132fd538c9aa54b671950e1297 and other subsequent commits
[4] https://osmocom.org/issues/5021

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
	- Caveat here is that I did the `brew edit` step mentioned above
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
