### PR TITLE
jhipster: depend on node@14

### DIFF
--- a/Formula/jhipster.rb
+++ b/Formula/jhipster.rb
@@ -3,9 +3,11 @@ require "language/node"
 class Jhipster < Formula
   desc "Generate, develop and deploy Spring Boot + Angular/React applications"
   homepage "https://www.jhipster.tech/"
+  # Check if this can be switched to the newest `node` at version bump
   url "https://registry.npmjs.org/generator-jhipster/-/generator-jhipster-7.0.1.tgz"
   sha256 "5e92b04561905adee9e91e4f2f8f12dd93d5ab389556753e09ee23fe34035873"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "37810f4f38600d90a53173949ba3eb8adb25820dd568d99e82f286f815ae38e6"
@@ -14,13 +16,16 @@ class Jhipster < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "13daac9bfb8bbb368fdd4d4670c870e6ceb2d43c10990219a790a41e697aaa4c"
   end
 
-  depends_on "node"
+  depends_on "node@14"
   depends_on "openjdk"
 
   def install
+    node = Formula["node@14"]
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install Dir["#{libexec}/bin/*"]
-    bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env
+    env = { PATH: "#{node.opt_bin}:$PATH" }
+    env.merge! Language::Java.overridable_java_home_env
+    bin.env_script_all_files libexec/"bin", env
   end
 
   test do


### PR DESCRIPTION
It doesn't work with Node 16 yet.

See #75595.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?