### PR TITLE
kedge: fix build with go 1.16 and deprecate

### DIFF
--- a/Formula/kedge.rb
+++ b/Formula/kedge.rb
@@ -14,10 +14,14 @@ class Kedge < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:  "1ff9804be018e8bf5bd0668ce1e1a647ab04005b4ea34fb22f49c50c215b4e13"
   end
 
+  # https://github.com/kedgeproject/kedge/issues/619
+  deprecate! date: "2021-02-21", because: :unsupported
+
   depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/kedgeproject").mkpath
     ln_s buildpath, buildpath/"src/github.com/kedgeproject/kedge"
     system "make", "bin"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#47627