### PR TITLE
python-tk: Separate tkinter from python@3.9

### DIFF
--- a/Aliases/python-tk
+++ b/Aliases/python-tk
@@ -1,0 +1,1 @@
+../Formula/python-tk@3.9.rb

--- a/Formula/python-tk@3.9.rb
+++ b/Formula/python-tk@3.9.rb
@@ -1,0 +1,43 @@
+class PythonTkAT39 < Formula
+  desc "Python interface to Tcl/Tk"
+  homepage "https://www.python.org/"
+  # Keep in sync with python@3.9.
+  url "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tar.xz"
+  sha256 "3c2034c54f811448f516668dce09d24008a0716c3a794dd8639b5388cbde247d"
+  license "Python-2.0"
+
+  livecheck do
+    url "https://www.python.org/ftp/python/"
+    regex(%r{href=.*?v?(3\.9(?:\.\d+)*)/?["' >]}i)
+  end
+
+  depends_on "python@3.9"
+  depends_on "tcl-tk"
+
+  def install
+    cd "Modules" do
+      tcltk_version = Formula["tcl-tk"].any_installed_version.major_minor
+      (Pathname.pwd/"setup.py").write <<~EOS
+        from setuptools import setup, Extension
+
+        setup(name="tkinter",
+              description="#{desc}",
+              version="#{version}",
+              ext_modules = [
+                Extension("_tkinter", ["_tkinter.c", "tkappinit.c"],
+                          define_macros=[("WITH_APPINIT", 1)],
+                          include_dirs=["#{Formula["tcl-tk"].opt_include}"],
+                          libraries=["tcl#{tcltk_version}", "tk#{tcltk_version}"],
+                          library_dirs=["#{Formula["tcl-tk"].opt_lib}"])
+              ]
+        )
+      EOS
+      system Formula["python@3.9"].bin/"python3", *Language::Python.setup_install_args(prefix)
+      rm_r Dir[lib/"python3.9/site-packages/*.egg-info"]
+    end
+  end
+
+  test do
+    system Formula["python@3.9"].bin/"python3", "-c", "import tkinter; root = tkinter.Tk()"
+  end
+end

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -20,5 +20,6 @@
   "openssl@1.1",
   "pangomm@2.46",
   "pyqt@5",
-  "python@3.9"
+  "python@3.9",
+  "python-tk@3.9"
 ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This trims the large `tcl-tk` dep tree on Linux, which pulls in a number of X11 dependencies. It will also resolve the cyclic dependency issue in `xcb-proto`.