### PR TITLE
libomp: update livecheck

### DIFF
--- a/Formula/libomp.rb
+++ b/Formula/libomp.rb
@@ -7,7 +7,7 @@ class Libomp < Formula
 
   livecheck do
     url "https://llvm.org/"
-    regex(/LLVM (\d+.\d+.\d+)/i)
+    regex(/LLVM (\d+\.\d+\.\d+)/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `libomp` to align with the check for `llvm`, as they're the same. As in #72107, this updates the regex to escape the periods, as they match anything otherwise.