### PR TITLE
json_spirit: add livecheck

### DIFF
--- a/Formula/json_spirit.rb
+++ b/Formula/json_spirit.rb
@@ -2,11 +2,20 @@ class JsonSpirit < Formula
   desc "C++ JSON parser/generator"
   homepage "https://www.codeproject.com/Articles/20027/JSON-Spirit-A-C-JSON-Parser-Generator-Implemented"
   url "https://github.com/png85/json_spirit/archive/json_spirit-4.0.8.tar.gz"
-  # Current release is misnamed on GitHub, previous versioning scheme and homepage
-  # dictate the release as "4.08".
+  # Current release is misnamed on GitHub. Previous versioning scheme and
+  # homepage dictate the release as "4.08".
   version "4.08"
   sha256 "43829f55755f725c06dd75d626d9e57d0ce68c2f0d5112fe9a01562c0501e94c"
   license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^json_spirit[._-]v?(\d+(?:\.\d+)+)$/i)
+    strategy :git do |tags, regex|
+      # Convert versions like `4.0.8` to `4.08`
+      tags.map { |tag| tag[regex, 1]&.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2\3') }.compact
+    end
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "ef7641e5dd587a4595e326e74f438c9f99e411acceaeee75dc7450835e126895"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `json_spirit` but the tag for the newest version, `4.0.8`, isn't given as newest. This is because the previous version format is like `4.07`, which is treated as `4.7` when it comes to version comparison. The formula overrides the version to `4.08`, so it's necessary to add a `livecheck` block with a `strategy` block to convert the `4.0.8` tag format to `4.08` for the check to work.

This may break in the future if versions depart from the `4.08` format long-term, as a `4.10.0` version would be erroneously converted to `4.100` in the `strategy` block. There hasn't been a new version in over five years, so this may never happen.