### PR TITLE
elan-init 1.0.3 (new formula)

### DIFF
--- a/Aliases/elan
+++ b/Aliases/elan
@@ -1,0 +1,1 @@
+../Formula/elan-init.rb

--- a/Formula/elan-init.rb
+++ b/Formula/elan-init.rb
@@ -1,0 +1,47 @@
+class ElanInit < Formula
+  desc "Lean Theorem Prover installer and version manager"
+  homepage "https://github.com/leanprover/elan"
+  url "https://github.com/leanprover/elan/archive/v1.0.3.tar.gz"
+  sha256 "fb3ddd8915a0694ead0f3a51fdf8b0a5540f983f44eee0e757339244c522b8ee"
+  license "Apache-2.0"
+  head "https://github.com/leanprover/elan.git"
+
+  depends_on "rust" => :build
+  # elan-init will run on arm64 Macs, but will fetch Leans that are x86_64.
+  depends_on arch: :x86_64
+  depends_on "gmp"
+
+  def install
+    ENV["RELEASE_TARGET_NAME"] = "homebrew-build"
+
+    system "cargo", "install", "--features", "no-self-update", *std_cargo_args
+
+    %w[lean leanpkg leanchecker leanc leanmake elan].each do |link|
+      bin.install_symlink "elan-init" => link
+    end
+
+    bash_output = Utils.safe_popen_read(bin/"elan", "completions", "bash")
+    (bash_completion/"elan").write bash_output
+    zsh_output = Utils.safe_popen_read(bin/"elan", "completions", "zsh")
+    (zsh_completion/"_elan").write zsh_output
+    fish_output = Utils.safe_popen_read(bin/"elan", "completions", "fish")
+    (fish_completion/"elan.fish").write fish_output
+  end
+
+  test do
+    system bin/"elan-init", "-y"
+    (testpath/"hello.lean").write <<~EOS
+      def id' {α : Type} (x : α) : α := x
+
+      inductive tree (α : Type) : Type
+      | node : α → list tree → tree
+
+      example (a b : Prop) : a ∧ b -> b ∧ a :=
+      begin
+          intro h, cases h,
+          split, repeat { assumption }
+      end
+    EOS
+    system bin/"lean", testpath/"hello.lean"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The Lean community prefers users to use the (here added) `elan`
formula (which is now aliased to lean), because Lean's development
moves quickly and backwards compatibility is not maintained between
versions, so different projects written in Lean will often depend
on many different versions of the Lean compiler.

I didn't deprecate the `lean` formula, I just replaced it, which seems safe to me given users who install Lean via the existing formula generally find themselves stuck and come ask for support, but let me know what your thoughts are.

It's also been a number of years since I've submitted a new formula, so apologies if I've made any process errors, happy for comments.