### PR TITLE
munt-mt32emu 2.4.0 (new formula)

### DIFF
--- a/Formula/munt-mt32emu.rb
+++ b/Formula/munt-mt32emu.rb
@@ -1,0 +1,16 @@
+class MuntMt32emu < Formula
+  desc "Roland MT-32 emulator library"
+  homepage "https://munt.sourceforge.io"
+  url "https://github.com/munt/munt/archive/libmt32emu_2_4_0.tar.gz"
+  sha256 "3a53a5ad59e7c92de10e81b9c50d00e5e249aa66e6d2d928d042392db963f2b9"
+  license "GPL-3.0-or-later"
+
+  depends_on "cmake" => :build
+
+  def install
+    cd "mt32emu" do
+      system "cmake", ".", *std_cmake_args
+      system "make", "install"
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?

As it is a simple library which we use in a big project, I have no simple test but I was able to confirm that the library works.

- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

It doesn't pass because there is no test do block (see above) - no other error detected

-----

Munt also has a command line utility and a QT GUI app. 
For simplicity and following how other package managers are handling it, the library is added as Munt-Mt32emu.
The utility and the app will be added as "Munt" once I pull off this pull request.