### PR TITLE
KDE formulas: remove "kde-" prefix 

### DIFF
--- a/Aliases/karchive
+++ b/Aliases/karchive
@@ -1,1 +1,0 @@
-../Formula/kde-karchive.rb

--- a/Aliases/kdoctools
+++ b/Aliases/kdoctools
@@ -1,1 +1,0 @@
-../Formula/kde-kdoctools.rb

--- a/Aliases/ki18n
+++ b/Aliases/ki18n
@@ -1,1 +1,0 @@
-../Formula/kde-ki18n.rb

--- a/Formula/extra-cmake-modules.rb
+++ b/Formula/extra-cmake-modules.rb
@@ -1,4 +1,4 @@
-class KdeExtraCmakeModules < Formula
+class ExtraCmakeModules < Formula
   desc "Extra modules and scripts for CMake"
   homepage "https://api.kde.org/frameworks/extra-cmake-modules/html/index.html"
   url "https://download.kde.org/stable/frameworks/5.79/extra-cmake-modules-5.79.0.tar.xz"
@@ -12,13 +12,6 @@ class KdeExtraCmakeModules < Formula
   livecheck do
     url :head
     regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
-  bottle do
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "b037f9a37b5602092d85b8af767ad3f46d970c295aff9bf4b55ca21ecdfd11c0"
-    sha256 cellar: :any_skip_relocation, big_sur:       "fc8d6944b8c8900f3fb464cc8f4589bec834d6b7ab9adbce8b380dcf8d7bc00b"
-    sha256 cellar: :any_skip_relocation, catalina:      "6461611d4f810ef660c4554eadb4f708fe1f952458d2cd374a8200e36895f1cc"
-    sha256 cellar: :any_skip_relocation, mojave:        "daccf07232ea1f687e2f20b0f86823f7ebf421da92f1f4e7608c5197f556ead4"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/karchive.rb
+++ b/Formula/karchive.rb
@@ -1,4 +1,4 @@
-class KdeKarchive < Formula
+class Karchive < Formula
   desc "Reading, creating, and manipulating file archives"
   homepage "https://api.kde.org/frameworks/karchive/html/index.html"
   url "https://download.kde.org/stable/frameworks/5.79/karchive-5.79.0.tar.xz"
@@ -12,17 +12,10 @@ class KdeKarchive < Formula
   revision 1
   head "https://invent.kde.org/frameworks/karchive.git"
 
-  bottle do
-    sha256 arm64_big_sur: "0b3b535f5402de3c1885d2064e1a56ad9724cd3cb9b03b7095bd1ace63f9c877"
-    sha256 big_sur:       "3e1b0e3b53f2879ba8eb38a04ae0b8530c26f6d411c45ff87366e4c55072e671"
-    sha256 catalina:      "1c0dfdc9b341296e4d6f3732207a6fd81497d9573471542ce1d0ea546c0ff435"
-    sha256 mojave:        "e8f81aeae13c7b409fb423074ed50da2a752e0ad7694921665f59e91bc9996d1"
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "doxygen" => :build
+  depends_on "extra-cmake-modules" => [:build, :test]
   depends_on "graphviz" => :build
-  depends_on "kde-extra-cmake-modules" => [:build, :test]
 
   depends_on "qt@5"
   depends_on "xz"

--- a/Formula/kdoctools.rb
+++ b/Formula/kdoctools.rb
@@ -1,4 +1,4 @@
-class KdeKdoctools < Formula
+class Kdoctools < Formula
   desc "Create documentation from DocBook"
   homepage "https://api.kde.org/frameworks/kdoctools/html/index.html"
   url "https://download.kde.org/stable/frameworks/5.79/kdoctools-5.79.0.tar.xz"
@@ -12,21 +12,14 @@ class KdeKdoctools < Formula
   revision 1
   head "https://invent.kde.org/frameworks/kdoctools.git"
 
-  bottle do
-    sha256 arm64_big_sur: "a0dda5a815bee9fb1dda9d0ff3e7403bd98f3829b4d212d8530da3759ae3c324"
-    sha256 big_sur:       "1a0d37dccc89e6cb718310025b98dffb8f17f968eb3990d068dd84732516a86a"
-    sha256 catalina:      "8392330a5b273dece3886f0bb7e2b4fe1c2a02ca61d00822127335c51d8072b0"
-    sha256 mojave:        "7e07c4f0dcae593a2a8aec84484360c581d8a244aea39660075f4c30a3362175"
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "docbook-xsl" => [:build, :test]
   depends_on "doxygen" => :build
+  depends_on "extra-cmake-modules" => [:build, :test]
   depends_on "gettext" => :build
-  depends_on "kde-extra-cmake-modules" => [:build, :test]
-  depends_on "kde-ki18n" => :build
+  depends_on "ki18n" => :build
 
-  depends_on "kde-karchive"
+  depends_on "karchive"
 
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"

--- a/Formula/ki18n.rb
+++ b/Formula/ki18n.rb
@@ -1,4 +1,4 @@
-class KdeKi18n < Formula
+class Ki18n < Formula
   desc "KDE Gettext-based UI text internationalization"
   homepage "https://api.kde.org/frameworks/ki18n/html/index.html"
   url "https://download.kde.org/stable/frameworks/5.79/ki18n-5.79.0.tar.xz"
@@ -11,17 +11,10 @@ class KdeKi18n < Formula
   revision 1
   head "https://invent.kde.org/frameworks/ki18n.git"
 
-  bottle do
-    sha256 arm64_big_sur: "3ebf24ce99afed3f6d8bc8127321611413fd88f5ccac67bd54ebfd5bfd97110d"
-    sha256 big_sur:       "3fab49671721c2ae1ef5dbeb4f39930d81dc0b9f4dc5b53e264ed43edd70b209"
-    sha256 catalina:      "99f6a40be017e93847a60d571b5493b124d132920de2d8bdf4a2d6fd2bfbe4f1"
-    sha256 mojave:        "40bab468d976d14924e62eb899f8b3300505960a51001d3bc2ed9348358d0d7d"
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "doxygen" => :build
+  depends_on "extra-cmake-modules" => [:build, :test]
   depends_on "graphviz" => :build
-  depends_on "kde-extra-cmake-modules" => [:build, :test]
   depends_on "gettext"
   depends_on "qt@5"
 

--- a/Formula/threadweaver.rb
+++ b/Formula/threadweaver.rb
@@ -1,4 +1,4 @@
-class KdeThreadweaver < Formula
+class Threadweaver < Formula
   desc "Helper for multithreaded programming"
   homepage "https://api.kde.org/frameworks/threadweaver/html/index.html"
   url "https://download.kde.org/stable/frameworks/5.79/threadweaver-5.79.0.tar.xz"
@@ -7,17 +7,10 @@ class KdeThreadweaver < Formula
   revision 1
   head "https://invent.kde.org/frameworks/threadweaver.git"
 
-  bottle do
-    sha256 arm64_big_sur: "4e2cc8b16301bc9e2fc14fda3748bf5c6806f1a5354fd8975bffe543afd609ac"
-    sha256 big_sur:       "14e86bf2b254bf6cc4a03eef9ce8fd440172befc09987963c06490bc5fb71475"
-    sha256 catalina:      "4ed11a2a30e6c38fb227c7b0177e7759c155320d4b3dd7de9a64386f3fbf9ed4"
-    sha256 mojave:        "47d34ce1fc476cbbbad3c8d7344a202a3169d450163e33cbf8d389dcf5f4bcf9"
-  end
-
   depends_on "cmake" => [:build, :test]
   depends_on "doxygen" => :build
+  depends_on "extra-cmake-modules" => [:build, :test]
   depends_on "graphviz" => :build
-  depends_on "kde-extra-cmake-modules" => [:build, :test]
   depends_on "qt@5"
 
   def install

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -72,6 +72,7 @@
   "kde-karchive": "karchive",
   "kde-kdoctools": "kdoctools",
   "kde-ki18n": "ki18n",
+  "kde-threadweaver": "threadweaver",
   "kibana@6.8": "kibana@6",
   "kibana@7.8": "kibana@7",
   "kotlin-compiler": "kotlin",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -70,6 +70,7 @@
   "jupyter": "jupyterlab",
   "kde-extra-cmake-modules": "extra-cmake-modules",
   "kde-karchive": "karchive",
+  "kde-kdoctools": "kdoctools",
   "kde-ki18n": "ki18n",
   "kibana@6.8": "kibana@6",
   "kibana@7.8": "kibana@7",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -70,6 +70,7 @@
   "jupyter": "jupyterlab",
   "kde-extra-cmake-modules": "extra-cmake-modules",
   "kde-karchive": "karchive",
+  "kde-ki18n": "ki18n",
   "kibana@6.8": "kibana@6",
   "kibana@7.8": "kibana@7",
   "kotlin-compiler": "kotlin",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -68,6 +68,7 @@
   "juju2": "juju",
   "juju@2.0": "juju",
   "jupyter": "jupyterlab",
+  "kde-extra-cmake-modules": "extra-cmake-modules",
   "kibana@6.8": "kibana@6",
   "kibana@7.8": "kibana@7",
   "kotlin-compiler": "kotlin",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -69,6 +69,7 @@
   "juju@2.0": "juju",
   "jupyter": "jupyterlab",
   "kde-extra-cmake-modules": "extra-cmake-modules",
+  "kde-karchive": "karchive",
   "kibana@6.8": "kibana@6",
   "kibana@7.8": "kibana@7",
   "kotlin-compiler": "kotlin",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As discussed in https://github.com/Homebrew/homebrew-core/pull/73032#discussion_r594283101 , I am submitting a PR to rename KDE formulas.