### PR TITLE
Revert "issue template: remind users to `brew update`"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -20,9 +20,9 @@ body:
       required: true
   - type: checkboxes
     attributes:
-      description: Please verify that you've followed this step.
+      description: Please verify that you've followed these steps
       options:
-        - label: Resolving the warnings from `brew doctor` did not fix my problem.
+        - label: The `brew doctor` above contains no "Warning" lines.
           required: true
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,12 +6,6 @@ body:
   - type: markdown
     attributes:
       value: Please note we will close your issue without comment if you do not fill out the issue checklist below and provide ALL the requested information. If you repeatedly fail to use the issue template, we will block you from ever submitting issues to Homebrew again.
-  - type: checkboxes
-    attributes:
-      description: Please verify that you've followed this step.
-      options:
-        - label: I did `brew update` and am still able to reproduce my issue.
-          required: true
   - type: textarea
     attributes:
       render: shell


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#75049, which broke the issue UI.