### PR TITLE
tcsh: add csh symlink

### DIFF
--- a/Formula/tcsh.rb
+++ b/Formula/tcsh.rb
@@ -4,6 +4,8 @@ class Tcsh < Formula
   url "https://astron.com/pub/tcsh/tcsh-6.22.03.tar.gz"
   mirror "https://ftp.osuosl.org/pub/blfs/conglomeration/tcsh/tcsh-6.22.03.tar.gz"
   sha256 "be2cfd653d2a0c7f506d2dd14c12324ba749bd484037be6df44a3973f52262b7"
+  license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url "https://astron.com/pub/tcsh/"
@@ -22,6 +24,7 @@ class Tcsh < Formula
   def install
     system "./configure", "--prefix=#{prefix}", "--sysconfdir=#{etc}"
     system "make", "install"
+    bin.install_symlink "tcsh" => "csh"
   end
 
   test do


### PR DESCRIPTION
csh provides a subset of tcsh.
This PR adds a csh symlink so that some tools on Linux that expect csh can
use the backward compatible tcsh instead.

On most Linux systems, csh is a symbolic link to tcsh.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
