### PR TITLE
bpytop: fix test

### DIFF
--- a/Formula/bpytop.rb
+++ b/Formula/bpytop.rb
@@ -48,7 +48,7 @@ class Bpytop < Formula
 
     log = (config/"error.log").read
     assert_match "bpytop version #{version} started with pid #{pid}", log
-    assert_not_match(/ERROR:/, log)
+    refute_match(/ERROR:/, log)
   ensure
     Process.kill("TERM", pid)
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes

```
Warning: Calling assert_not_match is deprecated! Use refute_match instead.
```

Spotted in #75515.