### PR TITLE
spawn-fcgi: add livecheck

### DIFF
--- a/Formula/spawn-fcgi.rb
+++ b/Formula/spawn-fcgi.rb
@@ -5,6 +5,11 @@ class SpawnFcgi < Formula
   sha256 "ab327462cb99894a3699f874425a421d934f957cb24221f00bb888108d9dd09e"
   license "BSD-3-Clause"
 
+  livecheck do
+    url "https://redmine.lighttpd.net/projects/spawn-fcgi/news"
+    regex(/href=.*?spawn-fcgi[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "89bc1faf59756165a4a27cd43fdbac4c5d81ba5e12613fc1152c181a60f5c0df"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `spawn-fcgi`. This PR adds a `livecheck` block that checks the "News" section of the site that's used as the `homepage`, as the release information contains links to the archive files.