### PR TITLE
mingw-w64: run remove_macosxsdk only on mac

### DIFF
--- a/Formula/mingw-w64.rb
+++ b/Formula/mingw-w64.rb
@@ -171,7 +171,9 @@ class MingwW64 < Formula
     EOS
 
     ENV["LC_ALL"] = "C"
-    ENV.remove_macosxsdk
+    on_macos do
+      ENV.remove_macosxsdk
+    end
     target_archs.each do |arch|
       target = "#{arch}-w64-mingw32"
       outarch = (arch == "i686") ? "i386" : "x86-64"


### PR DESCRIPTION
This method is not supported on Linux.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
