### PR TITLE
mx 5.292.6

### DIFF
--- a/Formula/mx.rb
+++ b/Formula/mx.rb
@@ -1,9 +1,14 @@
 class Mx < Formula
   desc "Command-line tool used for the development of Graal projects"
   homepage "https://github.com/graalvm/mx"
-  url "https://github.com/graalvm/mx/archive/refs/tags/5.292.5.tar.gz"
-  sha256 "18c2a8d1af4afd7245fab7fe60f46d6b80a984d23596b053da71f7ef53f68caa"
+  url "https://github.com/graalvm/mx/archive/refs/tags/5.292.6.tar.gz"
+  sha256 "92894dacb210c8f12701a16b275bfbd42390213520deb68bed045f40e3a87164"
   license "GPL-2.0-only"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:  "dd671091cb445364e11ea8765b21cebfecb0d4f587520ebfdabae5fada44827a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates `mx` to the latest version, `5.292.6`.

Besides that, `brew livecheck` is reporting an incorrect version as latest: `8.8` from a `checkstyle-8.8` tag. Version tags in this repository have a format like `5.292.6` but there are some unrelated tags that we need to avoid for the check to work properly.

This PR fixes the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`), so matching is restricted to only the version tags.