### PR TITLE
zookeeper: install original log4j.properties as well

### DIFF
--- a/Formula/zookeeper.rb
+++ b/Formula/zookeeper.rb
@@ -5,6 +5,7 @@ class Zookeeper < Formula
   mirror "https://archive.apache.org/dist/zookeeper/zookeeper-3.7.0/apache-zookeeper-3.7.0.tar.gz"
   sha256 "cb3980f61b66babe550dcb717c940160ba813512c0aca26c2b8a718fac5d465d"
   license "Apache-2.0"
+  revision 1
   head "https://gitbox.apache.org/repos/asf/zookeeper.git"
 
   bottle do
@@ -71,10 +72,12 @@ class Zookeeper < Formula
       EOS
     end
 
-    inreplace "conf/zoo_sample.cfg",
-              /^dataDir=.*/, "dataDir=#{var}/run/zookeeper/data"
     cp "conf/zoo_sample.cfg", "conf/zoo.cfg"
-    (etc/"zookeeper").install ["conf/zoo.cfg", "conf/zoo_sample.cfg"]
+    inreplace "conf/zoo.cfg",
+              /^dataDir=.*/, "dataDir=#{var}/run/zookeeper/data"
+    (etc/"zookeeper").install "conf/zoo.cfg"
+
+    (pkgshare/"examples").install "conf/log4j.properties", "conf/zoo_sample.cfg"
   end
 
   def post_install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Zookeeper has its default log4j.properties file but it's ignored through install procedure.
This PR installs the log4j.properties file as log4j_sample.properties as well as zoo_sample.cfg.