### PR TITLE
bas55 1.19 (new formula)

### DIFF
--- a/Formula/bas55.rb
+++ b/Formula/bas55.rb
@@ -1,0 +1,18 @@
+class Bas55 < Formula
+  desc "Minimal BASIC programming language interpreter as defined by ECMA-55"
+  homepage "https://jorgicor.niobe.org/bas55/"
+  url "https://jorgicor.niobe.org/bas55/bas55-1.19.tar.gz"
+  sha256 "566097e216dab029d51afefdacf7806f249d57d117ca3e875e27c6cf61098ee0"
+  license "MIT"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/bas55", "--version"
+  end
+end

--- a/Formula/bas55.rb
+++ b/Formula/bas55.rb
@@ -13,6 +13,11 @@ class Bas55 < Formula
   end
 
   test do
-    system "#{bin}/bas55", "--version"
+    (testpath/"hello.bas").write <<~EOS
+      10 PRINT "HELLO, WORLD"
+      20 END
+    EOS
+
+    assert_equal "HELLO, WORLD\n", shell_output("#{bin}/bas55 hello.bas")
   end
 end


### PR DESCRIPTION
Add formula for ECMA-55 Minimal BASIC System by Jorge Giner Cordero,
a BASIC language interpreter based on the ECMA-55 standard.
Everyone needs a BASIC language interpreter on their Mac, especially
one based on a standard.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
