### PR TITLE
gdcm: -undefined dynamic_lookup is macOS only

### DIFF
--- a/Formula/gdcm.rb
+++ b/Formula/gdcm.rb
@@ -57,7 +57,9 @@ class Gdcm < Formula
     ]
 
     mkdir "build" do
-      ENV.append "LDFLAGS", "-undefined dynamic_lookup"
+      on_macos do
+        ENV.append "LDFLAGS", "-undefined dynamic_lookup"
+      end
 
       system "cmake", "..", *args
       system "ninja"


### PR DESCRIPTION
This flags does not work/exist on linux, where the default
behaviour is anyway what this flags does on mac.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
