### PR TITLE
x264: update livecheck

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -11,12 +11,40 @@ class X264 < Formula
     version "r3048"
   end
 
-  # There's no guarantee that the versions we find on the `release-macos` index
-  # page are stable but there didn't appear to be a different way of getting
-  # the version information at the time of writing.
+  # Cross-check the abbreviated commit hashes from the release filenames with
+  # the latest commits in the `stable` Git branch:
+  # https://code.videolan.org/videolan/x264/-/commits/stable
   livecheck do
     url "https://artifacts.videolan.org/x264/release-macos/"
-    regex(%r{href=.*?x264[._-](r\d+)[._-][\da-z]+/?["' >]}i)
+    regex(%r{href=.*?x264[._-](r\d+)[._-]([\da-z]+)/?["' >]}i)
+    strategy :page_match do |page, regex|
+      # Match the version and abbreviated commit hash in filenames
+      matches = page.scan(regex)
+
+      # Fetch the `stable` Git branch Atom feed
+      stable_page_data = Homebrew::Livecheck::Strategy.page_content("https://code.videolan.org/videolan/x264/-/commits/stable?format=atom")
+      return [] if stable_page_data[:content] && stable_page_data[:content].empty?
+
+      # Extract commit hashes from the feed content
+      commit_hashes = stable_page_data[:content].scan(%r{/commit/([\da-z]+)}i).flatten
+      return [] if commit_hashes.empty?
+
+      # Only keep versions with a matching commit hash in the `stable` branch
+      matches.map do |match|
+        next nil unless match.length >= 2
+
+        release_hash = match[1]
+        commit_in_stable = false
+        commit_hashes.each do |commit_hash|
+          next unless commit_hash.start_with?(release_hash)
+
+          commit_in_stable = true
+          break
+        end
+
+        commit_in_stable ? match[0] : nil
+      end.compact
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As discussed in #75211, the existing `livecheck` block for `x264` is imperfect but checking the binary releases is the best we can do unless/until upstream provides a reasonable way for us to identify new `x264` releases (e.g., tag stable releases in the Git repository).

We currently check the `/x264/release-macos/` directory but we may need to switch to checking either the `/x264/release-macos-x86_64/` or `/x264/release-macos-arm64/` directory in the future if it's not kept up to date. The latter two directories currently contain an [unstable] release that's not present in the `release-macos` directory, so we'll have to wait and see how this plays out with future releases.

That said, the purpose of this PR is to add a `strategy` block that filters the versions livecheck identifies so we only return the ones that correspond to a commit in the `stable` Git branch. If we don't do this with a `strategy` block, then livecheck will sometimes return an unstable version as newest and contributors/maintainers will have to manually cross-check the VLC directory listing page with the `stable` Git branch commit hashes to determine if the version is stable. This is commonly overlooked, so an automated solution is better overall.

It's worth noting that this `strategy` block is much more complex than most, as it's necessary to fetch two pages to correctly identify stable versions. Additionally, this regex contains more than one capture group (as we need both the version and abbreviated commit hash) but the first capture group is still the version. This is a bit absurd overall but it works as expected and will avoid false positives and unnecessary human labor.