### PR TITLE
geogram: add livecheck

### DIFF
--- a/Formula/geogram.rb
+++ b/Formula/geogram.rb
@@ -5,6 +5,11 @@ class Geogram < Formula
   sha256 "4456d65baa014e9eb0352675f76eca260ed97eb386d23bc5c13af419dc2e8142"
   license all_of: ["BSD-3-Clause", :public_domain, "LGPL-3.0-or-later", "MIT"]
 
+  livecheck do
+    url "https://gforge.inria.fr/frs/?group_id=5833"
+    regex(/href=.*?geogram[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 big_sur:     "16a2b60356439f3a481677989c256085696690a1599636859bc18a31723e075d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `geogram`. This PR adds a `livecheck` block that checks the third-party download page, which links to the `stable` archive. The `gforge.inria.fr` page used as the `url` in the `livecheck` block is linked from the `homepage` as the location for downloads.