### PR TITLE
shellz: Set GO111MODULE=auto for Go 1.16

### DIFF
--- a/Formula/shellz.rb
+++ b/Formula/shellz.rb
@@ -18,6 +18,7 @@ class Shellz < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/evilsocket/shellz").install buildpath.children
 
     cd "src/github.com/evilsocket/shellz" do

--- a/Formula/shellz.rb
+++ b/Formula/shellz.rb
@@ -3,7 +3,7 @@ class Shellz < Formula
   homepage "https://github.com/evilsocket/shellz"
   url "https://github.com/evilsocket/shellz/archive/v1.5.0.tar.gz"
   sha256 "870bcc2d6e4fd20913556f95325bc3e1876f3243ef67295c33e2bcc990126e97"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:     "901aa899dffdce56b40da9b622acd01acb15103cbae6d06cb35320fc85ffa626"


### PR DESCRIPTION
This will allow this package to build with Go 1.16.

Epic: #47627
Upstream: https://github.com/evilsocket/shellz/issues/15

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
