### PR TITLE
openssl@1.1: re-parallelise build/install

### DIFF
--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -99,7 +99,6 @@ class OpensslAT11 < Formula
       end
     end
 
-    ENV.deparallelize
     system "perl", "./Configure", *(configure_args + arch_args)
     system "make"
     system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The issues around parallel builds were resolved in 2018 via https://github.com/openssl/openssl/pull/7583 and the referenced commits.

Sadly the tests still take 45 years to get through but this fairly significantly speeds up the build time.

Before:
```
==> Summary
/opt/homebrew/Cellar/openssl@1.1/1.1.1k: 8,064 files, 17.9MB, built in 7 minutes 40 seconds
```

After:
```
==> Summary
/opt/homebrew/Cellar/openssl@1.1/1.1.1k: 8,064 files, 17.9MB, built in 4 minutes 35 seconds
```