### PR TITLE
traefik@1: fix build by downgrading node@16 to node@14

### DIFF
--- a/Formula/traefik@1.rb
+++ b/Formula/traefik@1.rb
@@ -21,7 +21,7 @@ class TraefikAT1 < Formula
 
   depends_on "go" => :build
   depends_on "go-bindata" => :build
-  depends_on "node" => :build
+  depends_on "node@14" => :build
   depends_on "yarn" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Another build failure due to `node@16` (and probably `node-sass`) seen in https://github.com/Homebrew/homebrew-core/pull/76791#issuecomment-835534109

Unlike #77018, I didn't add a comment as `traefik@1` is a versioned formula (`traefik` is v2 and doesn't have `node` dependency). If a comment is preferred, it can be added.

I confirmed build failure with original Formula on local system with `--build-from-source`.
Also confirmed successful build after downgrade to `node@14`:
```console
🍺  /opt/homebrew/Cellar/node@14/14.16.1_1: 4,377 files, 59.6MB
==> Installing traefik@1
==> yarn upgrade
==> yarn install
==> yarn run build
==> go generate
==> go build -o /opt/homebrew/Cellar/traefik@1/1.7.30/bin/traefik ./cmd/traefik
==> Caveats
traefik@1 is keg-only, which means it was not symlinked into /opt/homebrew,
because this is an alternate version of another formula.

If you need to have traefik@1 first in your PATH, run:
  echo 'export PATH="/opt/homebrew/opt/traefik@1/bin:$PATH"' >> ~/.zshrc


To have launchd start traefik@1 now and restart at login:
  brew services start traefik@1
Or, if you don't want/need a background service you can just run:
  traefik
==> Summary
🍺  /opt/homebrew/Cellar/traefik@1/1.7.30: 7 files, 78.9MB, built in 2 minutes 6 seconds
```