### PR TITLE
workflows: add workflow to recreate linux self-hosted VM on schedule

### DIFF
--- a/.github/workflows/recreate-runner.yml
+++ b/.github/workflows/recreate-runner.yml
@@ -1,0 +1,34 @@
+name: Recreate Linux self-hosted runner on schedule
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Once each 24 hours, at 1 during the night
+    - cron: "0 0 1 1/1 *"
+
+jobs:
+  recreate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+      - name: Wait for idle runner
+        id: killable
+        uses: Homebrew/actions/wait-for-idle-runner@master
+        with:
+          github_token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          runner_name: linux-self-hosted-1
+      - name: Kill runner and create a new one
+        if: ${{ steps.killable.outputs.runner-found == 'true' && steps.killable.outputs.runner-idle == 'true' }}
+        uses: Homebrew/actions/create-gcloud-instance@master
+        with:
+          runner_name: linux-self-hosted-1
+          gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+          gcp_service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+          github_token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}


### PR DESCRIPTION
This workflow will run once each 24h to delete the Linux runner and create a new one,
to increase the security of the runner in case it is compromised.

This is a middle ground as we can't have disposable self-hosted runners.

Right now this PR is just a WIP that tries to understand how to fetch the list of runners
and their status from github.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
