### PR TITLE
duck: update livecheck

### DIFF
--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -1,15 +1,14 @@
 class Duck < Formula
   desc "Command-line interface for Cyberduck (a multi-protocol file transfer tool)"
   homepage "https://duck.sh/"
-  # check the changelog for the latest stable version: https://cyberduck.io/changelog/
   url "https://dist.duck.sh/duck-src-7.8.5.34493.tar.gz"
   sha256 "766b29ae7135c3dd0bcce85c910236baa52669c6535fc00eb6446a6b4c7d25c6"
   license "GPL-3.0-only"
   head "https://svn.cyberduck.io/trunk/"
 
   livecheck do
-    url "https://cyberduck.io/changelog/"
-    regex(/href=.*?Cyberduck[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+    url "https://dist.duck.sh/"
+    regex(/href=.*?duck-src[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `duck` checks the [Cyberduck changelog](https://cyberduck.io/changelog/) page but the version in the latest filenames is `7.8.5.34411`, which isn't a real version (i.e., the links give a 404). Whoever updated the page must have copied the links for `7.8.3.34411` and changed `7.8.3` to `7.8.5` but forgot to update the last set of digits, as the correct version is `7.8.5.34493`.

Though the formula mentions that you should check the Cyberduck changelog page for the latest stable version, the [installation instructions](https://trac.cyberduck.io/wiki/help/en/howto/cli#Installation) for the `duck` CLI tool point to https://dist.duck.sh/ to find downloads. It seems that we may be better off having livecheck simply check https://dist.duck.sh, as that's where the `duck-src` archives are found and the aforementioned Cyberduck changelog page doesn't even link to `duck-src` archive files. The releases in this directory all seem to be stable versions, so it seems appropriate to me.

Thoughts on this?