### PR TITLE
pcre: restore ability to build from source on el capitan (and anything pre-sierra)

### DIFF
--- a/Formula/pcre.rb
+++ b/Formula/pcre.rb
@@ -43,8 +43,8 @@ class Pcre < Formula
       --enable-pcregrep-libbz2
     ]
 
-    # JIT not currently supported for Apple Silicon
-    args << "--enable-jit" unless Hardware::CPU.arm?
+    # JIT not currently supported for Apple Silicon or OS older than sierra
+    args << "--enable-jit" if MacOS.version >= :sierra && !Hardware::CPU.arm?
 
     system "./autogen.sh" if build.head?
     system "./configure", *args


### PR DESCRIPTION
This restores the ability to build from source on pre-sierra OS.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
