### PR TITLE
ppl: update homepage and license, add livecheck

### DIFF
--- a/Formula/ppl.rb
+++ b/Formula/ppl.rb
@@ -1,11 +1,16 @@
 class Ppl < Formula
   desc "Parma Polyhedra Library: numerical abstractions for analysis, verification"
-  homepage "https://bugseng.com/ppl"
+  homepage "https://www.bugseng.com/ppl"
   url "https://www.bugseng.com/products/ppl/download/ftp/releases/1.2/ppl-1.2.tar.xz"
   mirror "https://deb.debian.org/debian/pool/main/p/ppl/ppl_1.2.orig.tar.xz"
   sha256 "691f0d5a4fb0e206f4e132fc9132c71d6e33cdda168470d40ac3cf62340e9a60"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 1
+
+  livecheck do
+    url "https://www.bugseng.com/ppl-download"
+    regex(/href=.*?ppl[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 arm64_big_sur: "f607e5d5ebefa0cb480bc84b1ba6e4eb1f2f07e7d7a00ae1f4c71958b5c82323"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the `homepage` for `ppl` to avoid the redirection from `bugseng.com` to `www.bugseng.com`. What do we think about updating the homepage to https://www.bugseng.com/parma-polyhedra-library instead? The [`/ppl`](https://www.bugseng.com/ppl) page links to it and it provides more information, links to documentation, downloads, etc. It seems like it would be more useful as the homepage overall.

This updates the `license` from `GPL-3.0` to `GPL-3.0-or-later`, as the [`/parma-polyhedra-library`](https://www.bugseng.com/parma-polyhedra-library) page lists the software as, "distributed under the terms of the GNU General Public License version 3 or any later version".

Lastly, this adds a `livecheck` block that checks the first-party `ppl` download page, which links to the `stable` archive.