### PR TITLE
lunchy-go: add go 1.16 support

### DIFF
--- a/Formula/lunchy-go.rb
+++ b/Formula/lunchy-go.rb
@@ -17,6 +17,7 @@ class LunchyGo < Formula
   conflicts_with "lunchy", because: "both install a `lunchy` binary"
 
   def install
+    ENV["GO111MODULE"] = "auto"
     system "go", "build", *std_go_args
     bin.install bin/"lunchy-go" => "lunchy"
   end


### PR DESCRIPTION
add go 1.16 support

external issue: https://github.com/sosedoff/lunchy-go/issues/12