### PR TITLE
moc: update livecheck

### DIFF
--- a/Formula/moc.rb
+++ b/Formula/moc.rb
@@ -37,7 +37,7 @@ class Moc < Formula
   end
 
   livecheck do
-    url "http://ftp.daper.net/pub/soft/moc/stable/"
+    url "https://moc.daper.net/download"
     regex(/href=.*?moc[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `moc` checks the directory listing page where the `stable` archive is found but this is currently unresponsive and can lead to a timeout. This PR updates the `livecheck` block to check the first-party download page, which links to the same `stable` archive.