### PR TITLE
Various formulae: resolve deprecated SPDX licenses

### DIFF
--- a/Formula/adns.rb
+++ b/Formula/adns.rb
@@ -3,7 +3,7 @@ class Adns < Formula
   homepage "https://www.chiark.greenend.org.uk/~ian/adns/"
   url "https://www.chiark.greenend.org.uk/~ian/adns/ftp/adns-1.6.0.tar.gz"
   sha256 "fb427265a981e033d1548f2b117cc021073dc8be2eaf2c45fd64ab7b00ed20de"
-  license "GPL-3.0"
+  license all_of: ["GPL-3.0-or-later", "LGPL-2.0-or-later"]
   head "git://git.chiark.greenend.org.uk/~ianmdlvl/adns.git"
 
   livecheck do

--- a/Formula/frei0r.rb
+++ b/Formula/frei0r.rb
@@ -3,7 +3,7 @@ class Frei0r < Formula
   homepage "https://frei0r.dyne.org/"
   url "https://files.dyne.org/frei0r/releases/frei0r-plugins-1.7.0.tar.gz"
   sha256 "1b1ff8f0f9bc23eed724e94e9a7c1d8f0244bfe33424bb4fe68e6460c088523a"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://files.dyne.org/frei0r/releases/"

--- a/Formula/fribidi.rb
+++ b/Formula/fribidi.rb
@@ -3,7 +3,7 @@ class Fribidi < Formula
   homepage "https://github.com/fribidi/fribidi"
   url "https://github.com/fribidi/fribidi/releases/download/v1.0.10/fribidi-1.0.10.tar.xz"
   sha256 "7f1c687c7831499bcacae5e8675945a39bacbad16ecaa945e9454a32df653c01"
-  license "LGPL-2.1"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "3a430c4eeb948c10595ffe163455f214f251bdb901f5846a0b67eb4f8aafdc71"

--- a/Formula/gdbm.rb
+++ b/Formula/gdbm.rb
@@ -4,7 +4,7 @@ class Gdbm < Formula
   url "https://ftp.gnu.org/gnu/gdbm/gdbm-1.18.1.tar.gz"
   mirror "https://ftpmirror.gnu.org/gdbm/gdbm-1.18.1.tar.gz"
   sha256 "86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/graphite2.rb
+++ b/Formula/graphite2.rb
@@ -3,7 +3,7 @@ class Graphite2 < Formula
   homepage "https://graphite.sil.org/"
   url "https://github.com/silnrsi/graphite/releases/download/1.3.14/graphite2-1.3.14.tgz"
   sha256 "f99d1c13aa5fa296898a181dff9b82fb25f6cc0933dbaa7a475d8109bd54209d"
-  license "LGPL-2.1"
+  license any_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later", "MPL-1.1+"]
   head "https://github.com/silnrsi/graphite.git"
 
   bottle do

--- a/Formula/lame.rb
+++ b/Formula/lame.rb
@@ -3,7 +3,7 @@ class Lame < Formula
   homepage "https://lame.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/lame/lame/3.100/lame-3.100.tar.gz"
   sha256 "ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e"
-  license "LGPL-2.0"
+  license "LGPL-2.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/libidn2.rb
+++ b/Formula/libidn2.rb
@@ -4,7 +4,7 @@ class Libidn2 < Formula
   url "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.0.tar.gz"
   mirror "https://ftpmirror.gnu.org/libidn/libidn2-2.3.0.tar.gz"
   sha256 "e1cb1db3d2e249a6a3eb6f0946777c2e892d5c5dc7bd91c74394fc3a01cab8b5"
-  license "GPL-2.0"
+  license any_of: ["GPL-2.0-or-later", "LGPL-3.0-or-later"]
 
   livecheck do
     url :stable

--- a/Formula/libksba.rb
+++ b/Formula/libksba.rb
@@ -3,7 +3,7 @@ class Libksba < Formula
   homepage "https://www.gnupg.org/related_software/libksba/"
   url "https://gnupg.org/ftp/gcrypt/libksba/libksba-1.5.0.tar.bz2"
   sha256 "ae4af129216b2d7fdea0b5bf2a788cd458a79c983bb09a43f4d525cc87aba0ba"
-  license "GPL-2.0"
+  license any_of: ["LGPL-3.0-or-later", "GPL-2.0-or-later"]
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libksba/"

--- a/Formula/libunistring.rb
+++ b/Formula/libunistring.rb
@@ -4,7 +4,7 @@ class Libunistring < Formula
   url "https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
   mirror "https://ftpmirror.gnu.org/libunistring/libunistring-0.9.10.tar.xz"
   sha256 "eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7"
-  license "GPL-3.0"
+  license any_of: ["GPL-2.0-only", "LGPL-3.0-or-later"]
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "73cc290ebcefd6354329317266d9e110e3a5967d0a8260d2cf7d4dd3edc9218c"

--- a/Formula/lzo.rb
+++ b/Formula/lzo.rb
@@ -3,7 +3,7 @@ class Lzo < Formula
   homepage "https://www.oberhumer.com/opensource/lzo/"
   url "https://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz"
   sha256 "c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://www.oberhumer.com/opensource/lzo/download/"

--- a/Formula/npth.rb
+++ b/Formula/npth.rb
@@ -4,7 +4,7 @@ class Npth < Formula
   url "https://gnupg.org/ftp/gcrypt/npth/npth-1.6.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/npth/npth-1.6.tar.bz2"
   sha256 "1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/npth/"

--- a/Formula/pixman.rb
+++ b/Formula/pixman.rb
@@ -3,7 +3,7 @@ class Pixman < Formula
   homepage "https://cairographics.org/"
   url "https://cairographics.org/releases/pixman-0.40.0.tar.gz"
   sha256 "6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc"
-  license "LGPL-2.1"
+  license "MIT"
 
   livecheck do
     url "https://cairographics.org/releases/?C=M&O=D"

--- a/Formula/rtmpdump.rb
+++ b/Formula/rtmpdump.rb
@@ -4,7 +4,7 @@ class Rtmpdump < Formula
   url "https://deb.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20151223.gitfa8646d.1.orig.tar.gz"
   version "2.4+20151223"
   sha256 "5c032f5c8cc2937eb55a81a94effdfed3b0a0304b6376147b86f951e225e3ab5"
-  license "GPL-2.0"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 1
   head "https://git.ffmpeg.org/rtmpdump.git", shallow: false
 

--- a/Formula/shellcheck.rb
+++ b/Formula/shellcheck.rb
@@ -3,7 +3,7 @@ class Shellcheck < Formula
   homepage "https://www.shellcheck.net/"
   url "https://github.com/koalaman/shellcheck/archive/v0.7.1.tar.gz"
   sha256 "50a219bde5c16fc0a40e2e3725b6c192ff589bc8a2569c32b62dcaece0495896"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/koalaman/shellcheck.git"
 
   bottle do

--- a/Formula/xvid.rb
+++ b/Formula/xvid.rb
@@ -3,7 +3,7 @@ class Xvid < Formula
   homepage "https://labs.xvid.com/"
   url "https://downloads.xvid.com/downloads/xvidcore-1.3.7.tar.bz2"
   sha256 "aeeaae952d4db395249839a3bd03841d6844843f5a4f84c271ff88f7aa1acff7"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://downloads.xvid.com/downloads/"

--- a/Formula/xz.rb
+++ b/Formula/xz.rb
@@ -6,7 +6,12 @@ class Xz < Formula
   url "https://downloads.sourceforge.net/project/lzmautils/xz-5.2.5.tar.gz"
   mirror "https://tukaani.org/xz/xz-5.2.5.tar.gz"
   sha256 "f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"
-  license "GPL-2.0"
+  license all_of: [
+    :public_domain,
+    "LGPL-2.1-or-later",
+    "GPL-2.0-or-later",
+    "GPL-3.0-or-later",
+  ]
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "c84206005787304416ed81094bd3a0cdd2ae8eb62649db5a3a44fa14b276d09f"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  - Note: `lzo` has a problem here about build-time checks, unrelated to licenses

-----
I believe that these formulae should all be `GPL-3.0-or-later`:

- [`adns`](https://www.chiark.greenend.org.uk/ucgi/~ianmdlvl/git?p=adns.git;a=blob;f=client/addrtext.c;h=6f893b1d60896414b6590c42bab4ba8889e2ced5;hb=HEAD)
- [`libunistring`](https://git.savannah.gnu.org/gitweb/?p=libunistring.git;a=blob;f=lib/Makefile.am;h=6136cedbfb3e42af71804e40434103c0f7f34542;hb=HEAD)
- [`shellcheck`](https://github.com/koalaman/shellcheck/blob/master/src/ShellCheck/Formatter/Quiet.hs)
- [`gdbm`](https://ftp.gnu.org/gnu/gdbm/gdbm-1.18.1.tar.gz); see, for example, `Makefile.in` after extracting that file
- [`graphite2`](https://github.com/silnrsi/graphite/blob/master/src/CmapCache.cpp)
- [`libidn2`](https://gitlab.com/libidn/libidn2/-/blob/master/src/idn2.c) (note: this was formerly marked as "GPL-2.0")

because of this clause (or similar) I found in the above files:

> you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.

----------------

I believe these formulae should be `GPL-2.0-or-later`:

- [`rtmpdump`](https://git.ffmpeg.org/gitweb/rtmpdump.git/blob/HEAD:/rtmpdump.c); you may need to download the [raw file](https://git.ffmpeg.org/gitweb/rtmpdump.git/blob_plain/HEAD:/rtmpdump.c) or clone the repo with `git clone git://git.ffmpeg.org/rtmpdump` to view the file
- [`frei0r`](https://github.com/dyne/frei0r/blob/master/src/filter/3dflippo/3dflippo.c)
- [`lzo`](https://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz); see `src/compr1b.h`
- [`xvid`](http://websvn.xvid.org/cvs/viewvc.cgi/trunk/xvidcore/src/decoder.c?view=markup)

because of the clause (or similar) I found in the above files:

> you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2, or (at your option) any later version. 

----------------

I believe these should be `LGPL-2.1-or-later`:

- [`fribidi`](https://github.com/fribidi/fribidi/blob/master/bin/fribidi-benchmark.c)
- [`npth`](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=npth.git;a=blob;f=configure.ac;h=8a9373c2da735a4dcaec3bb002cedafa05a6ef25;hb=HEAD)

because of the clause I found in the above files:

> you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.

----------------

`LGPL-2.0-or-later`:

- [`lame`](https://sourceforge.net/p/lame/svn/HEAD/tree/trunk/hip/lib/common.c)

has this clause:

> you can redistribute it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.

----------------

`MIT`:

- [`pixman`](https://cgit.freedesktop.org/pixman/tree/COPYING), formerly "LGPL-2.1"

---------------

`libksba`'s license was changed to `any_of: ["LGPL-3.0-or-later", "GPL-2.0-or-later"]` because in `src/ksba.h` from [here](https://www.gnupg.org/ftp/gcrypt/libksba/libksba-1.5.0.tar.bz2), I found this clause:

```
> KSBA is free software; you can redistribute it and/or modify
> it under the terms of either
>
>   - the GNU Lesser General Public License as published by the Free
>     Software Foundation; either version 3 of the License, or (at
>     your option) any later version.
>
> or
>
>   - the GNU General Public License as published by the Free
>     Software Foundation; either version 2 of the License, or (at
>     your option) any later version.
>
> or both in parallel, as here.
```

---------------

`xz` seems to be most complicated. Its license is at https://git.tukaani.org/?p=xz.git;a=blob;f=COPYING;h=20e60d5b2427334e1fec6701e7c5ad0da0bc8a5d;hb=HEAD. Based on that information, I used the following license:

```
license all_of: [
  :public_domain,
  "LGPL-2.1-or-later",
  "GPL-2.0-or-later",
  "GPL-3.0-or-later",
]
```

Not 100% sure on that, so please tell me if that's wrong!