### PR TITLE
unstable_allowlist: remove go

### DIFF
--- a/audit_exceptions/unstable_allowlist.json
+++ b/audit_exceptions/unstable_allowlist.json
@@ -3,7 +3,6 @@
   "automysqlbackup": "3.0-rc",
   "aview": "1.3.0rc",
   "ftgl": "2.1.3-rc",
-  "go": "1.15.",
   "libcaca": "0.99b",
   "premake": "4.4-beta",
   "pwnat": "0.3-beta",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

We are no longer using a non-stable version of Go, so the exception is
no longer needed.