### PR TITLE
ldc: build against our default llvm

### DIFF
--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -4,6 +4,7 @@ class Ldc < Formula
   url "https://github.com/ldc-developers/ldc/releases/download/v1.24.0/ldc-1.24.0-src.tar.gz"
   sha256 "fd9561ade916e9279bdcc166cf0e4836449c24e695ab4470297882588adbba3c"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/ldc-developers/ldc.git", shallow: false
 
   livecheck do
@@ -19,7 +20,7 @@ class Ldc < Formula
 
   depends_on "cmake" => :build
   depends_on "libconfig" => :build
-  depends_on "llvm@9" # due to a bug in llvm 10 https://bugs.llvm.org/show_bug.cgi?id=47226
+  depends_on "llvm"
 
   uses_from_macos "libxml2" => :build
 
@@ -32,13 +33,18 @@ class Ldc < Formula
     sha256 "91b74856982d4d5ede6e026f24e33887d931db11b286630554fc2ad0438cda44"
   end
 
+  # Add support for building against LLVM 11.1
+  # This is already merged upstream via https://github.com/ldc-developers/druntime/pull/195
+  # but it needs adjustments to apply against 1.24.0 tarball
+  patch :DATA
+
   def install
     ENV.cxx11
     (buildpath/"ldc-bootstrap").install resource("ldc-bootstrap")
 
     mkdir "build" do
       args = std_cmake_args + %W[
-        -DLLVM_ROOT_DIR=#{Formula["llvm@9"].opt_prefix}
+        -DLLVM_ROOT_DIR=#{Formula["llvm"].opt_prefix}
         -DINCLUDE_INSTALL_DIR=#{include}/dlang/ldc
         -DD_COMPILER=#{buildpath}/ldc-bootstrap/bin/ldmd2
       ]
@@ -46,6 +52,9 @@ class Ldc < Formula
       system "cmake", "..", *args
       system "make"
       system "make", "install"
+
+      # Workaround for https://github.com/ldc-developers/ldc/issues/3670
+      cp Formula["llvm"].opt_lib/"libLLVM.dylib", lib/"libLLVM.dylib"
     end
   end
 
@@ -66,3 +75,15 @@ class Ldc < Formula
     assert_match "Hello, world!", shell_output("./test")
   end
 end
+
+__END__
+--- ldc-1.24.0-src/runtime/druntime/src/ldc/intrinsics.di.ORIG	2021-02-19 00:16:52.000000000 +0000
++++ ldc-1.24.0-src/runtime/druntime/src/ldc/intrinsics.di	2021-02-19 00:17:05.000000000 +0000
+@@ -26,6 +26,7 @@
+ else version (LDC_LLVM_900)  enum LLVM_version =  900;
+ else version (LDC_LLVM_1000) enum LLVM_version = 1000;
+ else version (LDC_LLVM_1100) enum LLVM_version = 1100;
++else version (LDC_LLVM_1101) enum LLVM_version = 1101;
+ else static assert(false, "LDC LLVM version not supported");
+ 
+ enum LLVM_atleast(int major) = (LLVM_version >= major * 100);


### PR DESCRIPTION
Two changes are required:
* The intrinsics.di need a one-line adjustment to recognize LLVM 11.1 as a valid version.  This is already merged into the upstream HEAD but we need to adjust the patch a little when applying against the 1.24.0 tarball: https://github.com/ldc-developers/druntime/pull/195
* As @bayandin discovered when trying to make this change a few months ago, `brew test` failed due to a loading problem with `libLTO-ldc.dylib`: https://github.com/Homebrew/homebrew-core/pull/61117#issuecomment-711435584  I debugged this to a problem with it finding `libLLVM.dylib` correctly.  I filed this upstream as https://github.com/ldc-developers/ldc/issues/3670 but in the meantime we can just copy the library as a workaround.