### PR TITLE
castget: update stable and livecheck

### DIFF
--- a/Formula/castget.rb
+++ b/Formula/castget.rb
@@ -1,12 +1,12 @@
 class Castget < Formula
   desc "Command-line podcast and RSS enclosure downloader"
   homepage "https://castget.johndal.com/"
-  url "https://savannah.nongnu.org/download/castget/castget-2.0.1.tar.bz2"
+  url "https://download.savannah.gnu.org/releases/castget/castget-2.0.1.tar.bz2"
   sha256 "438b5f7ec7e31a45ed3756630fe447f42015acda53ec09202f48628726b5e875"
   license "LGPL-2.1-only"
 
   livecheck do
-    url "https://savannah.nongnu.org/download/castget/"
+    url "https://download.savannah.gnu.org/releases/castget/"
     regex(/href=.*?castget[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the `stable` and `livecheck` URLs for `castget` as they redirect from `savannah.nongnu.org/download/` to `https://download.savannah.gnu.org/releases/`. The `stable` URL still redirects to a mirror but this avoids one redirection, at least.