### PR TITLE
libgcrypt: remove patch

### DIFF
--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -19,10 +19,6 @@ class Libgcrypt < Formula
 
   depends_on "libgpg-error"
 
-  # Fix --disable-asm build on Intel. https://dev.gnupg.org/T5277
-  # Reverts https://dev.gnupg.org/rC8d404a629167d67ed56e45de3e65d1e0b7cdeb24
-  patch :DATA
-
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
@@ -51,47 +47,3 @@ class Libgcrypt < Formula
     assert_match "0e824ce7c056c82ba63cc40cffa60d3195b5bb5feccc999a47724cc19211aef6", output
   end
 end
-
-__END__
-diff --git a/src/g10lib.h b/src/g10lib.h
-index 243997e..1987265 100644
---- a/src/g10lib.h
-+++ b/src/g10lib.h
-@@ -217,7 +217,6 @@ char **_gcry_strtokenize (const char *string, const char *delim);
- 
- 
- /*-- src/hwfeatures.c --*/
--#if defined(HAVE_CPU_ARCH_X86)
- 
- #define HWF_PADLOCK_RNG         (1 << 0)
- #define HWF_PADLOCK_AES         (1 << 1)
-@@ -238,29 +237,21 @@ char **_gcry_strtokenize (const char *string, const char *delim);
- #define HWF_INTEL_RDTSC         (1 << 15)
- #define HWF_INTEL_SHAEXT        (1 << 16)
- 
--#elif defined(HAVE_CPU_ARCH_ARM)
--
- #define HWF_ARM_NEON            (1 << 0)
- #define HWF_ARM_AES             (1 << 1)
- #define HWF_ARM_SHA1            (1 << 2)
- #define HWF_ARM_SHA2            (1 << 3)
- #define HWF_ARM_PMULL           (1 << 4)
- 
--#elif defined(HAVE_CPU_ARCH_PPC)
--
- #define HWF_PPC_VCRYPTO         (1 << 0)
- #define HWF_PPC_ARCH_3_00       (1 << 1)
- #define HWF_PPC_ARCH_2_07       (1 << 2)
- 
--#elif defined(HAVE_CPU_ARCH_S390X)
--
- #define HWF_S390X_MSA           (1 << 0)
- #define HWF_S390X_MSA_4         (1 << 1)
- #define HWF_S390X_MSA_8         (1 << 2)
- #define HWF_S390X_VX            (1 << 3)
- 
--#endif
--
- gpg_err_code_t _gcry_disable_hw_feature (const char *name);
- void _gcry_detect_hw_features (void);
- unsigned int _gcry_get_hw_features (void);


### PR DESCRIPTION
The patch should no longer be necessary as of 1.9.2. Also, the
`--disable-asm` flag imposes a significant performance penalty, and
upstream recommend against using it where possible.

Ref. https://dev.gnupg.org/T5277

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?