### PR TITLE
luajit: update livecheck

### DIFF
--- a/Formula/luajit.rb
+++ b/Formula/luajit.rb
@@ -15,7 +15,7 @@ class Luajit < Formula
 
   livecheck do
     url "https://luajit.org/download.html"
-    regex(/class="downname">LuaJIT[._-]v?([\d.]+)</i)
+    regex(/href=.*?LuaJIT[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `luajit` to identify the version using a common pattern, which helps to bring the regex more in line with other checks (increasing standardization).

The existing regex identifies the version from the inner text of an HTML element with the `downname` class, which has a format like `LuaJIT-1.1.8`. This updates the regex to use the common pattern of identifying the version from an `href` attribute containing a link to the archive files used as `stable` in the formula.

In the process, this replaces `[\d.]+` (which we don't use due to its looseness) with the standard regex for versions like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`).