### PR TITLE
python@3.9, python-tk@3.9: tweak interaction to allow tkinter to work in virtualenvs

### DIFF
--- a/Formula/python-tk@3.9.rb
+++ b/Formula/python-tk@3.9.rb
@@ -5,6 +5,7 @@ class PythonTkAT39 < Formula
   url "https://www.python.org/ftp/python/3.9.2/Python-3.9.2.tar.xz"
   sha256 "3c2034c54f811448f516668dce09d24008a0716c3a794dd8639b5388cbde247d"
   license "Python-2.0"
+  revision 1
 
   livecheck do
     url "https://www.python.org/ftp/python/"
@@ -39,8 +40,9 @@ class PythonTkAT39 < Formula
               ]
         )
       EOS
-      system Formula["python@3.9"].bin/"python3", *Language::Python.setup_install_args(prefix)
-      rm_r Dir[lib/"python3.9/site-packages/*.egg-info"]
+      system Formula["python@3.9"].bin/"python3", *Language::Python.setup_install_args(libexec),
+                                                  "--install-lib=#{libexec}"
+      rm_r Dir[libexec/"*.egg-info"]
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes #73987.

* Move `sitecustomize.py` from `site-packages` to base prefix lib directory in the Cellar (bonus: `sys.base_prefix` now is modified correctly in venvs).
* Move `python-tk@3.9` to install outside of `site-packages` (uses `libexec` instead).
* Tweak `sitecustomize.py` to look for that `libexec` directory.

This allows `tkinter` to be treated more like a first-party lib rather than a third-party package, which means that `import _tkinter` will work in a venv by default.