### PR TITLE
dhcpdump: add livecheck

### DIFF
--- a/Formula/dhcpdump.rb
+++ b/Formula/dhcpdump.rb
@@ -1,9 +1,14 @@
 class Dhcpdump < Formula
   desc "Monitor DHCP traffic for debugging purposes"
-  homepage "https://www.mavetju.org/"
+  homepage "https://www.mavetju.org/unix/general.php"
   url "https://www.mavetju.org/download/dhcpdump-1.8.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/d/dhcpdump/dhcpdump_1.8.orig.tar.gz"
   sha256 "6d5eb9418162fb738bc56e4c1682ce7f7392dd96e568cc996e44c28de7f77190"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?dhcpdump[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "ea331a3bb132f7f9fbc334e85fd7d7cfc6cf7314df93bf123c5e042febbe1951"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `dhcpdump`. This PR updates the homepage to point to `/unix/general.php` (like `dhcping`) and adds a `livecheck` block that checks the homepage, which links to the `stable` archive. This aligns the check for the three mavetju.org formulae (`dhcpdump`, `dhcping`, and `dnstracer`).