### PR TITLE
sbt: depend on `arch: :x86_64`

### DIFF
--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -15,6 +15,7 @@ class Sbt < Formula
     sha256 cellar: :any_skip_relocation, all: "13bcd5a2344e0d9a6f92c979b92f11df41e110fa7bb1b5046aa30e404e6df99f"
   end
 
+  depends_on arch: :x86_64
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This doesn't work on ARM.