### PR TITLE
cherrytree: add livecheck

### DIFF
--- a/Formula/cherrytree.rb
+++ b/Formula/cherrytree.rb
@@ -1,9 +1,14 @@
 class Cherrytree < Formula
   desc "Hierarchical note taking application featuring rich text and syntax highlighting"
-  homepage "https://www.giuspen.com/cherrytree"
+  homepage "https://www.giuspen.com/cherrytree/"
   url "https://www.giuspen.com/software/cherrytree_0.99.33.tar.xz"
   sha256 "a1d264ded32d8b4c256b98721eda91d119573e2b35fd474bc0010d039a101edf"
   license "GPL-3.0-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?cherrytree[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 arm64_big_sur: "ec539ddc582136b6eb7201c16db7e815dd2d123d12de73a4c5dfcc70a3e82e5d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck is unable to find version information for `cherrytree`. This PR adds a `livecheck` block that checks the `homepage`, which links to the `stable` archive.

This also adds a trailing forward slash to the `homepage` URL, to avoid the redirection from `/cherrytree` to `/cherrytree/`.