### PR TITLE
sdl2_{gfx,mixer,net,ttf}: add license

### DIFF
--- a/Formula/sdl2_gfx.rb
+++ b/Formula/sdl2_gfx.rb
@@ -4,6 +4,7 @@ class Sdl2Gfx < Formula
   url "https://www.ferzkopp.net/Software/SDL2_gfx/SDL2_gfx-1.0.4.tar.gz"
   mirror "https://sources.voidlinux.org/SDL2_gfx-1.0.4/SDL2_gfx-1.0.4.tar.gz"
   sha256 "63e0e01addedc9df2f85b93a248f06e8a04affa014a835c2ea34bfe34e576262"
+  license "Zlib"
 
   livecheck do
     url :homepage

--- a/Formula/sdl2_mixer.rb
+++ b/Formula/sdl2_mixer.rb
@@ -3,6 +3,7 @@ class Sdl2Mixer < Formula
   homepage "https://www.libsdl.org/projects/SDL_mixer/"
   url "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.tar.gz"
   sha256 "b4cf5a382c061cd75081cf246c2aa2f9df8db04bdda8dcdc6b6cca55bede2419"
+  license "Zlib"
   head "https://hg.libsdl.org/SDL_mixer", using: :hg
 
   livecheck do

--- a/Formula/sdl2_net.rb
+++ b/Formula/sdl2_net.rb
@@ -3,6 +3,7 @@ class Sdl2Net < Formula
   homepage "https://www.libsdl.org/projects/SDL_net/"
   url "https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.0.1.tar.gz"
   sha256 "15ce8a7e5a23dafe8177c8df6e6c79b6749a03fff1e8196742d3571657609d21"
+  license "Zlib"
 
   livecheck do
     url :homepage

--- a/Formula/sdl2_ttf.rb
+++ b/Formula/sdl2_ttf.rb
@@ -3,6 +3,7 @@ class Sdl2Ttf < Formula
   homepage "https://www.libsdl.org/projects/SDL_ttf/"
   url "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.15.tar.gz"
   sha256 "a9eceb1ad88c1f1545cd7bd28e7cbc0b2c14191d40238f531a15b01b1b22cd33"
+  license "Zlib"
   head "https://hg.libsdl.org/SDL_ttf", using: :hg
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The license is the same as `sdl2`:

https://github.com/Homebrew/homebrew-core/blob/4add7553398a38944569c68ff794efc0a1503043/Formula/sdl2.rb#L1-L6

```
/*
  SDL_ttf:  A companion library to SDL for working with TrueType (tm) fonts
  Copyright (C) 1997-2019 Sam Lantinga <slouken@libsdl.org>

  This software is provided 'as-is', without any express or implied
  warranty.  In no event will the authors be held liable for any damages
  arising from the use of this software.

  Permission is granted to anyone to use this software for any purpose,
  including commercial applications, and to alter it and redistribute it
  freely, subject to the following restrictions:

  1. The origin of this software must not be misrepresented; you must not
     claim that you wrote the original software. If you use this software
     in a product, an acknowledgment in the product documentation would be
     appreciated but is not required.
  2. Altered source versions must be plainly marked as such, and must not be
     misrepresented as being the original software.
  3. This notice may not be removed or altered from any source distribution.
*/
```

https://spdx.org/licenses/Zlib.html

See also #73293.