### PR TITLE
various formulae: `s/assert_include /assert_includes /`

### DIFF
--- a/Formula/aws-iam-authenticator.rb
+++ b/Formula/aws-iam-authenticator.rb
@@ -33,7 +33,7 @@ class AwsIamAuthenticator < Formula
     system "#{bin}/aws-iam-authenticator", "init", "-i", "test"
     contents = Dir.entries(".")
     ["cert.pem", "key.pem", "aws-iam-authenticator.kubeconfig"].each do |created|
-      assert_include contents, created
+      assert_includes contents, created
     end
   end
 end

--- a/Formula/fileicon.rb
+++ b/Formula/fileicon.rb
@@ -25,6 +25,6 @@ class Fileicon < Formula
     system bin/"fileicon", "set", testpath, icon
     assert_predicate testpath/"Icon\r", :exist?
     stdout = shell_output "#{bin}/fileicon test #{testpath}"
-    assert_include stdout, "HAS custom icon: '#{testpath}'"
+    assert_includes stdout, "HAS custom icon: '#{testpath}'"
   end
 end

--- a/Formula/ghr.rb
+++ b/Formula/ghr.rb
@@ -28,6 +28,6 @@ class Ghr < Formula
   test do
     ENV["GITHUB_TOKEN"] = nil
     args = "-username testbot -repository #{testpath} v#{version} #{Dir.pwd}"
-    assert_include "token not found", shell_output("#{bin}/ghr #{args}", 15)
+    assert_includes "token not found", shell_output("#{bin}/ghr #{args}", 15)
   end
 end

--- a/Formula/lcdf-typetools.rb
+++ b/Formula/lcdf-typetools.rb
@@ -29,6 +29,6 @@ class LcdfTypetools < Formula
 
   test do
     font_name = (MacOS.version >= :catalina) ? "Arial\\ Unicode.ttf" : "Arial.ttf"
-    assert_include shell_output("#{bin}/otfinfo -p /Library/Fonts/#{font_name}"), "Arial"
+    assert_includes shell_output("#{bin}/otfinfo -p /Library/Fonts/#{font_name}"), "Arial"
   end
 end

--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -42,6 +42,6 @@ class Mas < Formula
 
   test do
     assert_equal version.to_s, shell_output("#{bin}/mas version").chomp
-    assert_include shell_output("#{bin}/mas info 497799835"), "Xcode"
+    assert_includes shell_output("#{bin}/mas info 497799835"), "Xcode"
   end
 end

--- a/Formula/sng.rb
+++ b/Formula/sng.rb
@@ -25,6 +25,6 @@ class Sng < Formula
   test do
     cp test_fixtures("test.png"), "test.png"
     system bin/"sng", "test.png"
-    assert_include File.read("test.sng"), "width: 8; height: 8; bitdepth: 8;"
+    assert_includes File.read("test.sng"), "width: 8; height: 8; bitdepth: 8;"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`assert_include` is deprecated and has been replaced by `assert_includes`.