### PR TITLE
zsh-completions: update caveat

### DIFF
--- a/Formula/zsh-completions.rb
+++ b/Formula/zsh-completions.rb
@@ -29,7 +29,7 @@ class ZshCompletions < Formula
       Additionally, if you receive "zsh compinit: insecure directories" warnings when attempting
       to load these completions, you may need to run this:
 
-        chmod -R go-w '#{HOMEBREW_PREFIX}/share/zsh'
+        chmod -R go-w '#{HOMEBREW_PREFIX}/share/zsh' '#{HOMEBREW_PREFIX}/bin' '#{HOMEBREW_PREFIX}/share'
     EOS
   end
 


### PR DESCRIPTION
Running `compaudit` revealed two additionnal repertories with incorrect settings in my installation:

zsh compinit: insecure directories, run compaudit for list.
Ignore insecure directories and continue [y] or abort compinit [n]? ncompinit: initialization aborted
$ ~ compaudit
There are insecure directories:
/usr/local/bin
/usr/local/share

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
