### PR TITLE
vifm: do not run make check with root

### DIFF
--- a/Formula/vifm.rb
+++ b/Formula/vifm.rb
@@ -23,7 +23,9 @@ class Vifm < Formula
                           "--without-libmagic",
                           "--without-X11"
     system "make"
-    system "make", "check"
+    # Run make check only when not root
+    # https://github.com/vifm/vifm/issues/654
+    system "make", "check" unless Process.uid.zero?
 
     ENV.deparallelize { system "make", "install" }
   end


### PR DESCRIPTION
We plan to get rid of root for Linux CI in the long term,
but avoid running make check with root as this is untested and unsupported.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
