### PR TITLE
tendermint: Fix test

### DIFF
--- a/Formula/tendermint.rb
+++ b/Formula/tendermint.rb
@@ -23,8 +23,8 @@ class Tendermint < Formula
   test do
     mkdir(testpath/"staging")
     shell_output("#{bin}/tendermint init --home #{testpath}/staging")
-    assert_true File.exist?(testpath/"staging/config/genesis.json")
-    assert_true File.exist?(testpath/"staging/config/config.toml")
-    assert_true Dir.exist?(testpath/"staging/data")
+    assert_predicate testpath/"staging/config/genesis.json", :exist?
+    assert_predicate testpath/"staging/config/config.toml", :exist?
+    assert_predicate testpath/"staging/data", :exist?
   end
 end


### PR DESCRIPTION
Fixes:
 MethodDeprecatedError: Calling assert_true is deprecated! Use assert(...) or assert_equal(true, ...) instead.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
