### PR TITLE
workflows: add workflow to recreate linux self-hosted VM on shedule

### DIFF
--- a/.github/actions/find-runner.js
+++ b/.github/actions/find-runner.js
@@ -1,0 +1,10 @@
+const { Octokit } = require("@octokit/action");
+
+const octokit = new Octokit();
+
+get_async()
+
+async function get_async () {
+  const data = await octokit.request('GET /repos/Homebrew/homebrew-core/actions/runners')
+  console.log("Result: %s", data);
+}

--- a/.github/workflows/recreate-runner.yml
+++ b/.github/workflows/recreate-runner.yml
@@ -1,0 +1,22 @@
+name: Recreate Linux self-hosted runner on schedule
+
+# on:
+#   workflow_dispatch:
+#   schedule:
+#     # Once each 24 hours, at 1 during the night
+#     - cron: "0 0 1 1/1 *"
+
+on: pull_request
+
+jobs:
+  recreate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          version: 12
+      - run: npm install @octokit/action
+      - run: node .github/actions/find-runner.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}


### PR DESCRIPTION
This workflow will run once each 24h to delete the linux runner and create a new one,
to increaste the security of the runner in case it is compromised.

This is a middle ground as we can't have disposable self-hosted runners.

Right now this PR is just a WIP that tries to understand how to fetch the list of runners
and their status from github.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
