### PR TITLE
rancher-cli: update livecheck

### DIFF
--- a/Formula/rancher-cli.rb
+++ b/Formula/rancher-cli.rb
@@ -8,7 +8,7 @@ class RancherCli < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `rancher-cli` to not use the `GithubLatest` strategy, as the "latest" version on GitHub is an unstable version (`v2.4.11-rc3`) and checking the Git tags provides the latest stable version. We only use the `GithubLatest` strategy when it's both necessary and correct but neither is true in this case.

This PR removes `strategy :github_latest` (so livecheck will check the Git tags by default) and adds the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`).