### PR TITLE
libu2f-host: update livecheck

### DIFF
--- a/Formula/libu2f-host.rb
+++ b/Formula/libu2f-host.rb
@@ -8,7 +8,7 @@ class Libu2fHost < Formula
 
   livecheck do
     url "https://developers.yubico.com/libu2f-host/Releases/"
-    regex(/href=.*?libu2f-host[._-]v?(\d+\.\d+\.\d+)\.t/i)
+    regex(/href=.*?libu2f-host[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the regex in the existing `livecheck` block for `libu2f-host` to better align with current guidelines. Namely, this uses the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`) instead of `\d+\.\d+\.\d+` (which would fail to match a version with fewer or more than three parts).