### PR TITLE
microplane: support go1.16

### DIFF
--- a/Formula/microplane.rb
+++ b/Formula/microplane.rb
@@ -17,13 +17,14 @@ class Microplane < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
+    ldflags = "-s -w -X main.version=#{version}"
 
     dir = buildpath/"src/github.com/Clever/microplane"
     dir.install buildpath.children
     cd "src/github.com/Clever/microplane" do
-      system "make", "install_deps"
-      system "make", "build"
-      bin.install "bin/mp"
+      system "dep", "ensure", "-v", "-vendor-only"
+      system "go", "build", *std_go_args, "-ldflags", ldflags, "-o", bin/"mp"
     end
   end
 


### PR DESCRIPTION
epic #47627 

Changed the build to no longer use makefile and work with go 1.16.  
Sadly upstream doesn't make use of github issues (https://github.com/Clever/microplane) so no issue was filed.  
If upstream doesn't switch to go modules brew should probably remove the formular.  


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
