### PR TITLE
7-zip 21.02a (new formula)

### DIFF
--- a/Aliases/7-zip
+++ b/Aliases/7-zip
@@ -1,0 +1,1 @@
+../Formula/sevenzip.rb

--- a/Formula/sevenzip.rb
+++ b/Formula/sevenzip.rb
@@ -6,12 +6,24 @@ class Sevenzip < Formula
   sha256 "ee9755feaa034e7075712bc6b1fad25440bd0a8f21f106a16e37bc4b409f1122"
   license all_of: ["LGPL-2.1-or-later", "BSD-3-Clause"]
 
+  on_linux do
+    depends_on "gcc@9" => :build
+  end
+
   def install
     cd "CPP/7zip/Bundles/Alone2" do
-      suffix = Hardware::CPU.arm? ? "arm64" : "x64"
-      system "make", "-f", "../../cmpl_mac_#{suffix}.mak"
+      on_macos do
+        suffix = Hardware::CPU.arm? ? "arm64" : "x64"
+        system "make", "-f", "../../cmpl_mac_#{suffix}.mak"
 
-      bin.install "b/m_#{suffix}/7zz"
+        bin.install "b/m_#{suffix}/7zz"
+      end
+
+      on_linux do
+        system "make", "CXX=#{Formula["gcc@9"].opt_bin}/g++-9", "-f", "../../cmpl_gcc.mak"
+
+        bin.install "b/g/7zz"
+      end
     end
   end
 

--- a/Formula/sevenzip.rb
+++ b/Formula/sevenzip.rb
@@ -1,0 +1,24 @@
+class Sevenzip < Formula
+  desc "7-Zip is a file archiver with a high compression ratio"
+  homepage "https://7-zip.org"
+  url "https://7-zip.org/a/7z2102-src.7z"
+  version "21.02a"
+  sha256 "ee9755feaa034e7075712bc6b1fad25440bd0a8f21f106a16e37bc4b409f1122"
+  license all_of: ["LGPL-2.1-or-later", "BSD-3-Clause"]
+
+  def install
+    cd "CPP/7zip/Bundles/Alone2" do
+      suffix = Hardware::CPU.arm? ? "arm64" : "x64"
+      system "make", "-f", "../../cmpl_mac_#{suffix}.mak"
+
+      bin.install "b/m_#{suffix}/7zz"
+    end
+  end
+
+  test do
+    (testpath/"foo.txt").write("hello world!\n")
+    system bin/"7zz", "a", "-t7z", "foo.7z", "foo.txt"
+    system bin/"7zz", "e", "foo.7z", "-oout"
+    assert_equal "hello world!\n", File.read(testpath/"out/foo.txt")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Surprising news that 7-zip officially add supports for linux and mac!

I currently only tested on macOS, maybe some adjustments are needed to work with linuxbrew.