### PR TITLE
cloc: switch to upstream fix for manpage issue

### DIFF
--- a/Formula/cloc.rb
+++ b/Formula/cloc.rb
@@ -4,7 +4,7 @@ class Cloc < Formula
   url "https://github.com/AlDanial/cloc/archive/1.88.tar.gz"
   sha256 "e85c2d1b3ec389d892955cf20b3fa5c797e81136e231d9a09e4f4c62e272f8cd"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/AlDanial/cloc.git"
 
   bottle do
@@ -65,6 +65,12 @@ class Cloc < Formula
     end
   end
 
+  # Needed to fix https://github.com/AlDanial/cloc/issues/571 in 1.88
+  patch do
+    url "https://github.com/AlDanial/cloc/commit/32d0a28f44fc8687fd5dbfc94e9b197cc68b7f60.patch?full_index=1"
+    sha256 "eee7e728802b6e95768e6290e2d8f5f9b63242186b35b8c94a2ef405f911e63d"
+  end
+
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
@@ -79,9 +85,7 @@ class Cloc < Formula
       end
     end
 
-    # Passing in $(PODDATE) needed to work around https://github.com/AlDanial/cloc/issues/571
-    # in 1.88; remove when fixed.
-    system "make", "-C", "Unix", "prefix=#{libexec}", "PODDATE=2020-09-12", "install"
+    system "make", "-C", "Unix", "prefix=#{libexec}", "install"
     bin.install libexec/"bin/cloc"
     bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
     man1.install libexec/"share/man/man1/cloc.1"


### PR DESCRIPTION
A couple weeks ago I submitted #72358 to workaround a user-reported bug in the manpage generation (#72328)  Since then the upstream project has fixed the issue in their git repo.

Let's switch to using their official fix since it's less likely to be accidentally left behind when this formula next gets a version bump.
