### PR TITLE
libxml2: don't require python at runtime

### DIFF
--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -31,7 +31,7 @@ class Libxml2 < Formula
 
   keg_only :provided_by_macos
 
-  depends_on "python@3.9"
+  depends_on "python@3.9" => [:build, :test]
   depends_on "readline"
 
   uses_from_macos "zlib"


### PR DESCRIPTION
This is especially helpful on Linux as `libxml2` is in a lot of dependencies.

This is gonna run on CI to make sure it doesn't break anything but should be merged without bottles.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----