### PR TITLE
node-build: remove `bottle :unneeded`.

### DIFF
--- a/Formula/node-build.rb
+++ b/Formula/node-build.rb
@@ -11,8 +11,6 @@ class NodeBuild < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  bottle :unneeded
-
   depends_on "autoconf"
   depends_on "openssl@1.1"
   depends_on "pkg-config"


### PR DESCRIPTION
It should have an identical checksum on all platforms.