### PR TITLE
git-sizer: fix version

### DIFF
--- a/Formula/git-sizer.rb
+++ b/Formula/git-sizer.rb
@@ -4,6 +4,7 @@ class GitSizer < Formula
   url "https://github.com/github/git-sizer/archive/v1.3.0.tar.gz"
   sha256 "c5f77d50eeda704a228f30f5a233ef0e56ef9f4cc83433d46e331b3247d28c6d"
   license "MIT"
+  revision 1
 
   bottle do
     rebuild 1
@@ -20,7 +21,7 @@ class GitSizer < Formula
     ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/github/git-sizer").install buildpath.children
     cd "src/github.com/github/git-sizer" do
-      system "go", "build", "-o", bin/"git-sizer"
+      system "go", "build", *std_go_args(ldflags: "-X main.ReleaseVersion=#{version}")
       prefix.install_metafiles
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`git-sizer` was being built in a way that it was not aware of its own version number:

```
$ git-sizer --version
git-sizer build
```

After [consulting with the author of `git-sizer`](https://github.com/github/git-sizer/issues/70), we were able to determine the fix in this PR.  We need to pass the version number to the "go build ..." command.