### PR TITLE
gnupg@2.2 (new versioned formula)

### DIFF
--- a/Formula/gnupg@2.2.rb
+++ b/Formula/gnupg@2.2.rb
@@ -1,0 +1,72 @@
+class GnupgAT22 < Formula
+  desc "GNU Pretty Good Privacy (PGP) package"
+  homepage "https://gnupg.org/"
+  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.27.tar.bz2"
+  sha256 "34e60009014ea16402069136e0a5f63d9b65f90096244975db5cea74b3d02399"
+  license "GPL-3.0-or-later"
+
+  livecheck do
+    url "https://gnupg.org/ftp/gcrypt/gnupg/"
+    regex(/href=.*?gnupg[._-]v?(2\.2(?:\.\d+)+)\.t/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "pkg-config" => :build
+  depends_on "gettext"
+  depends_on "gnutls"
+  depends_on "libassuan"
+  depends_on "libgcrypt"
+  depends_on "libgpg-error"
+  depends_on "libksba"
+  depends_on "libusb"
+  depends_on "npth"
+  depends_on "pinentry"
+
+  uses_from_macos "sqlite" => :build
+
+  on_linux do
+    depends_on "libidn"
+  end
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--sbindir=#{bin}",
+                          "--sysconfdir=#{etc}",
+                          "--enable-all-tests",
+                          "--enable-symcryptrun",
+                          "--with-pinentry-pgm=#{Formula["pinentry"].opt_bin}/pinentry"
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+
+  def post_install
+    (var/"run").mkpath
+    quiet_system "killall", "gpg-agent"
+  end
+
+  test do
+    (testpath/"batch.gpg").write <<~EOS
+      Key-Type: RSA
+      Key-Length: 2048
+      Subkey-Type: RSA
+      Subkey-Length: 2048
+      Name-Real: Testing
+      Name-Email: testing@foo.bar
+      Expire-Date: 1d
+      %no-protection
+      %commit
+    EOS
+    begin
+      system bin/"gpg", "--batch", "--gen-key", "batch.gpg"
+      (testpath/"test.txt").write "Hello World!"
+      system bin/"gpg", "--detach-sign", "test.txt"
+      system bin/"gpg", "--verify", "test.txt.sig"
+    ensure
+      system bin/"gpgconf", "--kill", "gpg-agent"
+    end
+  end
+end

--- a/style_exceptions/make_check_allowlist.json
+++ b/style_exceptions/make_check_allowlist.json
@@ -5,6 +5,7 @@
   "gmp",
   "gnupg",
   "gnupg@1.4",
+  "gnupg@2.2",
   "google-sparsehash",
   "jemalloc",
   "jpeg-turbo",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

In #75755, gnupg was upgraded to use the 2.3 branch. Per https://lists.gnupg.org/pipermail/gnupg-devel/2021-April/034846.html, 2.2 is still a LTS branch and is expected to be maintained through 2024. As we already have a 1.4 versioned formula for gnupg, I'm adding the 2.2 formula back as an option.

This is the same version of gnupg taken at 82a541975125ea0dd805f7e86831ce7c96a42eb4, with the following changes:
- class renamed
- bottle stanza removed
- `keg_only :versioned_formula` added
- livecheck updated to filter for version