### PR TITLE
libvncserver: use generic shared library and fix test for Linux

### DIFF
--- a/Formula/libvncserver.rb
+++ b/Formula/libvncserver.rb
@@ -28,7 +28,7 @@ class Libvncserver < Formula
   def install
     args = std_cmake_args + %W[
       -DJPEG_INCLUDE_DIR=#{Formula["jpeg-turbo"].opt_include}
-      -DJPEG_LIBRARY=#{Formula["jpeg-turbo"].opt_lib}/libjpeg.dylib
+      -DJPEG_LIBRARY=#{Formula["jpeg-turbo"].opt_lib}/#{shared_library("libjpeg")}
       -DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}
     ]
 
@@ -52,7 +52,7 @@ class Libvncserver < Formula
     EOS
 
     system ENV.cc, "server.cpp", "-I#{include}", "-L#{lib}",
-                   "-lvncserver", "-lc++", "-o", "server"
+                   "-lvncserver", "-o", "server"
     system "./server"
   end
 end


### PR DESCRIPTION
For the test: lc++ breaks the compilation on linux with gcc,
and is not needed on mac, so let's just remove it.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
