### PR TITLE
yajl: Fix CFLAGS in pkgconfig

### DIFF
--- a/Formula/yajl.rb
+++ b/Formula/yajl.rb
@@ -4,6 +4,7 @@ class Yajl < Formula
   url "https://github.com/lloyd/yajl/archive/2.1.0.tar.gz"
   sha256 "3fb73364a5a30efe615046d07e6db9d09fd2b41c763c5f7d3bfb121cd5c5ac5a"
   license "ISC"
+  revision 1
 
   bottle do
     rebuild 4
@@ -20,6 +21,13 @@ class Yajl < Formula
 
   # Configure uses cmake internally
   depends_on "cmake" => :build
+
+  # Remove it as soon as https://github.com/lloyd/yajl/pull/139 is resolved
+  # The same patch is applied in FreeBSD, Fedora and its derivatives
+  patch do
+    url "https://github.com/lloyd/yajl/commit/681eeb01ac1cfd56b3a21a409cd64781d26798f0.patch?full_index=1"
+    sha256 "b8b917dcf41b75205e33a4b9fda7a18b3578fbed0e88532b4437302b75b82f80"
+  end
 
   def install
     ENV.deparallelize


### PR DESCRIPTION
libvirt can't be built from source because yajl contains `CFLAGS` in
pkgconfig not matching layout of installed headers:
```
  ../src/util/virjson.c:36:11: fatal error: 'yajl/yajl_gen.h' file not
  found
  # include <yajl/yajl_gen.h>
            ^~~~~~~~~~~~~~~~~
  1 error generated.
```
Here's pkg-config output from meson logs:
```
  Called `/opt/homebrew/bin/pkg-config --cflags yajl` -> 0
  -I/opt/homebrew/Cellar/yajl/2.1.0/include/yajl
```
Here's actual layout of includedir:
```
  /opt/homebrew/Cellar/yajl/2.1.0/include/yajl/yajl_tree.h
  /opt/homebrew/Cellar/yajl/2.1.0/include/yajl/yajl_gen.h
  /opt/homebrew/Cellar/yajl/2.1.0/include/yajl/yajl_common.h
  /opt/homebrew/Cellar/yajl/2.1.0/include/yajl/yajl_version.h
  /opt/homebrew/Cellar/yajl/2.1.0/include/yajl/yajl_parse.h
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
