### PR TITLE
jenv: install fish function symlinks

### DIFF
--- a/Formula/jenv.rb
+++ b/Formula/jenv.rb
@@ -19,14 +19,11 @@ class Jenv < Formula
     if preferred == :fish
       <<~EOS
         To activate jenv, run the following commands:
-
           echo 'status --is-interactive; and source (jenv init -|psub)' >> #{shell_profile}
-
       EOS
     else
       <<~EOS
         To activate jenv, add the following to your #{shell_profile}:
-
           export PATH="$HOME/.jenv/bin:$PATH"
           eval "$(jenv init -)"
       EOS

--- a/Formula/jenv.rb
+++ b/Formula/jenv.rb
@@ -20,8 +20,8 @@ class Jenv < Formula
         To activate jenv, run the following commands:
 
           echo 'status --is-interactive; and source (jenv init -|psub)' >> #{shell_profile}
-          set -q XDG_CONFIG_HOME; or set XDG_CONFIG_HOME $HOME
-          ln -sf #{opt_libexec}/fish/*.fish $XDG_CONFIG_HOME/.config/fish/functions
+          set -q XDG_CONFIG_HOME; or set XDG_CONFIG_HOME $HOME/.config
+          ln -sf #{opt_libexec}/fish/*.fish $XDG_CONFIG_HOME/fish/functions
 
       EOS
     else

--- a/Formula/jenv.rb
+++ b/Formula/jenv.rb
@@ -12,6 +12,7 @@ class Jenv < Formula
   def install
     libexec.install Dir["*"]
     bin.write_exec_script libexec/"bin/jenv"
+    fish_function.install_symlink Dir[libexec/"fish/*.fish"]
   end
 
   def caveats
@@ -20,8 +21,6 @@ class Jenv < Formula
         To activate jenv, run the following commands:
 
           echo 'status --is-interactive; and source (jenv init -|psub)' >> #{shell_profile}
-          set -q XDG_CONFIG_HOME; or set XDG_CONFIG_HOME $HOME/.config
-          ln -sf #{opt_libexec}/fish/*.fish $XDG_CONFIG_HOME/fish/functions
 
       EOS
     else

--- a/Formula/jenv.rb
+++ b/Formula/jenv.rb
@@ -15,12 +15,23 @@ class Jenv < Formula
   end
 
   def caveats
-    <<~EOS
-      To activate jenv, add the following to your #{shell_profile}:
+    if preferred == :fish
+      <<~EOS
+        To activate jenv, run the following commands:
 
-        export PATH="$HOME/.jenv/bin:$PATH"
-        eval "$(jenv init -)"
-    EOS
+          echo 'status --is-interactive; and source (jenv init -|psub)' >> #{shell_profile}
+          set -q XDG_CONFIG_HOME; or set XDG_CONFIG_HOME $HOME
+          ln -sf #{opt_libexec}/fish/*.fish $XDG_CONFIG_HOME/.config/fish/functions
+
+      EOS
+    else
+      <<~EOS
+        To activate jenv, add the following to your #{shell_profile}:
+
+          export PATH="$HOME/.jenv/bin:$PATH"
+          eval "$(jenv init -)"
+      EOS
+    end
   end
 
   test do


### PR DESCRIPTION
The caveat isn't compatible with fish shell.
This PR changes the caveat for fish shell to show the
commands specified in the upstream's README here \[1\].

This PR does not change the caveat for other shells.

fixes https://github.com/jenv/jenv/issues/315

I have tested this PR and get the output below.

With bash set as default shell (`chsh -s $(which bash)`):

```
brew info jenv

jenv: stable 0.5.4, HEAD
Manage your Java environment
https://www.jenv.be/
/opt/homebrew/Cellar/jenv/0.5.4 (82 files, 72.3KB) *
  Built from source on 2021-05-07 at 17:19:07
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/jenv.rb
License: MIT
==> Options
--HEAD
	Install HEAD version
==> Caveats
To activate jenv, add the following to your /Users/dxia/.bash_profile:

  export PATH="$HOME/.jenv/bin:$PATH"
  eval "$(jenv init -)"
==> Analytics
install: 9,672 (30 days), 30,663 (90 days), 129,619 (365 days)
install-on-request: 9,670 (30 days), 30,635 (90 days), 128,558 (365 days)
build-error: 0 (30 days)
```

With fish set as default shell:

```
brew info jenv

jenv: stable 0.5.4, HEAD
Manage your Java environment
https://www.jenv.be/
/opt/homebrew/Cellar/jenv/0.5.4 (82 files, 72.3KB) *
  Built from source on 2021-05-07 at 17:19:07
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/jenv.rb
License: MIT
==> Options
--HEAD
	Install HEAD version
==> Caveats
To activate jenv, run the following commands:

  echo 'set -g fish_user_paths "/opt/homebrew/opt/jenv/bin" $fish_user_paths' >> ~/.config/fish/config.fish
  echo 'status --is-interactive; and source (jenv init -|psub)' >> ~/.config/fish/config.fish
  cp /opt/homebrew/opt/jenv/libexec/fish/jenv.fish ~/.config/fish/functions/jenv.fish
  cp /opt/homebrew/opt/jenv/libexec/fish/export.fish ~/.config/fish/functions/export.fish
==> Analytics
install: 9,672 (30 days), 30,663 (90 days), 129,619 (365 days)
install-on-request: 9,670 (30 days), 30,635 (90 days), 128,558 (365 days)
build-error: 0 (30 days)
```

1: https://github.com/jenv/jenv/blob/9bbc5ebfe6f38252a1a0f28897c7ae52e6a483a0/README.md


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----