### PR TITLE
ncurses: disable ada

### DIFF
--- a/Formula/ncurses.rb
+++ b/Formula/ncurses.rb
@@ -30,7 +30,8 @@ class Ncurses < Formula
                           "--enable-symlinks",
                           "--enable-widec",
                           "--with-shared",
-                          "--with-gpm=no"
+                          "--with-gpm=no",
+                          "--without-ada"
     system "make", "install"
     make_libncurses_symlinks
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This was Linux only in linuxbrew-core to prevent opportunistic linking but we should disable ada support on macOS for the same reason.
