### PR TITLE
netcat6: deprecate

### DIFF
--- a/Formula/netcat6.rb
+++ b/Formula/netcat6.rb
@@ -15,6 +15,11 @@ class Netcat6 < Formula
     sha256 sierra:        "bdb853a9a63a03555682eae734d9d9a7725591dfd16128cf59f208968ef16ef2"
   end
 
+  # Upstream appears to have stopped developing netcat6 and instead recommends
+  # using OpenBSD's netcat (which supports IPv6) or Nmap's netcat replacement
+  # (ncat).
+  deprecate! date: "2021-03-27", because: :deprecated_upstream
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [`netcat6` homepage](https://www.deepspace6.net/projects/netcat6.html) states "THIS PAGE IS OUTDATED AND ONLY STILL ACCESSABLE FOR HISTORICAL REASONS. URLs for downloading outdated sources were removed." and links to OpenBSD's netcat and Nmap's `netcat` replacement. The source files have also been removed from the [Sources](https://www.deepspace6.net/sections/sources.html) page, also with the aforementioned links.

While there isn't explicit wording saying that `netcat6` is deprecated, the explanations on the first-party site and removal of the download links imply that it won't be developed further and the OpenBSD version should simply be used instead. Basically, since OpenBSD's `netcat` supports IPv6, there's no longer a need for `netcat6`.