### PR TITLE
teleconsole,td,ssh-vault: add go1.16 support

### DIFF
--- a/Formula/ssh-vault.rb
+++ b/Formula/ssh-vault.rb
@@ -19,6 +19,7 @@ class SshVault < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/ssh-vault/ssh-vault").install buildpath.children
     cd "src/github.com/ssh-vault/ssh-vault" do
       system "dep", "ensure", "-vendor-only"

--- a/Formula/td.rb
+++ b/Formula/td.rb
@@ -20,6 +20,7 @@ class Td < Formula
   def install
     ENV["GOPATH"] = buildpath
     ENV["GOBIN"] = bin
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/Swatto/td").install buildpath.children
     cd "src/github.com/Swatto/td" do
       system "go", "install"

--- a/Formula/teleconsole.rb
+++ b/Formula/teleconsole.rb
@@ -64,6 +64,7 @@ class Teleconsole < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     mkdir_p buildpath/"src/github.com/gravitational"
     ln_s buildpath, buildpath/"src/github.com/gravitational/teleconsole"
     Language::Go.stage_deps resources, buildpath/"src"


### PR DESCRIPTION
Add go 1.16 support

#47627

external issues:
https://github.com/gravitational/teleconsole/issues/72
https://github.com/Swatto/td/issues/36
https://github.com/ssh-vault/ssh-vault/issues/48