### PR TITLE
mboxgrep: update url

### DIFF
--- a/Formula/mboxgrep.rb
+++ b/Formula/mboxgrep.rb
@@ -1,6 +1,6 @@
 class Mboxgrep < Formula
   desc "Scan a mailbox for messages matching a regular expression"
-  homepage "https://datatipp.se/mboxgrep/"
+  homepage "https://mboxgrep.datatipp.se"
   url "https://downloads.sourceforge.net/project/mboxgrep/mboxgrep/0.7.9/mboxgrep-0.7.9.tar.gz"
   sha256 "78d375a05c3520fad4bca88509d4da0dbe9fba31f36790bd20880e212acd99d7"
   license "GPL-2.0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I think this fixes the reason that it was disabled in the first place. Is it worth enabling again?
