### PR TITLE
kustomize: fix build error due to multiple tags with HEAD

### DIFF
--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -23,12 +23,11 @@ class Kustomize < Formula
 
   def install
     commit = Utils.git_head
-    tag = Utils.safe_popen_read("git", "tag", "--contains", "HEAD").strip
 
     cd "kustomize" do
       ldflags = %W[
         -s
-        -X sigs.k8s.io/kustomize/api/provenance.version=#{tag}
+        -X sigs.k8s.io/kustomize/api/provenance.version=#{name}/v#{version}
         -X sigs.k8s.io/kustomize/api/provenance.gitCommit=#{commit}
         -X sigs.k8s.io/kustomize/api/provenance.buildDate=#{Time.now.iso8601}
       ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`kustomize` failure from https://github.com/Homebrew/homebrew-core/pull/76791#issuecomment-835534109
The reason for failure is that there are multiple tags that contain HEAD:
```console
❯ git tag --contains HEAD
api/v0.8.9
cmd/config/v0.9.11
kustomize/v4.1.2
kyaml/v0.10.18
kyaml/v0.10.19
```
So, each newline is seen as another (invalid) argument to `ldflags`.

---

The code change is based on 1st default command in `goreleaser`
https://github.com/goreleaser/goreleaser/blob/a9ce8f89d498390431b86aab11a7a5a708edab40/internal/pipe/git/git.go#L172
```go
return git.Clean(git.Run("tag", "--points-at", "HEAD", "--sort", "-version:creatordate"))
```

Alternatively, there is a 2nd default command in `goreleaser` (as fallback if 1st fails):
https://github.com/goreleaser/goreleaser/blob/a9ce8f89d498390431b86aab11a7a5a708edab40/internal/pipe/git/git.go#L175
```go
return git.Clean(git.Run("describe", "--tags", "--abbrev=0"))
```

---

On side note, the `brew test` for HEAD will probably fail on both previous Formula and updated Formula since `git tag ...` for HEAD doesn't output anything.

However, the Formula does build, using arguments
```
-X sigs.k8s.io/kustomize/api/provenance.version=  
-X sigs.k8s.io/kustomize/api/provenance.gitCommit=1e3ce570773c2dcd0bb71df051a48725d7ebfc3a 
```