### PR TITLE
rtags: set -lc++abi flag only on macOS

### DIFF
--- a/Formula/rtags.rb
+++ b/Formula/rtags.rb
@@ -4,7 +4,7 @@ class Rtags < Formula
   url "https://github.com/Andersbakken/rtags.git",
       tag:      "v2.38",
       revision: "9687ccdb9e539981e7934e768ea5c84464a61139"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/Andersbakken/rtags.git"
 
   livecheck do
@@ -26,8 +26,10 @@ class Rtags < Formula
   depends_on "openssl@1.1"
 
   def install
-    # Homebrew llvm libc++.dylib doesn't correctly reexport libc++abi
-    ENV.append("LDFLAGS", "-lc++abi")
+    on_macos do
+      # Homebrew llvm libc++.dylib doesn't correctly reexport libc++abi
+      ENV.append("LDFLAGS", "-lc++abi")
+    end
 
     args = std_cmake_args << "-DRTAGS_NO_BUILD_CLANG=ON"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
