### PR TITLE
objc-run: remove `pour_bottle?` block

### DIFF
--- a/Formula/objc-run.rb
+++ b/Formula/objc-run.rb
@@ -14,14 +14,6 @@ class ObjcRun < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "65be98ab9f851e2184d33c710a7619e6fd55820f0bbd1ad969c77a3f0755dbeb"
   end
 
-  pour_bottle? do
-    reason "The bottle needs to be installed into #{Homebrew::DEFAULT_PREFIX}."
-    # https://github.com/Homebrew/homebrew-core/pull/76633
-    # Remove when the following issue is resolved:
-    # https://github.com/Homebrew/brew/issues/11302
-    satisfy { HOMEBREW_PREFIX.to_s == Homebrew::DEFAULT_PREFIX } unless Hardware::CPU.arm?
-  end
-
   def install
     bin.install "objc-run"
     pkgshare.install "examples", "test.bash"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Now that https://github.com/Homebrew/brew/pull/11332 has been merged, `brew bottle` should recognize that `$projectDirPath/build/usr/local/bin/clitest` should not be relocated and will not attempt to replace the `/usr/local` with `@@HOMEBREW_PREFIX`. This means that the bottles can truly be `cellar :any_skip_relocation` and work on all prefixes, removing the need for the `pour_bottle?` block.
