### PR TITLE
tomcat-native: not depends on tomcat

### DIFF
--- a/Formula/tomcat-native.rb
+++ b/Formula/tomcat-native.rb
@@ -17,7 +17,6 @@ class TomcatNative < Formula
   depends_on "apr"
   depends_on "openjdk"
   depends_on "openssl@1.1"
-  depends_on "tomcat"
 
   def install
     cd "native" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`tomcat-native` is independent of `tomcat`. To build `tomcat-native` do not require `tomcat`, and `tomcat-native` can worked with `tomcat`, `tomcat@9`, `tomcat@8`, even `tomcat@7`.