### PR TITLE
libsvg: fix for ARM/M1 Macs

### DIFF
--- a/Formula/libsvg.rb
+++ b/Formula/libsvg.rb
@@ -32,13 +32,8 @@ class Libsvg < Formula
 
   uses_from_macos "libxml2"
 
-  # Allow building on M1 Macs. libsvg uses a very old configuration for
-  # autotools that appears now to be deprecated (Cairo itself got rid of these
-  # macros in 2008). This patch adapts the fix Cairo made to unblock
-  # installation on modern computers. It is unlikely that this patch will be
-  # accepted upstream, since as far as I understand it libsvg is in
-  # less-than-maintainence mode.
-  # (https://cgit.freedesktop.org/cairo/commit/?id=afdf3917ee86a7d8ae17f556db96478682674a76)
+  # Allow building on M1 Macs. This patch is adapted from
+  # https://cgit.freedesktop.org/cairo/commit/?id=afdf3917ee86a7d8ae17f556db96478682674a76
   patch :DATA
 
   def install

--- a/Formula/libsvg.rb
+++ b/Formula/libsvg.rb
@@ -23,14 +23,53 @@ class Libsvg < Formula
     sha256 cellar: :any, mavericks:   "a6de74ce690bcc7dffd353139182dc0d896250cdca652c315356349f7e78729e"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "jpeg"
   depends_on "libpng"
-
+  
   uses_from_macos "libxml2"
+  
+  stable do
+    # Allow building on M1 Macs.
+    patch :DATA
+  end
+
 
   def install
+    system "autoreconf", "-fiv"
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end
 end
+
+__END__
+diff --git a/configure.in b/configure.in
+index a9f871e..c84d417 100755
+--- a/configure.in
++++ b/configure.in
+@@ -8,18 +8,18 @@ LIBSVG_VERSION=0.1.4
+ # libtool shared library version
+ 
+ # Increment if the interface has additions, changes, removals.
+-LT_CURRENT=1
++m4_define(LT_CURRENT, 1)
+ 
+ # Increment any time the source changes; set to
+ # 0 if you increment CURRENT
+-LT_REVISION=0
++m4_define(LT_REVISION, 0)
+ 
+ # Increment if any interfaces have been added; set to 0
+ # if any interfaces have been removed. removal has
+ # precedence over adding, so set to 0 if both happened.
+-LT_AGE=0
++m4_define(LT_AGE, 0)
+ 
+-VERSION_INFO="$LT_CURRENT:$LT_REVISION:$LT_AGE"
++VERSION_INFO="LT_CURRENT():LT_REVISION():LT_AGE()"
+ AC_SUBST(VERSION_INFO)
+ 
+ dnl ===========================================================================

--- a/Formula/libsvg.rb
+++ b/Formula/libsvg.rb
@@ -6,11 +6,6 @@ class Libsvg < Formula
   license "LGPL-2.1-or-later"
   revision 1
 
-  stable do
-    # Allow building on M1 Macs.
-    patch :DATA
-  end
-
   livecheck do
     url "https://cairographics.org/snapshots/"
     regex(/href=.*?libsvg[._-]v?(\d+(?:\.\d+)+)\.t/i)
@@ -36,6 +31,15 @@ class Libsvg < Formula
   depends_on "libpng"
 
   uses_from_macos "libxml2"
+
+  # Allow building on M1 Macs. libsvg uses a very old configuration for
+  # autotools that appears now to be deprecated (Cairo itself got rid of these
+  # macros in 2008). This patch adapts the fix Cairo made to unblock
+  # installation on modern computers. It is unlikely that this patch will be
+  # accepted upstream, since as far as I understand it libsvg is in
+  # less-than-maintainence mode.
+  # (https://cgit.freedesktop.org/cairo/commit/?id=afdf3917ee86a7d8ae17f556db96478682674a76)
+  patch :DATA
 
   def install
     system "autoreconf", "-fiv"

--- a/Formula/libsvg.rb
+++ b/Formula/libsvg.rb
@@ -6,6 +6,11 @@ class Libsvg < Formula
   license "LGPL-2.1-or-later"
   revision 1
 
+  stable do
+    # Allow building on M1 Macs.
+    patch :DATA
+  end
+
   livecheck do
     url "https://cairographics.org/snapshots/"
     regex(/href=.*?libsvg[._-]v?(\d+(?:\.\d+)+)\.t/i)
@@ -29,14 +34,8 @@ class Libsvg < Formula
   depends_on "pkg-config" => :build
   depends_on "jpeg"
   depends_on "libpng"
-  
-  uses_from_macos "libxml2"
-  
-  stable do
-    # Allow building on M1 Macs.
-    patch :DATA
-  end
 
+  uses_from_macos "libxml2"
 
   def install
     system "autoreconf", "-fiv"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I introduced a small patch to the very old libsvg automake configuration file that unblocks building. The patch was based on [a change](https://cgit.freedesktop.org/cairo/commit/?id=afdf3917ee86a7d8ae17f556db96478682674a76) Cairo (the biggest known consumer of libsvg, by chance) made to their own configuration in 2008. It is unlikely that this change will be accepted upstream, since I believe the official source is dead and it's largely hosted by Cairo.

TODO: fix test & style errors as necessary.