### PR TITLE
inetutils: disable setuid install

### DIFF
--- a/Formula/inetutils.rb
+++ b/Formula/inetutils.rb
@@ -5,6 +5,7 @@ class Inetutils < Formula
   mirror "https://ftpmirror.gnu.org/inetutils/inetutils-2.0.tar.xz"
   sha256 "e573d566e55393940099862e7f8994164a0ed12f5a86c3345380842bdc124722"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "82b61f26f0dc565334619a3ca34994cfea99088e25db94bd15706037a2c49b61"
@@ -37,7 +38,7 @@ class Inetutils < Formula
       args << "--program-prefix=g"
     end
     system "./configure", *args
-    system "make", "install"
+    system "make", "SUIDMODE=", "install"
 
     on_macos do
       # Binaries not shadowing macOS utils symlinked without 'g' prefix


### PR DESCRIPTION
This caused four programs to not be installed.

Closes https://github.com/Homebrew/homebrew-core/issues/77460.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
