### PR TITLE
libsvg-cairo: fix for ARM/M1 Macs

### DIFF
--- a/Formula/libsvg-cairo.rb
+++ b/Formula/libsvg-cairo.rb
@@ -21,14 +21,52 @@ class LibsvgCairo < Formula
     sha256 cellar: :any, yosemite:    "55bd8f9bfede25e71e9731d72ace27ce7724a4cce030a4e4e6969554ee64238d"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "cairo"
   depends_on "libpng"
   depends_on "libsvg"
 
+  # libsvg: fix for ARM/M1 Macs
+  # Patch to update to newer autotools
+  # (https://cgit.freedesktop.org/cairo/commit/?id=afdf3917ee86a7d8ae17f556db96478682674a76)
+  patch :DATA
+
   def install
-    system "./configure", "--disable-dependency-tracking", "--disable-debug",
+    system "autoreconf", "-fiv"
+    system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
   end
 end
+
+__END__
+diff --git a/configure.in b/configure.in
+index 3407e0d..627bbc5 100755
+--- a/configure.in
++++ b/configure.in
+@@ -8,18 +8,18 @@ LIBSVG_CAIRO_VERSION=0.1.6
+ # libtool shared library version
+
+ # Increment if the interface has additions, changes, removals.
+-LT_CURRENT=1
++m4_define(LT_CURRENT, 1)
+
+ # Increment any time the source changes; set to
+ # 0 if you increment CURRENT
+-LT_REVISION=1
++m4_define(LT_REVISION, 1)
+
+ # Increment if any interfaces have been added; set to 0
+ # if any interfaces have been removed. removal has
+ # precedence over adding, so set to 0 if both happened.
+-LT_AGE=0
++m4_define(LT_AGE, 0)
+
+-VERSION_INFO="$LT_CURRENT:$LT_REVISION:$LT_AGE"
++VERSION_INFO="LT_CURRENT():LT_REVISION():LT_AGE()"
+ AC_SUBST(VERSION_INFO)
+
+ dnl ===========================================================================


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [-] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This relies on https://github.com/Homebrew/homebrew-core/pull/74623, which is for libsvg, and very similar.
make check doesn't seem to run any sort of tests for libsvg or libsvg-cairo, so I'm not sure what to do as far as tests.

