### PR TITLE
Update various livecheck regex style

### DIFF
--- a/Formula/gpcslots2.rb
+++ b/Formula/gpcslots2.rb
@@ -7,7 +7,7 @@ class Gpcslots2 < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/gpcslots2[._-]v?(\d+(?:[-_.]\d+)+[a-z]?)}i)
+    regex(%r{url=.*?/gpcslots2[._-]v?(\d+(?:[._-]\d+)+[a-z]?)}i)
   end
 
   bottle :unneeded

--- a/Formula/latex2rtf.rb
+++ b/Formula/latex2rtf.rb
@@ -7,7 +7,7 @@ class Latex2rtf < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/latex2rtf/files/latex2rtf-unix/[^/]+/latex2rtf[._-](\d+(?:[-.]\d+)+[a-z]?)\.t}i)
+    regex(%r{url=.*?/latex2rtf/files/latex2rtf-unix/[^/]+/latex2rtf[._-](\d+(?:[.-]\d+)+[a-z]?)\.t}i)
   end
 
   bottle do

--- a/Formula/libtorrent-rasterbar.rb
+++ b/Formula/libtorrent-rasterbar.rb
@@ -8,7 +8,7 @@ class LibtorrentRasterbar < Formula
 
   livecheck do
     url :stable
-    regex(/^libtorrent[._-]v?(\d+(?:[-_.]\d+)+)$/i)
+    regex(/^libtorrent[._-]v?(\d+(?:[._]\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/nsd.rb
+++ b/Formula/nsd.rb
@@ -10,7 +10,7 @@ class Nsd < Formula
   # tendency to lead to an `execution expired` error.
   livecheck do
     url "https://github.com/NLnetLabs/nsd.git"
-    regex(/^NSD[._-]v?(\d+(?:[-_.]\d+)+).REL$/i)
+    regex(/^NSD[._-]v?(\d+(?:[._]\d+)+)[._-]REL$/i)
   end
 
   bottle do

--- a/Formula/popt.rb
+++ b/Formula/popt.rb
@@ -12,7 +12,7 @@ class Popt < Formula
   # shouldn't encounter problems with this method.
   livecheck do
     url :homepage
-    regex(/^(?:popt[._-])?v?(\d+(?:[._-]\d+)+)(?:-release)?$/i)
+    regex(/^(?:popt[._-])?v?(\d+(?:[._]\d+)+)(?:[._-]release)?$/i)
   end
 
   bottle do

--- a/Formula/rtf2latex2e.rb
+++ b/Formula/rtf2latex2e.rb
@@ -7,7 +7,7 @@ class Rtf2latex2e < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/rtf2latex2e[._-]v?(\d+(?:[._-]\d+)+)\.t}i)
+    regex(%r{url=.*?/rtf2latex2e[._-]v?(\d+(?:[.-]\d+)+)\.t}i)
   end
 
   bottle do

--- a/Formula/simutrans.rb
+++ b/Formula/simutrans.rb
@@ -8,8 +8,8 @@ class Simutrans < Formula
 
   livecheck do
     url "https://sourceforge.net/projects/simutrans/files/simutrans/"
+    regex(%r{href=.*?/files/simutrans/(\d+(?:[.-]\d+)+)/}i)
     strategy :page_match
-    regex(%r{href=.*?/files/simutrans/(\d+(?:[-_.]\d+)+)/}i)
   end
 
   bottle do

--- a/Formula/squirrel.rb
+++ b/Formula/squirrel.rb
@@ -8,7 +8,7 @@ class Squirrel < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/squirrel[._-]v?(\d+(?:[-_]\d+)+).stable\.t}i)
+    regex(%r{url=.*?/squirrel[._-]v?(\d+(?:[_-]\d+)+)[._-]stable\.t}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates various `livecheck` block regexes to address some minor stylistic issues. Namely:

* Replace `[-_.]` with `[._-]` (the standard order for this common character class). Also bring the variations in line, replacing `[-.]` with `[.-]` and `[-_]` with `[_-]`.
* Limit the use of `[._-]` as a delimiter between the numeric parts of a version in favor of more limited variations like `[._]` or `[.-]`. The latter variations are commonly used when versions are like `1_2_3` or `1-2-3` but we want the regex to continue matching if the format changes to a `1.2.3` format.
* Replace use of `.` as a delimiter with `[._-]`, which is more contextually appropriate.

This is part of ongoing work to bring existing `livecheck` blocks closer to our current guidelines and to improve standardization of regex patterns.