### PR TITLE
kubectx: depend on x86_64

### DIFF
--- a/Formula/kubectx.rb
+++ b/Formula/kubectx.rb
@@ -8,6 +8,7 @@ class Kubectx < Formula
 
   bottle :unneeded
 
+  depends_on arch: :x86_64
   depends_on "kubernetes-cli"
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`kubectx` depends on `kubernetes-cli`, which isn't bottled for ARM. 

Follow-up to https://github.com/Homebrew/homebrew-core/pull/72023