### PR TITLE
jflex: add livecheck

### DIFF
--- a/Formula/jflex.rb
+++ b/Formula/jflex.rb
@@ -5,6 +5,11 @@ class Jflex < Formula
   sha256 "a1e0d25e341d01de6b93ec32b45562905e69d06598113934b74f76b1be7927ab"
   revision 1
 
+  livecheck do
+    url "https://jflex.de/download.html"
+    regex(/href=.*?jflex[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle :unneeded
 
   depends_on "openjdk"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `jflex`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.