### PR TITLE
sync_gateway: add go 1.16 support

### DIFF
--- a/Formula/sync_gateway.rb
+++ b/Formula/sync_gateway.rb
@@ -39,6 +39,7 @@ class SyncGateway < Formula
                                          "--project-name", "sync_gateway",
                                          "--set-revision", Utils.git_head
     cd "build" do
+      ENV["GO111MODULE"] = "auto"
       mkdir "godeps"
       system "repo", "init", "-u", stable.url, "-m", "manifest/default.xml"
       cp manifest, ".repo/manifest.xml"


### PR DESCRIPTION
Add go 1.16 support 

https://github.com/Homebrew/homebrew-core/pull/71289

external issue: https://github.com/couchbase/sync_gateway/issues/4967