### PR TITLE
mesalib-glw: update stable and add livecheck

### DIFF
--- a/Formula/mesalib-glw.rb
+++ b/Formula/mesalib-glw.rb
@@ -1,10 +1,15 @@
 class MesalibGlw < Formula
   desc "Open-source implementation of the OpenGL specification"
   homepage "https://www.mesa3d.org"
-  url "https://mesa.freedesktop.org/archive/glw/glw-8.0.0.tar.bz2"
+  url "https://archive.mesa3d.org/glw/glw-8.0.0.tar.bz2"
   sha256 "2da1d06e825f073dcbad264aec7b45c649100e5bcde688ac3035b34c8dbc8597"
   license :cannot_represent
   revision 1
+
+  livecheck do
+    url "https://archive.mesa3d.org/glw/"
+    regex(/href=.*?glw[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "fed357436c36aa832c46cad896d75a9b3f0015658732af9cad3a18b19769ea72"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the `stable` URL for `mesalib-glw`, as it was redirecting from `mesa.freedesktop.org` to `archive.mesa3d.org`. This also adds a `livecheck` block that checks `archive.mesa3d.org/glw/`, which is a directory listing page where the `stable` archive is found.