### PR TITLE
mercury: add livecheck

### DIFF
--- a/Formula/mercury.rb
+++ b/Formula/mercury.rb
@@ -5,6 +5,11 @@ class Mercury < Formula
   sha256 "ef093ae81424c4f3fe696eff9aefb5fb66899e11bb17ae0326adfb70d09c1c1f"
   license all_of: ["GPL-2.0-only", "LGPL-2.0-only", "MIT"]
 
+  livecheck do
+    url "https://dl.mercurylang.org/"
+    regex(/href=.*?mercury-srcdist[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, big_sur:  "8b37f68829e59efd2127a32dfbcbf80d617196b6f35c970e1d4727b5076abb39"
     sha256 cellar: :any, catalina: "2b98c59507d6aa72db55b8864d9818f302fef92b5bbdc6630287276494a3bc62"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `mercury`. This PR adds a `livecheck` block that checks the download page for source files, which links to the `stable` archive.