### PR TITLE
scalastyle: add livecheck

### DIFF
--- a/Formula/scalastyle.rb
+++ b/Formula/scalastyle.rb
@@ -4,6 +4,13 @@ class Scalastyle < Formula
   url "https://oss.sonatype.org/content/repositories/releases/org/scalastyle/scalastyle_2.12/1.0.0/scalastyle_2.12-1.0.0-batch.jar"
   sha256 "e9dafd97be0d00f28c1e8bfcab951d0e5172b262a1d41da31d1fd65d615aedcb"
 
+  # In a filename like `scalastyle_2.12-1.0.0-batch.jar`, the first version is
+  # the Scala version (2.12) and the second is the Scalastyle version (1.0.0).
+  livecheck do
+    url :homepage
+    regex(/href=.*?scalastyle[._-]v?\d+(?:\.\d+)+-(\d+(?:\.\d+)+)-batch\.jar/i)
+  end
+
   bottle :unneeded
 
   resource "default_config" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `scalastyle`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` `jar` file.

It may be worth noting that `scalastyle` filenames (e.g., `scalastyle_2.12-1.0.0-batch.jar`) currently include the Scala version (`2.12`) and the Scalastyle version (`1.0.0`). The formula version only includes the Scalastyle version (`1.0.0`), so this `livecheck` block only captures the Scalastyle version as well (for the sake of version comparison).