### PR TITLE
enzyme 0.0.8 (new formula)

### DIFF
--- a/Formula/enzyme.rb
+++ b/Formula/enzyme.rb
@@ -1,0 +1,49 @@
+class Enzyme < Formula
+  desc "High-performance automatic differentiation of LLVM"
+  homepage "https://enzyme.mit.edu"
+  url "https://github.com/wsmoses/Enzyme/archive/v0.0.8.tar.gz"
+  sha256 "96349054789cca84a6f94e8d4c4a9a0f7f4677f31ccceed1cd5bfda9e07ed2b7"
+  license "Apache-2.0" => { with: "LLVM-exception" }
+  head "https://github.com/wsmoses/Enzyme.git"
+
+  depends_on "cmake" => :build
+  depends_on "llvm"
+
+  def install
+    mkdir "build" do
+      system "cmake", "../enzyme", *std_cmake_args, "-DLLVM_DIR=#{Formula["llvm"].opt_lib}/cmake/llvm"
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      extern double __enzyme_autodiff(void*, double);
+      double square(double x) {
+        return x * x;
+      }
+      double dsquare(double x) {
+        return __enzyme_autodiff(square, x);
+      }
+      int main() {
+        double i = 21.0;
+        printf("square(%.0f)=%.0f, dsquare(%.0f)=%.0f\\n", i, square(i), i, dsquare(i));
+      }
+    EOS
+
+    llvm = Formula["llvm"]
+    llvm_version = llvm.version.major
+    opt = llvm.opt_bin/"opt"
+    ENV["CC"] = llvm.opt_bin/"clang"
+
+    system ENV.cc, testpath/"test.c", "-S", "-emit-llvm", "-o", "input.ll", "-O2",
+                   "-fno-vectorize", "-fno-slp-vectorize", "-fno-unroll-loops"
+    system opt, "input.ll", "-load=#{opt_lib}/#{shared_library("LLVMEnzyme-#{llvm_version}")}",
+                "-enzyme", "-o", "output.ll", "-S"
+    system ENV.cc, "output.ll", "-O3", "-o", "test"
+
+    assert_equal "square(21)=441, dsquare(21)=42\n", shell_output("./test")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fails `brew audit --new` because of the llvm dependency. Enzyme requires the llvm formula, and not just built-in macOS clang.