### PR TITLE
kerl 2.1.1

### DIFF
--- a/Formula/kerl.rb
+++ b/Formula/kerl.rb
@@ -1,8 +1,8 @@
 class Kerl < Formula
   desc "Easy building and installing of Erlang/OTP instances"
   homepage "https://github.com/kerl/kerl"
-  url "https://github.com/kerl/kerl/archive/2.1.0.tar.gz"
-  sha256 "fedb123c96d064b1ff1ea386c3c3395e4cac485237edd8bd05aebb442cc46e86"
+  url "https://github.com/kerl/kerl/archive/2.1.1.tar.gz"
+  sha256 "e7a6c7d3e79559e65a8cb3732c176c13e14053160e2ff8ef35cad0acac13453d"
   license "MIT"
   head "https://github.com/kerl/kerl.git"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 33,190 bytes
- formula fetch time: 1.5 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.