### PR TITLE
Replace [\d.] usage in livecheck regexes

### DIFF
--- a/Formula/groovy.rb
+++ b/Formula/groovy.rb
@@ -7,7 +7,7 @@ class Groovy < Formula
 
   livecheck do
     url "https://dl.bintray.com/groovy/maven/"
-    regex(/href=.*?groovy-binary[._-]v?([\d.]+)\.zip/i)
+    regex(/href=.*?groovy-binary[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   bottle :unneeded

--- a/Formula/groovysdk.rb
+++ b/Formula/groovysdk.rb
@@ -7,7 +7,7 @@ class Groovysdk < Formula
 
   livecheck do
     url "https://dl.bintray.com/groovy/maven/"
-    regex(/href=.*?apache-groovy-sdk[._-]v?([\d.]+)\.zip/i)
+    regex(/href=.*?apache-groovy-sdk[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   bottle :unneeded

--- a/Formula/libev.rb
+++ b/Formula/libev.rb
@@ -7,7 +7,7 @@ class Libev < Formula
 
   livecheck do
     url "http://dist.schmorp.de/libev/"
-    regex(/href=.*?libev[._-]v?([\d.]+)\./i)
+    regex(/href=.*?libev[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/libosinfo.rb
+++ b/Formula/libosinfo.rb
@@ -7,7 +7,7 @@ class Libosinfo < Formula
 
   livecheck do
     url "https://releases.pagure.org/libosinfo/?C=M&O=D"
-    regex(/href=.*?libosinfo[._-]v?([\d.]+)\.t/i)
+    regex(/href=.*?libosinfo[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/libvirt-glib.rb
+++ b/Formula/libvirt-glib.rb
@@ -8,7 +8,7 @@ class LibvirtGlib < Formula
 
   livecheck do
     url "https://libvirt.org/sources/glib/"
-    regex(/href=.*?libvirt-glib[._-]v?([\d.]+)\.t/i)
+    regex(/href=.*?libvirt-glib[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -7,7 +7,7 @@ class Libvirt < Formula
 
   livecheck do
     url "https://libvirt.org/sources/"
-    regex(/href=.*?libvirt[._-]v?([\d.]+)\.t/i)
+    regex(/href=.*?libvirt[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/lzo.rb
+++ b/Formula/lzo.rb
@@ -7,7 +7,7 @@ class Lzo < Formula
 
   livecheck do
     url "https://www.oberhumer.com/opensource/lzo/download/"
-    regex(/href=.*?lzo[._-]v?([\d.]+)\./i)
+    regex(/href=.*?lzo[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/nagios-plugins.rb
+++ b/Formula/nagios-plugins.rb
@@ -8,7 +8,7 @@ class NagiosPlugins < Formula
 
   livecheck do
     url "https://nagios-plugins.org/download/"
-    regex(/href=.*?nagios-plugins[._-]v?([\d.]+)\.t/i)
+    regex(/href=.*?nagios-plugins[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/opencore-amr.rb
+++ b/Formula/opencore-amr.rb
@@ -7,7 +7,7 @@ class OpencoreAmr < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/opencore-amr[._-]v?([\d.]+)\.t}i)
+    regex(%r{url=.*?/opencore-amr[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do

--- a/Formula/orc.rb
+++ b/Formula/orc.rb
@@ -6,7 +6,7 @@ class Orc < Formula
 
   livecheck do
     url "https://gstreamer.freedesktop.org/src/orc/"
-    regex(/href=.*?orc[._-]v?([\d.]+\.[\d.]+\.[\d.]+)\.t/i)
+    regex(/href=.*?orc[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/usbredir.rb
+++ b/Formula/usbredir.rb
@@ -7,7 +7,7 @@ class Usbredir < Formula
 
   livecheck do
     url "https://www.spice-space.org/download/usbredir/"
-    regex(/href=.*?usbredir[._-]v?([\d.]+)\.t/i)
+    regex(/href=.*?usbredir[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/websocat.rb
+++ b/Formula/websocat.rb
@@ -7,7 +7,7 @@ class Websocat < Formula
 
   livecheck do
     url :stable
-    regex(/v([\d.]+$)/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates various `livecheck` blocks to bring them in line with our current regex guidelines/patterns. This PR focuses on regexes containing `[\d.]`, which we avoid using to match versions like `1.2.3` (as it can match more than that format).

The standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`)  is appropriate for these formulae, so I've replaced `[\d.]` with it here. Besides that, this updates `libev` and `lzo` to include a trailing file extension (as we typically use it to anchor the end of the regex when working with filenames) and modifies `websocat` to use the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`).

This is part of ongoing work intended to increase standardization of `livecheck` block regexes in anticipation of some internal changes to livecheck.