### PR TITLE
issue template: remind users to `brew update`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,6 +6,12 @@ body:
   - type: markdown
     attributes:
       value: Please note we will close your issue without comment if you do not fill out the issue checklist below and provide ALL the requested information. If you repeatedly fail to use the issue template, we will block you from ever submitting issues to Homebrew again.
+  - type: checkboxes
+    attributes:
+      description: Please verify that you've followed this step.
+      options:
+        - label: I did `brew update` and am still able to reproduce my issue.
+          required: true
   - type: textarea
     attributes:
       render: shell

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -20,9 +20,9 @@ body:
       required: true
   - type: checkboxes
     attributes:
-      description: Please verify that you've followed these steps
+      description: Please verify that you've followed this step.
       options:
-        - label: The `brew doctor` above contains no "Warning" lines.
+        - label: Resolving the warnings from `brew doctor` did not fix my problem.
           required: true
   - type: textarea
     attributes:


### PR DESCRIPTION
Also, tweak the wording of the `brew doctor` checkbox. Most users seem to just ignore it and check the box anyway. I think trying to nudge them into resolving it might be more productive.