### PR TITLE
Replace (?:\.\d+)* in livecheck regexes where not necessary

### DIFF
--- a/Formula/babl.rb
+++ b/Formula/babl.rb
@@ -9,7 +9,7 @@ class Babl < Formula
 
   livecheck do
     url "https://download.gimp.org/pub/babl/0.1/"
-    regex(/href=.*?babl[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?babl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/dnsdist.rb
+++ b/Formula/dnsdist.rb
@@ -7,7 +7,7 @@ class Dnsdist < Formula
 
   livecheck do
     url "https://downloads.powerdns.com/releases/"
-    regex(/href=.*?dnsdist[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?dnsdist[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/faac.rb
+++ b/Formula/faac.rb
@@ -6,7 +6,7 @@ class Faac < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/faac[._-]v?(\d+(?:\.\d+)*)\.t}i)
+    regex(%r{url=.*?/faac[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do

--- a/Formula/faad2.rb
+++ b/Formula/faad2.rb
@@ -6,7 +6,7 @@ class Faad2 < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/faad2[._-]v?(\d+(?:\.\d+)*)\.t}i)
+    regex(%r{url=.*?/faad2[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do

--- a/Formula/gegl.rb
+++ b/Formula/gegl.rb
@@ -8,7 +8,7 @@ class Gegl < Formula
 
   livecheck do
     url "https://download.gimp.org/pub/gegl/0.4/"
-    regex(/href=.*?gegl[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?gegl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/getmail.rb
+++ b/Formula/getmail.rb
@@ -7,7 +7,7 @@ class Getmail < Formula
 
   livecheck do
     url :homepage
-    regex(/href=.*?getmail[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?getmail[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -9,7 +9,7 @@ class Gnutls < Formula
 
   livecheck do
     url "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/"
-    regex(/href=.*?gnutls[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?gnutls[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/libraw.rb
+++ b/Formula/libraw.rb
@@ -7,7 +7,7 @@ class Libraw < Formula
 
   livecheck do
     url "https://www.libraw.org/download/"
-    regex(/href=.*?LibRaw[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?LibRaw[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/openldap.rb
+++ b/Formula/openldap.rb
@@ -7,7 +7,7 @@ class Openldap < Formula
 
   livecheck do
     url "https://www.openldap.org/software/download/OpenLDAP/openldap-release/"
-    regex(/href=.*?openldap[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?openldap[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -7,7 +7,7 @@ class Pdns < Formula
 
   livecheck do
     url "https://downloads.powerdns.com/releases/"
-    regex(/href=.*?pdns[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?pdns[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/pdnsrec.rb
+++ b/Formula/pdnsrec.rb
@@ -7,7 +7,7 @@ class Pdnsrec < Formula
 
   livecheck do
     url "https://downloads.powerdns.com/releases/"
-    regex(/href=.*?pdns-recursor[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?pdns-recursor[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/poppler.rb
+++ b/Formula/poppler.rb
@@ -9,7 +9,7 @@ class Poppler < Formula
 
   livecheck do
     url :homepage
-    regex(/href=.*?poppler[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?poppler[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -9,7 +9,7 @@ class Postgresql < Formula
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"
-    regex(%r{href=["']?v?(\d+(?:\.\d+)*)/?["' >]}i)
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -8,7 +8,7 @@ class PostgresqlAT10 < Formula
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"
-    regex(%r{href=["']?v?(10(?:\.\d+)*)/?["' >]}i)
+    regex(%r{href=["']?v?(10(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do

--- a/Formula/postgresql@11.rb
+++ b/Formula/postgresql@11.rb
@@ -8,7 +8,7 @@ class PostgresqlAT11 < Formula
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"
-    regex(%r{href=["']?v?(11(?:\.\d+)*)/?["' >]}i)
+    regex(%r{href=["']?v?(11(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -8,7 +8,7 @@ class PostgresqlAT12 < Formula
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"
-    regex(%r{href=["']?v?(12(?:\.\d+)*)/?["' >]}i)
+    regex(%r{href=["']?v?(12(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do

--- a/Formula/potrace.rb
+++ b/Formula/potrace.rb
@@ -8,7 +8,7 @@ class Potrace < Formula
   livecheck do
     url "http://potrace.sourceforge.net/"
     strategy :page_match
-    regex(/href=.*?potrace[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?potrace[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do

--- a/Formula/solr@7.7.rb
+++ b/Formula/solr@7.7.rb
@@ -12,7 +12,7 @@ class SolrAT77 < Formula
   # https://lucene.apache.org/solr/downloads.html#about-versions-and-support
   livecheck do
     url "https://lucene.apache.org/solr/downloads.html"
-    regex(/href=.*?solr[._-]v?(7(?:\.\d+)*)\.t/i)
+    regex(/href=.*?solr[._-]v?(7(?:\.\d+)+)\.t/i)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` blocks for various formulae to replace `(?:\.\d+)*` (e.g., `v?(\d+(?:\.\d+)*)`, `v?(12(?:\.\d+)+)`, etc.) with `(?:\.\d+)+` when the looseness of the `*` version isn't necessary or beneficial. This essentially converts these regexes to use the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`) or brings the existing regex closer to this.

The main idea behind this PR is that we only want to use the loose version of the regex (the one containing `(?:\.\d+)*`) when it's necessary or potentially beneficial. These formulae don't publish versions that only contain digits with no trailing parts (e.g., `123` instead of `1.2.3`), so it's fine to use the default regex.

This is part of ongoing work to better standardize regexes in existing `livecheck` blocks, as this will benefit a forthcoming change to livecheck.

-----

Due to the simple nature of these changes and the number of formulae involved, would it be more appropriate to squash-merge this instead of rebase-and-merge?