### PR TITLE
asdf: disable update command (currently runs git commands inside brew repo)

### DIFF
--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -4,6 +4,7 @@ class Asdf < Formula
   url "https://github.com/asdf-vm/asdf/archive/v0.8.0.tar.gz"
   sha256 "9b667ca135c194f38d823c62cc0dc3dbe00d7a9f60caa0c06ecb3047944eadfa"
   license "MIT"
+  revision 1
   head "https://github.com/asdf-vm/asdf.git"
 
   bottle :unneeded
@@ -26,6 +27,7 @@ class Asdf < Formula
     zsh_completion.install "completions/_asdf"
     libexec.install "bin/private"
     prefix.install Dir["*"]
+    touch prefix/"asdf_updates_disabled"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

**Current Issue**
asdf's update command runs git commands inside location of asdf installation (`ASDF_DIR`).
When asdf is installed via Homebrew, this location is not asdf's git repo, but homebrew/brew's git repo:
```zsh
❯ cd $ASDF_DIR

❯ git remote -v
origin	https://github.com/Homebrew/brew (fetch)
origin	https://github.com/Homebrew/brew (push)
```

Running asdf update ends up modifying brew's repo to detached HEAD:
```zsh
❯ asdf update
Note: switching to '3.0.4'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at ee52b1917 Merge pull request #10763 from Homebrew/revert-10595-ruby-shims
Updated asdf to release 3.0.4
```

**Changes**
asdf provides a way to disable the update command for distribution via package managers.
- Permalink: https://github.com/asdf-vm/asdf/blob/456d8e36ca76b36b848453a63b54ffeb214bce7e/lib/commands/command-update.bash#L9-L11
- Snippet:
   ```bash
    if [ -f asdf_updates_disabled ] || ! git rev-parse --is-inside-work-tree &>/dev/null; then
      printf "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.\\n"
      exit 42
   ```

By adding this file, `asdf update` can be disabled:
```
❯ brew install asdf
==> Downloading https://github.com/asdf-vm/asdf/archive/v0.8.0.tar.gz
==> Downloading from https://codeload.github.com/asdf-vm/asdf/tar.gz/v0.8.0
##O#- #
==> Caveats
zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Summary
🍺  /opt/homebrew/Cellar/asdf/0.8.0: 116 files, 243.2KB, built in 2 seconds

❯ asdf update
Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.
```