### PR TITLE
auditbeat, go-jira, kafka, maxwell: use File.read over IO.read

### DIFF
--- a/Formula/auditbeat.rb
+++ b/Formula/auditbeat.rb
@@ -91,7 +91,7 @@ class Auditbeat < Formula
     sleep 5
     touch testpath/"files/touch"
     sleep 30
-    s = IO.readlines(testpath/"auditbeat/auditbeat").last(1)[0]
+    s = File.readlines(testpath/"auditbeat/auditbeat").last(1)[0]
     assert_match(/"action":\["(initial_scan|created)"\]/, s)
     realdirpath = File.realdirpath(testpath)
     assert_match "\"path\":\"#{realdirpath}/files/touch\"", s

--- a/Formula/go-jira.rb
+++ b/Formula/go-jira.rb
@@ -29,6 +29,6 @@ class GoJira < Formula
     expected_templates = %w[comment components create edit issuetypes list view worklog debug]
 
     assert_equal([], expected_templates - files)
-    assert_equal("{{ . | toJson}}\n", IO.read("#{template_dir}/debug"))
+    assert_equal("{{ . | toJson}}\n", File.read("#{template_dir}/debug"))
   end
 end

--- a/Formula/kafka.rb
+++ b/Formula/kafka.rb
@@ -118,6 +118,6 @@ class Kafka < Formula
       sleep 10
     end
 
-    assert_match(/test message/, IO.read("#{testpath}/kafka/demo.out"))
+    assert_match(/test message/, File.read("#{testpath}/kafka/demo.out"))
   end
 end

--- a/Formula/maxwell.rb
+++ b/Formula/maxwell.rb
@@ -33,6 +33,6 @@ class Maxwell < Formula
     sleep 15
 
     # Validate that we actually got in to Maxwell far enough to attempt to connect.
-    assert_match "ERROR Maxwell - SQLException: Communications link failure", IO.read("#{testpath}/maxwell.log")
+    assert_match "ERROR Maxwell - SQLException: Communications link failure", File.read("#{testpath}/maxwell.log")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

https://github.com/Homebrew/brew/pull/11140

There wasn't anything really exploitable here. They were just flagged because they were dynamic strings.
