### PR TITLE
openssl@1.1: add stable mirror

### DIFF
--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -3,6 +3,7 @@ class OpensslAT11 < Formula
   homepage "https://openssl.org/"
   url "https://www.openssl.org/source/openssl-1.1.1k.tar.gz"
   mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.1.1k.tar.gz"
+  mirror "https://www.openssl.org/source/old/1.1.1/openssl-1.1.1k.tar.gz"
   sha256 "892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5"
   license "OpenSSL"
   version_scheme 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

When a new OpenSSL version is released, the original URLs stop working. This is a problem because the bottle is not relocatable so it will break installs for a short period while we build the new version.

I've provided a mirror to the archive in the "old" directory. It will 404 currently - this is expected. What happens is the archive is simply moved into this directory when the next version is released, so this change guarantees at least one will work.

We previously used Homebrew/mirror for this but that has been retired.