### PR TITLE
igraph 0.9.1

### DIFF
--- a/Formula/igraph.rb
+++ b/Formula/igraph.rb
@@ -1,8 +1,8 @@
 class Igraph < Formula
   desc "Network analysis package"
   homepage "https://igraph.org/"
-  url "https://github.com/igraph/igraph/releases/download/0.9.0/igraph-0.9.0.tar.gz"
-  sha256 "012e5d5a50420420588c33ec114c6b3000ccde544db3f25c282c1931c462ad7a"
+  url "https://github.com/igraph/igraph/releases/download/0.9.1/igraph-0.9.1.tar.gz"
+  sha256 "1902810650e8f9d98feefa3eca735db5a879416d00a08f68aad2ca07964cee9f"
   license "GPL-2.0-or-later"
 
   bottle do
@@ -14,16 +14,39 @@ class Igraph < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "arpack"
   depends_on "glpk"
-  depends_on "gmp"
-
-  on_linux do
-    depends_on "openblas"
-  end
+  depends_on "openblas"
 
   def install
     mkdir "build" do
-      system "cmake", "-G", "Unix Makefiles", "-DIGRAPH_ENABLE_TLS=ON", "..", *std_cmake_args
+      # explanation of extra options:
+      # * we want a shared library, not a static one
+      # * link-time optimization should be enabled if the compiler supports it
+      # * thread-local storage of global variables is enabled
+      # * GLPK is used as an external dependency
+      # * GraphML support should be compiled in (needs libxml2)
+      # * use external BLAS and LAPACK from OpenBLAS
+      # * use external ARPACK (also from Homebrew)
+      # * use vendored CXSparse (the entire SuiteSparse is too big
+      #   a dependency and igraph does not need most of it)
+      # * use external GLPK (also from Homebrew)
+      # * use vendored mini-GMP (external GMP has no additional benefits and it
+      #   is heavyweight)
+      system "cmake", "-G", "Unix Makefiles",
+                      "-DBUILD_SHARED_LIBS=ON",
+                      "-DIGRAPH_ENABLE_LTO=AUTO",
+                      "-DIGRAPH_ENABLE_TLS=ON",
+                      "-DIGRAPH_GLPK_SUPPORT=ON",
+                      "-DIGRAPH_GRAPHML_SUPPORT=ON",
+                      "-DIGRAPH_USE_INTERNAL_ARPACK=OFF",
+                      "-DIGRAPH_USE_INTERNAL_BLAS=OFF",
+                      "-DIGRAPH_USE_INTERNAL_CXSPARSE=ON",
+                      "-DIGRAPH_USE_INTERNAL_GLPK=OFF",
+                      "-DIGRAPH_USE_INTERNAL_GMP=ON",
+                      "-DIGRAPH_USE_INTERNAL_LAPACK=OFF",
+                      "-DBLA_VENDOR=OpenBLAS",
+                      "..", *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Formula/igraph.rb
+++ b/Formula/igraph.rb
@@ -16,7 +16,9 @@ class Igraph < Formula
   depends_on "cmake" => :build
   depends_on "arpack"
   depends_on "glpk"
+  depends_on "gmp"
   depends_on "openblas"
+  depends_on "suite-sparse"
 
   def install
     mkdir "build" do
@@ -24,15 +26,11 @@ class Igraph < Formula
       # * we want a shared library, not a static one
       # * link-time optimization should be enabled if the compiler supports it
       # * thread-local storage of global variables is enabled
-      # * GLPK is used as an external dependency
+      # * force the usage of external dependencies from Homebrew where possible
       # * GraphML support should be compiled in (needs libxml2)
-      # * use external BLAS and LAPACK from OpenBLAS
-      # * use external ARPACK (also from Homebrew)
-      # * use vendored CXSparse (the entire SuiteSparse is too big
-      #   a dependency and igraph does not need most of it)
-      # * use external GLPK (also from Homebrew)
-      # * use vendored mini-GMP (external GMP has no additional benefits and it
-      #   is heavyweight)
+      # * BLAS and LAPACK should come from OpenBLAS
+      # * prevent the usage of ccache even if it is installed to ensure that we
+      #    have a clean build
       system "cmake", "-G", "Unix Makefiles",
                       "-DBUILD_SHARED_LIBS=ON",
                       "-DIGRAPH_ENABLE_LTO=AUTO",
@@ -41,11 +39,12 @@ class Igraph < Formula
                       "-DIGRAPH_GRAPHML_SUPPORT=ON",
                       "-DIGRAPH_USE_INTERNAL_ARPACK=OFF",
                       "-DIGRAPH_USE_INTERNAL_BLAS=OFF",
-                      "-DIGRAPH_USE_INTERNAL_CXSPARSE=ON",
+                      "-DIGRAPH_USE_INTERNAL_CXSPARSE=OFF",
                       "-DIGRAPH_USE_INTERNAL_GLPK=OFF",
-                      "-DIGRAPH_USE_INTERNAL_GMP=ON",
+                      "-DIGRAPH_USE_INTERNAL_GMP=OFF",
                       "-DIGRAPH_USE_INTERNAL_LAPACK=OFF",
                       "-DBLA_VENDOR=OpenBLAS",
+                      "-DUSE_CCACHE=OFF",
                       "..", *std_cmake_args
       system "make"
       system "make", "install"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The purpose of PR is twofold:

* it updates `igraph` to its most recent version (0.9.1)
* it also changes the formula to use external dependencies instead of igraph's vendored dependencies where the vendored dependency exists in Homebrew and it does not add significant weight to igraph itself

In particular:

* BLAS and LAPACK are now used from OpenBLAS instead of igraph's own vendored copy
* ARPACK is now used from Homebrew instead of igraph's own vendored copy (which is outdated and is less stable on certain eigenproblems than the one in Homebrew)
* GMP is not used as an external dependency any more; igraph uses only a minor fragment of GMP's full functionality, and it vendors Mini-GMP exactly because of this
* GLPK is used from Homebrew (just like before)
* CXSparse is used from igraph's vendored copy -- Homebrew contains SuiteSparse, which indeed contains CXSparse, but most of it is not needed by igraph so it is easier to use the vendored copy

Other notable changes:

* The previous version of the formula erroneously built a static library instead of a shared one; this is now fixed.
* Link-time optimization is enabled if the compiler supports it.

The build configuration of this formula now aligns almost perfectly with igraph from MacPorts, except for CXSparse. (MacPorts has a granular breakdown of SuiteSparse into smaller sub-libraries so one can simply link to CXSparse; this is not possible with Homeebrew's version of SuiteSparse as far as I know).