### PR TITLE
klee 2.2, wllvm 1.3.0, python-tabulate 0.89 (new formulae)

### DIFF
--- a/Formula/klee.rb
+++ b/Formula/klee.rb
@@ -1,0 +1,145 @@
+class Klee < Formula
+  desc "Symbolic Execution Engine"
+  homepage "https://klee.github.io/"
+  url "https://github.com/klee/klee/archive/v2.2.tar.gz"
+  sha256 "1ff2e37ed3128e005b89920fad7bcf98c7792a11a589dd443186658f5eb91362"
+  license "NCSA"
+  head "https://github.com/klee/klee.git"
+
+  depends_on "cmake" => :build
+  depends_on "gperftools"
+  depends_on "llvm"
+  depends_on "python-tabulate"
+  depends_on "python@3.9"
+  depends_on "sqlite"
+  depends_on "wllvm"
+  depends_on "z3"
+
+  uses_from_macos "zlib"
+
+  # klee needs a version of libc++ compiled with wllvm
+  resource "libcxx" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/llvm-project-11.1.0.src.tar.xz"
+    sha256 "74d2529159fd118c3eac6f90107b5611bccc6f647fdea104024183e8d5e25831"
+  end
+
+  def install
+    libcxx_install_dir = libexec/"libcxx"
+    libcxx_src_dir = buildpath/"libcxx"
+    resource("libcxx").stage libcxx_src_dir
+
+    cd libcxx_src_dir do
+      # Use build configuration at
+      # https://github.com/klee/klee/blob/v#{version}/scripts/build/p-libcxx.inc
+      libcxx_args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] } + %W[
+        -DCMAKE_C_COMPILER=wllvm
+        -DCMAKE_CXX_COMPILER=wllvm++
+        -DCMAKE_INSTALL_PREFIX=#{libcxx_install_dir}
+        -DLLVM_ENABLE_PROJECTS=libcxx;libcxxabi
+        -DLLVM_ENABLE_THREADS:BOOL=OFF
+        -DLLVM_ENABLE_EH:BOOL=OFF
+        -DLLVM_ENABLE_RTTI:BOOL=OFF
+        -DLIBCXX_ENABLE_THREADS:BOOL=OFF
+        -DLIBCXX_ENABLE_SHARED:BOOL=ON
+        -DLIBCXXABI_ENABLE_THREADS:BOOL=OFF
+      ]
+      on_macos do
+        libcxx_args << "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY:BOOL=OFF"
+      end
+      on_linux do
+        libcxx_args << "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY:BOOL=ON"
+      end
+
+      mkdir "llvm/build" do
+        with_env(
+          LLVM_COMPILER:      "clang",
+          LLVM_COMPILER_PATH: Formula["llvm"].opt_bin,
+        ) do
+          system "cmake", "..", *libcxx_args
+          system "make", "cxx"
+          system "make", "-C", "projects", "install"
+
+          Dir[libcxx_install_dir/"lib/#{shared_library("*")}", libcxx_install_dir/"lib/*.a"].each do |sl|
+            next if File.symlink? sl
+
+            system "extract-bc", sl
+          end
+        end
+      end
+    end
+
+    # CMake options are documented at
+    # https://github.com/klee/klee/blob/v#{version}/README-CMake.md
+    args = std_cmake_args + %W[
+      -DKLEE_RUNTIME_BUILD_TYPE=Release
+      -DLLVM_CONFIG_BINARY=#{Formula["llvm"].opt_bin}/llvm-config
+      -DENABLE_DOCS=OFF
+      -DENABLE_SYSTEM_TESTS=OFF
+      -DENABLE_KLEE_ASSERTS=ON
+      -DENABLE_KLEE_LIBCXX=ON
+      -DENABLE_KLEE_EH_CXX=OFF
+      -DENABLE_KLEE_UCLIBC=OFF
+      -DENABLE_POSIX_RUNTIME=OFF
+      -DENABLE_SOLVER_METASMT=OFF
+      -DENABLE_SOLVER_STP=OFF
+      -DENABLE_UNIT_TESTS=OFF
+      -DENABLE_TCMALLOC=ON
+      -DENABLE_SOLVER_Z3=ON
+      -DENABLE_ZLIB=ON
+      -DKLEE_LIBCXX_DIR=#{libcxx_install_dir}
+      -DKLEE_LIBCXX_INCLUDE_DIR=#{libcxx_install_dir}/include/c++/v1
+      -DKLEE_LIBCXXABI_SRC_DIR=#{libcxx_src_dir}/libcxxabi
+    ]
+
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  # Test adapted from
+  # http://klee.github.io/tutorials/testing-function/
+  test do
+    (testpath/"get_sign.c").write <<~EOS
+      #include "klee/klee.h"
+
+      int get_sign(int x) {
+        if (x == 0)
+          return 0;
+        if (x < 0)
+          return -1;
+        else
+          return 1;
+      }
+
+      int main() {
+        int a;
+        klee_make_symbolic(&a, sizeof(a), "a");
+        return get_sign(a);
+      }
+    EOS
+
+    ENV["CC"] = Formula["llvm"].opt_bin/"clang"
+
+    system ENV.cc, "-I#{opt_include}", "-emit-llvm",
+                    "-c", "-g", "-O0", "-disable-O0-optnone",
+                    testpath/"get_sign.c"
+
+    expected_output = <<~EOS
+      KLEE: done: total instructions = 33
+      KLEE: done: completed paths = 3
+      KLEE: done: generated tests = 3
+    EOS
+    output = pipe_output("#{bin}/klee get_sign.bc 2>&1")
+    assert_match expected_output, output
+    assert_predicate testpath/"klee-out-0", :exist?
+
+    assert_match "['get_sign.bc']", shell_output("#{bin}/ktest-tool klee-last/test000001.ktest")
+
+    system ENV.cc, "-I#{opt_include}", "-L#{opt_lib}", "-lkleeRuntest", testpath/"get_sign.c"
+    with_env(KTEST_FILE: "klee-last/test000001.ktest") do
+      system "./a.out"
+    end
+  end
+end

--- a/Formula/python-tabulate.rb
+++ b/Formula/python-tabulate.rb
@@ -1,0 +1,41 @@
+class PythonTabulate < Formula
+  include Language::Python::Virtualenv
+
+  desc "Pretty-print tabular data in Python"
+  homepage "https://pypi.org/project/tabulate/"
+  url "https://files.pythonhosted.org/packages/ae/3d/9d7576d94007eaf3bb685acbaaec66ff4cdeb0b18f1bf1f17edbeebffb0a/tabulate-0.8.9.tar.gz"
+  sha256 "eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7"
+  license "MIT"
+
+  depends_on "python@3.9"
+
+  def install
+    virtualenv_install_with_resources
+
+    xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
+    site_packages = "lib/python#{xy}/site-packages"
+    pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
+    (prefix/site_packages/"homebrew-py-tabulate.pth").write pth_contents
+  end
+
+  test do
+    (testpath/"in.txt").write <<~EOS
+      name qty
+      eggs 451
+      spam 42
+    EOS
+
+    (testpath/"out.txt").write <<~EOS
+      +------+-----+
+      | name | qty |
+      +------+-----+
+      | eggs | 451 |
+      +------+-----+
+      | spam | 42  |
+      +------+-----+
+    EOS
+
+    assert_equal (testpath/"out.txt").read, shell_output("#{bin}/tabulate -f grid #{testpath}/in.txt")
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "from tabulate import tabulate"
+  end
+end

--- a/Formula/wllvm.rb
+++ b/Formula/wllvm.rb
@@ -1,0 +1,34 @@
+class Wllvm < Formula
+  include Language::Python::Virtualenv
+
+  desc "Toolkit for building whole-program LLVM bitcode files"
+  homepage "https://pypi.org/project/wllvm/"
+  url "https://files.pythonhosted.org/packages/63/cd/0cc7994c2a94983adb8b07f34a88e6a815f4d18a1e29eb68d094e5863f18/wllvm-1.3.0.tar.gz"
+  sha256 "a98dd48350d8aae80fe03b92efb11c3e1b92f6aee482f4331f7c97265ca7a602"
+  license "MIT"
+
+  depends_on "llvm"
+  depends_on "python@3.9"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    ENV.prepend_path "PATH", Formula["llvm"].opt_bin
+    (testpath/"test.c").write "int main() { return 0; }"
+
+    with_env(LLVM_COMPILER: "clang") do
+      system bin/"wllvm", testpath/"test.c", "-o", testpath/"test"
+    end
+    assert_predicate testpath/".test.o", :exist?
+    assert_predicate testpath/".test.o.bc", :exist?
+
+    # extract-bc currently does not work on ARM.
+    # https://github.com/SRI-CSL/whole-program-llvm/issues/29
+    unless Hardware::CPU.arm?
+      system bin/"extract-bc", testpath/"test"
+      assert_predicate testpath/"test.bc", :exist?
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`klee` and `wllvm` do not pass `brew audit --new`, because of dependencies on `llvm` and `sqlite`.

The `llvm` dependency is genuine: `klee` and `wllvm` require binaries that come only with the `llvm` formula (`llvm-config`, `llvm-link`, and `llvm-ar`).

`klee` will link with `sqlite` through `python@3.9`, so there will still be linkage with the `sqlite` formula even if I remove the `sqlite` dependency.

I put all three formulae in one PR because `klee` depends on both `wllvm` and `python-tabulate`.