### PR TITLE
mesa: update stable and add livecheck

### DIFF
--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -3,10 +3,15 @@ class Mesa < Formula
 
   desc "Graphics Library"
   homepage "https://www.mesa3d.org/"
-  url "https://mesa.freedesktop.org/archive/mesa-20.3.4.tar.xz"
+  url "https://archive.mesa3d.org/mesa-20.3.4.tar.xz"
   sha256 "dc21a987ec1ff45b278fe4b1419b1719f1968debbb80221480e44180849b4084"
   license "MIT"
   head "https://gitlab.freedesktop.org/mesa/mesa.git"
+
+  livecheck do
+    url "https://archive.mesa3d.org/"
+    regex(/href=.*?mesa[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 arm64_big_sur: "a3e65d929df4b5bcb70c71abb33140e6fbcc8192876042a443ae71ba134d9b03"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the `stable` URL for `mesa`, as it was redirecting from `mesa.freedesktop.org` to `archive.mesa3d.org`. This also adds a `livecheck` block that checks `archive.mesa3d.org`, which is a directory listing page where the `stable` archive is found.