### PR TITLE
fix url style for apache-geode primary url

### DIFF
--- a/Formula/apache-geode.rb
+++ b/Formula/apache-geode.rb
@@ -1,7 +1,7 @@
 class ApacheGeode < Formula
   desc "In-memory Data Grid for fast transactional data processing"
   homepage "https://geode.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=geode/1.13.2/apache-geode-1.13.2.tgz"
+  url "https://www.apache.org/dyn/closer.lua/geode/1.13.2/apache-geode-1.13.2.tgz?action=download"
   mirror "https://archive.apache.org/dist/geode/1.13.2/apache-geode-1.13.2.tgz"
   mirror "https://downloads.apache.org/geode/1.13.2/apache-geode-1.13.2.tgz"
   sha256 "bc2d2e9bcec8f2fdfa2419894962314a3e3569fa617c3e2f6beca8097197ad02"


### PR DESCRIPTION
Apache has been making changes today that break some URLs that used to work.  Updating to the more-working flavor...

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
