### PR TITLE
libusb: upstream Linux fix

### DIFF
--- a/Formula/libusb.rb
+++ b/Formula/libusb.rb
@@ -25,6 +25,10 @@ class Libusb < Formula
     depends_on "libtool" => :build
   end
 
+  on_linux do
+    depends_on "systemd"
+  end
+
   def install
     args = %W[--disable-dependency-tracking --prefix=#{prefix}]
 
@@ -37,8 +41,8 @@ class Libusb < Formula
   test do
     cp_r (pkgshare/"examples"), testpath
     cd "examples" do
-      system ENV.cc, "-lusb-1.0", "-L#{lib}", "-I#{include}/libusb-1.0",
-             "listdevs.c", "-o", "test"
+      system ENV.cc, "listdevs.c", "-L#{lib}", "-I#{include}/libusb-1.0",
+             "-lusb-1.0", "-o", "test"
       system "./test"
     end
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

@iMIchka I think this is a more clear way of fixing this test on Linux than adding `-lusb-1.0` to the very end (I've tested locally and it works).  Hopefully the way I'm doing this won't create confusion when reviewing the merge conflict, but let me know if should make this change in linuxbrew-core first.