### PR TITLE
berkeley-db: update urls to avoid redirections

### DIFF
--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -1,6 +1,6 @@
 class BerkeleyDb < Formula
   desc "High performance key/value database"
-  homepage "https://www.oracle.com/technology/products/berkeley-db/index.html"
+  homepage "https://www.oracle.com/database/technologies/related/berkeleydb.html"
   # Requires registration to download so we mirror it
   url "https://dl.bintray.com/homebrew/mirror/berkeley-db-18.1.32.tar.gz"
   mirror "https://fossies.org/linux/misc/db-18.1.32.tar.gz"
@@ -8,8 +8,7 @@ class BerkeleyDb < Formula
   revision 1
 
   livecheck do
-    url "https://www.oracle.com/technetwork/database/" \
-    "database-technologies/berkeleydb/downloads/index.html"
+    url "https://www.oracle.com/database/technologies/related/berkeleydb-downloads.html"
     regex(%r{href=.*?/berkeley-db/db[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 

--- a/Formula/berkeley-db@4.rb
+++ b/Formula/berkeley-db@4.rb
@@ -1,6 +1,6 @@
 class BerkeleyDbAT4 < Formula
   desc "High performance key/value database"
-  homepage "https://www.oracle.com/technology/products/berkeley-db/index.html"
+  homepage "https://www.oracle.com/database/technologies/related/berkeleydb.html"
   url "https://download.oracle.com/berkeley-db/db-4.8.30.tar.gz"
   sha256 "e0491a07cdb21fb9aa82773bbbedaeb7639cbd0e7f96147ab46141e0045db72a"
   license "Sleepycat"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the `homepage` and `livecheck` URLs to avoid redirections. The current `homepage` corresponds to the current [`berkeleydb-downloads.html`](https://www.oracle.com/database/technologies/related/berkeleydb-downloads.html) page used in the `livecheck` block but I've updated `homepage` to the [`berkeleydb.html`](https://www.oracle.com/database/technologies/related/berkeleydb.html) page, as this feels more appropriate. I updated the `homepage` for `berkeley-db@4` in the same fashion, to keep the formulae aligned.