### PR TITLE
ncmpcpp: only add -liconv to LDFLAGS on macOS

### DIFF
--- a/Formula/ncmpcpp.rb
+++ b/Formula/ncmpcpp.rb
@@ -31,7 +31,11 @@ class Ncmpcpp < Formula
 
   def install
     ENV.cxx11
-    ENV.append "LDFLAGS", "-liconv"
+
+    on_macos do
+      ENV.append "LDFLAGS", "-liconv"
+    end
+
     ENV.append "BOOST_LIB_SUFFIX", "-mt"
     ENV.append "CXXFLAGS", "-D_XOPEN_SOURCE_EXTENDED"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
