### PR TITLE
Bump htslib, bcftools, and samtools to 1.12

### DIFF
--- a/Formula/bcftools.rb
+++ b/Formula/bcftools.rb
@@ -1,9 +1,11 @@
 class Bcftools < Formula
   desc "Tools for BCF/VCF files and variant calling from samtools"
   homepage "https://www.htslib.org/"
-  url "https://github.com/samtools/bcftools/releases/download/1.11/bcftools-1.11.tar.bz2"
-  sha256 "3ceee47456ec481f34fa6c34beb6fe892b5b365933191132721fdf126e45a064"
-  license "MIT"
+  url "https://github.com/samtools/bcftools/releases/download/1.12/bcftools-1.12.tar.bz2"
+  sha256 "7a0e6532b1495b9254e38c6698d955e5176c1ee08b760dfea2235ee161a024f5"
+  # The bcftools source code is MIT/Expat-licensed, but when it is configured
+  # with --enable-libgsl the resulting executable is GPL-licensed.
+  license "GPL-3.0-or-later"
 
   livecheck do
     url :stable
@@ -20,7 +22,6 @@ class Bcftools < Formula
 
   depends_on "gsl"
   depends_on "htslib"
-  depends_on "xz"
 
   def install
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/gsl.rb
+++ b/Formula/gsl.rb
@@ -4,7 +4,7 @@ class Gsl < Formula
   url "https://ftp.gnu.org/gnu/gsl/gsl-2.6.tar.gz"
   mirror "https://ftpmirror.gnu.org/gsl/gsl-2.6.tar.gz"
   sha256 "b782339fc7a38fe17689cb39966c4d821236c28018b6593ddb6fd59ee40786a8"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "b4d8687427eb3a7f951c211f5a0b8051ca0bbaf174e68265fb6619d43b282aeb"

--- a/Formula/htslib.rb
+++ b/Formula/htslib.rb
@@ -1,8 +1,8 @@
 class Htslib < Formula
   desc "C library for high-throughput sequencing data formats"
   homepage "https://www.htslib.org/"
-  url "https://github.com/samtools/htslib/releases/download/1.11/htslib-1.11.tar.bz2"
-  sha256 "cffadd9baa6fce27b8fe0b01a462b489f06a5433dfe92121f667f40f632538d7"
+  url "https://github.com/samtools/htslib/releases/download/1.12/htslib-1.12.tar.bz2"
+  sha256 "2280141b46e953ba4ae01b98335a84f8e6ccbdb6d5cdbab7f70ee4f7e3b6f4ca"
   license "MIT"
 
   livecheck do
@@ -27,11 +27,15 @@ class Htslib < Formula
   def install
     system "./configure", "--prefix=#{prefix}", "--enable-libcurl"
     system "make", "install"
-    pkgshare.install "test"
   end
 
   test do
-    sam = pkgshare/"test/ce#1.sam"
+    sam = testpath/"test.sam"
+    sam.write <<~EOS
+      @SQ	SN:chr1	LN:500
+      r1	0	chr1	100	0	4M	*	0	0	ATGC	ABCD
+      r2	0	chr1	200	0	4M	*	0	0	AATT	EFGH
+    EOS
     assert_match "SAM", shell_output("#{bin}/htsfile #{sam}")
     system "#{bin}/bgzip -c #{sam} > sam.gz"
     assert_predicate testpath/"sam.gz", :exist?

--- a/Formula/samtools.rb
+++ b/Formula/samtools.rb
@@ -1,8 +1,8 @@
 class Samtools < Formula
   desc "Tools for manipulating next-generation sequencing data"
   homepage "https://www.htslib.org/"
-  url "https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2"
-  sha256 "e283cebd6c1c49f0cf8a3ca4fa56e1d651496b4d2e42f80ab75991a9ece4e5b6"
+  url "https://github.com/samtools/samtools/releases/download/1.12/samtools-1.12.tar.bz2"
+  sha256 "6da3770563b1c545ca8bdf78cf535e6d1753d6383983c7929245d5dba2902dcb"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
Bump the three formulae, and also make minor improvements to _htslib.rb_ and _bcftools.rb_ as described in the commit messages.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

~~For bcftools, `audit --strict` complains that “GPL-3.0” should specify “-only” or “-or-later”. The bcftools source code is itself MIT/Expat-licensed, but when the executable is linked with the GNU Scientific Library, as it is here, the resulting executable is GPL-licensed. I have copied the license tag from _Formula/gsl.rb_, so determining whether both license tags should be only or or-later should really be done by someone knowledgable about GSL, e.g., brew's _Formula/gsl.rb_ maintainer.~~
