### PR TITLE
Replace \d+.\d+.\d+ in livecheck with standard regex

### DIFF
--- a/Formula/sord.rb
+++ b/Formula/sord.rb
@@ -7,7 +7,7 @@ class Sord < Formula
 
   livecheck do
     url "https://download.drobilla.net"
-    regex(/href=.*?sord[._-]v?(\d+.\d+.\d+)\.t/i)
+    regex(/href=.*?sord[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/sratom.rb
+++ b/Formula/sratom.rb
@@ -7,7 +7,7 @@ class Sratom < Formula
 
   livecheck do
     url "https://download.drobilla.net"
-    regex(/href=.*?sratom[._-]v?(\d+.\d+.\d+)\.t/i)
+    regex(/href=.*?sratom[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` blocks for `sord` and `sratom` to bring them in line with our current regex guidelines/patterns.

The regexes in these formulae were using `\d+.\d+.\d+` to match a version like `1.2.3` but we can simply use the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`) instead. The standard regex will match versions with fewer or more numeric parts, so it won't miss versions that unexpectedly differ from the prevailing format. [The original regexes also had unescaped periods, which we don't want as they would match anything (as seen in `llvm`, `libomp`, etc.).]

As an aside, it may be worth nothing that I haven't replaced the `\d+\.\d+\.\d+` (note the escaped periods) regexes in `llvm`/`libomp`. The reason for this is because the check for those formulae loosely matches text like `LLVM 1.2.3` on the LLVM homepage. Usually we anchor the start/end of the regex (and the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`) is fine in that context) but since the regex needs to be loose/open-ended, the idea is that the strictness of the version format may help to ensure we're only matching the text that we want. I may revisit those checks in the future to see if we can improve them but I've left them for now.

This is part of ongoing work intended to increase standardization of `livecheck` block regexes in anticipation of some internal changes to livecheck.