### PR TITLE
git-sizer: Set GO111MODULE=auto for Go 1.16

### DIFF
--- a/Formula/git-sizer.rb
+++ b/Formula/git-sizer.rb
@@ -17,6 +17,7 @@ class GitSizer < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/github/git-sizer").install buildpath.children
     cd "src/github.com/github/git-sizer" do
       system "go", "build", "-o", bin/"git-sizer"


### PR DESCRIPTION
This will let git-sizer build with Go 1.16.

master on git-sizer already has a go.mod but a release hasn't been
tagged yet.

Existing issue on git-sizer to update to 1.16: github/git-sizer#68.

Epic: #47627

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
