### PR TITLE
postgresql@9.6 & postgresql@9.5 build fine on Apple Silicon

### DIFF
--- a/Formula/postgresql@9.5.rb
+++ b/Formula/postgresql@9.5.rb
@@ -16,7 +16,6 @@ class PostgresqlAT95 < Formula
   # https://www.postgresql.org/support/versioning/
   deprecate! date: "2021-02-11", because: :unsupported
 
-  depends_on arch: :x86_64
   depends_on "openssl@1.1"
   depends_on "readline"
 

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -21,7 +21,6 @@ class PostgresqlAT96 < Formula
   # https://www.postgresql.org/support/versioning/
   deprecate! date: "2021-11-11", because: :unsupported
 
-  depends_on arch: :x86_64
   depends_on "openssl@1.1"
   depends_on "readline"
 


### PR DESCRIPTION
Despite https://github.com/Homebrew/homebrew-core/pull/68082, postgresql@9.6 builds fine on my M1 Mac, and 729c5e5 now won't let me upgrade from 9.6.20 to 9.6.21.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
