### PR TITLE
sonarqube-lts: update livecheck

### DIFF
--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -5,12 +5,13 @@ class SonarqubeLts < Formula
   sha256 "9991d4df42c10c181005df6a4aff6b342baf9be2f3ad0e83e52a502f44d2e2d8"
   license "LGPL-3.0-or-later"
 
-  # The regex below should only match the LTS release archive on the Sonarqube
-  # downloads page. This is necessary because the usual index page for releases
-  # doesn't distinguish between current and LTS releases.
+  # Upstream doesn't distinguish LTS releases in the URL or filename, so this
+  # only matches versions for the formula's current major/minor version. This
+  # won't identify a new LTS version with a different major/minor but updating
+  # the `stable` URL with the new LTS will fix the check until the next time.
   livecheck do
-    url "https://www.sonarqube.org/downloads/"
-    regex(/downloads-lts.+?href=.*?sonarqube[._-]v?(\d+(?:\.\d+)+)\.(?:zip|t)/im)
+    url "https://binaries.sonarsource.com/Distribution/sonarqube/"
+    regex(/href=.*?sonarqube[._-]v?(#{Regexp.escape(version.major_minor)}(?:\.\d+)*)\.zip/i)
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

A new major LTS release of `sonarqube` happened recently (8.9.0) and the first-party downloads page changed, so we can't identify LTS versions in the same way as before. This PR updates the `livecheck` block to check the directory listing page where the `stable` archive is found and it only matches versions with the same major/minor as the formula.

This assumes the major/minor will remain the same for LTS versions over a period of time and we'll only see patch changes (e.g., 8.9.0 to 8.9.1). This seemed to be true for the 7.9 LTS series but please correct me if this assumption isn't accurate.

Since this only matches versions with the same major/minor as the formula, it won't identify a new LTS release with a different major/minor and this version change will need to be manually identified outside of livecheck. However, when the `stable` URL is updated to use an archive for the new major/minor version, the `livecheck` block will automatically adapt accordingly. For example, this matches 7.9.x versions but it will match 8.9.x versions when the formula is version bumped for the new LTS release.

This isn't ideal but there's quite a bit of time between major LTS releases, so the shortcomings are relatively minor. There may be a better way of approaching this (now or in the future) but this should work for the time being.