### PR TITLE
workflows/tests: set HOMEBREW_BOTTLE_DOMAIN

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ env:
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_CHANGE_ARCH_TO_ARM: 1
+  HOMEBREW_BOTTLE_DOMAIN: 'https://dl.bintray.com/homebrew'
 jobs:
   tap_syntax:
     if: github.repository == 'Homebrew/homebrew-core'


### PR DESCRIPTION
This is a temporary workaround for the Bintray access issues. See https://github.com/Homebrew/brew/issues/10739#issuecomment-787482280.