### PR TITLE
ocaml-findlib: install topfind

### DIFF
--- a/Formula/ocaml-findlib.rb
+++ b/Formula/ocaml-findlib.rb
@@ -3,7 +3,8 @@ class OcamlFindlib < Formula
   homepage "http://projects.camlcity.org/projects/findlib.html"
   url "http://download.camlcity.org/download/findlib-1.8.1.tar.gz"
   sha256 "8e85cfa57e8745715432df3116697c8f41cb24b5ec16d1d5acd25e0196d34303"
-  revision 3
+  license "MIT"
+  revision 4
 
   livecheck do
     url "http://download.camlcity.org/download/"
@@ -23,15 +24,20 @@ class OcamlFindlib < Formula
   uses_from_macos "m4" => :build
 
   def install
+    # Specify HOMEBREW_PREFIX here so those are the values baked into the compile,
+    # rather than the Cellar
     system "./configure", "-bindir", bin,
                           "-mandir", man,
-                          "-sitelib", lib/"ocaml",
+                          "-sitelib", HOMEBREW_PREFIX/"lib/ocaml",
                           "-config", etc/"findlib.conf",
-                          "-no-topfind"
+                          "-no-camlp4"
+
     system "make", "all"
     system "make", "opt"
-    inreplace "findlib.conf", prefix, HOMEBREW_PREFIX
-    system "make", "install"
+
+    # Override the above paths for the install step only
+    system "make", "install", "OCAML_SITELIB=#{lib}/ocaml",
+                              "OCAML_CORE_STDLIB=#{lib}/ocaml"
 
     # Avoid conflict with ocaml-num package
     rm_rf Dir[lib/"ocaml/num", lib/"ocaml/num-top"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`topfind` is used by many packages, and disabling it is [not recommended](https://github.com/ocaml/ocamlfind/blob/9e406208dfe60160fbdc1ea135d1cc0e2ef8e216/INSTALL#L57-L62).

I've made some tweaks to the paths to make this all work correctly.