### PR TITLE
Update redirecting livecheck URLs

### DIFF
--- a/Formula/alsa-lib.rb
+++ b/Formula/alsa-lib.rb
@@ -6,7 +6,7 @@ class AlsaLib < Formula
   license "LGPL-2.1-or-later"
 
   livecheck do
-    url "https://www.alsa-project.org/files/pub/lib"
+    url "https://www.alsa-project.org/files/pub/lib/"
     regex(/href=.*?alsa-lib[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/ipcalc.rb
+++ b/Formula/ipcalc.rb
@@ -5,7 +5,7 @@ class Ipcalc < Formula
   sha256 "dda9c571ce3369e5b6b06e92790434b54bec1f2b03f1c9df054c0988aa4e2e8a"
 
   livecheck do
-    url "http://jodies.de/ipcalc-archive"
+    url "http://jodies.de/ipcalc-archive/"
     regex(/href=.*?ipcalc[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/lrzip.rb
+++ b/Formula/lrzip.rb
@@ -6,7 +6,7 @@ class Lrzip < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "http://ck.kolivas.org/apps/lrzip"
+    url "http://ck.kolivas.org/apps/lrzip/"
     regex(/href=.*?lrzip[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/nuttcp.rb
+++ b/Formula/nuttcp.rb
@@ -1,6 +1,6 @@
 class Nuttcp < Formula
   desc "Network performance measurement tool"
-  homepage "https://www.nuttcp.net/nuttcp"
+  homepage "https://www.nuttcp.net/nuttcp/"
   url "https://www.nuttcp.net/nuttcp/nuttcp-8.2.2.tar.bz2"
   sha256 "7ead7a89e7aaa059d20e34042c58a198c2981cad729550d1388ddfc9036d3983"
   license "GPL-2.0"

--- a/Formula/poco.rb
+++ b/Formula/poco.rb
@@ -7,7 +7,7 @@ class Poco < Formula
   head "https://github.com/pocoproject/poco.git", branch: "develop"
 
   livecheck do
-    url "https://pocoproject.org/releases"
+    url "https://pocoproject.org/releases/"
     regex(%r{href=.*?poco[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 

--- a/Formula/s-lang.rb
+++ b/Formula/s-lang.rb
@@ -7,7 +7,7 @@ class SLang < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://www.jedsoft.org/releases/slang"
+    url "https://www.jedsoft.org/releases/slang/"
     regex(/href=.*?slang[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/sdl_ttf.rb
+++ b/Formula/sdl_ttf.rb
@@ -6,7 +6,7 @@ class SdlTtf < Formula
   revision 1
 
   livecheck do
-    url "https://www.libsdl.org/projects/SDL_ttf/release"
+    url "https://www.libsdl.org/projects/SDL_ttf/release/"
     regex(/href=.*?SDL_ttf[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/z80dasm.rb
+++ b/Formula/z80dasm.rb
@@ -6,7 +6,7 @@ class Z80dasm < Formula
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://www.tablix.org/~avian/z80dasm"
+    url "https://www.tablix.org/~avian/z80dasm/"
     regex(/href=.*?z80dasm[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a bulk PR to update `livecheck` URLs (and a `homepage`) that are redirecting to the same URL with a trailing forward slash. These changes allow us to avoid the unnecessary redirection in each case.

I'll be handling some others that involved other changes in separate PRs.