### PR TITLE
qtads: update livecheck

### DIFF
--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -33,9 +33,12 @@ class Qtads < Formula
     end
   end
 
+  # The first-party download page links to releases on GitHub, so we manually
+  # check that for now. If the formula is modified in the future to use a
+  # release from GitHub, this should be modified to use `url :stable`.
   livecheck do
     url :head
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `qtads` to add a preceding explanation of why we're checking `head` instead of `stable`.

This also adds the standard regex for Git tags and removes `strategy :github_latest`, as we currently only use `GithubLatest` when it's necessary and correct. In this case it's not currently necessary and I had simply [added this `livecheck` block](https://github.com/Homebrew/homebrew-livecheck/pull/1310) at a time when we were considering checking the "latest" release more frequently. If the `GithubLatest` strategy ends up being necessary in the future, we can always switch this back.