### PR TITLE
x264: r3053 and update livecheck

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -7,15 +7,15 @@ class X264 < Formula
   stable do
     # the latest commit on the stable branch
     url "https://code.videolan.org/videolan/x264.git",
-        revision: "b86ae3c66f51ac9eab5ab7ad09a9d62e67961b8a"
-    version "r3048"
+        revision: "c347e7a0b476d77674e2c9a6f137f57da026e8fc"
+    version "r3053"
   end
 
   # There's no guarantee that the versions we find on the `release-macos` index
   # page are stable but there didn't appear to be a different way of getting
   # the version information at the time of writing.
   livecheck do
-    url "https://artifacts.videolan.org/x264/release-macos/"
+    url "https://artifacts.videolan.org/x264/release-macos-x86_64/"
     regex(%r{href=.*?x264[._-](r\d+)[._-][\da-z]+/?["' >]}i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

### Notes

Recent commit (https://code.videolan.org/videolan/x264/-/commit/c347e7a0b476d77674e2c9a6f137f57da026e8fc) appears to have split `macos` target into `macos-x86_64` and `macos-arm64`, which I think also impacted release livecheck path.

Looking at https://artifacts.videolan.org/x264, it appears that the old `release-macos/` is the only location not updated:

| | | |
|-|-|-|
release-win64/ |   | 13-Apr-2021 20:55
release-win32/ |   | 13-Apr-2021 20:55
release-macos-arm64/ |   | 13-Apr-2021 20:55
release-macos-x86_64/ |   | 13-Apr-2021 20:55
release-debian-amd64/ |   | 13-Apr-2021 20:55
release-debian-aarch64/ |   | 13-Apr-2021 20:54
**release-macos/** |   | **12-Apr-2021 20:30**


Tested on Rosetta.