### PR TITLE
pkg-config: remove `pour_bottle?` block

### DIFF
--- a/Formula/pkg-config.rb
+++ b/Formula/pkg-config.rb
@@ -12,17 +12,11 @@ class PkgConfig < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "ffd4491f62201d14b7eca6beff954a2ab265351589cd5b3b79b8bbb414485574"
-    sha256 cellar: :any_skip_relocation, big_sur:       "0040b6ebe07f60549800b211343fd5fb3cf83c866d9f62e40f5fb2f38b71e161"
-    sha256 cellar: :any_skip_relocation, catalina:      "80f141e695f73bd058fd82e9f539dc67471666ff6800c5e280b5af7d3050f435"
-    sha256 cellar: :any_skip_relocation, mojave:        "0d14b797dba0e0ab595c9afba8ab7ef9c901b60b4f806b36580ef95ebb370232"
-    sha256 cellar: :any_skip_relocation, high_sierra:   "8c6160305abd948b8cf3e0d5c6bb0df192fa765bbb9535dda0b573cb60abbe52"
-  end
-
-  pour_bottle? do
-    # The pc_path is baked into the binary and relocatable detection doesn't pick it up
-    reason "The bottle only works in the default #{Homebrew::DEFAULT_PREFIX} location."
-    satisfy { HOMEBREW_PREFIX.to_s == Homebrew::DEFAULT_PREFIX }
+    sha256 arm64_big_sur: "ffd4491f62201d14b7eca6beff954a2ab265351589cd5b3b79b8bbb414485574"
+    sha256 big_sur:       "0040b6ebe07f60549800b211343fd5fb3cf83c866d9f62e40f5fb2f38b71e161"
+    sha256 catalina:      "80f141e695f73bd058fd82e9f539dc67471666ff6800c5e280b5af7d3050f435"
+    sha256 mojave:        "0d14b797dba0e0ab595c9afba8ab7ef9c901b60b4f806b36580ef95ebb370232"
+    sha256 high_sierra:   "8c6160305abd948b8cf3e0d5c6bb0df192fa765bbb9535dda0b573cb60abbe52"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Now that https://github.com/Homebrew/brew/pull/11332 has been merged, `brew bottle` will correctly identify the `$(brew --repository)` reference in `bin/pkg-config` as making the bottle non-relocatable. The new bottle will no longer be `cellar: :any_skip_relocation` so the `pour_bottle?` block is no longer needed.
