### PR TITLE
cmd/aspell-dictionaries: don't use private API

### DIFF
--- a/cmd/aspell-dictionaries.rb
+++ b/cmd/aspell-dictionaries.rb
@@ -24,7 +24,8 @@ module Homebrew
     dictionary_mirror = "https://ftpmirror.gnu.org/aspell/dict"
     languages = {}
 
-    index_output, = curl_output("#{dictionary_url}/0index.html")
+    require "open-uri"
+    index_output, = URI("#{dictionary_url}/0index.html").open.read
     index_output.split("<tr><td>").each do |line|
       next unless line.start_with?("<a ")
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is unfortunate and I don't like using `open-uri`, but we can't be using private API in homebrew-core.