### PR TITLE
ngircd: add livecheck

### DIFF
--- a/Formula/ngircd.rb
+++ b/Formula/ngircd.rb
@@ -6,6 +6,11 @@ class Ngircd < Formula
   sha256 "55c16fd26009f6fc6a007df4efac87a02e122f680612cda1ce26e17a18d86254"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://ngircd.barton.de/download.php"
+    regex(/href=.*?ngircd[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 big_sur:  "9fe092e3ca8de75453b4aa667067e1cd863c041b8055ae7981e51f3506ac19c4"
     sha256 catalina: "95f504faeffb209318e93a050c632805178e91cd1e9475bbccfa9eb040b8d785"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `ngircd`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.