### PR TITLE
gromacs: fails with gcc 5 and 6

### DIFF
--- a/Formula/gromacs.rb
+++ b/Formula/gromacs.rb
@@ -22,6 +22,9 @@ class Gromacs < Formula
   depends_on "gcc" # for OpenMP
   depends_on "openblas"
 
+  fails_with gcc: "5"
+  fails_with gcc: "6"
+
   def install
     # Non-executable GMXRC files should be installed in DATADIR
     inreplace "scripts/CMakeLists.txt", "CMAKE_INSTALL_BINDIR",


### PR DESCRIPTION
Fixes (on linux):
CMake Error at cmake/gmxTestCompilerProblems.cmake:73 (message):
GCC version 7 or later required. Earlier versions don't have full C++17
support.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
