### PR TITLE
idris2: coreutils is needed to run too

### DIFF
--- a/Formula/idris2.rb
+++ b/Formula/idris2.rb
@@ -13,8 +13,8 @@ class Idris2 < Formula
     sha256 cellar: :any, mojave:   "ab173b9e9ef6083e6ae2fe22f8a55892e80c064ec9b9838afa5b6488ae9a8529"
   end
 
-  depends_on "coreutils" => :build
   depends_on "chezscheme"
+  depends_on "coreutils"
 
   def install
     ENV.deparallelize


### PR DESCRIPTION
The `idris2` that is generated is essentially a very tiny script that uses `realpath` at startup to
figure out what `LD_LIBRARY_PATH` to set before running the executable that `chez` produced.

So we need `coreutils` for the build but also to actually run the executable.

I experienced this recently while setting up a macOS CI and I have just noticed that it had been
reported to us previously: https://github.com/idris-lang/Idris2/issues/874

Unfortunately I cannot run the `brew` tests mentioned in CONTRIBUTING myself as I am not a brew user.