### PR TITLE
k9s 0.24.8

### DIFF
--- a/Formula/k9s.rb
+++ b/Formula/k9s.rb
@@ -2,8 +2,8 @@ class K9s < Formula
   desc "Kubernetes CLI To Manage Your Clusters In Style!"
   homepage "https://k9scli.io/"
   url "https://github.com/derailed/k9s.git",
-      tag:      "v0.24.7",
-      revision: "303de07663dcb20899852a98d3ebf6ce2f1c7922"
+      tag:      "v0.24.8",
+      revision: "627c38cb360f7a9b6eb5f856c7658838644d1540"
   license "Apache-2.0"
   head "https://github.com/derailed/k9s.git"
 
@@ -15,12 +15,6 @@ class K9s < Formula
   end
 
   depends_on "go" => :build
-
-  # remove in next release
-  patch do
-    url "https://github.com/derailed/k9s/commit/82b1c8a.patch?full_index=1"
-    sha256 "50dfe6931023e45fd630d4b12d64e3a9aeae1ade7ed5ee7e87222e6d79fc9f35"
-  end
 
   def install
     system "go", "build", "-ldflags",


### PR DESCRIPTION
This PR bumps k9s formula to 0.24.8 release

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
