### PR TITLE
libgcrypt: update livecheck

### DIFF
--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -7,7 +7,7 @@ class Libgcrypt < Formula
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libgcrypt/"
-    regex(/libgcrypt[._-]v?(\d+\.\d+\.\d+)/i)
+    regex(/href=.*?libgcrypt[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the regex in the existing `livecheck` block for `libgcrypt` to align with our current regex guidelines. This PR addresses the following:

* When matching filenames on an HTML page, restrict matching to `href` attributes when appropriate.
* Use the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`) instead of `\d+\.\d+\.\d+` (which would fail to match a version with fewer or more than three parts).