### PR TITLE
Rogerrouter (new formula + dependencies)

### DIFF
--- a/Formula/capi20.rb
+++ b/Formula/capi20.rb
@@ -1,0 +1,46 @@
+class Capi20 < Formula
+  desc "Handle requests from CAPI-driven applications via FRITZ!Box routers"
+  homepage "https://www.tabos.org"
+  url "https://gitlab.com/tabos/libcapi/-/archive/v3.2.3/libcapi-v3.2.3.tar.bz2"
+  sha256 "e0fcf2e8a59a0b64316e7da671c3a726c3aca22602f65a6679442535fe270f98"
+  license "LGPL-2.1-only"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      -Denable-post-install=false
+    ]
+
+    mkdir "build" do
+      system "meson", *args, ".."
+      system "ninja"
+      system "ninja", "install"
+    end
+
+    # meson-internal gives wrong install_names for dylibs due to their unusual installation location
+    # create softlinks to fix
+    ln_s Dir.glob("#{lib}/capi20/*dylib"), lib
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <capi20.h>
+      int main() {
+        unsigned applid = capi_alloc_applid(0);
+        int ok = !capi_validapplid(applid);
+        capi_freeapplid(applid);
+        return ok;
+      }
+    EOS
+    flags = %W[
+      -L#{lib}
+      -lcapi20
+    ]
+    system ENV.cc, "test.cpp", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Formula/librm.rb
+++ b/Formula/librm.rb
@@ -1,0 +1,78 @@
+class Librm < Formula
+  desc "Router Manager Library for FRITZ!Box Router"
+  homepage "https://www.tabos.org"
+  url "https://gitlab.com/tabos/librm/-/archive/2.2.1/librm-2.2.1.tar.bz2"
+  sha256 "9175de95a5049844556351bfd0c82fa51b31256f207d3b4782c530d3ae910c3b"
+  license "LGPL-2.1-only"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "capi20"
+  depends_on "gdk-pixbuf"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "gst-plugins-base"
+  depends_on "gst-plugins-good"
+  depends_on "gstreamer"
+  depends_on "gtk+3"
+  depends_on "gtk-mac-integration"
+  depends_on "gupnp"
+  depends_on "json-glib"
+  depends_on "libsndfile"
+  depends_on "libsoup"
+  depends_on "spandsp"
+  depends_on "speex"
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      -Denable-post-install=false
+    ]
+
+    mkdir "build" do
+      system "meson", *args, ".."
+      system "ninja"
+      system "ninja", "install"
+    end
+
+    # meson-internal gives wrong install_names for dylibs due to their unusual installation location
+    # create softlinks to fix
+    ln_s Dir.glob("#{lib}/rm/*dylib"), lib
+  end
+
+  def post_install
+    system "#{Formula["glib"].opt_bin}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
+    system "#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache", "-f", "-t", "#{HOMEBREW_PREFIX}/share/icons/hicolor"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <glib.h>
+      #include <rm/rm.h>
+      int main() {
+        gchar *result = rm_number_scramble("012345678");
+        g_assert_cmpstr(result, ==, "01XXXXXX8");
+        g_free(result);
+        return 0;
+      }
+    EOS
+    gdk_pixbuf = Formula["gdk-pixbuf"]
+    glib = Formula["glib"]
+    libsoup = Formula["libsoup"]
+    flags = %W[
+      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{libsoup.opt_include}/libsoup-2.4
+      -L#{gdk_pixbuf.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{lib}
+      -lgdk_pixbuf-2.0
+      -lglib-2.0
+      -lrm
+    ]
+    system ENV.cc, "test.cpp", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Formula/rogerrouter.rb
+++ b/Formula/rogerrouter.rb
@@ -1,0 +1,50 @@
+class Rogerrouter < Formula
+  desc "All-in-one solution for FRITZ!Box routers"
+  homepage "https://www.tabos.org"
+  url "https://gitlab.com/tabos/rogerrouter/-/archive/2.3.90/rogerrouter-2.3.90.tar.bz2"
+  sha256 "11dd452f608215db7bfd027fee666694f473378d8f936f4410a99f8b1c94ddf3"
+  license "GPL-2.0-only"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "adwaita-icon-theme"
+  depends_on "capi20"
+  depends_on "gettext"
+  depends_on "ghostscript"
+  depends_on "gtk+3"
+  depends_on "hicolor-icon-theme"
+  depends_on "libgdata"
+  depends_on "libhandy"
+  depends_on "librm"
+  depends_on "libsoup"
+  depends_on "poppler"
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      -Denable-post-install=false
+    ]
+
+    mkdir "build" do
+      system "meson", *args, ".."
+      system "ninja"
+      system "ninja", "install"
+    end
+
+    # meson-internal gives wrong install_names for dylibs due to their unusual installation location
+    # create softlinks to fix
+    ln_s Dir.glob("#{lib}/roger/*dylib"), lib
+  end
+
+  def post_install
+    system "#{Formula["glib"].opt_bin}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
+    system "#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache", "-f", "-t", "#{HOMEBREW_PREFIX}/share/icons/hicolor"
+    system "lpadmin", "-p", "Roger-Router-Fax", "-m", "drv:///sample.drv/generic.ppd", \
+           "-v", "socket://localhost:9100/", "-E", "-o", "PageSize=A4"
+  end
+
+  test do
+    system "#{bin}/roger", "--help"
+  end
+end


### PR DESCRIPTION
- [ X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ X ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Notes:
- These formulae were previously maintained on the project's [homepage](https://gitlab.com/tabos/rogerrouter/-/tree/master/build-aux/macosx/HomebrewFormula) but the original maintainer can't do it anymore. Also, the formulas got moved from the repo's root directory which means they aren't found anymore when tapping into it.
- This PR is meant to finally move the formulae into homebrew-core to facilitate their community-based maintenance and installation (without a custom tap).
- The PR contains the (improved) main formula as well as two of its dependencies, each in a single commit (in the correct order).

Cheers!
