### PR TITLE
rgbds: update build dependencies

### DIFF
--- a/Formula/rgbds.rb
+++ b/Formula/rgbds.rb
@@ -18,6 +18,7 @@ class Rgbds < Formula
     sha256 cellar: :any, mojave:        "a61753b345b81f0378916971fdf7629744556fe6d3c04c85afdec27669641e48"
   end
 
+  depends_on "bison" => :build
   depends_on "pkg-config" => :build
   depends_on "libpng"
 


### PR DESCRIPTION
Bison 3.x is required starting after 0.4.2, but the default on most systems is below that.
To fix `brew install rgbds --HEAD` for the time being, and next release when it'll come out,
require brew's (updated) Bison.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I do not have `brew` installed on my system, I am upstream reporting a bug submitted to us. Given the change's simplicity, I'm largely confident that it should be correct. If it isn't, I'll set up a VM to tick the rest of the boxes properly.