### PR TITLE
cairo: enable xlib on macos (#919)

### DIFF
--- a/Formula/cairo.rb
+++ b/Formula/cairo.rb
@@ -4,7 +4,7 @@ class Cairo < Formula
   url "https://cairographics.org/releases/cairo-1.16.0.tar.xz"
   sha256 "5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331"
   license any_of: ["LGPL-2.1-only", "MPL-1.1"]
-  revision 4
+  revision 5
 
   livecheck do
     url "https://cairographics.org/releases/?C=M&O=D"
@@ -30,17 +30,14 @@ class Cairo < Formula
   depends_on "freetype"
   depends_on "glib"
   depends_on "libpng"
+  depends_on "libx11"
+  depends_on "libxcb"
+  depends_on "libxext"
+  depends_on "libxrender"
   depends_on "lzo"
   depends_on "pixman"
 
   uses_from_macos "zlib"
-
-  on_linux do
-    depends_on "libx11"
-    depends_on "libxcb"
-    depends_on "libxext"
-    depends_on "libxrender"
-  end
 
   # Avoid segfaults on Big Sur. Remove at version bump.
   # https://gitlab.freedesktop.org/cairo/cairo/-/issues/420
@@ -57,20 +54,13 @@ class Cairo < Formula
       --enable-svg
       --enable-tee
       --disable-valgrind
+      --enable-xcb
+      --enable-xlib
+      --enable-xlib-xrender
     ]
     on_macos do
       args += %w[
         --enable-quartz-image
-        --disable-xcb
-        --disable-xlib
-        --disable-xlib-xrender
-      ]
-    end
-    on_linux do
-      args += %w[
-        --enable-xcb
-        --enable-xlib
-        --enable-xlib-xrender
       ]
     end
 


### PR DESCRIPTION
See https://github.com/Homebrew/discussions/discussions/919. The x11 backend was originally disabled in the Cairo build because it forced a dependency on Xquartz. Since the removal/deprecation of the :x11 dependency in homebrew, this functionality can be happily restored with dependencies on lower level libraries (libx11,libxcb,libxrender).

The trigger for this change is that the current disabling of x11 in cairo makes the newly added giza package (Formula/giza.rb) useless on macos. It would also enable some of my other user-maintained taps (e.g. splash and denoise from: https://github.com/danieljprice/homebrew-all) to become part of homebrew-core

Also simplifies the cairo formula, since the functionality of cairo is now identical on linux and macos.

-----
- [X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
