### PR TITLE
gnupg: remove unused adns dependency

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -18,7 +18,6 @@ class Gnupg < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "adns"
   depends_on "gettext"
   depends_on "gnutls"
   depends_on "libassuan"


### PR DESCRIPTION
remove build dependency 'adns', which has been deprecated since GnuPG v2.1 - see here for more info: https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commit;h=2e734a3ce159de8fb60df2bd5d454f98ca710717

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
