### PR TITLE
eccodes: add pthread parallel support 

### DIFF
--- a/Formula/eccodes.rb
+++ b/Formula/eccodes.rb
@@ -4,6 +4,7 @@ class Eccodes < Formula
   url "https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-2.20.0-Source.tar.gz"
   sha256 "207a3d7966e75d85920569b55a19824673e8cd0b50db4c4dac2d3d52eacd7985"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://software.ecmwf.int/wiki/display/ECC/Releases"
@@ -32,7 +33,8 @@ class Eccodes < Formula
 
     mkdir "build" do
       system "cmake", "..", "-DENABLE_NETCDF=ON", "-DENABLE_PNG=ON",
-                            "-DENABLE_PYTHON=OFF", *std_cmake_args
+                            "-DENABLE_PYTHON=OFF", "-DENABLE_ECCODES_THREADS=ON",
+                             *std_cmake_args
       system "make", "install"
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

ecCodes should be built with [thread safe support](https://confluence.ecmwf.int/display/UDOC/Is+ecCodes+thread-safe+-+ecCodes+FAQ). This allows for safe usage in other grib2 toolchains that have parallel support -- such as xarray+dask via the 'cfgrib' engine.

There is an option of either openmp or pthreads for parallel support. I have chosen to use pthreads to reduce the extra dependency.