### PR TITLE
fastlane: Lock to Ruby 2.6

### DIFF
--- a/Formula/fastlane.rb
+++ b/Formula/fastlane.rb
@@ -4,6 +4,7 @@ class Fastlane < Formula
   url "https://github.com/fastlane/fastlane/archive/2.180.0.tar.gz"
   sha256 "f91c275bce16f9b0e5c2720ec278abdffec405ad983ec75269d12832f589178c"
   license "MIT"
+  revision 1
   head "https://github.com/fastlane/fastlane.git"
 
   livecheck do
@@ -18,7 +19,9 @@ class Fastlane < Formula
     sha256 cellar: :any, mojave:        "42425e2bd0d5322fee4ec9e788bf12822e82c677bb3989cdb48bb004020c588e"
   end
 
-  depends_on "ruby@2.7"
+  # Issue with Ruby 2.7 not finding gems correctly
+  # https://github.com/fastlane/fastlane/issues/18517
+  depends_on "ruby@2.6"
 
   def install
     ENV["GEM_HOME"] = libexec


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes https://github.com/fastlane/fastlane/issues/18517

There is some specific issue with Ruby 2.7 installed via homebrew that returns incorrect results for `Gem::SpecFetcher.fetcher.suggest_gems_from_name("cocoapods")`. This **does not** happen with Ruby 2.7 installed via other methods. Going to lock `fastlane` to Ruby 2.6 (which works properly) until the actual problem and proper solution is figured out 🤷‍♂️ 

cc: @SMillerDev 
