### PR TITLE
monetdb: add livecheck

### DIFF
--- a/Formula/monetdb.rb
+++ b/Formula/monetdb.rb
@@ -6,6 +6,11 @@ class Monetdb < Formula
   license "MPL-2.0"
   head "https://dev.monetdb.org/hg/MonetDB", using: :hg
 
+  livecheck do
+    url "https://www.monetdb.org/downloads/sources/Latest/"
+    regex(/href=.*?MonetDB[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "9ccb9b0e293542899b7b2e8b542301dd4b436f5d504cce68ea1c7390c2d1b475"
     sha256 big_sur:       "6fcd9e767b822fb50fdc2f041eb232a479752fbf8411c636541de5080307aebe"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `monetdb`. This PR adds a `livecheck` block that checks the first-party [`/downloads/sources/Latest/`](https://www.monetdb.org/downloads/sources/Latest/) URL, which redirects to the directory listing page for the latest stable version.

It's necessary to check this "latest" URL because the [first-party downloads page](https://www.monetdb.org/Downloads) doesn't link to archive files (only generic directories) and source archives are kept in date-based directories like `Oct2020-SP3` (whereas versions for `monetdb` are like `11.39.13`).