### PR TITLE
pgweb,piknik,qpm: add go1.16 support

### DIFF
--- a/Formula/pgweb.rb
+++ b/Formula/pgweb.rb
@@ -17,6 +17,7 @@ class Pgweb < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/sosedoff/pgweb").install buildpath.children
 
     cd "src/github.com/sosedoff/pgweb" do

--- a/Formula/piknik.rb
+++ b/Formula/piknik.rb
@@ -23,6 +23,7 @@ class Piknik < Formula
   def install
     ENV["GOPATH"] = buildpath
     ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"
+    ENV["GO111MODULE"] = "auto"
     dir = buildpath/"src/github.com/jedisct1/"
     dir.install Dir["*"]
     ln_s buildpath/"src", dir

--- a/Formula/qpm.rb
+++ b/Formula/qpm.rb
@@ -18,6 +18,7 @@ class Qpm < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src").mkpath
     ln_s buildpath, "src/qpm.io"
     system "go", "build", "-o", "bin/qpm", "qpm.io/qpm"


### PR DESCRIPTION
Add go 1.16 support

https://github.com/Homebrew/homebrew-core/issues/47627

external issues:

https://github.com/Cutehacks/qpm/issues/61
https://github.com/jedisct1/piknik/issues/34
https://github.com/sosedoff/pgweb/issues/504