### PR TITLE
ADIOS2: New FindPython.cmake

### DIFF
--- a/Formula/adios2.rb
+++ b/Formula/adios2.rb
@@ -52,7 +52,7 @@ class Adios2 < Formula
       -DCMAKE_DISABLE_FIND_PACKAGE_FLEX=TRUE
       -DCMAKE_DISABLE_FIND_PACKAGE_LibFFI=TRUE
       -DCMAKE_DISABLE_FIND_PACKAGE_NVSTREAM=TRUE
-      -DPYTHON_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3
+      -DPython_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3
       -DADIOS2_BUILD_TESTING=OFF
       -DADIOS2_BUILD_EXAMPLES=OFF
     ]


### PR DESCRIPTION
With ADIOS 2.6.0, the new Python logic requires a `Python_EXECUTABLE` hint.

This seems to just coincidentally still find the right Python on macOS bu causes build-issues on Linux:
https://github.com/Homebrew/linuxbrew-core/issues/22225#issuecomment-813761312

cc @chuckatkins @KyleFromKitware @williamfgc @pnorbert

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
