### PR TITLE
parquet-cli 1.12.0 (new formula)

### DIFF
--- a/Formula/parquet-cli.rb
+++ b/Formula/parquet-cli.rb
@@ -1,0 +1,40 @@
+class ParquetCli < Formula
+  desc "Apache Parquet command-line tools and utilities"
+  homepage "https://parquet.apache.org/"
+  url "https://github.com/apache/parquet-mr.git",
+      tag:      "apache-parquet-1.12.0",
+      revision: "db75a6815f2ba1d1ee89d1a90aeb296f1f3a8f20"
+  license "Apache-2.0"
+  head "https://github.com/apache/parquet-mr.git"
+
+  depends_on "maven" => :build
+  depends_on "openjdk"
+
+  # This file generated with `red-parquet` gem:
+  #   Arrow::Table.new("values" => ["foo", "Homebrew", "bar"]).save("homebrew.parquet")
+  resource("test-parquet") do
+    url "https://gist.github.com/bayandin/2144b5fc6052153c1a33fd2679d50d95/raw/7d793910a1afd75ee4677f8c327491f7bdd2256b/homebrew.parquet"
+    sha256 "5caf572cb0df5ce9d6893609de82d2369b42c3c81c611847b6f921d912040118"
+  end
+
+  def install
+    cd "parquet-cli" do
+      system "mvn", "clean", "package", "-DskipTests=true"
+      system "mvn", "dependency:copy-dependencies"
+      libexec.install "target/parquet-cli-#{version}-runtime.jar"
+      libexec.install Dir["target/dependency/*"]
+      (bin/"parquet").write <<~EOS
+        #!/bin/sh
+        set -e
+        exec "#{Formula["openjdk"].opt_bin}/java" -cp "#{libexec}/*" org.apache.parquet.cli.Main "$@"
+      EOS
+    end
+  end
+
+  test do
+    resource("test-parquet").stage testpath
+
+    output = shell_output("#{bin}/parquet cat #{testpath}/homebrew.parquet")
+    assert_match "{\"values\": \"Homebrew\"}", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

As `parquet-tools` is now deprecated (#73909), this adds a new formula for `parquet-cli`. 