### PR TITLE
soci: don't build tests (workaround M1 macOS compilation issue)

### DIFF
--- a/Formula/soci.rb
+++ b/Formula/soci.rb
@@ -16,9 +16,6 @@ class Soci < Formula
   depends_on "sqlite"
 
   def install
-    # NOTE: SOCI_TESTS disabled temporarily on macOS M1 machines as
-    # soci 4.0.1 relies on an older version of Catch which fails to
-    # detect macOS machines running on arm64 architecture
     args = std_cmake_args + %w[
       -DSOCI_TESTS:BOOL=OFF
       -DWITH_SQLITE3:BOOL=ON

--- a/Formula/soci.rb
+++ b/Formula/soci.rb
@@ -16,7 +16,11 @@ class Soci < Formula
   depends_on "sqlite"
 
   def install
+    # NOTE: SOCI_TESTS disabled temporarily on macOS M1 machines as
+    # soci 4.0.1 relies on an older version of Catch which fails to
+    # detect macOS machines running on arm64 architecture
     args = std_cmake_args + %w[
+      -DSOCI_TESTS:BOOL=OFF
       -DWITH_SQLITE3:BOOL=ON
       -DWITH_BOOST:BOOL=OFF
       -DWITH_MYSQL:BOOL=OFF


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a (somewhat crude) fix for errors seen when compiling `soci` on M1 macOS machines.

I've also filed an issue upstream, at https://github.com/SOCI/soci/issues/852.