### PR TITLE
libxml2: update livecheck

### DIFF
--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -8,8 +8,8 @@ class Libxml2 < Formula
   revision 2
 
   livecheck do
-    url "http://xmlsoft.org/sources"
-    regex(/href=.*?libxml2[._-]v?([\d.]+\.[\d.]+\.[\d.]+)\.t/i)
+    url "http://xmlsoft.org/sources/"
+    regex(/href=.*?libxml2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `libxml2` to avoid a redirection with the `url` and to use the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`)instead of the unnecessarily specific `v?([\d.]+\.[\d.]+\.[\d.]+)`. The latter change is part of updating some older regexes to bring them up to current guidelines.