### PR TITLE
sstp-client: rollback to 1.0.13

### DIFF
--- a/Formula/sstp-client.rb
+++ b/Formula/sstp-client.rb
@@ -1,8 +1,8 @@
 class SstpClient < Formula
   desc "SSTP (Microsofts Remote Access Solution for PPP over SSL) client"
   homepage "https://sstp-client.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/sstp-client/sstp-client/sstp-client-1.0.14.tar.gz"
-  sha256 "e0eccae251ab7264cabbabf3ec8d45ef981187684c9ef34613bf5f70affe10e7"
+  url "https://downloads.sourceforge.net/project/sstp-client/sstp-client/sstp-client-1.0.13.tar.gz"
+  sha256 "961258fca0795d8ad60b047942cf7cb53d025d353fd1e4ba08c2b75799f5321b"
   license "GPL-2.0"
 
   livecheck do

--- a/Formula/sstp-client.rb
+++ b/Formula/sstp-client.rb
@@ -3,7 +3,7 @@ class SstpClient < Formula
   homepage "https://sstp-client.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/sstp-client/sstp-client/sstp-client-1.0.13.tar.gz"
   sha256 "961258fca0795d8ad60b047942cf7cb53d025d353fd1e4ba08c2b75799f5321b"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   version_scheme 1
 
   livecheck do

--- a/Formula/sstp-client.rb
+++ b/Formula/sstp-client.rb
@@ -4,6 +4,7 @@ class SstpClient < Formula
   url "https://downloads.sourceforge.net/project/sstp-client/sstp-client/sstp-client-1.0.13.tar.gz"
   sha256 "961258fca0795d8ad60b047942cf7cb53d025d353fd1e4ba08c2b75799f5321b"
   license "GPL-2.0"
+  version_scheme 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
This reverts commit b140fd69fafc07022fcd636949749ca3218de063.

The version 1.0.14 disappeared from SourceForge and the stable URL
returns an HTTP 404 error. This is also mentioned in issue #68679.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`brew audit --strict <formula>` does not pass with following error:
```
  * Formula sstp-client contains deprecated SPDX licenses: ["GPL-2.0"].
    You may need to add `-only` or `-or-later` for GNU licenses (e.g. `GPL`, `LGPL`, `AGPL`, `GFDL`).
    For a list of valid licenses check: https://spdx.org/licenses/
Error: 1 problem in 1 formula detected
```
I don't know if this should be adressed in this PR, therefore I'll leave this at it is.