### PR TITLE
bluepill: update livecheck

### DIFF
--- a/Formula/bluepill.rb
+++ b/Formula/bluepill.rb
@@ -7,9 +7,13 @@ class Bluepill < Formula
   license "BSD-2-Clause"
   head "https://github.com/linkedin/bluepill.git"
 
+  # Typically the preceding `v` is optional in livecheck regexes but we need it
+  # to be required here to omit older versions that break version comparison
+  # (e.g., 9.0.0). Note: We don't use the `GithubLatest` strategy here because
+  # the "latest" version is sometimes incorrect.
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `bluepill` uses the `GithubLatest` strategy to identify the latest version. Currently, the "latest" version on GitHub is `5.5.4`, the version used in the formula is `5.8.0`, and the actual latest version may be `5.8.1`. Since `v5.5.4` was tagged after `v5.8.1`, it's treated as "latest" and livecheck can't identify the correct latest version.

We only use `GithubLatest` when it's both necessary and correct but in this case it isn't correct. We were using it before because there are older tags (e.g., `9.0.0`) in the repository that are erroneously treated as newer than the current version (`5.8.1`) due to `Version` comparison. We use the `Git` strategy when `GithubLatest` is used but is no longer correct/necessary but it's necessary to work around this tag issue in the process.

This PR addresses these issues by removing `strategy :github_latest` (returning to using the `Git` strategy) and adding a modified version of the standard regex for Git tags like `1.2.3`/`v1.2.3` where the leading `v` is required rather than optional (`v?`). The older tags don't have a leading `v` like the current tag scheme (e.g., `v1.2.3`), so this effectively omits the problematic older tags.

Upstream consistently uses a leading `v` in the tag versions, so this works for now. If `bluepill` ever exceeds version `9.0.0`, we can modify this `livecheck` block to simply use the standard regex for Git tags like `1.2.3`/`v1.2.3` (i.e., `/^v?(\d+(?:\.\d+)+)$/i`) and remove the explanatory comment.