### PR TITLE
rbenv-default-gems: remove `bottle :unneeded`.

### DIFF
--- a/Formula/rbenv-default-gems.rb
+++ b/Formula/rbenv-default-gems.rb
@@ -7,8 +7,6 @@ class RbenvDefaultGems < Formula
   revision 1
   head "https://github.com/sstephenson/rbenv-default-gems.git"
 
-  bottle :unneeded
-
   depends_on "rbenv"
 
   # Upstream patch: https://github.com/sstephenson/rbenv-default-gems/pull/3


### PR DESCRIPTION
It should have an identical checksum on all platforms.