### PR TITLE
go@1.14: deprecate

### DIFF
--- a/Formula/go@1.14.rb
+++ b/Formula/go@1.14.rb
@@ -19,6 +19,8 @@ class GoAT114 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2021-02-16", because: :unsupported
+
   depends_on arch: :x86_64
 
   resource "gotools" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Deprecated after 1.16's release.