### PR TITLE
kubectx: remove kubectl dependency

### DIFF
--- a/Formula/kubectx.rb
+++ b/Formula/kubectx.rb
@@ -8,8 +8,6 @@ class Kubectx < Formula
 
   bottle :unneeded
 
-  depends_on "kubernetes-cli"
-
   def install
     bin.install "kubectx", "kubens"
 


### PR DESCRIPTION
Since [0.9.0](https://github.com/ahmetb/kubectx/releases/tag/v0.9.0) `kubectx` no longer has a dependency on the `kubectl` binary.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?


