### PR TITLE
Allow kubernetes-cli --HEAD to build on Apple Silicon

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -19,6 +19,8 @@ class KubernetesCli < Formula
   end
 
   depends_on "go" => :build
+  depends_on "bash" => :build
+  env :std
 
   uses_from_macos "rsync" => :build
 


### PR DESCRIPTION
See #68455. My understanding is we're still waiting for a stable upstream release in early April, but this allows `brew install --build-from-source --HEAD kubernetes-cli` to successfully build on M1.

I'm creating PR for feedback, as I think this causes no regression for Intel users, and will only help M1 users who have been waiting a while for this formula.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
