### PR TITLE
argocd: update version to v2.0.1 and add argocd-util symlink

### DIFF
--- a/Formula/argocd.rb
+++ b/Formula/argocd.rb
@@ -2,8 +2,8 @@ class Argocd < Formula
   desc "GitOps Continuous Delivery for Kubernetes"
   homepage "https://argoproj.io"
   url "https://github.com/argoproj/argo-cd.git",
-      tag:      "v2.0.0",
-      revision: "f5119c06686399134b3f296d44445bcdbc778d42"
+      tag:      "v2.0.1",
+      revision: "33eaf11e3abd8c761c726e815cbb4b6af7dcb030"
   license "Apache-2.0"
 
   bottle do
@@ -20,6 +20,7 @@ class Argocd < Formula
     inreplace "Makefile", "CGO_ENABLED=0", ""
     system "make", "cli-local"
     bin.install "dist/argocd"
+    bin.install_symlink "argocd" => "argocd-util"
 
     output = Utils.safe_popen_read("#{bin}/argocd", "completion", "bash")
     (bash_completion/"argocd").write output
@@ -30,6 +31,9 @@ class Argocd < Formula
   test do
     assert_match "argocd controls a Argo CD server",
       shell_output("#{bin}/argocd --help")
+
+    assert_match "argocd-util has internal utility tools used by Argo CD",
+      shell_output("#{bin}/argocd-util --help")
 
     # Providing argocd with an empty config file returns the contexts table header
     touch testpath/"argocd-config"


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Starting from v2.0.0 the `argocd` binary includes set of commands intended for operators that help to manage Argo CD. The operator-specific set of command is available if the binary name is `argocd-util`. PR adds `argocd-util` symlink so to make operator-specific commands available via `argocd-util` command.