### PR TITLE
libx11: Fix issue with sed barfing on unicode characters

### DIFF
--- a/Formula/libx11.rb
+++ b/Formula/libx11.rb
@@ -19,6 +19,8 @@ class Libx11 < Formula
   depends_on "xorgproto"
 
   def install
+    ENV.delete "LC_ALL"
+    ENV["LC_CTYPE"] = "C"
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}


### PR DESCRIPTION
Resolves the `sed: RE error: illegal byte sequence` error re-introduced by the removal of `Library/Homebrew/shims/mac/super/sed`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
