### PR TITLE
ldid v2.1.4

### DIFF
--- a/Formula/ldid.rb
+++ b/Formula/ldid.rb
@@ -2,8 +2,8 @@ class Ldid < Formula
   desc "Lets you manipulate the signature block in a Mach-O binary"
   homepage "https://cydia.saurik.com/info/ldid/"
   url "https://git.saurik.com/ldid.git",
-      tag:      "v2.1.3",
-      revision: "d4a4dbe847733d55834ebc60f0678c350fa3ebd5"
+      tag:      "v2.1.4",
+      revision: "2edb2a9307f1bd3909dadc20e80857c6e40c00c5"
   license "AGPL-3.0-or-later"
   head "https://git.saurik.com/ldid.git"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Kind of important, because 2.1.3 had a regression that caused it to corrupt fat binaries.

There should probably be a test case for fat binaries, but `ENV.cc` may not be clang...