### PR TITLE
gnss-sdr 0.0.14 (new formula)

### DIFF
--- a/Formula/gnss-sdr.rb
+++ b/Formula/gnss-sdr.rb
@@ -1,0 +1,31 @@
+class GnssSdr < Formula
+  desc "Open-source software-defined GNSS receiver"
+  homepage "https://gnss-sdr.org/"
+  url "https://github.com/gnss-sdr/gnss-sdr/archive/refs/tags/v0.0.14.tar.gz"
+  sha256 "b1636455ce70be9cb93793ee5a68faa47d8bcdafeddbcab55669f545e6271b6d"
+  license "GPL-3.0-only"
+  head "https://github.com/gnss-sdr/gnss-sdr.git"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "cmake" => :build
+  depends_on "libtool" => :build
+  depends_on "gnuradio"
+  depends_on "hdf5"
+  depends_on "openblas"
+
+  def install
+    inreplace "src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/CMakeLists.txt" do |s|
+      s.gsub!(/^set\(prefix .+\)$/, "set(prefix \"#{prefix}\")")
+      s.gsub!(/^set\(libdir .+\)$/, "set(libdir \"#{lib}\")")
+      s.gsub!(/^set\(includedir .+\)$/, "set(include \"#{include}}\")")
+    end
+    system "cmake", "-S", ".", "-B", "build", "-DBLA_VENDOR=OpenBLAS", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    system "gnss-sdr", "-version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Currently the port *does not* pass `brew audit --strict gnss-sdr`, as it installs a config helper that references the clang shim:
```
brew audit --new gnss-sdr
gnss-sdr:
  * Files were found with references to the Homebrew shims directory.
    The offending files are:
      bin/volk_gnsssdr-config-info
Error: 1 problem in 1 formula detected
```

```
volk_gnsssdr-config-info --cflags
/usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang:::  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign
/usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang++:::   -Wall
generic:::Clang:::-O3 -DNDEBUG  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign
sse2_64_mmx:::Clang:::-O3 -DNDEBUG  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign -m64 -mmmx -msse -msse2
sse3_64_mmx:::Clang:::-O3 -DNDEBUG  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign -m64 -mmmx -msse -msse2 -msse3
ssse3_64_mmx:::Clang:::-O3 -DNDEBUG  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign -m64 -mmmx -msse -msse2 -msse3 -mssse3
sse4_a_64_mmx:::Clang:::-O3 -DNDEBUG  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign -m64 -mmmx -msse -msse2 -msse3 -msse4a -mpopcnt
sse4_1_64_mmx:::Clang:::-O3 -DNDEBUG  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign -m64 -mmmx -msse -msse2 -msse3 -mssse3 -msse4.1
sse4_2_64_mmx:::Clang:::-O3 -DNDEBUG  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign -m64 -mmmx -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt
avx_64_mmx:::Clang:::-O3 -DNDEBUG  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign -m64 -mmmx -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mavx
avx2_64_mmx:::Clang:::-O3 -DNDEBUG  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign -m64 -mmmx -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mavx -mfma -mavx2
avx512f_64_mmx:::Clang:::-O3 -DNDEBUG  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign -m64 -mmmx -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mavx -mfma -mavx2 -mavx512f
avx512cd_64_mmx:::Clang:::-O3 -DNDEBUG  -Wall -Werror=incompatible-pointer-types -Werror=pointer-sign -m64 -mmmx -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mavx -mfma -mavx2 -mavx512f -mavx512cd
```

I can set this with another substitution in the `inreplace`, but I'm not entirely clear on how to get the path for the compiler.