### PR TITLE
abyss: update livecheck

### DIFF
--- a/Formula/abyss.rb
+++ b/Formula/abyss.rb
@@ -7,7 +7,7 @@ class Abyss < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `abyss` to replace `strategy :github_latest` with the standard regex for Git tags like `1.2.3`/`v1.2.3`. The "latest" release on GitHub is currently an `rresolver-release` tag instead of `2.2.5`, so it doesn't seem to be reliable.

Besides that, it's not necessary to use `GithubLatest` here, as we can successfully obtain the latest version from the Git tags. We only use the `GithubLatest` strategy when it's both correct and necessary, neither of which is true.