### PR TITLE
ack: remove `bottle :unneeded`.

### DIFF
--- a/Formula/ack.rb
+++ b/Formula/ack.rb
@@ -14,7 +14,7 @@ class Ack < Formula
     end
   end
 
-  bottle :unneeded
+  depends_on "pod2man" => :build
 
   uses_from_macos "perl"
 
@@ -38,7 +38,7 @@ class Ack < Formula
       man1.install "blib/man1/ack.1"
     else
       bin.install "ack-v#{version.to_s.tr("-", "_")}" => "ack"
-      system "pod2man", "#{bin}/ack", "ack.1"
+      system "#{Formula["pod2man"].opt_bin}/pod2man", "#{bin}/ack", "ack.1", "--release=ack v#{version}"
       man1.install "ack.1"
     end
   end


### PR DESCRIPTION
Let's build a bottle for `ack`. It should have an identical checksum on all platforms (after https://github.com/Homebrew/brew/pull/11150 is merged).

This is a test case for:
- making all `bottle :unneeded` get bottled
- ensuring checksums are (hopefully) identical for non-compiled software on all macOS versions (and even Linux)
- a potential test for `all: $SHA256` bottles

`ack` was picked because it's small and I have it installed on my machine purely for testing like this 😁 