### PR TITLE
kind: fix test, use `main` branch for `--HEAD`

### DIFF
--- a/Formula/kind.rb
+++ b/Formula/kind.rb
@@ -34,8 +34,10 @@ class Kind < Formula
   end
 
   test do
+    ENV["DOCKER_HOST"] = "unix://#{testpath}/invalid.sock"
+
     # Should error out as creating a kind cluster requires root
     status_output = shell_output("#{bin}/kind get kubeconfig --name homebrew 2>&1", 1)
-    assert_match "ERROR: could not locate any control plane nodes", status_output
+    assert_match "Cannot connect to the Docker daemon", status_output
   end
 end

--- a/Formula/kind.rb
+++ b/Formula/kind.rb
@@ -4,7 +4,7 @@ class Kind < Formula
   url "https://github.com/kubernetes-sigs/kind/archive/v0.10.0.tar.gz"
   sha256 "9ede2b77b451417e36a208cc5183a21f0420f7b6a6230146ba7d76ab34b99bc7"
   license "Apache-2.0"
-  head "https://github.com/kubernetes-sigs/kind.git"
+  head "https://github.com/kubernetes-sigs/kind.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "4b233d91a8d967dd1c2e0b1cda5abfc9c18d67d7062d74193d6bbb3247726227"
@@ -35,6 +35,6 @@ class Kind < Formula
   test do
     # Should error out as creating a kind cluster requires root
     status_output = shell_output("#{bin}/kind get kubeconfig --name homebrew 2>&1", 1)
-    assert_match "failed to list clusters", status_output
+    assert_match "ERROR: could not locate any control plane nodes", status_output
   end
 end

--- a/Formula/kind.rb
+++ b/Formula/kind.rb
@@ -14,6 +14,7 @@ class Kind < Formula
   end
 
   depends_on "go" => :build
+  depends_on "docker" => :test
 
   def install
     system "go", "build", "-o", bin/"kind"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently, `kind` package cannot be installed using `--HEAD`. This is because the branch name was renamed from `master` to `main`. Also, `brew test kind` was failed.

This PR fixes the above two issues by appending `main` branch name and fixing the test assertion message.

## Errors before this fix

### Install with `--HEAD`

```shell
❯ brew install --head kind
Updating Homebrew...
==> Cloning https://github.com/kubernetes-sigs/kind.git
Updating /Users/shuuji3/Library/Caches/Homebrew/kind--git
fatal: couldn't find remote ref refs/heads/master
Error: Failed to download resource "kind"
Failure while executing; `git fetch origin` exited with 128. Here's the output:
fatal: couldn't find remote ref refs/heads/master
```

### Test

```shell
❯ brew test kind
==> Testing kind
==> /opt/homebrew/Cellar/kind/0.10.0/bin/kind get kubeconfig --name homebrew 2>&1
Error: kind: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /failed\ to\ list\ clusters/ to match "ERROR: could not locate any control plane nodes\n".
/opt/homebrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/minitest-5.14.4/lib/minitest/assertions.rb:183:in `assert'
/opt/homebrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/minitest-5.14.4/lib/minitest/assertions.rb:295:in `assert_match'
/opt/homebrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/kind.rb:38:in `block in <class:Kind>'
/opt/homebrew/Homebrew/Library/Homebrew/formula.rb:1975:in `block (3 levels) in run_test'
/opt/homebrew/Homebrew/Library/Homebrew/utils.rb:558:in `with_env'
/opt/homebrew/Homebrew/Library/Homebrew/formula.rb:1974:in `block (2 levels) in run_test'
/opt/homebrew/Homebrew/Library/Homebrew/formula.rb:924:in `with_logging'
/opt/homebrew/Homebrew/Library/Homebrew/formula.rb:1973:in `block in run_test'
/opt/homebrew/Homebrew/Library/Homebrew/mktemp.rb:63:in `block in run'
/opt/homebrew/Homebrew/Library/Homebrew/mktemp.rb:63:in `chdir'
/opt/homebrew/Homebrew/Library/Homebrew/mktemp.rb:63:in `run'
/opt/homebrew/Homebrew/Library/Homebrew/formula.rb:2224:in `mktemp'
/opt/homebrew/Homebrew/Library/Homebrew/formula.rb:1967:in `run_test'
/opt/homebrew/Homebrew/Library/Homebrew/test.rb:43:in `block in <main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/opt/homebrew/Homebrew/Library/Homebrew/test.rb:48:in `<main>'
```

## Confirmation after the change

I did test for two patterns: `brew install kind --build-from-source` and `brew install kind --HEAD`.

```shell
❯ brew uninstall --force kind; brew install --build-from-source kind; brew test kind; brew audit --strict kind; brew style kind
Uninstalling kind... (8 files, 8.3MB)
Updating Homebrew...
==> Downloading https://github.com/kubernetes-sigs/kind/archive/v0.10.0.tar.gz
Already downloaded: /Users/shuuji3/Library/Caches/Homebrew/downloads/bd92f5dd9abc22fe37f64ae666690a665493935fa4c6689ec7feef5e9141d5d4--kind-0.10.0.tar.gz
==> go build -o /opt/homebrew/Cellar/kind/0.10.0/bin/kind
==> Caveats
fish completions have been installed to:
  /opt/homebrew/share/fish/vendor_completions.d
==> Summary
🍺  /opt/homebrew/Cellar/kind/0.10.0: 8 files, 8.3MB, built in 13 seconds
==> Testing kind
==> /opt/homebrew/Cellar/kind/0.10.0/bin/kind get kubeconfig --name homebrew 2>&1

1 file inspected, no offenses detected
```

```shell
❯ brew uninstall --force kind; brew install --HEAD kind; brew test kind; brew audit --strict kind; brew style kind
Uninstalling kind... (8 files, 8.3MB)
Updating Homebrew...
==> Cloning https://github.com/kubernetes-sigs/kind.git
Updating /Users/shuuji3/Library/Caches/Homebrew/kind--git
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
HEAD is now at 247fea5a Merge pull request #2176 from BenTheElder/new-node-image
==> go build -o /opt/homebrew/Cellar/kind/HEAD-247fea5/bin/kind
==> Caveats
fish completions have been installed to:
  /opt/homebrew/share/fish/vendor_completions.d
==> Summary
🍺  /opt/homebrew/Cellar/kind/HEAD-247fea5: 8 files, 8.3MB, built in 14 seconds
Removing: /Users/shuuji3/Library/Caches/Homebrew/kind--0.10.0.tar.gz... (1.8MB)
==> Testing kind
==> /opt/homebrew/Cellar/kind/HEAD-247fea5/bin/kind get kubeconfig --name homebrew 2>&1

1 file inspected, no offenses detected
```