### PR TITLE
ballerina: update livecheck

### DIFF
--- a/Formula/ballerina.rb
+++ b/Formula/ballerina.rb
@@ -6,8 +6,8 @@ class Ballerina < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://ballerina.io/learn/installing-ballerina/"
-    regex(/href=.*?ballerina[._-]v?(\d+(?:\.\d+)+)/i)
+    url "https://ballerina.io/downloads/"
+    regex(%r{href=.*?/downloads/.*?ballerina[._-]v?(\d+(?:\.\d+)+)\.}i)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `ballerina` to check the [first-party downloads page](https://ballerina.io/downloads/), as the `/learn/installing-ballerina/` page only links to what they treat as the latest version and this is currently an alpha version (`swan-lake-alpha2`), which the regex rightly doesn't match.

The downloads page lists the same alpha version but it also lists the latest stable release (`1.2.13`) below that and this is what we're matching here.  This may or may not need to be updated again once the `2.0.0` release stabilizes but this will work for now.