### PR TITLE
stout: fix build with go 1.16 and deprecate

### DIFF
--- a/Formula/stout.rb
+++ b/Formula/stout.rb
@@ -13,10 +13,14 @@ class Stout < Formula
     sha256 cellar: :any_skip_relocation, sierra:      "26554af96b6044316abecb1a2142e81b1aab8315bff941cbdad9b39fe143b74e"
   end
 
+  # https://github.com/cloudflare/Stout/issues/58
+  deprecate! date: "2021-02-21", because: :unmaintained
+
   depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
 
     # Compatibility with newer Go.
     # Reported upstream, but the project is unmaintained.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#47627