### PR TITLE
docker-credential-helper: fix build with Go 1.16

### DIFF
--- a/Formula/docker-credential-helper.rb
+++ b/Formula/docker-credential-helper.rb
@@ -18,6 +18,7 @@ class DockerCredentialHelper < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     dir = buildpath/"src/github.com/docker/docker-credential-helpers"
     dir.install buildpath.children - [buildpath/".brew_home"]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

#47627

https://github.com/docker/docker-credential-helpers/issues/196