### PR TITLE
CONTRIBUTING.md: Add line about commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 First time contributing to Homebrew? Read our [Code of Conduct](https://github.com/Homebrew/.github/blob/HEAD/CODE_OF_CONDUCT.md#code-of-conduct).
 
+Ensure your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit).
+
 ### To report a bug
 
 * run `brew update` (twice)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [N/A] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [N/A] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [N/A] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [N/A] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I saw there was a bot check for the commit messages after I had already went through the checklist above and got my PR ready, I figure it'd make sense to add a line about the commit styles in the CONTRIBUTING.md guide.
