### PR TITLE
fastlane: Fix Ruby dependency version

### DIFF
--- a/Formula/fastlane.rb
+++ b/Formula/fastlane.rb
@@ -4,6 +4,7 @@ class Fastlane < Formula
   url "https://github.com/fastlane/fastlane/archive/2.180.1.tar.gz"
   sha256 "244323e068e35092a7cf40b4e461ed2cd97b2bc42122e47f5410ce0fd04dd995"
   license "MIT"
+  revision 1
   head "https://github.com/fastlane/fastlane.git"
 
   livecheck do

--- a/Formula/fastlane.rb
+++ b/Formula/fastlane.rb
@@ -18,9 +18,7 @@ class Fastlane < Formula
     sha256 cellar: :any, mojave:        "73aaa47abe9c23fe4918c4a210fa89c2e3686449d4fbf9d0fc863c40c0ff1bc2"
   end
 
-  # Issue with Ruby 2.7 not finding gems correctly
-  # https://github.com/fastlane/fastlane/issues/18517
-  depends_on "ruby@2.6"
+  depends_on "ruby@2.7"
 
   def install
     ENV["GEM_HOME"] = libexec


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The compatibility issue with Ruby 2.7 was resolved in Fastlane `2.180.1` ([ref](https://github.com/fastlane/fastlane/pull/18520#pullrequestreview-631882323)) which is the currently used version.

I did **not** increase the `revision` because the current install script actually linked to Ruby 2.7 instead of 2.6, so the bottle is still correct and will work. This can be verified by installing the current bottle, looking in `/opt/homebrew/bin/fastlane`, and see that it references `/opt/homebrew/opt/ruby@2.7/bin`.

This can also be seen here:

<img width="706" alt="Screenshot 2021-04-14 at 14 25 06" src="https://user-images.githubusercontent.com/189580/114709781-47e1c680-9d2d-11eb-92e9-b4eee4fca8c8.png">
