### PR TITLE
protobuf, dvc, mitmproxy: depend on `six` as a formula

### DIFF
--- a/Formula/dvc.rb
+++ b/Formula/dvc.rb
@@ -6,6 +6,7 @@ class Dvc < Formula
   url "https://files.pythonhosted.org/packages/0f/3b/d51f69c500718eb65875dc8134370d1aedf1983327e284ab1464fc36c85a/dvc-2.1.0.tar.gz"
   sha256 "46cfbf0db27107fb3a2d5c643e3a948bb24539bf165ef70e77ce64283959e481"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "b46bdccddfdba0c66b2347139c6c233ac9ab5c0444fc3a06dd9dbf111b6726da"
@@ -23,6 +24,7 @@ class Dvc < Formula
   depends_on "protobuf"
   depends_on "python-tabulate"
   depends_on "python@3.9"
+  depends_on "six"
 
   # When updating, check that the extra packages in pypi_formula_mappings.json
   # correctly reflects the following extra packages in setup.py:
@@ -540,11 +542,6 @@ class Dvc < Formula
   resource "shtab" do
     url "https://files.pythonhosted.org/packages/4f/9f/1718447f3db4ddc308da97135bdb2a5df325301f99c9a02b8c3e95e573e9/shtab-1.3.6.tar.gz"
     sha256 "7e587e2889b4e51339b6c59c956b3f0eb5194113967d913515025406d5be849c"
-  end
-
-  resource "six" do
-    url "https://files.pythonhosted.org/packages/6b/34/415834bfdafca3c5f451532e8a8d9ba89a21c9743a0c59fbd0205c7f9426/six-1.15.0.tar.gz"
-    sha256 "30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"
   end
 
   resource "smmap" do

--- a/Formula/mitmproxy.rb
+++ b/Formula/mitmproxy.rb
@@ -3,10 +3,12 @@ class Mitmproxy < Formula
 
   desc "Intercept, modify, replay, save HTTP/S traffic"
   homepage "https://mitmproxy.org"
+  # At version bump, check whether `protobuf` resource
+  # can be replaced with the formula
   url "https://github.com/mitmproxy/mitmproxy/archive/v6.0.2.tar.gz"
   sha256 "15b32ce31e707d35de1707afe09e82bbf3d643bdd93968c5512caba80523c606"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/mitmproxy/mitmproxy.git"
 
   bottle do
@@ -17,8 +19,8 @@ class Mitmproxy < Formula
   end
 
   depends_on "openssl@1.1"
-  depends_on "protobuf"
   depends_on "python@3.9"
+  depends_on "six"
 
   uses_from_macos "libffi"
 
@@ -159,11 +161,6 @@ class Mitmproxy < Formula
   resource "ruamel.yaml" do
     url "https://files.pythonhosted.org/packages/17/2f/f38332bf6ba751d1c8124ea70681d2b2326d69126d9058fbd9b4c434d268/ruamel.yaml-0.16.12.tar.gz"
     sha256 "076cc0bc34f1966d920a49f18b52b6ad559fbe656a0748e3535cf7b3f29ebf9e"
-  end
-
-  resource "six" do
-    url "https://files.pythonhosted.org/packages/6b/34/415834bfdafca3c5f451532e8a8d9ba89a21c9743a0c59fbd0205c7f9426/six-1.15.0.tar.gz"
-    sha256 "30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"
   end
 
   resource "sortedcontainers" do

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -4,6 +4,7 @@ class Protobuf < Formula
   url "https://github.com/protocolbuffers/protobuf/releases/download/v3.17.0/protobuf-all-3.17.0.tar.gz"
   sha256 "96da1cb0648c7c1b2e68ef7089149dce18ecf8d0582a171315b3991a59e629c6"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -26,11 +27,7 @@ class Protobuf < Formula
   end
 
   depends_on "python@3.9" => [:build, :test]
-
-  resource "six" do
-    url "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
-    sha256 "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
-  end
+  depends_on "six"
 
   def install
     # Don't build in debug mode. See:
@@ -53,18 +50,10 @@ class Protobuf < Formula
     ENV.append_to_cflags "-I#{include}"
     ENV.append_to_cflags "-L#{lib}"
 
-    resource("six").stage do
-      system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)
-    end
     chdir "python" do
-      system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec),
+      system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(prefix),
                         "--cpp_implementation"
     end
-
-    version = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
-    site_packages = "lib/python#{version}/site-packages"
-    pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
-    (prefix/site_packages/"homebrew-protobuf.pth").write pth_contents
   end
 
   test do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -88,6 +88,9 @@
   "poetry": {
     "extra_packages": ["importlib-metadata", "typing-extensions"]
   },
+  "protobuf": {
+    "exclude_packages": ["six"]
+  },
   "regipy": {
     "exclude_packages": ["tabulate"]
   },

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -40,10 +40,10 @@
   "diffoscope": "diffoscope[cmdline]",
   "dvc": {
     "extra_packages": [
-        "gcsfs", "pydrive2", "six", "boto3", "adlfs", "azure-identity", "knack",
+        "gcsfs", "pydrive2", "boto3", "adlfs", "azure-identity", "knack",
         "oss2", "pycryptodome", "paramiko[invoke]", "webdavclient3"
     ],
-    "exclude_packages": ["tabulate", "protobuf"]
+    "exclude_packages": ["protobuf", "six", "tabulate"]
   },
   "ipython": {
     "extra_packages": ["ipykernel"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://github.com/Homebrew/homebrew-core/issues/73875.

This is a follow up to #74909.