### PR TITLE
buildozer: remove livecheck

### DIFF
--- a/Formula/buildozer.rb
+++ b/Formula/buildozer.rb
@@ -5,11 +5,6 @@ class Buildozer < Formula
   sha256 "c28eef4d30ba1a195c6837acf6c75a4034981f5b4002dda3c5aa6e48ce023cf1"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "6e6fbe3529f8024adcfb4a07a878d24290e0005bdb139a370f955750311470c6"
     sha256 cellar: :any_skip_relocation, big_sur:       "a4d0c0665fff008552b629d97d0194a47e272e110fa01843fc95042163ae8d53"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a follow-up to #72470, which was merged before I could review it. The short version is that this `livecheck` block isn't needed and it's better to simply use the default check (which uses the `Git` strategy to check the Git tags) instead of `GithubLatest`. The longer explanation is as follows (from my comment on a similar `buildifier` PR, https://github.com/Homebrew/homebrew-core/pull/72469#pullrequestreview-604152749):

> By default, livecheck is checking the Git tags and correctly giving `4.0.1` as the latest version.
>
> We only use the `GithubLatest` strategy when 1) there's a "latest" release and it's correct and 2) checking the Git tags doesn't give the "latest" version. Both `Git` and `GithubLatest` return `4.0.1` right now, so the latter isn't true. FWIW, the reason why we limit use of `GithubLatest` is that github.com is rate limited and this can cause unexpected CI failures (this sometimes happened in homebrew/homebrew-livecheck).
> 
> Based on the available evidence right now, `GithubLatest` doesn't seem necessary here. There _are_ a small number of repositories that have a problematic habit of creating a tag/release that looks stable (e.g., `1.2.3`), marking it as "pre-release", and then later marking it as "latest" when it's actually released. Unless `buildifier` is one of these exceptional cases, we should simply omit this `livecheck` block and continue to use the default check here (`Git`).