### PR TITLE
id3tool: add license

### DIFF
--- a/Formula/id3tool.rb
+++ b/Formula/id3tool.rb
@@ -3,6 +3,7 @@ class Id3tool < Formula
   homepage "http://nekohako.xware.cx/id3tool/"
   url "http://nekohako.xware.cx/id3tool/id3tool-1.2a.tar.gz"
   sha256 "7908d66c5aabe2a53ae8019e8234f4231485d80be4b2fe72c9d04013cff1caec"
+  license "BSD-3-Clause"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds a `license` for `id3tool`. The [`README`](https://github.com/Homebrew/homebrew-core/files/6287499/README.txt) states that `1.2` has been licensed under the "modified BSD" license. Using `licensee` after removing `getopt`'s license from [`COPYING`](https://github.com/Homebrew/homebrew-core/files/6287505/COPYING.txt), it seems to be the BSD 3-Clause license (excuse my unfamiliarity with licenses 😅).

```
License:        NOASSERTION
Matched files:  COPYING.txt
COPYING.txt:
  Content hash:  c73f37039451d544fdf63644daefedce334fb8dd
  License:       NOASSERTION
  Closest non-matching licenses:
    BSD-3-Clause similarity:        87.94%
    BSD-4-Clause similarity:        84.33%
    BSD-3-Clause-Clear similarity:  83.21%
```
