### PR TITLE
maven: add livecheck

### DIFF
--- a/Formula/maven.rb
+++ b/Formula/maven.rb
@@ -7,6 +7,11 @@ class Maven < Formula
   license "Apache-2.0"
   revision 1
 
+  livecheck do
+    url "https://maven.apache.org/download.cgi"
+    regex(/href=.*?apache-maven[._-]v?(\d+(?:\.\d+)+)-bin\.t/i)
+  end
+
   bottle :unneeded
 
   depends_on "openjdk"


### PR DESCRIPTION
relates to #73722

include livecheck to check against the official announcement (rather than just check against the artifact)