### PR TITLE
gwenhywfar: enable Qt5, cpp GUIs

### DIFF
--- a/Formula/gwenhywfar.rb
+++ b/Formula/gwenhywfar.rb
@@ -4,6 +4,7 @@ class Gwenhywfar < Formula
   url "https://www.aquamaniac.de/rdm/attachments/download/364/gwenhywfar-5.6.0.tar.gz"
   sha256 "57af46920991290372752164f9a7518b222f99bca2ef39c77deab57d14914bc7"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url "https://www.aquamaniac.de/rdm/projects/gwenhywfar/files"
@@ -17,19 +18,28 @@ class Gwenhywfar < Formula
     sha256 mojave:        "d33d0fcd0524fcdbf99150eb23dbf0f0482fa47294b24b0f2985c0d27e2a10a2"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "cmake" => :test
   depends_on "gettext"
   depends_on "gnutls"
   depends_on "libgcrypt"
   depends_on "openssl@1.1"
   depends_on "pkg-config" # gwenhywfar-config needs pkg-config for execution
+  depends_on "qt@5"
+
+  patch do # fixes out-of-tree builds, can be removed with 5.6.1+ release. https://www.aquamaniac.de/rdm/issues/232
+    url "https://www.aquamaniac.de/rdm/projects/gwenhywfar/repository/revisions/b953672c5f668c2ed3960607e6e25651a2cc98db/diff/m4/ax_have_qt.m4?format=diff"
+    sha256 "da7c1ddce2b8d1f19293d43b0db8449a4e45b79801101e866aa42f212f750ecd"
+  end
 
   def install
     inreplace "gwenhywfar-config.in.in", "@PKG_CONFIG@", "pkg-config"
-    system "autoreconf", "-fiv" if build.head?
+    system "autoreconf", "-fiv" # needed because of the patch. Otherwise only needed for head build (if build.head?)
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-guis=cocoa"
+                          "--with-guis=cocoa cpp qt5"
     system "make", "install"
   end
 
@@ -43,7 +53,33 @@ class Gwenhywfar < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-I#{include}/gwenhywfar5", "-L#{lib}", "-lgwenhywfar", "-o", "test"
-    system "./test"
+    system ENV.cc, "test.c", "-I#{include}/gwenhywfar5", "-L#{lib}", "-lgwenhywfar", "-o", "test_c"
+    system "./test_c"
+
+    system ENV.cxx, "test.c", "-I#{include}/gwenhywfar5", "-L#{lib}", "-lgwenhywfar", "-o", "test_cpp"
+    system "./test_cpp"
+
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_gwen)
+
+      find_package(Qt5 REQUIRED Core Widgets)
+      find_package(gwenhywfar REQUIRED)
+      find_package(gwengui-cpp REQUIRED)
+      find_package(gwengui-qt5 REQUIRED)
+
+      add_executable(${PROJECT_NAME} test.c)
+
+      target_link_libraries(${PROJECT_NAME} PUBLIC
+                      gwenhywfar::core
+                      gwenhywfar::gui-cpp
+                      gwenhywfar::gui-qt5
+      )
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+
+    system "cmake", testpath.to_s, *args
+    system "make"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds support for Qt and C++ backends, as well some additional tests. Qt5 support was fixed upstream, hence the patch and an obligatory `autoreconf`. Both can be removed once the new version is released. 

