### PR TITLE
luaradio: fix env script

### DIFF
--- a/Formula/luaradio.rb
+++ b/Formula/luaradio.rb
@@ -33,8 +33,7 @@ class Luaradio < Formula
 
     env = {
       PATH:      "#{Formula["luajit-openresty"].opt_bin}:$PATH",
-      LUA_PATH:  "#{lib}/lua/5.1/?.lua${LUA_PATH:+:$LUA_PATH}",
-      LUA_CPATH: "#{lib}/lua/5.1/?.so${LUA_CPATH:+:$LUA_CPATH}",
+      LUA_CPATH: "#{lib}/lua/5.1/?.so${LUA_CPATH:+;$LUA_CPATH};;",
     }
 
     bin.env_script_all_files libexec/"bin", env


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Lua path separators are `;` not `:`. Also, `luaradio` does not ship any
`.lua` files, so setting `LUA_PATH` should not be needed.