### PR TITLE
asciidoc: update repo location for formula

### DIFF
--- a/Formula/asciidoc.rb
+++ b/Formula/asciidoc.rb
@@ -3,10 +3,10 @@ class Asciidoc < Formula
 
   desc "Formatter/translator for text files to numerous formats. Includes a2x"
   homepage "https://asciidoc.org/"
-  url "https://github.com/asciidoc/asciidoc-py3/archive/9.1.0.tar.gz"
-  sha256 "8a6e3ae99785d9325fba0856e04dbe532492af3cb20d49831bfd757166d46c6b"
+  url "https://github.com/asciidoc-py/asciidoc-py/archive/9.1.0.tar.gz"
+  sha256 "5056c20157349f8dc74f005b6e88ccbf1078c4e26068876f13ca3d1d7d045fe7"
   license "GPL-2.0-only"
-  head "https://github.com/asciidoc/asciidoc-py3.git"
+  head "https://github.com/asciidoc-py/asciidoc-py.git"
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Updates the repo name for the asciidoc formula to its new home at https://github.com/asciidoc-py/asciidoc-py.