### PR TITLE
percona-xtrabackup: update livecheck

### DIFF
--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -5,8 +5,8 @@ class PerconaXtrabackup < Formula
   sha256 "064fe405f8c1f94edd9300756bdf979eae0a41c5cad15762caabfe24f5332eac"
 
   livecheck do
-    url "https://github.com/percona/percona-xtrabackup.git"
-    regex(/^percona-xtrabackup[._-]v?(\d+(?:\.\d+)+)$/i)
+    url "https://www.percona.com/downloads/Percona-XtraBackup-LATEST/"
+    regex(/value=.*?Percona-XtraBackup[._-]v?(\d+(?:\.\d+)+-\d+)["' >]/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `percona-xtrabackup`, as livecheck was checking the Git tags on GitHub and erroneously giving `8.0.14` as the latest version instead of `8.0.22-15`.

The `livecheck` block in this PR is in line with the checks for `percona-server` and `percona-toolkit`. Additionally, this change aligns the check with the `stable` source, which we prefer whenever possible.