### PR TITLE
ipfs: remove version on go dependency

### DIFF
--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -21,7 +21,7 @@ class Ipfs < Formula
     sha256 cellar: :any_skip_relocation, mojave:   "868371961578f442159865ff5111d778dbc730cda71058f942cbb354e6a46029"
   end
 
-  depends_on "go@1.14" => :build
+  depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
Makes ipfs formula buildable on Apple Silicon

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
