### PR TITLE
Link to the background for FUSE on macOS deprecation.

### DIFF
--- a/Formula/afuse.rb
+++ b/Formula/afuse.rb
@@ -17,7 +17,7 @@ class Afuse < Formula
   depends_on "pkg-config" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/archivemount.rb
+++ b/Formula/archivemount.rb
@@ -14,7 +14,7 @@ class Archivemount < Formula
   depends_on "libarchive"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/avfs.rb
+++ b/Formula/avfs.rb
@@ -16,7 +16,7 @@ class Avfs < Formula
   depends_on "xz"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/bindfs.rb
+++ b/Formula/bindfs.rb
@@ -21,7 +21,7 @@ class Bindfs < Formula
   depends_on "pkg-config" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/btfs.rb
+++ b/Formula/btfs.rb
@@ -18,7 +18,7 @@ class Btfs < Formula
   depends_on "libtorrent-rasterbar"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/cryfs.rb
+++ b/Formula/cryfs.rb
@@ -23,7 +23,7 @@ class Cryfs < Formula
   depends_on "openssl@1.1"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/curlftpfs.rb
+++ b/Formula/curlftpfs.rb
@@ -22,7 +22,7 @@ class Curlftpfs < Formula
   # TODO: depend on specific X11 formulae instead
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/dislocker.rb
+++ b/Formula/dislocker.rb
@@ -10,7 +10,7 @@ class Dislocker < Formula
   depends_on "mbedtls"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -22,7 +22,7 @@ class Encfs < Formula
   depends_on "openssl@1.1"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/ext2fuse.rb
+++ b/Formula/ext2fuse.rb
@@ -14,7 +14,7 @@ class Ext2fuse < Formula
   depends_on "e2fsprogs"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/ext4fuse.rb
+++ b/Formula/ext4fuse.rb
@@ -18,7 +18,7 @@ class Ext4fuse < Formula
   depends_on "pkg-config" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/fuse-zip.rb
+++ b/Formula/fuse-zip.rb
@@ -19,7 +19,7 @@ class FuseZip < Formula
   depends_on "libzip"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/gcsfuse.rb
+++ b/Formula/gcsfuse.rb
@@ -15,7 +15,7 @@ class Gcsfuse < Formula
   depends_on "go" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/gitfs.rb
+++ b/Formula/gitfs.rb
@@ -15,7 +15,7 @@ class Gitfs < Formula
   uses_from_macos "libffi"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/gocryptfs.rb
+++ b/Formula/gocryptfs.rb
@@ -16,7 +16,7 @@ class Gocryptfs < Formula
   depends_on "openssl@1.1"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/goofys.rb
+++ b/Formula/goofys.rb
@@ -17,7 +17,7 @@ class Goofys < Formula
   depends_on "go" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/ifuse.rb
+++ b/Formula/ifuse.rb
@@ -21,7 +21,7 @@ class Ifuse < Formula
   depends_on "libplist"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/mp3fs.rb
+++ b/Formula/mp3fs.rb
@@ -18,7 +18,7 @@ class Mp3fs < Formula
   depends_on "libvorbis"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/ntfs-3g.rb
+++ b/Formula/ntfs-3g.rb
@@ -34,7 +34,7 @@ class Ntfs3g < Formula
   depends_on "gettext"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/rofs-filtered.rb
+++ b/Formula/rofs-filtered.rb
@@ -15,7 +15,7 @@ class RofsFiltered < Formula
   depends_on "cmake" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/s3-backer.rb
+++ b/Formula/s3-backer.rb
@@ -15,7 +15,7 @@ class S3Backer < Formula
   depends_on "openssl@1.1"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/s3fs.rb
+++ b/Formula/s3fs.rb
@@ -20,7 +20,7 @@ class S3fs < Formula
   depends_on "nettle"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/s3ql.rb
+++ b/Formula/s3ql.rb
@@ -22,7 +22,7 @@ class S3ql < Formula
   uses_from_macos "libffi"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/securefs.rb
+++ b/Formula/securefs.rb
@@ -16,7 +16,7 @@ class Securefs < Formula
   depends_on "cmake" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/simple-mtpfs.rb
+++ b/Formula/simple-mtpfs.rb
@@ -18,7 +18,7 @@ class SimpleMtpfs < Formula
   depends_on "libmtp"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/squashfuse.rb
+++ b/Formula/squashfuse.rb
@@ -21,7 +21,7 @@ class Squashfuse < Formula
   depends_on "zstd"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/sshfs.rb
+++ b/Formula/sshfs.rb
@@ -19,7 +19,7 @@ class Sshfs < Formula
   depends_on "libfuse"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   def install

--- a/Formula/tup.rb
+++ b/Formula/tup.rb
@@ -15,7 +15,7 @@ class Tup < Formula
   depends_on "pkg-config" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/wdfs.rb
+++ b/Formula/wdfs.rb
@@ -17,7 +17,7 @@ class Wdfs < Formula
   depends_on "neon"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do

--- a/Formula/xmount.rb
+++ b/Formula/xmount.rb
@@ -19,7 +19,7 @@ class Xmount < Formula
   depends_on "openssl@1.1"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires FUSE (see https://github.com/Homebrew/homebrew-core/pull/64491)"
   end
 
   on_linux do


### PR DESCRIPTION
MacFUSE-based formulas were disabled, but understanding why they were disabled and what the correct next steps are is not easy. It took me a while to find the pull request with extensive justification (https://github.com/Homebrew/homebrew-core/pull/64491).

I noticed that there is a lot of confusion and unneeded frustration with this breakage (https://github.com/borgbackup/borg/issues/5522, https://github.com/Homebrew/homebrew-core/commit/8c2f17e3b653347ada86d353243e2d6b6cb10fda, https://github.com/Homebrew/brew/issues/9401).

Thus I am proposing linking to the explanation from the error message.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? (fails as intended)
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? (does not install as intended)