### PR TITLE
mpich: switched back to clang

### DIFF
--- a/Formula/mpich.rb
+++ b/Formula/mpich.rb
@@ -5,6 +5,7 @@ class Mpich < Formula
   mirror "https://fossies.org/linux/misc/mpich-3.4.1.tar.gz"
   sha256 "8836939804ef6d492bcee7d54abafd6477d2beca247157d92688654d13779727"
   license "mpich2"
+  revision 1
 
   livecheck do
     url "https://www.mpich.org/static/downloads/"
@@ -54,8 +55,6 @@ class Mpich < Formula
                           "--enable-shared",
                           "--enable-sharedlibs=gcc-osx",
                           "--with-pm=hydra",
-                          "CC=gcc-#{Formula["gcc"].any_installed_version.major}",
-                          "CXX=g++-#{Formula["gcc"].any_installed_version.major}",
                           "FC=gfortran-#{Formula["gcc"].any_installed_version.major}",
                           "F77=gfortran-#{Formula["gcc"].any_installed_version.major}",
                           "--disable-silent-rules",

--- a/Formula/mpich.rb
+++ b/Formula/mpich.rb
@@ -53,7 +53,6 @@ class Mpich < Formula
                           "--enable-g=dbg",
                           "--enable-romio",
                           "--enable-shared",
-                          "--enable-sharedlibs=gcc-osx",
                           "--with-pm=hydra",
                           "FC=gfortran-#{Formula["gcc"].any_installed_version.major}",
                           "F77=gfortran-#{Formula["gcc"].any_installed_version.major}",


### PR DESCRIPTION
Restores initial behavior of using system clang and not gcc-10 as the C compiler

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
