### PR TITLE
crystal: 1.0.0

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -2,15 +2,14 @@ class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
   license "Apache-2.0"
-  revision 3
 
   stable do
-    url "https://github.com/crystal-lang/crystal/archive/0.36.1.tar.gz"
-    sha256 "e6806aa04f60dfe0aaf3cfef103e252f6ac3d8400ea3305b0d1b8463b052ec88"
+    url "https://github.com/crystal-lang/crystal/archive/1.0.0.tar.gz"
+    sha256 "6b85c9139a891732c1f10638030635ff9dbe4e6818cad81a5dbd72db40913019"
 
     resource "shards" do
-      url "https://github.com/crystal-lang/shards/archive/v0.13.0.tar.gz"
-      sha256 "82a496aa450624afceab79bd9f7e6e1a43de41f61095512d08c3a3063c4da723"
+      url "https://github.com/crystal-lang/shards/archive/v0.14.1.tar.gz"
+      sha256 "040b080acb4d4d44bfe07897219fdcb7525f783e253d8878d8381bf78f13f328"
     end
   end
 
@@ -37,21 +36,23 @@ class Crystal < Formula
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libevent"
   depends_on "libyaml"
-  depends_on "llvm"
+  # NOTE: Using llvm@11 is possible but compiling in release mode
+  #       has currently a known issue https://github.com/crystal-lang/crystal/issues/10359
+  depends_on "llvm@9"
   depends_on "openssl@1.1" # std uses it but it's not linked
   depends_on "pcre"
   depends_on "pkg-config" # @[Link] will use pkg-config if available
 
   resource "boot" do
     on_macos do
-      url "https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-darwin-x86_64.tar.gz"
-      version "0.35.1-1"
-      sha256 "7d75f70650900fa9f1ef932779bc23f79a199427c4219204fa9e221c330a1ab6"
+      url "https://github.com/crystal-lang/crystal/releases/download/0.36.1/crystal-0.36.1-1-darwin-x86_64.tar.gz"
+      version "0.36.1-1"
+      sha256 "3b381d4ac1241514d63b1f243ed183a1b10945b0e77c5dd625067e91a657ef75"
     end
     on_linux do
-      url "https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-linux-x86_64.tar.gz"
-      version "0.35.1-1"
-      sha256 "6c3fd36073b32907301b0a9aeafd7c8d3e9b9ba6e424ae91ba0c5106dc23f7f9"
+      url "https://github.com/crystal-lang/crystal/releases/download/0.36.1/crystal-0.36.1-1-linux-x86_64.tar.gz"
+      version "0.36.1-1"
+      sha256 "38cc7514f8d9e463665ebaf7232d3a6c46a7397fc9ff5c05fd0f9e4706febb18"
     end
   end
 


### PR DESCRIPTION
There is a new crystal release.

During this version development we concluded that there are some known issues with llvm 11 that are yet unresolved.
Using the compiler to emit binaries in release mode might trigger this issue. So, to play it safe it advised to stay on llvm@9 (or 10 if it would be available) for a little longer.