### PR TITLE
gitlab-runner: Run service with higher priority

### DIFF
--- a/Formula/gitlab-runner.rb
+++ b/Formula/gitlab-runner.rb
@@ -51,6 +51,9 @@ class GitlabRunner < Formula
           <key>KeepAlive</key><true/>
           <key>RunAtLoad</key><true/>
           <key>Disabled</key><false/>
+          <key>LegacyTimers</key><true/>
+          <key>ProcessType</key>
+          <string>Interactive</string>
           <key>Label</key>
           <string>#{plist_name}</string>
           <key>ProgramArguments</key>


### PR DESCRIPTION
By default launchd will execute with ProcessType "standard" which has less resources assigned.
Also without forcing LegacyTimers, all applications with timers executed from gitlab-ci may use less precise timers. This made our unit tests with timers fail all the time while they were working fine when gitlab-runner is not started by launchd.

See also https://www.unix.com/man-page/mojave/5/launchd.plist/

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
