### PR TITLE
babeld: align test with linux

### DIFF
--- a/Formula/babeld.rb
+++ b/Formula/babeld.rb
@@ -32,10 +32,6 @@ class Babeld < Formula
 
   test do
     shell_output("#{bin}/babeld -I #{testpath}/test.pid -L #{testpath}/test.log", 1)
-    expected = <<~EOS
-      Couldn't tweak forwarding knob.: Operation not permitted
-      kernel_setup failed.
-    EOS
-    assert_equal expected, (testpath/"test.log").read
+    assert_match "kernel_setup failed", (testpath/"test.log").read
   end
 end


### PR DESCRIPTION
The linux test outputs:
Couldn't write sysctl: Read-only file system
kernel_setup failed

which is slightly different from the mac output.
Let's just check for the last part of the message which is
the same.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
