### PR TITLE
djl-serving: fix sha256 mismatch

### DIFF
--- a/Formula/djl-serving.rb
+++ b/Formula/djl-serving.rb
@@ -2,8 +2,9 @@ class DjlServing < Formula
   desc "This module contains an universal model serving implementation"
   homepage "https://github.com/awslabs/djl/tree/master/serving"
   url "https://djl-ai.s3.amazonaws.com/publish/djl-serving/serving-0.11.0.tar"
-  sha256 "93dfd5e4efca5208918b016338209de37b96796af6dc584e269093c116f04030"
+  sha256 "a7bdd3397744e7cca57dc551cca9180ee88f5e630d31cef01a46cfb0dc73f666"
   license "Apache-2.0"
+  revision 1
 
   bottle :unneeded
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

One of failures seen in OpenJDK 16 CI run: https://github.com/Homebrew/homebrew-core/pull/72535#issuecomment-832105454

```console
==> brew fetch --retry djl-serving
==> FAILED
==> Downloading https://djl-ai.s3.amazonaws.com/publish/djl-serving/serving-0.11.0.tar
Downloaded to: /Users/brew/Library/Caches/Homebrew/downloads/7c00f1d17b84e0dfaa8a3ba1461cf12eabc2f7d602d925606c5bacca8f302454--serving-0.11.0.tar
SHA256: a7bdd3397744e7cca57dc551cca9180ee88f5e630d31cef01a46cfb0dc73f666
==> Retrying download
==> Downloading https://djl-ai.s3.amazonaws.com/publish/djl-serving/serving-0.11.0.tar
Downloaded to: /Users/brew/Library/Caches/Homebrew/downloads/7c00f1d17b84e0dfaa8a3ba1461cf12eabc2f7d602d925606c5bacca8f302454--serving-0.11.0.tar
SHA256: a7bdd3397744e7cca57dc551cca9180ee88f5e630d31cef01a46cfb0dc73f666
Warning: Formula reports different sha256: 93dfd5e4efca5208918b016338209de37b96796af6dc584e269093c116f04030
```

Looking at the GitHub latest: https://github.com/deepjavalibrary/djl/releases/tag/v0.11.0
The same tag was updated on May 3rd, but this formula was added on March 24 - #73649 
So, it may have been updated in-place.

---

https://search.maven.org/artifact/ai.djl/serving

Version | Updated | OSS Index
-- | -- | --
‎ 0.11.0 | 01-May-2021 | open_in_new
‎ 0.10.0 | 23-Feb-2021 | open_in_new
‎ 0.9.0 | 17-Dec-2020 | open_in_new
