### PR TITLE
pipx: use assert_predicate for test

### DIFF
--- a/Formula/pipx.rb
+++ b/Formula/pipx.rb
@@ -64,7 +64,7 @@ class Pipx < Formula
   test do
     assert_match "PIPX_HOME", shell_output("#{bin}/pipx --help")
     system "#{bin}/pipx", "install", "csvkit"
-    assert_true FileTest.exist?("#{testpath}/.local/bin/csvjoin")
+    assert_predicate testpath/".local/bin/csvjoin", :exist?
     system "#{bin}/pipx", "uninstall", "csvkit"
     assert_no_match Regexp.new("csvjoin"), shell_output("#{bin}/pipx list")
   end


### PR DESCRIPTION
assert_true does not exist anymore, use the more
standard way to test for a file presence

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
