### PR TITLE
argon2: set lib path explicitely (fix for Linux)

### DIFF
--- a/Formula/argon2.rb
+++ b/Formula/argon2.rb
@@ -17,9 +17,9 @@ class Argon2 < Formula
   end
 
   def install
-    system "make", "PREFIX=#{prefix}", "ARGON2_VERSION=#{version}"
+    system "make", "PREFIX=#{prefix}", "ARGON2_VERSION=#{version}", "LIBRARY_REL=lib"
     system "make", "test"
-    system "make", "install", "PREFIX=#{prefix}", "ARGON2_VERSION=#{version}"
+    system "make", "install", "PREFIX=#{prefix}", "ARGON2_VERSION=#{version}", "LIBRARY_REL=lib"
     doc.install "argon2-specs.pdf"
   end
 


### PR DESCRIPTION
else their makefile will put the .so files in lib/x86_64-linux-gnu,
and we support only plain "lib" folders on Linux

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
