### PR TITLE
jumanpp: update livecheck

### DIFF
--- a/Formula/jumanpp.rb
+++ b/Formula/jumanpp.rb
@@ -6,7 +6,7 @@ class Jumanpp < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://lotus.kuee.kyoto-u.ac.jp/nl-resource/jumanpp/"
+    url :homepage
     regex(/href=.*?jumanpp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates this existing `livecheck` block for `jumanpp` to check the homepage, as the existing URL (presumably a directory listing page) now gives a `403 Forbidden` response. The homepage links to the tarball, so no regex changes were necessary.