### PR TITLE
ecasound: add livecheck

### DIFF
--- a/Formula/ecasound.rb
+++ b/Formula/ecasound.rb
@@ -4,6 +4,11 @@ class Ecasound < Formula
   url "https://ecasound.seul.org/download/ecasound-2.9.3.tar.gz"
   sha256 "468bec44566571043c655c808ddeb49ae4f660e49ab0072970589fd5a493f6d4"
 
+  livecheck do
+    url "https://www.eca.cx/ecasound/download.php"
+    regex(/href=.*?ecasound[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 big_sur:     "d3a693686266e5570afbd54ecaede7930145c6a69461e7839c97857b373c63f6"
     sha256 catalina:    "f6fede56fea73bdfd32cebd514448b50dec47542ff7d76342f950a61160a9fff"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `ecasound`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.