### PR TITLE
carina: disable because unsupported

### DIFF
--- a/Formula/carina.rb
+++ b/Formula/carina.rb
@@ -17,7 +17,7 @@ class Carina < Formula
     sha256 cellar: :any_skip_relocation, yosemite:    "0706998cd1dc286030e20382ac69a96c744ec558784685f769aa4276966dcd12"
   end
 
-  deprecate! date: "2021-02-20", because: "getcarina.com is down and the repo is unmaintained"
+  disable! date: "2021-02-20", because: :unsupported
 
   depends_on "go" => :build
 

--- a/Formula/carina.rb
+++ b/Formula/carina.rb
@@ -17,10 +17,13 @@ class Carina < Formula
     sha256 cellar: :any_skip_relocation, yosemite:    "0706998cd1dc286030e20382ac69a96c744ec558784685f769aa4276966dcd12"
   end
 
+  deprecate! date: "2021-02-20", because: "getcarina.com is down and the repo is unmaintained"
+
   depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     ENV.prepend_create_path "PATH", buildpath/"bin"
 
     carinapath = buildpath/"src/github.com/getcarina/carina"


### PR DESCRIPTION
Cannot open upstream issue. site seems dead and tool is unmaintained. 

very low installs over the last year ~45: https://formulae.brew.sh/formula/carina

adding go 1.16 support to unblock 1.16 but we should probably nuke this formula

#47627