### PR TITLE
speedtest-cli 2.1.3

### DIFF
--- a/Formula/speedtest-cli.rb
+++ b/Formula/speedtest-cli.rb
@@ -1,8 +1,8 @@
 class SpeedtestCli < Formula
   desc "Command-line interface for https://speedtest.net bandwidth tests"
   homepage "https://github.com/sivel/speedtest-cli"
-  url "https://github.com/sivel/speedtest-cli/archive/v2.1.2.tar.gz"
-  sha256 "a877142eec0ee8dda86519c36fe789480ed6fa603b016b620affd77fbf79b0d9"
+  url "https://github.com/sivel/speedtest-cli/archive/v2.1.3.tar.gz"
+  sha256 "45e3ca21c3ce3c339646100de18db8a26a27d240c29f1c9e07b6c13995a969be"
   license "Apache-2.0"
   head "https://github.com/sivel/speedtest-cli.git"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 24,771 bytes
- formula fetch time: 0.5 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.