### PR TITLE
librasterlite: add license

### DIFF
--- a/Formula/librasterlite.rb
+++ b/Formula/librasterlite.rb
@@ -3,6 +3,7 @@ class Librasterlite < Formula
   homepage "https://www.gaia-gis.it/fossil/librasterlite/index"
   url "https://www.gaia-gis.it/gaia-sins/librasterlite-sources/librasterlite-1.1g.tar.gz"
   sha256 "0a8dceb75f8dec2b7bd678266e0ffd5210d7c33e3d01b247e9e92fa730eebcb3"
+  license any_of: ["MPL-1.1", "GPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 7
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

From the [homepage](https://www.gaia-gis.it/fossil/librasterlite/index):

> **Please note**: librasterlite is now re-licensed under the [MPL tri-license](http://www.mozilla.org/MPL/boilerplate-1.1/mpl-tri-license-html) terms; you are free to choose the best-fit license between:
>   * the [MPL 1.1](http://www.mozilla.org/MPL/MPL-1.1.html)
>   * the [GPL v2.0](http://www.gnu.org/licenses/gpl-2.0.html#TOC1) or any subsequent version
>   * the [LGPL v2.1](http://www.gnu.org/licenses/lgpl-2.1.html) or any subsequent version