### PR TITLE
qscintilla2: update livecheck

### DIFF
--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -7,7 +7,7 @@ class Qscintilla2 < Formula
 
   livecheck do
     url "https://www.riverbankcomputing.com/software/qscintilla/download"
-    regex(/href=.*?QScintilla(?:.gpl)?[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?QScintilla(?:[._-](?:gpl|src))?[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `qscintilla2` to match a new file name format that has appeared. The existing `livecheck` block isn't matching the latest version on the first-party download page, as the file name is `QScintilla_src-2.12.1.tar.gz` but the regex only matches the previous version formats like `QScintilla-2.11.6.tar.gz` or `QScintilla_gpl-2.11.2.tar.gz`.

This modifies the regex to also match the `QScintilla_src` prefix, while continuing to match the previous file name formats.