### PR TITLE
terragrunt: Replace dependency with caveats

### DIFF
--- a/Formula/terragrunt.rb
+++ b/Formula/terragrunt.rb
@@ -13,10 +13,32 @@ class Terragrunt < Formula
   end
 
   depends_on "go" => :build
-  depends_on "terraform"
 
   def install
     system "go", "build", "-ldflags", "-s -w -X main.VERSION=v#{version}", *std_go_args
+  end
+
+  def caveats
+    <<~EOS
+      Terragrunt has been installed as
+        #{HOMEBREW_PREFIX}/bin/terragrunt
+
+      Terragrunt requires a version of `terraform` to be in the user's path.
+
+      Teams using terragrunt/terraform need to use the same version of
+      terraform. To prevent accidental version changes via `brew upgrade`, we
+      recommend using `tfenv` to install and manage `terraform` versions:
+        brew install tfenv
+        tfenv install <required terraform version>
+        tfenv use <required terraform version>
+
+      See: https://github.com/tfutils/tfenv
+
+      Terraform can also be installed directly with homebrew.  This is only
+      recommended when NOT working as part of a team (i.e., for solo projects,
+      learning, or experimenting):
+        brew install terraform
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Terragrunt requires terraform to be installed on the user's path, but
installing terraform via homebrew is problematic for several reasons:
  - Teams (and CI/CD pipelines) need to use the same version of
      terraform, and to upgrade deliberately. Using homebrew to install
      can lead to accidental upgrades via `brew upgrade`. When this
      happens, it's often easier to force users and pipelines to also
      upgrade rather than try to roll back to the previous version.
  - New team members face difficulties in installing the correct
      version via homebrew when the team is not using the latest.
  - When a new version is available, team members must use caution
      when upgrading. I.e.: auto cleanup must be disabled, and users
      must `brew switch` back to the correct version after
      `brew upgrade`.
  - Having terraform as a dependency is a conflict for users who
      manage terraform versions via `tfenv`.  When a terraform upgrade
      is available, such users must unlink `tfenv`, link `terraform`,
      run the upgrade, unlink terraform, and link `tfenv`.

This commit removes terraform as a terragrunt dependency, and adds
caveats with instructions to install terraform either via `tfenv`
(recommended), or directly via homebrew.

Note that this is a fix for https://github.com/gruntwork-io/terragrunt/issues/580.  A previous PR (#73326) was created to remove `terraform` as a dependency, but was closed.  This PR fixes the previous objection by adding `caveats` with instructions for how to install `terraform` either via `tfenv` or homebrew.
