### PR TITLE
cpptest: make test portable

### DIFF
--- a/Formula/cpptest.rb
+++ b/Formula/cpptest.rb
@@ -40,7 +40,7 @@ class Cpptest < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", "-L#{lib}", "-lcpptest", "-o", "test"
+    system ENV.cxx, "test.cpp", "-std=c++11", "-L#{lib}", "-lcpptest", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
Fixes (on Linux):
In file included from /home/linuxbrew/.linuxbrew/opt/cpptest/include/cpptest.h:34:0,
                 from test.cpp:2:
/home/linuxbrew/.linuxbrew/opt/cpptest/include/cpptest-suite.h:58:17: error: ‘std::unique_ptr’ has not been declared
   void add(std::unique_ptr<Suite> suite);
                 ^
/home/linuxbrew/.linuxbrew/opt/cpptest/include/cpptest-suite.h:58:27: error: expected ‘,’ or ‘...’ before ‘<’ token
   void add(std::unique_ptr<Suite> suite);

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
