### PR TITLE
Mockery: indicate that Go is only a build dependency

### DIFF
--- a/Formula/mockery.rb
+++ b/Formula/mockery.rb
@@ -13,7 +13,7 @@ class Mockery < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "c6021ba38358d6dfaec61d4a4c6ebd5729ea78f95ef41c52a5903083e87d6b05"
   end
 
-  depends_on "go"
+  depends_on "go" => :build
 
   def install
     system "go", "build", *std_go_args, "-ldflags", "-s -w -X github.com/vektra/mockery/v2/pkg/config.SemVer=#{version}"


### PR DESCRIPTION
Mockery is a CLI tool built with Go, and since—to my knowledge—it doesn't need Go at runtime, Go should only be marked as a build dependency so Homebrew doesn't have to also install Go when installing Mockery from a bottle.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
