### PR TITLE
broot: install man page and shell completions

### DIFF
--- a/Formula/broot.rb
+++ b/Formula/broot.rb
@@ -4,6 +4,7 @@ class Broot < Formula
   url "https://github.com/Canop/broot/archive/v1.2.7.tar.gz"
   sha256 "7e592f79e5fd6766bcaa67e6635f2fc2f7ad08dfa9410c6713f7e06609856812"
   license "MIT"
+  revision 1
   head "https://github.com/Canop/broot.git"
 
   bottle do
@@ -19,6 +20,23 @@ class Broot < Formula
 
   def install
     system "cargo", "install", *std_cargo_args
+
+    # Replace man page "#version" and "#date" based on logic in release.sh
+    inreplace "man/page" do |s|
+      s.gsub! "#version", version
+      s.gsub! "#date", Time.now.utc.strftime("%Y/%m/%d")
+    end
+    man1.install "man/page" => "broot.1"
+
+    # Completion scripts are generated in the crate's build directory,
+    # which includes a fingerprint hash. Try to locate it first
+    out_dir = Dir["target/release/build/broot-*/out"].first
+    bash_completion.install "#{out_dir}/broot.bash"
+    bash_completion.install "#{out_dir}/br.bash"
+    fish_completion.install "#{out_dir}/broot.fish"
+    fish_completion.install "#{out_dir}/br.fish"
+    zsh_completion.install "#{out_dir}/_broot"
+    zsh_completion.install "#{out_dir}/_br"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Man Page generation based on logic in [broot's release.sh](https://github.com/Canop/broot/blob/4d44b1585cde2b95e4742ca8615bd9c0b2772072/release.sh#L16-L18), which is run for GitHub release:
```sh
cp man/page build/broot.1
sed -i "s/#version/$version/g" build/broot.1
sed -i "s/#date/$(date +'%Y\/%m\/%d')/g" build/broot.1
```

Shell completions install based on ripgrep.

**Original Formula Output**
```console
❯ brew install broot
...
==> Pouring broot-1.2.7.arm64_big_sur.bottle.tar.gz
🍺  /opt/homebrew/Cellar/broot/1.2.7: 8 files, 5.5MB

❯ man broot
No manual entry for broot

❯ head -n5 /opt/homebrew/share/zsh/site-functions/_broot
head: /opt/homebrew/share/zsh/site-functions/_broot: No such file or directory
```

**New Formula Output**
```console
❯ brew install --build-from-source broot
...

❯ man broot
broot(1)                         broot manpage                        broot(1)

...

1.2.7                             2021/03/07                          broot(1)


❯ head -n5 /opt/homebrew/share/zsh/site-functions/_broot
#compdef broot

autoload -U is-at-least

_broot() {
```

**New Formula HEAD man page**
```console
❯ brew install --build-from-source broot --head
...

❯ man broot
broot(1)                         broot manpage                        broot(1)

...

HEAD-4d44b15                      2021/03/07                          broot(1)
```