### PR TITLE
mysql-connector-c++: update livecheck

### DIFF
--- a/Formula/mysql-connector-c++.rb
+++ b/Formula/mysql-connector-c++.rb
@@ -5,8 +5,8 @@ class MysqlConnectorCxx < Formula
   sha256 "9af06495a6a080fed62da70978f1cb0c66f058edd5ea9eda9345a64bf8ec688f"
 
   livecheck do
-    url :homepage
-    regex(/href=.*?mysql-connector-c%2B%2B[._-]v?(\d+.\d+.\d+)-/i)
+    url "https://dev.mysql.com/downloads/connector/cpp/?tpl=files&os=src"
+    regex(/href=.*?mysql-connector-c%2B%2B[._-]v?(\d+(?:\.\d+)+)[._-]src\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `mysql-connector-c++` to follow the pattern used in the `mysql` formula (i.e., check the first-party downloads page using the `?tpl=files&os=src` query string parameters to find the version from the latest source tarball).

In the process, this also replaces the `\d+.\d+.\d+` regex with the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`). The reasoning here is the same as #72235: the standard regex will correctly match versions with fewer/more than three numeric parts and also the original regex mistakenly contains unescaped periods (which would match anything).