### PR TITLE
bind: some improvements

### DIFF
--- a/Formula/bind.rb
+++ b/Formula/bind.rb
@@ -11,6 +11,7 @@ class Bind < Formula
   url "https://downloads.isc.org/isc/bind9/9.16.13/bind-9.16.13.tar.xz"
   sha256 "a54cc793fa5b69b35f610f2095760f8238dff5cfd52419f7ee1c9c227da4cc08"
   license "MPL-2.0"
+  revision 1
   version_scheme 1
   head "https://gitlab.isc.org/isc-projects/bind9.git"
 
@@ -55,6 +56,7 @@ class Bind < Formula
 
     args = [
       "--prefix=#{prefix}",
+      "--sysconfdir=#{pkgetc}",
       "--with-json-c",
       "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}",
       "--with-libjson=#{Formula["json-c"].opt_prefix}",
@@ -73,110 +75,30 @@ class Bind < Formula
 
     (buildpath/"named.conf").write named_conf
     system "#{sbin}/rndc-confgen", "-a", "-c", "#{buildpath}/rndc.key"
-    etc.install "named.conf", "rndc.key"
+    pkgetc.install "named.conf", "rndc.key"
   end
 
   def post_install
     (var/"log/named").mkpath
-
-    # Create initial configuration/zone/ca files.
-    # (Mirrors Apple system install from 10.8)
-    unless (var/"named").exist?
-      (var/"named").mkpath
-      (var/"named/localhost.zone").write localhost_zone
-      (var/"named/named.local").write named_local
-    end
+    (var/"named").mkpath
   end
 
   def named_conf
     <<~EOS
-      //
-      // Include keys file
-      //
-      include "#{etc}/rndc.key";
-
-      // Declares control channels to be used by the rndc utility.
-      //
-      // It is recommended that 127.0.0.1 be the only address used.
-      // This also allows non-privileged users on the local host to manage
-      // your name server.
-
-      //
-      // Default controls
-      //
-      controls {
-          inet 127.0.0.1 port 54 allow { any; }
-          keys { "rndc-key"; };
+      logging {
+          category default {
+              _default_log;
+          };
+          channel _default_log {
+              file "#{var}/log/named/named.log" versions 10 size 1m;
+              severity info;
+              print-time yes;
+          };
       };
 
       options {
           directory "#{var}/named";
-          /*
-           * If there is a firewall between you and nameservers you want
-           * to talk to, you might need to uncomment the query-source
-           * directive below.  Previous versions of BIND always asked
-           * questions using port 53, but BIND 8.1 uses an unprivileged
-           * port by default.
-           */
-          // query-source address * port 53;
       };
-      //
-      // a caching only nameserver config
-      //
-      zone "localhost" IN {
-          type master;
-          file "localhost.zone";
-          allow-update { none; };
-      };
-
-      zone "0.0.127.in-addr.arpa" IN {
-          type master;
-          file "named.local";
-          allow-update { none; };
-      };
-
-      logging {
-              category default {
-                      _default_log;
-              };
-
-              channel _default_log  {
-                      file "#{var}/log/named/named.log";
-                      severity info;
-                      print-time yes;
-              };
-      };
-    EOS
-  end
-
-  def localhost_zone
-    <<~EOS
-      $TTL    86400
-      $ORIGIN localhost.
-      @            1D IN SOA    @ root (
-                          42        ; serial (d. adams)
-                          3H        ; refresh
-                          15M        ; retry
-                          1W        ; expiry
-                          1D )        ; minimum
-
-                  1D IN NS    @
-                  1D IN A        127.0.0.1
-    EOS
-  end
-
-  def named_local
-    <<~EOS
-      $TTL    86400
-      @       IN      SOA     localhost. root.localhost.  (
-                                            1997022700 ; Serial
-                                            28800      ; Refresh
-                                            14400      ; Retry
-                                            3600000    ; Expire
-                                            86400 )    ; Minimum
-                    IN      NS      localhost.
-
-      1       IN      PTR     localhost.
     EOS
   end
 
@@ -198,8 +120,8 @@ class Bind < Formula
         <array>
           <string>#{opt_sbin}/named</string>
           <string>-f</string>
-          <string>-c</string>
-          <string>#{etc}/named.conf</string>
+          <string>-L</string>
+          <string>#{var}/log/named/named.log</string>
         </array>
         <key>ServiceIPC</key>
         <false/>


### PR DESCRIPTION
1. Install named.conf, rndc.key and bind.keys in /usr/local/etc/bind
   to keep all config files together, as is common with many other
   daemons like apache, nginx, etc.
2. Don't create or load "localhost" and "0.0.127.in-addr.arpa" zones,
   because a modern recursive resolver should not answer these queries.
   Additionally, they were incomplete anyway, as they did not do the
   IPv6 equivalent. Modern BIND creates empty reverse zones for private
   address space by itself (including 127.in-addr.arpa)
3. In the simplified config, don't define a controls section, and let
   BIND create a default control channel, using the key in the rndc.key
   file, and listen for controls on the default port 953.
4. In the logging section, add sized-based rotation for the log file,
   and limit it to 10 versions, to avoid a situation where a single
   log file keeps growing and potentially filling up the disk.
5. In the plist file, specify the -L option to log BIND's initial
   startup messages to the log file as well, otherwise they go to
   syslog and get lost.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
