### PR TITLE
juman: add livecheck

### DIFF
--- a/Formula/juman.rb
+++ b/Formula/juman.rb
@@ -1,8 +1,13 @@
 class Juman < Formula
   desc "Japanese morphological analysis system"
-  homepage "http://nlp.ist.i.kyoto-u.ac.jp/index.php?JUMAN"
-  url "http://nlp.ist.i.kyoto-u.ac.jp/nl-resource/juman/juman-7.01.tar.bz2"
+  homepage "https://nlp.ist.i.kyoto-u.ac.jp/index.php?JUMAN"
+  url "https://nlp.ist.i.kyoto-u.ac.jp/nl-resource/juman/juman-7.01.tar.bz2"
   sha256 "64bee311de19e6d9577d007bb55281e44299972637bd8a2a8bc2efbad2f917c6"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?juman[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 arm64_big_sur: "9b0c1166c946ef258a558961fa82660502d705bbbecf6b8735a805b093802432"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `juman`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This also updates the `homepage` and `stable` URLs to use https, as the existing URLs redirect from http to https.