### PR TITLE
Bump semgrep 0.45.0

### DIFF
--- a/Formula/semgrep.rb
+++ b/Formula/semgrep.rb
@@ -4,8 +4,8 @@ class Semgrep < Formula
   desc "Easily detect and prevent bugs and anti-patterns in your codebase"
   homepage "https://semgrep.dev"
   url "https://github.com/returntocorp/semgrep.git",
-      tag:      "v0.44.0",
-      revision: "0e901d43d6457f6c988dd00487abb83522b25ad3"
+      tag:      "v0.45.0",
+      revision: "972ac1d2391ceeb19d71913b37f0570ad421b9fc"
   license "LGPL-2.1-only"
   head "https://github.com/returntocorp/semgrep.git", branch: "develop"
 

--- a/Formula/semgrep.rb
+++ b/Formula/semgrep.rb
@@ -87,8 +87,13 @@ class Semgrep < Formula
   end
 
   resource "ruamel.yaml" do
-    url "https://files.pythonhosted.org/packages/16/8b/54a26c1031595e5edd0e616028b922d78d8ffba8bc775f0a4faeada846cc/ruamel.yaml-0.16.10.tar.gz"
-    sha256 "099c644a778bf72ffa00524f78dd0b6476bca94a1da344130f4bf3381ce5b954"
+    url "https://files.pythonhosted.org/packages/e3/be/2ccf0b81a47452fa6131232338a9d16fe3e28f25667b04ce1ab263df1be2/ruamel.yaml-0.17.0.tar.gz"
+    sha256 "3572505e63dd35b5dea62cd0386d03c4f2a53da29a3af09f428114cc85c564aa"
+  end
+
+  resource "ruamel.yaml.clib" do
+    url "https://files.pythonhosted.org/packages/fa/a1/f9c009a633fce3609e314294c7963abe64934d972abea257dce16a15666f/ruamel.yaml.clib-0.2.2.tar.gz"
+    sha256 "2d24bd98af676f4990c4d715bcdc2a60b19c56a3fb3a763164d2d8ca0e806ba7"
   end
 
   resource "six" do


### PR DESCRIPTION
I'm redoing the PR for semgrep 0.45.0 (#74239) due to permission issues. The original PR was made by a CI bot appearing as @brendongo but the real Brendon is on vacation and I don't have the permission to update the original PR. Apologies for the mess! 😬

This updates the dependencies for the new constraint `ruamel.yaml==0.17.0`.

I am not upgrading junit-xml to junit-xml-2 [as suggested last week](https://github.com/Homebrew/homebrew-core/pull/73902#issuecomment-806632065) by @bayandin because I don't know how it's used or how to test it. I [opened a ticket](https://github.com/returntocorp/semgrep/issues/2865) for someone more knowledgeable to take care of it.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? --> there is one and we're dropping it, see message above
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
