### PR TITLE
rtmpdump: update livecheck

### DIFF
--- a/Formula/rtmpdump.rb
+++ b/Formula/rtmpdump.rb
@@ -10,7 +10,7 @@ class Rtmpdump < Formula
 
   livecheck do
     url "https://cdn-aws.deb.debian.org/debian/pool/main/r/rtmpdump/"
-    regex(/href=.*?rtmpdump[._-]v?(\d.\d\+\d*).*.orig\.t/i)
+    regex(/href=.*?rtmpdump[._-]v?(\d+(?:[.+]\d+)+)[^"' >]*?\.orig\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `rtmpdump` to better align with current regex guidelines. Namely, this PR:

* Replaces `\d.\d\+\d*` with a modified version of the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`). In this case, the `\.` delimiter is replaced with `[.+]`, which is the simplest way of matching the `2.4+20151223` version format. It's also possible to use something more explicit like `v?(\d+(?:\.\d+)+(?:\+\d+)?)` but this is likely harder to understand and I'm not sure the additional specificity buys us much in this particular context.
* Replaces `.*.orig` with `[^"' >]*?\.orig`, which matches anything within the bounds of the `href` attribute (instead of anything at all) and also properly escapes the period before `orig`.