### PR TITLE
lttng-ust 2.12.1 (new formula)

### DIFF
--- a/.github/workflows/linux-pr-tests.yml
+++ b/.github/workflows/linux-pr-tests.yml
@@ -25,6 +25,7 @@ on:
       - "Formula/libunwind.rb"
       - "Formula/libva.rb"
       - "Formula/linux-headers.rb"
+      - "Formula/lttng-ust.rb"
       - "Formula/numactl.rb"
       - "Formula/strace.rb"
       - "Formula/valgrind.rb"

--- a/Formula/lttng-ust.rb
+++ b/Formula/lttng-ust.rb
@@ -1,0 +1,22 @@
+class LttngUst < Formula
+  desc "Linux Trace Toolkit Next Generation Userspace Tracer"
+  homepage "https://lttng.org/"
+  url "https://lttng.org/files/lttng-ust/lttng-ust-2.12.1.tar.bz2"
+  sha256 "48a3948b168195123a749d22818809bd25127bb5f1a66458c3c012b210d2a051"
+  license all_of: ["LGPL-2.1-only", "MIT", "GPL-2.0-only", "BSD-3-Clause", "BSD-2-Clause", "GPL-3.0-or-later"]
+
+  depends_on :linux
+  depends_on "numactl"
+  depends_on "userspace-rcu"
+
+  def install
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make", "install"
+  end
+
+  test do
+    cp_r (share/"doc/lttng-ust/examples/demo").children, testpath
+    system "make"
+    system "./demo"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`lttng-ust` is required by `dotnet` on Linux. Linuxbrew-core PR: https://github.com/Homebrew/linuxbrew-core/pull/22539

CI might fail for this PR as linuxbrew-core adds a compiler flag in the test block for `userspace-rcu`: https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/userspace-rcu.rb#L34