### PR TITLE
tree: update livecheck

### DIFF
--- a/Formula/tree.rb
+++ b/Formula/tree.rb
@@ -6,8 +6,8 @@ class Tree < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "http://mama.indstate.edu/users/ice/tree/src"
-    regex(/href=.*?tree[._-]v?(.*?)\.t/i)
+    url "http://mama.indstate.edu/users/ice/tree/src/"
+    regex(/href=.*?tree[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `tree` to avoid a redirection with the `url` and to use the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`) instead of the unnecessarily broad `v?(.*?)`. The latter change is part of updating some older regexes to bring them up to current guidelines.