### PR TITLE
fish: link against brewed ncurses

### DIFF
--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -4,6 +4,7 @@ class Fish < Formula
   url "https://github.com/fish-shell/fish-shell/releases/download/3.2.2/fish-3.2.2.tar.xz"
   sha256 "5944da1a8893d11b0828a4fd9136ee174549daffb3d0adfdd8917856fe6b4009"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url :stable
@@ -24,9 +25,8 @@ class Fish < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "ncurses"
   depends_on "pcre2"
-
-  uses_from_macos "ncurses"
 
   def install
     args = %W[
@@ -34,8 +34,9 @@ class Fish < Formula
       -Dextra_completionsdir=#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d
       -Dextra_confdir=#{HOMEBREW_PREFIX}/share/fish/vendor_conf.d
     ]
-    system "cmake", ".", *std_cmake_args, *args
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   def post_install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Link `fish` against brewed `ncurses` -- this lets fish benefit from fixes to
terminal handling (such as character widths), as well as letting it use the
Homebrew-provided `terminfo` database (for terminal types like `tmux-256color`
and `alacritty-direct`).

Brewed `zsh` is also linked against brew-provided `ncurses`.
