### PR TITLE
asdf: install into libexec and bin.write_exec_script to opt_libexec/bin/asdf

### DIFF
--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -14,7 +14,6 @@ class Asdf < Formula
     fish_completion.install "completions/asdf.fish"
     zsh_completion.install "completions/_asdf"
     bin.write_exec_script (opt_libexec/"bin/asdf")
-    prefix.install_metafiles
   end
 
   def post_install

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -28,11 +28,11 @@ class Asdf < Formula
 
   def caveats
     <<~EOS
-      Add shims in $PATH by having the following line your ~/.zshenv or ~/bash_profile: 
-        export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"
+      Add shims in $PATH by having the following line your ~/.zshenv or #{shell_profile}: 
+        export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
       To support package version per session using asdf shell <name> <version>
-      Add the following line to your ~/.bash_profile or ~/.zshrc file:
+      Add the following line to your #{shell_profile} file:
         . #{opt_libexec}/lib/asdf.sh
       If you use Fish shell then add the following line to your ~/.config/fish/config.fish:
         . #{opt_libexec}/lib/asdf.fish

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -19,7 +19,7 @@ class Asdf < Formula
     touch libexec/"asdf_updates_disabled"
     bin.write_exec_script (opt_libexec/"bin/asdf")
     (prefix/"asdf.sh").write ". #{opt_libexec}/asdf.sh\n"
-    (prefix/"asdf.fish").write ". #{opt_libexec}/asdf.fish\n"
+    (prefix/"asdf.fish").write "source #{opt_libexec}/asdf.fish\n"
   end
 
   def post_install
@@ -28,14 +28,14 @@ class Asdf < Formula
 
   def caveats
     <<~EOS
-      Add shims in $PATH by having the following line your #{shell_profile} or ~/.zshenv:
+      Add shims in $PATH by having the following line your ~/.zshenv or #{shell_profile}:
         export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
       To support package version per session using asdf shell <name> <version>
       Add the following line to your #{shell_profile} file:
         . #{opt_libexec}/lib/asdf.sh
       If you use Fish shell then add the following line to your ~/.config/fish/config.fish:
-        . #{opt_libexec}/lib/asdf.fish
+        source #{opt_libexec}/lib/asdf.fish
       Restart your terminal for the settings to take effect.
     EOS
   end

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -11,7 +11,6 @@ class Asdf < Formula
   depends_on "coreutils"
   depends_on "git"
 
-
   def install
     bash_completion.install "completions/asdf.bash"
     fish_completion.install "completions/asdf.fish"

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -13,8 +13,12 @@ class Asdf < Formula
     bash_completion.install "completions/asdf.bash"
     fish_completion.install "completions/asdf.fish"
     zsh_completion.install "completions/_asdf"
-    libexec.install Dir["*"]
-    bin.write_exec_script (libexec/"bin/asdf")
+    bin.write_exec_script (opt_libexec/"bin/asdf")
+    prefix.install_metafiles
+  end
+
+  def post_install
+  	system bin/"asdf", "reshim"
   end
 
   test do

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -30,12 +30,20 @@ class Asdf < Formula
     <<~EOS
       Add shims in $PATH by having the following line your ~/.zshenv or #{shell_profile}:
         export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+      If you use Fish shell add the following line to your ~/.config/fish/config.fish:
+      	set PATH (
+		      if test -n "$ASDF_DATA_DIR"
+		        echo $ASDF_DATA_DIR/shims
+		      else
+		        echo $HOME/.asdf/shims
+		      end
+		    ) $PATH
 
       To support package version per session using asdf shell <name> <version>
-      Add the following line to your #{shell_profile} file:
-        . #{opt_libexec}/lib/asdf.sh
-      If you use Fish shell then add the following line to your ~/.config/fish/config.fish:
-        source #{opt_libexec}/lib/asdf.fish
+	      Add the following line to your #{shell_profile} file:
+    	    . #{opt_libexec}/lib/asdf.sh
+	      If you use Fish shell add the following line to your ~/.config/fish/config.fish:
+    	    source #{opt_libexec}/lib/asdf.fish
       Restart your terminal for the settings to take effect.
     EOS
   end

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -28,7 +28,7 @@ class Asdf < Formula
 
   def caveats
     <<~EOS
-      Add shims in $PATH by having the following line your ~/.zshenv or #{shell_profile}:
+      Add shims in $PATH by having the following line your #{shell_profile}:
         export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
       If you use Fish shell add the following line to your ~/.config/fish/config.fish:
         set PATH (

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -18,14 +18,28 @@ class Asdf < Formula
     libexec.install Dir["*"]
     touch libexec/"asdf_updates_disabled"
     bin.write_exec_script (opt_libexec/"bin/asdf")
-    (prefix/"asdf.sh").write "source #{opt_libexec}/asdf.sh\n"
-    (prefix/"asdf.fish").write "source #{opt_libexec}/asdf.fish\n"
+    (prefix/"asdf.sh").write ". #{opt_libexec}/asdf.sh\n"
+    (prefix/"asdf.fish").write ". #{opt_libexec}/asdf.fish\n"
   end
 
   def post_install
     system bin/"asdf", "reshim"
   end
 
+  def caveats
+    <<~EOS
+      Add shims in $PATH by having the following line your ~/.zshenv or ~/bash_profile: 
+        export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"
+
+      To support package version per session using asdf shell <name> <version>
+      Add the following line to your ~/.bash_profile or ~/.zshrc file:
+        . #{opt_libexec}/lib/asdf.sh
+      If you use Fish shell then add the following line to your ~/.config/fish/config.fish:
+        . #{opt_libexec}/lib/asdf.fish
+      Restart your terminal for the settings to take effect.
+    EOS
+  end
+        
   test do
     output = shell_output("#{bin}/asdf plugin-list 2>&1", 1)
     assert_match "Oohes nooes ~! No plugins installed", output

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -31,19 +31,19 @@ class Asdf < Formula
       Add shims in $PATH by having the following line your ~/.zshenv or #{shell_profile}:
         export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
       If you use Fish shell add the following line to your ~/.config/fish/config.fish:
-      	set PATH (
-		      if test -n "$ASDF_DATA_DIR"
-		        echo $ASDF_DATA_DIR/shims
-		      else
-		        echo $HOME/.asdf/shims
-		      end
-		    ) $PATH
+        set PATH (
+          if test -n "$ASDF_DATA_DIR"
+            echo $ASDF_DATA_DIR/shims
+          else
+            echo $HOME/.asdf/shims
+          end
+        ) $PATH
 
       To support package version per session using asdf shell <name> <version>
-	      Add the following line to your #{shell_profile} file:
-    	    . #{opt_libexec}/lib/asdf.sh
-	      If you use Fish shell add the following line to your ~/.config/fish/config.fish:
-    	    source #{opt_libexec}/lib/asdf.fish
+          Add the following line to your #{shell_profile} file:
+            . #{opt_libexec}/lib/asdf.sh
+          If you use Fish shell add the following line to your ~/.config/fish/config.fish:
+            source #{opt_libexec}/lib/asdf.fish
       Restart your terminal for the settings to take effect.
     EOS
   end

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -13,6 +13,8 @@ class Asdf < Formula
     bash_completion.install "completions/asdf.bash"
     fish_completion.install "completions/asdf.fish"
     zsh_completion.install "completions/_asdf"
+    libexec.install Dir["*"]
+    touch libexec/"asdf_updates_disabled"
     bin.write_exec_script (opt_libexec/"bin/asdf")
   end
 

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -18,6 +18,8 @@ class Asdf < Formula
     libexec.install Dir["*"]
     touch libexec/"asdf_updates_disabled"
     bin.write_exec_script (opt_libexec/"bin/asdf")
+    (prefix/"asdf.sh").write "source #{opt_libexec}/asdf.sh\n"
+    (prefix/"asdf.fish").write "source #{opt_libexec}/asdf.fish\n"
   end
 
   def post_install

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -17,7 +17,7 @@ class Asdf < Formula
   end
 
   def post_install
-  	system bin/"asdf", "reshim"
+    system bin/"asdf", "reshim"
   end
 
   test do

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -8,6 +8,9 @@ class Asdf < Formula
   head "https://github.com/asdf-vm/asdf.git"
 
   bottle :unneeded
+  
+  depends_on "git"
+  depends_on "coreutils"
 
   def install
     bash_completion.install "completions/asdf.bash"

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -8,9 +8,9 @@ class Asdf < Formula
   head "https://github.com/asdf-vm/asdf.git"
 
   bottle :unneeded
-  
-  depends_on "git"
   depends_on "coreutils"
+  depends_on "git"
+
 
   def install
     bash_completion.install "completions/asdf.bash"

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -28,7 +28,7 @@ class Asdf < Formula
 
   def caveats
     <<~EOS
-      Add shims in $PATH by having the following line your ~/.zshenv or #{shell_profile}: 
+      Add shims in $PATH by having the following line your #{shell_profile} or ~/.zshenv:
         export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
       To support package version per session using asdf shell <name> <version>
@@ -39,7 +39,7 @@ class Asdf < Formula
       Restart your terminal for the settings to take effect.
     EOS
   end
-        
+
   test do
     output = shell_output("#{bin}/asdf plugin-list 2>&1", 1)
     assert_match "Oohes nooes ~! No plugins installed", output

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -4,7 +4,7 @@ class Asdf < Formula
   url "https://github.com/asdf-vm/asdf/archive/v0.8.0.tar.gz"
   sha256 "9b667ca135c194f38d823c62cc0dc3dbe00d7a9f60caa0c06ecb3047944eadfa"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/asdf-vm/asdf.git"
 
   bottle :unneeded
@@ -25,8 +25,8 @@ class Asdf < Formula
     bash_completion.install "completions/asdf.bash"
     fish_completion.install "completions/asdf.fish"
     zsh_completion.install "completions/_asdf"
-    libexec.install "bin/private"
-    prefix.install Dir["*"]
+    libexec.install Dir["*"]
+    bin.write_exec_script (libexec/"bin/asdf")
     touch prefix/"asdf_updates_disabled"
   end
 

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -15,7 +15,6 @@ class Asdf < Formula
     zsh_completion.install "completions/_asdf"
     libexec.install Dir["*"]
     bin.write_exec_script (libexec/"bin/asdf")
-    touch prefix/"asdf_updates_disabled"
   end
 
   test do

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -9,15 +9,6 @@ class Asdf < Formula
 
   bottle :unneeded
 
-  depends_on "autoconf"
-  depends_on "automake"
-  depends_on "coreutils"
-  depends_on "libtool"
-  depends_on "libyaml"
-  depends_on "openssl@1.1"
-  depends_on "readline"
-  depends_on "unixodbc"
-
   conflicts_with "homeshick",
     because: "asdf and homeshick both install files in lib/commands"
 

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -9,9 +9,6 @@ class Asdf < Formula
 
   bottle :unneeded
 
-  conflicts_with "homeshick",
-    because: "asdf and homeshick both install files in lib/commands"
-
   def install
     bash_completion.install "completions/asdf.bash"
     fish_completion.install "completions/asdf.fish"


### PR DESCRIPTION
### Changes
* Installing under libexec to maintain relative paths for sourcing scripts. 
* No longer installing files under `lib`
* Binary in `/usr/local/bin/` will point to `/usr/local/opt/asdf/libexec/bin/asdf` to keep the shims from breaking on updates. 
* Caveat added for new users to:
  * Optionally sourcing `asdf/libexec/lib/asdf.sh` if needing `$ asdf shell <package> <version>`
  * Export shims in`$PATH` since `asdf/libexec/lib/asdf.sh` does not do that. As opposed to `asdf/libexec/asdf.sh`
* With [changes](https://github.com/Homebrew/homebrew-core/pull/73173#discussion_r597160016) suggested by @cho-m 
  * Existing shims will not break, will instead having a layer of indirection. New shims will not do that. 
  * Current sourcing of `asdf/asdf.sh` will not break as it points to `asdf/libexec/asdf.sh`
  * Existing users do not need to update their `$PATH` if they are currently sourcing `asdf/asdf.sh` as it points to `asdf/libexec/asdf.sh`


### Migration
No need with migration for existing installation.
So, existing solutions such as `source "$(brew --prefix asdf)/asdf.sh"`  will work fine


But can also add shim manually to `$PATH` 
and optionally do `source "$(brew --prefix asdf)/libexec/lib/asdf.sh"` for `$ asdf shell <package> <version>`


### Caveat

The caveat currently pending review mentions the "newer" approach, it's not necessary to follow through for current users. 
Updating `$PATH` => **Mandatory**
Sourcing `libexec/lib/asdf.sh"` => **Optional**

```ruby
  def caveats
    <<~EOS
      Add shims in $PATH by having the following line your ~/.zshenv or #{shell_profile}:
        export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"

      To support package version per session using asdf shell <name> <version>
      Add the following line to your #{shell_profile} file:
         . #{opt_libexec}/lib/asdf.sh
      Restart your terminal for the settings to take effect.
    EOS
  end
```

### Relevant PR(s):
*Code*
https://github.com/asdf-vm/asdf/pull/897 
*Documentation*
https://github.com/asdf-vm/asdf/pull/898



### Motivation 
1) asdf should not create symlinks to `/usr/local/lib`
2) asdf should not require sourcing a file in order to display `asdf help` after installing. 
3) asdf should not require sourcing a file that modifies `$PATH`, instead expect users themselves to define what's needed in ENV variables, if that's a custom `asdf` directory, or setting their shims directory under `$PATH`, for zsh that would fall under `.zshenv` and not `.zshrc`. 


If a user can't call `asdf help` without getting an error after installing it without additional configuration, then I consider it a bug. 
There are situations where additional setup is mandatory, like databases, but asdf is and should not be treated as such
Beyond that, the current Homebrew formula for a what essentially constitutes a collection of shell script that depend on each other is implemented wrong. 
**This is the most important take away from this.** 

Fixing:
https://github.com/asdf-vm/asdf/issues/785
https://github.com/asdf-vm/asdf/issues/891
https://github.com/asdf-vm/asdf/issues/607
https://github.com/asdf-vm/asdf/issues/394
https://github.com/asdf-vm/asdf/issues/428

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
