### PR TITLE
librasterlite: add livecheck

### DIFF
--- a/Formula/librasterlite.rb
+++ b/Formula/librasterlite.rb
@@ -5,6 +5,10 @@ class Librasterlite < Formula
   sha256 "0a8dceb75f8dec2b7bd678266e0ffd5210d7c33e3d01b247e9e92fa730eebcb3"
   revision 7
 
+  livecheck do
+    skip "No longer developed"
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "19919f543a85e1890dfaee593945ce9427d71ac10c7f02b5895a2654981f1d91"
     sha256 cellar: :any, big_sur:       "d6fc5943cd16fd63e2e0c599c2790fb97ec6af38ccc61305e6cfafdaa195a81d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `librasterlite` homepage states:

> Caveat: this is an obsolete project no longer supported by any development activity.
This HTML page is just intended for historical documentation purposes and not for any real usage.
>
> Please use [librasterlite2](https://www.gaia-gis.it/fossil/librasterlite2/index) as a more powerfull [sic] full replacement.

The current version of `librasterlite` is 1.1g, which was released on 2013-05-05. The current version of `librasterlite2` is 1.1.0-beta1 and all existing versions are unstable (e.g., `1.0.0-devel`, `1.0.0-rc0`, 1.1.0-beta0`, etc.).

Seeing as this is no longer developed but `librasterlite2` is unstable, this PR adds a `livecheck` block that skips the formula for the time being.