### PR TITLE
gradle-profiler: update for gradle 7.0

### DIFF
--- a/Formula/gradle-profiler.rb
+++ b/Formula/gradle-profiler.rb
@@ -12,11 +12,7 @@ class GradleProfiler < Formula
   def install
     rm_f Dir["bin/*.bat"]
     libexec.install %w[bin lib]
-    env = if Hardware::CPU.arm?
-      Language::Java.overridable_java_home_env("11")
-    else
-      Language::Java.overridable_java_home_env
-    end
+    Language::Java.overridable_java_home_env
     (bin/"gradle-profiler").write_env_script libexec/"bin/gradle-profiler", env
   end
 

--- a/Formula/gradle-profiler.rb
+++ b/Formula/gradle-profiler.rb
@@ -7,12 +7,7 @@ class GradleProfiler < Formula
 
   bottle :unneeded
 
-  # gradle currently does not support Java 16
-  if Hardware::CPU.arm?
-    depends_on "openjdk@11"
-  else
-    depends_on "openjdk"
-  end
+  depends_on "openjdk"
 
   def install
     rm_f Dir["bin/*.bat"]
@@ -28,7 +23,7 @@ class GradleProfiler < Formula
   test do
     (testpath/"settings.gradle").write ""
     (testpath/"build.gradle").write 'println "Hello"'
-    output = shell_output("#{bin}/gradle-profiler --gradle-version 6.5 --profile chrome-trace")
+    output = shell_output("#{bin}/gradle-profiler --gradle-version 7.0 --profile chrome-trace")
     assert_includes output, "* Results written to"
   end
 end

--- a/Formula/gradle-profiler.rb
+++ b/Formula/gradle-profiler.rb
@@ -12,7 +12,7 @@ class GradleProfiler < Formula
   def install
     rm_f Dir["bin/*.bat"]
     libexec.install %w[bin lib]
-    Language::Java.overridable_java_home_env
+    env = Language::Java.overridable_java_home_env
     (bin/"gradle-profiler").write_env_script libexec/"bin/gradle-profiler", env
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The test doesn't work anymore with Java 16. Spotted in #72535. Since `gradle` is now at version 7.0, I also updated the `depends_on` block.