### PR TITLE
chronograf: fix build issue from incompatible node-sass@4.13 and node@16

### DIFF
--- a/Formula/chronograf.rb
+++ b/Formula/chronograf.rb
@@ -17,7 +17,8 @@ class Chronograf < Formula
 
   depends_on "go" => :build
   depends_on "go-bindata" => :build
-  depends_on "node" => :build
+  # Switch to `node` when chronograf updates dependency node-sass>=6.0.0
+  depends_on "node@14" => :build
   depends_on "yarn" => :build
   depends_on "influxdb"
   depends_on "kapacitor"
@@ -25,9 +26,6 @@ class Chronograf < Formula
   def install
     Language::Node.setup_npm_environment
 
-    cd "ui" do # fix compatibility with the latest node
-      system "yarn", "upgrade", "parcel@1.11.0"
-    end
     system "make", "dep"
     system "make", ".jssrc"
     system "make", "chronograf"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Build failure for `chronograf` seen in PRs for `go 1.16.4` and `rust 1.52.0`

Issue is incompatibility with `node>=16` and `node-sass<6.0.0`:
- https://www.npmjs.com/package/node-sass for `node` support info (limitations due to new C++14 requirement).
- `chronograf` currently uses 4.13.1 for their build: https://github.com/influxdata/chronograf/blob/1.8.10/ui/yarn.lock#L7603-L7604
    ```
    node-sass@^4.13.0:
      version "4.13.1"
    ```

The options are to either
1. Downgrade `node@16` to `node@14`
2. Upgrade `node-sass@4.13` to `node-sass@6.0`

Currently going with (1) based on recommendations https://github.com/Homebrew/homebrew-core/pull/76780#issuecomment-837927645