### PR TITLE
gitbucket: fix test hanging

### DIFF
--- a/Formula/gitbucket.rb
+++ b/Formula/gitbucket.rb
@@ -57,17 +57,11 @@ class Gitbucket < Formula
 
   test do
     java = Formula["openjdk"].opt_bin/"java"
-    begin
-      pid = fork do
-        exec "'#{java}' -jar #{libexec}/gitbucket.war --port=#{free_port} > output"
-      end
-      sleep 12
-      File.read("output") !~ /Exception/
-    ensure
-      Process.kill "SIGTERM", pid
-      Process.wait pid
-      # gitbucket leaves orphaned processees behind
-      quiet_system "pkill", "-9", "-f", "gitbucket"
+    fork do
+      $stdout.reopen(testpath/"output")
+      exec "'#{java}' -jar #{libexec}/gitbucket.war --port=#{free_port}"
     end
+    sleep 12
+    File.read("output") !~ /Exception/
   end
 end

--- a/Formula/gitbucket.rb
+++ b/Formula/gitbucket.rb
@@ -57,10 +57,19 @@ class Gitbucket < Formula
 
   test do
     java = Formula["openjdk"].opt_bin/"java"
-    fork do
-      exec "'#{java}' -jar #{libexec}/gitbucket.war --port=#{free_port} > output"
+    begin
+      pid = fork do
+        exec "'#{java}' -jar #{libexec}/gitbucket.war --port=#{free_port} > output"
+      end
+      puts "PID"
+      puts pid
+      sleep 12
+      File.read("output") !~ /Exception/
+    ensure
+      Process.kill "SIGTERM", pid
+      Process.wait pid
+      # gitbucket leaves orphaned processees behind
+      quiet_system "pkill", "-9", "-f", "gitbucket"
     end
-    sleep 12
-    File.read("output") !~ /Exception/
   end
 end

--- a/Formula/gitbucket.rb
+++ b/Formula/gitbucket.rb
@@ -61,8 +61,6 @@ class Gitbucket < Formula
       pid = fork do
         exec "'#{java}' -jar #{libexec}/gitbucket.war --port=#{free_port} > output"
       end
-      puts "PID"
-      puts pid
       sleep 12
       File.read("output") !~ /Exception/
     ensure


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This hanged during the last CI run of the openjdk 16 PR #72535. The fix is based on `inlets` `cleanup` method.