### PR TITLE
grc: remove `bottle :unneeded`.

### DIFF
--- a/Formula/grc.rb
+++ b/Formula/grc.rb
@@ -14,8 +14,9 @@ class Grc < Formula
 
   def install
     # fix non-standard prefix installs
-    inreplace ["grc", "grc.1"], "/etc", etc
-    inreplace ["grcat", "grcat.1"], "/usr/local", HOMEBREW_PREFIX
+    inreplace "grc", "/usr/local/etc/", "#{etc}/"
+    inreplace "grc.1", " /etc/", " #{etc}/"
+    inreplace ["grcat", "grcat.1"], "/usr/local/share/grc/", "#{pkgshare}/"
 
     # so that the completions don't end up in etc/profile.d
     inreplace "install.sh",

--- a/Formula/grc.rb
+++ b/Formula/grc.rb
@@ -8,8 +8,6 @@ class Grc < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/garabik/grc.git", branch: "devel"
 
-  bottle :unneeded
-
   depends_on "python@3.9"
 
   conflicts_with "cc65", because: "both install `grc` binaries"


### PR DESCRIPTION
It should have an identical checksum on all platforms.