### PR TITLE
llvm: update livecheck

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -39,8 +39,8 @@ class Llvm < Formula
   end
 
   livecheck do
-    url :homepage
-    regex(/LLVM (\d+.\d+.\d+)/i)
+    url :stable
+    regex(/^llvmorg[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `llvm` checks the homepage and was briefly reporting `11.0.1` as newest, though the formula was already updated to `11.1.0`. Since then, the homepage was updated to include release information for `11.1.0` and the check now correctly reports `11.1.0` as newest.

The first-party website links to GitHub releases on the [download page](https://releases.llvm.org/download.html) and the formula uses a `stable` archive from GitHub, so this PR updates the `livecheck` block to align the check with the `stable` source.

This change makes sense if the formula is going to be bumped to a new version regardless of whether it has been announced on the homepage at the time (as happened in the case of `11.1.0`). Otherwise, if we don't want to treat a new version as released until it's announced on the first-party homepage, we can stick with the existing check.