### PR TITLE
embulk: drop old OSX support

### DIFF
--- a/Formula/embulk.rb
+++ b/Formula/embulk.rb
@@ -7,6 +7,7 @@ class Embulk < Formula
   url "https://github.com/embulk/embulk/releases/download/v0.9.23/embulk-0.9.23.jar"
   sha256 "153977fad482bf52100dd96f47e897c87b48de4fb13bccd6b3101475d3a5ebb9"
   license "Apache-2.0"
+  revision 1
   version_scheme 1
 
   livecheck do
@@ -19,13 +20,8 @@ class Embulk < Formula
   depends_on "openjdk@8"
 
   def install
-    # Execute through /bin/bash to be compatible with OS X 10.9.
-    libexec.install "embulk-#{version}.jar" => "embulk.jar"
-    (bin/"embulk").write <<~EOS
-      #!/bin/bash
-      export JAVA_HOME="${JAVA_HOME:-#{Formula["openjdk@8"].opt_prefix}}"
-      exec /bin/bash "#{libexec}/embulk.jar" "$@"
-    EOS
+    libexec.install "embulk-#{version}.jar"
+    bin.write_jar_script libexec/"embulk-#{version}.jar", "embulk", java_version: "1.8"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Remove "exec /bin/bash" because now OS X 10.9 is not supported by Homebrew.