### PR TITLE
Replace `pour_bottle?` blocks with symbols

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -34,12 +34,7 @@ class Gcc < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   depends_on "gmp"
   depends_on "isl"

--- a/Formula/gcc@10.rb
+++ b/Formula/gcc@10.rb
@@ -19,12 +19,7 @@ class GccAT10 < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   depends_on arch: :x86_64
   depends_on "gmp"

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -17,12 +17,7 @@ class GccAT49 < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   # https://gcc.gnu.org/gcc-4.9/
   deprecate! date: "2021-04-11", because: :deprecated_upstream

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -17,12 +17,7 @@ class GccAT5 < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   depends_on maximum_macos: [:high_sierra, :build]
 

--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -19,12 +19,7 @@ class GccAT6 < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   depends_on arch: :x86_64
   depends_on "gmp"

--- a/Formula/gcc@7.rb
+++ b/Formula/gcc@7.rb
@@ -19,12 +19,7 @@ class GccAT7 < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   depends_on arch: :x86_64
   depends_on "gmp"

--- a/Formula/gcc@8.rb
+++ b/Formula/gcc@8.rb
@@ -18,12 +18,7 @@ class GccAT8 < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   depends_on arch: :x86_64
   depends_on "gmp"

--- a/Formula/gcc@9.rb
+++ b/Formula/gcc@9.rb
@@ -19,12 +19,7 @@ class GccAT9 < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   depends_on arch: :x86_64
   depends_on "gmp"

--- a/Formula/libgccjit.rb
+++ b/Formula/libgccjit.rb
@@ -36,10 +36,7 @@ class Libgccjit < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  pour_bottle? do
-    reason "The bottle needs the Xcode CLT to be installed."
-    satisfy { MacOS::CLT.installed? }
-  end
+  pour_bottle? only_if: :clt_installed
 
   depends_on "gcc" => :test
   depends_on "gmp"

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -21,12 +21,7 @@ class Llvm < Formula
   end
 
   # Clang cannot find system headers if Xcode CLT is not installed
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   keg_only :provided_by_macos
 

--- a/Formula/llvm@11.rb
+++ b/Formula/llvm@11.rb
@@ -20,12 +20,7 @@ class LlvmAT11 < Formula
   end
 
   # Clang cannot find system headers if Xcode CLT is not installed
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   keg_only :versioned_formula
 

--- a/Formula/llvm@7.rb
+++ b/Formula/llvm@7.rb
@@ -13,12 +13,7 @@ class LlvmAT7 < Formula
   end
 
   # Clang cannot find system headers if Xcode CLT is not installed
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   keg_only :versioned_formula
 

--- a/Formula/llvm@8.rb
+++ b/Formula/llvm@8.rb
@@ -13,12 +13,7 @@ class LlvmAT8 < Formula
   end
 
   # Clang cannot find system headers if Xcode CLT is not installed
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   keg_only :versioned_formula
 

--- a/Formula/llvm@9.rb
+++ b/Formula/llvm@9.rb
@@ -14,12 +14,7 @@ class LlvmAT9 < Formula
   end
 
   # Clang cannot find system headers if Xcode CLT is not installed
-  pour_bottle? do
-    on_macos do
-      reason "The bottle needs the Xcode CLT to be installed."
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   keg_only :versioned_formula
 

--- a/Formula/python@3.7.rb
+++ b/Formula/python@3.7.rb
@@ -19,16 +19,7 @@ class PythonAT37 < Formula
 
   # setuptools remembers the build flags python is built with and uses them to
   # build packages later. Xcode-only systems need different flags.
-  pour_bottle? do
-    on_macos do
-      reason <<~EOS
-        The bottle needs the Apple Command Line Tools to be installed.
-          You can install them, if desired, with:
-            xcode-select --install
-      EOS
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   keg_only :versioned_formula
 

--- a/Formula/python@3.8.rb
+++ b/Formula/python@3.8.rb
@@ -19,16 +19,7 @@ class PythonAT38 < Formula
 
   # setuptools remembers the build flags python is built with and uses them to
   # build packages later. Xcode-only systems need different flags.
-  pour_bottle? do
-    on_macos do
-      reason <<~EOS
-        The bottle needs the Apple Command Line Tools to be installed.
-          You can install them, if desired, with:
-            xcode-select --install
-      EOS
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   keg_only :versioned_formula
 

--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -20,16 +20,7 @@ class PythonAT39 < Formula
 
   # setuptools remembers the build flags python is built with and uses them to
   # build packages later. Xcode-only systems need different flags.
-  pour_bottle? do
-    on_macos do
-      reason <<~EOS
-        The bottle needs the Apple Command Line Tools to be installed.
-          You can install them, if desired, with:
-            xcode-select --install
-      EOS
-      satisfy { MacOS::CLT.installed? }
-    end
-  end
+  pour_bottle? only_if: :clt_installed
 
   depends_on "pkg-config" => :build
   depends_on "gdbm"

--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -20,10 +20,7 @@ class SwiftFormat < Formula
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
-  pour_bottle? do
-    reason "The bottle needs the Xcode CLT to be installed."
-    satisfy { MacOS::CLT.installed? }
-  end
+  pour_bottle? only_if: :clt_installed
 
   depends_on xcode: ["12.5", :build]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://github.com/Homebrew/brew/pull/11389

Now that https://github.com/Homebrew/brew/pull/11389 has been merged and tagged, we can use preset symbols (which right now only includes the `:clt_required` symbol) here to replace the often-used `pour_bottle?` block that checks whether the CLT is installed or not.

There are a few groups of formulae affected:

---

First is `python` formulae. There should be no functional or messaging changes for these formulae

---

Next are the `gcc` and `llvm` formulae. While there are no functional changes to these, the message that's displayed when attempting to install from a bottle without the CLT installed has changed from this:

```
The bottle needs the Xcode CLT to be installed.
```

To this:

```
The bottle needs the Apple Command Line Tools to be installed.
  You can install them, if desired, with:
    xcode-select --install
```

---

Lastly, the `swift-format` and `libgccjit` formulae _may_ have functional changes. Before, their `pour_bottle?` blocks looked like this:

```ruby
pour_bottle? do
  reason "The bottle needs the Xcode CLT to be installed."
  satisfy { MacOS::CLT.installed? }
end
```

Now, they are equivalent to this:

```ruby
pour_bottle? do
  on_macos do
    reason <<~EOS
      The bottle needs the Apple Command Line Tools to be installed.
        You can install them, if desired, with:
          xcode-select --install
    EOS
    satisfy { MacOS::CLT.installed? }
  end
end
```

Note the addition of an `on_macos` block in addition to the messaging change. I don't think this will be an issue because neither of these formulae have Linux bottles and even if they did, they couldn't depend on the CLT being installed so it would seem reasonable for this to be moved to an `on_macos` block anyway.
