### PR TITLE
libdrm: add docutils as dependency

### DIFF
--- a/Formula/libdrm.rb
+++ b/Formula/libdrm.rb
@@ -4,15 +4,14 @@ class Libdrm < Formula
   url "https://dri.freedesktop.org/libdrm/libdrm-2.4.104.tar.xz"
   sha256 "d66ad8b5c2441015ac1333e40137bb803c3bde3612ff040286fcc12158ea1bcb"
   license "MIT"
+  revision 1
 
   livecheck do
     url "https://dri.freedesktop.org/libdrm/"
     regex(/href=.*?libdrm[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  depends_on "docbook" => :build
-  depends_on "docbook-xsl" => :build
-  depends_on "libxslt" => :build
+  depends_on "docutils" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Since `libdrm v2.4.104` format of their docs was switched from DocBook to RST. Details: https://github.com/freedesktop/mesa-drm/commit/05b0a955d33a7a1d6a3171f4051fa4ed2f3327a6