### PR TITLE
qcachegrind: update livecheck

### DIFF
--- a/Formula/qcachegrind.rb
+++ b/Formula/qcachegrind.rb
@@ -10,7 +10,7 @@ class Qcachegrind < Formula
   # is 80+ (beta) or 90+ (RC), as these aren't stable releases.
   livecheck do
     url "https://download.kde.org/Attic/applications/"
-    regex(%r{href=.*?v?(\d+\.\d+\.(?:(?!8\d|9\d)\d+)(?:\.\d+)*)/?["' >]}i)
+    regex(%r{href=.*?v?(\d+\.\d+\.(?:(?![89]\d)\d+)(?:\.\d+)*)/?["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This refactors part of the regex in the existing `livecheck` block for `qcachegrind`, replacing `8\d|9\d` with `[89]\d`. This is functionally identical but easier to read/understand.