### PR TITLE
Replace (\d+) in livecheck regexes

### DIFF
--- a/Formula/agedu.rb
+++ b/Formula/agedu.rb
@@ -8,7 +8,7 @@ class Agedu < Formula
 
   livecheck do
     url :homepage
-    regex(/href=.*?agedu[._-]v?(\d+)(?:\.[\da-z]+)?\.t/i)
+    regex(/href=.*?agedu[._-]v?(\d+(?:\.\d+)*)(?:[._-][\da-z]+)?\.t/i)
   end
 
   bottle do

--- a/Formula/b43-fwcutter.rb
+++ b/Formula/b43-fwcutter.rb
@@ -8,7 +8,7 @@ class B43Fwcutter < Formula
 
   livecheck do
     url "https://bues.ch/b43/fwcutter/"
-    regex(/href=.*?b43-fwcutter[._-]v?(\d+)\.t/i)
+    regex(/href=.*?b43-fwcutter[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
   bottle do

--- a/Formula/ex-vi.rb
+++ b/Formula/ex-vi.rb
@@ -6,7 +6,7 @@ class ExVi < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/ex[._-]v?(\d+)\.t}i)
+    regex(%r{url=.*?/ex[._-]v?(\d+(?:\.\d+)*)\.t}i)
   end
 
   bottle do

--- a/Formula/ipbt.rb
+++ b/Formula/ipbt.rb
@@ -8,7 +8,7 @@ class Ipbt < Formula
 
   livecheck do
     url :homepage
-    regex(/href=.*?ipbt[._-]v?(\d+)(?:\.[\da-z]+)?\.t/i)
+    regex(/href=.*?ipbt[._-]v?(\d+(?:\.\d+)*)(?:[._-][\da-z]+)?\.t/i)
   end
 
   bottle do

--- a/Formula/perltidy.rb
+++ b/Formula/perltidy.rb
@@ -7,7 +7,7 @@ class Perltidy < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/Perl-Tidy[._-]v?(\d+)\.t}i)
+    regex(%r{url=.*?/Perl-Tidy[._-]v?(\d+(?:\.\d+)*)\.t}i)
   end
 
   bottle do

--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -8,7 +8,7 @@ class Portmidi < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/portmidi-src[._-]v?(\d+)\.}i)
+    regex(%r{url=.*?/portmidi-src[._-]v?(\d+(?:\.\d+)*)\.}i)
   end
 
   bottle do

--- a/Formula/spigot.rb
+++ b/Formula/spigot.rb
@@ -8,7 +8,7 @@ class Spigot < Formula
 
   livecheck do
     url :homepage
-    regex(/href=.*?spigot[._-]v?(\d+)(?:\.[\da-z]+)?\.t/i)
+    regex(/href=.*?spigot[._-]v?(\d+(?:\.\d+)*)(?:[._-][\da-z]+)?\.t/i)
   end
 
   bottle do

--- a/Formula/tnftp.rb
+++ b/Formula/tnftp.rb
@@ -6,7 +6,7 @@ class Tnftp < Formula
 
   livecheck do
     url :homepage
-    regex(/href=.*?tnftp[._-]v?(\d+)\.t/i)
+    regex(/href=.*?tnftp[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
   bottle do

--- a/Formula/tnftpd.rb
+++ b/Formula/tnftpd.rb
@@ -6,7 +6,7 @@ class Tnftpd < Formula
 
   livecheck do
     url :homepage
-    regex(/href=.*?tnftpd[._-]v?(\d+)\.t/i)
+    regex(/href=.*?tnftpd[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
   bottle do

--- a/Formula/txr.rb
+++ b/Formula/txr.rb
@@ -7,7 +7,7 @@ class Txr < Formula
 
   livecheck do
     url "http://www.kylheku.com/cgit/txr"
-    regex(/href=.*?txr[._-]v?(\d+)\.t/i)
+    regex(/href=.*?txr[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` blocks for various formulae which use a regex that includes `(\d+)` to capture a version that only includes digits (e.g., `123`). In these cases, we usually use a looser version of the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`): `v?(\d+(?:\.\d+)*)`.

The difference is that the looser regex uses `*` for the repeating period/digit group, so it not only matches versions like `1.2.3` but also matches a version that only contains digits (e.g., `123`, `20210101`, etc.). Should the version format unexpectedly change in the future, the `(\d+)` regex would fail to match versions like `1.2.3` and would require someone to notice this outside of livecheck. This is the primary reason why `v?(\d+(?:\.\d+)*)` is used instead of `v?(\d+)` for versions like this.

As an aside, `v?(\d+(?:\.\d+)*)` is fine for these particular formulae, since the source they're checking doesn't include versions that we need to avoid. There are some other formulae that check a source where we have to be stricter about the digit-only format to avoid versions that we shouldn't match. For example, a Git repository may have tags like `123` and `20210101` and we would need to use `v?(\d{6,8})` to only match the date-based versions. Though some of these use a date-based version, there isn't any benefit of using the `\d{6,8}` approach in these particular cases.

In general, this is part of an ongoing effort to improve standardization of `livecheck` block regexes across formulae, as this will benefit some forthcoming changes to livecheck.