### PR TITLE
objc-run: remove relocation hacks

### DIFF
--- a/Formula/objc-run.rb
+++ b/Formula/objc-run.rb
@@ -10,16 +10,17 @@ class ObjcRun < Formula
     sha256 cellar: :any_skip_relocation, all: "e779505f8071d158730517e91004a15c2364dbf03acceebd1643e27338792f98"
   end
 
-  def install
-    # Keep bottles uniform before keg-relocation
-    inreplace "objc-run", "/usr/local", HOMEBREW_PREFIX
-    bin.install "objc-run"
-    pkgshare.install "examples", "test.bash"
+  pour_bottle? do
+    reason "The bottle needs to be installed into #{Homebrew::DEFAULT_PREFIX}."
+    # https://github.com/Homebrew/homebrew-core/pull/76633
+    # Remove when the following issue is resolved:
+    # https://github.com/Homebrew/brew/issues/11302
+    satisfy { HOMEBREW_PREFIX.to_s == Homebrew::DEFAULT_PREFIX } unless Hardware::CPU.arm?
   end
 
-  def post_install
-    # Undo mistaken keg relocation
-    inreplace bin/"objc-run", HOMEBREW_PREFIX, "/usr/local"
+  def install
+    bin.install "objc-run"
+    pkgshare.install "examples", "test.bash"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

These were added in #76394, but may not have been the right thing to do.

-----

For the record, I'm not convinced removing the `post_install` method here is a good idea either, as it could break this formula for Intel users with a non-default prefix.

Keg-relocation mistakenly substitutes `/usr/local` in the following path
```
projectDirPath/build/usr/local/bin/clitest
```
to
```
projectDirPath/build@@HOMEBREW_PREFIX@@/bin/clitest
```
which will resolve to the wrong path in a non-default prefix.

I'm personally inclined to just revert #76394 entirely, at least until https://github.com/Homebrew/brew/issues/11302 is fixed.

CC @MikeMcQuaid