### PR TITLE
dnstwist: fix test

### DIFF
--- a/Formula/dnstwist.rb
+++ b/Formula/dnstwist.rb
@@ -87,6 +87,6 @@ class Dnstwist < Formula
     assert_match "Fetching content from:", output
     assert_match "//brew.sh", output
     assert_match(/Processing \d+ permutations/, output)
-    assert_not_match(/notice: missing module/, output)
+    refute_match(/notice: missing module/, output)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes
```
Warning: Calling assert_not_match is deprecated! Use refute_match instead.
```
Spotted in #75515.
