### PR TITLE
wifi-password: remove `bottle :unneeded`

### DIFF
--- a/Formula/wifi-password.rb
+++ b/Formula/wifi-password.rb
@@ -4,8 +4,6 @@ class WifiPassword < Formula
   url "https://github.com/rauchg/wifi-password/archive/0.1.0.tar.gz"
   sha256 "6af6a34a579063eb21c067f10b7c2eb5995995eceb70e6a1f571dc78d4f3651b"
 
-  bottle :unneeded
-
   def install
     bin.install "wifi-password.sh" => "wifi-password"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See #75943.
