### PR TITLE
git 2.31.0

### DIFF
--- a/Formula/git-gui.rb
+++ b/Formula/git-gui.rb
@@ -2,8 +2,8 @@ class GitGui < Formula
   desc "Tcl/Tk UI for the git revision control system"
   homepage "https://git-scm.com"
   # NOTE: Please keep these values in sync with git.rb when updating.
-  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.30.2.tar.xz"
-  sha256 "41f7d90c71f9476cd387673fcb10ce09ccbed67332436a4cc58d7af32c355faa"
+  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.31.0.tar.xz"
+  sha256 "e8f162cbdb3283e13cd7388d864ed23485f1b046a19e969f12ed2685fb789a40"
   license "GPL-2.0-only"
   head "https://github.com/git/git.git", shallow: false
 

--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -2,8 +2,8 @@ class Git < Formula
   desc "Distributed revision control system"
   homepage "https://git-scm.com"
   # NOTE: Please keep these values in sync with git-gui.rb when updating.
-  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.30.2.tar.xz"
-  sha256 "41f7d90c71f9476cd387673fcb10ce09ccbed67332436a4cc58d7af32c355faa"
+  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.31.0.tar.xz"
+  sha256 "e8f162cbdb3283e13cd7388d864ed23485f1b046a19e969f12ed2685fb789a40"
   license "GPL-2.0-only"
   head "https://github.com/git/git.git", shallow: false
 
@@ -23,13 +23,13 @@ class Git < Formula
   depends_on "pcre2"
 
   resource "html" do
-    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-htmldocs-2.30.2.tar.xz"
-    sha256 "29b8ab81966ec7c1a3ed47fb7fe23f0b78289c18d11d58c0dc8749613e0419dc"
+    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-htmldocs-2.31.0.tar.xz"
+    sha256 "2ff3c0403870c3f02cdd46af1cd749b0c5d7826bfe00bee09ba1d0c2f19f554b"
   end
 
   resource "man" do
-    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-2.30.2.tar.xz"
-    sha256 "5e64ace225e6dd0749b09c7adce765a538a922699c8997421ee255c3165e2aaa"
+    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-2.31.0.tar.xz"
+    sha256 "185ddcbc31ae6b8d33c3ab78f6022ee6cc79dd867c1b2e5c3767821124e780ec"
   end
 
   resource "Net::SMTP::SSL" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

```
❯ brew install --build-from-source Formula/git.rb
Error: Failed to load cask: Formula/git.rb
Cask 'git' is unreadable: wrong constant name #<Class:0x00007fe064263120>
Warning: Treating Formula/git.rb as a formula.
==> Downloading https://mirrors.edge.kernel.org/pub/software/scm/git/git-htmldocs-2.31.0.tar.xz
######################################################################## 100.0%
==> Downloading https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-2.31.0.tar.xz
######################################################################## 100.0%
==> Downloading https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Net-SMTP-SSL-1.04.tar.gz
Already downloaded: /Users/jef.lecompte/Library/Caches/Homebrew/downloads/0726c68dac390b617cefcc880f076b50795463c1fba286d46a53082ebed2bc9d--Net-SMTP-SSL-1.04.tar.gz
==> Downloading https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.31.0.tar.xz
######################################################################## 100.0%
==> make install prefix=/usr/local/Cellar/git/2.31.0 sysconfdir=/usr/local/etc CC=clang CFLAGS= LDFLAGS= NO_TCLTK=1 NO_OPENSSL=1 APPLE_COMMON_CRYPTO=1
==> make CC=clang CFLAGS= LDFLAGS=
==> make clean
==> make
==> make test
==> make CC=clang CFLAGS= LDFLAGS=
==> Caveats
The Tcl/Tk GUIs (e.g. gitk, git-gui) are now in the `git-gui` formula.

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completions and functions have been installed to:
  /usr/local/share/zsh/site-functions

Emacs Lisp files have been installed to:
  /usr/local/share/emacs/site-lisp/git
==> Summary
🍺  /usr/local/Cellar/git/2.31.0: 1,505 files, 41MB, built in 1 minute 11 seconds
```

```
❯ brew test Formula/git.rb
==> Testing git
==> /usr/local/Cellar/git/2.31.0/bin/git init
==> /usr/local/Cellar/git/2.31.0/bin/git add haunted house
==> /usr/local/Cellar/git/2.31.0/bin/git config user.name 'A U Thor'
==> /usr/local/Cellar/git/2.31.0/bin/git config user.email author@example.com
==> /usr/local/Cellar/git/2.31.0/bin/git commit -a -m Initial Commit
==> /usr/local/Cellar/git/2.31.0/bin/git ls-files
==> /usr/local/Cellar/git/2.31.0/bin/git add foo bar
==> /usr/local/Cellar/git/2.31.0/bin/git commit -a -m Second Commit
==> /usr/local/Cellar/git/2.31.0/bin/git send-email --from=test@example.com --to=dev@null.com --smtp-server=smtp.gmail.com --smtp-server-port=587 --smtp-encrypt
```

```
❯ brew audit --strict ./Formula/git.rb
Error: Failed to load cask: ./Formula/git.rb
Cask 'git' is unreadable: wrong constant name #<Class:0x00007fe34eb2cda0>
Warning: Treating ./Formula/git.rb as a formula.
```

```
❯ git --version
git version 2.31.0
```