### PR TITLE
pcre++: update homepage, add livecheck

### DIFF
--- a/Formula/pcre++.rb
+++ b/Formula/pcre++.rb
@@ -1,10 +1,15 @@
 class Pcrexx < Formula
   desc "C++ wrapper for the Perl Compatible Regular Expressions"
-  homepage "https://www.daemon.de/PCRE"
+  homepage "https://www.daemon.de/projects/pcrepp/"
   url "https://www.daemon.de/idisk/Apps/pcre++/pcre++-0.9.5.tar.gz"
   mirror "https://distfiles.openadk.org/pcre++-0.9.5.tar.gz"
   sha256 "77ee9fc1afe142e4ba2726416239ced66c3add4295ab1e5ed37ca8a9e7bb638a"
   license "LGPL-2.1-only"
+
+  livecheck do
+    url "https://www.daemon.de/projects/pcrepp/download/"
+    regex(/href=.*?pcre\+\+[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `pcre++`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.

This also updates the homepage to avoid the redirection from `/PCRE` to `/projects/pcrepp/`.