### PR TITLE
rtmidi: add livecheck

### DIFF
--- a/Formula/rtmidi.rb
+++ b/Formula/rtmidi.rb
@@ -4,6 +4,11 @@ class Rtmidi < Formula
   url "https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-4.0.0.tar.gz"
   sha256 "370cfe710f43fbeba8d2b8c8bc310f314338c519c2cf2865e2d2737b251526cd"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?rtmidi[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "80a67ef458c2888992bb8cc547d58959082df3ed13f0427b2fd7db14a59bac8b"
     sha256 cellar: :any, big_sur:       "2eee6c3a73e0621703d2cff69249bdbc6cb6f46c91b2599bb74953d0292f5277"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `rtmidi`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.