### PR TITLE
nspr: update livecheck

### DIFF
--- a/Formula/nspr.rb
+++ b/Formula/nspr.rb
@@ -7,7 +7,7 @@ class Nspr < Formula
 
   livecheck do
     url "https://ftp.mozilla.org/pub/nspr/releases/"
-    regex(/v(\d+(?:\.\d+)*)/i)
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the regex in the existing `livecheck` block for `nspr` to better follow current standards. Namely, this is matching version directories on an HTML page, so this updates the regex to match within `href` attributes, following the common pattern for this particular situation.

In the process, this converts the version matching part to the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`). This is part of ongoing work to improve standardization of regexes in `livecheck` blocks.