### PR TITLE
pidgin: update livecheck

### DIFF
--- a/Formula/pidgin.rb
+++ b/Formula/pidgin.rb
@@ -7,8 +7,9 @@ class Pidgin < Formula
   revision 1
 
   livecheck do
-    url :stable
-    regex(%r{url=.*?/pidgin[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url "https://sourceforge.net/projects/pidgin/files/Pidgin/"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `pidgin` uses the `Sourceforge` strategy to check the SourceForge project's RSS feed for new versions. However, the project contains more than just the `pidgin` releases we're interested in and other software has pushed the latest `pidgin` version out of the RSS feed, so the check is now giving an `Unable to get versions` error.

This resolves the issue by updating the `livecheck` block to check the page that lists the version directories for `pidgin`. This issue has affected other formulae on SourceForge and this is the typical way to resolve it (when possible).