### PR TITLE
ktoblzcheck: fix build for ARM, update license

### DIFF
--- a/Formula/ktoblzcheck.rb
+++ b/Formula/ktoblzcheck.rb
@@ -22,7 +22,7 @@ class Ktoblzcheck < Formula
   depends_on "python@3.9"
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", ".", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{opt_lib}"
     system "make"
     system "make", "install"
   end

--- a/Formula/ktoblzcheck.rb
+++ b/Formula/ktoblzcheck.rb
@@ -3,7 +3,7 @@ class Ktoblzcheck < Formula
   homepage "https://ktoblzcheck.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ktoblzcheck/ktoblzcheck-1.53.tar.gz"
   sha256 "18b9118556fe83240f468f770641d2578f4ff613cdcf0a209fb73079ccb70c55"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
   revision 1
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This change should hopefully fix [the following error](https://github.com/Homebrew/homebrew-core/runs/2023049109?check_suite_focus=true#step:6:53):

```
==> /opt/homebrew/Cellar/ktoblzcheck/1.53_1/bin/ktoblzcheck --outformat=oneline 10000000 123456789
dyld: Library not loaded: @rpath/libktoblzcheck.1.dylib
  Referenced from: /opt/homebrew/Cellar/ktoblzcheck/1.53_1/bin/ktoblzcheck
  Reason: image not found
```

If the ARM build is successful, it should also enable the bottling of `aqbanking` for ARM.