### PR TITLE
libosmium: add M1/Apple Silicon Support

### DIFF
--- a/Formula/libosmium.rb
+++ b/Formula/libosmium.rb
@@ -21,6 +21,12 @@ class Libosmium < Formula
     sha256 "beffbdfab060854fd770178a8db9c028b5b6ee4a059a2fed82c46390a85f3f31"
   end
 
+  # Apple Silicon support via @fxcoudert. Can be removed on next release.
+  patch do
+    url "https://github.com/osmcode/libosmium/commit/c587e53e8c7125b738e38614b4b2a1b9a5df0784.patch?full_index=1"
+    sha256 "86dc10774a3886dfb051b95c5c7a9acbcf4d06e6b532482430858314f6336f30"
+  end
+
   def install
     resource("protozero").stage { libexec.install "include" }
     system "cmake", ".", "-DINSTALL_GDALCPP=ON",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I take literally no credit here, FX's fix got merged upstream and I just happened to stumble across that.

Closes https://github.com/Homebrew/homebrew-core/pull/68774.