### PR TITLE
ship: fix build - incompatible node@16 and node-sass@4

### DIFF
--- a/Formula/ship.rb
+++ b/Formula/ship.rb
@@ -13,7 +13,8 @@ class Ship < Formula
   end
 
   depends_on "go" => :build
-  depends_on "node" => :build
+  # Switch to `node` when ship updates dependency node-sass>=6.0.0
+  depends_on "node@14" => :build
   depends_on "yarn" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

One of failures from https://github.com/Homebrew/homebrew-core/pull/76791#issuecomment-835534109

Node@16
```make
❯ brew install ship --build-from-source
==> Downloading https://github.com/replicatedhq/ship/archive/v0.55.0.tar.gz
Already downloaded: /Users/cho-m/Library/Caches/Homebrew/downloads/5f17222cc17e06b4852f1c15fe257233af704d3b0c490836b4f9359f7c1a37bc--ship-0.55.0.tar.gz
==> make VERSION=0.55.0 build-minimal
Last 15 lines from /Users/cho-m/Library/Logs/Homebrew/ship/01.make:
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/private/tmp/ship-20210518-23506-v4uxml/ship-0.55.0/web/app/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (node:events:365:28)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)
gyp ERR! System Darwin 20.4.0
gyp ERR! command "/opt/homebrew/Cellar/node/16.1.0/bin/node" "/private/tmp/ship-20210518-23506-v4uxml/ship-0.55.0/web/app/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
gyp ERR! cwd /private/tmp/ship-20210518-23506-v4uxml/ship-0.55.0/web/app/node_modules/node-sass
gyp ERR! node -v v16.1.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
Build failed with error code: 1
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
make[1]: *** [.state/package] Error 1
make: *** [build-ui] Error 2
```

Node@14:
```make
❯ brew install ship --build-from-source
==> Downloading https://github.com/replicatedhq/ship/archive/v0.55.0.tar.gz
Already downloaded: /Users/cho-m/Library/Caches/Homebrew/downloads/5f17222cc17e06b4852f1c15fe257233af704d3b0c490836b4f9359f7c1a37bc--ship-0.55.0.tar.gz
==> make VERSION=0.55.0 build-minimal
🍺  /opt/homebrew/Cellar/ship/0.55.0: 5 files, 68.2MB, built in 3 minutes 40 seconds
```