### PR TITLE
cassandra-cpp-driver: set libuv root path

### DIFF
--- a/Formula/cassandra-cpp-driver.rb
+++ b/Formula/cassandra-cpp-driver.rb
@@ -24,7 +24,7 @@ class CassandraCppDriver < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", *std_cmake_args, "-DLIBUV_ROOT_DIR=#{Formula["libuv"].opt_prefix}"
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
Fixes (on linux):
Could NOT find libuv, try to set the path to libuv root folder in the system variable LIBUV_ROOT_DIR (missing: LIBUV_INCLUDE_DIR)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
