### PR TITLE
formula_renames: libsasl2 -> cyrus-sasl

### DIFF
--- a/formula_renames.json
+++ b/formula_renames.json
@@ -77,6 +77,7 @@
   "letsencrypt": "certbot",
   "libcppa": "caf",
   "libmongoclient": "mongo-cxx-driver",
+  "libsasl2": "cyrus-sasl",
   "lua51": "lua@5.1",
   "mat": "mat2",
   "maven32": "maven@3.2",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`libsasl2` is currently a linux-only formula in linuxbrew-core. Those 2 formulae are the same. So rename let's rename it here and delete the formula from linuxbrew-core after that (it isn't used by anything anymore).