### PR TITLE
jpeginfo: add livecheck

### DIFF
--- a/Formula/jpeginfo.rb
+++ b/Formula/jpeginfo.rb
@@ -7,6 +7,11 @@ class Jpeginfo < Formula
   revision 1
   head "https://github.com/tjko/jpeginfo.git"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?jpeginfo[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any, arm64_big_sur: "883d13008806a89bd05f612ffd27940a5985f47ad9c950af76f719b6a781bb1e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `jpeginfo`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.