### PR TITLE
Update wasmer -cmake -wabt +llvm

### DIFF
--- a/Formula/wasmer.rb
+++ b/Formula/wasmer.rb
@@ -13,8 +13,8 @@ class Wasmer < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "ca3bb35344bf5e3269e123842f622180939b3b240f0e98f1824ca79305212cae"
   end
 
-  depends_on "llvm" => :build
   depends_on "libffi" => :build
+  depends_on "llvm" => :build
   depends_on "rust" => :build
 
   uses_from_macos "ncurses"

--- a/Formula/wasmer.rb
+++ b/Formula/wasmer.rb
@@ -15,8 +15,13 @@ class Wasmer < Formula
 
   depends_on "llvm" => :build
   depends_on "rust" => :build
+  depends_on "libffi" => :build
+
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
 
   def install
+    ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
     chdir "lib/cli" do
       system "cargo", "install", "--features", "cranelift,llvm", *std_cargo_args
     end

--- a/Formula/wasmer.rb
+++ b/Formula/wasmer.rb
@@ -13,13 +13,12 @@ class Wasmer < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "ca3bb35344bf5e3269e123842f622180939b3b240f0e98f1824ca79305212cae"
   end
 
-  depends_on "cmake" => :build
+  depends_on "llvm" => :build
   depends_on "rust" => :build
-  depends_on "wabt" => :build
 
   def install
     chdir "lib/cli" do
-      system "cargo", "install", "--features", "cranelift", *std_cargo_args
+      system "cargo", "install", "--features", "cranelift,llvm", *std_cargo_args
     end
   end
 

--- a/Formula/wasmer.rb
+++ b/Formula/wasmer.rb
@@ -14,8 +14,8 @@ class Wasmer < Formula
   end
 
   depends_on "llvm" => :build
-  depends_on "rust" => :build
   depends_on "libffi" => :build
+  depends_on "rust" => :build
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"


### PR DESCRIPTION
Wasmer no longer requires cmake or wabt.
When building the bottle we want to install llvm so that compiler is also supported

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
