### PR TITLE
crosstool-ng: Use python from homebrew

### DIFF
--- a/Formula/crosstool-ng.rb
+++ b/Formula/crosstool-ng.rb
@@ -3,7 +3,7 @@ class CrosstoolNg < Formula
   homepage "https://crosstool-ng.github.io/"
   url "http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.24.0.tar.xz"
   sha256 "804ced838ea7fe3fac1e82f0061269de940c82b05d0de672e7d424af98f22d2d"
-  license "LGPL-2.1"
+  license "GPL-2.0-only"
   revision 2
   head "https://github.com/crosstool-ng/crosstool-ng.git"
 

--- a/Formula/crosstool-ng.rb
+++ b/Formula/crosstool-ng.rb
@@ -4,7 +4,7 @@ class CrosstoolNg < Formula
   url "http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.24.0.tar.xz"
   sha256 "804ced838ea7fe3fac1e82f0061269de940c82b05d0de672e7d424af98f22d2d"
   license "LGPL-2.1"
-  revision 1
+  revision 2
   head "https://github.com/crosstool-ng/crosstool-ng.git"
 
   bottle do
@@ -33,6 +33,7 @@ class CrosstoolNg < Formula
   depends_on "m4"
   depends_on "make"
   depends_on "ncurses"
+  depends_on "python@3.9"
   depends_on "xz"
 
   uses_from_macos "flex" => :build
@@ -46,6 +47,7 @@ class CrosstoolNg < Formula
     ENV["BISON"] = "#{Formula["bison"].opt_bin}/bison"
     ENV["M4"] = "#{Formula["m4"].opt_bin}/m4"
     ENV["MAKE"] = "#{Formula["make"].opt_bin}/gmake"
+    ENV["PYTHON"] = "#{Formula["python@3.9"].opt_bin}/python3"
     ENV.append "LDFLAGS", "-lintl"
 
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
macOS doesn't recommend to use scripting runtimes bundled with the OS
since 10.15:

https://developer.apple.com/documentation/macos-release-notes/macos-catalina-10_15-release-notes

Closes crosstool-ng/crosstool-ng#1308

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
