### PR TITLE
cdparanoia: add livecheck

### DIFF
--- a/Formula/cdparanoia.rb
+++ b/Formula/cdparanoia.rb
@@ -4,6 +4,11 @@ class Cdparanoia < Formula
   url "https://downloads.xiph.org/releases/cdparanoia/cdparanoia-III-10.2.src.tgz"
   sha256 "005db45ef4ee017f5c32ec124f913a0546e77014266c6a1c50df902a55fe64df"
 
+  livecheck do
+    url "https://www.xiph.org/paranoia/down.html"
+    regex(/href=.*?cdparanoia-III[._-]v?(\d+(?:\.\d+)+)\.src\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "79d03f652937117697ae235b7bbb8558be9cb86edc42c330316204a288d5cb59"
     sha256 cellar: :any, big_sur:       "2b7649f89581be2a35b246e4aab15e936573d3920f794ae5187e23b796874dbf"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `cdparanoia`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.