### PR TITLE
ledit: add license, update livecheck

### DIFF
--- a/Formula/ledit.rb
+++ b/Formula/ledit.rb
@@ -4,10 +4,14 @@ class Ledit < Formula
   url "https://github.com/chetmurthy/ledit/archive/ledit-2-05.tar.gz"
   version "2.05"
   sha256 "493ee6eae47cc92f1bee5f3c04a2f7aaa0812e4bdf17e03b32776ab51421392c"
+  license "BSD-3-Clause"
 
   livecheck do
-    url :homepage
-    regex(/current .*? is v?(\d+(?:\.\d+)+) /i)
+    url :stable
+    regex(/^ledit[._-]v?(\d+(?:[.-]\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.gsub("-", ".") }.compact
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `ledit` checks the homepage but it's reporting version `2.04` (from 2018-01-24) as newest instead of `2.05` (tagged 2020-09-09 on GitHub and used as the current version in the formula). This is because the homepage hasn't been updated to include information about the current `2.05` release and it doesn't seem like this will happen soon.

Since the homepage isn't a reliable indicator of the latest version, this updates the `livecheck` block to check the Git tags in the upstream GitHub repository (i.e., the `stable` source). The tags use a format like `ledit-2-05`, `ledit-2-02-1`, etc. and this `strategy` block simply replaces the hyphens with periods to match the formula version format.

Edit: Per Carlo's suggestion, this also adds `license "BSD-3-Clause"`, referencing the [`LICENSE` file in the upstream repository](https://github.com/chetmurthy/ledit/blob/master/LICENSE).