### PR TITLE
berkeley-db: disable static libraries and remove docs

### DIFF
--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -2,10 +2,10 @@ class BerkeleyDb < Formula
   desc "High performance key/value database"
   homepage "https://www.oracle.com/technology/products/berkeley-db/index.html"
   # Requires registration to download so we mirror it
-  url "https://dl.bintray.com/homebrew/mirror/berkeley-db-18.1.32.tar.gz"
-  mirror "https://fossies.org/linux/misc/db-18.1.32.tar.gz"
-  sha256 "fa1fe7de9ba91ad472c25d026f931802597c29f28ae951960685cde487c8d654"
-  revision 1
+  url "https://dl.bintray.com/homebrew/mirror/berkeley-db-18.1.40.tar.gz"
+  mirror "https://fossies.org/linux/misc/db-18.1.40.tar.gz"
+  sha256 "0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8"
+  license "AGPL-3.0-only"
 
   livecheck do
     url "https://www.oracle.com/technetwork/database/" \
@@ -32,6 +32,7 @@ class BerkeleyDb < Formula
     # the system berkeley db 1.x
     args = %W[
       --disable-debug
+      --disable-static
       --prefix=#{prefix}
       --mandir=#{man}
       --enable-cxx
@@ -45,11 +46,10 @@ class BerkeleyDb < Formula
     # BerkeleyDB requires you to build everything from the build_unix subdirectory
     cd "build_unix" do
       system "../dist/configure", *args
-      system "make", "install"
+      system "make", "install", "DOCLIST=license"
 
-      # use the standard docs location
-      doc.parent.mkpath
-      mv prefix/"docs", doc
+      # delete docs dir because it is huge
+      rm_rf prefix/"docs"
     end
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Related to https://github.com/Homebrew/homebrew-core/pull/71996, since we it is easier for us to just support BerkeleyDB in perl, I wanted to figure out why the `berkeley-db` bottle is so large compared to the size package size in Linux distros.  We can reduce the size by deleting the docs directory (these are readily available online), and disabling static library generation.   