### PR TITLE
cmake: update livecheck

### DIFF
--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -6,9 +6,11 @@ class Cmake < Formula
   license "BSD-3-Clause"
   head "https://gitlab.kitware.com/cmake/cmake.git"
 
+  # The "latest" release on GitHub has been an unstable version before, so we
+  # check the Git tags instead.
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `cmake` uses the `GithubLatest` strategy but it returns an `Unable to get versions` error because the "latest" version on GitHub is currently a prerelease version (`v3.20.0-rc2`). We only use the `GithubLatest` strategy when it's both necessary (i.e., checking Git tags isn't sufficient to identify the latest version) and a correct stable version.

Since this repository can treat prerelease versions as "latest", it's necessary to check the Git tags instead and this updates the `livecheck` block accordingly. Just to be clear, we don't check the [first-party download page](https://cmake.org/download/) (which links to GitHub releases) since it has had intermittent `execution expired` errors in the past.