### PR TITLE
include-what-you-use: use symlinks

### DIFF
--- a/Formula/include-what-you-use.rb
+++ b/Formula/include-what-you-use.rb
@@ -56,11 +56,8 @@ class IncludeWhatYouUse < Formula
     # formula. This would be indicated by include-what-you-use failing to
     # locate stddef.h and/or stdlib.h when running the test block below.
     # https://clang.llvm.org/docs/LibTooling.html#libtooling-builtin-includes
-    mkdir_p libexec/"lib/clang/#{llvm.version}"
-    cp_r llvm.opt_lib/"clang/#{llvm.version}/include",
-      libexec/"lib/clang/#{llvm.version}"
-    mkdir_p libexec/"include"
-    cp_r llvm.opt_include/"c++", libexec/"include"
+    (libexec/"lib").install_symlink llvm.lib/"clang"
+    (libexec/"include").install_symlink llvm.include/"c++"
   end
 
   test do


### PR DESCRIPTION
We previously tried to avoid symlinking to prevent the symlinks from
becoming invalidated between minor version bumps. However, the last two
minor version bumps of llvm required revision bumps to IWYU anyway [1],
so I think there's no point avoiding the use of symlnks now.

[1] #69984, #71315

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?