### PR TITLE
bettercap: Add HEAD and remove dep to fix build

### DIFF
--- a/Formula/bettercap.rb
+++ b/Formula/bettercap.rb
@@ -4,6 +4,7 @@ class Bettercap < Formula
   url "https://github.com/bettercap/bettercap/archive/v2.29.tar.gz"
   sha256 "c414be98a48d9f279460b325dddaef8479132a1470c6f305790d79e04dac1297"
   license "GPL-3.0-only"
+  head "https://github.com/bettercap/bettercap.git"
 
   bottle do
     sha256 cellar: :any, big_sur:  "6de77638b77e9b826cd2085147a5c312156d578f3376f2e0cc3397be9a48e7bd"
@@ -11,7 +12,6 @@ class Bettercap < Formula
     sha256 cellar: :any, mojave:   "4b59d7b9b41bcd5ee77ca8dc5ecb00c4ba158910dc30c2083c5e4dee6b994e1d"
   end
 
-  depends_on "dep" => :build
   depends_on "go" => :build
   depends_on "pkg-config" => :build
   depends_on "libusb"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Added the HEAD because why not.
Removed dep because it is depreciated, and _it actually causes builds from source to fail!_ 
```
==> hack/build-all.bash
Last 15 lines from /Users/<me>/Library/Logs/Homebrew/dep/01.build-all.bash:
2021-02-26 20:27:05 -0600

hack/build-all.bash

Building for darwin/amd64 with CGO_ENABLED=1
go: cannot find main module, but found Gopkg.lock in /private/tmp/dep-20210226-84700-15dc1op/src/github.com/golang/dep
	to create a module there, run:
	go mod init
```
Removing it fixes building, since `go build` automatically downloads modules at build time anyway (from go 1.11 onwards), so it can be safely removed.

Tested this locally on M1 Mac on macOS 11.2.2 and it builds successfully with no errors.