### PR TITLE
igraph: fix test for linux

### DIFF
--- a/Formula/igraph.rb
+++ b/Formula/igraph.rb
@@ -42,7 +42,7 @@ class Igraph < Formula
       }
     EOS
     system ENV.cc, "test.c", "-I#{include}/igraph", "-L#{lib}",
-                   "-ligraph", "-o", "test"
+                   "-ligraph", "-lm", "-o", "test"
     assert_match "Diameter = 9", shell_output("./test")
   end
 end


### PR DESCRIPTION
Fixes:
/home/linuxbrew/.linuxbrew/bin/ld: complex.c:(.text+0xcf6): undefined reference to `cos'

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
