### PR TITLE
github/workflows: bottle with `--only-json-tab`

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -48,15 +48,15 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - name: Run brew test-bot --only-formulae
+      - name: Run brew test-bot --keep-old --only-json-tab
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           mkdir bottles
           cd bottles
-          brew test-bot --keep-old --only-formulae ${{github.event.inputs.formula}}
+          brew test-bot --keep-old --only-json-tab --only-formulae ${{github.event.inputs.formula}}
 
-      - name: Output brew test-bot --only-formulae failures
+      - name: Output brew test-bot --keep-old --only-json-tab failures
         if: always()
         run: |
           cat bottles/steps_output.txt

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -49,15 +49,15 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - name: Run brew test-bot --only-formulae
+      - name: Run brew test-bot --only-json-tab  --only-formulae
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           mkdir bottles
           cd bottles
-          brew test-bot --only-formulae ${{github.event.inputs.formula}}
+          brew test-bot --only-json-tab --only-formulae ${{github.event.inputs.formula}}
 
-      - name: Output brew test-bot --only-formulae failures
+      - name: Output brew test-bot --only-json-tab --only-formulae failures
         if: always()
         run: |
           cat bottles/steps_output.txt

--- a/.github/workflows/linux-dispatch-build-bottle.yml
+++ b/.github/workflows/linux-dispatch-build-bottle.yml
@@ -37,15 +37,15 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Run brew test-bot --only-formulae
+      - name: Run brew test-bot --keep-old --only-json-tab --only-formulae
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           mkdir ~/bottles
           cd ~/bottles
-          brew test-bot --keep-old --only-formulae ${{github.event.inputs.formula}}
+          brew test-bot --keep-old --only-json-tab --only-formulae ${{github.event.inputs.formula}}
 
-      - name: Output brew test-bot --only-formulae failures
+      - name: Output brew test-bot --keep-old --only-json-tab --only-formulae failures
         if: always()
         run: |
           cat ~/bottles/steps_output.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,13 +110,13 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - name: Run brew test-bot --only-formulae
+      - name: Run brew test-bot --only-json-tab --only-formulae
         run: |
           mkdir bottles
           cd bottles
-          brew test-bot --only-formulae
+          brew test-bot --only-json-tab --only-formulae
 
-      - name: Output brew test-bot --only-formulae failures
+      - name: Output brew test-bot --only-json-tab --only-formulae failures
         if: always()
         run: |
           cat bottles/steps_output.txt


### PR DESCRIPTION
Depends on https://github.com/Homebrew/homebrew-test-bot/pull/597

Build all our (new) bottles excluding the tab (which is uploaded and
downloaded from GitHub Packages instead).

This will enable a few things:
- bottles that can be (more) reproducible (as we embed a timestamp without this which means they can't be reproducible more than a  second apart)
- bottles between macOS versions (and perhaps even Linux) that have identical checksums and can be deduplicated by only uploading a single bottle (as GitHub Packages will not store multiple bottles with the same `sha256`)
- bottles identical between macOS and Linux can be migrated to use `all: $SHA256` (already in a Homebrew/brew tag) to share a single bottle for all platforms.
- remove all `bottle :unneeded` and bottle everything
- reduce (perhaps remove) our need for `brew mirror` as in favour of relying on bottles rather than building from source in more cases

Note to @iMichka: you'll definitely want to ensure these flags are passed through and added to all relevenat linuxbrew-core locations on merge. CC me on that PR if you need help with that.