### PR TITLE
unixodbc: fix SQLSpecialColumns on ARM64

### DIFF
--- a/Formula/unixodbc.rb
+++ b/Formula/unixodbc.rb
@@ -4,6 +4,7 @@ class Unixodbc < Formula
   url "http://www.unixodbc.org/unixODBC-2.3.9.tar.gz"
   sha256 "52833eac3d681c8b0c9a5a65f2ebd745b3a964f208fc748f977e44015a31b207"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url "http://www.unixodbc.org/download.html"
@@ -23,6 +24,12 @@ class Unixodbc < Formula
   conflicts_with "libiodbc", because: "both install `odbcinst.h`"
   conflicts_with "virtuoso", because: "both install `isql` binaries"
 
+  # fix issue with SQLSpecialColumns on ARM64
+  # remove for 2.3.10
+  # https://github.com/lurcher/unixODBC/issues/60
+  # https://github.com/lurcher/unixODBC/pull/69
+  patch :DATA
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
@@ -37,3 +44,33 @@ class Unixodbc < Formula
     system bin/"odbcinst", "-j"
   end
 end
+
+__END__
+--- a/DriverManager/drivermanager.h
++++ b/DriverManager/drivermanager.h
+@@ -1091,11 +1177,23 @@ void return_to_pool( DMHDBC connection );
+ #define DM_SQLSPECIALCOLUMNS        72
+ #define CHECK_SQLSPECIALCOLUMNS(con)    (con->functions[72].func!=NULL)
+ #define SQLSPECIALCOLUMNS(con,stmt,it,cn,nl1,sn,nl2,tn,nl3,s,n)\
+-                                    (con->functions[72].func)\
++                                    ((SQLRETURN (*) (\
++                                           SQLHSTMT, SQLUSMALLINT,\
++                                           SQLCHAR*, SQLSMALLINT,\
++                                           SQLCHAR*, SQLSMALLINT,\
++                                           SQLCHAR*, SQLSMALLINT,\
++                                           SQLUSMALLINT, SQLUSMALLINT))\
++                                    con->functions[72].func)\
+                                         (stmt,it,cn,nl1,sn,nl2,tn,nl3,s,n)
+ #define CHECK_SQLSPECIALCOLUMNSW(con)    (con->functions[72].funcW!=NULL)
+ #define SQLSPECIALCOLUMNSW(con,stmt,it,cn,nl1,sn,nl2,tn,nl3,s,n)\
+-                                    (con->functions[72].funcW)\
++                                    ((SQLRETURN (*) (\
++                                        SQLHSTMT, SQLUSMALLINT,\
++                                        SQLWCHAR*, SQLSMALLINT,\
++                                        SQLWCHAR*, SQLSMALLINT,\
++                                        SQLWCHAR*, SQLSMALLINT,\
++                                        SQLUSMALLINT, SQLUSMALLINT))\
++                                    con->functions[72].funcW)\
+                                         (stmt,it,cn,nl1,sn,nl2,tn,nl3,s,n)
+ 
+ #define DM_SQLSTATISTICS            73


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note that while I made more extensive changes in https://github.com/lurcher/unixODBC/pull/69, those changes do not apply cleanly to 2.3.9 due to other changes made upstream since then. Since SQLSpecialColumns is the only API that runs in to an issue with the macOS ARM64 ABI calling convention, I extracted just those changes here.
