### PR TITLE
feat: create otp-cli source

### DIFF
--- a/Formula/otp-cli.rb
+++ b/Formula/otp-cli.rb
@@ -1,0 +1,33 @@
+class OtpCli < Formula
+  desc "otp-cli is a tool for generate otp code in terminal."
+  homepage "https://github.com/chyroc/otp-cli"
+
+  url "https://github.com/chyroc/otp-cli/releases/download/v0.2.0/otp-cli-0.2.0.tar.gz"
+  sha256 "7e223d86e924e95e722b6c2b69acd0a4963085df2726132fcc6c0731caa93150"
+  head "https://github.com/chyroc/otp-cli"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    bin_path = buildpath/"src/github.com/chyroc/otp-cli"
+    bin_path.install Dir["*"]
+    cd bin_path do
+      system "go", "build", "-o", bin/"otp-cli", "."
+    end
+  end
+
+  test do
+    # "2>&1" redirects standard error to stdout. The "2" at the end means "the
+    # exit code should be 2".
+    assert_match "otp-cli", shell_output("#{bin}/otp-cli -h 2>&1", 2)
+  end
+
+  def caveats; <<~EOS
+    otp-cli has been installed, have fun!
+    More information:
+      https://github.com/chyroc/otp-cli
+  EOS
+  end
+end

--- a/Formula/otp-cli.rb
+++ b/Formula/otp-cli.rb
@@ -9,13 +9,7 @@ class OtpCli < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-
-    bin_path = buildpath/"src/github.com/chyroc/otp-cli"
-    bin_path.install Dir["*"]
-    cd bin_path do
-      system "go", "build", *std_go_args
-    end
+    system "go", "build", *std_go_args
   end
 
   test do

--- a/Formula/otp-cli.rb
+++ b/Formula/otp-cli.rb
@@ -1,5 +1,5 @@
 class OtpCli < Formula
-  desc "otp-cli is a tool for generate otp code in terminal."
+  desc "Tool for generate otp code in terminal"
   homepage "https://github.com/chyroc/otp-cli"
 
   url "https://github.com/chyroc/otp-cli/releases/download/v0.2.0/otp-cli-0.2.0.tar.gz"
@@ -24,10 +24,4 @@ class OtpCli < Formula
     assert_match "otp-cli", shell_output("#{bin}/otp-cli -h 2>&1", 2)
   end
 
-  def caveats; <<~EOS
-    otp-cli has been installed, have fun!
-    More information:
-      https://github.com/chyroc/otp-cli
-  EOS
-  end
 end

--- a/Formula/otp-cli.rb
+++ b/Formula/otp-cli.rb
@@ -1,6 +1,3 @@
-# frozen_string_literal: true
-
-# brew config for otp-cli
 class OtpCli < Formula
   desc "Tool for generate otp code in terminal"
   homepage "https://github.com/chyroc/otp-cli"

--- a/Formula/otp-cli.rb
+++ b/Formula/otp-cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # brew config for otp-cli
 class OtpCli < Formula
   desc "Tool for generate otp code in terminal"

--- a/Formula/otp-cli.rb
+++ b/Formula/otp-cli.rb
@@ -23,5 +23,4 @@ class OtpCli < Formula
     # exit code should be 2".
     assert_match "otp-cli", shell_output("#{bin}/otp-cli -h 2>&1", 2)
   end
-
 end

--- a/Formula/otp-cli.rb
+++ b/Formula/otp-cli.rb
@@ -1,10 +1,10 @@
 class OtpCli < Formula
   desc "Tool for generate otp code in terminal"
   homepage "https://github.com/chyroc/otp-cli"
-
   url "https://github.com/chyroc/otp-cli/releases/download/v0.3.0/otp-cli-0.3.0.tar.gz"
   sha256 "b0c3a0afb4f886db32bcc12ed3d6eec985fe9cf4487e4db412557dfbdd5dcafe"
   head "https://github.com/chyroc/otp-cli"
+  license "Apache-2.0"
 
   depends_on "go" => :build
 

--- a/Formula/otp-cli.rb
+++ b/Formula/otp-cli.rb
@@ -1,10 +1,11 @@
+# brew config for otp-cli
 class OtpCli < Formula
   desc "Tool for generate otp code in terminal"
   homepage "https://github.com/chyroc/otp-cli"
   url "https://github.com/chyroc/otp-cli/releases/download/v0.3.0/otp-cli-0.3.0.tar.gz"
   sha256 "b0c3a0afb4f886db32bcc12ed3d6eec985fe9cf4487e4db412557dfbdd5dcafe"
-  head "https://github.com/chyroc/otp-cli"
   license "Apache-2.0"
+  head "https://github.com/chyroc/otp-cli"
 
   depends_on "go" => :build
 

--- a/Formula/otp-cli.rb
+++ b/Formula/otp-cli.rb
@@ -2,8 +2,8 @@ class OtpCli < Formula
   desc "Tool for generate otp code in terminal"
   homepage "https://github.com/chyroc/otp-cli"
 
-  url "https://github.com/chyroc/otp-cli/releases/download/v0.2.0/otp-cli-0.2.0.tar.gz"
-  sha256 "7e223d86e924e95e722b6c2b69acd0a4963085df2726132fcc6c0731caa93150"
+  url "https://github.com/chyroc/otp-cli/releases/download/v0.3.0/otp-cli-0.3.0.tar.gz"
+  sha256 "b0c3a0afb4f886db32bcc12ed3d6eec985fe9cf4487e4db412557dfbdd5dcafe"
   head "https://github.com/chyroc/otp-cli"
 
   depends_on "go" => :build
@@ -14,13 +14,11 @@ class OtpCli < Formula
     bin_path = buildpath/"src/github.com/chyroc/otp-cli"
     bin_path.install Dir["*"]
     cd bin_path do
-      system "go", "build", "-o", bin/"otp-cli", "."
+      system "go", "build", *std_go_args
     end
   end
 
   test do
-    # "2>&1" redirects standard error to stdout. The "2" at the end means "the
-    # exit code should be 2".
-    assert_match "otp-cli", shell_output("#{bin}/otp-cli -h 2>&1", 2)
+    assert_equal "otp-cli version v0.3.0\n", shell_output("#{bin}/otp-cli version")
   end
 end

--- a/Formula/otp-cli.rb
+++ b/Formula/otp-cli.rb
@@ -13,6 +13,13 @@ class OtpCli < Formula
   end
 
   test do
-    assert_equal "otp-cli version v0.3.0\n", shell_output("#{bin}/otp-cli version")
+    (testpath/"secret.txt").write "testsecret"
+
+    assert_equal "otp-cli version v#{pkg_version}\n", shell_output("#{bin}/otp-cli version")
+    from_string = shell_output("#{bin}/otp-cli -s testsecret")
+    assert_equal 7, from_string.length
+    from_file = shell_output("#{bin}/otp-cli -f secret.txt")
+    assert_equal 7, from_file.length
+    assert_equal from_string, from_file
   end
 end


### PR DESCRIPTION
about otp-cli: https://github.com/chyroc/otp-cli

otp-cli is a tool for generate otp code in terminal.

NAME:
   otp-cli - generate otp client

USAGE:
   main [global options] command [command options] [arguments...]

COMMANDS:
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --secret value, -s value       otp secret text
   --secret-file value, -f value  otp secret file
   --copy, -c                     copy to clipboard (default: false)
   --quiet, -q                    not output to console (default: false)
   --help, -h                     show help (default: false)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
