### PR TITLE
path-extractor: disable due to no license

### DIFF
--- a/Formula/path-extractor.rb
+++ b/Formula/path-extractor.rb
@@ -16,6 +16,9 @@ class PathExtractor < Formula
     sha256 cellar: :any_skip_relocation, mavericks:   "f883b0656efe0d31b35b98ab0c82d82f1fa827b39d3712136c49bae2363f539d"
   end
 
+  # https://github.com/edi9999/path-extractor/issues/8
+  disable! date: "2021-02-20", because: :no_license
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See also: #47627