### PR TITLE
minimal-racket: update livecheck

### DIFF
--- a/Formula/minimal-racket.rb
+++ b/Formula/minimal-racket.rb
@@ -5,9 +5,13 @@ class MinimalRacket < Formula
   sha256 "ef1a2dc5af4e68938a12f5fc25d1a9b3a0344e133da9c4d79132e23ac116493c"
   license any_of: ["MIT", "Apache-2.0"]
 
+  # File links on the download page are created using JavaScript, so we parse
+  # the filename from a string in an object. We match the version from the
+  # "Unix Source + built packages" option, as the `racket-minimal` archive is
+  # only found on the release page for a given version (e.g., `/releases/8.0/`).
   livecheck do
-    url "https://download.racket-lang.org/all-versions.html"
-    regex(/>Version ([\d.]+)/i)
+    url "https://download.racket-lang.org/"
+    regex(/["'][^"']*?racket(?:-minimal)?[._-]v?(\d+(?:\.\d+)+)-src-builtpkgs\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `minimal-racket` to check the main download page (instead of the `/all-versions.html` page), identifying the version from the latest non-minimal `src-builtpkgs` tarball. The link to the minimal tarball that we use in the formula is only found on the release page for a given version (e.g., `/releases/8.0/`), so this is probably as close as we can get.

My reasoning for this change is that the `/all-versions.html` page hasn't been updated to contain a link to the download page for the latest `minimal-racket` version (though the page exists), so there's a chance of unreliability in the future. The main download page is linked from the homepage, so it's likely it will continue to reliably provide the latest release information.

Alternatively, we can check the `/releases/` directory listing page but checking the download page may be a more reliable indicator of a version being released, depending on when a new version appears in these locations.

In the process, this replaces `[\d.]+` (which we don't use because of its looseness) with the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`).