### PR TITLE
Revert "workflows/tests: set HOMEBREW_BOTTLE_DOMAIN (#72171)"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ env:
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_CHANGE_ARCH_TO_ARM: 1
-  HOMEBREW_BOTTLE_DOMAIN: 'https://dl.bintray.com/homebrew'
 jobs:
   tap_syntax:
     if: github.repository == 'Homebrew/homebrew-core'


### PR DESCRIPTION
This reverts commit 3327087e98798eb70b4d3e590628f12d04870f89.

HOMEBREW_BOTTLE_DOMAIN has been set in brew [1], so there's no need to also
set it here.

[1] https://github.com/Homebrew/brew/commit/ff367939ce2d67028a83a19ed5deff112740498f
