### PR TITLE
freeswitch: fix build error for undeclared identifier 'NSIG'

### DIFF
--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -151,6 +151,12 @@ class Freeswitch < Formula
   end
 
   def install
+    # Fix build error "use of undeclared identifier 'NSIG'"
+    # Remove when fixed upstream: https://github.com/signalwire/freeswitch/issues/1145
+    on_macos do
+      ENV.append_to_cflags "-D_DARWIN_C_SOURCE"
+    end
+
     resource("spandsp").stage do
       system "./bootstrap.sh"
       system "./configure", "--disable-debug",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Try to fix the `freeswitch` error seen in PR #76780.

I confirmed error on local `--build-from-source`:
```make
In file included from ./include/apr_general.h:33:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/signal.h:69:42: error: use of undeclared identifier 'NSIG'
extern __const char *__const sys_signame[NSIG];
                                         ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/signal.h:70:42: error: use of undeclared identifier 'NSIG'
extern __const char *__const sys_siglist[NSIG];
                                         ^
2 errors generated.

```

The condition to define `NSIG` is:
```c
#if !defined(_ANSI_SOURCE) && (!defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE))
#define NSIG	__DARWIN_NSIG
#endif
```