### PR TITLE
cocoapods: Add support for Apple Silicon

### DIFF
--- a/Formula/cocoapods.rb
+++ b/Formula/cocoapods.rb
@@ -4,6 +4,7 @@ class Cocoapods < Formula
   url "https://github.com/CocoaPods/CocoaPods/archive/1.10.1.tar.gz"
   sha256 "7629705179e4bfd894bebe4ed62c28d1cc539103f6d1924f4c8127f46cbd13e1"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "08794cfd260bf206eed3496805816661da367bffdf9af748cd812b1c40a0de75"
@@ -13,6 +14,7 @@ class Cocoapods < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "ruby" if Hardware::CPU.arm?
 
   uses_from_macos "libffi", since: :catalina
   uses_from_macos "ruby", since: :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds the patch from https://github.com/CocoaPods/CocoaPods/pull/10576, and also starts depending on the non-built-in Ruby for the ARM platform. This is because the version of Ruby that ships with macOS is deprecated by Apple, and reports itself as x86_64 even when running under ARM. More info about this can be found here: [Ruby on Apple Silicon M1 Macs](https://betterprogramming.pub/ruby-on-apple-silicon-m1-macs-fb159849b2f5)

I've managed to install all dependencies in a React Native project after installing it this way, which I think should be a good stress test 🎉 