### PR TITLE
php@7.2 builds fine on Apple Silicon

### DIFF
--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -23,7 +23,6 @@ class PhpAT72 < Formula
   depends_on "xz" => :build
   depends_on "apr"
   depends_on "apr-util"
-  depends_on arch: :x86_64
   depends_on "argon2"
   depends_on "aspell"
   depends_on "autoconf"


### PR DESCRIPTION
Similar to https://github.com/Homebrew/homebrew-core/pull/73138:

Despite https://github.com/Homebrew/homebrew-core/pull/68082, `php@7.2` builds find on M1 Macs, and all tests pass.

2bb681f5f6250519bf6d904ff34efc2e40960943 blocks users from installing, even with `--build-from-source` flag.

```
~ ▶ brew install --build-from-source php@7.2
Warning: php@7.2 has been deprecated because it is deprecated upstream!
==> Downloading https://www.php.net/distributions/php-7.2.34.tar.xz
Already downloaded: /Users/jacob/Library/Caches/Homebrew/downloads/a6d684a9a63292d6f055edc3972e94980476123145a6f3347ec66ac3042dbcfd--php-7.2.34.tar.xz
==> Patching
==> ./buildconf --force
==> ./configure --prefix=/opt/homebrew/Cellar/php@7.2/7.2.34_2 --localstatedir=/opt/homebrew/var --sysconfdir=/opt/homeb
==> make
==> make install
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear config-set php_ini /opt/homebrew/etc/php/7.2/php.ini system
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear config-set php_dir /opt/homebrew/share/pear@7.2 system
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear config-set doc_dir /opt/homebrew/share/pear@7.2/doc system
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear config-set ext_dir /opt/homebrew/lib/php/pecl/20170718 system
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear config-set bin_dir /opt/homebrew/opt/php@7.2/bin system
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear config-set data_dir /opt/homebrew/share/pear@7.2/data system
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear config-set cfg_dir /opt/homebrew/share/pear@7.2/cfg system
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear config-set www_dir /opt/homebrew/share/pear@7.2/htdocs system
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear config-set man_dir /opt/homebrew/share/man system
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear config-set test_dir /opt/homebrew/share/pear@7.2/test system
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear config-set php_bin /opt/homebrew/opt/php@7.2/bin/php system
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/pear update-channels
==> Caveats
To enable PHP in Apache add the following to httpd.conf and restart Apache:
    LoadModule php7_module /opt/homebrew/opt/php@7.2/lib/httpd/modules/libphp7.so

    <FilesMatch \.php$>
        SetHandler application/x-httpd-php
    </FilesMatch>

Finally, check DirectoryIndex includes index.php
    DirectoryIndex index.php index.html

The php.ini and php-fpm.ini file can be found in:
    /opt/homebrew/etc/php/7.2/

php@7.2 is keg-only, which means it was not symlinked into /opt/homebrew,
because this is an alternate version of another formula.

If you need to have php@7.2 first in your PATH, run:
  echo 'export PATH="/opt/homebrew/opt/php@7.2/bin:$PATH"' >> ~/.zshrc
  echo 'export PATH="/opt/homebrew/opt/php@7.2/sbin:$PATH"' >> ~/.zshrc

For compilers to find php@7.2 you may need to set:
  export LDFLAGS="-L/opt/homebrew/opt/php@7.2/lib"
  export CPPFLAGS="-I/opt/homebrew/opt/php@7.2/include"


To have launchd start php@7.2 now and restart at login:
  brew services start php@7.2
Or, if you don't want/need a background service you can just run:
  php-fpm
==> Summary
🍺  /opt/homebrew/Cellar/php@7.2/7.2.34_2: 509 files, 75.5MB, built in 2 minutes 48 seconds
```

```
~ ▶ brew test php@7.2
==> Testing php@7.2
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/php -i
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/sbin/php-fpm -t
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/phpdbg -V
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/php-cgi -m
==> /opt/homebrew/Cellar/php@7.2/7.2.34_2/bin/php -m
==> curl -s 127.0.0.1:60980
[14-Mar-2021 12:12:08] NOTICE: fpm is running, pid 10187
[14-Mar-2021 12:12:08] NOTICE: ready to handle connections
==> curl -s 127.0.0.1:60980
[14-Mar-2021 12:12:11] NOTICE: Terminating ...
[14-Mar-2021 12:12:11] NOTICE: exiting, bye-bye!
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
