### PR TITLE
launchdns: bump revision to quiet audit failure

### DIFF
--- a/Formula/launchdns.rb
+++ b/Formula/launchdns.rb
@@ -4,7 +4,7 @@ class Launchdns < Formula
   url "https://github.com/josh/launchdns/archive/v1.0.4.tar.gz"
   sha256 "60f6010659407e3d148c021c88e1c1ce0924de320e99a5c58b21c8aece3888aa"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/josh/launchdns.git"
 
   bottle do


### PR DESCRIPTION
When this formula was bumped from 1.0.3 to 1.0.4 (#43422) the `revision 1` line was left behind accidentally.

`brew audit` should have prevented this (that check was added in early 2016) but somehow this slipped through.  The problem is that now this formula refuses to be rebottled since `audit` still complains about that `revision` line being there.

Just removing the line won't fix the problem since then it will just complain about the version going backward. It seems the best thing to do now is to just bump the revision *again* so that the formula is back in a happy state.