### PR TITLE
dpkg 1.20.9; remove po4a for ARM64/Apple Silicon support

### DIFF
--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -21,6 +21,7 @@ class Dpkg < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "po4a" => :build
   depends_on "gettext"
   depends_on "gnu-tar"
   depends_on "gpatch"

--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -4,8 +4,8 @@ class Dpkg < Formula
   # Please use a mirror as the primary URL as the
   # dpkg site removes tarballs regularly which means we get issues
   # unnecessarily and older versions of the formula are broken.
-  url "https://deb.debian.org/debian/pool/main/d/dpkg/dpkg_1.20.7.1.tar.xz"
-  sha256 "0aad2de687f797ef8ebdabc7bafd16dc1497f1ce23bd9146f9aa73f396a5636f"
+  url "https://deb.debian.org/debian/pool/main/d/dpkg/dpkg_1.20.9.tar.xz"
+  sha256 "5ce242830f213b5620f08e6c4183adb1ef4dc9da28d31988a27c87c71fe534ce"
   license "GPL-2.0-only"
 
   livecheck do
@@ -25,7 +25,6 @@ class Dpkg < Formula
   depends_on "gnu-tar"
   depends_on "gpatch"
   depends_on "perl"
-  depends_on "po4a"
   depends_on "xz" # For LZMA
 
   uses_from_macos "bzip2"

--- a/Formula/po4a.rb
+++ b/Formula/po4a.rb
@@ -8,6 +8,7 @@ class Po4a < Formula
   url "https://github.com/mquinson/po4a/releases/download/v0.63/po4a-0.63.tar.gz"
   sha256 "e21be3ee545444bae2fe6a44aeb9d320604708cc2e4c601bcb3cc440db75b4ce"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/mquinson/po4a.git"
 
   bottle do
@@ -18,8 +19,7 @@ class Po4a < Formula
 
   depends_on "docbook-xsl" => :build
   depends_on "gettext"
-
-  uses_from_macos "perl"
+  depends_on "perl"
 
   resource "Locale::gettext" do
     url "https://cpan.metacpan.org/authors/id/P/PV/PVANDRY/gettext-1.07.tar.gz"
@@ -27,8 +27,6 @@ class Po4a < Formula
   end
 
   resource "Module::Build" do
-    # po4a requires Module::Build v0.4200 and above, while standard
-    # MacOS Perl installation has 0.4003
     url "https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-0.4231.tar.gz"
     sha256 "7e0f4c692c1740c1ac84ea14d7ea3d8bc798b2fb26c09877229e04f430b2b717"
   end
@@ -70,13 +68,6 @@ class Po4a < Formula
     resources.each do |r|
       r.stage do
         system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}", "NO_MYMETA=1"
-
-        # Work around restriction on 10.15+ where .bundle files cannot be loaded
-        # from a relative path -- while in the middle of our build we need to
-        # refer to them by their full path.  Workaround adapted from:
-        #   https://github.com/fink/fink-distributions/issues/461#issuecomment-563331868
-        inreplace "Makefile", "blib/", "$(shell pwd)/blib/" if r.name == "TermReadKey"
-
         system "make", "install"
       end
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`po4a` is the only blocker here to `dpkg` working on AMR64/Apple Silicon, because `po4a` seems to have issues with the system perl and the way Apple "hides" dynamic libraries now from what I can determine 🙃.

More and more given Apple is working towards removing the system Perl/Ruby/Python/etc honestly I don't really see a reason to not just start using Homebrew's `perl` everywhere anyway, which would resolve the issue `po4a` is having, but I assume not using Homebrew's perl before Apple kills off the system one is an intentional choice?