### PR TITLE
raptor: add livecheck

### DIFF
--- a/Formula/raptor.rb
+++ b/Formula/raptor.rb
@@ -4,6 +4,11 @@ class Raptor < Formula
   url "http://download.librdf.org/source/raptor2-2.0.15.tar.gz"
   sha256 "ada7f0ba54787b33485d090d3d2680533520cd4426d2f7fb4782dd4a6a1480ed"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?raptor2[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "2970bdade24bb5ec9afe4b79e89234016147cb506f6b450bcfd66c50fce1cede"
     sha256 cellar: :any, big_sur:       "5b58712f0ba9fc647c6b241f80ce3697e25c851f80b26cb8f89f28809905126f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `raptor`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.