### PR TITLE
grepcidr: add livecheck

### DIFF
--- a/Formula/grepcidr.rb
+++ b/Formula/grepcidr.rb
@@ -5,6 +5,11 @@ class Grepcidr < Formula
   sha256 "61886a377dabf98797145c31f6ba95e6837b6786e70c932324b7d6176d50f7fb"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?grepcidr[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d2a44c09499df8266ce513c939722e15a3b8365cb9802a1311450d470ad01b0e"
     sha256 cellar: :any_skip_relocation, big_sur:       "1aee569b691f9aee204924d4059b55b5d28be63394350b9ed5993d42a131c081"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `grepcidr`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.