### PR TITLE
qhull: update livecheck

### DIFF
--- a/Formula/qhull.rb
+++ b/Formula/qhull.rb
@@ -7,9 +7,11 @@ class Qhull < Formula
   license "Qhull"
   head "https://github.com/qhull/qhull.git"
 
+  # It's necessary to match the version from the link text, as the filename
+  # only contains the year (`2020`), not a full version like `2020.2`.
   livecheck do
-    url :head
-    regex(/^v?(\d{4}(?:\.\d+)+)$/i)
+    url "http://www.qhull.org/download/"
+    regex(/href=.*?qhull[._-][^"' >]+?[._-]src[^>]*?\.t[^>]+?>[^<]*Qhull v?(\d+(?:\.\d+)*)/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `qhull` to check the first-party download page, which links to the `stable` archive. This aligns the check with the `stable` source, which we prefer.