### PR TITLE
tests.yml: remove spaces in logs/failed bottles directory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@main
         with:
-          name: logs (${{ matrix.version }})
+          name: logs-${{ matrix.version }}
           path: bottles/logs
 
       - name: Delete logs and home
@@ -151,7 +151,7 @@ jobs:
         if: always() && steps.bottles.outputs.failures > 0
         uses: actions/upload-artifact@main
         with:
-          name: bottles (${{ matrix.version }})
+          name: bottles-${{ matrix.version }}
           path: bottles/failed
 
       # Must be run before the `Upload bottles` step so that failed


### PR DESCRIPTION
Currently, failed bottles are stored in a directory called "bottles
(11.0)" (or similarly for logs or other OS versions). This creates
spaces in the directory name, which just isn't pleasant to deal with.

I've replaced the space with a `-`, and removed the parentheses.