### PR TITLE
allure update download url

### DIFF
--- a/Formula/allure.rb
+++ b/Formula/allure.rb
@@ -1,7 +1,7 @@
 class Allure < Formula
   desc "Flexible lightweight test report tool"
   homepage "https://github.com/allure-framework/allure2"
-  url "https://dl.bintray.com/qameta/maven/io/qameta/allure/allure-commandline/2.13.8/allure-commandline-2.13.8.zip"
+  url "https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/2.13.8/allure-commandline-2.13.8.zip"
   sha256 "d1d5736fdea09c873aff6bbd78e1e69a207a0087975de1d0648a26bdc183fd88"
   license "Apache-2.0"
 


### PR DESCRIPTION
Replace download url from Bintray to Maven Central for allrue since Bintray reached EOL

This change was already accepted & merged https://github.com/Homebrew/homebrew-core/pull/49632 
by it was reverted by https://github.com/Homebrew/homebrew-core/pull/56549 somehow

Context: https://github.com/allure-framework/allure2/issues/1198#issuecomment-808903936