### PR TITLE
composer: update livecheck

### DIFF
--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -6,8 +6,8 @@ class Composer < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/composer/composer.git"
-    regex(/^[\d.]+$/i)
+    url "https://getcomposer.org/download/"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/composer\.phar}i)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `composer` to check the first-party download page, which links to the `phar` files we use as `stable`. This aligns the check with the `stable` source, which we prefer.