### PR TITLE
tomcat@10 10.0.2 (new formula)

### DIFF
--- a/Aliases/tomcat@10
+++ b/Aliases/tomcat@10
@@ -1,0 +1,1 @@
+../Formula/tomcat.rb

--- a/Aliases/tomcat@9
+++ b/Aliases/tomcat@9
@@ -1,1 +1,0 @@
-../Formula/tomcat.rb

--- a/Formula/tomcat.rb
+++ b/Formula/tomcat.rb
@@ -1,0 +1,63 @@
+class Tomcat < Formula
+  desc "Implementation of Java Servlet and JavaServer Pages"
+  homepage "https://tomcat.apache.org/"
+  url "https://www.apache.org/dyn/closer.lua?path=tomcat/tomcat-10/v10.0.2/bin/apache-tomcat-10.0.2.tar.gz"
+  mirror "https://archive.apache.org/dist/tomcat/tomcat-10/v10.0.2/bin/apache-tomcat-10.0.2.tar.gz"
+  sha256 "f20791fa8354d1517052ef8c3a6a5705dd9a1ebdbdce0affee9e5a6bd7e55ee2"
+  license "Apache-2.0"
+
+  bottle :unneeded
+
+  depends_on "openjdk"
+
+  def install
+    # Remove Windows scripts
+    rm_rf Dir["bin/*.bat"]
+
+    # Install files
+    prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]
+    libexec.install Dir["*"]
+    (bin/"catalina").write_env_script "#{libexec}/bin/catalina.sh", JAVA_HOME: Formula["openjdk"].opt_prefix
+  end
+
+  plist_options manual: "catalina run"
+
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Disabled</key>
+          <false/>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{opt_bin}/catalina</string>
+            <string>run</string>
+          </array>
+          <key>KeepAlive</key>
+          <true/>
+        </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    ENV["CATALINA_BASE"] = testpath
+    cp_r Dir["#{libexec}/*"], testpath
+    rm Dir["#{libexec}/logs/*"]
+
+    pid = fork do
+      exec bin/"catalina", "start"
+    end
+    sleep 3
+    begin
+      system bin/"catalina", "stop"
+    ensure
+      Process.wait pid
+    end
+    assert_predicate testpath/"logs/catalina.out", :exist?
+  end
+end

--- a/Formula/tomcat@9.rb
+++ b/Formula/tomcat@9.rb
@@ -1,4 +1,4 @@
-class Tomcat < Formula
+class TomcatAT9 < Formula
   desc "Implementation of Java Servlet and JavaServer Pages"
   homepage "https://tomcat.apache.org/"
   url "https://www.apache.org/dyn/closer.lua?path=tomcat/tomcat-9/v9.0.43/bin/apache-tomcat-9.0.43.tar.gz"
@@ -6,7 +6,13 @@ class Tomcat < Formula
   sha256 "30703af07182c3c815a7e44376939b69da406ab64bd6f9c5ced9c455ad013a1b"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+  end
+
   bottle :unneeded
+
+  keg_only :versioned_formula
 
   depends_on "openjdk"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Tomcat 10 has been released, but it moves from Java EE 8 to Jakarta EE 9, and not compatible with previous versions.
Because Jakarta EE hasn't been used widely, so I think homebrew should remain formula `tomcat` at version 9 and add a versioned formula `tomcat@10`.
