### PR TITLE
docutils: Create symlinks without the .py extension

### DIFF
--- a/Formula/docutils.rb
+++ b/Formula/docutils.rb
@@ -5,6 +5,7 @@ class Docutils < Formula
   homepage "https://docutils.sourceforge.io"
   url "https://downloads.sourceforge.net/project/docutils/docutils/0.17.1/docutils-0.17.1.tar.gz"
   sha256 "686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "8c6f650a9ceec0e34b6d1463d40448e171027c230cfeba1d7bfa971c15d3ed0e"
@@ -17,6 +18,10 @@ class Docutils < Formula
 
   def install
     virtualenv_install_with_resources
+
+    Dir.glob("#{libexec}/bin/*.py") do |f|
+      bin.install_symlink f => File.basename(f, ".py")
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Related to https://github.com/Homebrew/homebrew-core/pull/74369
Now after installation of `binutils` symlinks with the .py extension are created (`rst2man.py`). Additionally create symlinks without the .py extension, because many external dependencies are searching for `rst2man` in the PATH. 