### PR TITLE
stp 2.3.3 (new formula)

### DIFF
--- a/Formula/stp.rb
+++ b/Formula/stp.rb
@@ -1,0 +1,70 @@
+class Stp < Formula
+  desc "Simple Theorem Prover, an efficient SMT solver for bitvectors"
+  homepage "https://stp.github.io/"
+  url "https://github.com/stp/stp/archive/refs/tags/2.3.3.tar.gz"
+  sha256 "ea6115c0fc11312c797a4b7c4db8734afcfce4908d078f386616189e01b4fffa"
+  license "MIT"
+  head "https://github.com/stp/stp.git"
+
+  # stp refuses to build with system bison and flex
+  depends_on "bison" => :build
+  depends_on "cmake" => :build
+  depends_on "flex" => :build
+  depends_on "boost"
+  depends_on "cryptominisat"
+  depends_on "minisat"
+  depends_on "python@3.9"
+
+  uses_from_macos "perl"
+
+  def install
+    site_packages = prefix/Language::Python.site_packages("python3")
+    site_packages.mkpath
+    inreplace "lib/Util/GitSHA1.cpp.in", "@CMAKE_CXX_COMPILER@", ENV.cxx
+
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DPYTHON_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3",
+                    "-DPYTHON_LIB_INSTALL_DIR=#{site_packages}",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"prob.smt").write <<~EOS
+      (set-logic QF_BV)
+      (assert (= (bvsdiv (_ bv3 2) (_ bv2 2)) (_ bv0 2)))
+      (check-sat)
+      (exit)
+    EOS
+    assert_equal "sat", shell_output("#{bin}/stp --SMTLIB2 prob.smt").chomp
+
+    (testpath/"test.c").write <<~EOS
+      #include "stp/c_interface.h"
+      #include <assert.h>
+      int main() {
+        VC vc = vc_createValidityChecker();
+        Expr c = vc_varExpr(vc, "c", vc_bvType(vc, 32));
+        Expr a = vc_bvConstExprFromInt(vc, 32, 5);
+        Expr b = vc_bvConstExprFromInt(vc, 32, 6);
+        Expr xp1 = vc_bvPlusExpr(vc, 32, a, b);
+        Expr eq = vc_eqExpr(vc, xp1, c);
+        Expr eq2 = vc_notExpr(vc, eq);
+        int ret = vc_query(vc, eq2);
+        assert(ret == false);
+        vc_printCounterExample(vc);
+        vc_Destroy(vc);
+        return 0;
+      }
+    EOS
+
+    expected_output = <<~EOS
+      COUNTEREXAMPLE BEGIN:\s
+      ASSERT( c = 0x0000000B );
+      COUNTEREXAMPLE END:\s
+    EOS
+
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lstp", "-o", "test"
+    assert_equal expected_output.chomp, shell_output("./test").chomp
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Audit fails with the following error:
```
❯ brew audit --new stp
stp:
  * Dependency 'bison' is provided by macOS; please replace 'depends_on' with 'uses_from_macos'.
  * Dependency 'flex' is provided by macOS; please replace 'depends_on' with 'uses_from_macos'.
Error: 2 problems in 1 formula detected
```
However, `stp` will fail to build with system `bison` and `flex`. Insisting on brewed `bison` and `flex` is in `stp`'s [`CMakeLists.txt`](https://github.com/stp/stp/blob/9a59a72e82d67cefeb88d8baa34965f70acb5d1c/CMakeLists.txt#L530-L552).

Previously proposed in #50020.