### PR TITLE
aws-okta: deprecate

### DIFF
--- a/Formula/aws-okta.rb
+++ b/Formula/aws-okta.rb
@@ -12,6 +12,9 @@ class AwsOkta < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "910418c2dd89b78a7d665cdd8082d9941de433c6c8db800ce0515dfb6c1eb25b"
   end
 
+  # See https://github.com/segmentio/aws-okta/issues/278
+  deprecate! date: "2020-01-20", because: :deprecated_upstream
+
   depends_on "go" => :build
 
   on_linux do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Hi, I deprecated `aws-okta` upstream last Jan. https://github.com/segmentio/aws-okta/issues/278

There was some momentum behind a new community fork, but it looks to have languished https://github.com/aws-okta/aws-okta
