### PR TITLE
tcpflow: update livecheck

### DIFF
--- a/Formula/tcpflow.rb
+++ b/Formula/tcpflow.rb
@@ -6,7 +6,7 @@ class Tcpflow < Formula
   license "GPL-3.0"
 
   livecheck do
-    url "http://downloads.digitalcorpora.org/downloads/tcpflow/"
+    url "https://downloads.digitalcorpora.org/downloads/tcpflow/"
     regex(/href=.*?tcpflow[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `tcpflow` to use `https` for the `url`, as the existing `http` URL was redirecting.