### PR TITLE
composer 2.0.11

### DIFF
--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -1,8 +1,8 @@
 class Composer < Formula
   desc "Dependency Manager for PHP"
   homepage "https://getcomposer.org/"
-  url "https://getcomposer.org/download/2.0.10/composer.phar"
-  sha256 "92cb8b75268b23d1275e6d72dd398b29244505bea6d1f247ba126fd45a990645"
+  url "https://getcomposer.org/download/2.0.11/composer.phar"
+  sha256 "eabf2917072096a94679193762501319e621e2b369a4a1256b2c27f4e6984477"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 2,210,024 bytes
- formula fetch time: 2.6 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.