### PR TITLE
clusterctl: add livecheck

### DIFF
--- a/Formula/clusterctl.rb
+++ b/Formula/clusterctl.rb
@@ -5,6 +5,11 @@ class Clusterctl < Formula
   sha256 "38924e4d386cf61e3761ccc5e0738bdc8b355c6281f81fc972b15c640a0a61ed"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c9d431c82b44e2fbffd942cd109122c26647596bf1308f016ab91c1364af3313"
     sha256 cellar: :any_skip_relocation, big_sur:       "394bcb29c3a32b3c6f9ab6d2b307970f099ea6eab792c5f5238dad05be986b06"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds a `livecheck` block for `clusterctl`. We use the `GithubLatest` strategy here because they mark the latest release on GitHub. It so happens that they did not do so (yet) for `0.3.16`.

This is also evident from their workflow to update the Formula automatically ([workflow](https://github.com/kubernetes-sigs/cluster-api/blob/master/.github/workflows/update-homebrew-formula-on-release.yml) and [related PR](kubernetes-sigs/cluster-api/pull/4357)), which bumps on releasing rather than on tagging.

CC @chenrui333