### PR TITLE
pango: fix rpath

### DIFF
--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -4,6 +4,7 @@ class Pango < Formula
   url "https://download.gnome.org/sources/pango/1.48/pango-1.48.4.tar.xz"
   sha256 "418913fb062071a075846244989d4a67aa5c80bf0eae8ee4555a092fd566a37a"
   license "LGPL-2.0-or-later"
+  revision 1
   head "https://gitlab.gnome.org/GNOME/pango.git"
 
   bottle do
@@ -30,6 +31,7 @@ class Pango < Formula
                       "-Dintrospection=enabled",
                       "-Duse_fontconfig=true",
                       ".."
+      inreplace "build.ninja", "@rpath", opt_lib
       system "ninja", "-v"
       system "ninja", "install", "-v"
     end


### PR DESCRIPTION
rpath for opt_lib prefixes

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
