### PR TITLE
r: add caveat about binaries and cask install

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -94,6 +94,20 @@ class R < Formula
     ln_s site_library, lib/"R/site-library"
   end
 
+  def caveats
+    on_macos do
+      <<~EOS
+        This installation of R does not use binary packages from CRAN.
+        Instead it will install packages from source which will require additional system
+        dependencies and longer install times.
+
+        If you are installing packages from CRAN it is highly recommended that you
+        instead install R with:
+          brew install --cask r
+      EOS
+    end
+  end
+
   test do
     assert_equal "[1] 2", shell_output("#{bin}/Rscript -e 'print(1+1)'").chomp
     assert_equal ".dylib", shell_output("#{bin}/R CMD config DYLIB_EXT").chomp


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is a follow on to #73761 

I've added a caveat directing people to install with cask if they are planning to use packages from CRAN on macOS. The distributed version of the R binary for macOS defaults to installing binary packages from CRAN. This is not only much faster, but avoids needing to have all of the correct build-time dependencies for building packages from source. 

As far as I know (and others smarter than me!) there isn't a way to build R and accept CRAN binaries because (some) CRAN binaries have hardcoded links to shared libraries.

Example of confusion + recommendations: https://github.com/tidyverse/tidyverse/issues/154#issuecomment-427136970 and https://twitter.com/jimhester_/status/1374342249568481288 