### PR TITLE
digdag: remove unnecessary intermediate script

### DIFF
--- a/Formula/digdag.rb
+++ b/Formula/digdag.rb
@@ -4,6 +4,7 @@ class Digdag < Formula
   url "https://dl.digdag.io/digdag-0.10.0.jar"
   sha256 "0a3aed836d8af1a47ed53dda63c02ce3ecfec6b564d55b556a18b122dec7f3d7"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://github.com/treasure-data/digdag.git"
@@ -16,9 +17,7 @@ class Digdag < Formula
 
   def install
     libexec.install "digdag-#{version}.jar"
-    (libexec/"bin").write_jar_script libexec/"digdag-#{version}.jar", "digdag"
-    (libexec/"bin/digdag").chmod 0755
-    (bin/"digdag").write_env_script libexec/"bin/digdag", Language::Java.java_home_env("1.8")
+    bin.write_jar_script libexec/"digdag-#{version}.jar", "digdag", java_version: "1.8"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove unnecessary script "libexec/bin/digdag"