### PR TITLE
lcov: update test

### DIFF
--- a/Formula/lcov.rb
+++ b/Formula/lcov.rb
@@ -82,6 +82,6 @@ class Lcov < Formula
     system "#{bin}/lcov", "--gcov-tool", gcov, "--directory", ".", "--capture", "--output-file", "all_coverage.info"
 
     assert_predicate testpath/"all_coverage.info", :exist?
-    assert_include (testpath/"all_coverage.info").read, testpath/"hello.c"
+    assert_includes (testpath/"all_coverage.info").read, testpath/"hello.c"
   end
 end


### PR DESCRIPTION
Fixes

    MethodDeprecatedError: Calling assert_include is deprecated! Use assert_includes instead.

from #74843.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?