### PR TITLE
tree-sitter: fix sha256

### DIFF
--- a/Formula/tree-sitter.rb
+++ b/Formula/tree-sitter.rb
@@ -4,7 +4,7 @@ class TreeSitter < Formula
   desc "Parser generator tool and incremental parsing library"
   homepage "https://tree-sitter.github.io/"
   url "https://github.com/tree-sitter/tree-sitter/archive/v0.19.4.tar.gz"
-  sha256 "b90c1107a3e09b2dbef9ba317db9fde18f7222898d8470782f539cee286eebad"
+  sha256 "98e6b7f77d277235ef43023a8eee37745d1bc315c138481ed1b054cff158e817"
   license "MIT"
   head "https://github.com/tree-sitter/tree-sitter.git"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Following Homebrew/linuxbrew-core#22644, fixes the source `sha256` to match the current release of `tree-sitter`.