### PR TITLE
go@1.{9,10,11,12}: disable

### DIFF
--- a/Formula/go@1.10.rb
+++ b/Formula/go@1.10.rb
@@ -16,7 +16,7 @@ class GoAT110 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2019-02-25", because: :unsupported
+  disable! date: "2021-02-16", because: :unsupported
 
   depends_on arch: :x86_64
 

--- a/Formula/go@1.11.rb
+++ b/Formula/go@1.11.rb
@@ -16,7 +16,7 @@ class GoAT111 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2019-09-03", because: :unsupported
+  disable! date: "2021-02-16", because: :unsupported
 
   depends_on arch: :x86_64
 

--- a/Formula/go@1.12.rb
+++ b/Formula/go@1.12.rb
@@ -16,7 +16,7 @@ class GoAT112 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-02-25", because: :unsupported
+  disable! date: "2021-02-16", because: :unsupported
 
   depends_on arch: :x86_64
 

--- a/Formula/go@1.9.rb
+++ b/Formula/go@1.9.rb
@@ -16,7 +16,7 @@ class GoAT19 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2018-08-04", because: :unsupported
+  disable! date: "2021-02-16", because: :unsupported
 
   depends_on arch: :x86_64
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

These old formulae have been unsupported for a while, so it's time to disable them. I chose the release date of go1.16 as the disable date.

We currently carry seven versions of go when [policy](https://docs.brew.sh/Versions#acceptable-versioned-formulae) dictates we should only have five. I disabled three because, judging from #71289, we might need a `go@1.15` soon.