### PR TITLE
six: build for multiple pythons

### DIFF
--- a/Formula/six.rb
+++ b/Formula/six.rb
@@ -6,22 +6,29 @@ class Six < Formula
   url "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
   sha256 "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "33a1b6980a4636327e204a1d9a0cbf5c7c9286e56e3ba6b1226e63b93fc01fb9"
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.7" => [:build, :test] unless Hardware::CPU.arm?
+  depends_on "python@3.8" => [:build, :test]
+  depends_on "python@3.9" => [:build, :test]
 
   def install
-    system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
+    deps.map(&:to_formula).each do |python|
+      system python.opt_bin/"python3", *Language::Python.setup_install_args(prefix)
+    end
   end
 
   test do
-    system Formula["python@3.9"].opt_bin/"python3", "-c", <<~EOS
-      import six
-      assert not six.PY2
-      assert six.PY3
-    EOS
+    deps.map(&:to_formula).each do |python|
+      system python.opt_bin/"python3", "-c", <<~EOS
+        import six
+        assert not six.PY2
+        assert six.PY3
+      EOS
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This will allow it to be used as a dependency for formulae that depend
on Python3.7 or Python3.8.

This also makes it easier to use as a dependency for `protobuf`. (#75381)