### PR TITLE
speedtest-cli 2.1.3

### DIFF
--- a/Formula/speedtest-cli.rb
+++ b/Formula/speedtest-cli.rb
@@ -1,8 +1,8 @@
 class SpeedtestCli < Formula
   desc "Command-line interface for https://speedtest.net bandwidth tests"
   homepage "https://github.com/sivel/speedtest-cli"
-  url "https://github.com/sivel/speedtest-cli/archive/v2.1.2.tar.gz"
-  sha256 "a877142eec0ee8dda86519c36fe789480ed6fa603b016b620affd77fbf79b0d9"
+  url "https://github.com/sivel/speedtest-cli/archive/v2.1.3.tar.gz"
+  sha256 "45e3ca21c3ce3c339646100de18db8a26a27d240c29f1c9e07b6c13995a969be"
   license "Apache-2.0"
   head "https://github.com/sivel/speedtest-cli.git"
 


### PR DESCRIPTION
Update the version of `speedtest-cli`

This version will fix the current issue we have with the version 2.1.2:
```
Retrieving speedtest.net configuration...
Traceback (most recent call last):
  File "/usr/local/bin/speedtest-cli", line 2000, in <module>
    main()
  File "/usr/local/bin/speedtest-cli", line 1986, in main
    shell()
  File "/usr/local/bin/speedtest-cli", line 1875, in shell
    secure=args.secure
  File "/usr/local/bin/speedtest-cli", line 1091, in __init__
    self.get_config()
  File "/usr/local/bin/speedtest-cli", line 1174, in get_config
    map(int, server_config['ignoreids'].split(','))
ValueError: invalid literal for int() with base 10: ''
```

:octocat: 