### PR TITLE
tcptraceroute: fix arm64/Apple Silicon build

### DIFF
--- a/Formula/tcptraceroute.rb
+++ b/Formula/tcptraceroute.rb
@@ -31,12 +31,17 @@ class Tcptraceroute < Formula
     sha256 cellar: :any, high_sierra: "e71cda023bb22dc514fda3d22af13bf8f0db80c1937add70b67cf7447d40a67f"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "libnet"
 
   uses_from_macos "libpcap"
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+    # Regenerate configure script for arm64/Apple Silicon support.
+    system "autoreconf", "--verbose", "--install", "--force"
+
+    system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-libnet=#{HOMEBREW_PREFIX}",
                           "--mandir=#{man}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Removed the debug flag because:
```
configure: WARNING: unrecognized options: --disable-debug
```

Strict audit failure:
```
tcptraceroute:
  * Formula tcptraceroute contains deprecated SPDX licenses: ["GPL-2.0"].
    You may need to add `-only` or `-or-later` for GNU licenses (e.g. `GPL`, `LGPL`, `AGPL`, `GFDL`).
    For a list of valid licenses check: https://spdx.org/licenses/
Error: 1 problem in 1 formula detected
```

Build:
```
==> Summary
🍺  /opt/homebrew/Cellar/tcptraceroute/1.5beta7_2: 17 files, 159.7KB, built in 16 seconds

~> file /opt/homebrew/opt/tcptraceroute/bin/tcptraceroute
/opt/homebrew/opt/tcptraceroute/bin/tcptraceroute: Mach-O 64-bit executable arm64
```