### PR TITLE
terraform-inventory: fix build with Go 1.16

### DIFF
--- a/Formula/terraform-inventory.rb
+++ b/Formula/terraform-inventory.rb
@@ -31,14 +31,14 @@ class TerraformInventory < Formula
   def install
     ENV["GOPATH"] = buildpath
     ENV["GO111MODULE"] = "auto"
-    
+
     mkdir_p buildpath/"src/github.com/adammck/"
     ln_sf buildpath, buildpath/"src/github.com/adammck/terraform-inventory"
     Language::Go.stage_deps resources, buildpath/"src"
 
     system "go", "build", "-o", bin/"terraform-inventory", "-ldflags", "-X main.build_version='#{version}'"
   end
-  
+
   test do
     example = <<~EOS
       {

--- a/Formula/terraform-inventory.rb
+++ b/Formula/terraform-inventory.rb
@@ -29,13 +29,7 @@ class TerraformInventory < Formula
   end
 
   def install
-    ENV["GOPATH"] = buildpath
-
-    mkdir_p buildpath/"src/github.com/adammck/"
-    ln_sf buildpath, buildpath/"src/github.com/adammck/terraform-inventory"
-    Language::Go.stage_deps resources, buildpath/"src"
-
-    system "go", "build", "-o", bin/"terraform-inventory", "-ldflags", "-X main.build_version='#{version}'"
+    system "go", "build", *std_go_args
   end
 
   test do

--- a/Formula/terraform-inventory.rb
+++ b/Formula/terraform-inventory.rb
@@ -29,9 +29,16 @@ class TerraformInventory < Formula
   end
 
   def install
-    system "go", "build", *std_go_args
-  end
+    ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
+    
+    mkdir_p buildpath/"src/github.com/adammck/"
+    ln_sf buildpath, buildpath/"src/github.com/adammck/terraform-inventory"
+    Language::Go.stage_deps resources, buildpath/"src"
 
+    system "go", "build", "-o", bin/"terraform-inventory", "-ldflags", "-X main.build_version='#{version}'"
+  end
+  
   test do
     example = <<~EOS
       {

--- a/Formula/vultr.rb
+++ b/Formula/vultr.rb
@@ -16,7 +16,10 @@ class Vultr < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/JamesClonk").mkpath
+    ln_s buildpath, buildpath/"src/github.com/JamesClonk/vultr"
+    system "go", "build", "-o", bin/"vultr"
   end
 
   test do

--- a/Formula/vultr.rb
+++ b/Formula/vultr.rb
@@ -16,10 +16,7 @@ class Vultr < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/JamesClonk").mkpath
-    ln_s buildpath, buildpath/"src/github.com/JamesClonk/vultr"
-    system "go", "build", "-o", bin/"vultr"
+    system "go", "build", *std_go_args
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/homebrew-core/issues/47627 references this