### PR TITLE
elan-init, lean: depend on coreutils

### DIFF
--- a/Formula/elan-init.rb
+++ b/Formula/elan-init.rb
@@ -15,7 +15,10 @@ class ElanInit < Formula
   depends_on "rust" => :build
   # elan-init will run on arm64 Macs, but will fetch Leans that are x86_64.
   depends_on arch: :x86_64
+  depends_on "coreutils"
   depends_on "gmp"
+
+  conflicts_with "lean", because: "`lean` and `elan-init` install the same binaries"
 
   def install
     ENV["RELEASE_TARGET_NAME"] = "homebrew-build"
@@ -49,5 +52,6 @@ class ElanInit < Formula
       end
     EOS
     system bin/"lean", testpath/"hello.lean"
+    system bin/"leanpkg", "help"
   end
 end

--- a/Formula/lean.rb
+++ b/Formula/lean.rb
@@ -21,9 +21,12 @@ class Lean < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "coreutils"
   depends_on "gmp"
   depends_on "jemalloc"
   depends_on macos: :mojave
+
+  conflicts_with "elan-init", because: "`lean` and `elan-init` install the same binaries"
 
   def install
     mkdir "src/build" do
@@ -45,6 +48,7 @@ class Lean < Formula
           split, repeat { assumption }
       end
     EOS
-    system "#{bin}/lean", testpath/"hello.lean"
+    system bin/"lean", testpath/"hello.lean"
+    system bin/"leanpkg", "help"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`leanpkg` is a thing that [depends on `coreutils`](https://github.com/leanprover-community/lean/blob/a528e9be5890604872b8036b529ab919d7531837/bin/leanpkg#L6-L11).

`lean` therefore, which installs it, depends on `coreutils`, as does `elan-init`, which installs `lean` and transitively therefore does as well.