### PR TITLE
pacman4console: add livecheck

### DIFF
--- a/Formula/pacman4console.rb
+++ b/Formula/pacman4console.rb
@@ -5,6 +5,11 @@ class Pacman4console < Formula
   sha256 "9a5c4a96395ce4a3b26a9896343a2cdf488182da1b96374a13bf5d811679eb90"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?pacman[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "b9f6328a3b683121a3ef8cfb48d6db7c6a25ba07f73a006430298ca7fc5bf658"
     sha256 big_sur:       "299dbf7613b12c270c398dc9aa3255eb5f987331c4a1ace1f1ef811bb6070514"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `pacman4console`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.