### PR TITLE
leveldb: set `RPATH` for ARM

### DIFF
--- a/Formula/leveldb.rb
+++ b/Formula/leveldb.rb
@@ -16,9 +16,11 @@ class Leveldb < Formula
   depends_on "snappy"
 
   def install
-    args = *std_cmake_args + %w[
+    args = *std_cmake_args + %W[
       -DLEVELDB_BUILD_TESTS=OFF
       -DLEVELDB_BUILD_BENCHMARKS=OFF
+      -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
+      -DCMAKE_INSTALL_RPATH=#{rpath}
     ]
 
     mkdir "build" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes

    ==> /opt/homebrew/Cellar/leveldb/1.23/bin/leveldbutil 2>&1
    sh: line 1: 77854 Abort trap: 6           /opt/homebrew/Cellar/leveldb/1.23/bin/leveldbutil 2>&1
    dyld: Library not loaded: @rpath/libleveldb.1.dylib
      Referenced from: /opt/homebrew/Cellar/leveldb/1.23/bin/leveldbutil
      Reason: image not found