### PR TITLE
capstone: use standard make install

### DIFF
--- a/Formula/capstone.rb
+++ b/Formula/capstone.rb
@@ -18,7 +18,7 @@ class Capstone < Formula
     ENV["HOMEBREW_CAPSTONE"] = "1"
     ENV["PREFIX"] = prefix
     system "./make.sh"
-    system "./make.sh", "install"
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do


### PR DESCRIPTION
The make.sh way does not work under linux.
Both methods did install the same files on mac, so
it's probably safe to use "make install" for both platforms

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
