### PR TITLE
lastpass: remove unneeded workaround and fix build on Linux

### DIFF
--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -25,6 +25,9 @@ class LastpassCli < Formula
   depends_on "openssl@1.1"
   depends_on "pinentry"
 
+  uses_from_macos "curl"
+  uses_from_macos "libxslt"
+
   def install
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The dependency on `curl` was conditional on macOS being Mojave or later.  This is unneeded now that Mojave is the oldest system we support, and removing it also fixes the build on Linux.  