### PR TITLE
workflows: enable commit signing for BrewTestBot

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -136,10 +136,16 @@ jobs:
       - name: Setup git
         uses: Homebrew/actions/git-user-config@master
 
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Upload and publish bottles on Bintray
         env:
           HOMEBREW_BINTRAY_USER: brewtestbot
           HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
         run: |
           cd ~/bottles
           brew pr-upload --verbose --keep-old

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -137,10 +137,16 @@ jobs:
       - name: Setup git
         uses: Homebrew/actions/git-user-config@master
 
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Upload and publish bottles on Bintray
         env:
           HOMEBREW_BINTRAY_USER: brewtestbot
           HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
         run: |
           cd ~/bottles
           brew pr-upload --verbose

--- a/.github/workflows/linux-dispatch-build-bottle.yml
+++ b/.github/workflows/linux-dispatch-build-bottle.yml
@@ -118,10 +118,16 @@ jobs:
       - name: Setup git
         uses: Homebrew/actions/git-user-config@master
 
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Upload and publish bottles on Bintray
         env:
           HOMEBREW_BINTRAY_USER: brewtestbot
           HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
         run: |
           cd ~/bottles
           brew pr-upload --verbose --keep-old

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -57,9 +57,15 @@ jobs:
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master
 
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Pull bottles
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_BINTRAY_USER: brewtestbot
           HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
         run: brew pr-pull --debug --workflows=tests.yml ${{github.event.inputs.args}} ${{github.event.inputs.pull_request}}

--- a/.github/workflows/remove-disabled-formulae.yml
+++ b/.github/workflows/remove-disabled-formulae.yml
@@ -22,9 +22,16 @@ jobs:
         with:
           username: BrewTestBot
 
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Remove disabled formulae
         id: remove_disabled
         uses: Homebrew/actions/remove-disabled-formulae@master
+        env:
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Create pull request
         if: ${{ steps.remove_disabled.outputs.formulae-removed == 'true' }}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR enables commit signing for BrewTestBot in `homebrew-core`'s workflows. I don't have commit access so I could only push this to a branch of my fork – and so I'm unsure how/if we can test this.

I've simply added the `setup-commit-signing` action step to all workflows where I found a "Push commits" step, along with the necessary secrets for committing.