### PR TITLE
openlibm: remove `keg-only`, add license

### DIFF
--- a/Formula/openlibm.rb
+++ b/Formula/openlibm.rb
@@ -3,6 +3,7 @@ class Openlibm < Formula
   homepage "https://openlibm.org"
   url "https://github.com/JuliaMath/openlibm/archive/v0.7.5.tar.gz"
   sha256 "be983b9e1e40e696e8bbb7eb8f6376d3ca0ae675ae6d82936540385b0eeec15b"
+  license all_of: ["MIT", "ISC", "BSD-2-Clause"]
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "9f5a7236623f95551f78125570bf0cfddc1e790df87f22d10fe8c65f436c0968"
@@ -10,8 +11,6 @@ class Openlibm < Formula
     sha256 cellar: :any, catalina:      "c0cde03193f6151f1b6e49a1d1af14af2b5052dffcd3b09527b6d62ad28a1193"
     sha256 cellar: :any, mojave:        "ab439cf5a655dc9db2ed8f05b4059f85b7ec0414d7123c2f683ab1d90dd24d55"
   end
-
-  keg_only :provided_by_macos
 
   def install
     lib.mkpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is not provided by macOS. Its headers are contained inside an
`openlibm` subdirectory, and the library it provides is named
`libopenlibm`.

Trying to `dlopen` `libopenlibm` will return an error, and the SDK
contains no files with names that match `openlibm`.