### PR TITLE
ffe: update livecheck

### DIFF
--- a/Formula/ffe.rb
+++ b/Formula/ffe.rb
@@ -8,7 +8,7 @@ class Ffe < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/ffe[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
+    regex(%r{url=.*?/(?:ffe[._-])?v?(\d+(?:\.\d+)+(?:-\d+)?[a-z]?)\.t}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew livecheck` is giving `0.3.9` as the newest version, since the regex in the existing `livecheck` block isn't able to match the `0.3.9a` version.

This updates the regex so it can match versions with a trailing letter and makes the leading `ffe-` text in tarball filenames optional, as the latest version is `0.3.9a.tar.gz` (instead of the previous `ffe-0.3.9.tar.gz` format).