### PR TITLE
libbluray: update livecheck

### DIFF
--- a/Formula/libbluray.rb
+++ b/Formula/libbluray.rb
@@ -7,7 +7,7 @@ class Libbluray < Formula
 
   livecheck do
     url "https://download.videolan.org/pub/videolan/libbluray/"
-    regex(%r{>([\d.]+)/<}i)
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `libbluray` to better follow our current regex guidelines, which brings it more in line with other formulae. This PR:

* Replaces `[\d.]+` (which we avoid due to its looseness) with the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`).
* Restricts matching to `href` attributes, which helps to minimize the scope. This is a directory listing HTML page containing links to version directories (e.g., `1.2.3/`), so we use the typical start (`href=["']?`) and end (`/?["' >]`) anchors for this context.