### PR TITLE
grc 1.12

### DIFF
--- a/Formula/grc.rb
+++ b/Formula/grc.rb
@@ -3,10 +3,9 @@ class Grc < Formula
 
   desc "Colorize logfiles and command output"
   homepage "https://korpus.juls.savba.sk/~garabik/software/grc.html"
-  url "https://github.com/garabik/grc/archive/v1.11.3.tar.gz"
-  sha256 "b167babd8f073a68f5a3091f833e4036fb8d86504e746694747a3ee5048fa7a9"
+  url "https://github.com/garabik/grc/archive/v1.12.tar.gz"
+  sha256 "4ca20134775ca15b2e26b4a464786aacd8c114cc793557b53959592b279b8d3c"
   license "GPL-2.0-or-later"
-  revision 2
   head "https://github.com/garabik/grc.git", branch: "devel"
 
   bottle :unneeded
@@ -22,22 +21,15 @@ class Grc < Formula
 
     # so that the completions don't end up in etc/profile.d
     inreplace "install.sh",
-      "mkdir -p $PROFILEDIR\ncp -fv grc.bashrc $PROFILEDIR", ""
+      "mkdir -p $PROFILEDIR\ncp -fv grc.sh $PROFILEDIR", ""
 
     rewrite_shebang detected_python_shebang, "grc", "grcat"
 
     system "./install.sh", prefix, HOMEBREW_PREFIX
-    etc.install "grc.bashrc"
+    etc.install "grc.sh"
     etc.install "grc.zsh"
     etc.install "grc.fish"
     zsh_completion.install "_grc"
-  end
-
-  # Apply the upstream fix from garabik/grc@ddc789bf to preexisting config files
-  def post_install
-    grc_bashrc = etc/"grc.bashrc"
-    bad = /^    alias ls='colourify ls --color'$/
-    inreplace grc_bashrc, bad, "    alias ls='colourify ls'" if grc_bashrc.exist? && File.read(grc_bashrc) =~ bad
   end
 
   test do


### PR DESCRIPTION
One incompatibility that might affect some people is that the `grc.bashrc` file (which can be `source`'d from the user's bashrc) has been renamed `grc.sh`  Not sure what the best way to handle that is... worthy of a `caveats` block?

This change also means I dropped the `post_install` that doesn't look relevant anymore cc @ilovezfs 