### PR TITLE
terrahub: add livecheck

### DIFF
--- a/Formula/terrahub.rb
+++ b/Formula/terrahub.rb
@@ -7,6 +7,11 @@ class Terrahub < Formula
   sha256 "d2c66e3beaf28df2953f3830b771f1a34596ef51adaea321fe12ee39ada62b43"
   license "MPL-2.0"
 
+  livecheck do
+    url "https://github.com/tfxor/terrahub.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "8fb1ab5d692f7c6eb00c58882edfe883ed1b7bc130fcbacef2c59a2b05939054"
     sha256 cellar: :any_skip_relocation, big_sur:       "637b0c5d0b5bb4842335e447baa3d9cb75e50435c402669e69411b2c927a750f"

--- a/Formula/terrahub.rb
+++ b/Formula/terrahub.rb
@@ -8,8 +8,8 @@ class Terrahub < Formula
   license "MPL-2.0"
 
   livecheck do
-    url "https://github.com/tfxor/terrahub.git"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://registry.npmjs.org/terrahub/latest"
+    regex(/"version":\s*?"([^"]+)"/i)
   end
 
   bottle do


### PR DESCRIPTION
terrahub: add livecheck

---

Current livecheck tracks down the alpha and beta releases, adding livecheck to avoid the npmjs checks (#71278, #71356)