### PR TITLE
hypre: update homepage

### DIFF
--- a/Formula/hypre.rb
+++ b/Formula/hypre.rb
@@ -1,6 +1,6 @@
 class Hypre < Formula
   desc "Library featuring parallel multigrid methods for grid problems"
-  homepage "https://computation.llnl.gov/casc/hypre/software.html"
+  homepage "https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods"
   url "https://github.com/hypre-space/hypre/archive/v2.20.0.tar.gz"
   sha256 "5be77b28ddf945c92cde4b52a272d16fb5e9a7dc05e714fc5765948cba802c01"
   license any_of: ["MIT", "Apache-2.0"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `homepage` for `hypre` redirects from `https://computation.llnl.gov/casc/hypre/software.html` to `https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods/software`.

This PR avoids the redirection by updating the `homepage` to the current [Overview](https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods) page, as it seems more appropriate (instead of the [Software](https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods/software) page).