### PR TITLE
aptly: add support for go1.16

### DIFF
--- a/Formula/aptly.rb
+++ b/Formula/aptly.rb
@@ -18,6 +18,7 @@ class Aptly < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     ENV["GOBIN"] = bin
     (buildpath/"src/github.com/aptly-dev/aptly").install buildpath.children
     cd "src/github.com/aptly-dev/aptly" do


### PR DESCRIPTION
add support for go 1.16 by switching to go module based installs.

#47627


upstream issue: https://github.com/aptly-dev/aptly/issues/934