### PR TITLE
neon: add license

### DIFF
--- a/Formula/neon.rb
+++ b/Formula/neon.rb
@@ -4,6 +4,7 @@ class Neon < Formula
   url "https://notroj.github.io/neon/neon-0.31.2.tar.gz"
   mirror "https://fossies.org/linux/www/neon-0.31.2.tar.gz"
   sha256 "cf1ee3ac27a215814a9c80803fcee4f0ede8466ebead40267a9bd115e16a8678"
+  license "LGPL-2.0-or-later"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

From `README.md`:

    The neon library source code is licensed under the GNU Library GPL;
    see src/COPYING.LIB for full details.

Headers in `src` state:

    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Library General Public
    License as published by the Free Software Foundation; either
    version 2 of the License, or (at your option) any later version.