### PR TITLE
coin3d: update livecheck

### DIFF
--- a/Formula/coin3d.rb
+++ b/Formula/coin3d.rb
@@ -15,7 +15,7 @@ class Coin3d < Formula
 
   livecheck do
     url :stable
-    regex(/^Coin-(\d+\.\d+\.\d+)$/i)
+    regex(/^Coin[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the regex in the existing `livecheck` block for `coin3d` to better align with current standards. This PR addresses the following:

* Use `[._-]` to handle the delimiter between the name and version.
* Use the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`) instead of `\d+\.\d+\.\d+` (which would fail to match a version with fewer or more than three parts).