### PR TITLE
leaps, modd, mpdviz: Add go 1.16 support

### DIFF
--- a/Formula/leaps.rb
+++ b/Formula/leaps.rb
@@ -20,6 +20,7 @@ class Leaps < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/jeffail/leaps").install buildpath.children
     cd "src/github.com/jeffail/leaps" do
       system "dep", "ensure", "-vendor-only"

--- a/Formula/modd.rb
+++ b/Formula/modd.rb
@@ -17,6 +17,7 @@ class Modd < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/cortesi/modd").install buildpath.children
     cd "src/github.com/cortesi/modd" do
       system "go", "build", *std_go_args, "./cmd/modd"

--- a/Formula/mpdviz.rb
+++ b/Formula/mpdviz.rb
@@ -41,6 +41,7 @@ class Mpdviz < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     Language::Go.stage_deps resources, buildpath/"src"
 
     system "go", "build", "-o", "mpdviz"


### PR DESCRIPTION
Add go 1.16 support

https://github.com/Homebrew/homebrew-core/issues/47627

external issues:
https://github.com/cortesi/modd/issues/96
https://github.com/Jeffail/leaps/issues/54
https://github.com/lucy/mpdviz/issues/7

