### PR TITLE
postgresql@9.5: remove livecheck

### DIFF
--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -5,11 +5,6 @@ class PostgresqlAT95 < Formula
   sha256 "7628c55eb23768a2c799c018988d8f2ab48ee3d80f5e11259938f7a935f0d603"
   license "PostgreSQL"
 
-  livecheck do
-    url "https://ftp.postgresql.org/pub/source/"
-    regex(%r{href=["']?v?(9\.5(?:\.\d+)*)/?["' >]}i)
-  end
-
   bottle do
     sha256 big_sur:  "3be3ba84a56c9977313e3cc9e5473230fa2805f69d9dd4dceb18c1fc26dd824c"
     sha256 catalina: "07d235dbc8b2d5e9fb31194f163aa2903513738264a95cdb6cff31f7eb9e9ca4"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The final release date for the `postgresql` 9.5 series was 2021-02-11. This PR removes the `livecheck` block so that livecheck will automatically skip it (due to the formula being deprecated).