### PR TITLE
rav1e: revision for cargo-c

### DIFF
--- a/Formula/rav1e.rb
+++ b/Formula/rav1e.rb
@@ -4,8 +4,8 @@ class Rav1e < Formula
   url "https://github.com/xiph/rav1e/archive/v0.4.1.tar.gz"
   sha256 "b0be59435a40e03b973ecc551ca7e632e03190b5a20f944818afa3c2ecf4852d"
   license "BSD-2-Clause"
-  head "https://github.com/xiph/rav1e.git"
   revision 1
+  head "https://github.com/xiph/rav1e.git"
 
   livecheck do
     url :stable

--- a/Formula/rav1e.rb
+++ b/Formula/rav1e.rb
@@ -5,6 +5,7 @@ class Rav1e < Formula
   sha256 "b0be59435a40e03b973ecc551ca7e632e03190b5a20f944818afa3c2ecf4852d"
   license "BSD-2-Clause"
   head "https://github.com/xiph/rav1e.git"
+  revision 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The only formula currently using the `cinstall` command of `cargo-c` is `rav1e`.  The 0.8.0 `cargo-c` release in https://github.com/Homebrew/homebrew-core/pull/74433 includes https://github.com/lu-zero/cargo-c/pull/179 which made release the default profile for the `cinstall` command. Bumping the revision of this formula will enable the shared library to be re-bottled in release mode instead of debug mode. The default mode of `cinstall` regressed to debug quite a while ago but it was only noticed recently.