### PR TITLE
waffle 1.6.2 (new formula)

### DIFF
--- a/Formula/waffle.rb
+++ b/Formula/waffle.rb
@@ -1,0 +1,32 @@
+class Waffle < Formula
+  desc "C library for selecting an OpenGL API and window system at runtime"
+  homepage "http://www.waffle-gl.org/"
+  url "https://gitlab.freedesktop.org/mesa/waffle/-/raw/website/files/release/waffle-1.6.2/waffle-1.6.2.tar.xz"
+  sha256 "41ff9e042497e482c7294e210ebd9962e937631829a548e5811c637337cec5a5"
+  license "BSD-2-Clause"
+  head "https://gitlab.freedesktop.org/mesa/waffle.git"
+
+  depends_on "cmake" => :build
+  depends_on "docbook-xsl" => :build
+  depends_on "pkg-config" => :test
+
+  def install
+    args = std_cmake_args + %w[
+      -Dwaffle_build_examples=1
+      -Dwaffle_build_htmldocs=1
+      -Dwaffle_build_manpages=1
+    ]
+
+    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make", "install"
+    end
+  end
+
+  test do
+    cp_r prefix/"share/doc/waffle1/examples", testpath
+    cd "examples"
+    system "make", "-f", "Makefile.example"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This is a follow-up to @yurikoles' https://github.com/Homebrew/homebrew-core/pull/52469. Since the discussion in that PR, a new release has recently been tagged upstream which includes the needed patch/MR.