### PR TITLE
openshift-cli: Fix for Linux

### DIFF
--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -27,7 +27,13 @@ class OpenshiftCli < Formula
   depends_on "heimdal" => :build
   depends_on "socat"
 
+  uses_from_macos "krb5"
+
   def install
+    on_linux do
+      # See https://github.com/golang/go/issues/26487
+      ENV.O0
+    end
     ENV["GOPATH"] = buildpath
     dir = buildpath/"src/github.com/openshift/oc"
     dir.install buildpath.children - [buildpath/".brew_home"]


### PR DESCRIPTION
- uses krb5

- needs ENV.O0: this is a known upstream issue and we used the same fix in the ethereum formula

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
