### PR TITLE
hdf5-mpi: add livecheck, license

### DIFF
--- a/Formula/hdf5-mpi.rb
+++ b/Formula/hdf5-mpi.rb
@@ -3,7 +3,16 @@ class Hdf5Mpi < Formula
   homepage "https://www.hdfgroup.org/HDF5"
   url "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.0/src/hdf5-1.12.0.tar.bz2"
   sha256 "97906268640a6e9ce0cde703d5a71c9ac3092eded729591279bf2e3ca9765f61"
+  license "BSD-3-Clause"
   revision 1
+
+  # This regex isn't matching filenames within href attributes (as we normally
+  # do on HTML pages) because this page uses JavaScript to handle the download
+  # buttons and the HTML doesn't contain the related URLs.
+  livecheck do
+    url "https://www.hdfgroup.org/downloads/hdf5/source-code/"
+    regex(/>\s*hdf5[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "483dd167599e83c428e8dd159fa2bbf44a217edf85c61978e2bfd19bda025a39"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `hdf5-mpi`. This PR adds a `livecheck` block that checks the [first-party download page for source code](https://www.hdfgroup.org/downloads/hdf5/source-code/), which contains information for the `stable` archive.

For what it's worth, this regex isn't matching filenames within href attributes (as we normally do on HTML pages) because this page uses JavaScript to handle the download buttons and the HTML doesn't contain the related URLs.

This also adds `BSD-3-Clause` license information, referencing https://github.com/HDFGroup/hdf5/blob/develop/COPYING.