### PR TITLE
selenium-server-standalone: refactor assert_true in test

### DIFF
--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -61,7 +61,7 @@ class SeleniumServerStandalone < Formula
     output = JSON.parse(output)
 
     assert_equal 0, output["status"]
-    assert_true output["value"]["ready"]
+    assert_equal true, output["value"]["ready"]
     assert_equal version, output["value"]["build"]["version"]
   end
 end

--- a/Formula/selenium-server-standalone.rb
+++ b/Formula/selenium-server-standalone.rb
@@ -56,7 +56,7 @@ class SeleniumServerStandalone < Formula
   test do
     port = free_port
     fork { exec "#{bin}/selenium-server -port #{port}" }
-    sleep 3
+    sleep 6
     output = shell_output("curl --silent localhost:#{port}/wd/hub/status")
     output = JSON.parse(output)
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`assert_true` is deprecated. This is one of the failures spotted in #72535.