### PR TITLE
field3d: explicitly define open-mpi dependency

### DIFF
--- a/Formula/field3d.rb
+++ b/Formula/field3d.rb
@@ -17,6 +17,7 @@ class Field3d < Formula
   depends_on "boost"
   depends_on "hdf5"
   depends_on "ilmbase"
+  depends_on "open-mpi"
 
   def install
     ENV.cxx11


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/homebrew-core/pull/74545/checks?check_run_id=2267430609 indicated this dependency, it was just hidden.