### PR TITLE
libgnt: update livecheck

### DIFF
--- a/Formula/libgnt.rb
+++ b/Formula/libgnt.rb
@@ -6,8 +6,9 @@ class Libgnt < Formula
   license "GPL-2.0"
 
   livecheck do
-    url :stable
-    regex(%r{url=.*?/libgnt[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url "https://sourceforge.net/projects/pidgin/files/libgnt/"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Like #73711, the existing `livecheck` block for `libgnt` uses the `Sourceforge` strategy to check the SourceForge project's RSS feed for new versions. However, the project contains more than just the `libgnt` releases we're interested in and other software has pushed the latest `libgnt` version out of the RSS feed, so the check is now giving an `Unable to get versions` error.

This resolves the issue by updating the `livecheck` block to check the page that lists the version directories for `libgnt`. This issue has affected other formulae on SourceForge and this is the typical way to resolve it (when possible).