### PR TITLE
cf-tool: add go 1.16 support

### DIFF
--- a/Formula/cf-tool.rb
+++ b/Formula/cf-tool.rb
@@ -16,6 +16,7 @@ class CfTool < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/xalanq/cf-tool").install buildpath.children
     cd "src/github.com/xalanq/cf-tool" do
       system "go", "build", "-o", "cf", "-trimpath", "-ldflags", "-s -w", "cf.go"


### PR DESCRIPTION
upstream: https://github.com/xalanq/cf-tool/issues/125

adding go 1.16 support

#47627
