### PR TITLE
dhcping: add livecheck

### DIFF
--- a/Formula/dhcping.rb
+++ b/Formula/dhcping.rb
@@ -5,6 +5,11 @@ class Dhcping < Formula
   mirror "https://deb.debian.org/debian/pool/main/d/dhcping/dhcping_1.2.orig.tar.gz"
   sha256 "32ef86959b0bdce4b33d4b2b216eee7148f7de7037ced81b2116210bc7d3646a"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?dhcping[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "8126f3068682d4e4629158c4bec5f71fe557671ee93521d4a46286fcc8a9e53a"
     sha256 cellar: :any_skip_relocation, big_sur:       "cea21616fd5abd22da30648e6744ff16630f3ead891b8336ca668c3fa3f93a0a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `dhcping`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.