### PR TITLE
botan: let the build script detect the platform and compiler

### DIFF
--- a/Formula/botan.rb
+++ b/Formula/botan.rb
@@ -26,8 +26,6 @@ class Botan < Formula
     args = %W[
       --prefix=#{prefix}
       --docdir=share/doc
-      --cc=#{ENV.compiler}
-      --os=darwin
       --with-zlib
       --with-bzip2
       --with-sqlite3


### PR DESCRIPTION
Checked locally:
INFO: Implicit --cc-bin=clang++ due to environment variable CXX
INFO: Autodetected platform information: OS="Darwin" machine="x86_64" proc="i386"
INFO: Guessing target OS is darwin (use --os to set)
INFO: Guessing target processor is a x86_64 (use --cpu to set)

Fixes the build on Linux

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
