### PR TITLE
inspircd: fix build on linux, enable more extra modules, and fix configure flags

### DIFF
--- a/Formula/inspircd.rb
+++ b/Formula/inspircd.rb
@@ -29,8 +29,11 @@ class Inspircd < Formula
   skip_clean "logs"
 
   def install
-    system "./configure", "--enable-extras", "argon2 ldap mysql pgsql regex_stdlib ssl_gnutls"
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--enable-extras",
+                          "argon2 ldap mysql pgsql regex_posix regex_stdlib ssl_gnutls sslrehashsignal"
+    system "./configure", "--disable-auto-extras",
+                          "--distribution-label", "homebrew-#{revision}",
+                          "--prefix", prefix
     system "make", "install"
   end
 

--- a/Formula/inspircd.rb
+++ b/Formula/inspircd.rb
@@ -4,6 +4,7 @@ class Inspircd < Formula
   url "https://github.com/inspircd/inspircd/archive/v3.9.0.tar.gz"
   sha256 "5bda0fc3d41908cda4580de39d62e8be4840da45f31e072cfca337b838add567"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url "https://github.com/inspircd/inspircd.git"

--- a/Formula/inspircd.rb
+++ b/Formula/inspircd.rb
@@ -19,6 +19,8 @@ class Inspircd < Formula
 
   depends_on "pkg-config" => :build
 
+  uses_from_macos "openldap"
+
   skip_clean "data"
   skip_clean "logs"
 

--- a/Formula/inspircd.rb
+++ b/Formula/inspircd.rb
@@ -18,6 +18,10 @@ class Inspircd < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "argon2"
+  depends_on "gnutls"
+  depends_on "libpq"
+  depends_on "mysql-client"
 
   uses_from_macos "openldap"
 
@@ -25,7 +29,7 @@ class Inspircd < Formula
   skip_clean "logs"
 
   def install
-    system "./configure", "--enable-extras=ldap"
+    system "./configure", "--enable-extras", "argon2 ldap mysql pgsql regex_stdlib ssl_gnutls"
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I'm the upstream for this software. Since package options were removed in 2018 we've encountered several users who have tried to use this package but have hit the issue of it not shipping any TLS support, SQL modules, and no modern regex modules. I've fixed this and also fixed the build under Linuxbrew and synced the configure options with what we recommend that packagers use.