### PR TITLE
libxc: change order of linker flags in test

### DIFF
--- a/Formula/libxc.rb
+++ b/Formula/libxc.rb
@@ -39,7 +39,7 @@ class Libxc < Formula
         printf(\"%d.%d.%d\", major, minor, micro);
       }
     EOS
-    system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lm", "-lxc", "-o", "ctest"
+    system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lxc", "-o", "ctest", "-lm"
     system "./ctest"
 
     (testpath/"test.f90").write <<~EOS


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fix is needed in certain formula on Linux because of an issue with the default behavior with `ld`: https://github.com/Homebrew/linuxbrew-core/pull/18266#issuecomment-568773835.  It should not change anything on macOS but I will rebuild just to be sure.