### PR TITLE
Update "minetest_game" resource (-> 5.4.0) to match recently updated "minetest" in minetest.rb

### DIFF
--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -6,10 +6,12 @@ class Minetest < Formula
   stable do
     url "https://github.com/minetest/minetest/archive/5.4.0.tar.gz"
     sha256 "6e9b299e156651be9bcf973a9232cff32215de31dfae5ea770a71d1757cab014"
+    # When updating, check the following URL as the resource below might also need to be updated:
+    # https://github.com/minetest/minetest_game/releases
 
     resource "minetest_game" do
-      url "https://github.com/minetest/minetest_game/archive/5.3.0.tar.gz"
-      sha256 "06c6c1d4b97af211dd0fa518a3e68a205f594e9816a4b2477e48d4d21d278e2d"
+      url "https://github.com/minetest/minetest_game/archive/5.4.0.tar.gz"
+      sha256 "520d2056085ec11e8806cf5a8f928537797d27a86704770bf408c113ea9881cb"
     end
   end
 


### PR DESCRIPTION
This PR complements #71861 by updating the default game that comes with Minetest to the latest version.

1. Updated URL and hash value for "minetest_game" resource.
2. Added a comment instructing future maintainers to also check to see if a new version of "[minetest game](https://github.com/minetest/minetest_game)" has been posted as Minetest and Minetest Game should be updated together.

P.S. I have not had a chance to test this, but I was able to download the file via the updated URL, and the hash is correct for the new file.

(CCing the following [minetest](https://github.com/minetest/) maintainers to keep them in the loop: @celeron55 , @rubenwardy , and @sfan5 )

Take care,
[Solomon](https://SqlQuantumLeap.com/)...
