### PR TITLE
exiftool: fix suffix for Linux

### DIFF
--- a/Formula/exiftool.rb
+++ b/Formula/exiftool.rb
@@ -28,7 +28,11 @@ class Exiftool < Formula
     libexec.install "lib"
     bin.install "exiftool"
     doc.install Dir["html/*"]
-    man1.install "blib/man1/exiftool.1"
+    suffix = ""
+    on_linux do
+      suffix = "p"
+    end
+    man1.install "blib/man1/exiftool.1#{suffix}"
     man3.install Dir["blib/man3/*"]
   end
 


### PR DESCRIPTION
Fixes:
Error: An exception occurred within a child process:
Errno::ENOENT: No such file or directory - blib/man1/exiftool.1

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
