### PR TITLE
hdf5@1.8: update livecheck

### DIFF
--- a/Formula/hdf5@1.8.rb
+++ b/Formula/hdf5@1.8.rb
@@ -1,12 +1,14 @@
 class Hdf5AT18 < Formula
   desc "File format designed to store large amounts of data"
   homepage "https://www.hdfgroup.org/HDF5"
+  # NOTE: 1.8.23 is expected to be the last release for HDF5-1.8
+  # (see: https://portal.hdfgroup.org/display/support/HDF5%201.8.22#HDF51.8.22-futureFutureofHDF5-1.8).
   url "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.22/src/hdf5-1.8.22.tar.bz2"
   sha256 "0ac77e1c22bce5bbbdb337bd7f97aeb5ef43c727a84ccb6d683d092eb57ebd8e"
 
   livecheck do
-    url "https://support.hdfgroup.org/ftp/HDF5/current18/src/"
-    regex(/href=.*?hdf5[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/"
+    regex(%r{href=["']?hdf5[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `hdf5@1.8` to check the directory listing page where the current `stable` archive is found. The previous `/ftp/HDF5/current18/src/` directory only goes up to version `1.8.21` and doesn't include the current version used in the formula (`1.8.22`). The [first-party download page](https://portal.hdfgroup.org/display/support/Download+HDF5) lists `1.8.22` as the newest and the [page for the release](https://portal.hdfgroup.org/display/support/HDF5+1.8.22) also links to the `/ftp/HDF5/releases/hdf5-1.8/` directory (used in this PR), so this seems appropriate.

I also added a comment before the `stable` URL to note that version `1.8.23` is expected to be the last release for the 1.8 series. If that version is officially acknowledged as the final release when it's published, we should consider deprecating the formula and removing the `livecheck` block at that time (so it will be automatically skipped).