### PR TITLE
gource: add missing LDFLAG on Linux

### DIFF
--- a/Formula/gource.rb
+++ b/Formula/gource.rb
@@ -36,6 +36,9 @@ class Gource < Formula
     # clang on Mt. Lion will try to build against libstdc++,
     # despite -std=gnu++0x
     ENV.libcxx
+    on_linux do
+      ENV.append "LDFLAGS", "-lpthread"
+    end
 
     system "autoreconf", "-f", "-i" if build.head?
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Backport of https://github.com/Homebrew/linuxbrew-core/pull/22310/files.