### PR TITLE
libsvg: update license

### DIFF
--- a/Formula/libsvg.rb
+++ b/Formula/libsvg.rb
@@ -3,7 +3,7 @@ class Libsvg < Formula
   homepage "https://cairographics.org/"
   url "https://cairographics.org/snapshots/libsvg-0.1.4.tar.gz"
   sha256 "4c3bf9292e676a72b12338691be64d0f38cd7f2ea5e8b67fbbf45f1ed404bc8f"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
   revision 1
 
   livecheck do


### PR DESCRIPTION
Nearly all the files with a license annotation indicate
`LGPLG-2.1-or-later`. For example, in `src/svg.c`:

    /* libsvg - Library for parsing/rendering SVG documents

       Copyright © 2002 USC/Information Sciences Institute

       This program is free software; you can redistribute it and/or
       modify it under the terms of the GNU Library General Public License as
       published by the Free Software Foundation; either version 2 of the
       License, or (at your option) any later version.

       This program is distributed in the hope that it will be useful,
       but WITHOUT ANY WARRANTY; without even the implied warranty of
       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
       Library General Public License for more details.

       You should have received a copy of the GNU Library General Public
       License along with this program; if not, write to the
       Free Software Foundation, Inc., 59 Temple Place - Suite 330,
       Boston, MA 02111-1307, USA.

       Author: Carl Worth <cworth@isi.edu>
    */

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?