### PR TITLE
dwm: add livecheck

### DIFF
--- a/Formula/dwm.rb
+++ b/Formula/dwm.rb
@@ -7,6 +7,11 @@ class Dwm < Formula
   revision 2
   head "https://git.suckless.org/dwm", using: :git
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?dwm[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "7fd3a01a1f29927ca94c2c5ea32b4ee0c9f31d9ea39adc04e76ab40517663149"
     sha256 cellar: :any, big_sur:       "afd787afd9c6ea4cc81c100f324d2b8aa4c65c2a06e43ca87d54135425b347cf"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `dwm`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.