### PR TITLE
cyrus-sasl 2.1.27 (new formula)

### DIFF
--- a/Formula/cyrus-sasl.rb
+++ b/Formula/cyrus-sasl.rb
@@ -5,8 +5,6 @@ class CyrusSasl < Formula
   sha256 "26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5"
   license "BSD-3-Clause-Attribution"
 
-  keg_only :provided_by_macos
-
   depends_on "openssl@1.1"
 
   def install

--- a/Formula/cyrus-sasl.rb
+++ b/Formula/cyrus-sasl.rb
@@ -1,0 +1,39 @@
+class CyrusSasl < Formula
+  desc "Simple Authentication and Security Layer"
+  homepage "https://www.cyrusimap.org/sasl/"
+  url "https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.27/cyrus-sasl-2.1.27.tar.gz"
+  sha256 "26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5"
+  license "BSD-3-Clause-Attribution"
+
+  keg_only :provided_by_macos
+
+  depends_on "openssl@1.1"
+
+  def install
+    system "./configure",
+      "--disable-macos-framework",
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <sasl/saslutil.h>
+      #include <assert.h>
+      #include <stdio.h>
+      int main(void) {
+        char buf[123] = "\\0";
+        unsigned len = 0;
+        int ret = sasl_encode64("Hello, world!", 13, buf, sizeof buf, &len);
+        assert(ret == SASL_OK);
+        printf("%u %s", len, buf);
+        return 0;
+      }
+    EOS
+
+    system ENV.cxx, "-o", "test", "test.cpp", "-I#{include}", "-L#{lib}", "-lsasl2"
+    assert_equal "20 SGVsbG8sIHdvcmxkIQ==", shell_output("./test")
+  end
+end


### PR DESCRIPTION
See https://www.cyrusimap.org/sasl/

macOS provides `/usr/lib/libsasl2.dylib`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See the companion PR https://github.com/Homebrew/brew/pull/10808 `rubocops: Permit uses_from_macos "cyrus-sasl"`
