### PR TITLE
`minikube`: remove `kubernetes-cli` dependency

### DIFF
--- a/Formula/minikube.rb
+++ b/Formula/minikube.rb
@@ -16,7 +16,6 @@ class Minikube < Formula
 
   depends_on "go" => :build
   depends_on "go-bindata" => :build
-  depends_on "kubernetes-cli"
 
   def install
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This removes the unnecessary `kubernetes-cli` dependency from the `minikube` formula. It is not necessary for any of `minikube`'s functionality.

 `minikube` itself supports a `--kubernetes-version` flag to run whatever `kube-apiserver` version you wish. The upstream kubernetes project supports the latest 3 minor versions:


https://kubernetes.io/docs/setup/release/version-skew-policy/#supported-versions
> The Kubernetes project maintains release branches for the most recent three minor releases (1.21, 1.20, 1.19). Kubernetes 1.19 and newer receive approximately 1 year of patch support. Kubernetes 1.18 and older received approximately 9 months of patch support.

and it may be practical to run an older version due to support by platforms such as Amazon EKS's latest supported kubernetes version being `1.19`: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

This becomes an issue for the `kubernetes-cli` package being a dependency due to the versioning skew policy for `kubectl`:

https://kubernetes.io/docs/setup/release/version-skew-policy/#kubectl
> `kubectl` is supported within one minor version (older or newer) of `kube-apiserver`.
>
> Example:
>
>     `kube-apiserver` is at 1.21
>     `kubectl` is supported at 1.22, 1.21, and 1.20

This means that, for example, a user may wish to run the supported kubernetes 1.19 in their `minikube` cluster (which is practical if you want a 1:1 development environment with something in production), thus the `kubectl` version homebrew installs as a dependency would be incompatible with it. I've ran into compatibility issues before because of this.