### PR TITLE
zellij 0.8.0 (new formula)

### DIFF
--- a/Formula/zellij.rb
+++ b/Formula/zellij.rb
@@ -1,0 +1,22 @@
+class Zellij < Formula
+  desc "Pluggable terminal workspace, with terminal multiplexer as the base feature"
+  homepage "https://zellij.dev"
+  url "https://github.com/zellij-org/zellij/archive/refs/tags/v0.8.0.tar.gz"
+  sha256 "850d1a68219debdb4e05f7f58e70b31f440425247caaa1b29b9be1b6c7869207"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+
+    (bash_completion/"zellij").write Utils.safe_popen_read("#{bin}/zellij", "generate-completion", "bash")
+    (zsh_completion/"_zellij").write Utils.safe_popen_read("#{bin}/zellij", "generate-completion", "zsh")
+    (fish_completion/"zellij.fish").write Utils.safe_popen_read("#{bin}/zellij", "generate-completion", "fish")
+  end
+
+  test do
+    assert_match(/keybinds:.*/, shell_output("#{bin}/zellij setup --dump-config", 1))
+    assert_match("zellij #{version}", shell_output("#{bin}/zellij --version"))
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR proposes the terminal pluggable worspace [zellij](https://zellij.dev), it's basic feature is a terminal multiplexer like tmux. But zellij's panes can be plugins.
