### PR TITLE
modules: build for ARM

### DIFF
--- a/Formula/modules.rb
+++ b/Formula/modules.rb
@@ -3,6 +3,7 @@ class Modules < Formula
   homepage "https://modules.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/modules/Modules/modules-4.7.0/modules-4.7.0.tar.bz2"
   sha256 "68099b98f075c669af3a6eb638b75a2feefc8dd7f778bcae3f5504ded9c1b2ca"
+  license "GPL-2.0-or-later"
   revision 1
 
   livecheck do

--- a/Formula/modules.rb
+++ b/Formula/modules.rb
@@ -3,6 +3,7 @@ class Modules < Formula
   homepage "https://modules.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/modules/Modules/modules-4.7.0/modules-4.7.0.tar.bz2"
   sha256 "68099b98f075c669af3a6eb638b75a2feefc8dd7f778bcae3f5504ded9c1b2ca"
+  revision 1
 
   livecheck do
     url :stable
@@ -15,11 +16,13 @@ class Modules < Formula
     sha256 cellar: :any, mojave:   "aa32c14b7dd52792cbe7272aa4951745a80ad44e441bf0a85e4aab9f4643a9f4"
   end
 
+  depends_on "tcl-tk"
+
   def install
     args = %W[
       --prefix=#{prefix}
       --datarootdir=#{share}
-      --with-tcl=#{MacOS.sdk_path}/System/Library/Frameworks/Tcl.framework
+      --with-tcl=#{Formula["tcl-tk"].opt_lib}
       --without-x
     ]
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This should fix the build error on ARM:

    ld: warning: ignoring file /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Tcl.framework/libtclstub8.5.a, file is universal (2 slices) but does not contain the arm64 architecture: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Tcl.framework/libtclstub8.5.a

Also, built-in tcl is buggy, so we probably shouldn't be using it
anymore anyway. (cf. #67378)