### PR TITLE
man-db: disable gettext opportunistic linkage

### DIFF
--- a/Formula/man-db.rb
+++ b/Formula/man-db.rb
@@ -53,12 +53,12 @@ class ManDb < Formula
       --prefix=#{prefix}
       --disable-cache-owner
       --disable-setuid
+      --disable-nls
       --program-prefix=g
     ]
 
     system "./configure", *args
 
-    system "make", "CFLAGS=#{ENV.cflags}"
     system "make", "install"
 
     # Symlink commands without 'g' prefix into libexec/bin and


### PR DESCRIPTION
Needed for https://github.com/Homebrew/homebrew-core/pull/69460

After a bunch of time staring at configure output I've determined that man-db failing to build from source was caused by opportunistic linkage against GNU gettext. Below is a configure output with gettext linked vs unlinked:

```diff
diff --git a/without_gettext b/with_gettext
index 8f68c64..4ee7cc4 100644
--- a/without_gettext
+++ b/with_gettext
@@ -880,9 +881,9 @@ checking for readdir... yes
 checking whether readlink signature is correct... yes
 checking whether readlink handles trailing slash correctly... no
 checking for working re_compile_pattern... no
-checking libintl.h usability... no
-checking libintl.h presence... no
-checking for libintl.h... no
+checking libintl.h usability... yes
+checking libintl.h presence... yes
+checking for libintl.h... yes
 checking whether isblank is declared... yes
 checking whether rename honors trailing slash on destination... no
 checking whether rename honors trailing slash on source... no
@@ -975,8 +976,10 @@ checking for GNU gettext in libc... no
 checking for iconv... yes
 checking for working iconv... yes
 checking how to link with libiconv... -liconv
-checking for GNU gettext in libintl... no
-checking whether to use NLS... no
+checking for GNU gettext in libintl... yes
+checking whether to use NLS... yes
+checking where the gettext function comes from... external libintl
+checking how to link with libintl... -lintl -Wl,-framework -Wl,CoreFoundation
 checking for iconv... (cached) yes
 checking for working iconv... (cached) yes
 checking how to link with libiconv... -liconv
```

Passing `--disable-nls` seems to disable the opportunistic linkage properly.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----