### PR TITLE
griffon: disable as unsupported

### DIFF
--- a/Formula/griffon.rb
+++ b/Formula/griffon.rb
@@ -6,6 +6,8 @@ class Griffon < Formula
 
   bottle :unneeded
 
+  disable! date: "2021-04-01", because: :unsupported
+
   def install
     rm_f Dir["bin/*.bat"]
     libexec.install Dir["*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
5 downloads in the past year and the latest major version (that we don't ship) does not support this command anymore.

See https://github.com/Homebrew/homebrew-core/issues/74335