### PR TITLE
sponge: add livecheck

### DIFF
--- a/Formula/sponge.rb
+++ b/Formula/sponge.rb
@@ -5,6 +5,11 @@ class Sponge < Formula
   sha256 "4fc86d56a8a276a0cec71cdabda5ccca50c7a44a2a1ccd888476741d1ce6831d"
   license "GPL-2.0-only"
 
+  livecheck do
+    url "https://git.joeyh.name/index.cgi/moreutils.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "5b0e74d146e19640d3075302bdd5ad212bee4971c12b3420f043d61c5a037081"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to identify versions for `sponge`. This PR adds a `livecheck` block that checks the upstream Git repository, as the `stable` archive is a tag archive from there.