### PR TITLE
xfig 3.2.8a (new formula)

### DIFF
--- a/Formula/xfig.rb
+++ b/Formula/xfig.rb
@@ -1,0 +1,41 @@
+class Xfig < Formula
+  desc "Facility for interactive generation of figures"
+  homepage "https://mcj.sourceforge.io"
+  url "https://downloads.sourceforge.net/mcj/xfig-3.2.8a.tar.xz"
+  sha256 "ba43c0ea85b230d3efa5a951a3239e206d0b033d044c590a56208f875f888578"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/xfig[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
+  end
+
+  depends_on "fig2dev"
+  depends_on "ghostscript"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "libx11"
+  depends_on "libxaw3d"
+  depends_on "libxi"
+  depends_on "libxpm"
+  depends_on "libxt"
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --with-appdefaultdir=#{etc}/X11/app-defaults
+    ]
+
+    system "./configure", *args
+    # "LDFLAGS" argument can be deleted the next release after 3.2.8a. See discussion at
+    # https://sourceforge.net/p/mcj/discussion/general/thread/36ff8854e8/#fa9d.
+    system "make", "LDFLAGS=-ltiff -ljpeg -lpng", "install-strip"
+  end
+
+  test do
+    assert_equal "Xfig #{version}", shell_output("#{bin}/xfig -V 2>&1").strip
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Xfig is an X11 drawing program. Researchers who write their publications with latex often use xfig to draw diagrams. According to the debian popularity contest, xfig is regularly used (vote) by 517 users, which is 0.27% of the user base and rank 5828. The backend program to xfig, fig2dev, is listed in the same statistics to be voted for by 2305 users, which gives it a share of 1.20 percent and rank 2928. For fig2dev, a homebrew formula exists. The latter had 14058 install events in the last 90 days, which gives it rank 499 according to homebrew analytics data. Really, these two programs should be used in combination, and a formula should also exist for xfig.

I am the maintainer of xfig and had an [exchange](https://sourceforge.net/p/mcj/discussion/general/thread/36ff8854e8) with a homebrew user who had to install xfig from sources. This pull request for a new xfig formula, containing a specific make command line which is commented on in the formula itself, is the outcome of the discussion. See also further comments in the formula file.

Since I do not have easy access to a Mac, I would not be able to contribute much to this formula.  The tests above were run under linux, hence I am not sure whether the test performs flawlessly under Darwin. Anyhow, homebrew policy does not welcome authors to maintain formulae for their own program. Perhaps, contributors to the fig2dev formula could engage in the xfig formula?

Questions:
Part of the dependencies should be ":recommended", but brew audit objected to the ":recommended" tag, therefore it was removed. Should one disobey the output of brew audit here?
At runtime, some X core fonts are needed. Does a cask or a formula exist that provides additional core fonts? Otherwise, xfig emits some warning messages, and some user interface items might look less pleasing.
What about automake's "make check" in the test section? Homebrew policy seems to reject these.

Thanks for your time.