### PR TITLE
rpm: update livecheck

### DIFF
--- a/Formula/rpm.rb
+++ b/Formula/rpm.rb
@@ -8,8 +8,8 @@ class Rpm < Formula
   version_scheme 1
 
   livecheck do
-    url "https://github.com/rpm-software-management/rpm.git"
-    regex(/rpm[._-]v?(\d+(?:\.\d+)+)-release/i)
+    url "https://rpm.org/download.html"
+    regex(/href=.*?rpm[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `rpm` is reporting `4.16.1.2` as newest but the actual newest version is `4.16.1.3` (as seen in the formula). This PR updates the `livecheck` block to check the first-party download page, which links to the `stable` archive. This fixes this version mismatch issue and also brings the check closer to  the `stable` source, which we prefer whenever possible.