### PR TITLE
ilmbase: deprecate

### DIFF
--- a/Formula/ilmbase.rb
+++ b/Formula/ilmbase.rb
@@ -13,6 +13,9 @@ class Ilmbase < Formula
     sha256 mojave:        "53b8f2f3e3e1ef9b6c22de5993eec29ab6d9cc46109df39a7eb7b49f0b8e02a2"
   end
 
+  # https://github.com/AcademySoftwareFoundation/openexr/pull/929
+  deprecate! date: "2021-04-05", because: :unsupported
+
   depends_on "cmake" => :build
 
   def install


### PR DESCRIPTION
Starting with 3.0.0, ilmbase is removed per AcademySoftwareFoundation/openexr#929

---

also relates to #74383

