### PR TITLE
snap-telemetry: fix build with go 1.16 and deprecate

### DIFF
--- a/Formula/snap-telemetry.rb
+++ b/Formula/snap-telemetry.rb
@@ -15,6 +15,9 @@ class SnapTelemetry < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:  "50ce1be7d6e83f309d8fd62bf2b36cb03c29b726d575abfbeef895b3f628fb46"
   end
 
+  # https://github.com/intelsdi-x/snap/commit/e3a6c8e39994b3980df0c7b069d5ede810622952
+  deprecate! date: "2018-12-20", because: :deprecated_upstream
+
   depends_on "glide" => :build
   depends_on "go" => :build
 
@@ -22,6 +25,7 @@ class SnapTelemetry < Formula
     ENV["GOPATH"] = buildpath
     ENV["CGO_ENABLED"] = "0"
     ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    ENV["GO111MODULE"] = "auto"
 
     snapteld = buildpath/"src/github.com/intelsdi-x/snap"
     snapteld.install buildpath.children


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#47627
