### PR TITLE
apache-arrow: expose parquet cmake configuration

### DIFF
--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -67,6 +67,8 @@ class ApacheArrow < Formula
       system "make"
       system "make", "install"
     end
+
+    (lib/"cmake").install_symlink "arrow" => "parquet"
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
symlink `lib/cmake/parquet` to `lib/cmake/arrow` to expose Parquet to cmake's find_package().
