### PR TITLE
terraform@0.1{1,2,3}: deprecate

### DIFF
--- a/Formula/terraform@0.11.rb
+++ b/Formula/terraform@0.11.rb
@@ -14,6 +14,8 @@ class TerraformAT011 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2021-04-14", because: :unsupported
+
   depends_on "go" => :build
   depends_on "gox" => :build
 

--- a/Formula/terraform@0.12.rb
+++ b/Formula/terraform@0.12.rb
@@ -13,6 +13,8 @@ class TerraformAT012 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2021-04-14", because: :unsupported
+
   depends_on "go" => :build
   depends_on macos: :catalina
 

--- a/Formula/terraform@0.13.rb
+++ b/Formula/terraform@0.13.rb
@@ -13,6 +13,8 @@ class TerraformAT013 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2021-04-14", because: :unsupported
+
   depends_on "go@1.14" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Given upstream's articulation of their support policy (see #75981), it seems unlikely that these formulae should ever have been accepted into homebrew/core in the first place. (The official HashiCorp tap, for example, only provides a formula for the latest version of `terraform`.)

It also doesn't look like they continue to meet the requirements we set for versioned formulae, so it's time that these formulae are deprecated. I chose the deprecation date as the release date of version 0.15.

Users who still need earlier versions of `terraform` can install them using `tfenv`, or by `brew extract`ing the old versions into their own tap.