### PR TITLE
capi20 3.2.3 (new formula)

### DIFF
--- a/Formula/capi20.rb
+++ b/Formula/capi20.rb
@@ -1,0 +1,46 @@
+class Capi20 < Formula
+  desc "Handle requests from CAPI-driven applications via FRITZ!Box routers"
+  homepage "https://www.tabos.org"
+  url "https://gitlab.com/tabos/libcapi/-/archive/v3.2.3/libcapi-v3.2.3.tar.bz2"
+  sha256 "e0fcf2e8a59a0b64316e7da671c3a726c3aca22602f65a6679442535fe270f98"
+  license "LGPL-2.1-only"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      -Denable-post-install=false
+    ]
+
+    mkdir "build" do
+      system "meson", *args, ".."
+      system "ninja"
+      system "ninja", "install"
+    end
+
+    # meson-internal gives wrong install_names for dylibs due to their unusual installation location
+    # create softlinks to fix
+    ln_s Dir.glob("#{lib}/capi20/*dylib"), lib
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <capi20.h>
+      int main() {
+        unsigned applid = capi_alloc_applid(0);
+        int ok = !capi_validapplid(applid);
+        capi_freeapplid(applid);
+        return ok;
+      }
+    EOS
+    flags = %W[
+      -L#{lib}
+      -lcapi20
+    ]
+    system ENV.cc, "test.cpp", "-o", "test", *flags
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [ X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ X ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Important: this is the first of three PRs for the main product: rogerrouter

Notes (apply to all three PRs):
- These formulae were previously maintained on the project's [homepage](https://gitlab.com/tabos/rogerrouter/-/tree/master/build-aux/macosx/HomebrewFormula) but the original maintainer can't do it anymore. Also, the formulas got moved from the repo's root directory which means they aren't found anymore when tapping into it.
- This PR is meant to finally move the formulae into homebrew-core to facilitate their community-based maintenance and installation (without a custom tap).
- The formulae were improved for homebrew-core compliance

Cheers!
