### PR TITLE
apr: install to prefix and delete .exp file

### DIFF
--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -5,7 +5,7 @@ class Apr < Formula
   mirror "https://archive.apache.org/dist/apr/apr-1.7.0.tar.bz2"
   sha256 "e2e148f0b2e99b8e5c6caa09f6d4fb4dd3e83f744aa72a952f94f5a14436f7ea"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "d8adb33071a6a845ff928b6166377dea6de5b642b412042002386416354932b9"
@@ -46,28 +46,25 @@ class Apr < Formula
     # Needed to apply the patch.
     system "autoconf"
 
-    # Stick it in libexec otherwise it pollutes lib with a .exp file.
-    system "./configure", "--prefix=#{libexec}"
+    system "./configure", *std_configure_args
     system "make", "install"
-    bin.install_symlink Dir["#{libexec}/bin/*"]
-    lib.install_symlink Dir["#{libexec}/lib/*.a"]
-    lib.install_symlink Dir["#{libexec}/lib/#{shared_library("*")}"]
-    (lib/"pkgconfig").install_symlink Dir["#{libexec}/lib/pkgconfig/*"]
-    (include/"apr-#{version.major}").install_symlink Dir["#{libexec}/include/apr-#{version.major}/*.h"]
 
-    rm Dir[libexec/"lib/*.la"]
+    # Install symlinks so that linkage doesn't break for reverse dependencies.
+    (libexec/"lib").install_symlink Dir["#{lib}/#{shared_library("*")}"]
+
+    rm Dir["#{lib}/*.{la,exp}"]
 
     # No need for this to point to the versioned path.
-    inreplace libexec/"bin/apr-#{version.major}-config", libexec, opt_libexec
+    inreplace bin/"apr-#{version.major}-config", prefix, opt_prefix
 
     on_linux do
       # Avoid references to the Homebrew shims directory
-      inreplace libexec/"build-#{version.major}/libtool", HOMEBREW_SHIMS_PATH/"linux/super/", "/usr/bin/"
+      inreplace prefix/"build-#{version.major}/libtool", HOMEBREW_SHIMS_PATH/"linux/super/", "/usr/bin/"
     end
   end
 
   test do
-    assert_match opt_libexec.to_s, shell_output("#{bin}/apr-#{version.major}-config --prefix")
+    assert_match opt_prefix.to_s, shell_output("#{bin}/apr-#{version.major}-config --prefix")
     (testpath/"test.c").write <<~EOS
       #include <stdio.h>
       #include <apr-#{version.major}/apr_version.h>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`.exp` is used on Windows only, so it is safe to delete.