### PR TITLE
chmlib: add livecheck

### DIFF
--- a/Formula/chmlib.rb
+++ b/Formula/chmlib.rb
@@ -1,10 +1,15 @@
 class Chmlib < Formula
   desc "Library for dealing with Microsoft ITSS/CHM files"
-  homepage "http://www.jedrea.com/chmlib"
+  homepage "http://www.jedrea.com/chmlib/"
   url "http://www.jedrea.com/chmlib/chmlib-0.40.tar.gz"
   mirror "https://download.tuxfamily.org/slitaz/sources/packages/c/chmlib-0.40.tar.gz"
   sha256 "512148ed1ca86dea051ebcf62e6debbb00edfdd9720cde28f6ed98071d3a9617"
   license "LGPL-2.1"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?chmlib[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `chmlib`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This also updates the `homepage` URL to include a trailing forward slash, to avoid the redirection from `/chmlib` to `/chmlib/`.