### PR TITLE
ko: fix build for go 1.16

### DIFF
--- a/Formula/ko.rb
+++ b/Formula/ko.rb
@@ -2,7 +2,7 @@ class Ko < Formula
   desc "Build and deploy Go applications on Kubernetes"
   homepage "https://github.com/google/ko"
   url "https://github.com/google/ko/archive/v0.8.0.tar.gz"
-  sha256 "8ecb73697915b19ae5f3a647d877656ccaaa9f46f6c5f22e81cb8763cc0a8a18"
+  sha256 "a1b90267574102d3fb43cab7587bbe54f221e5b79ca731781a89c7d0c1f5b2ef"
   license "Apache-2.0"
 
   bottle do


### PR DESCRIPTION
SHA mismatch. this fixes that


filed issue upstream: https://github.com/google/ko/issues/315