### PR TITLE
mongo-cxx-driver: fix rpath for ARM

### DIFF
--- a/Formula/mongo-cxx-driver.rb
+++ b/Formula/mongo-cxx-driver.rb
@@ -25,7 +25,8 @@ class MongoCxxDriver < Formula
     system "cmake", ".", *std_cmake_args,
                         "-DBUILD_VERSION=#{version}",
                         "-DLIBBSON_DIR=#{mongo_c_prefix}",
-                        "-DLIBMONGOC_DIR=#{mongo_c_prefix}"
+                        "-DLIBMONGOC_DIR=#{mongo_c_prefix}",
+                        "-DCMAKE_INSTALL_RPATH=#{lib}"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Should hopefully fix
```
dyld: Library not loaded: @rpath/libbsoncxx._noabi.dylib
  Referenced from: /opt/homebrew/opt/mongo-cxx-driver/lib/libmongocxx._noabi.dylib
  Reason: image not found
```