### PR TITLE
opencascade: update homepage, livecheck

### DIFF
--- a/Formula/opencascade.rb
+++ b/Formula/opencascade.rb
@@ -1,6 +1,6 @@
 class Opencascade < Formula
   desc "3D modeling and numerical simulation software for CAD/CAM/CAE"
-  homepage "https://www.opencascade.com/content/overview"
+  homepage "https://dev.opencascade.org/"
   url "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/V7_5_0;sf=tgz"
   version "7.5.0"
   sha256 "c8df7d23051b86064f61299a5f7af30004c115bdb479df471711bab0c7166654"
@@ -8,7 +8,7 @@ class Opencascade < Formula
   revision 1
 
   livecheck do
-    url "https://www.opencascade.com/content/latest-release"
+    url "https://dev.opencascade.org/release"
     regex(/href=.*?opencascade[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `opencascade` to check the current first-party download page, as the existing URL was giving a `404 Not Found` response.

Similarly, this updates the homepage to simply use `https://dev.opencascade.org`, as the existing URL redirects to an "Overview" page at `dev.opencascade.org` but it only contains some comments with no content.