### PR TITLE
groovy: update livecheck

### DIFF
--- a/Formula/groovy.rb
+++ b/Formula/groovy.rb
@@ -6,8 +6,8 @@ class Groovy < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://dl.bintray.com/groovy/maven/"
-    regex(/href=.*?groovy-binary[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+    url "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/"
+    regex(/href=.*?apache-groovy-binary[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `groovy` is reporting `3.0.7` as the latest version, as `3.0.8` isn't present in the checked location.

This PR updates the `livecheck` block to check the directory listing page where the current `stable` archive is found. This addresses the issue with the reported version while also aligning the check with the `stable` source (which we prefer, when possible).