### PR TITLE
lensfun: add license

### DIFF
--- a/Formula/lensfun.rb
+++ b/Formula/lensfun.rb
@@ -5,6 +5,12 @@ class Lensfun < Formula
   homepage "https://lensfun.github.io/"
   url "https://downloads.sourceforge.net/project/lensfun/0.3.95/lensfun-0.3.95.tar.gz"
   sha256 "82c29c833c1604c48ca3ab8a35e86b7189b8effac1b1476095c0529afb702808"
+  license all_of: [
+    "LGPL-3.0-only",
+    "GPL-3.0-only",
+    "CC-BY-3.0",
+    :public_domain,
+  ]
   revision 4
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

From the readme:

    LICENSE
    -------

    The libraries which are part of this package are licensed under the terms
    of the GNU Lesser General Public License, version 3. Libraries are located
    under the subdirectory libs/ of the source package. A copy of the license
    is available in the file lgpl-3.0.txt which can be found in the source
    archive. You can read it here: http://www.gnu.org/licenses/lgpl-3.0.html

    The documentation files, including those autogenerated with Doxygen,
    are covered as well by GNU Lesser General Public License, version 3.

    Applications which are part of this package are licensed under the terms
    of the GNU General Public License, version 3. Applications are located
    under the apps/ subdirectory of the source package. A copy of the license
    can be found in the file gpl-3.0.txt which can be found in the source
    archive. You can read it here: http://www.gnu.org/licenses/gpl-3.0.html

    Also the build system (the contents of the build/ subdirectory plus the
    ac.py file) is licensed under GPL v3.

    Test programs and tools are put into public domain, unless explicitly
    specified otherwise in the header of the source files. Test programs
    are located under the tests/ subdirectory, and tools are located in tools/.

    The lens database is licensed under the Creative Commons Attribution-Share
    Alike 3.0 license. The database is located under the data/ subdirectory
    of the source package. You can read it here:
    http://creativecommons.org/licenses/by-sa/

The relevant source files don't contain any licensing information, so I assume this is `-only` rather than `-or-later`.