### PR TITLE
r disable binary flag

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -4,7 +4,7 @@ class R < Formula
   url "https://cran.r-project.org/src/base/R-4/R-4.0.4.tar.gz"
   sha256 "523f27d69744a08c8f0bd5e1e6c3d89a4db29ed983388ba70963a3cd3a4a802e"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://cran.rstudio.com/banner.shtml"
@@ -54,11 +54,6 @@ class R < Formula
     ["gettext", "readline", "xz"].each do |f|
       ENV.append "CPPFLAGS", "-I#{Formula[f].opt_include}"
       ENV.append "LDFLAGS", "-L#{Formula[f].opt_lib}"
-    end
-
-    on_macos do
-      # Enable binaries on macos
-      ENV.append "CPPFLAGS", "-DPLATFORM_PKGTYPE='\"mac.binary\"'" unless Hardware::CPU.arm?
     end
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This undoes #73315 which isn't actually correct. Some of the binary packages on CRAN use hard-coded links to system paths, and this installation method will not work with those. Thanks to @jimhester for point this out. 

Perhaps instead of attempting to enable binaries, we could add a recommendation to use the cask install for r (I can submit a separate PR that adds this to the caveats to this formula, but I think this reverting PR should go first separately since it can break loading some CRAN packages). 