### PR TITLE
openmodelica: build with `gcc@10`

### DIFF
--- a/Formula/openmodelica.rb
+++ b/Formula/openmodelica.rb
@@ -18,7 +18,7 @@ class Openmodelica < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "cmake" => :build
-  depends_on "gcc" => :build # for gfortran
+  depends_on "gcc@10" => :build # for gfortran
   depends_on "gnu-sed" => :build
   depends_on "libtool" => :build
   depends_on "openjdk" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This didn't build in the GCC version bump PR, so the bottles are
currently missing.

Not sure if we need to set `FC=gfortran-10` here, but hopefully
superenv takes care of that already.