### PR TITLE
rapidjson: Fix build error when ccache is installed

### DIFF
--- a/Formula/rapidjson.rb
+++ b/Formula/rapidjson.rb
@@ -4,6 +4,7 @@ class Rapidjson < Formula
   url "https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz"
   sha256 "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e"
   license "MIT"
+  revision 1
   head "https://github.com/miloyip/rapidjson.git"
 
   bottle do
@@ -21,6 +22,11 @@ class Rapidjson < Formula
   depends_on "doxygen" => :build
 
   conflicts_with "mesos", because: "mesos installs a copy of rapidjson headers"
+
+  patch do
+    url "https://github.com/Tencent/rapidjson/commit/2850576d53c63d1a9e472a785531697da89e41dc.patch?full_index=1"
+    sha256 "5b0117910629b03027ce27000e5d4713756ce21bc7ab099c76b2ccb84df518dd"
+  end
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The `RapidJSON` formula fails to build from source if `ccache` is installed on the system:
```
[brett] Taps/homebrew/homebrew-core [master]  % brew install -s rapidjson
==> Downloading https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz
Already downloaded: /Users/brett/Library/Caches/Homebrew/downloads/1162750ef7f177edea51e3a8d7792250c8376c3260982579c2f784dcd5de979a--rapidjson-1.1.0.tar.gz
==> cmake .
==> make install
Last 15 lines from /Users/brett/Library/Logs/Homebrew/rapidjson/02.make:
Generating annotated compound index...
Generating alphabetical compound index...
Generating hierarchical class index...
Generating member index...
Generating file index...
Generating file member index...
Generating example index...
finalizing index lists...
writing tag file...
Running plantuml with JAVA...
lookup cache used 2664/65536 hits=39541 misses=2958
finished...
/opt/homebrew/Cellar/cmake/3.20.1/bin/cmake -E touch /tmp/rapidjson-20210428-36993-1rej5u/rapidjson-1.1.0/doc/html
[ 25%] Built target doc
make: *** [all] Error 2

Do not report this issue to Homebrew/brew or Homebrew/core!
```

This is because of a bug in their CMake configuration script, and there is a pull request (https://github.com/Tencent/rapidjson/pull/1693) fixing the problem, but the pull request has been left open for a year and the upstream maintainer doesn't seem to be going to merge it in any time soon.

After applying this patch, I can successfully build both `1.1.0` and `--HEAD` version from source.