### PR TITLE
bork: update head to use main branch

### DIFF
--- a/Formula/bork.rb
+++ b/Formula/bork.rb
@@ -4,7 +4,7 @@ class Bork < Formula
   url "https://github.com/skylarmacdonald/bork/archive/v0.12.0.tar.gz"
   sha256 "525f797a5ad01734d298852a038c2a2cb338ee9bb038c560bb20ecf142b1588b"
   license "Apache-2.0"
-  head "https://github.com/skylarmacdonald/bork.git"
+  head "https://github.com/skylarmacdonald/bork.git", branch: "main"
 
   bottle :unneeded
 


### PR DESCRIPTION
Default `head` is `master`

But this repo uses `main`
https://github.com/skylarmacdonald/bork/branches

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes: https://github.com/skylarmacdonald/bork/issues/25