### PR TITLE
fastlane: use regular ruby version

### DIFF
--- a/Formula/fastlane.rb
+++ b/Formula/fastlane.rb
@@ -19,7 +19,7 @@ class Fastlane < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "79bfdf70efde7a05fca33771ab93730ac11a0d9aed8d3e1c90bf6f04f6ee6ca4"
   end
 
-  depends_on "ruby@2.7"
+  depends_on "ruby"
 
   def install
     ENV["GEM_HOME"] = libexec
@@ -29,7 +29,7 @@ class Fastlane < Formula
     system "gem", "install", "fastlane-#{version}.gem", "--no-document"
 
     (bin/"fastlane").write_env_script libexec/"bin/fastlane",
-      PATH:                            "#{Formula["ruby@2.7"].opt_bin}:#{libexec}/bin:$PATH",
+      PATH:                            "#{Formula["ruby"].opt_bin}:#{libexec}/bin:$PATH",
       FASTLANE_INSTALLED_VIA_HOMEBREW: "true",
       GEM_HOME:                        libexec.to_s,
       GEM_PATH:                        libexec.to_s


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

[As of version 2.183.0 Fastlane is compatible with Ruby 3.0.](https://github.com/fastlane/fastlane/releases/tag/2.183.0) This PR changes the dependency from being pinned on an older version (`ruby@2.7`) to using the regular `ruby` formula.
