### PR TITLE
sfml: make bottle relocatable

### DIFF
--- a/Formula/sfml.rb
+++ b/Formula/sfml.rb
@@ -35,7 +35,7 @@ class Sfml < Formula
     rm_rf Dir["extlibs/*"] - ["extlibs/headers"]
 
     system "cmake", ".", *std_cmake_args,
-                         "-DCMAKE_INSTALL_RPATH=#{opt_lib}",
+                         "-DCMAKE_INSTALL_RPATH=#{rpath}",
                          "-DSFML_MISC_INSTALL_PREFIX=#{share}/SFML",
                          "-DSFML_INSTALL_PKGCONFIG_FILES=TRUE",
                          "-DSFML_BUILD_DOC=TRUE"


### PR DESCRIPTION
Using `opt_lib` as the RPATH breaks relocatability.

See ebf0954f15d912099c4d8fa00082a96b7f7ec84d and e1847b64a72c05772bfb450aa4e2fb2236d08eb5.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?