### PR TITLE
antlr4-cpp-runtime: update livecheck

### DIFF
--- a/Formula/antlr4-cpp-runtime.rb
+++ b/Formula/antlr4-cpp-runtime.rb
@@ -6,7 +6,7 @@ class Antlr4CppRuntime < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://www.antlr.org/download/"
+    url "https://www.antlr.org/download.html"
     regex(/href=.*?antlr4-cpp-runtime[._-]v?(\d+(?:\.\d+)+)-source\.zip/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `antlr4-cpp-runtime` to use the [first-party download page](https://www.antlr.org/download.html) (`/download.html`) instead of the [pseudo-file-listing page](https://www.antlr.org/download/) (`/download/`), as the latter doesn't have a link to the latest `-source` archive. The `download.html` page links to the latest `-source` archive, so it seems like a more reliable source to check.