### PR TITLE
py2cairo: deprecate, remove livecheck

### DIFF
--- a/Formula/py2cairo.rb
+++ b/Formula/py2cairo.rb
@@ -6,11 +6,6 @@ class Py2cairo < Formula
   license "LGPL-2.1"
   revision 1
 
-  livecheck do
-    url :stable
-    regex(/^v?(1\.18(?:\.\d+)*)$/i)
-  end
-
   bottle do
     sha256 cellar: :any, arm64_big_sur: "de68fca224353b7e7b8426e24324fdb6fd0cc5a6180db4ad0ccd02b43919b0bc"
     sha256 cellar: :any, big_sur:       "80feea24d8039acef848c76075f8911493762d75b883b56bf4d87f14d5a3bbac"
@@ -18,6 +13,10 @@ class Py2cairo < Formula
     sha256 cellar: :any, mojave:        "f01c39e8f71339cdec156309fb7358f5bb3e292fb0a84a071c3a935b58234120"
     sha256 cellar: :any, high_sierra:   "76dbdbbd42c2a59cae7e9ddc05ad26d331194c8a132e24e7316ceb551a40272b"
   end
+
+  # Python 2 support was dropped in version 1.19.0 and this formula is pinned
+  # to the last preceding version.
+  deprecate! date: "2021-03-15", because: :versioned_formula
 
   depends_on "pkg-config" => :build
   depends_on "cairo"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

~This updates the existing `livecheck` block for `py2cairo` to skip the formula, as it's pinned to the last version that supports Python 2. Python 2 support was dropped in version 1.19.0 and 1.18.2 was the last version before that.~

This deprecates `py2cairo`, as Python 2 support was dropped in version 1.19.0 and this formula will never be updated beyond 1.18.2. This also removes the `livecheck` block, so the formula will be automatically skipped due to being deprecated.