### PR TITLE
sbt: Remove x86 dependency

### DIFF
--- a/Formula/sbt.rb
+++ b/Formula/sbt.rb
@@ -15,7 +15,6 @@ class Sbt < Formula
     sha256 cellar: :any_skip_relocation, all: "97d2ea0187ad1c17d6c6e0978b9deb31787e71bb391dc8b60ec4e487a2faf774"
   end
 
-  depends_on arch: :x86_64
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

# Context

12 days ago [brew added the `depends_on arch: :x86_64` statement](https://github.com/Homebrew/homebrew-core/pull/76056) for the SBT formula. However, based on [this comment](https://github.com/sbt/sbt/issues/6162#issuecomment-774519485) and actual usage on a mac with M1, it seems to be compatible.

I've found an error running the `brew test sbt` command, but I completely lack of context, so I would appreciate some help in order to determine if that is because SBT would not be compatible, or it is because some other reasons and we can move forward removing the x86 dependency.

# Steps followed

## Reproduce the error

```bash
$ uname -a
Darwin x.local 20.4.0 Darwin Kernel Version 20.4.0: Thu Apr 22 21:46:41 PDT 2021; root:xnu-7195.101.2~1/RELEASE_ARM64_T8101 arm64

$ brew upgrade
==> Upgrading 1 outdated package:
sbt 1.5.0 -> 1.5.1
==> Upgrading sbt 1.5.0 -> 1.5.1
sbt: The x86_64 architecture is required for this software.
Error: sbt: An unsatisfied requirement failed this build.
```

## Disable x86 requirement

```bash
$ cd $(brew --repo homebrew/core)
$ git checkout -b fix-sbt origin/master
$ cd Formula
$ vim sbt.rb
// Remove the `depends_on arch: :x86_64` line
```

## Test results

SBT 1.5.2 is properly installed and being able to run:

```bash
$ mkdir tmp
$ cd tmp
$ sbt
[info] Updated file /Users/javiercane/tmp/project/build.properties: set sbt.version to 1.5.2
[info] welcome to sbt 1.5.2 (Amazon.com Inc. Java 16.0.1)
[info] loading global plugins from /Users/javiercane/.sbt/1.0/plugins
[info] loading project definition from /Users/javiercane/tmp/project
[info] set current project to tmp (in build file:/Users/javiercane/tmp/)
[info] sbt server started at local:///Users/javiercane/.sbt/1.0/server/370b5118e9c44604ae57/sock
[info] started sbt server
sbt:tmp> console
[info] Starting scala interpreter...
Welcome to Scala 2.12.13 (OpenJDK 64-Bit Server VM, Java 16.0.1).
Type in expressions for evaluation. Or try :help.

scala> println("🎉")
🎉
```

## Homebrew debug

Running [the Homebrew contributing instructions](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md) it throws an exception:

```bash
brew test sbt
==> Installing 'bundler' gem
Fetching bundler-1.17.3.gem
Fetching gem metadata from https://rubygems.org/.........
Fetching zeitwerk 2.4.2
Fetching concurrent-ruby 1.1.8
Fetching minitest 5.14.4
Installing zeitwerk 2.4.2
Installing minitest 5.14.4
Fetching public_suffix 4.0.6
Installing concurrent-ruby 1.1.8
Fetching ast 2.4.2
Installing public_suffix 4.0.6
Installing ast 2.4.2
Fetching bindata 2.4.8
Fetching msgpack 1.4.2
Using bundler 1.17.3
Fetching byebug 11.1.3
Installing bindata 2.4.8
Installing msgpack 1.4.2 with native extensions
Fetching coderay 1.1.3
Installing byebug 11.1.3 with native extensions
Installing coderay 1.1.3
Fetching colorize 0.8.1
Installing colorize 0.8.1
Fetching highline 2.0.3
Installing highline 2.0.3
Fetching connection_pool 2.2.3
Installing connection_pool 2.2.3
Fetching diff-lcs 1.4.4
Installing diff-lcs 1.4.4
Fetching docile 1.3.5
Installing docile 1.3.5
Fetching unf_ext 0.0.7.7
Installing unf_ext 0.0.7.7 with native extensions
Fetching hpricot 0.8.6
Installing hpricot 0.8.6 with native extensions
Fetching mime-types-data 3.2021.0225
Installing mime-types-data 3.2021.0225
Fetching net-http-digest_auth 1.4.1
Installing net-http-digest_auth 1.4.1
Fetching mini_portile2 2.5.0
Installing mini_portile2 2.5.0
Fetching racc 1.5.2
Installing racc 1.5.2 with native extensions
Fetching rubyntlm 0.6.3
Installing rubyntlm 0.6.3
Fetching webrick 1.7.0
Installing webrick 1.7.0
Fetching webrobots 0.1.2
Installing webrobots 0.1.2
Fetching method_source 1.0.0
Installing method_source 1.0.0
Fetching mustache 1.1.1
Installing mustache 1.1.1
Fetching parallel 1.20.1
Fetching rainbow 3.0.0
Installing parallel 1.20.1
Fetching sorbet-runtime 0.5.6274
Installing rainbow 3.0.0
Fetching plist 3.6.0
Installing sorbet-runtime 0.5.6274
Installing plist 3.6.0
Fetching rack 2.2.3
Fetching rdiscount 2.2.0.2
Installing rack 2.2.3
Installing rdiscount 2.2.0.2 with native extensions
Fetching regexp_parser 2.1.1
Installing regexp_parser 2.1.1
Fetching rexml 3.2.5
Installing rexml 3.2.5
Fetching rspec-support 3.10.2
Installing rspec-support 3.10.2
Fetching sorbet-static 0.5.6274 (universal-darwin-20)
Installing sorbet-static 0.5.6274 (universal-darwin-20)
Fetching ruby-progressbar 1.11.0
Installing ruby-progressbar 1.11.0
Fetching unicode-display_width 2.0.0
Installing unicode-display_width 2.0.0
Fetching ruby-macho 2.5.0
Installing ruby-macho 2.5.0
Fetching simplecov-html 0.12.3
Installing simplecov-html 0.12.3
Fetching simplecov_json_formatter 0.1.2
Installing simplecov_json_formatter 0.1.2
Fetching sorbet-runtime-stub 0.2.0
Installing sorbet-runtime-stub 0.2.0
Fetching thor 1.1.0
Installing thor 1.1.0
Fetching warning 1.2.0
Installing warning 1.2.0
Fetching parser 3.0.1.0
Installing parser 3.0.1.0
Fetching addressable 2.7.0
Installing addressable 2.7.0
Fetching i18n 1.8.9
Installing i18n 1.8.9
Fetching tzinfo 2.0.4
Installing tzinfo 2.0.4
Fetching elftools 1.1.3
Installing elftools 1.1.3
Fetching commander 4.6.0
Installing commander 4.6.0
Fetching net-http-persistent 4.0.1
Installing net-http-persistent 4.0.1
Fetching bootsnap 1.7.4
Installing bootsnap 1.7.4 with native extensions
Fetching mime-types 3.3.1
Installing mime-types 3.3.1
Fetching unf 0.1.4
Installing unf 0.1.4
Fetching pry 0.14.1
Installing pry 0.14.1
Fetching nokogiri 1.11.3 (x86_64-darwin)
Installing nokogiri 1.11.3 (x86_64-darwin)
Fetching parallel_tests 3.7.0
Installing parallel_tests 3.7.0
Fetching rspec-core 3.10.1
Installing rspec-core 3.10.1
Fetching rspec-expectations 3.10.1
Installing rspec-expectations 3.10.1
Fetching rspec-mocks 3.10.2
Installing rspec-mocks 3.10.2
Fetching sorbet 0.5.6274
Installing sorbet 0.5.6274
Fetching simplecov 0.21.2
Installing simplecov 0.21.2
Fetching rubocop-ast 1.4.1
Installing rubocop-ast 1.4.1
Fetching activesupport 6.1.3.1
Installing activesupport 6.1.3.1
Fetching patchelf 1.3.0
Installing patchelf 1.3.0
Fetching parlour 6.0.0
Installing parlour 6.0.0
Fetching domain_name 0.5.20190701
Installing domain_name 0.5.20190701
Fetching rspec-github 2.3.1
Installing rspec-github 2.3.1
Fetching rspec-retry 0.6.2
Installing rspec-retry 0.6.2
Fetching rspec-its 1.3.0
Installing rspec-its 1.3.0
Fetching rspec 3.10.0
Installing rspec 3.10.0
Fetching rspec-sorbet 1.8.0
Installing rspec-sorbet 1.8.0
Fetching spoom 1.0.9
Installing spoom 1.0.9
Fetching simplecov-cobertura 1.4.2
Installing simplecov-cobertura 1.4.2
Fetching rubocop 1.13.0
Installing rubocop 1.13.0
Fetching http-cookie 1.0.3
Installing http-cookie 1.0.3
Fetching rspec-wait 0.0.9
Fetching tapioca 0.4.21
Installing tapioca 0.4.21
Fetching ronn 0.7.3
Fetching mechanize 2.8.0
Installing rspec-wait 0.0.9
Fetching rubocop-performance 1.11.0
Installing mechanize 2.8.0
Installing rubocop-performance 1.11.0
Fetching rubocop-rails 2.9.1
Installing ronn 0.7.3
Fetching rubocop-rspec 2.3.0
Fetching rubocop-sorbet 0.6.1
Installing rubocop-rails 2.9.1
Installing rubocop-rspec 2.3.0
Installing rubocop-sorbet 0.6.1
Bundle complete! 31 Gemfile dependencies, 84 gems now installed.
Bundled gems are installed into `../../../../Homebrew/vendor/bundle`
Post-install message from sorbet:

  Thanks for installing Sorbet! To use it in your project, first run:

    bundle exec srb init

  which will get your project ready to use with Sorbet.
  After that whenever you want to typecheck your code, run:

    bundle exec srb tc

  For more docs see: https://sorbet.org/docs/adopting
==> Testing sbt
==> /opt/homebrew/Cellar/sbt/1.5.2/bin/sbt --sbt-create about
==> /opt/homebrew/Cellar/sbt/1.5.2/bin/sbt sbtVersion
Picked up _JAVA_OPTIONS: -Duser.home=/Users/javiercane/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp -Dsbt.log.noformat=true
Picked up _JAVA_OPTIONS: -Duser.home=/Users/javiercane/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp -Dsbt.log.noformat=true
==> /opt/homebrew/Cellar/sbt/1.5.2/bin/sbtn about
Last 15 lines from /Users/javiercane/Library/Logs/Homebrew/sbt/test.02.sbtn:
	at sbt.xMain.run(Main.scala:46)
	at xsbt.boot.Launch$.$anonfun$run$1(Launch.scala:149)
	at xsbt.boot.Launch$.withContextLoader(Launch.scala:176)
	at xsbt.boot.Launch$.run(Launch.scala:149)
	at xsbt.boot.Launch$.$anonfun$apply$1(Launch.scala:44)
	at xsbt.boot.Launch$.launch(Launch.scala:159)
	at xsbt.boot.Launch$.apply(Launch.scala:44)
	at xsbt.boot.Launch$.apply(Launch.scala:21)
	at xsbt.boot.Boot$.runImpl(Boot.scala:78)
	at xsbt.boot.Boot$.run(Boot.scala:73)
	at xsbt.boot.Boot$.main(Boot.scala:21)
	at xsbt.boot.Boot.main(Boot.scala)
[error] [launcher] error during sbt launcher: java.lang.ClassCastException: class java.lang.NoClassDefFoundError cannot be cast to class xsbti.FullReload (java.lang.NoClassDefFoundError is in module java.base of loader 'bootstrap'; xsbti.FullReload is in unnamed module of loader 'app')
[error] failed to connect to server
Error: sbt: failed
An exception occurred within a child process:
  BuildError: Failed executing: /opt/homebrew/Cellar/sbt/1.5.2/bin/sbtn about
/opt/homebrew/Library/Homebrew/formula.rb:2163:in `block in system'
/opt/homebrew/Library/Homebrew/formula.rb:2099:in `open'
/opt/homebrew/Library/Homebrew/formula.rb:2099:in `system'
/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/sbt.rb:45:in `block in <class:Sbt>'
/opt/homebrew/Library/Homebrew/formula.rb:1963:in `block (3 levels) in run_test'
/opt/homebrew/Library/Homebrew/utils.rb:558:in `with_env'
/opt/homebrew/Library/Homebrew/formula.rb:1962:in `block (2 levels) in run_test'
/opt/homebrew/Library/Homebrew/formula.rb:924:in `with_logging'
/opt/homebrew/Library/Homebrew/formula.rb:1961:in `block in run_test'
/opt/homebrew/Library/Homebrew/mktemp.rb:63:in `block in run'
/opt/homebrew/Library/Homebrew/mktemp.rb:63:in `chdir'
/opt/homebrew/Library/Homebrew/mktemp.rb:63:in `run'
/opt/homebrew/Library/Homebrew/formula.rb:2212:in `mktemp'
/opt/homebrew/Library/Homebrew/formula.rb:1955:in `run_test'
/opt/homebrew/Library/Homebrew/test.rb:43:in `block in <main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
class Sbt < Formula
  desc "Build tool for Scala projects"
  homepage "https://www.scala-sbt.org/"
  url "https://github.com/sbt/sbt/releases/download/v1.5.2/sbt-1.5.2.tgz"
  mirror "https://sbt-downloads.cdnedge.bluemix.net/releases/v1.5.2/sbt-1.5.2.tgz"
  sha256 "9d01f7eb1a3830190d53ed4d8b8b9a6380f013ad30573a04e330d1de42ff0212"
  license "Apache-2.0"

  livecheck do
    url :stable
    regex(/^v?(\d+(?:\.\d+)+)$/i)
  end
"/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/sbt.rb" 48L, 1576B
class Sbt < Formula
  desc "Build tool for Scala projects"
  homepage "https://www.scala-sbt.org/"
  url "https://github.com/sbt/sbt/releases/download/v1.5.2/sbt-1.5.2.tgz"
  mirror "https://sbt-downloads.cdnedge.bluemix.net/releases/v1.5.2/sbt-1.5.2.tgz"
  sha256 "9d01f7eb1a3830190d53ed4d8b8b9a6380f013ad30573a04e330d1de42ff0212"
  license "Apache-2.0"

  livecheck do
    url :stable
    regex(/^v?(\d+(?:\.\d+)+)$/i)
  end

  bottle do
    sha256 cellar: :any_skip_relocation, all: "97d2ea0187ad1c17d6c6e0978b9deb31787e71bb391dc8b60ec4e487a2faf774"
  end

  depends_on "openjdk"

  def install
    inreplace "bin/sbt" do |s|
      s.gsub! 'etc_sbt_opts_file="/etc/sbt/sbtopts"', "etc_sbt_opts_file=\"#{etc}/sbtopts\""
      s.gsub! "/etc/sbt/sbtopts", "#{etc}/sbtopts"
    end

    libexec.install "bin"
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/opt/homebrew/Library/Homebrew/test.rb:48:in `<main>'
```