### PR TITLE
open-mpi: remove `op-avx` from `enable-mca-no-build`

### DIFF
--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -4,6 +4,7 @@ class OpenMpi < Formula
   url "https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.1.tar.bz2"
   sha256 "e24f7a778bd11a71ad0c14587a7f5b00e68a71aa5623e2157bafee3d44c07cda"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :homepage
@@ -64,7 +65,7 @@ class OpenMpi < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --enable-ipv6
-      --enable-mca-no-build=op-avx,reachable-netlink
+      --enable-mca-no-build=reachable-netlink
       --with-libevent=#{Formula["libevent"].opt_prefix}
       --with-sge
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `op-avx` flag disables building features that take advantage of AVX
instructions.

Since `open-mpi` is able to detect CPU features at runtime, disabling
this is not necessary, and simply leads to lower performance for users
with newer machines.

See also https://github.com/open-mpi/ompi/issues/8306, https://github.com/open-mpi/ompi/pull/8361.
