### PR TITLE
Migrate ballerina to swan lake releases and include bal alias

### DIFF
--- a/Aliases/bal
+++ b/Aliases/bal
@@ -1,0 +1,1 @@
+../Formula/ballerina.rb

--- a/Formula/ballerina.rb
+++ b/Formula/ballerina.rb
@@ -1,8 +1,8 @@
 class Ballerina < Formula
   desc "Programming Language for Network Distributed Applications"
   homepage "https://ballerina.io"
-  url "https://dist.ballerina.io/downloads/1.2.13/ballerina-1.2.13.zip"
-  sha256 "ba2b6cbf09f5129a72afa3f494da5c7304d9321b32c4a1504c5a2b11644c2c57"
+  url "https://dist.ballerina.io/downloads/swan-lake-alpha2/ballerina-swan-lake-alpha2.zip"
+  sha256 "17c8c2101d18d1058132a102d5f3e7d5536a0da503384f6ddc14318ac864fdf4"
   license "Apache-2.0"
 
   livecheck do
@@ -12,17 +12,17 @@ class Ballerina < Formula
 
   bottle :unneeded
 
-  depends_on "openjdk@8"
+  depends_on "openjdk@11"
 
   def install
     # Remove Windows files
     rm Dir["bin/*.bat"]
 
-    chmod 0755, "bin/ballerina"
+    chmod 0755, "bin/bal"
 
-    bin.install "bin/ballerina"
+    bin.install "bin/bal"
     libexec.install Dir["*"]
-    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("11"))
   end
 
   test do
@@ -32,7 +32,7 @@ class Ballerina < Formula
         io:println("Hello, World!");
       }
     EOS
-    output = shell_output("#{bin}/ballerina run helloWorld.bal")
+    output = shell_output("#{bin}/bal run helloWorld.bal")
     assert_equal "Hello, World!", output.chomp
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Now ballerina main [download version is swan lake alpha 2](https://ballerina.io/downloads/). Hence this needs to be switched from old 1.2.x release channels. 

On the other hand `ballerina` command has been changed to `bal` command, therefore i have added `bal` as an alias.