### PR TITLE
lensfun: avoid malloc error, fix #71192

### DIFF
--- a/Formula/lensfun.rb
+++ b/Formula/lensfun.rb
@@ -5,7 +5,7 @@ class Lensfun < Formula
   homepage "https://lensfun.github.io/"
   url "https://downloads.sourceforge.net/project/lensfun/0.3.95/lensfun-0.3.95.tar.gz"
   sha256 "82c29c833c1604c48ca3ab8a35e86b7189b8effac1b1476095c0529afb702808"
-  revision 3
+  revision 4
 
   bottle do
     sha256 arm64_big_sur: "d88e64dba59fb70ca04c45029ba2908d9d731dd94b835cbf88f488dd66c8c96c"
@@ -21,6 +21,12 @@ class Lensfun < Formula
   depends_on "glib"
   depends_on "libpng"
   depends_on "python@3.9"
+
+  # This patch can be removed when new Lensfun release (v0.3.96) is available.
+  patch do
+    url "https://github.com/lensfun/lensfun/commit/de954c952929316ea2ad0f6f1e336d9d8164ace0.patch?full_index=1"
+    sha256 "67f0d2f33160bb1ab2b4d1e0465ad5967dbd8f8e3ba1d231b5534ec641014e3b"
+  end
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This applies a patch to fix the malloc error mentioned in issue #71192. The patch is already merged in upstream (https://github.com/lensfun/lensfun/commit/de954c9).