### PR TITLE
caddy: fix build with Go 1.16

### DIFF
--- a/Formula/caddy.rb
+++ b/Formula/caddy.rb
@@ -15,8 +15,8 @@ class Caddy < Formula
   depends_on "go" => :build
 
   resource "xcaddy" do
-    url "https://github.com/caddyserver/xcaddy/archive/v0.1.7.tar.gz"
-    sha256 "9915970e69c07324f4d032741741516523147b6250e1426b16e6b794d4a56f05"
+    url "https://github.com/caddyserver/xcaddy/archive/v0.1.8.tar.gz"
+    sha256 "517e800e2c3edfa0bcb5a80092d2cc7dc2f7d1c21a91ec6e77393df127b182f9"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

xcaddy is the build tools. v0.1.8 fixes issues with Go 1.16.

#71289