### PR TITLE
[kde-kguiaddons] new formula

### DIFF
--- a/Aliases/kguiaddons
+++ b/Aliases/kguiaddons
@@ -1,0 +1,1 @@
+../Formula/kde-kguiaddons.rb

--- a/Formula/kde-kguiaddons.rb
+++ b/Formula/kde-kguiaddons.rb
@@ -1,0 +1,56 @@
+class KdeKguiaddons < Formula
+  desc "Addons to QtGui"
+  homepage "https://api.kde.org/frameworks/kguiaddons/html/index.html"
+  url "https://download.kde.org/stable/frameworks/5.79/kguiaddons-5.79.0.tar.xz"
+  sha256 "bc00488e123a1f7905682393b140b80c8340cb131cc0baa3fb6ad575878f1c85"
+  license all_of: [
+    "LGPL-2.0-only",
+    "LGPL-2.0-or-later",
+    any_of: ["GPL-2.0-only", "GPL-3.0-only"],
+    any_of: ["LGPL-2.1-only", "LGPL-3.0-only"],
+  ]
+  head "https://invent.kde.org/frameworks/kguiaddons.git"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "kde-extra-cmake-modules" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qt@5"
+
+  def install
+    args = std_cmake_args
+    args << "-D BUILD_QCH=ON"
+    args << "-D BUILD_TESTING=OFF"
+    args << "-D BUILD_TESTS=OFF"
+    args << "-D BUILD_UNITTESTS=OFF"
+    args << "-D CMAKE_INSTALL_BUNDLEDIR=#{bin}"
+    args << "-D KDE_INSTALL_LIBDIR=lib"
+    args << "-D KDE_INSTALL_PLUGINDIR=lib/qt5/plugins"
+    args << "-D KDE_INSTALL_QMLDIR=lib/qt5/qml"
+    args << "-D KDE_INSTALL_QTPLUGINDIR=lib/qt5/plugins"
+
+    args << "-DWITH_WAYLAND=OFF"
+
+    mkdir "build" do
+      system "cmake", "..", "-G", "Ninja", *args
+      system "ninja"
+      system "ninja", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~EOS
+      project(test_KF5GuiAddons)
+      find_package(Qt5 REQUIRED Core Gui)
+      find_package(KF5GuiAddons REQUIRED)
+    EOS
+
+    args = std_cmake_args
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    system "cmake", testpath.to_s, *args
+    system "make"
+  end
+end

--- a/Formula/kde-kguiaddons.rb
+++ b/Formula/kde-kguiaddons.rb
@@ -61,6 +61,6 @@ class KdeKguiaddons < Formula
     args << "-DQt5_DIR=#{Formula["qt@5"].opt_lib/"cmake/Qt5"}"
 
     system "cmake", testpath.to_s, *args
-    system "make"
+    system "cmake"
   end
 end

--- a/Formula/kde-kguiaddons.rb
+++ b/Formula/kde-kguiaddons.rb
@@ -39,17 +39,27 @@ class KdeKguiaddons < Formula
       system "ninja", "install"
       prefix.install "install_manifest.txt"
     end
+
+    pkgshare.install "autotests"
+    pkgshare.install "tests"
   end
 
   test do
     (testpath/"CMakeLists.txt").write <<~EOS
-      project(test_KF5GuiAddons)
-      find_package(Qt5 REQUIRED Core Gui)
-      find_package(KF5GuiAddons REQUIRED)
+      include(FeatureSummary)
+      find_package(ECM NO_MODULE)
+      set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} "#{pkgshare}/cmake")
+
+      add_subdirectory(autotests)
+      add_subdirectory(tests)
     EOS
 
+    cp_r (pkgshare/"autotests"), testpath
+    cp_r (pkgshare/"tests"), testpath
+
     args = std_cmake_args
-    args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"
+    args << "-DQt5_DIR=#{Formula["qt@5"].opt_lib/"cmake/Qt5"}"
+
     system "cmake", testpath.to_s, *args
     system "make"
   end

--- a/Formula/kde-kguiaddons.rb
+++ b/Formula/kde-kguiaddons.rb
@@ -6,8 +6,8 @@ class KdeKguiaddons < Formula
   license all_of: [
     "LGPL-2.0-only",
     "LGPL-2.0-or-later",
-    any_of: ["GPL-2.0-only", "GPL-3.0-only"],
-    any_of: ["LGPL-2.1-only", "LGPL-3.0-only"],
+    { any_of: ["GPL-2.0-only", "GPL-3.0-only"] },
+    { any_of: ["LGPL-2.1-only", "LGPL-3.0-only"] },
   ]
   head "https://invent.kde.org/frameworks/kguiaddons.git"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

I need to set up the licenses as follows:

```
  license all_of: [
    "LGPL-2.0-only",
    "LGPL-2.0-or-later",
    any_of: ["GPL-2.0-only", "GPL-3.0-only"],
    any_of: ["LGPL-2.1-only", "LGPL-3.0-only"],
  ]
```

Since brew uses hash table for that purpose, it's impossible to define more than one subset of "any_of" or "all_of". Unless I am missing some way of doing it properly, this is a bug:

```
/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/kde-kguiaddons.rb:9: warning: key :any_of is duplicated and overwritten on line 10
kde-kguiaddons:
  * 10: col 5: Duplicated key in hash literal.
```

The formula was previously tested by many users of the [`kde-mac/kde`](https://invent.kde.org/packaging/homebrew-kde) tap, so we're not expecting any functional issues here.

See also the issue tracking this effort on our GitLab instance: https://invent.kde.org/packaging/homebrew-kde/-/issues/23