### PR TITLE
jp,ironcli,hivemind,mailhog: add go 1.16 support

### DIFF
--- a/Formula/hivemind.rb
+++ b/Formula/hivemind.rb
@@ -18,6 +18,7 @@ class Hivemind < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/DarthSim/hivemind/").install Dir["*"]
     system "go", "build", "-o", "#{bin}/hivemind", "-v", "github.com/DarthSim/hivemind/"
   end

--- a/Formula/ironcli.rb
+++ b/Formula/ironcli.rb
@@ -18,6 +18,7 @@ class Ironcli < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/iron-io/ironcli").install buildpath.children
     cd "src/github.com/iron-io/ironcli" do
       system "dep", "ensure", "-vendor-only"

--- a/Formula/jp.rb
+++ b/Formula/jp.rb
@@ -17,6 +17,7 @@ class Jp < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     build_root = buildpath/"src/github.com/sgreben/jp"
     build_root.install Dir["*"]
     cd build_root do

--- a/Formula/mailhog.rb
+++ b/Formula/mailhog.rb
@@ -122,6 +122,7 @@ class Mailhog < Formula
   def install
     ENV["GOPATH"] = buildpath
     ENV["GOBIN"] = bin
+    ENV["GO111MODULE"] = "auto"
 
     path = buildpath/"src/github.com/mailhog/MailHog"
     path.install buildpath.children


### PR DESCRIPTION
Add go 1.16 support

#47627

external issues:
https://github.com/sgreben/jp/issues/28
https://github.com/iron-io/ironcli/issues/151
https://github.com/DarthSim/hivemind/issues/21
https://github.com/mailhog/MailHog/issues/339