### PR TITLE
or-tools: fix test

### DIFF
--- a/Formula/or-tools.rb
+++ b/Formula/or-tools.rb
@@ -45,6 +45,7 @@ class OrTools < Formula
            "-I#{include}", "-L#{lib}", "-lortools",
            "-L#{Formula["gflags"].opt_lib}", "-lgflags",
            "-L#{Formula["glog"].opt_lib}", "-lglog",
+           "-L#{Formula["abseil"].opt_lib}", "-labsl_time",
            pkgshare/"simple_lp_program.cc", "-o", "simple_lp_program"
     system "./simple_lp_program"
     # Routing Solver


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew test or-tools` currently fails with the following error:
```
Undefined symbols for architecture x86_64:
  "absl::lts_2020_09_23::ToInt64Milliseconds(absl::lts_2020_09_23::Duration)", referenced from:
      operations_research::MPSolver::wall_time() const in simple_lp_program-3d4feb.o
  "absl::lts_2020_09_23::Now()", referenced from:
      operations_research::MPSolver::DurationSinceConstruction() const in simple_lp_program-3d4feb.o
  "absl::lts_2020_09_23::Duration::operator-=(absl::lts_2020_09_23::Duration)", referenced from:
      absl::lts_2020_09_23::operator-(absl::lts_2020_09_23::Duration, absl::lts_2020_09_23::Duration) in simple_lp_program-3d4feb.o
ld: symbol(s) not found for architecture x86_64
```

This PR fixes this issue, the compilation simply needed to link with `abseil`. This issue curently blocks #71937.