### PR TITLE
libosinfo: add missing osinfo-db

### DIFF
--- a/Formula/libosinfo.rb
+++ b/Formula/libosinfo.rb
@@ -4,6 +4,7 @@ class Libosinfo < Formula
   url "https://releases.pagure.org/libosinfo/libosinfo-1.9.0.tar.xz"
   sha256 "b4f3418154ef3f43d9420827294916aea1827021afc06e1644fc56951830a359"
   license "LGPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://releases.pagure.org/libosinfo/?C=M&O=D"
@@ -21,12 +22,16 @@ class Libosinfo < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "check"
+  depends_on "vala" => :build
   depends_on "gettext"
   depends_on "glib"
   depends_on "libsoup"
-  depends_on "libxml2"
+  depends_on "osinfo-db"
   depends_on "usb.ids"
+
+  uses_from_macos "pod2man" => :build
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
 
   resource "pci.ids" do
     url "https://raw.githubusercontent.com/pciutils/pciids/7906a7b1f2d046072fe5fed27236381cff4c5624/pci.ids"
@@ -46,7 +51,7 @@ class Libosinfo < Formula
       system "meson", *std_meson_args, *flags, ".."
       system "ninja", "install", "-v"
     end
-    (share/"osinfo/.keep").write ""
+    share.install_symlink HOMEBREW_PREFIX/"share/osinfo"
   end
 
   test do

--- a/Formula/osinfo-db-tools.rb
+++ b/Formula/osinfo-db-tools.rb
@@ -1,0 +1,40 @@
+class OsinfoDbTools < Formula
+  desc "Tools for managing the libosinfo database files"
+  homepage "https://libosinfo.org/"
+  url "https://releases.pagure.org/libosinfo/osinfo-db-tools-1.9.0.tar.xz"
+  sha256 "255f1c878bacec70c3020ff5a9cb0f6bd861ca0009f24608df5ef6f62d5243c0"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url "https://releases.pagure.org/libosinfo/?C=M&O=D"
+    regex(/href=.*?osinfo-db-tools[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "json-glib"
+  depends_on "libarchive"
+  depends_on "libsoup"
+  depends_on "python@3.9"
+
+  uses_from_macos "pod2man" => :build
+  uses_from_macos "libxml2"
+
+  def install
+    mkdir "build" do
+      system "meson", *std_meson_args, ".."
+      system "ninja", "install", "-v"
+    end
+  end
+
+  def post_install
+    share.install_symlink HOMEBREW_PREFIX/"share/osinfo"
+  end
+
+  test do
+    assert_equal "#{share}/osinfo", shell_output("#{bin}/osinfo-db-path --system").strip
+  end
+end

--- a/Formula/osinfo-db.rb
+++ b/Formula/osinfo-db.rb
@@ -1,0 +1,22 @@
+class OsinfoDb < Formula
+  desc "Osinfo database of operating systems for virtualization provisioning tools"
+  homepage "https://libosinfo.org/"
+  url "https://releases.pagure.org/libosinfo/osinfo-db-20210531.tar.xz"
+  sha256 "e46d769692e5bd985abe2e376209adafec33db77f10b35999c71b7a140963ec0"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url "https://releases.pagure.org/libosinfo/?C=M&O=D"
+    regex(/href=.*?osinfo-db[._-]v?(\d+(?:\.\d+)*)\.t/i)
+  end
+
+  depends_on "osinfo-db-tools" => [:build, :test]
+
+  def install
+    system "osinfo-db-import", "--dir=#{share}/osinfo", cached_download
+  end
+
+  test do
+    system "osinfo-db-validate", "--system"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

While working on a formula for `virt-manager`, I noticed that `osinfo-query os` wasn't returning anything because `osinfo-db`, usually distributed as a `libosinfo` dependency, wasn't installed.

I've addressed this by adding two new formulae and updating `libosinfo`'s dependencies:

- `osinfo-db`: the operating system database (no binaries); and
- `osinfo-db-tools`: only required when building `osinfo-db` (some Linux distributions make `libosinfo` dependent on `osinfo-db-tools`, but I've followed Arch's approach and made it a build dependency of `osinfo-db`).

This is my first contribution so there's a good chance I've missed something, but I'm happy to patch and rebase based on your feedback.

Please note the last line in `libosinfo.rb`'s `install` method:

```ruby
share.install_symlink HOMEBREW_PREFIX/"share/osinfo"
```

I tested various alternatives to this, but for `osinfo-query` (and other commands) to work without a user-supplied database path, `libosinfo` needs to find them where it expects, and kegs understandably can't write to (or add symlinks from) other kegs. This may be more robust, but it wasn't clear if the symlink would be updated when `osinfo-db` is upgraded:

```ruby
share.install_symlink "#{Formula["osinfo-db"].share}/osinfo"
```

If there's a "best practice" approach for this, please let me know.