### PR TITLE
less: update livecheck

### DIFF
--- a/Formula/less.rb
+++ b/Formula/less.rb
@@ -7,7 +7,7 @@ class Less < Formula
 
   livecheck do
     url :homepage
-    regex(/less[._-]v?(\d+).+?released.+?general use/i)
+    regex(/less[._-]v?(\d+(?:\.\d+)*).+?released.+?general use/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`less` is now at version `581.2`, a quick bug fix for `581`. This PR updates the `livecheck` block's `regex` to be able to match 0 or more "point" releases.