### PR TITLE
Update livecheck regexes matching version directories

### DIFF
--- a/Formula/alluxio.rb
+++ b/Formula/alluxio.rb
@@ -7,7 +7,7 @@ class Alluxio < Formula
 
   livecheck do
     url "https://downloads.alluxio.io/downloads/files/"
-    regex(%r{href=.*?(\d+(?:\.\d+)+)/?["' >]}i)
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle :unneeded

--- a/Formula/docbook.rb
+++ b/Formula/docbook.rb
@@ -8,7 +8,7 @@ class Docbook < Formula
 
   livecheck do
     url "https://docbook.org/xml/"
-    regex(%r{href=.*?(\d+(?:\.\d+)+)/?["' >]}i)
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do

--- a/Formula/speech-tools.rb
+++ b/Formula/speech-tools.rb
@@ -8,7 +8,7 @@ class SpeechTools < Formula
 
   livecheck do
     url "http://festvox.org/packed/festival/?C=M&O=D"
-    regex(%r{href=.*?(\d+(?:\.\d+)+)/?["' >]}i)
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` blocks for `alluxio`, `docbook`, and `speech-tools` to use the standard regex for matching version directories on an HTML directory listing page (`%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i`).

The only difference between the existing regexes and the aforementioned regex is that `href=.*?` is replaced with `href=["']?v?`. In practical terms, this will prevent the regex from matching directories that start with some text and end in a version (e.g., `something-else-1.2.3`), as we've had problems before with directories being updated to include software other than what we're interested in and ending up with false positives.

Besides that, adding `v?` turns the version part into the full standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`).

In general, this brings these regexes in line with other existing `livecheck` blocks using the standard regex for version directories on an HTML page. This improves regex standardization across formulae, which will be helpful for some forthcoming internal changes to livecheck.