### PR TITLE
mdds: remove livecheck

### DIFF
--- a/Formula/mdds.rb
+++ b/Formula/mdds.rb
@@ -5,10 +5,6 @@ class Mdds < Formula
   sha256 "a66a2a8293a3abc6cd9baff7c236156e2666935cbfb69a15d64d38141638fecf"
   license "MIT"
 
-  livecheck do
-    url :head
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f4c421f18efdd519f3ca12a78295c2b1c5e36f6726369736e68ed07870e40a33"
     sha256 cellar: :any_skip_relocation, big_sur:       "59ebe66bdf74479076e8df76ba906f2bda539f819c778abaf608acbae04343f3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This removes the `livecheck` block from `mdds`, as it only contains `url :head`. In this case, `stable` is currently uncheckable (the upstream site simply returns a blank page) and livecheck will simply use the `head` URL, so it checks the same source without the `livecheck` block.

It's better not to have this particular block as removing it would allow livecheck to automatically check `stable` in the future if the source were to change to a supported URL (or the existing URL becomes supported through strategy changes/additions). We prefer to align the check with the `stable` source whenever possible and this is in keeping with that guideline.