### PR TITLE
stone-soup: update livecheck

### DIFF
--- a/Formula/stone-soup.rb
+++ b/Formula/stone-soup.rb
@@ -6,8 +6,8 @@ class StoneSoup < Formula
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://crawl.develz.org/download.htm"
-    regex(/Stable.*?>v?(\d+(?:\.\d+)+)</i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `stone-soup` currently works but it was created a long time ago and is potentially a bit fragile. This PR updates the `livecheck` block to check the GitHub repository tags (as `stable` is a tag archive from GitHub) and to use the standard regex for Git tags like `1.2.3`/`v1.2.3`. This brings the check more in line with our current standards.