### PR TITLE
rocksdb: add head, fix ARM build

### DIFF
--- a/Formula/rocksdb.rb
+++ b/Formula/rocksdb.rb
@@ -1,9 +1,20 @@
 class Rocksdb < Formula
   desc "Embeddable, persistent key-value store for fast storage"
   homepage "https://rocksdb.org/"
-  url "https://github.com/facebook/rocksdb/archive/v6.17.3.tar.gz"
-  sha256 "bdd4790516f5ae17f83882dca1316f4dcaf4b245edbd641e7ec4ac3444c3c841"
   license any_of: ["GPL-2.0-only", "Apache-2.0"]
+  head "https://github.com/facebook/rocksdb.git"
+
+  stable do
+    url "https://github.com/facebook/rocksdb/archive/v6.17.3.tar.gz"
+    sha256 "bdd4790516f5ae17f83882dca1316f4dcaf4b245edbd641e7ec4ac3444c3c841"
+
+    # Add artifact suffix to shared library
+    # https://github.com/facebook/rocksdb/pull/7755
+    patch do
+      url "https://github.com/facebook/rocksdb/commit/98f3f3143007bcb5455105a05da7eeecc9cf53a0.patch?full_index=1"
+      sha256 "6fb59cd640ed8c39692855115b72e8aa8db50a7aa3842d53237e096e19f88fc1"
+    end
+  end
 
   bottle do
     sha256 cellar: :any, big_sur:  "64c9409aa489f322acc46bec6460303058daf642155f59d2f64dd8f3cd41161f"
@@ -20,13 +31,6 @@ class Rocksdb < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
-  # Add artifact suffix to shared library
-  # https://github.com/facebook/rocksdb/pull/7755
-  patch do
-    url "https://github.com/facebook/rocksdb/commit/98f3f3143007bcb5455105a05da7eeecc9cf53a0.patch?full_index=1"
-    sha256 "6fb59cd640ed8c39692855115b72e8aa8db50a7aa3842d53237e096e19f88fc1"
-  end
-
   def install
     ENV.cxx11
     args = std_cmake_args + %w[
@@ -39,6 +43,8 @@ class Rocksdb < Formula
       -DWITH_ZLIB=ON
       -DWITH_ZSTD=ON
     ]
+
+    args << "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath -Wl,#{lib}"
 
     # build regular rocksdb
     mkdir "build" do


### PR DESCRIPTION
A simple PR that adds the ability to build Rocksdb from master. Also added a `cmake` linker option to ensure generated executables can find the rocksdb dylib that was built, and performed some minor cleanup to ensure `brew audit` passes.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Tested on 
```
HOMEBREW_VERSION: 3.0.5-38-g636ac91
ORIGIN: https://github.com/Homebrew/brew
HEAD: 636ac918173ca07c2f2a59fd0e096fa94c22e04a
Last commit: 10 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 97c319503876b791e7b379d2d645b51e60072a82
Core tap last commit: 5 minutes ago
Core tap branch: rocksdb_head
HOMEBREW_PREFIX: /opt/homebrew
HOMEBREW_CASK_OPTS: []
HOMEBREW_MAKE_JOBS: 8
Homebrew Ruby: 2.6.3 => /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby
CPU: octa-core 64-bit arm_firestorm_icestorm
Clang: 12.0 build 1200
Git: 2.24.3 => /Library/Developer/CommandLineTools/usr/bin/git
Curl: 7.64.1 => /usr/bin/curl
macOS: 11.2.3-arm64
CLT: 12.4.0.0.1.1610135815
Xcode: N/A
Rosetta 2: false
```
