### PR TITLE
p0f: add livecheck

### DIFF
--- a/Formula/p0f.rb
+++ b/Formula/p0f.rb
@@ -5,6 +5,11 @@ class P0f < Formula
   sha256 "543b68638e739be5c3e818c3958c3b124ac0ccb8be62ba274b4241dbdec00e7f"
   license "LGPL-2.1-only"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?p0f[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+  end
+
   bottle do
     rebuild 2
     sha256 arm64_big_sur: "c2b5dfb6885142c3066f900623a1cb1e4920335ad80455f49ae463f2bb07e953"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `p0f`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.