### PR TITLE
cryfs: Show tap information

### DIFF
--- a/Formula/cryfs.rb
+++ b/Formula/cryfs.rb
@@ -3,7 +3,7 @@ class Cryfs < Formula
   homepage "https://www.cryfs.org"
   url "https://github.com/cryfs/cryfs/releases/download/0.10.2/cryfs-0.10.2.tar.xz"
   sha256 "5531351b67ea23f849b71a1bc44474015c5718d1acce039cf101d321b27f03d5"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
 
   bottle do
     rebuild 1
@@ -22,6 +22,7 @@ class Cryfs < Formula
   depends_on "libomp"
   depends_on "openssl@1.1"
 
+  opoo "CryFS doesn't live in homebrew-core anymore. To install, please run `brew install cryfs/tap/cryfs`."
   on_macos do
     disable! date: "2021-04-08", because: "requires FUSE"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The CryFS formula is disabled because it depends on FUSE. It is now available via a tap maintained by the project authors, but installing it from homebrew-core was part of the official installation instructions for quite some time.

This PR adds a message to users who follow old installation instructions of the project so they're not stuck in a dead end but know how to actually install it.