### PR TITLE
glab: fix non-bash shell completion

### DIFF
--- a/Formula/glab.rb
+++ b/Formula/glab.rb
@@ -4,6 +4,7 @@ class Glab < Formula
   url "https://github.com/profclems/glab/archive/v1.15.0.tar.gz"
   sha256 "d2551b1ae3c8ec61e0d161e8a75efb16fea1e0716eed0095f23bcf5bfbc8d758"
   license "MIT"
+  revision 1
   head "https://github.com/profclems/glab.git"
 
   bottle do
@@ -18,12 +19,9 @@ class Glab < Formula
   def install
     system "make", "GLAB_VERSION=#{version}"
     bin.install "bin/glab"
-    output = Utils.safe_popen_read({ "SHELL" => "bash" }, bin/"glab", "completion", "bash")
-    (bash_completion/"glab").write output
-    output = Utils.safe_popen_read({ "SHELL" => "zsh" }, bin/"glab", "completion", "zsh")
-    (zsh_completion/"_glab").write output
-    output = Utils.safe_popen_read({ "SHELL" => "fish" }, bin/"glab", "completion", "fish")
-    (fish_completion/"glab.fish").write output
+    (bash_completion/"glab").write Utils.safe_popen_read(bin/"glab", "completion", "--shell=bash")
+    (zsh_completion/"_glab").write Utils.safe_popen_read(bin/"glab", "completion", "--shell=zsh")
+    (fish_completion/"glab.fish").write Utils.safe_popen_read(bin/"glab", "completion", "--shell=fish")
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Because `glab` expects the `-s`/`--shell` option, the formula mistakenly installed the same bash completion for both zsh and fish as well.