### PR TITLE
openvpn: update homepage and livecheck

### DIFF
--- a/Formula/openvpn.rb
+++ b/Formula/openvpn.rb
@@ -1,12 +1,12 @@
 class Openvpn < Formula
   desc "SSL/TLS VPN implementing OSI layer 2 or 3 secure network extension"
-  homepage "https://openvpn.net/index.php/download/community-downloads.html"
+  homepage "https://openvpn.net/community/"
   url "https://swupdate.openvpn.org/community/releases/openvpn-2.5.0.tar.xz"
   mirror "https://build.openvpn.net/downloads/releases/openvpn-2.5.0.tar.xz"
   sha256 "029a426e44d656cb4e1189319c95fe6fc9864247724f5599d99df9c4c3478fbd"
 
   livecheck do
-    url :homepage
+    url "https://openvpn.net/community-downloads/"
     regex(/href=.*?openvpn[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the `homepage` and `livecheck` URLs for `openvpn`, primarily to avoid a redirection.

This switches the `homepage` from the [Community Downloads](https://openvpn.net/community-downloads/) page to the [Community](https://openvpn.net/community/) page, as this feels a little more appropriate as a homepage.

With the change in the homepage, I updated the `livecheck` block to check the current Community Downloads page URL (i.e., avoiding the previous redirection).