### PR TITLE
Harmonize installs of rust-using formulae.

### DIFF
--- a/Formula/cloudformation-guard.rb
+++ b/Formula/cloudformation-guard.rb
@@ -38,6 +38,6 @@ class CloudformationGuard < Formula
     (testpath/"test-ruleset").write <<~EOS
       AWS::EC2::Volume Size == 99
     EOS
-    system "#{bin}/cfn-guard", "check", "-r", "test-ruleset", "-t", "test-template.yml"
+    system bin/"cfn-guard", "check", "-r", "test-ruleset", "-t", "test-template.yml"
   end
 end

--- a/Formula/cmdshelf.rb
+++ b/Formula/cmdshelf.rb
@@ -23,7 +23,7 @@ class Cmdshelf < Formula
   end
 
   test do
-    system "#{bin}/cmdshelf", "remote", "add", "test", "git@github.com:toshi0383/scripts.git"
+    system bin/"cmdshelf", "remote", "add", "test", "git@github.com:toshi0383/scripts.git"
     list_output = shell_output("#{bin}/cmdshelf remote list").chomp
     assert_equal "test:git@github.com:toshi0383/scripts.git", list_output
   end

--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -54,11 +54,11 @@ class Deno < Formula
       system "cargo", "install", "-vv", "-j1", *std_cargo_args
     end
 
-    bash_output = Utils.safe_popen_read("#{bin}/deno", "completions", "bash")
+    bash_output = Utils.safe_popen_read(bin/"deno", "completions", "bash")
     (bash_completion/"deno").write bash_output
-    zsh_output = Utils.safe_popen_read("#{bin}/deno", "completions", "zsh")
+    zsh_output = Utils.safe_popen_read(bin/"deno", "completions", "zsh")
     (zsh_completion/"_deno").write zsh_output
-    fish_output = Utils.safe_popen_read("#{bin}/deno", "completions", "fish")
+    fish_output = Utils.safe_popen_read(bin/"deno", "completions", "fish")
     (fish_completion/"deno.fish").write fish_output
   end
 

--- a/Formula/diesel.rb
+++ b/Formula/diesel.rb
@@ -28,13 +28,12 @@ class Diesel < Formula
       system "cargo", "install", *std_cargo_args
     end
 
-    system "#{bin}/diesel completions bash > diesel.bash"
-    system "#{bin}/diesel completions zsh > _diesel"
-    system "#{bin}/diesel completions fish > diesel.fish"
-
-    bash_completion.install "diesel.bash"
-    zsh_completion.install "_diesel"
-    fish_completion.install "diesel.fish"
+    bash_output = Utils.safe_popen_read(bin/"diesel", "completions", "bash")
+    (bash_completion/"diesel").write bash_output
+    zsh_output = Utils.safe_popen_read(bin/"diesel", "completions", "zsh")
+    (zsh_completion/"_diesel").write zsh_output
+    fish_output = Utils.safe_popen_read(bin/"diesel", "completions", "fish")
+    (fish_completion/"diesel.fish").write fish_output
   end
 
   test do

--- a/Formula/gleam.rb
+++ b/Formula/gleam.rb
@@ -26,7 +26,7 @@ class Gleam < Formula
 
   test do
     Dir.chdir testpath
-    system "#{bin}/gleam", "new", "test_project"
+    system bin/"gleam", "new", "test_project"
     Dir.chdir "test_project"
     system "rebar3", "eunit"
   end

--- a/Formula/gnirehtet.rb
+++ b/Formula/gnirehtet.rb
@@ -42,8 +42,8 @@ class Gnirehtet < Formula
   end
 
   test do
-    gnirehtet_err = "#{testpath}/gnirehtet.err"
-    gnirehtet_out = "#{testpath}/gnirehtet.out"
+    gnirehtet_err = testpath/"gnirehtet.err"
+    gnirehtet_out = testpath/"gnirehtet.out"
 
     port = free_port
     begin

--- a/Formula/just.rb
+++ b/Formula/just.rb
@@ -28,7 +28,7 @@ class Just < Formula
       default:
         touch it-worked
     EOS
-    system "#{bin}/just"
+    system bin/"just"
     assert_predicate testpath/"it-worked", :exist?
   end
 end

--- a/Formula/kickstart.rb
+++ b/Formula/kickstart.rb
@@ -41,7 +41,7 @@ class Kickstart < Formula
     EOS
 
     # Run template interpolation
-    system "#{bin}/kickstart", "--no-input", testpath.to_s
+    system bin/"kickstart", "--no-input", testpath.to_s
 
     assert_predicate testpath/"myfilename.txt", :exist?
     assert_equal "kickstart is awesome!", (testpath/"myfilename.txt").read

--- a/Formula/kondo.rb
+++ b/Formula/kondo.rb
@@ -43,7 +43,7 @@ class Kondo < Formula
     #
     # We're going to simulate a user pressing "n" for no.
     # The result of this should be that the dummy file still exists after kondo has exited.
-    Open3.popen3("#{bin}/kondo") do |stdin, _stdout, _, wait_thr|
+    Open3.popen3(bin/"kondo") do |stdin, _stdout, _, wait_thr|
       # Simulate a user pressing "n" then pressing return/enter.
       stdin.write("n\n")
 
@@ -56,7 +56,7 @@ class Kondo < Formula
 
     # The concept is the same as the above test, except this time we will simulate pressing "y" for yes.
     # The result of this should be that the dummy file still no longer exists after kondo has exited.
-    Open3.popen3("#{bin}/kondo") do |stdin, _stdout, _, wait_thr|
+    Open3.popen3(bin/"kondo") do |stdin, _stdout, _, wait_thr|
       # Simulate a user pressing "y" then pressing return/enter.
       stdin.write("y\n")
 

--- a/Formula/mdbook.rb
+++ b/Formula/mdbook.rb
@@ -22,6 +22,6 @@ class Mdbook < Formula
   test do
     # simulate user input to mdbook init
     system "sh", "-c", "printf \\n\\n | #{bin}/mdbook init"
-    system "#{bin}/mdbook", "build"
+    system bin/"mdbook", "build"
   end
 end

--- a/Formula/oxipng.rb
+++ b/Formula/oxipng.rb
@@ -19,6 +19,6 @@ class Oxipng < Formula
   end
 
   test do
-    system "#{bin}/oxipng", "--pretend", test_fixtures("test.png")
+    system bin/"oxipng", "--pretend", test_fixtures("test.png")
   end
 end

--- a/Formula/procs.rb
+++ b/Formula/procs.rb
@@ -17,16 +17,16 @@ class Procs < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    system "#{bin}/procs", "--completion", "bash"
-    system "#{bin}/procs", "--completion", "fish"
-    system "#{bin}/procs", "--completion", "zsh"
+    system bin/"procs", "--completion", "bash"
+    system bin/"procs", "--completion", "fish"
+    system bin/"procs", "--completion", "zsh"
     bash_completion.install "procs.bash" => "procs"
     fish_completion.install "procs.fish"
     zsh_completion.install "_procs"
   end
 
   test do
-    output = shell_output("#{bin}/procs")
+    output = shell_output(bin/"procs")
     count = output.lines.count
     assert count > 2
     assert output.start_with?(" PID:")

--- a/Formula/rbspy.rb
+++ b/Formula/rbspy.rb
@@ -29,8 +29,8 @@ class Rbspy < Formula
     EOS
 
     (testpath/"recording.gz").write Base64.decode64(recording.delete("\n"))
-    system "#{bin}/rbspy", "report", "-f", "summary", "-i", "recording.gz",
-                           "-o", "result"
+    system bin/"rbspy", "report", "-f", "summary", "-i", "recording.gz",
+                        "-o", "result"
 
     expected_result = <<~EOS
       % self  % total  name

--- a/Formula/rustup-init.rb
+++ b/Formula/rustup-init.rb
@@ -23,10 +23,6 @@ class RustupInit < Formula
   end
 
   def install
-    cargo_home = buildpath/"cargo_home"
-    cargo_home.mkpath
-    ENV["CARGO_HOME"] = cargo_home
-
     system "cargo", "install", "--features", "no-self-update", *std_cargo_args
   end
 

--- a/Formula/safe-rm.rb
+++ b/Formula/safe-rm.rb
@@ -26,7 +26,7 @@ class SafeRm < Formula
     (testpath/".config/safe-rm").write bar
     touch foo
     touch bar
-    system "#{bin}/safe-rm", foo
+    system bin/"safe-rm", foo
     refute_predicate foo, :exist?
     shell_output("#{bin}/safe-rm #{bar} 2>&1", 64)
     assert_predicate bar, :exist?

--- a/Formula/sn0int.rb
+++ b/Formula/sn0int.rb
@@ -26,13 +26,12 @@ class Sn0int < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    system "#{bin}/sn0int completions bash > sn0int.bash"
-    system "#{bin}/sn0int completions fish > sn0int.fish"
-    system "#{bin}/sn0int completions zsh > _sn0int"
-
-    bash_completion.install "sn0int.bash"
-    fish_completion.install "sn0int.fish"
-    zsh_completion.install "_sn0int"
+    bash_output = Utils.safe_popen_read(bin/"sn0int", "completions", "bash")
+    (bash_completion/"sn0int").write bash_output
+    zsh_output = Utils.safe_popen_read(bin/"sn0int", "completions", "zsh")
+    (zsh_completion/"_sn0int").write zsh_output
+    fish_output = Utils.safe_popen_read(bin/"sn0int", "completions", "fish")
+    (fish_completion/"sn0int.fish").write fish_output
 
     system "make", "-C", "docs", "man"
     man1.install "docs/_build/man/1/sn0int.1"
@@ -48,6 +47,6 @@ class Sn0int < Formula
           -- nothing to do here
       end
     EOS
-    system "#{bin}/sn0int", "run", "-vvxf", testpath/"true.lua"
+    system bin/"sn0int", "run", "-vvxf", testpath/"true.lua"
   end
 end

--- a/Formula/sniffglue.rb
+++ b/Formula/sniffglue.rb
@@ -34,6 +34,6 @@ class Sniffglue < Formula
 
   test do
     testpath.install resource("testdata")
-    system "#{bin}/sniffglue", "-r", "SkypeIRC.pcap"
+    system bin/"sniffglue", "-r", "SkypeIRC.pcap"
   end
 end

--- a/Formula/svgcleaner.rb
+++ b/Formula/svgcleaner.rb
@@ -37,6 +37,6 @@ class Svgcleaner < Formula
            style="fill:#0000ff;fill-opacity:0.75;stroke:#000000"/>
       </svg>
     EOS
-    system "#{bin}/svgcleaner", "in.svg", "out.svg"
+    system bin/"svgcleaner", "in.svg", "out.svg"
   end
 end

--- a/Formula/wapm.rb
+++ b/Formula/wapm.rb
@@ -30,7 +30,7 @@ class Wapm < Formula
     Dir.mkdir ENV["WASMER_DIR"]
     Dir.mkdir ENV["WASMER_CACHE_DIR"]
 
-    system "#{bin}/wapm", "install", "cowsay"
+    system bin/"wapm", "install", "cowsay"
 
     expected_output = <<~'EOF'
        _____________

--- a/Formula/xplr.rb
+++ b/Formula/xplr.rb
@@ -22,7 +22,7 @@ class Xplr < Formula
   test do
     input, = Open3.popen2 "SHELL=/bin/sh script -q output.txt"
     input.puts "stty rows 80 cols 130"
-    input.puts "#{bin}/xplr"
+    input.puts bin/"xplr"
     input.putc "q"
     input.puts "exit"
 

--- a/Formula/xsv.rb
+++ b/Formula/xsv.rb
@@ -22,6 +22,6 @@ class Xsv < Formula
 
   test do
     (testpath/"test.csv").write("first header,second header")
-    system "#{bin}/xsv", "stats", "test.csv"
+    system bin/"xsv", "stats", "test.csv"
   end
 end

--- a/Formula/zellij.rb
+++ b/Formula/zellij.rb
@@ -17,9 +17,12 @@ class Zellij < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    (bash_completion/"zellij").write Utils.safe_popen_read("#{bin}/zellij", "generate-completion", "bash")
-    (zsh_completion/"_zellij").write Utils.safe_popen_read("#{bin}/zellij", "generate-completion", "zsh")
-    (fish_completion/"zellij.fish").write Utils.safe_popen_read("#{bin}/zellij", "generate-completion", "fish")
+    bash_output = Utils.safe_popen_read(bin/"zellij", "generate-completion", "bash")
+    (bash_completion/"zellij").write bash_output
+    zsh_output = Utils.safe_popen_read(bin/"zellij", "generate-completion", "zsh")
+    (zsh_completion/"_zellij").write zsh_output
+    fish_output = Utils.safe_popen_read(bin/"zellij", "generate-completion", "fish")
+    (fish_completion/"zellij.fish").write fish_output
   end
 
   test do


### PR DESCRIPTION
Makes those that install completions do so in the same way,
and removes some unnecessary string interpolations.

Comes from style comments shared in a review of #77349.

Not sure what the homebrew-core policy is on refactoring changes like this, but was fairly easy to apply, so if this is useful, here's a PR for it. If not feel free to close.

CC @carlocab 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
