### PR TITLE
xonsh: add 'main' as the name of the renamed master branch for HEAD

### DIFF
--- a/Formula/xonsh.rb
+++ b/Formula/xonsh.rb
@@ -6,7 +6,7 @@ class Xonsh < Formula
   url "https://files.pythonhosted.org/packages/39/af/ba93eb37f0340c3f225dcb45858aa6169c05b03f9044c528fe2e770952a0/xonsh-0.9.27.tar.gz"
   sha256 "82aa7c50eb161c74e0b12c4f9c772d228a1e90b21afb948c0dc9dfb2b63f5fd5"
   license "BSD-2-Clause-Views"
-  head "https://github.com/xonsh/xonsh.git"
+  head "https://github.com/xonsh/xonsh.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "a789ba640efa248ae6dce5fab63d43e094e50fe2a3d6fab12a46aee3b0e8431f"


### PR DESCRIPTION
Upstream was recently renamed from master to [main](https://github.com/xonsh/xonsh/tree/main)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
I've also built with the added `--HEAD` flag as that's the part that is changing
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
