### PR TITLE
Solr: fixed an issue with running solr as a service on ARM (m1)

### DIFF
--- a/Formula/solr.rb
+++ b/Formula/solr.rb
@@ -5,6 +5,7 @@ class Solr < Formula
   mirror "https://archive.apache.org/dist/lucene/solr/8.8.0/solr-8.8.0.tgz"
   sha256 "7318752d1d30fa2ef839eb3d2df0f2bdb2709d304aa4870b02b33b91e945b054"
   license "Apache-2.0"
+  revision 1
 
   bottle :unneeded
 
@@ -46,7 +47,7 @@ class Solr < Formula
             <string>start</string>
             <string>-f</string>
             <string>-s</string>
-            <string>/usr/local/var/lib/solr</string>
+            <string>#{HOMEBREW_PREFIX}/var/lib/solr</string>
           </array>
           <key>ServiceDescription</key>
           <string>#{name}</string>


### PR DESCRIPTION
When running Solr as a service with `brew services start solr` command, the homebrew.mxcl.solr.plist should use /opt/homebrew/var/lib/solr directory when run on ARM, and not the /usr/local/var/lib/solr as if it runs on intel.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? (both intel and ARM)
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
