### PR TITLE
gradle-profiler 0.16.0

### DIFF
--- a/Formula/gradle-profiler.rb
+++ b/Formula/gradle-profiler.rb
@@ -7,12 +7,22 @@ class GradleProfiler < Formula
 
   bottle :unneeded
 
-  depends_on "openjdk"
+  # gradle currently does not support Java 16
+  if Hardware::CPU.arm?
+    depends_on "openjdk@11"
+  else
+    depends_on "openjdk"
+  end
 
   def install
     rm_f Dir["bin/*.bat"]
     libexec.install %w[bin lib]
-    (bin/"gradle-profiler").write_env_script libexec/"bin/gradle-profiler", Language::Java.overridable_java_home_env
+    env = if Hardware::CPU.arm?
+      Language::Java.overridable_java_home_env("11")
+    else
+      Language::Java.overridable_java_home_env
+    end
+    (bin/"gradle-profiler").write_env_script libexec/"bin/gradle-profiler", env
   end
 
   test do

--- a/Formula/gradle-profiler.rb
+++ b/Formula/gradle-profiler.rb
@@ -1,8 +1,8 @@
 class GradleProfiler < Formula
   desc "Profiling and benchmarking tool for Gradle builds"
   homepage "https://github.com/gradle/gradle-profiler/"
-  url "https://repo.gradle.org/gradle/ext-releases-local/org/gradle/profiler/gradle-profiler/0.15.0/gradle-profiler-0.15.0.zip"
-  sha256 "0cd279754502f796ea4bc684decd201cd8eea67566b3a6ef8b55f84cc4021d34"
+  url "https://repo.gradle.org/gradle/ext-releases-local/org/gradle/profiler/gradle-profiler/0.16.0/gradle-profiler-0.16.0.zip"
+  sha256 "f376581ed7b788d9d3d640a2ddde88747ce2e8a0e297991a77b98e6b7a257fbb"
   license "Apache-2.0"
 
   bottle :unneeded


### PR DESCRIPTION
Bump gradle-profiler to version 0.16.0.

Release notes: https://github.com/gradle/gradle-profiler/releases/tag/v0.16.0

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?