### PR TITLE
mlton: fix version and bump version scheme

### DIFF
--- a/Formula/mlton.rb
+++ b/Formula/mlton.rb
@@ -2,8 +2,10 @@ class Mlton < Formula
   desc "Whole-program, optimizing compiler for Standard ML"
   homepage "http://mlton.org"
   url "https://downloads.sourceforge.net/project/mlton/mlton/20210117/mlton-20210117.src.tgz"
+  version "20210117"
   sha256 "ec7a5a54deb39c7c0fa746d17767752154e9cb94dbcf3d15b795083b3f0f154b"
   license "HPND"
+  version_scheme 1
   head "https://github.com/MLton/mlton.git"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`mlton` currently has a `version` string of `20210117.src` but it should be `20210117`

<!-- It seems that a change to `brew` sometime between #61983 (Oct. 2, 2020) and #69640 (Jan. 23, 2021) resulted in the `version` string being incorrectly determined from the formula URL -->