### PR TITLE
zip: disable 2 tests on Linux to avoid a circular dependency

### DIFF
--- a/Formula/zip.rb
+++ b/Formula/zip.rb
@@ -54,11 +54,17 @@ class Zip < Formula
 
     system "#{bin}/zip", "test.zip", "test1", "test2", "test3"
     assert_predicate testpath/"test.zip", :exist?
-    assert_match "test of test.zip OK", shell_output("#{bin}/zip -T test.zip")
+    on_macos do
+      # zip -T needs unzip, disabled under Linux to avoid a circular dependency
+      assert_match "test of test.zip OK", shell_output("#{bin}/zip -T test.zip")
+    end
 
     # test bzip2 support that should be automatically linked in using the bzip2 library in macOS
     system "#{bin}/zip", "-Z", "bzip2", "test2.zip", "test1", "test2", "test3"
     assert_predicate testpath/"test2.zip", :exist?
-    assert_match "test of test2.zip OK", shell_output("#{bin}/zip -T test2.zip")
+    on_macos do
+      # zip -T needs unzip, disabled under Linux to avoid a circular dependency
+      assert_match "test of test2.zip OK", shell_output("#{bin}/zip -T test2.zip")
+    end
   end
 end


### PR DESCRIPTION
zip depends on unzip; and unzip depends on zip for their respective tests

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
