### PR TITLE
gcc: update ARM sources

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -5,8 +5,8 @@ class Gcc < Formula
     # Branch from the Darwin maintainer of GCC with Apple Silicon support,
     # located at https://github.com/iains/gcc-darwin-arm64 and
     # backported with his help to gcc-10 branch. Too big for a patch.
-    url "https://github.com/fxcoudert/gcc/archive/gcc-10-arm-20201228.tar.gz"
-    sha256 "dd5377a13f0ee4645bce1c18ed7327ea4ad5f8bd5c6a2a24eb299c647d3d43f4"
+    url "https://github.com/fxcoudert/gcc/archive/gcc-10-arm-20210220.tar.gz"
+    sha256 "53beed690e4e0355d972ad58917a11e01af1cfe67b2e7602ca1ef89c98417a67"
     version "10.2.0"
   else
     url "https://ftp.gnu.org/gnu/gcc/gcc-10.2.0/gcc-10.2.0.tar.xz"

--- a/Formula/scipy.rb
+++ b/Formula/scipy.rb
@@ -4,6 +4,7 @@ class Scipy < Formula
   url "https://files.pythonhosted.org/packages/16/48/ff7026d26dfd92520f00b109333e22c05a235f0c9115a5a2d7679cdf39ef/scipy-1.6.0.tar.gz"
   sha256 "cb6dc9f82dfd95f6b9032a8d7ea70efeeb15d5b5fd6ed4e8537bb3c673580566"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/scipy/scipy.git"
 
   bottle do


### PR DESCRIPTION
Will fix some C/Fortran mix-language ABI mismatch, see https://github.com/iains/gcc-darwin-arm64/issues/32
Important enough to ship a new bottle for ARM, but probably not to force an update on all users