### PR TITLE
mozilla-addon-sdk: disable

### DIFF
--- a/Formula/mozilla-addon-sdk.rb
+++ b/Formula/mozilla-addon-sdk.rb
@@ -1,11 +1,13 @@
 class MozillaAddonSdk < Formula
   desc "Create Firefox add-ons using JS, HTML, and CSS"
-  homepage "https://developer.mozilla.org/en-US/Add-ons/SDK"
+  homepage "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons"
   url "https://archive.mozilla.org/pub/mozilla.org/labs/jetpack/addon-sdk-1.17.zip"
   sha256 "16e29d92214a556c8422db156b541fb8c47addfcb3cd879e0a4ca879d6a31f65"
   license "MPL-2.0"
 
   bottle :unneeded
+
+  disable! date: "2021-03-24", because: :unsupported
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

> In the past, there were several toolsets for developing Firefox extensions, but as of November 2017, extensions must be built using WebExtensions APIs. Other toolsets, such as overlay add-ons, bootstrapped add-ons, and the Add-on SDK, are no longer supported.