### PR TITLE
imagemagick, imagemagick@6: update mirror and livecheck

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -2,13 +2,13 @@ class Imagemagick < Formula
   desc "Tools and libraries to manipulate images in many formats"
   homepage "https://www.imagemagick.org/"
   url "https://dl.bintray.com/homebrew/mirror/ImageMagick-7.0.11-0.tar.xz"
-  mirror "https://www.imagemagick.org/download/releases/ImageMagick-7.0.11-0.tar.xz"
+  mirror "https://download.imagemagick.org/ImageMagick/download/releases/ImageMagick-7.0.11-0.tar.xz"
   sha256 "ef49558c7d2648d3001306b1e65c542acab6476a24fcbd275beae6240576c0ac"
   license "ImageMagick"
   head "https://github.com/ImageMagick/ImageMagick.git"
 
   livecheck do
-    url "https://www.imagemagick.org/download/"
+    url "https://download.imagemagick.org/ImageMagick/download/"
     regex(/href=.*?ImageMagick[._-]v?(\d+(?:\.\d+)+-\d+)\.t/i)
   end
 

--- a/Formula/imagemagick@6.rb
+++ b/Formula/imagemagick@6.rb
@@ -5,13 +5,13 @@ class ImagemagickAT6 < Formula
   # ImageMagick site removes tarballs regularly which means we get issues
   # unnecessarily and older versions of the formula are broken.
   url "https://dl.bintray.com/homebrew/mirror/imagemagick%406-6.9.12-0.tar.xz"
-  mirror "https://www.imagemagick.org/download/releases/ImageMagick-6.9.12-0.tar.xz"
+  mirror "https://download.imagemagick.org/ImageMagick/download/releases/ImageMagick-6.9.12-0.tar.xz"
   sha256 "0e2a35c164c4e8ce43f24f3bdfeed0b795fe2ac8dfa7c9a8dfb477126c36ac2d"
   license "ImageMagick"
   head "https://github.com/imagemagick/imagemagick6.git"
 
   livecheck do
-    url "https://www.imagemagick.org/download/"
+    url "https://download.imagemagick.org/ImageMagick/download/"
     regex(/href=.*?ImageMagick[._-]v?(6(?:\.\d+)+(?:-\d+)?)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the `mirror` (i.e., upstream) and `livecheck` URLs for `imagemagick` and `imagemagick@6`, as they were redirecting from `www.imagemagick.org/...` to `download.imagemagick.org/ImageMagick/...`.