### PR TITLE
wcslib: update livecheck

### DIFF
--- a/Formula/wcslib.rb
+++ b/Formula/wcslib.rb
@@ -7,7 +7,7 @@ class Wcslib < Formula
 
   livecheck do
     url :homepage
-    regex(/href=.*?wcslib\.t.+?WCSLIB v?(\d+(?:\.\d+)+)</im)
+    regex(/href=.*?wcslib[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The homepage for `wcslib` previously linked to an unversioned tarball and we had to work around this in the existing `livecheck` block's regex by checking the inner text of the link to the file. The homepage is currently linking to a versioned tarball (`wcslib-7.4.tar.bz2`), so we can update the regex to align with other checks that are identifying versions from a filename in an `href` attribute on an HTML page.