### PR TITLE
openmodelica 1.16.5 (new formula)

### DIFF
--- a/Formula/openmodelica.rb
+++ b/Formula/openmodelica.rb
@@ -1,0 +1,71 @@
+class Openmodelica < Formula
+  desc "Open-source modeling and simulation tool"
+  homepage "https://openmodelica.org/"
+  # GitHub's archives lack submodules, must pull:
+  url "https://github.com/OpenModelica/OpenModelica.git",
+    tag:      "v1.16.5",
+    revision: "11fcab4f2d6895f2db073572b2bff1a43177313f"
+  license "GPL-3.0-only"
+  head "https://github.com/OpenModelica/OpenModelica.git"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "cmake" => :build
+  depends_on "gcc" => :build # for gfortran
+  depends_on "gnu-sed" => :build
+  depends_on "libtool" => :build
+  depends_on "openjdk" => :build
+  depends_on "pkg-config" => :build
+
+  depends_on "boost"
+  depends_on "gettext"
+  depends_on "hdf5"
+  depends_on "hwloc"
+  depends_on "lp_solve"
+  depends_on "omniorb"
+  depends_on "openblas"
+  depends_on "qt@5"
+  depends_on "readline"
+  depends_on "sundials"
+
+  uses_from_macos "curl"
+  uses_from_macos "expat"
+  uses_from_macos "libffi"
+  uses_from_macos "ncurses"
+
+  def install
+    ENV.append_to_cflags "-I#{MacOS.sdk_path_if_needed}/usr/include/ffi"
+    args = %W[
+      --prefix=#{prefix}
+      --disable-debug
+      --disable-modelica3d
+      --with-cppruntime
+      --with-hwloc
+      --with-lapack=-lopenblas
+      --with-omlibrary=core
+      --with-omniORB
+    ]
+
+    system "autoconf"
+    system "./configure", *args
+    # omplot needs qt & OpenModelica #7240.
+    # omparser needs OpenModelica #7247
+    # omshell, omedit, omnotebook, omoptim need QTWebKit: #19391 & #19438
+    # omsens_qt fails with: "OMSens_Qt is not supported on MacOS"
+    system "make", "omc", "omlibrary-core", "omsimulator"
+    prefix.install Dir["build/*"]
+  end
+
+  test do
+    system "#{bin}/omc", "--version"
+    system "#{bin}/OMSimulator", "--version"
+    (testpath/"test.mo").write <<~EOS
+      model test
+      Real x;
+      initial equation x = 10;
+      equation der(x) = -x;
+      end test;
+    EOS
+    assert_match "class test", shell_output("#{bin}/omc #{testpath/"test.mo"}")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Initial formula.  Currently omparser (hence omedit), omnotebook, omshell, & omsens_qt don't build due to upstream errors.  Hope to fix that soon.