### PR TITLE
Neko: Fix build on m1

### DIFF
--- a/Formula/neko.rb
+++ b/Formula/neko.rb
@@ -44,15 +44,24 @@ class Neko < Formula
     sha256 "7fbe2f67e076efa2d7aa200456d4e5cc1e06d21f78ac5f2eed183f3fcce5db96"
   end
 
+  # Fix mariadb-connector-c CMake error: "Flow control statements are not properly nested."
+  # https://github.com/HaxeFoundation/neko/pull/225
+  patch do
+    url "https://github.com/HaxeFoundation/neko/commit/660fba028af1b77be8cb227b8a44cc0ef16aba79.patch?full_index=1"
+    sha256 "7b0a60494eaef7c67cd15e5d80d867fee396ac70e99000603fba0dc3cd5e1158"
+  end
+
+  # Fix m1 specifics
+  # https://github.com/HaxeFoundation/neko/pull/224
+  patch do
+    url "https://github.com/HaxeFoundation/neko/commit/ff5da9b0e96cc0eabc44ad2c10b7a92623ba49ee.patch?full_index=1"
+    sha256 "ac843dfc7585535f3b08fee2b22e667fa6c38e62dcf8374cdfd1d8fcbdbcdcfd"
+  end
+
   def install
     inreplace "libs/mysql/CMakeLists.txt",
               %r{https://downloads.mariadb.org/f/},
               "https://downloads.mariadb.com/Connectors/c/"
-
-    # Workaround issue where lock_acquire(), lock_try(), and lock_release()
-    # conflict with some symbols in Mach headers:
-    #   https://github.com/HaxeFoundation/neko/issues/215#issuecomment-745617663
-    inreplace %w[vm/neko.h.in vm/others.c vm/threads.c libs/ui/ui.c], /\slock_/, " HOMEBREW_lock_"
 
     # Work around for https://github.com/HaxeFoundation/neko/issues/216 where
     # maria-connector fails to detect the location of iconv.dylib on Big Sur.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

* Add upstream PR HaxeFoundation/neko#224: m1 build
* Add upstream PR HaxeFoundation/neko#225: Fix "Flow control statements
  are not properly nested." error from newer CMake
* Drop Homebrew-specific function renaming for `lock_*` functions were
  conflicting with Mach functions of the same names - replace with
  upstream PR 224 (above)

Signed-off-by: Daniel Llewellyn <diddledan@ubuntu.com>
