### PR TITLE
csound: make bottle relocatable

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -65,6 +65,10 @@ class Csound < Formula
     resource("ableton-link").stage { cp_r "include/ableton", buildpath }
     resource("getfem").stage { cp_r "src/gmm", buildpath }
 
+    inreplace "CMakeLists.txt",
+       /^    add_definitions\("-DCS_DEFAULT_PLUGINDIR=\\"\$\{CS_FRAMEWORK_FULL_PATH\}\\""\)$/,
+       "    add_definitions(\"-DCS_DEFAULT_PLUGINDIR=\\\".\\\"\")"
+
     args = std_cmake_args + %W[
       -DABLETON_LINK_HOME=#{buildpath}/ableton
       -DBUILD_ABLETON_LINK_OPCODES=ON
@@ -73,7 +77,7 @@ class Csound < Formula
       -DBUILD_LUA_INTERFACE=OFF
       -DBUILD_PYTHON_INTERFACE=OFF
       -DBUILD_WEBSOCKET_OPCODE=OFF
-      -DCMAKE_INSTALL_RPATH=#{frameworks}
+      -DCMAKE_INSTALL_RPATH=@loader_path/../Frameworks
       -DCS_FRAMEWORK_DEST=#{frameworks}
       -DGMM_INCLUDE_DIR=#{buildpath}/gmm
       -DJAVA_MODULE_INSTALL_DIR=#{libexec}
@@ -96,6 +100,9 @@ class Csound < Formula
 
   def caveats
     <<~EOS
+      You should add to #{shell_profile}:
+        export OPCODE6DIR64=#{opt_frameworks}/CsoundLib64.framework/Resources/Opcodes64
+
       To use the Python bindings, you may need to add to #{shell_profile}:
         export DYLD_FRAMEWORK_PATH="$DYLD_FRAMEWORK_PATH:#{opt_frameworks}"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I think this makes Csound bottles relocatable on macOS.

Because Csound needs the RPATH to be `@loader_path/../Frameworks`, this PR **does not** use the `rpath` helper method introduced in https://github.com/Homebrew/brew/pull/11187 (which returns `@loader_path/../lib` on macOS). One way to use the `rpath` helper method here would be to set the RPATH to—

```ruby
rpath.sub(%r{/lib('?)$}, '/Frameworks\1')
```

—but, since the Csound formula requires macOS, this might be more trouble than it’s worth.

Related to https://github.com/Homebrew/homebrew-core/issues/75458.