### PR TITLE
assert_not_match

### DIFF
--- a/Formula/bpytop.rb
+++ b/Formula/bpytop.rb
@@ -48,7 +48,7 @@ class Bpytop < Formula
 
     log = (config/"error.log").read
     assert_match "bpytop version #{version} started with pid #{pid}", log
-    assert_not_match "ERROR:", log
+    assert_not_match(/ERROR:/, log)
   ensure
     Process.kill("TERM", pid)
   end

--- a/Formula/dnstwist.rb
+++ b/Formula/dnstwist.rb
@@ -87,6 +87,6 @@ class Dnstwist < Formula
     assert_match "Fetching content from:", output
     assert_match "//brew.sh", output
     assert_match(/Processing \d+ permutations/, output)
-    assert_not_match "notice: missing module", output
+    assert_not_match(/notice: missing module/, output)
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
test-unit 3.2.9, which is the system gem version on macOS Big Sur, does not allow a string in `assert_not_match`, only in `assert_match`. The current version does. The function versions that allow strings first check to see if the argument is a String and convert it to a Regexp anyway. The new form is causing test failures in formulae using `assert_not_match` with a string in its test: `bpytop.rb` and `dnstwist.rb`.

https://github.com/test-unit/test-unit/blob/3.2.9/lib/test/unit/assertions.rb#L532-L539

https://github.com/test-unit/test-unit/blob/3.2.9/lib/test/unit/assertions.rb#L711-L715

Partially reverts https://github.com/Homebrew/homebrew-core/pull/71286

cc @Rylan12  @SMillerDev 