### PR TITLE
bonnie++: fix livecheck

### DIFF
--- a/Formula/bonnie++.rb
+++ b/Formula/bonnie++.rb
@@ -6,8 +6,8 @@ class Bonniexx < Formula
   license "GPL-2.0-only"
 
   livecheck do
-    url "https://www.coker.com.au/bonnie++/experimental/"
-    regex(/href=.*?bonnie\+\+[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://doc.coker.com.au/projects/bonnie/"
+    regex(/href=.*?bonnie\+\+[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
The url is actually the same (this is just where it redirects to)

The functional part of the change is allowing a single lowercase letter after the version number which the project sometimes uses (including for the current "2.00a" version)
