### PR TITLE
resticprofile 0.13.1 (new formula)

### DIFF
--- a/Formula/resticprofile.rb
+++ b/Formula/resticprofile.rb
@@ -1,0 +1,44 @@
+class Resticprofile < Formula
+  desc "Configuration profiles for restic backup"
+  homepage "https://github.com/creativeprojects/resticprofile"
+  url "https://github.com/creativeprojects/resticprofile.git",
+      tag:      "v0.13.1",
+      revision: "d64dc4f77bae0f07f51c2dc76d7c820e2c415dda"
+  license "GPL-3.0-only"
+  head "https://github.com/creativeprojects/resticprofile.git"
+
+  depends_on "go" => :build
+
+  depends_on "restic"
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.commit=#{Utils.git_head}
+      -X main.date=#{Time.now.utc.rfc3339}
+      -X main.builtBy=homebrew
+    ].join(" ")
+
+    system "go", "build", *std_go_args, "-ldflags", ldflags
+  end
+
+  test do
+    assert_match "resticprofile version #{version}", shell_output("#{bin}/resticprofile version")
+
+    (testpath/"restic_repo").mkdir
+    (testpath/"password.txt").write("key")
+    (testpath/"profiles.yaml").write <<~EOS
+      default:
+        repository: "local:#{testpath}/restic_repo"
+        password-file: "password.txt"
+        initialize: true
+    EOS
+
+    (testpath/"testfile").write("This is a testfile")
+
+    system "#{bin}/resticprofile", "backup", "testfile"
+    system "#{bin}/resticprofile", "restore", "latest", "-t", "#{testpath}/restore"
+    assert compare_file "testfile", "#{testpath}/restore/testfile"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This MR adds the formula [resticprofile](https://github.com/creativeprojects/resticprofile).

I created the tests similar to the [restic](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/restic.rb) ones.