### PR TITLE
consul: fix arm64 build for Go 1.16

### DIFF
--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -31,7 +31,8 @@ class Consul < Formula
     on_linux do
       ENV["XC_OS"] = "linux"
     end
-    ENV["XC_ARCH"] = "amd64"
+    cpu = Hardware::CPU.arm? ? "arm64" : "amd64"
+    ENV["XC_ARCH"] = cpu
     ENV["GOPATH"] = buildpath
     contents = Dir["{*,.git,.gitignore}"]
     (buildpath/"src/github.com/hashicorp/consul").install contents


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Fix consul for `arm64` `go1.16` build https://github.com/Homebrew/homebrew-core/pull/71289