### PR TITLE
jenkins, jenkins-lts: update livecheck

### DIFF
--- a/Formula/jenkins-lts.rb
+++ b/Formula/jenkins-lts.rb
@@ -6,8 +6,8 @@ class JenkinsLts < Formula
   license "MIT"
 
   livecheck do
-    url "https://get.jenkins.io/war-stable/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url "https://www.jenkins.io/download/"
+    regex(%r{href=.*?/war-stable/v?(\d+(?:\.\d+)+)/jenkins\.war}i)
   end
 
   bottle :unneeded

--- a/Formula/jenkins.rb
+++ b/Formula/jenkins.rb
@@ -6,8 +6,8 @@ class Jenkins < Formula
   license "MIT"
 
   livecheck do
-    url "https://get.jenkins.io/war/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url "https://www.jenkins.io/download/"
+    regex(%r{href=.*?/war/v?(\d+(?:\.\d+)+)/jenkins\.war}i)
   end
 
   head do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `jenkins` and `jenkins-lts` either returns an incorrect version (e.g., `4.0` instead of `2.283`) or leads to a timeout.

This checks the [first-party download page](https://www.jenkins.io/download/), which links to the `war` file used as `stable`. The only difference in the `jenkins` and `jenkins-lts` `livecheck` blocks is the `/war/` and `/war-stable/` paths in the regexes, which restricts matching to the appropriate version on the page.