### PR TITLE
id3tool: add livecheck

### DIFF
--- a/Formula/id3tool.rb
+++ b/Formula/id3tool.rb
@@ -4,6 +4,11 @@ class Id3tool < Formula
   url "http://nekohako.xware.cx/id3tool/id3tool-1.2a.tar.gz"
   sha256 "7908d66c5aabe2a53ae8019e8234f4231485d80be4b2fe72c9d04013cff1caec"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?id3tool[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "eec5850fee5d290bad13de2cb4456b2e600560632be7b86309ac5c3f3f03697f"
     sha256 cellar: :any_skip_relocation, big_sur:       "7a6a25738f1961b7ebb929fe0e4746a60ef71fd28af06ea305c5f5d95ef10e60"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `id3tool`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.