### PR TITLE
lcs: add livecheck

### DIFF
--- a/Formula/lcs.rb
+++ b/Formula/lcs.rb
@@ -6,6 +6,13 @@ class Lcs < Formula
   license "GPL-2.0"
   head "https://svn.code.sf.net/p/lcsgame/code/trunk"
 
+  # This formula is using an unstable trunk version and we can't reliably
+  # identify new versions in this case, so we skip it unless/until it's updated
+  # to use a stable version in the future.
+  livecheck do
+    skip "Formula uses an unstable trunk version"
+  end
+
   bottle do
     sha256 arm64_big_sur: "1ec069485376de05c00be777102bcef25f3f1349d84ecfc2e53990d6c6e403dd"
     sha256 big_sur:       "9e3c6957bab58eaf828f8420fd7e493bb352544ec552c96eb24c8d1ec8d4adc6"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds a `livecheck` block to skip `lcs`, as it's using an unstable `trunk` version and we can't identify the latest version in this state. By default, livecheck is checking the SourceForge RSS feed, which is a waste of effort unless/until the formula is updated to use a stable version in the future. If that ever happens, the `livecheck` block can be removed/replaced.