### PR TITLE
Additional KDE Frameworks

### DIFF
--- a/Formula/kde-attica.rb
+++ b/Formula/kde-attica.rb
@@ -1,0 +1,60 @@
+class KdeAttica < Formula
+  desc "Open Collaboration Service client library"
+  homepage "https://api.kde.org/frameworks/attica/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/attica-5.79.0.tar.xz"
+  sha256 "8af244b41f08448ea3693e9f7d9b50de9df76b416016cd1143dfc581dd65d9dc"
+  license all_of: [
+    "LGPL-2.0-or-later",
+    any_of: ["LGPL-2.1-only", "LGPL-3.0-only"],
+  ]
+  head "https://invent.kde.org/frameworks/attica.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+
+    pkgshare.install "tests"
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      include(FeatureSummary)
+      find_package(ECM 5.71.0 NO_MODULE)
+      set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} "#{pkgshare}/cmake")
+
+      add_subdirectory(tests)
+    EOS
+
+    cp_r (pkgshare/"tests"), testpath
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_lib/"cmake/Qt5"}"
+    args << "-DQt5Widgets_DIR=#{Formula["qt@5"].opt_lib/"cmake/Qt5Widgets"}"
+
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-extra-cmake-modules.rb
+++ b/Formula/kde-extra-cmake-modules.rb
@@ -37,8 +37,16 @@ class KdeExtraCmakeModules < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write("find_package(ECM REQUIRED)")
-    system "cmake", ".", "-Wno-dev"
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_ECM)
+      find_package(Qt5 REQUIRED Core)
+      find_package(ECM REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    system "cmake", testpath.to_s, *args
+    system "make"
 
     expected="ECM_DIR:PATH=#{HOMEBREW_PREFIX}/share/ECM/cmake"
     assert_match expected, File.read(testpath/"CMakeCache.txt")

--- a/Formula/kde-kcodecs.rb
+++ b/Formula/kde-kcodecs.rb
@@ -1,0 +1,59 @@
+class KdeKcodecs < Formula
+  desc "String encoding library"
+  homepage "https://api.kde.org/frameworks/kcodecs/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kcodecs-5.79.0.tar.xz"
+  sha256 "c81fa7229cb70021339d4c822517980e30f0a9dc79f143f577a6d56dcd6f64a9"
+  license all_of: [
+    "BSD-3-Clause",
+    "GPL-2.0-or-later",
+    "LGPL-2.0-only",
+    "LGPL-2.0-or-later",
+    "LGPL-2.1-or-later",
+    "MIT",
+    "MPL-1.1",
+  ]
+  head "https://invent.kde.org/frameworks/kcodecs.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "gperf" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5Codecs)
+      find_package(Qt5 REQUIRED Core)
+      find_package(KF5Codecs REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-kconfig.rb
+++ b/Formula/kde-kconfig.rb
@@ -1,0 +1,58 @@
+class KdeKconfig < Formula
+  desc "Persistent platform-independent application settings"
+  homepage "https://api.kde.org/frameworks/kconfig/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kconfig-5.79.0.tar.xz"
+  sha256 "f948718ac87f573b14bbf73e4af02d488f023cfcf011425af7cdbc0cefca510a"
+  license all_of: [
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "GPL-2.0-or-later",
+    "LGPL-2.0-only",
+    "LGPL-2.0-or-later",
+    "MIT",
+    any_of: ["LGPL-2.1-only", "LGPL-3.0-only"],
+  ]
+  head "https://invent.kde.org/frameworks/kconfig.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5Config)
+      find_package(Qt5 REQUIRED Core Xml)
+      find_package(KF5Config REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-kdbusaddons.rb
+++ b/Formula/kde-kdbusaddons.rb
@@ -1,0 +1,55 @@
+class KdeKdbusaddons < Formula
+  desc "Addons to QtDBus"
+  homepage "https://api.kde.org/frameworks/kdbusaddons/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kdbusaddons-5.79.0.tar.xz"
+  sha256 "2071c5a06226b77c4cb1d4e46b50258c980e57448fdbb1a49259db64a7a2539f"
+  license all_of: [
+    "LGPL-2.0-only",
+    "LGPL-2.0-or-later",
+    any_of: ["LGPL-2.1-only", "LGPL-3.0-only"],
+  ]
+  head "https://invent.kde.org/frameworks/kdbusaddons.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "dbus"
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5DBusAddons)
+      find_package(Qt5 REQUIRED Core DBus)
+      find_package(KF5DBusAddons REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-kdnssd.rb
+++ b/Formula/kde-kdnssd.rb
@@ -1,0 +1,53 @@
+class KdeKdnssd < Formula
+  desc "Abstraction to system DNSSD features"
+  homepage "https://api.kde.org/frameworks/kdnssd/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kdnssd-5.79.1.tar.xz"
+  sha256 "9716aeed43b794948a78444ea645ba14f24f13395d410a78a68b1f8428f51898"
+  license all_of: [
+    "BSD-3-Clause",
+    "LGPL-2.0-or-later",
+  ]
+  head "https://invent.kde.org/frameworks/kdnssd.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5DNSSD)
+      find_package(Qt5 REQUIRED Core Network)
+      find_package(KF5DNSSD REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-kguiaddons.rb
+++ b/Formula/kde-kguiaddons.rb
@@ -1,0 +1,56 @@
+class KdeKguiaddons < Formula
+  desc "Addons to QtGui"
+  homepage "https://api.kde.org/frameworks/kguiaddons/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kguiaddons-5.79.0.tar.xz"
+  sha256 "bc00488e123a1f7905682393b140b80c8340cb131cc0baa3fb6ad575878f1c85"
+  license all_of: [
+    "LGPL-2.0-only",
+    "LGPL-2.0-or-later",
+    any_of: ["GPL-2.0-only", "GPL-3.0-only"],
+    any_of: ["LGPL-2.1-only", "LGPL-3.0-only"],
+  ]
+  head "https://invent.kde.org/frameworks/kguiaddons.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    args << "-DWITH_WAYLAND=OFF"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5GuiAddons)
+      find_package(Qt5 REQUIRED Core Gui)
+      find_package(KF5GuiAddons REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-kidletime.rb
+++ b/Formula/kde-kidletime.rb
@@ -1,0 +1,53 @@
+class KdeKidletime < Formula
+  desc "Monitoring user activity"
+  homepage "https://api.kde.org/frameworks/kidletime/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kidletime-5.79.0.tar.xz"
+  sha256 "53e59c7f8465753f58d23543a1bc25f83ed9f0cd6381a800f9cff7cd488ce25e"
+  license all_of: [
+    "GPL-2.0-or-later",
+    "LGPL-2.0-only",
+    "MIT",
+  ]
+  head "https://invent.kde.org/frameworks/kidletime.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5IdleTime)
+      find_package(Qt5 REQUIRED Core)
+      find_package(KF5IdleTime REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-kitemmodels.rb
+++ b/Formula/kde-kitemmodels.rb
@@ -1,0 +1,53 @@
+class KdeKitemmodels < Formula
+  desc "Models for Qt Model/View system"
+  homepage "https://api.kde.org/frameworks/kitemmodels/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kitemmodels-5.79.0.tar.xz"
+  sha256 "7a29b2b7f20a3dbfd65a12e38f431716e14c8d43f9f1edc32e15e03920503dbd"
+  license all_of: [
+    "LGPL-2.0-or-later",
+    "LGPL-2.1-only",
+    "LGPL-2.1-or-later",
+  ]
+  head "https://invent.kde.org/frameworks/kitemmodels.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5ItemModels)
+      find_package(Qt5 REQUIRED Core)
+      find_package(KF5ItemModels REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-kitemviews.rb
+++ b/Formula/kde-kitemviews.rb
@@ -1,0 +1,53 @@
+class KdeKitemviews < Formula
+  desc "Widget addons for Qt Model/View"
+  homepage "https://api.kde.org/frameworks/kitemviews/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kitemviews-5.79.0.tar.xz"
+  sha256 "d4022ec9599e5b99c6c3e11e1145e6f85d1a87a0d57d9a42aec24605bb87415c"
+  license all_of: [
+    "GPL-2.0-or-later",
+    "LGPL-2.0-only",
+    "LGPL-2.0-or-later",
+  ]
+  head "https://invent.kde.org/frameworks/kitemviews.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5ItemViews)
+      find_package(Qt5 REQUIRED Core Widgets)
+      find_package(KF5ItemViews REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-kplotting.rb
+++ b/Formula/kde-kplotting.rb
@@ -1,0 +1,52 @@
+class KdeKplotting < Formula
+  desc "Lightweight plotting framework"
+  homepage "https://api.kde.org/frameworks/kplotting/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kplotting-5.79.0.tar.xz"
+  sha256 "c67238fb1395197b2ee2a65f327458132106df6110765952bd979b11cfbb5c51"
+  license all_of: [
+    "GPL-2.0-or-later",
+    "LGPL-2.0-or-later",
+  ]
+  head "https://invent.kde.org/frameworks/kplotting.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5Plotting)
+      find_package(Qt5 REQUIRED Core Widgets)
+      find_package(KF5Plotting REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-kunitconversion.rb
+++ b/Formula/kde-kunitconversion.rb
@@ -1,0 +1,52 @@
+class KdeKunitconversion < Formula
+  desc "Support for unit conversion"
+  homepage "https://api.kde.org/frameworks/kunitconversion/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kunitconversion-5.79.0.tar.xz"
+  sha256 "549c31f8adc5806a1e1a1657b9ea9d80bce5c21b2bcd832f5642afbdaba856a7"
+  license all_of: [
+    "LGPL-2.0-or-later",
+  ]
+  head "https://invent.kde.org/frameworks/kunitconversion.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "gettext" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "kde-ki18n"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5UnitConversion)
+      find_package(Qt5 REQUIRED Core)
+      find_package(KF5UnitConversion REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-kwindowsystem.rb
+++ b/Formula/kde-kwindowsystem.rb
@@ -1,0 +1,53 @@
+class KdeKwindowsystem < Formula
+  desc "Access to the windowing system"
+  homepage "https://api.kde.org/frameworks/kwindowsystem/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kwindowsystem-5.79.0.tar.xz"
+  sha256 "b8aef806276b5f12e9810473679401a6715b3b86e786eb874b12b2b6ed16f196"
+  license all_of: [
+    "LGPL-2.1-or-later",
+    "MIT",
+    any_of: ["LGPL-2.1-only", "LGPL-3.0-only"],
+  ]
+  head "https://invent.kde.org/frameworks/kwindowsystem.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5WindowSystem)
+      find_package(Qt5 REQUIRED Core Widgets)
+      find_package(KF5WindowSystem REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-solid.rb
+++ b/Formula/kde-solid.rb
@@ -1,0 +1,59 @@
+class KdeSolid < Formula
+  desc "Hardware integration and detection"
+  homepage "https://api.kde.org/frameworks/solid/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/solid-5.79.0.tar.xz"
+  sha256 "34c3699100f117709f459adbe08c94562af387bf45a1901cbca0106cc4d07a0c"
+  license all_of: [
+    "BSD-3-Clause",
+    "LGPL-2.0-only",
+    "LGPL-2.1-or-later",
+    any_of: ["LGPL-2.1-only", "LGPL-3.0-only"],
+  ]
+  head "https://invent.kde.org/frameworks/solid.git"
+
+  depends_on "bison" => :build
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "flex" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+    # setTime_t function is deprecated since 5.8.
+    # args << "-DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -DQT_DISABLE_DEPRECATED_BEFORE=0x050700"
+    # args << "-DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -DQT_DISABLE_DEPRECATED_BEFORE=0x050700"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5Solid)
+      find_package(Qt5 REQUIRED Core)
+      find_package(KF5Solid REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-syntax-highlighting.rb
+++ b/Formula/kde-syntax-highlighting.rb
@@ -1,0 +1,55 @@
+class KdeSyntaxHighlighting < Formula
+  desc "Syntax highlighting engine for structured text and code"
+  homepage "https://api.kde.org/frameworks/syntax-highlighting/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/syntax-highlighting-5.79.1.tar.xz"
+  sha256 "b2825ebee4c527f96562d18abb553195809dcc32174a4b998c71850e24527990"
+  license all_of: [
+    "GPL-2.0-only",
+    "LGPL-2.0-only",
+    "LGPL-2.0-or-later",
+    "LGPL-2.1-or-later",
+    "MIT",
+  ]
+  head "https://invent.kde.org/frameworks/syntax-highlighting.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5SyntaxHighlighting)
+      find_package(Qt5 REQUIRED Core Gui)
+      find_package(KF5SyntaxHighlighting REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

As discussed in https://github.com/Homebrew/discussions/discussions/994, I am submitting a first batch PR for a bunch of KDE Frameworks. These ones are relatively simple, with little to none dependencies on top of the `qt@5`. All of these were previously tested by many users of the [`kde-mac/kde`](https://invent.kde.org/packaging/homebrew-kde) tap, so we're not expecting any functional issues here.

See also the issue tracking this effort on our GitLab instance: https://invent.kde.org/packaging/homebrew-kde/-/issues/23

Remaining tasks:
- [x] Add License info
- [ ] Add aliases
- [ ] Review the `args` – are any of these excessive?