### PR TITLE
with-readline: add livecheck

### DIFF
--- a/Formula/with-readline.rb
+++ b/Formula/with-readline.rb
@@ -5,6 +5,11 @@ class WithReadline < Formula
   sha256 "d12c71eb57ef1dbe35e7bd7a1cc470a4cb309c63644116dbd9c88762eb31b55d"
   revision 2
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?with-readline[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "7a8f7ff1d33453d059ac6ac6b23883fa3f86d720cb25415e590e81ca2e6255dd"
     sha256 cellar: :any, big_sur:       "0700f15130da53328bff304e2cfdb422ad2bc4fff64a0377063af94cf46d3655"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `with-readline`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.