### PR TITLE
vamp-plugin-sdk: add livecheck

### DIFF
--- a/Formula/vamp-plugin-sdk.rb
+++ b/Formula/vamp-plugin-sdk.rb
@@ -5,6 +5,11 @@ class VampPluginSdk < Formula
   sha256 "aeaf3762a44b148cebb10cde82f577317ffc9df2720e5445c3df85f3739ff75f"
   head "https://code.soundsoftware.ac.uk/hg/vamp-plugin-sdk", using: :hg
 
+  livecheck do
+    url "https://code.soundsoftware.ac.uk/projects/vamp-plugin-sdk/files"
+    regex(/href=.*?vamp-plugin-sdk[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "aa6184c469e855de77725477097a0c6998a04d4753bc852aa756123edaac446c"
     sha256 cellar: :any, big_sur:       "21e590739905e6794c11e4f7037adfa6fa83da4d7c2ab2b083c43563449d8a45"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `vamp-plugin-sdk`. This PR adds a `livecheck` block that checks the third-party(?) download page that links to the `stable` archive.

For reference, this doesn't check the first-party [page for the SDK](https://www.vamp-plugins.org/develop.html), as it hasn't been updated to link to the latest version. The page is currently linking to 2.9 instead of 2.10, though 2.10 has been released for almost a year at this point.