### PR TITLE
Aliases/pyqt5: symlink to pyqt@5

### DIFF
--- a/Aliases/pyqt5
+++ b/Aliases/pyqt5
@@ -1,1 +1,1 @@
-../Formula/pyqt.rb
+../Formula/pyqt@5.rb


### PR DESCRIPTION
It currently points to pyqt, which is pyqt@6.

Fixes #73409.