### PR TITLE
hueadm 1.2.0 (new formula)

### DIFF
--- a/Formula/hueadm.rb
+++ b/Formula/hueadm.rb
@@ -1,0 +1,20 @@
+require "language/node"
+
+class Hueadm < Formula
+  desc "Command-line management interface to phillips hue"
+  homepage "https://github.com/bahamas10/hueadm"
+  url "https://registry.npmjs.org/hueadm/-/hueadm-1.2.0.tgz"
+  sha256 "8b5936a84f112ce1d1ca9a2a917223755413e3dfa3854088fb4f2c01e2470e72"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match "ECONNREFUSED", shell_output("#{bin}/hueadm -U test -H 127.0.0.1 rules 2>&1", 1)
+  end
+end


### PR DESCRIPTION
Installs the node-based hueadm utility, a command-line
interface to Philips Hue smart home hubs.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
