### PR TITLE
opensc: add pcsc-lite as a dependency

### DIFF
--- a/Formula/opensc.rb
+++ b/Formula/opensc.rb
@@ -22,6 +22,7 @@ class Opensc < Formula
   depends_on "automake" => :build
   depends_on "docbook-xsl" => :build
   depends_on "libtool" => :build
+  depends_on "pcsc-lite" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl@1.1"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm not 100% sure what the best fix for this.  `opensc` needs `pcsc-lite` on Linux to build, and is keg-only because it is provided by `PCSC.framework`.  Should this `depends_on "pcsc-lite"` be in an `on_linux do` block?  Or should we use `pcsc-lite` to build on Linux and macOS?
