### PR TITLE
clojure-lsp: disable

### DIFF
--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -24,7 +24,8 @@ class ClojureLsp < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "d1e46a6739dbc18dd5366855a5de4a2bf55957f453bbc70b5a38b768c845c833"
   end
   
-  disable! date: "2021-03-25", because: "does not provide the native binary, which is the recommended way of using clojure-lsp now. Please see https://github.com/clojure-lsp/homebrew-brew"
+  disable! date: "2021-03-25", because: "does not provide the native binary, which is the recommended way of using clojure-lsp now.\
+Please see https://github.com/clojure-lsp/homebrew-brew"
 
   depends_on "clojure" => :build
   # The Java Runtime version only recognizes class file versions up to 52.0

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -24,7 +24,7 @@ class ClojureLsp < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "d1e46a6739dbc18dd5366855a5de4a2bf55957f453bbc70b5a38b768c845c833"
   end
   
-  disable! date: "2021-03-25", because: "does not provide the native binary, which is the recommended way of using clojure-lsp now. Please see https://clojure-lsp.github.io/clojure-lsp/installation/#macos."
+  disable! date: "2021-03-25", because: "does not provide the native binary, which is the recommended way of using clojure-lsp now. Please see https://github.com/clojure-lsp/homebrew-brew"
 
 
   depends_on "clojure" => :build

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -26,7 +26,6 @@ class ClojureLsp < Formula
   
   disable! date: "2021-03-25", because: "does not provide the native binary, which is the recommended way of using clojure-lsp now. Please see https://github.com/clojure-lsp/homebrew-brew"
 
-
   depends_on "clojure" => :build
   # The Java Runtime version only recognizes class file versions up to 52.0
   depends_on "openjdk@11"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -23,7 +23,7 @@ class ClojureLsp < Formula
     sha256 cellar: :any_skip_relocation, catalina:      "352d8a0f6581fc9e56e7ec103f716f966995eeb2d0d9a2065bf4b4fcb9630160"
     sha256 cellar: :any_skip_relocation, mojave:        "d1e46a6739dbc18dd5366855a5de4a2bf55957f453bbc70b5a38b768c845c833"
   end
-  
+
   disable! date: "2021-03-25", because: "does not provide the native binary, which is the recommended way of using clojure-lsp now.\
 Please see https://github.com/clojure-lsp/homebrew-brew"
 

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -23,6 +23,9 @@ class ClojureLsp < Formula
     sha256 cellar: :any_skip_relocation, catalina:      "352d8a0f6581fc9e56e7ec103f716f966995eeb2d0d9a2065bf4b4fcb9630160"
     sha256 cellar: :any_skip_relocation, mojave:        "d1e46a6739dbc18dd5366855a5de4a2bf55957f453bbc70b5a38b768c845c833"
   end
+  
+  disable! date: "2021-03-25", because: "does not provide the native binary, which is the recommended way of using clojure-lsp now. Please see https://clojure-lsp.github.io/clojure-lsp/installation/#macos."
+
 
   depends_on "clojure" => :build
   # The Java Runtime version only recognizes class file versions up to 52.0

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -24,8 +24,8 @@ class ClojureLsp < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "d1e46a6739dbc18dd5366855a5de4a2bf55957f453bbc70b5a38b768c845c833"
   end
 
-  disable! date: "2021-03-25", because: "does not provide the native binary, which is the recommended way of using clojure-lsp now.\
-Please see https://github.com/clojure-lsp/homebrew-brew"
+  disable! date: "2021-03-25", because: "does not provide the native binary,\
+ which is the recommended way of using clojure-lsp now. Please see https://github.com/clojure-lsp/homebrew-brew"
 
   depends_on "clojure" => :build
   # The Java Runtime version only recognizes class file versions up to 52.0


### PR DESCRIPTION
We are not maintaining this formula anymore and the recommended version is the one that uses Graal VM.