### PR TITLE
odin: update livecheck

### DIFF
--- a/Formula/odin.rb
+++ b/Formula/odin.rb
@@ -9,7 +9,7 @@ class Odin < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+[a-z]?)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `odin` uses the `GithubLatest` strategy. Unfortunately, the "latest" release on GitHub is a `pre-dev-2021-04` tag instead of `v0.13.0`, so "latest" isn't correct.

This PR switches from `GithubLatest` to the `Git` strategy by removing the `strategy` line and adding a version of the standard regex for Git tags that's been altered to allow for an optional letter at the end of the version (e.g., `0.0.5d`). The `GithubLatest` strategy didn't appear to be necessary for this formula anyway, as we can obtain the correct latest version by checking the Git tags.