### PR TITLE
mpfi: add livecheck

### DIFF
--- a/Formula/mpfi.rb
+++ b/Formula/mpfi.rb
@@ -5,6 +5,11 @@ class Mpfi < Formula
   sha256 "2383d457b208c6cd3cf2e66b69c4ce47477b2a0db31fbec0cd4b1ebaa247192f"
   license "GPL-3.0"
 
+  livecheck do
+    url "https://gforge.inria.fr/frs/?group_id=157"
+    regex(/href=.*?mpfi[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any, arm64_big_sur: "294ebea233e52a6a0153e535a031e3bbea8bd4b36c4323c9d715512d77defc41"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `mpfi`. This PR adds a `livecheck` block that checks the third-party download page (linked to from the homepage) where the `stable` archive is found.