### PR TITLE
autoconf@2.69 2.69 (new formula)

### DIFF
--- a/Formula/autoconf@2.69.rb
+++ b/Formula/autoconf@2.69.rb
@@ -1,0 +1,35 @@
+class AutoconfAT269 < Formula
+  desc "Automatic configure script builder"
+  homepage "https://www.gnu.org/software/autoconf"
+  url "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz"
+  mirror "https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz"
+  sha256 "954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969"
+  license "GPL-2.0-or-later"
+
+  keg_only :versioned_formula
+
+  uses_from_macos "m4"
+  uses_from_macos "perl"
+
+  def install
+    on_macos do
+      ENV["PERL"] = "/usr/bin/perl"
+
+      # force autoreconf to look for and use our glibtoolize
+      inreplace "bin/autoreconf.in", "libtoolize", "glibtoolize"
+      # also touch the man page so that it isn't rebuilt
+      inreplace "man/autoreconf.1", "libtoolize", "glibtoolize"
+    end
+
+    system "./configure", "--prefix=#{prefix}",
+                          "--with-lispdir=#{elisp}"
+    system "make", "install"
+
+    rm_f info/"standards.info"
+  end
+
+  test do
+    cp prefix/"share/autoconf/autotest/autotest.m4", "autotest.m4"
+    system bin/"autoconf", "autotest.m4"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula is lifted from the homebrew-core history from the last version that was still `2.69`.

Autoconf 2.70 introduces a change where many macros no longer require other macros as they did in the past (http://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=blob_plain;f=NEWS;hb=97fbc5c184acc6fa591ad094eae86917f03459fa), causing configure scripts to generate and execute signficantly differently. This is causing substantial problems for many packages to build - this issue was made apparent in https://github.com/erlang/otp/issues/4821 but will affect any autoconf package not anticipating the change (or explicit about its macro dependencies). This formula will allow any legacy programs to continue to build while autoconf configurations are updated.

A small change was needed to correct the test file copy (`prefix` instead of `pkgshare`, the latter was appending the version number).

I've also got this published here, in the interim, for testing: https://github.com/cjntaylor/homebrew-personal