### PR TITLE
ldc: use workaround only on macos

### DIFF
--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -57,8 +57,10 @@ class Ldc < Formula
       system "make"
       system "make", "install"
 
-      # Workaround for https://github.com/ldc-developers/ldc/issues/3670
-      cp Formula["llvm"].opt_lib/"libLLVM.dylib", lib/"libLLVM.dylib"
+      on_macos do
+        # Workaround for https://github.com/ldc-developers/ldc/issues/3670
+        cp Formula["llvm"].opt_lib/"libLLVM.dylib", lib/"libLLVM.dylib"
+      end
     end
   end
 


### PR DESCRIPTION
This is not needed on Linux. Besides, this file conflicts with
the same file provided by llvm (as llvm is not keg only on linux)

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
