### PR TITLE
purescript 0.14.1

### DIFF
--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -1,32 +1,35 @@
 class Purescript < Formula
   desc "Strongly typed programming language that compiles to JavaScript"
   homepage "https://www.purescript.org/"
-  url "https://hackage.haskell.org/package/purescript-0.14.0/purescript-0.14.0.tar.gz"
-  sha256 "606ea389095c6f7fcea35f13594a2b56462a76942d9ceb5a94de191a924766af"
+  url "https://hackage.haskell.org/package/purescript-0.14.1/purescript-0.14.1.tar.gz"
+  sha256 "db13fbb071c92e004c630a6d1a995b42622b187435f87da9d656f80ab0561933"
   license "BSD-3-Clause"
+  head "https://github.com/purescript/purescript.git"
 
   bottle do
     sha256 cellar: :any_skip_relocation, catalina: "acc7ee0fc127b4d7e7fdcd4bccb83461b4c09e03236c43217d120dcc83275920"
     sha256 cellar: :any_skip_relocation, mojave:   "a8e180565f3214a371f552b4e83420182710040fa7c8fcf85a62f007799dc45a"
   end
 
-  head do
-    url "https://github.com/purescript/purescript.git"
-
-    depends_on "hpack" => :build
-  end
-
-  depends_on "cabal-install" => :build
-  depends_on "ghc@8.6" => :build
+  depends_on "ghc" => :build
+  depends_on "haskell-stack" => :build
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
-  def install
-    system "hpack" if build.head?
+  resource "purescript-ast" do
+    url "https://hackage.haskell.org/package/purescript-ast-0.1.1.0/purescript-ast-0.1.1.0.tar.gz"
+    sha256 "a2f5403f9663d57957f2ae1692e52bdff0dd677876f93c1ae9bbf7b0ef9af38b"
+  end
+  resource "purescript-cst" do
+    url "https://hackage.haskell.org/package/purescript-cst-0.1.1.0/purescript-cst-0.1.1.0.tar.gz"
+    sha256 "3999f4b5c824099ea9cc9a74dd543b28ba9c5e57cbef2ff2966baa0b58725816"
+  end
 
-    system "cabal", "v2-update"
-    system "cabal", "v2-install", "-frelease", *std_cabal_v2_args
+  def install
+    (buildpath/"lib"/"purescript-ast").install resource("purescript-ast")
+    (buildpath/"lib"/"purescript-cst").install resource("purescript-cst")
+    system "stack", "install", "--system-ghc", "--no-install-ghc", "--skip-ghc-check", "--local-bin-path=#{bin}"
   end
 
   test do


### PR DESCRIPTION
This updates the formula to build with the default ghc allowing it to build on Big Sur finally.

hpack usage is also removed per https://github.com/purescript/purescript/commit/f36ff2a984e7743b8a0967becb9dee5d684fc30a
