### PR TITLE
bug.yml: remind users to `brew update` twice

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -16,7 +16,7 @@ body:
     attributes:
       description: Please verify that you've followed these steps.
       options:
-        - label: I ran `brew update` and am still able to reproduce my issue.
+        - label: I ran `brew update` twice and am still able to reproduce my issue.
           required: true
         - label: I have resolved all warnings from `brew doctor` and that did not fix my problem.
           required: true


### PR DESCRIPTION
The autoupdate that happens with `brew install` doesn't switch users
properly over to GitHub Packages from Bintray for some reason, so
there's a need to do it twice to migrate properly.

See, for example https://github.com/Homebrew/brew/issues/11155, https://github.com/Homebrew/homebrew-core/issues/75243.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?