### PR TITLE
driftctl: update formula

### DIFF
--- a/Formula/driftctl.rb
+++ b/Formula/driftctl.rb
@@ -15,10 +15,25 @@ class Driftctl < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags",
-             "-s -w -X github.com/cloudskiff/driftctl/build.env=release
-             -X github.com/cloudskiff/driftctl/pkg/version.version=v#{version}",
-             *std_go_args
+    ENV["CGO_ENABLED"] = "0"
+
+    ldflags = %W[
+      -s -w
+      -X github.com/cloudskiff/driftctl/build.env=release
+      -X github.com/cloudskiff/driftctl/pkg/version.version=v#{version}",
+    ].join(" ")
+
+    system "go", "build", "-ldflags", ldflags,
+                          *std_go_args
+
+    output = Utils.safe_popen_read("#{bin}/driftctl", "completion", "bash")
+    (bash_completion/"driftctl").write output
+
+    output = Utils.safe_popen_read("#{bin}/driftctl", "completion", "zsh")
+    (zsh_completion/"_driftctl").write output
+
+    output = Utils.safe_popen_read("#{bin}/driftctl", "completion", "fish")
+    (fish_completion/"driftctl.fish").write output
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This change adds a number of improvements to the formula:

- Change how build flags are assembled and set `CGO_ENABLED` to `0`

- Install completion script for _Bash_, _ZSH_ and _Fish_ shells