### PR TITLE
iozone: update homepage, stable, livecheck

### DIFF
--- a/Formula/iozone.rb
+++ b/Formula/iozone.rb
@@ -1,12 +1,12 @@
 class Iozone < Formula
   desc "File system benchmark tool"
-  homepage "http://www.iozone.org/"
-  url "http://www.iozone.org/src/current/iozone3_491.tgz"
+  homepage "https://www.iozone.org/"
+  url "https://www.iozone.org/src/current/iozone3_491.tgz"
   sha256 "057d310cc0c16fcb35ac6de25bee363d54503377cbd93a6122797f8277aab6f0"
   license :cannot_represent
 
   livecheck do
-    url "http://www.iozone.org/src/current"
+    url "https://www.iozone.org/src/current/"
     regex(/href=.*?iozone[._-]?v?(\d+(?:[._]\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the `livecheck` block URL to include a trailing forward slash, to avoid an unnecessary redirection. At the same time, this updates the `iozone.org` URLs to use `https` instead of `http`, as it now seems to be supported.