### PR TITLE
zsh-navigation-tools: add license

### DIFF
--- a/Formula/zsh-navigation-tools.rb
+++ b/Formula/zsh-navigation-tools.rb
@@ -3,6 +3,7 @@ class ZshNavigationTools < Formula
   homepage "https://github.com/psprint/zsh-navigation-tools"
   url "https://github.com/psprint/zsh-navigation-tools/archive/v2.2.7.tar.gz"
   sha256 "ee832b81ce678a247b998675111c66aa1873d72aa33c2593a65626296ca685fc"
+  license any_of: ["GPL-3.0-only", "MIT"]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "a968a06b57fd74fb842f504c30d61e8c22aa57da9f84d8aca3159f1b5c2eb284"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `LICENSE` says it is dual-licensed under MIT and GPLv3. There is no
indication of the "at your option" qualifier except in the boilerplate
copy of the GPL.