### PR TITLE
libunwind 1.5.0 (new formula)

### DIFF
--- a/.github/workflows/linux-pr-tests.yml
+++ b/.github/workflows/linux-pr-tests.yml
@@ -21,6 +21,7 @@ on:
       - "Formula/libpciaccess.rb"
       - "Formula/libseccomp.rb"
       - "Formula/libtirpc.rb"
+      - "Formula/libunwind.rb"
       - "Formula/libva.rb"
       - "Formula/linux-headers.rb"
       - "Formula/strace.rb"

--- a/Formula/libunwind.rb
+++ b/Formula/libunwind.rb
@@ -1,0 +1,31 @@
+class Libunwind < Formula
+  desc "C API for determining the call-chain of a program"
+  homepage "https://www.nongnu.org/libunwind/"
+  url "https://download.savannah.nongnu.org/releases/libunwind/libunwind-1.5.0.tar.gz"
+  sha256 "90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017"
+  license "MIT"
+
+  depends_on :linux
+
+  uses_from_macos "xz"
+  uses_from_macos "zlib"
+
+  def install
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <libunwind.h>
+      int main() {
+        unw_context_t uc;
+        unw_getcontext(&uc);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{include}", "test.c", "-L#{lib}", "-lunwind", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`libunwind` is one of several missing dependencies for `dotnet` on Linux. See https://github.com/Homebrew/linuxbrew-core/issues/22063

Original linuxbrew-core PR: https://github.com/Homebrew/linuxbrew-core/pull/22537