### PR TITLE
vert,wego,uru: add go 1.16 support

### DIFF
--- a/Formula/uru.rb
+++ b/Formula/uru.rb
@@ -16,6 +16,7 @@ class Uru < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/bitbucket.org/jonforums/uru").install Dir["*"]
     system "go", "build", "-ldflags", "-s", "bitbucket.org/jonforums/uru/cmd/uru"
     bin.install "uru" => "uru_rt"

--- a/Formula/vert.rb
+++ b/Formula/vert.rb
@@ -18,6 +18,7 @@ class Vert < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/Masterminds/vert").install buildpath.children
     cd "src/github.com/Masterminds/vert" do
       system "dep", "ensure", "-vendor-only"

--- a/Formula/wego.rb
+++ b/Formula/wego.rb
@@ -38,6 +38,7 @@ class Wego < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/schachmat").mkpath
     ln_sf buildpath, buildpath/"src/github.com/schachmat/wego"
     Language::Go.stage_deps resources, buildpath/"src"


### PR DESCRIPTION
Add go 1.16 support

#47627

external issues:
https://github.com/schachmat/wego/issues/152
https://github.com/Masterminds/vert/issues/11
https://bitbucket.org/jonforums/uru/issues/113/add-go-module-support