### PR TITLE
alluxio: deprecate/disable

### DIFF
--- a/Formula/alluxio.rb
+++ b/Formula/alluxio.rb
@@ -15,6 +15,10 @@ class Alluxio < Formula
   # Alluxio requires Java 8 or Java 11
   depends_on "openjdk@11"
 
+  on_macos do
+    disable! date: "2021-10-13", because: "requires FUSE"
+  end
+
   def default_alluxio_conf
     <<~EOS
       alluxio.master.hostname=localhost


### PR DESCRIPTION
The newest version of this formula (v2.5.1) installs pre-built binaries with a dependency on osxfuse. In
the tarball:

    ❯ otool -L lib/libjnifuse.dylib
    lib/libjnifuse.dylib:
            ./libjnifuse.dylib (compatibility version 0.0.0, current version 0.0.0)
            /usr/local/lib/libosxfuse.2.dylib (compatibility version 12.0.0, current version 12.7.0)
            /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
            /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)

I can't find any documentation about building this from source, so I
don't know if it can be built without the fuse dependency.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?