### PR TITLE
influxdb fix bundling of UI assets

### DIFF
--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -4,6 +4,7 @@ class Influxdb < Formula
   url "https://github.com/influxdata/influxdb/archive/v2.0.6.tar.gz"
   sha256 "b8f019cfb85f7fdcdd5399dc2418cdc1ac302f99da0d031c2e307ecb62e129cd"
   license "MIT"
+  revision 1
   head "https://github.com/influxdata/influxdb.git"
 
   # The regex below omits a rogue `v9.9.9` tag that breaks version comparison.
@@ -22,27 +23,69 @@ class Influxdb < Formula
   depends_on "bazaar" => :build
   depends_on "go" => :build
   depends_on "pkg-config" => :build
+  depends_on "protobuf" => :build
   depends_on "rust" => :build
-  depends_on "yarn" => :build
-  depends_on "protobuf"
 
+  # NOTE: The version here is specified in the go.mod of influxdb.
+  # If you're upgrading to a newer influxdb version, check to see if this needs upgraded too.
   resource "pkg-config-wrapper" do
-    url "https://github.com/influxdata/pkg-config/archive/refs/tags/0.2.1.tar.gz"
-    sha256 "a31955bae060799b482d36ed522e76d55e1002d879d38371ed43d254b51f59d5"
+    url "https://github.com/influxdata/pkg-config/archive/refs/tags/v0.2.7.tar.gz"
+    sha256 "9bfe2c06b09fe7f3274f4ff8da1d87c9102640285bb38dad9a8c26dd5b9fe5af"
+  end
+
+  # NOTE: The version/URL here is specified in scripts/fetch-ui-assets.sh in influxdb.
+  # If you're upgrading to a newer influxdb version, check to see if this needs upgraded too.
+  resource "ui-assets" do
+    url "https://github.com/influxdata/ui/releases/download/OSS-v2.0.5/build.tar.gz"
+    sha256 "37ffbc072ba801ec5a0abdd76a3f19a8cd75f59856274e20630929f73cedaf55"
   end
 
   def install
+    # Set up the influxdata pkg-config wrapper to enable just-in-time compilation & linking
+    # of the Rust components in the server.
     resource("pkg-config-wrapper").stage do
       system "go", "build", *std_go_args, "-o", buildpath/"bootstrap/pkg-config"
     end
     ENV.prepend_path "PATH", buildpath/"bootstrap"
 
+    # Extract pre-build UI resources to the location expected by go-bindata.
+    resource("ui-assets").stage(buildpath/"ui/build")
+
+    # Embed UI files into the Go source code.
+    system "make", "generate"
+
+    # Build the CLI and server.
     ldflags = "-s -w -X main.version=#{version}"
-    system "go", "build", *std_go_args, "-ldflags", ldflags, "-o", bin/"influx", "./cmd/influx"
-    system "go", "build", *std_go_args, "-ldflags", ldflags, "-o", bin/"influxd", "./cmd/influxd"
+    system "go", "build", *std_go_args(ldflags: ldflags), "-o", bin/"influx", "./cmd/influx"
+    system "go", "build", *std_go_args(ldflags: ldflags), "-tags", "assets", "-o", bin/"influxd", "./cmd/influxd"
   end
 
   test do
-    assert_match "assets-path:", shell_output("#{bin}/influxd print-config")
+    ENV["INFLUXD_BOLT_PATH"] = "#{testpath}/influxd.bolt"
+    ENV["INFLUXD_ENGINE_PATH"] = "#{testpath}/engine"
+
+    influxd_port = free_port
+    influx_host = "http://localhost:#{influxd_port}"
+    ENV["INFLUX_HOST"] = influx_host
+
+    influxd = fork do
+      exec "#{bin}/influxd", "--store=memory",
+                             "--bolt-path=#{testpath}/influxd.bolt",
+                             "--engine-path=#{testpath}/engine",
+                             "--http-bind-address=:#{influxd_port}",
+                             "--log-level=error"
+    end
+    sleep 20
+
+    # Check that the CLI works and can talk to the server.
+    assert_match "OK", shell_output("#{bin}/influx ping")
+
+    # Check that the server has properly bundled UI assets and serves them as HTML.
+    curl_output = shell_output("curl --silent --head #{influx_host}")
+    assert_match "200 OK", curl_output
+    assert_match "text/html", curl_output
+  ensure
+    Process.kill("TERM", influxd)
+    Process.wait influxd
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Closes #75302 

Newer versions of InfluxDB pull pre-built assets for the embedded UI from a separate GitHub repo. This commit updates the formula to download those assets as a resource, and adds the `make` command / `go` tags required for the build to find and embed the files.