### PR TITLE
lmdb: update livecheck

### DIFF
--- a/Formula/lmdb.rb
+++ b/Formula/lmdb.rb
@@ -8,7 +8,7 @@ class Lmdb < Formula
   head "https://git.openldap.org/openldap/openldap.git", branch: "mdb.master"
 
   livecheck do
-    url :head
+    url :stable
     regex(/^LMDB[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR simply updates the existing `livecheck` block for `lmdb` to use `url :stable` instead of `url :head`, as we prefer to align the check with the `stable` source whenever possible. In this case, the `stable` URL is processed into the same Git URL as `head`, so there's no functional change here.