### PR TITLE
ant-contrib: remove `bottle :unneeded`

### DIFF
--- a/Formula/ant-contrib.rb
+++ b/Formula/ant-contrib.rb
@@ -9,8 +9,6 @@ class AntContrib < Formula
     regex(%r{url=.*?/ant-contrib[._-]v?(\d+(?:\.\d+)+(?:[a-z]\d+)?)-bin\.t}i)
   end
 
-  bottle :unneeded
-
   depends_on "ant"
 
   def install


### PR DESCRIPTION
relates to #75943

