### PR TITLE
libelf: build without gettext

### DIFF
--- a/Formula/libelf.rb
+++ b/Formula/libelf.rb
@@ -30,7 +30,6 @@ class Libelf < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "gettext" => :build
   depends_on "libtool" => :build
 
   def install


### PR DESCRIPTION
Let's see if this is needed or not.

See #73092.