### PR TITLE
netcat: fix arm64/Apple Silicon build

### DIFF
--- a/Formula/netcat.rb
+++ b/Formula/netcat.rb
@@ -3,7 +3,7 @@ class Netcat < Formula
   homepage "https://netcat.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/netcat/netcat/0.7.1/netcat-0.7.1.tar.bz2"
   sha256 "b55af0bbdf5acc02d1eb6ab18da2acd77a400bafd074489003f3df09676332bb"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/netcat.rb
+++ b/Formula/netcat.rb
@@ -15,7 +15,13 @@ class Netcat < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:  "1f346605e0236ea7880258da2abf0bde1d7d8d8735a07d6d32feaf12425ff6da"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+
   def install
+    # Regenerate configure script for arm64/Apple Silicon support.
+    system "autoreconf", "--verbose", "--install", "--force"
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Audit failure:
```
netcat:
  * Formula netcat contains deprecated SPDX licenses: ["GPL-2.0"].
    You may need to add `-only` or `-or-later` for GNU licenses (e.g. `GPL`, `LGPL`, `AGPL`, `GFDL`).
    For a list of valid licenses check: https://spdx.org/licenses/
Error: 1 problem in 1 formula detected
```

Can you tell I recently moved over to an M1 Mac and discovered a variety of ancient software has no idea what to do with an Apple ARM chip? 🌝
