### PR TITLE
volta: use canonical name for openssl

### DIFF
--- a/Formula/volta.rb
+++ b/Formula/volta.rb
@@ -19,7 +19,7 @@ class Volta < Formula
 
   depends_on "rust" => :build
 
-  uses_from_macos "openssl"
+  uses_from_macos "openssl@1.1"
 
   on_linux do
     depends_on "pkg-config" => :build


### PR DESCRIPTION
Fixes:
Dependency 'openssl' is an alias; use the canonical name 'openssl@1.1'.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
