### PR TITLE
libsecret: add linux dependency

### DIFF
--- a/Formula/libsecret.rb
+++ b/Formula/libsecret.rb
@@ -21,6 +21,10 @@ class Libsecret < Formula
   depends_on "glib"
   depends_on "libgcrypt"
 
+  on_linux do
+    depends_on "libxslt" => :build
+  end
+
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 


### PR DESCRIPTION
Fixes:
configure:16819: error: xsltproc is required to build manual pages

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
