### PR TITLE
coreutils: remove unneeded Linux workaround and upstream fix

### DIFF
--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -28,6 +28,10 @@ class Coreutils < Formula
 
   uses_from_macos "gperf" => :build
 
+  on_linux do
+    depends_on "attr"
+  end
+
   conflicts_with "aardvark_shell_utils", because: "both install `realpath` binaries"
   conflicts_with "b2sum", because: "both install `b2sum` binaries"
   conflicts_with "ganglia", because: "both install `gstat` binaries"
@@ -40,11 +44,6 @@ class Coreutils < Formula
 
   def install
     system "./bootstrap" if build.head?
-
-    # Fix configure: error: you should not run configure as root
-    on_linux do
-      ENV["FORCE_UNSAFE_CONFIGURE"] = "1" if ENV["HOMEBREW_GITHUB_ACTIONS"]
-    end
 
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The workaround is unneeded because we no longer build as root in Linux.