### PR TITLE
kubectx 0.9.2, switch to go build

### DIFF
--- a/Formula/kubectx.rb
+++ b/Formula/kubectx.rb
@@ -1,17 +1,17 @@
 class Kubectx < Formula
   desc "Tool that can switch between kubectl contexts easily and create aliases"
   homepage "https://github.com/ahmetb/kubectx"
-  url "https://github.com/ahmetb/kubectx/archive/v0.9.1.tar.gz"
-  sha256 "8f68e19b841a1f1492536dc27f9b93ea3204c7e4fd0ad2e3c483d1b8e95be675"
+  url "https://github.com/ahmetb/kubectx/archive/v0.9.2.tar.gz"
+  sha256 "bb52df9891da9d0e4a2eda573c89b57f9df97da2148e3b0bfd5c15aa181cb4f3"
   license "Apache-2.0"
   head "https://github.com/ahmetb/kubectx.git"
 
-  bottle :unneeded
-
+  depends_on "go" => :build
   depends_on "kubernetes-cli"
 
   def install
-    bin.install "kubectx", "kubens"
+    system "go", "build", *std_go_args, "./cmd/kubectx"
+    system "go", "build", *std_go_args, "-o", bin/"kubens", "./cmd/kubens"
 
     bash_completion.install "completion/kubectx.bash" => "kubectx"
     bash_completion.install "completion/kubens.bash" => "kubens"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Since version 0.9, `kubectx` has been rewritten in Go, this PR updates the formula to the latest version and switches to the new go-based build instead of installing the old bash scripts.

Possibly supersedes #71922