### PR TITLE
s-search,spaceinvaders-go,rack: add go 1.16 support

### DIFF
--- a/Formula/rack.rb
+++ b/Formula/rack.rb
@@ -20,6 +20,7 @@ class Rack < Formula
   def install
     ENV["GOPATH"] = buildpath
     ENV["TRAVIS_TAG"] = version
+    ENV["GO111MODULE"] = "auto"
 
     rackpath = buildpath/"src/github.com/rackspace/rack"
     rackpath.install Dir["{*,.??*}"]

--- a/Formula/s-search.rb
+++ b/Formula/s-search.rb
@@ -25,6 +25,7 @@ class SSearch < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     Language::Go.stage_deps resources, buildpath/"src"
     cd("src/github.com/FiloSottile/gvt") { system "go", "install" }
     (buildpath/"src/github.com/zquestz").mkpath

--- a/Formula/spaceinvaders-go.rb
+++ b/Formula/spaceinvaders-go.rb
@@ -37,6 +37,7 @@ class SpaceinvadersGo < Formula
   def install
     # This builds with Go.
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     sipath = buildpath/"src/github.com/asib/spaceinvaders"
     sipath.install Dir["{*,.git}"]
     Language::Go.stage_deps resources, buildpath/"src"


### PR DESCRIPTION
Add go 1.16 support

#47627

external issues:
https://github.com/asib/spaceinvaders/issues/5
https://github.com/zquestz/s/issues/149
https://github.com/rackspace/rack/issues/469