### PR TITLE
argyll-cms: fix build on Big Sur/Apple Silicon

### DIFF
--- a/Formula/argyll-cms.rb
+++ b/Formula/argyll-cms.rb
@@ -3,7 +3,7 @@ class ArgyllCms < Formula
   homepage "https://www.argyllcms.com/"
   url "https://www.argyllcms.com/Argyll_V2.1.2_src.zip"
   sha256 "be378ca836b17b8684db05e9feaab138d711835ef00a04a76ac0ceacd386a3e3"
-  license "AGPL-3.0"
+  license "AGPL-3.0-only"
 
   livecheck do
     url "https://www.argyllcms.com/downloadsrc.html"

--- a/Formula/argyll-cms.rb
+++ b/Formula/argyll-cms.rb
@@ -46,6 +46,10 @@ class ArgyllCms < Formula
       inreplace "numlib/numsup.c", "CLOCK_MONOTONIC", "UNDEFINED_GIBBERISH"
     end
 
+    # These two inreplaces make sure /opt/homebrew can be found by the
+    # Jamfile, which otherwise fails to locate system libraries
+    inreplace "Jamtop", "/usr/include/x86_64-linux-gnu$(subd)", "#{HOMEBREW_PREFIX}/include$(subd)"
+    inreplace "Jamtop", "/usr/lib/x86_64-linux-gnu", "#{HOMEBREW_PREFIX}/lib"
     system "sh", "makeall.sh"
     system "./makeinstall.sh"
     rm "bin/License.txt"

--- a/Formula/argyll-cms.rb
+++ b/Formula/argyll-cms.rb
@@ -29,7 +29,7 @@ class ArgyllCms < Formula
   # https://www.mikeash.com/pyblog/objc_msgsends-new-prototype.html
   # Submitted upstream: https://www.freelists.org/post/argyllcms/Patch-Fix-macOS-build-failures-from-obj-msgSend-definition-change
   patch do
-    url "https://www.freelists.org/archives/argyllcms/02-2020/bin7VecLntD2x.bin"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/f6ede0dff06c2d9e3383416dc57c5157704b6f3a/argyll-cms/fix_objc_msgSend.diff"
     sha256 "fa86f5f21ed38bec6a20a79cefb78ef7254f6185ef33cac23e50bb1de87507a4"
   end
 

--- a/Formula/argyll-cms.rb
+++ b/Formula/argyll-cms.rb
@@ -33,6 +33,12 @@ class ArgyllCms < Formula
     sha256 "fa86f5f21ed38bec6a20a79cefb78ef7254f6185ef33cac23e50bb1de87507a4"
   end
 
+  # Fixes a missing header, which is an error by default on arm64 but not x86_64
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/f6ede0dff06c2d9e3383416dc57c5157704b6f3a/argyll-cms/unistd_import.diff"
+    sha256 "5ce1e66daf86bcd43a0d2a14181b5e04574757bcbf21c5f27b1f1d22f82a8a6e"
+  end
+
   def install
     # dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
     # Reported 20 Aug 2017 to graeme AT argyllcms DOT com


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a smaller and more targeted version of #68127, which doesn't require rewriting the buildsystem.

This branch has a few fixes:

* Switches to our copy of the first patch, since the URL to the mailing list attachment changed at least once.
* Adds a second patch which adds a missing include; this fixes an error introduced by the promotion of `implicit-function-declaration` to an error by default.
* Ensures the buildsystem finds our libraries on Apple Silicon. This broke now that we're not in `/usr/local`. I'll attempt to work with the developers to get a more longterm solution, which might include adding Homebrew to the default path. Since the bundled versions of the libraries are quite old and don't build on Apple Silicon, this is necessary to get it to work.