### PR TITLE
pow: deprecate

### DIFF
--- a/Formula/pow.rb
+++ b/Formula/pow.rb
@@ -6,6 +6,10 @@ class Pow < Formula
 
   bottle :unneeded
 
+  # The related GitHub repository (basecamp/pow) was archived sometime between
+  # 2018-06-11 and 2019-04-10 (referencing Wayback Machine snapshots)
+  deprecate! date: "2021-04-21", because: :repo_archived
+
   depends_on "node"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The related [GitHub repository for `pow`](https://github.com/basecamp/pow) (linked from the homepage) was archived somewhere between 2018-06-11 and 2019-04-10 (referencing Wayback Machine snapshots). This PR deprecates the formula, as the software seemingly won't receive further updates.