### PR TITLE
pyenv: add `rehash` command to post install

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -45,6 +45,10 @@ class Pyenv < Formula
     #   - https://github.com/pyenv/pyenv/issues/1056#issuecomment-356818337
     #   - https://github.com/Homebrew/homebrew-core/pull/22727
   end
+  
+  def post_install
+    system "pyenv", "rehash"
+  end
 
   test do
     shell_output("eval \"$(#{bin}/pyenv init -)\" && pyenv versions")


### PR DESCRIPTION
Currently anybody using pyenv has to run `pyenv rehash` after an update to fix the broken python installation paths on their system. I think this can be run after every update without incident.

Command documentation: https://github.com/pyenv/pyenv/blob/master/COMMANDS.md#pyenv-rehash

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Not yet. Will get on the checkmarks.

This issue is discussed at the pyenv project over here: https://github.com/pyenv/pyenv/issues/1716