### PR TITLE
pyenv-pip-migrate: 20181205

### DIFF
--- a/Formula/pyenv-pip-migrate.rb
+++ b/Formula/pyenv-pip-migrate.rb
@@ -1,8 +1,9 @@
 class PyenvPipMigrate < Formula
   desc "Migrate pip packages from one Python version to another"
   homepage "https://github.com/pyenv/pyenv-pip-migrate"
-  url "https://github.com/pyenv/pyenv-pip-migrate/archive/v20130527.tar.gz"
-  sha256 "1ec5a590a05792843d493a66825ede852b6afc6e95a6a2d2a813e73497c6637a"
+  url "https://github.com/pyenv/pyenv-pip-migrate/archive/88f09de2a06f95bd1933b950ec2b66671ae36fbd.tar.gz"
+  version "20181205"
+  sha256 "bd79295dd5412a6b90311e316e1b78553fc2c612dd6b4dec15cc030d7213fcfb"
   license "MIT"
   head "https://github.com/pyenv/pyenv-pip-migrate.git"
 

--- a/Formula/pyenv-pip-migrate.rb
+++ b/Formula/pyenv-pip-migrate.rb
@@ -1,9 +1,8 @@
 class PyenvPipMigrate < Formula
   desc "Migrate pip packages from one Python version to another"
   homepage "https://github.com/pyenv/pyenv-pip-migrate"
-  url "https://github.com/pyenv/pyenv-pip-migrate/archive/88f09de2a06f95bd1933b950ec2b66671ae36fbd.tar.gz"
-  version "20181205"
-  sha256 "bd79295dd5412a6b90311e316e1b78553fc2c612dd6b4dec15cc030d7213fcfb"
+  url "https://github.com/pyenv/pyenv-pip-migrate/archive/v20181205.tar.gz"
+  sha256 "c064c76b854fa905c40e71b5223699bacf18ca492547aad93cdde2b98ca4e58c"
   license "MIT"
   head "https://github.com/pyenv/pyenv-pip-migrate.git"
 


### PR DESCRIPTION
Update to latest commit and following CalVer used in the current (and only) release. The project has not made a new release in quite some time and the current release contains bugs. There is an [open issue](https://github.com/pyenv/pyenv-pip-migrate/issues/6) asking for a new release. I figured using the latest commit on the stable branch would be an acceptable solution in the absence of on official release.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
