### PR TITLE
python@3.9: Ignore user pip config in postinstall

### DIFF
--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -336,6 +336,7 @@ class PythonAT39 < Formula
            "--no-deps",
            "--no-index",
            "--upgrade",
+           "--isolated",
            "--target=#{site_packages}",
            bundled/"setuptools-#{resource("setuptools").version}-py3-none-any.whl",
            bundled/"pip-#{resource("pip").version}-py3-none-any.whl",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Closes #74131

-----

If a user's pip config has:

```
[install]
user = true
```

python@3.9 formula postinstall step would fail, as pip disallows the use
of `--user` and `--target` options together.

To ensure deterministic successful postinstall, user's pip config is
ignored by running pip in isolated mode during the postinstall step.
