### PR TITLE
imake: add livecheck

### DIFF
--- a/Formula/imake.rb
+++ b/Formula/imake.rb
@@ -6,6 +6,11 @@ class Imake < Formula
   license "MIT"
   revision 3
 
+  livecheck do
+    url "https://xorg.freedesktop.org/releases/individual/util/"
+    regex(/href=.*?imake[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "7eafaa82ad84b47d8f4bd76bdca5ccfa065f622ea31b1d2c05fb316af8f60015"
     sha256 big_sur:       "c382f4319ca3b0138c5d20bfeea095d76ca9c972e166550b58f259f03a5d267c"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `imake`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.