### PR TITLE
zeek: Link with libmaxminddb for GeoIP support

### DIFF
--- a/Formula/zeek.rb
+++ b/Formula/zeek.rb
@@ -5,7 +5,7 @@ class Zeek < Formula
       tag:      "v4.0.0",
       revision: "7b5263139e9909757c38dfca4c99abebf958df67"
   license "BSD-3-Clause"
-  revision 2
+  revision 3
   head "https://github.com/zeek/zeek.git"
 
   bottle do

--- a/Formula/zeek.rb
+++ b/Formula/zeek.rb
@@ -20,6 +20,7 @@ class Zeek < Formula
   depends_on "swig" => :build
   depends_on "caf"
   depends_on "geoip"
+  depends_on "libmaxminddb"
   depends_on macos: :mojave
   depends_on "openssl@1.1"
   depends_on "python@3.9"
@@ -34,6 +35,7 @@ class Zeek < Formula
                       "-DBUILD_SHARED_LIBS=on",
                       "-DINSTALL_AUX_TOOLS=on",
                       "-DINSTALL_ZEEKCTL=on",
+                      "-DUSE_GEOIP=on",
                       "-DCAF_ROOT=#{Formula["caf"].opt_prefix}",
                       "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
                       "-DZEEK_ETC_INSTALL_DIR=#{etc}",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

With the previous Zeek that was available via Homebrew, if you used Zeek Package Manager to add on a package such as https://github.com/brimdata/geoip-conn and then process some traffic, it would fail saying `Zeek was not configured for GeoIP support`. Modern Zeek versions need to be linked with libmaxminddb for their GeoIP support, so this change makes that work. If there's no Zeek package installed that uses the geolocation support, Zeek still runs fine.

A similar change has already been done for the Linux binaries that are managed by the Zeek core dev team at https://github.com/zeek/zeek/issues/1086, so I'm just hoping to bring a similar change to the Homebrew one so Zeek users who do binary installs on any platform can install and use such GeoIP packages rather than having to recompile Zeek.