### PR TITLE
hdf5: update livecheck

### DIFF
--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -6,9 +6,12 @@ class Hdf5 < Formula
   license "BSD-3-Clause"
   revision 1
 
+  # This regex isn't matching filenames within href attributes (as we normally
+  # do on HTML pages) because this page uses JavaScript to handle the download
+  # buttons and the HTML doesn't contain the related URLs.
   livecheck do
-    url "https://www.hdfgroup.org/downloads/hdf5/"
-    regex(/Newsletter for HDF5[._-]v?(.*?) Release/i)
+    url "https://www.hdfgroup.org/downloads/hdf5/source-code/"
+    regex(/>\s*hdf5[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates the existing `livecheck` block for `hdf5` to use the same `livecheck` block from `hdf5-mpi` in #74432.

The existing `livecheck` block checks the first-party download page but this page only links to binaries. This PR updates the block to check the download page for source files, since this is what we use as the `stable` archive and we prefer to align the check with the `stable` source.

Additionally, this reworks the regex to match the version from tarball filenames, which is closer to our typical regexes for HTML pages. This helps to bring the regex closer to our current standards. Notably, this uses the standard regex for versions like `1.2.3`/`v1.2.3` (`v?(\d+(?:\.\d+)+)`) instead of the very loose `(.*?)` that was being used here.

For what it's worth, this regex isn't matching filenames within `href` attributes (as we normally do on HTML pages) because this page uses JavaScript to handle the download buttons and the HTML doesn't contain the related URLs.