### PR TITLE
sift: Update for Go 1.16

### DIFF
--- a/Formula/sift.rb
+++ b/Formula/sift.rb
@@ -36,6 +36,8 @@ class Sift < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
+
     (buildpath/"src/github.com/svent/sift").install buildpath.children
     Language::Go.stage_deps resources, buildpath/"src"
     cd "src/github.com/svent/sift" do

--- a/Formula/sift.rb
+++ b/Formula/sift.rb
@@ -5,7 +5,7 @@ class Sift < Formula
   homepage "https://sift-tool.org"
   url "https://github.com/svent/sift/archive/v0.9.0.tar.gz"
   sha256 "bbbd5c472c36b78896cd7ae673749d3943621a6d5523d47973ed2fc6800ae4c8"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:     "08978d211e26b262c551418ca7c6d93f2b05a0e7887e10831a5a70f23f445e8f"


### PR DESCRIPTION
sift: Fix for Go 1.16 and update SPDX license

Set GO111MODULE=auto to build with Go 1.16 and update the deprecated license.

The formula is using the deprecated `go_resource` function and therefore, does
not pass `brew audit --strict`.

```
sift:
  * 22: col 3: `go_resource`s are deprecated. Please ask upstream to implement Go vendoring
  * 27: col 3: `go_resource`s are deprecated. Please ask upstream to implement Go vendoring
  * 32: col 3: `go_resource`s are deprecated. Please ask upstream to implement Go vendoring
```

The project appears to be largely unmaintained but I've created svent/sift#116
upstream to resolve this. If that gets merged and released, the usage of
`go_resource` can be dropped.

Epic: #47627

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
