### PR TITLE
snag: Set GO111MODULE=auto for Go 1.16

### DIFF
--- a/Formula/snag.rb
+++ b/Formula/snag.rb
@@ -21,6 +21,7 @@ class Snag < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
 
     (buildpath/"src/github.com/Tonkpils/").mkpath
     ln_s buildpath, buildpath/"src/github.com/Tonkpils/snag"


### PR DESCRIPTION
This will allow this package to build with Go 1.16.

Epic: #47627
Upstream issue: https://github.com/Tonkpils/snag/issues/66

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
