### PR TITLE
apache-forrest: deprecate

### DIFF
--- a/Formula/apache-forrest.rb
+++ b/Formula/apache-forrest.rb
@@ -16,6 +16,8 @@ class ApacheForrest < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "53aed268e732c00ae5d57d4b98287c59f12c124f5a1b925d02aefacdc6dc5132"
   end
 
+  deprecate! date: "2020-02-01", because: :unmaintained
+
   depends_on "openjdk"
 
   resource "deps" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Deprecating `apache-forrest` since its homepage states

> Project Forrest has retired. For details please refer to its Attic page. 

The attic page says

> Apache Forrest moved into the Attic in February 2020. [...] The website, downloads and issue tracker all remain open, though the issue tracker is read-only.

Related to #72535.
