### PR TITLE
zebra: update homepage and livecheck

### DIFF
--- a/Formula/zebra.rb
+++ b/Formula/zebra.rb
@@ -1,12 +1,12 @@
 class Zebra < Formula
   desc "Information management system"
-  homepage "https://www.indexdata.com/zebra"
+  homepage "https://www.indexdata.com/resources/software/zebra/"
   url "http://ftp.indexdata.dk/pub/zebra/idzebra-2.2.2.tar.gz"
   sha256 "513c2bf272e12745d4a7b58599ded0bc1292a84e9dc420a32eb53b6601ae0000"
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://www.indexdata.com/resources/software/zebra"
+    url :homepage
     regex(%r{>Latest:</strong>.*?v?(\d+(?:\.\d+)+)<}i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `homepage` for `zebra` redirects to `https://www.indexdata.com/resources/software/zebra/`, so this updates it accordingly. The existing `livecheck` URL redirects to the same URL with a trailing forward slash, so updating it to use `url :homepage` also avoids this unnecessary redirection (which is the main purpose of this PR).