### PR TITLE
sdl_mixer: set cocoa flag only on macOS

### DIFF
--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -50,11 +50,15 @@ class SdlMixer < Formula
 
   test do
     testpath.install resource("playwave")
+    cocoa = ""
+    on_macos do
+      cocoa = "-Wl,-framework,Cocoa"
+    end
     system ENV.cc, "-o", "playwave", "playwave.c", "-I#{include}/SDL",
                    "-I#{Formula["sdl"].opt_include}/SDL",
                    "-L#{lib}", "-lSDL_mixer",
                    "-L#{Formula["sdl"].lib}", "-lSDLmain", "-lSDL",
-                   "-Wl,-framework,Cocoa"
+                   cocoa
     Utils.safe_popen_read({ "SDL_VIDEODRIVER" => "dummy", "SDL_AUDIODRIVER" => "disk" },
                           "./playwave", test_fixtures("test.wav"))
     assert_predicate testpath/"sdlaudio.raw", :exist?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
