### PR TITLE
intermodal 0.1.12 (new formula)

### DIFF
--- a/Formula/intermodal.rb
+++ b/Formula/intermodal.rb
@@ -1,0 +1,29 @@
+class Intermodal < Formula
+  desc "User-friendly and featureful command-line BitTorrent metainfo utility"
+  homepage "https://imdl.io"
+  url "https://github.com/casey/intermodal/archive/refs/tags/v0.1.12.tar.gz"
+  sha256 "cd62894e519dc5aa0284a5f48aab86e1a45c3bc96b8a5481741adb6960d4751a"
+  license "CC0-1.0"
+  head "https://github.com/casey/intermodal.git"
+
+  depends_on "help2man" => :build
+  depends_on "openssl@1.1" => :build
+  depends_on "rust" => :build
+
+  def install
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
+    system "cargo", "install", *std_cargo_args
+    system "cargo", "run", "--package", "gen", "--", "--bin", bin/"imdl", "man"
+    system "cargo", "run", "--package", "gen", "--", "--bin", bin/"imdl", "completion-scripts"
+
+    man1.install Dir["target/gen/man/*.1"]
+    bash_completion.install "target/gen/completions/imdl.bash"
+    fish_completion.install "target/gen/completions/imdl.fish"
+    zsh_completion.install "target/gen/completions/_imdl"
+  end
+
+  test do
+    system bin/"imdl", "torrent", "create", "--input", test_fixtures("test.flac"), "--output", "test.torrent"
+    system bin/"imdl", "torrent", "verify", "--content", test_fixtures("test.flac"), "--input", "test.torrent"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Intermodal is a user-friendly and featureful command-line BitTorrent metainfo utility. The binary is called imdl and runs on Linux, Windows, and macOS. It can create, display, and verify .torrent files, as well as generate magnet links.

Documentation: https://imdl.io/book/

Also, is this the correct way to add shell completion files? I didn't find documentation on this.