### PR TITLE
ktlint: depend on openjdk@11

### DIFF
--- a/Formula/ktlint.rb
+++ b/Formula/ktlint.rb
@@ -7,7 +7,7 @@ class Ktlint < Formula
 
   bottle :unneeded
 
-  depends_on "openjdk"
+  depends_on "openjdk@11"
 
   def install
     libexec.install "ktlint"

--- a/Formula/ktlint.rb
+++ b/Formula/ktlint.rb
@@ -4,6 +4,7 @@ class Ktlint < Formula
   url "https://github.com/pinterest/ktlint/releases/download/0.40.0/ktlint"
   sha256 "4739662e9ac9a9894a1eb47844cbb5610971f15af332eac94d108d4f55ebc19e"
   license "MIT"
+  revision 1
 
   bottle :unneeded
 


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/issues/72336
KtLint fails to run on JDK 15 · Issue #1063 · pinterest/ktlint

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
