### PR TITLE
telegraf: fix v1.18.2 source tarball sha256 hash

### DIFF
--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -2,7 +2,7 @@ class Telegraf < Formula
   desc "Server-level metric gathering agent for InfluxDB"
   homepage "https://www.influxdata.com/"
   url "https://github.com/influxdata/telegraf/archive/v1.18.2.tar.gz"
-  sha256 "e83eb358416322a0e434381e6a54e4b497b49583092ab3fa41597cde16ef8f69"
+  sha256 "19856eef5762c0740f3531d5c4d55e25d8a9de34278ee6e1dcef49dfd48942e1"
   license "MIT"
   head "https://github.com/influxdata/telegraf.git"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Pending on upstream confirmation of tarball update: influxdata/telegraf#9260
SHA256 mismatch failure seen in https://github.com/Homebrew/homebrew-core/pull/76791#issuecomment-835534109

For now, I haven't touched the `livecheck` as I don't know if the GitHub or download page is better to monitor.