### PR TITLE
*formula: add depends_on :macos 

### DIFF
--- a/Formula/aws-keychain.rb
+++ b/Formula/aws-keychain.rb
@@ -7,6 +7,8 @@ class AwsKeychain < Formula
 
   bottle :unneeded
 
+  depends_on :macos
+
   def install
     bin.install "aws-keychain"
   end

--- a/Formula/bartycrouch.rb
+++ b/Formula/bartycrouch.rb
@@ -14,6 +14,7 @@ class Bartycrouch < Formula
   end
 
   depends_on xcode: ["12.0", :build]
+  depends_on :macos
 
   def install
     system "make", "install", "prefix=#{prefix}"

--- a/Formula/brightness.rb
+++ b/Formula/brightness.rb
@@ -17,6 +17,8 @@ class Brightness < Formula
     sha256 cellar: :any_skip_relocation, mavericks:     "222e314519f00aa2ad858c718f0dbed624f486f307828ed93a85d1df4e08a8f8"
   end
 
+  depends_on :macos
+
   def install
     system "make"
     system "make", "prefix=#{prefix}", "install"

--- a/Formula/chrome-cli.rb
+++ b/Formula/chrome-cli.rb
@@ -17,6 +17,7 @@ class ChromeCli < Formula
   end
 
   depends_on xcode: :build
+  depends_on :macos
 
   def install
     # Release builds

--- a/Formula/dark-mode.rb
+++ b/Formula/dark-mode.rb
@@ -14,6 +14,7 @@ class DarkMode < Formula
   end
 
   depends_on xcode: :build
+  depends_on :macos
   depends_on macos: :mojave
 
   def install

--- a/Formula/defaultbrowser.rb
+++ b/Formula/defaultbrowser.rb
@@ -15,6 +15,8 @@ class Defaultbrowser < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:    "f0ccf84abbd31469f80c4d232292dd280a978d3f04a1a6db46079902d9821d1e"
   end
 
+  depends_on :macos
+
   def install
     system "make", "install", "PREFIX=#{prefix}"
   end

--- a/Formula/docker-machine-parallels.rb
+++ b/Formula/docker-machine-parallels.rb
@@ -17,6 +17,7 @@ class DockerMachineParallels < Formula
 
   depends_on "go" => :build
   depends_on "docker-machine"
+  depends_on :macos
 
   def install
     system "make", "build"

--- a/Formula/dockutil.rb
+++ b/Formula/dockutil.rb
@@ -7,6 +7,8 @@ class Dockutil < Formula
 
   bottle :unneeded
 
+  depends_on :macos
+
   def install
     bin.install "scripts/dockutil"
   end

--- a/Formula/duti.rb
+++ b/Formula/duti.rb
@@ -21,6 +21,7 @@ class Duti < Formula
   end
 
   depends_on "autoconf" => :build
+  depends_on :macos
 
   # Fix compilation on macOS 10.14 Mojave
   patch do

--- a/Formula/fileicon.rb
+++ b/Formula/fileicon.rb
@@ -13,6 +13,8 @@ class Fileicon < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "154c80c94f29f209b78252e71d914647a8300c66c02acda672b8574e8e704e92"
   end
 
+  depends_on :macos
+
   def install
     bin.install "bin/fileicon"
     man1.install "man/fileicon.1"

--- a/Formula/fmdiff.rb
+++ b/Formula/fmdiff.rb
@@ -19,6 +19,7 @@ class Fmdiff < Formula
   end
 
   # Needs FileMerge.app, which is part of Xcode.
+  depends_on :macos
   depends_on :xcode
 
   def install

--- a/Formula/folderify.rb
+++ b/Formula/folderify.rb
@@ -17,6 +17,7 @@ class Folderify < Formula
   end
 
   depends_on "imagemagick"
+  depends_on :macos
   depends_on "python@3.9"
 
   def install

--- a/Formula/fsevent_watch.rb
+++ b/Formula/fsevent_watch.rb
@@ -13,6 +13,8 @@ class FseventWatch < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "4f9c9f11ee85b971d840b9b3626ed55c7b9160308900de2278a7b159a384f0f0"
   end
 
+  depends_on :macos
+
   def install
     bin.mkpath
     system "make", "install", "PREFIX=#{prefix}", "CFLAGS=-DCLI_VERSION=\\\"#{version}\\\""

--- a/Formula/fsevents-tools.rb
+++ b/Formula/fsevents-tools.rb
@@ -25,6 +25,8 @@ class FseventsTools < Formula
     depends_on "pkg-config" => :build
   end
 
+  depends_on :macos
+
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/gtk-mac-integration.rb
+++ b/Formula/gtk-mac-integration.rb
@@ -32,6 +32,7 @@ class GtkMacIntegration < Formula
   depends_on "gettext"
   depends_on "gtk+"
   depends_on "gtk+3"
+  depends_on :macos
 
   def install
     args = %W[

--- a/Formula/ical-buddy.rb
+++ b/Formula/ical-buddy.rb
@@ -14,6 +14,8 @@ class IcalBuddy < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "4f621e8b12e2c2e5e7c9fdd97ee973b7d4b14ce58eb5a5f7a9db32243f0f99f1"
   end
 
+  depends_on :macos
+
   def install
     args = %W[icalBuddy icalBuddy.1 icalBuddyLocalization.1
               icalBuddyConfig.1 COMPILER=#{ENV.cc}]

--- a/Formula/imessage-ruby.rb
+++ b/Formula/imessage-ruby.rb
@@ -18,6 +18,8 @@ class ImessageRuby < Formula
     sha256 cellar: :any_skip_relocation, mavericks:     "7b546ccf5cf13a7d474c635a57eebc8e74ff61ea6c7c3cdfefffe4c78737ab47"
   end
 
+  depends_on :macos
+
   def install
     system "rake", "standalone:install", "prefix=#{prefix}"
   end

--- a/Formula/ios-sim.rb
+++ b/Formula/ios-sim.rb
@@ -16,6 +16,7 @@ class IosSim < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "ddbe9d541710ab4dd219db3f766e878ff8698dcd88c25a247e5c44e165ea2773"
   end
 
+  depends_on :macos
   depends_on "node"
 
   def install

--- a/Formula/launch.rb
+++ b/Formula/launch.rb
@@ -22,6 +22,7 @@ class Launch < Formula
   end
 
   depends_on xcode: :build
+  depends_on :macos
 
   def install
     rm_rf "launch" # We'll build it ourself, thanks.

--- a/Formula/m-cli.rb
+++ b/Formula/m-cli.rb
@@ -8,6 +8,8 @@ class MCli < Formula
 
   bottle :unneeded
 
+  depends_on :macos
+
   def install
     prefix.install Dir["*"]
     inreplace prefix/"m" do |s|

--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -19,6 +19,7 @@ class Macvim < Formula
   depends_on "cscope"
   depends_on "gettext"
   depends_on "lua"
+  depends_on :macos
   depends_on "python@3.9"
   depends_on "ruby"
 

--- a/Formula/mplayershell.rb
+++ b/Formula/mplayershell.rb
@@ -18,7 +18,7 @@ class Mplayershell < Formula
   end
 
   depends_on xcode: :build
-
+  depends_on :macos
   depends_on "mplayer"
 
   def install

--- a/Formula/rem.rb
+++ b/Formula/rem.rb
@@ -18,6 +18,7 @@ class Rem < Formula
   end
 
   depends_on xcode: :build
+  depends_on :macos
 
   conflicts_with "remind", because: "both install `rem` binaries"
 

--- a/Formula/sbjson.rb
+++ b/Formula/sbjson.rb
@@ -15,6 +15,7 @@ class Sbjson < Formula
   end
 
   depends_on xcode: :build
+  depends_on :macos
 
   def install
     xcodebuild "-project", "SBJson5.xcodeproj",

--- a/Formula/screenresolution.rb
+++ b/Formula/screenresolution.rb
@@ -18,6 +18,8 @@ class Screenresolution < Formula
     sha256 cellar: :any_skip_relocation, mavericks:     "9e6944af938c0c9ec9e1e4a79a6849fabb222baa0d977a9425bee6a2827595d0"
   end
 
+  depends_on :macos
+
   def install
     system "make", "CC=#{ENV.cc}"
     system "make", "PREFIX=#{prefix}", "install"

--- a/Formula/sourcekitten.rb
+++ b/Formula/sourcekitten.rb
@@ -14,6 +14,7 @@ class Sourcekitten < Formula
   end
 
   depends_on xcode: ["11.4", :build]
+  depends_on :macos
   depends_on xcode: "6.0"
 
   def install

--- a/Formula/switchaudio-osx.rb
+++ b/Formula/switchaudio-osx.rb
@@ -18,6 +18,7 @@ class SwitchaudioOsx < Formula
   end
 
   depends_on xcode: :build
+  depends_on :macos
 
   def install
     xcodebuild "-project", "AudioSwitcher.xcodeproj",

--- a/Formula/terminal-notifier.rb
+++ b/Formula/terminal-notifier.rb
@@ -17,6 +17,7 @@ class TerminalNotifier < Formula
   end
 
   depends_on xcode: :build
+  depends_on :macos
 
   def install
     xcodebuild "-project", "Terminal Notifier.xcodeproj",

--- a/Formula/veclibfort.rb
+++ b/Formula/veclibfort.rb
@@ -16,6 +16,7 @@ class Veclibfort < Formula
   end
 
   depends_on "gcc" # for gfortran
+  depends_on :macos
 
   def install
     system "make", "all"

--- a/Formula/xcenv.rb
+++ b/Formula/xcenv.rb
@@ -8,6 +8,8 @@ class Xcenv < Formula
 
   bottle :unneeded
 
+  depends_on :macos
+
   def install
     prefix.install ["bin", "libexec"]
   end

--- a/Formula/xcodegen.rb
+++ b/Formula/xcodegen.rb
@@ -14,6 +14,7 @@ class Xcodegen < Formula
   end
 
   depends_on xcode: ["10.2", :build]
+  depends_on :macos
 
   def install
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/xctool.rb
+++ b/Formula/xctool.rb
@@ -12,6 +12,7 @@ class Xctool < Formula
     sha256 cellar: :any, high_sierra: "055172ba606bf94416513e418007f849a08ff24a3b3484fb67c1b4f854123bb9"
   end
 
+  depends_on :macos
   depends_on xcode: "7.0"
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

These formulae should all explicitly depend on macOS.  This was already added in linuxbrew-core so I'm just upstreaming the changes to reduce the diff between the repos.  I've only included formula here which are not deprecated or disabled and don't have missing or deprecated licenses.  I'll take care of those other cases in individual PRs for those formulae.