### PR TITLE
points2grid: deprecate

### DIFF
--- a/Formula/points2grid.rb
+++ b/Formula/points2grid.rb
@@ -12,6 +12,8 @@ class Points2grid < Formula
     sha256 cellar: :any, mojave:   "6f7cf1d33b5c66044ecdb7afddf198b96959eb0b7ab6281b9fbcd9dad7f995aa"
   end
 
+  deprecate! date: "2021-05-06", because: :repo_archived
+
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "gdal"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The repository is now archived.

It isn't clear when that happened, so I just chose today's date. It
should've happened somewhat recently. `points2grid` was rebuilt without
audit errors in #71169.

Addresses an error in CI at #76631.