### PR TITLE
jinja2-cli: align test with Linux version

### DIFF
--- a/Formula/jinja2-cli.rb
+++ b/Formula/jinja2-cli.rb
@@ -33,7 +33,12 @@ class Jinja2Cli < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("script -q /dev/null #{bin}/jinja2 --version")
+    on_macos do
+      assert_match version.to_s, shell_output("script -q /dev/null #{bin}/jinja2 --version")
+    end
+    on_linux do
+      assert_match version.to_s, shell_output("script -q /dev/null -e -c \"#{bin}/jinja2 --version\"")
+    end
     expected_result = <<~EOS
       The Beatles:
       - Ringo Starr


### PR DESCRIPTION
"script" has different flags on Linux

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
