### PR TITLE
ghc: update livecheck

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -7,7 +7,7 @@ class Ghc < Formula
 
   livecheck do
     url "https://www.haskell.org/ghc/download.html"
-    regex(/href=.*?download[._-]ghc[._-][^"' >]+?\.html[^>]*?>\s*?v?(\d+(?:\.\d+)+)\s*?</i)
+    regex(/href=.*?download[._-]ghc[._-][^"' >]+?\.html[^>]*?>\s*?v?(8(?:\.\d+)+)\s*?</i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Since we have a `ghc@9` formula now, livecheck picks up false version
updates for ghc.

Before:

    ❯ brew livecheck ghc
    ghc : 8.10.4 ==> 9.0.1

After:

    ❯ brew livecheck ghc
    ghc : 8.10.4 ==> 8.10.4