### PR TITLE
sundials: update livecheck

### DIFF
--- a/Formula/sundials.rb
+++ b/Formula/sundials.rb
@@ -6,7 +6,7 @@ class Sundials < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://computation.llnl.gov/projects/sundials/sundials-software"
+    url "https://computing.llnl.gov/projects/sundials/sundials-software"
     regex(/href=.*?sundials[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the `livecheck` URL for `sundials` to avoid a redirection (i.e., updating it to the current URL). The `homepage` and `stable` URLs were already using the `computing.llnl.gov` domain (instead of `computation.llnl.gov`) and this simply brings the `livecheck` block in line.