### PR TITLE
apache-brooklyn-cli: add go 1.16 support

### DIFF
--- a/Formula/apache-brooklyn-cli.rb
+++ b/Formula/apache-brooklyn-cli.rb
@@ -21,6 +21,7 @@ class ApacheBrooklynCli < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/apache/brooklyn-client").install "cli"
     cd "src/github.com/apache/brooklyn-client/cli" do
       system "go", "build", "-o", bin/"br", ".../br"


### PR DESCRIPTION
add support for go 1.16

#47627

Cannot open issue upstream, issues not enabled