### PR TITLE
claws-mail: add livecheck

### DIFF
--- a/Formula/claws-mail.rb
+++ b/Formula/claws-mail.rb
@@ -6,6 +6,11 @@ class ClawsMail < Formula
   license "GPL-3.0-or-later"
   revision 1
 
+  livecheck do
+    url "https://www.claws-mail.org/releases.php"
+    regex(/href=.*?claws-mail[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "bbd1c67af463fb0645306523ebe20d37833aa8e3d38c042e8ce60d378c53d1d0"
     sha256 big_sur:       "cc9a93ec8f3322edcd9c9be0a3c9b059d130008115e19276533675432cae1c67"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `claws-mail`. This PR adds a `livecheck` block that checks the first-party "releases" page, which links to the `stable` archive.

For what it's worth, the `www` subdomain of `claws-mail.org` wasn't resolving while testing this but it started working again after a few minutes. The website works the same without the `www` subdomain but I'll hold off on updating these URLs unless/until we run into this problem again.