### PR TITLE
embulk: update livecheck

### DIFF
--- a/Formula/embulk.rb
+++ b/Formula/embulk.rb
@@ -11,7 +11,7 @@ class Embulk < Formula
 
   livecheck do
     url :homepage
-    regex(%r{Stable.+?href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}im)
+    regex(%r{(?<!un)Stable.+?href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}im)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR updates `embulk`'s `livecheck` block by modifying the `regex`. The older `regex` wasn't strict enough – it matched [un]stable too, and the word "unstable" is present on the homepage just above the `0.10.x` release archive.

Hopefully, this should prevent the automated bump PRs that update the formula to the unstable version.