### PR TITLE
qpid-proton disabled unit tests

### DIFF
--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -21,6 +21,7 @@ class QpidProton < Formula
     mkdir "build" do
       system "cmake", "..", "-DBUILD_BINDINGS=",
                          "-DLIB_INSTALL_DIR=#{lib}",
+                         "-DBUILD_TESTING=OFF",
                          "-Dproactor=libuv",
                          *std_cmake_args
       system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix to remove unit tests so that hopefully it will build on ARM (the catch library has some assembly code inside that osx arm doesn't like).

Related: https://github.com/Homebrew/homebrew-core/pull/71978