### PR TITLE
neovim: properly fix shims audit

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -71,12 +71,6 @@ class Neovim < Formula
     ENV.prepend_path "LUA_CPATH", "#{buildpath}/deps-build/lib/lua/5.1/?.so"
     lua_path = "--lua-dir=#{Formula["luajit-openresty"].opt_prefix}"
 
-    cmake_compiler_args = []
-    on_macos do
-      cmake_compiler_args << "-DCMAKE_C_COMPILER=/usr/bin/clang"
-      cmake_compiler_args << "-DCMAKE_CXX_COMPILER=/usr/bin/clang++"
-    end
-
     cd "deps-build" do
       %w[
         mpack/mpack-1.0.8-0.rockspec
@@ -96,12 +90,13 @@ class Neovim < Formula
 
     mkdir "build" do
       cmake_args = std_cmake_args
-      cmake_args += cmake_compiler_args
       cmake_args += %W[
         -DLIBLUV_INCLUDE_DIR=#{Formula["luv"].opt_include}
         -DLIBLUV_LIBRARY=#{Formula["luv"].opt_lib}/libluv_a.a
       ]
       system "cmake", "..", *cmake_args
+      # Patch out references to Homebrew shims
+      inreplace "config/auto/versiondef.h", /#{HOMEBREW_LIBRARY}[^ ]+/o, ENV.cc
       system "make", "install"
     end
   end


### PR DESCRIPTION
https://github.com/homebrew/homebrew-core/pull/59219 was not the correct fix for the shims audit as this merely bypasses our shims. Instead patch the CMake-generated header to elide mention of the compiler shim.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----