### PR TITLE
ruby@2.6: scheduled deprecation date and livecheck

### DIFF
--- a/Formula/ruby@2.6.rb
+++ b/Formula/ruby@2.6.rb
@@ -19,6 +19,8 @@ class RubyAT26 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2022-04-05", because: :unsupported
+
   depends_on "pkg-config" => :build
   depends_on "libyaml"
   depends_on "openssl@1.1"

--- a/Formula/ruby@2.6.rb
+++ b/Formula/ruby@2.6.rb
@@ -5,6 +5,11 @@ class RubyAT26 < Formula
   sha256 "f43ead5626202d5432d2050eeab606e547f0554299cc1e5cf573d45670e59611"
   license "Ruby"
 
+  livecheck do
+    url "https://www.ruby-lang.org/en/downloads/"
+    regex(/href=.*?ruby[._-]v?(2\.6(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "f0042ce8ff23f1a095d2dd6184ac5aac2658adea9ef1ea965d88388dc9a4bcca"
     sha256 big_sur:       "b98af7d62a3d5fa120b5debbea3ab72674c018d773cc528fe43ad1b26fc048fb"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [release of Ruby 2.6.7](https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-6-7-released/) started the last phase of Ruby 2.6 life – the security maintenance phase. The security maintenance phase is currently scheduled for a year since the 2.6.7 release, therefore end of life of Ruby 2.6 is scheduled for 2022-04-05. It usually doesn’t happen precisely on the scheduled day, but we want to keep this date around.

The live check is the one from `ruby` and `ruby@2.7` modified to check for 2.6