### PR TITLE
fossil: update homepage, stable, livecheck

### DIFF
--- a/Formula/fossil.rb
+++ b/Formula/fossil.rb
@@ -1,14 +1,14 @@
 class Fossil < Formula
   desc "Distributed software configuration management"
-  homepage "https://www.fossil-scm.org/"
-  url "https://www.fossil-scm.org/index.html/uv/fossil-src-2.14.tar.gz"
+  homepage "https://www.fossil-scm.org/home/"
+  url "https://www.fossil-scm.org/home/uv/fossil-src-2.14.tar.gz"
   sha256 "b8d0c920196dd8ae29152fa7448e513a1fa7c588871b785e3fbfc07b42a05fb9"
   license "BSD-2-Clause"
   head "https://www.fossil-scm.org/", using: :fossil
 
   livecheck do
-    url "https://www.fossil-scm.org/index.html/uv/download.js"
-    regex(/"title": *?"Version (\d+(?:\.\d+)+)\s*?\(/i)
+    url "https://www.fossil-scm.org/home/uv/download.js"
+    regex(/"title":\s*?"Version (\d+(?:\.\d+)+)\s*?\(/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the `homepage`, `stable`, and `livecheck` URLs to avoid redirections. The updated `homepage` URL still involves a temporary redirection but this shaves off one redirection (from `/` to `/home/`), at least.

This also updates the `livecheck` block's regex to be a little more loose about potential whitespace between the object key and value. This doesn't make a difference at the moment but `\s*?` can potentially match different types of whitespace other than just a literal space, which is handy if we happen to encounter characters that act like a space but wouldn't match ` *?`.