### PR TITLE
ipfs: use latest Go instead of only 1.14

### DIFF
--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -24,12 +24,10 @@ class Ipfs < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/ipfs/go-ipfs").install buildpath.children
-    cd("src/github.com/ipfs/go-ipfs") { system "make", "install" }
-    bin.install "bin/ipfs"
+    system "make", "build"
+    bin.install "cmd/ipfs/ipfs"
 
-    cd("src/github.com/ipfs/go-ipfs") { bash_completion.install "misc/completion/ipfs-completion.bash" }
+    bash_completion.install "misc/completion/ipfs-completion.bash"
   end
 
   plist_options manual: "ipfs daemon"

--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -21,7 +21,7 @@ class Ipfs < Formula
     sha256 cellar: :any_skip_relocation, mojave:   "868371961578f442159865ff5111d778dbc730cda71058f942cbb354e6a46029"
   end
 
-  depends_on "go@1.14" => :build
+  depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
IPFS needs Go ≥1.14, not =1.14.
Go 1.14 is depreciated so we should stop using it.
Also, a bottle of 1.14 is not available for arm64 so just using the latest go saves time that would be spent compiling go 1.14.
No other changes have been made.