### PR TITLE
php@7.2: revision bump

### DIFF
--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -6,7 +6,7 @@ class PhpAT72 < Formula
   mirror "https://fossies.org/linux/www/php-7.2.34.tar.xz"
   sha256 "409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
   license "PHP-3.01"
-  revision 3
+  revision 4
 
   bottle do
     sha256 arm64_big_sur: "654540bd31c20f81d618ca5d4696702f17bf6319dbbfe4c99d40e4a8bde5e8cc"

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -17,7 +17,7 @@ class PhpAT72 < Formula
 
   keg_only :versioned_formula
 
-  disable! date: "2021-11-30", because: :deprecated_upstream
+  deprecate! date: "2021-11-30", because: :deprecated_upstream
 
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

All the other php formulas have been bumped with #76306, but php@7.2 has been left out. However, the current php@7.2 binaries throw an error because they're looking for an old libldap.

```
$ /usr/local/opt/php@7.2/bin/php -v
dyld: Library not loaded: /usr/local/opt/openldap/lib/libldap-2.4.2.dylib
  Referenced from: /usr/local/opt/php@7.2/bin/php
  Reason: image not found
```

This is why I'd like to propose to bump php@7.2 as well.