### PR TITLE
libressl: Also bootstrap CA bundle using System keychain

### DIFF
--- a/Formula/libressl.rb
+++ b/Formula/libressl.rb
@@ -47,7 +47,10 @@ class Libressl < Formula
 
   def post_install
     on_macos do
+      ohai "Regenerating CA certificate bundle from keychain, this may take a while..."
+
       keychains = %w[
+        /Library/Keychains/System.keychain
         /System/Library/Keychains/SystemRootCertificates.keychain
       ]
 
@@ -56,8 +59,9 @@ class Libressl < Formula
         /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m,
       )
 
+      # Check that the certificate has not expired
       valid_certs = certs.select do |cert|
-        IO.popen("#{bin}/openssl x509 -inform pem -checkend 0 -noout", "w") do |openssl_io|
+        IO.popen("#{bin}/openssl x509 -inform pem -checkend 0 -noout &>/dev/null", "w") do |openssl_io|
           openssl_io.write(cert)
           openssl_io.close_write
         end
@@ -65,9 +69,26 @@ class Libressl < Formula
         $CHILD_STATUS.success?
       end
 
+      # Check that the certificate is trusted in keychain
+      trusted_certs = begin
+        tmpfile = Tempfile.new
+
+        valid_certs.select do |cert|
+          tmpfile.rewind
+          tmpfile.write cert
+          tmpfile.truncate cert.size
+          tmpfile.flush
+          IO.popen("/usr/bin/security verify-cert -l -L -R offline -c #{tmpfile.path} &>/dev/null")
+
+          $CHILD_STATUS.success?
+        end
+      ensure
+        tmpfile&.close!
+      end
+
       # LibreSSL install a default pem - We prefer to use macOS for consistency.
       rm_f %W[#{etc}/libressl/cert.pem #{etc}/libressl/cert.pem.default]
-      (etc/"libressl/cert.pem").atomic_write(valid_certs.join("\n"))
+      (etc/"libressl/cert.pem").atomic_write(trusted_certs.join("\n") << "\n")
     end
   end
 


### PR DESCRIPTION
Add /Library/Keychains/System.keychain to the keychains used for for seeding the cert.pem bundle.

Same has been done for:
* openssl@1.1: https://github.com/Homebrew/homebrew-core/pull/71191
* gnutls: https://github.com/Homebrew/homebrew-core/pull/71282

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
