### PR TITLE
grpc: use tarball instead of git checkout

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -1,10 +1,8 @@
 class Grpc < Formula
   desc "Next generation open source RPC library and framework"
   homepage "https://grpc.io/"
-  url "https://github.com/grpc/grpc.git",
-      tag:      "v1.36.3",
-      revision: "ce05bf557ced2d311bad8ee520f9f8088f715bd8",
-      shallow:  false
+  url "https://github.com/grpc/grpc/archive/v1.36.3.tar.gz"
+  sha256 "bb6de0544adddd54662ba1c314eff974e84c955c39204a4a2b733ccd990354b7"
   license "Apache-2.0"
   head "https://github.com/grpc/grpc.git"
 
@@ -23,6 +21,8 @@ class Grpc < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "cmake" => :build
+  depends_on "googletest" => :build unless Hardware::CPU.arm?
+  depends_on "google-benchmark" => :build unless Hardware::CPU.arm?
   depends_on "libtool" => :build
   depends_on "pkg-config" => :test
   depends_on "abseil"
@@ -64,6 +64,7 @@ class Grpc < Formula
           -DCMAKE_INSTALL_RPATH=#{lib}
           -DBUILD_SHARED_LIBS=ON
           -DgRPC_BUILD_TESTS=ON
+          -DgRPC_BENCHMARK_PROVIDER=package
         ] + std_cmake_args
         system "cmake", *args
         system "make", "grpc_cli"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Using a git checkout was introduced in 120d4814f71b34f47b79cb90c869caf145d376bd
to address build failures due to missing dependencies.

I don't think this formula is missing any dependencies any longer, so
let's try to build it directly from the tarball.