### PR TITLE
zsh-completions: Install in standard completion path

### DIFF
--- a/Formula/zsh-completions.rb
+++ b/Formula/zsh-completions.rb
@@ -3,6 +3,8 @@ class ZshCompletions < Formula
   homepage "https://github.com/zsh-users/zsh-completions"
   url "https://github.com/zsh-users/zsh-completions/archive/0.32.0.tar.gz"
   sha256 "d2d20836fb60d2e5de11b08f1a8373484dc01260d224e64c6de9eec44137fa63"
+  license "MIT-Modern-Variant"
+  revision 1
   head "https://github.com/zsh-users/zsh-completions.git"
 
   bottle do
@@ -10,20 +12,16 @@ class ZshCompletions < Formula
   end
 
   def install
-    pkgshare.install Dir["src/_*"]
-    inreplace "#{share}/zsh-completions/_ghc", "/usr/local", HOMEBREW_PREFIX
+    inreplace "src/_ghc", "/usr/local", HOMEBREW_PREFIX
+    zsh_completion.install Dir["src/*"]
   end
 
   def caveats
     <<~EOS
       To activate these completions, add the following to your .zshrc:
 
-        if type brew &>/dev/null; then
-          FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
-
-          autoload -Uz compinit
-          compinit
-        fi
+        autoload -Uz compinit
+        compinit
 
       You may also need to force rebuild `zcompdump`:
 
@@ -38,10 +36,9 @@ class ZshCompletions < Formula
 
   test do
     (testpath/"test.zsh").write <<~EOS
-      fpath=(#{pkgshare} $fpath)
       autoload _ack
       which _ack
     EOS
-    assert_match(/^_ack/, shell_output("/bin/zsh test.zsh"))
+    assert_match(/^_ack/, shell_output("/bin/zsh -fd test.zsh"))
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Install zsh-completions in standard zsh_completion path. This should also avoid unnecessary `$fpath` customization for the user.

Additionally, the test has been updated to validate correctness of installation without any rc customization.
