### PR TITLE
pypi_formula_mappings: add ansible-lint

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -1,5 +1,8 @@
 {
   "ansible": false,
+  "ansible-lint": {
+      "extra_packages": ["ansible-base"]
+  },
   "ansible@2.8": false,
   "cloudformation-cli": {
     "extra_packages": ["cloudformation-cli-go-plugin", "cloudformation-cli-java-plugin"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

ansible-lint also depends on ansible-base, but this isn't accounted for
by `update-python-resources`.

Cf. #72114, #71393, #70801