### PR TITLE
amp: fix ARM64/Apple Silicon build

### DIFF
--- a/Formula/amp.rb
+++ b/Formula/amp.rb
@@ -3,7 +3,8 @@ class Amp < Formula
   homepage "https://amp.rs"
   url "https://github.com/jmacdonald/amp/archive/0.6.2.tar.gz"
   sha256 "9279efcecdb743b8987fbedf281f569d84eaf42a0eee556c3447f3dc9c9dfe3b"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/jmacdonald/amp.git"
 
   bottle do
@@ -19,6 +20,20 @@ class Amp < Formula
   uses_from_macos "libiconv"
 
   def install
+    # Upstream specifies very old versions of onig_sys/cc that
+    # cause issues when using Homebrew's clang shim on Apple Silicon.
+    # Forcefully upgrade `onig_sys` and `cc` to slightly newer versions
+    # that enable a succesful build.
+    # https://github.com/jmacdonald/amp/issues/222
+    inreplace "Cargo.lock" do |f|
+      f.gsub! "68.0.1", "68.2.1"
+      f.gsub! "5c6be7c4f985508684e54f18dd37f71e66f3e1ad9318336a520d7e42f0d3ea8e",
+              "195ebddbb56740be48042ca117b8fb6e0d99fe392191a9362d82f5f69e510379"
+      f.gsub! "1.0.45", "1.0.67"
+      f.gsub! "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be",
+              "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+    end
+
     system "cargo", "install", *std_cargo_args
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Explicitly telling it we're building on an ARM64 platform seems to workaround this issue. I'm not 100% sure but I think this might be a Rust/Cargo issue rather than a specific upstream problem.

```
The following warnings were emitted during compilation:

warning: error: unknown target triple 'unknown-apple-macosx11.0.0', please use -triple or -arch

error: failed to run custom build command for `miniz-sys v0.1.10`

Caused by:
  process didn't exit successfully: `/private/tmp/amp-20210423-81499-u43bqd/amp-0.6.2/target/release/build/miniz-sys-8206f807ea976702/build-script-build` (exit code: 1)
  --- stdout
  TARGET = Some("aarch64-apple-darwin")
  OPT_LEVEL = Some("3")
  HOST = Some("aarch64-apple-darwin")
  CC_aarch64-apple-darwin = None
  CC_aarch64_apple_darwin = None
  HOST_CC = None
  CC = Some("clang")
  CFLAGS_aarch64-apple-darwin = None
  CFLAGS_aarch64_apple_darwin = None
  HOST_CFLAGS = None
  CFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("false")
  running: "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=aarch64-apple-darwin" "-Wall" "-Wextra" "-o" "/private/tmp/amp-20210423-81499-u43bqd/amp-0.6.2/target/release/build/miniz-sys-963bfefa5e55ce3c/out/miniz.o" "-c" "miniz.c"
  cargo:warning=error: unknown target triple 'unknown-apple-macosx11.0.0', please use -triple or -arch
  exit code: 1
```