### PR TITLE
htpdate: update livecheck

### DIFF
--- a/Formula/htpdate.rb
+++ b/Formula/htpdate.rb
@@ -5,7 +5,7 @@ class Htpdate < Formula
   sha256 "5f1f959877852abb3153fa407e8532161a7abe916aa635796ef93f8e4119f955"
 
   livecheck do
-    url "http://www.vervest.org/htp/archive/c/?C=M&O=D"
+    url "http://www.vervest.org/htp/download"
     regex(/href=.*?htpdate[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The URL in the existing `livecheck` block for `htpdate` is now giving a `403 Forbidden` response. This PR updates the URL to the download page, which links to the `stable` archive.