### PR TITLE
autorest: add `depends_on arch: :x86_64`

### DIFF
--- a/Formula/autorest.rb
+++ b/Formula/autorest.rb
@@ -11,6 +11,7 @@ class Autorest < Formula
     sha256 cellar: :any_skip_relocation, all: "d032c14ed42501e7000e032c59574f0ff3e6946a72d3fd2ce4205afd5c77092e"
   end
 
+  depends_on arch: :x86_64
   depends_on "node"
 
   resource "homebrew-petstore" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://github.com/Homebrew/homebrew-core/pull/76641#issuecomment-832519098 and below.