### PR TITLE
speedtest-cli: remove `bottle :unneeded`

### DIFF
--- a/Formula/speedtest-cli.rb
+++ b/Formula/speedtest-cli.rb
@@ -6,8 +6,6 @@ class SpeedtestCli < Formula
   license "Apache-2.0"
   head "https://github.com/sivel/speedtest-cli.git"
 
-  bottle :unneeded
-
   def install
     bin.install "speedtest.py" => "speedtest"
     bin.install_symlink "speedtest" => "speedtest-cli"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See #75943.
