### PR TITLE
irssi: fix on Apple silicon

### DIFF
--- a/Formula/irssi.rb
+++ b/Formula/irssi.rb
@@ -1,7 +1,7 @@
 class Irssi < Formula
   desc "Modular IRC client"
   homepage "https://irssi.org/"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 2
 
   stable do

--- a/Formula/irssi.rb
+++ b/Formula/irssi.rb
@@ -1,10 +1,30 @@
 class Irssi < Formula
   desc "Modular IRC client"
   homepage "https://irssi.org/"
-  url "https://github.com/irssi/irssi/releases/download/1.2.2/irssi-1.2.2.tar.xz"
-  sha256 "6727060c918568ba2ff4295ad736128dba0b995d7b20491bca11f593bd857578"
   license "GPL-2.0"
-  revision 1
+  revision 2
+
+  stable do
+    # We can switch back to a tarball after the next release;
+    # irssi's autogen refuses to work from a tarball
+    url "https://github.com/irssi/irssi.git", tag: "1.2.2"
+
+    # Backports an upstream patch which disables some autoconf behaviour;
+    # prerequisite for the next patch to work.
+    # https://github.com/irssi/irssi/pull/1268
+    patch do
+      url "https://github.com/Homebrew/formula-patches/raw/467f95fcd0438b5f7a88ae0c406a8f73bc93b501/irssi/nostdinc.diff"
+      sha256 "00a7fe5e796ec3e37d629e0484f08f23b0fa33a428088d120ac0d8283054449c"
+    end
+
+    # Backports a patch which adjusts how irssi uses curses headers,
+    # required for it to work properly on Apple silicon.
+    # https://github.com/irssi/irssi/pull/1290
+    patch do
+      url "https://github.com/Homebrew/formula-patches/raw/467f95fcd0438b5f7a88ae0c406a8f73bc93b501/irssi/curses_check.patch"
+      sha256 "a505394680e518712e9d0ab0ff14622d34b633b8310dbbfa42b5ad1df7fd3050"
+    end
+  end
 
   livecheck do
     url "https://irssi.org/download/"
@@ -28,6 +48,11 @@ class Irssi < Formula
     depends_on "libtool" => :build
     depends_on "lynx" => :build
   end
+
+  # Needed while we're regenerating configure due to the patch
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
 
   depends_on "pkg-config" => :build
   depends_on "glib"
@@ -58,10 +83,10 @@ class Irssi < Formula
       args << "--with-ncurses=#{Formula["ncurses"].prefix}"
     end
 
-    if build.head?
-      ENV["NOCONFIGURE"] = "yes"
-      system "./autogen.sh", *args
-    end
+    # Restore this to an `if build.head?` conditional
+    # once we no longer need the patch
+    ENV["NOCONFIGURE"] = "yes"
+    system "./autogen.sh", *args
 
     system "./configure", *args
     # "make" and "make install" must be done separately on some systems


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

While irssi built, it didn't work properly. As noted in #68856, text was rendered incorrectly. This eventually turned out to be an issue with how irssi was prototyping ncurses functions, rather than using the library's real headers, though it only affets Apple silicon and not Intel. It was fixed upstream in https://github.com/irssi/irssi/pull/1290. This backports that patch, plus one more patch needed for it.

I've switched over to using the irssi git repo because they don't support performing autoreconf from the tarball, and patching the generated configure files was honestly a pain. We can switch back to the tarball on the next release.