### PR TITLE
bcoin: switch to node@14

### DIFF
--- a/Formula/bcoin.rb
+++ b/Formula/bcoin.rb
@@ -6,7 +6,7 @@ class Bcoin < Formula
   url "https://github.com/bcoin-org/bcoin/archive/v2.1.2.tar.gz"
   sha256 "b4c63598ee1efc17e4622ef88c1dff972692da1157e8daf7da5ea8abc3d234df"
   license "MIT"
-  revision 2
+  revision 3
   head "https://github.com/bcoin-org/bcoin.git"
 
   bottle do
@@ -19,11 +19,12 @@ class Bcoin < Formula
   end
 
   depends_on "python@3.9" => :build
-  depends_on "node"
+  depends_on "node@14"
 
   def install
-    system "#{Formula["node"].libexec}/bin/npm", "install", *Language::Node.std_npm_install_args(libexec)
-    (bin/"bcoin").write_env_script libexec/"bin/bcoin", PATH: "#{Formula["node"].opt_bin}:$PATH"
+    node = Formula["node@14"]
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    (bin/"bcoin").write_env_script libexec/"bin/bcoin", PATH: "#{node.opt_bin}:$PATH"
   end
 
   test do
@@ -40,7 +41,7 @@ class Bcoin < Formula
         await node.ensure();
       })();
     EOS
-    system "#{Formula["node"].bin}/node", testpath/"script.js"
+    system "#{Formula["node@14"].bin}/node", testpath/"script.js"
     assert File.directory?("#{testpath}/.bcoin")
   end
 end


### PR DESCRIPTION
This may be compatible with Node 16. However, it seems less wasteful of
CI resources to switch this to Node 14 first and back to Node 16 later,
rather than re-run #75595 with a revision bump to `bcoin`.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?