### PR TITLE
github/workflows: remove Bintray upload.

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -13,7 +13,7 @@ on:
         description: Issue number, where comment on failure would be posted
         required: false
       upload:
-        description: Whether to upload built bottles to Bintray or not
+        description: "Whether to upload built bottles or not (default: false)"
         required: false
 
 env:
@@ -150,14 +150,6 @@ jobs:
         run: |
           cd ~/bottles
           brew pr-upload --verbose --keep-old --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/homebrew/core"
-
-      - name: Upload and publish bottles on Bintray
-        env:
-          HOMEBREW_BINTRAY_USER: brewtestbot
-          HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
-        run: |
-          cd ~/bottles
-          brew pr-upload --verbose --keep-old --no-commit --root-url="https://homebrew.bintray.com/bottles"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -10,7 +10,7 @@ on:
         description: Issue number, where comment on failure would be posted
         required: false
       upload:
-        description: Whether to upload built bottles to Bintray or not
+        description: "Whether to upload built bottles or not (default: false)"
         required: false
 
 env:
@@ -151,14 +151,6 @@ jobs:
         run: |
           cd ~/bottles
           brew pr-upload --verbose --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/homebrew/core"
-
-      - name: Upload and publish bottles on Bintray
-        env:
-          HOMEBREW_BINTRAY_USER: brewtestbot
-          HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
-        run: |
-          cd ~/bottles
-          brew pr-upload --verbose --no-commit --root-url="https://homebrew.bintray.com/bottles"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master

--- a/.github/workflows/linux-dispatch-build-bottle.yml
+++ b/.github/workflows/linux-dispatch-build-bottle.yml
@@ -10,7 +10,7 @@ on:
         description: Issue number, where comment on failure would be posted
         required: false
       upload:
-        description: Whether to upload built bottles to Bintray or not
+        description: "Whether to upload built bottles or not (default: false)"
         required: false
 
 env:
@@ -24,8 +24,6 @@ jobs:
     container:
       image: ghcr.io/homebrew/ubuntu16.04:master
       options: --user=linuxbrew
-    env:
-      HOMEBREW_BOTTLE_DOMAIN: https://homebrew.bintray.com/
     steps:
       - name: ${{github.event.inputs.formula}}
         id: print_details
@@ -123,16 +121,6 @@ jobs:
         uses: Homebrew/actions/setup-commit-signing@master
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
-
-      - name: Upload and publish bottles on Bintray
-        env:
-          HOMEBREW_BINTRAY_USER: brewtestbot
-          HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
-          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
-          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
-        run: |
-          cd ~/bottles
-          brew pr-upload --verbose --keep-old --committer="$BREWTESTBOT_NAME_EMAIL"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -71,13 +71,6 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
         run: brew pr-pull --debug --workflows=tests.yml --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/homebrew/core" ${{github.event.inputs.args}} ${{github.event.inputs.pull_request}}
 
-      - name: Pull bottles and publish to Bintray
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          HOMEBREW_BINTRAY_USER: brewtestbot
-          HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
-        run: brew pr-pull --debug --workflows=tests.yml --no-commit --root-url="https://homebrew.bintray.com/bottles" ${{github.event.inputs.args}} ${{github.event.inputs.pull_request}}
-
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
         with:


### PR DESCRIPTION
There will be a brownout in ~30m from now so let's stop uploading bottles to Bintray.