### PR TITLE
timg 1.2.1 (new formula)

### DIFF
--- a/Formula/timg.rb
+++ b/Formula/timg.rb
@@ -1,0 +1,29 @@
+class Timg < Formula
+  desc "Terminal image and video viewer"
+  homepage "https://timg.sh/"
+  url "https://github.com/hzeller/timg/archive/refs/tags/v1.2.1.tar.gz"
+  sha256 "2ef2e1b79c3bf82e951ad35628bc0387fe8260052614a213385de82fcfa901ec"
+  license "GPL-2.0-only"
+  head "https://github.com/hzeller/timg.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "ffmpeg"
+  depends_on "graphicsmagick"
+  depends_on "jpeg-turbo"
+  depends_on "libexif"
+  depends_on "libpng"
+  depends_on "webp"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/timg", "--version"
+    system "#{bin}/timg", "-g10x10", test_fixtures("test.gif")
+    system "#{bin}/timg", "-g10x10", test_fixtures("test.png")
+    system "#{bin}/timg", "-pq", "-g10x10", "-o", testpath/"test-output.txt", test_fixtures("test.jpg")
+    assert_match "38;2;255;38;0;49m", (testpath/"test-output.txt").read
+  end
+end


### PR DESCRIPTION
Add formula for timg to homebrew-core.
Timg is a terminal image and video viewer.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
