### PR TITLE
cwlogs: fix build with go 1.16 and deprecate

### DIFF
--- a/Formula/cwlogs.rb
+++ b/Formula/cwlogs.rb
@@ -12,12 +12,16 @@ class Cwlogs < Formula
     sha256 cellar: :any_skip_relocation, mojave:   "d0e1bda71db260a905c5f88da3fce0074ab59576ef6c12948eeae2ae5faf6435"
   end
 
+  # https://github.com/segmentio/cwlogs/issues/37
+  deprecate! date: "2021-02-21", because: :unmaintained
+
   depends_on "go" => :build
   depends_on "govendor" => :build
 
   def install
     ENV["GOPATH"] = buildpath
     ENV["CGO_ENABLED"] = "0"
+    ENV["GO111MODULE"] = "auto"
 
     path = buildpath/"src/github.com/segmentio/cwlogs"
     path.install Dir["{*,.git}"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#47627