### PR TITLE
zig head requires llvm12

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -1,11 +1,14 @@
 class Zig < Formula
   desc "Programming language designed for robustness, optimality, and clarity"
   homepage "https://ziglang.org/"
-  url "https://ziglang.org/download/0.7.1/zig-0.7.1.tar.xz"
-  sha256 "2db3b944ab368d955b48743d9f7c963b8f96de1a441ba5a35e197237cc6dae44"
   license "MIT"
   revision 1
-  head "https://github.com/ziglang/zig.git"
+
+  stable do
+    url "https://ziglang.org/download/0.7.1/zig-0.7.1.tar.xz"
+    sha256 "2db3b944ab368d955b48743d9f7c963b8f96de1a441ba5a35e197237cc6dae44"
+    depends_on "llvm@11"
+  end
 
   bottle do
     sha256 cellar: :any, big_sur:  "36024d6e9270699221abc2fe0d49b9f16e9bfc62636b33750f94d89a07e0e308"
@@ -13,8 +16,12 @@ class Zig < Formula
     sha256 cellar: :any, mojave:   "63643cea7d45ce511f4cd0a4e7089a64e2dedecc9cd900eaff805c011b299cda"
   end
 
+  head do
+    url "https://github.com/ziglang/zig.git"
+    depends_on "llvm"
+  end
+
   depends_on "cmake" => :build
-  depends_on "llvm@11"
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
Zig's HEAD version requires LLVM 12. I assume 0.7 could work with LLVM 12 also, but it doesn't require it, so I left the stable version with 11.

------

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

