### PR TITLE
influxdb: update livecheck

### DIFF
--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -6,9 +6,10 @@ class Influxdb < Formula
   license "MIT"
   head "https://github.com/influxdata/influxdb.git"
 
+  # The regex below omits a rogue `v9.9.9` tag that breaks version comparison.
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?((?!9\.9\.9)\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

~This updates the existing `livecheck` block for `influxdb` to check the Git tags instead of using the `GithubLatest` strategy, as `influxdb` maintains multiple major/minor versions and the "latest" release on GitHub doesn't correspond with the latest 1.x release. The [first-party download page](https://portal.influxdata.com/downloads/) provides v2.0.4 and v1.8.4 versions but the "latest" release on GitHub is v1.7.11. We only use the `GithubLatest` strategy when it's both necessary and correct and the latter doesn't appear to be true here.~

~This removes `strategy :github_latest` and replaces it with a version of the standard regex for Git tags like `1.2.3`/`v1.2.3` (i.e., `/^v?(\d+(?:\.\d+)+)$/i`) which has been modified to use `version.major` as the major part of the version. This will ensure that livecheck only returns versions that match the major version that's currently used in the formula.~

~This is necessary, as the 2.x versions would always be reported as newest and we would end up missing 1.8.5, etc. This won't tell us when a new major version is available but I think it's fine to leave that up to maintainers/contributors. If/when this formula is updated to a different major version, the `livecheck` block will automatically match versions with the new major version without needing to be modified.~

This updates the existing `livecheck` block for `influxdb` to check the Git tags instead of using the `GithubLatest` strategy. We only use the `GithubLatest` strategy when it's both necessary and correct and neither appears to be true here.

The regex used here is a version of the standard regex for Git tags like `1.2.3`/`v1.2.3` (i.e., `/^v?(\d+(?:\.\d+)+)$/i`) which has been modified to omit a rogue `v9.9.9` version that breaks version comparison (as it's seen as newer than `2.0.4`, etc.).