### PR TITLE
zpaq: fix build flags

### DIFF
--- a/Formula/zpaq.rb
+++ b/Formula/zpaq.rb
@@ -5,6 +5,7 @@ class Zpaq < Formula
   version "7.15"
   sha256 "e85ec2529eb0ba22ceaeabd461e55357ef099b80f61c14f377b429ea3d49d418"
   license "Unlicense"
+  revision 1
   head "https://github.com/zpaq/zpaq.git"
 
   bottle do
@@ -20,6 +21,9 @@ class Zpaq < Formula
   end
 
   def install
+    # When building on non-Intel this is supposed to be manually uncommented
+    # from the Makefile!  (It's also missing "-D" though)
+    inreplace "Makefile", "# CPPFLAGS+=NOJIT", "CPPFLAGS+=-DNOJIT" unless Hardware::CPU.intel?
     system "make"
     system "make", "check"
     system "make", "install", "PREFIX=#{prefix}"


### PR DESCRIPTION
~~* As probably everybody remembers from the #67713 saga we don't want to ever build with `-march=native` since that means that an Intel build machine can generate AVX2 instructions which then fail to work when they later try to run under Rosetta 2. The build shims already tweak the `-m` flag how we want it.~~
* The package assumes that it's building on x86_64 unless you comment out a particular line in the Makefile, which was causing ARM to fail.  (There is also a typo in the original line which I tried to file upstream at https://github.com/zpaq/zpaq/pull/19 although they aren't accepting patches there since it's an unofficial mirror; I'll follow up with an email to the maintainer)

@dtrodrigues -- please try an ARM build on this PR so we can see if it works now there