### PR TITLE
workflows/tests-linux: include "Linux" in name

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions CI
+name: GitHub Actions CI - Linux
 on:
   pull_request:
     paths:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I noticed that it's hard to tell the two "GitHub Actions CI" workflows (`tests.yml` and `tests-linux.yml`) apart because the have the same name:

<img width="176" alt="Screen Shot 2021-02-28 at 12 35 03 PM" src="https://user-images.githubusercontent.com/32525609/109427859-44cf8880-79c2-11eb-9fec-c535739ef492.png">

This just makes browsing the actions tab a little bit more tricky. This PR adds the word "Linux" to the Linux tests to add clarity.
