### PR TITLE
carrot2: use gradlew to build with Gradle 6

### DIFF
--- a/Formula/carrot2.rb
+++ b/Formula/carrot2.rb
@@ -12,16 +12,11 @@ class Carrot2 < Formula
     sha256 cellar: :any_skip_relocation, mojave:   "dd82165536db4f4a723d1789f376dca7c1a617fc1ee402818e991ff8734c39d5"
   end
 
-  depends_on "gradle" => :build
   depends_on "openjdk"
 
   def install
-    # Make possible to build the formula with the latest available in Homebrew gradle
-    inreplace "gradle/validation/check-environment.gradle",
-      /expectedGradleVersion = '[^']+'/,
-      "expectedGradleVersion = '#{Formula["gradle"].version}'"
-
-    system "gradle", "assemble", "--no-daemon"
+    # Remove `./gradlew` and use Homebrew gradle when carrot2 supports Gradle 7+
+    system "./gradlew", "assemble", "--no-daemon"
 
     cd "distribution/build/dist" do
       inreplace "dcs/conf/logging/appender-file.xml", "${dcs:home}/logs", var/"log/carrot2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

May need to confirm that `./gradlew` is drop-in replacement to `gradle`.

From `carrot2` release workflow: https://github.com/carrot2/carrot2/blob/master/etc/release-workflow.txt#L18, the command used is `gradlew clean assemble check`. Probably fine with only `assemble` like previous formula since build dir is already clean and might not need to run checks.

Homebrew `gradle` (7.0.2) failure:
```console
❯ brew install carrot2 --build-from-source
==> Cloning https://github.com/carrot2/carrot2.git
Updating /Users/cho-m/Library/Caches/Homebrew/carrot2--git
==> Checking out tag release/4.2.1
HEAD is now at 936bcf7fa Merge branch 'master' into bugfix/4.2.x
HEAD is now at 936bcf7fa Merge branch 'master' into bugfix/4.2.x
Entering 'dcs/contexts/frontend/theme'
Entering 'dcs/contexts/frontend/ui'
/Users/cho-m/Library/Caches/Homebrew/carrot2--git/dcs/contexts/frontend/theme
/Users/cho-m/Library/Caches/Homebrew/carrot2--git/dcs/contexts/frontend/ui
==> gradle assemble --no-daemon
Last 15 lines from /Users/cho-m/Library/Logs/Homebrew/carrot2/01.gradle:
* Where:
Build file '/private/tmp/carrot2-20210518-23541-1tyuu5l/core/build.gradle' line: 1

* What went wrong:
A problem occurred evaluating project ':core'.
> Failed to apply plugin class 'com.palantir.gradle.versions.FixLegacyJavaConfigurationsPlugin'.
   > Configuration with name 'compile' not found.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
==============================================================================

* Get more help at https://help.gradle.org

BUILD FAILED in 11s
```

Successful build using `./gradlew` (Gradle 6.8.3):
```console
❯ brew install carrot2 --build-from-source
==> Cloning https://github.com/carrot2/carrot2.git
Updating /Users/cho-m/Library/Caches/Homebrew/carrot2--git
==> Checking out tag release/4.2.1
HEAD is now at 936bcf7fa Merge branch 'master' into bugfix/4.2.x
HEAD is now at 936bcf7fa Merge branch 'master' into bugfix/4.2.x
Entering 'dcs/contexts/frontend/theme'
Entering 'dcs/contexts/frontend/ui'
/Users/cho-m/Library/Caches/Homebrew/carrot2--git/dcs/contexts/frontend/theme
/Users/cho-m/Library/Caches/Homebrew/carrot2--git/dcs/contexts/frontend/ui
==> ./gradlew assemble --no-daemon
==> Caveats
To have launchd start carrot2 now and restart at login:
  brew services start carrot2
Or, if you don't want/need a background service you can just run:
  carrot2
==> Summary
🍺  /usr/local/Cellar/carrot2/4.2.1: 865 files, 38.5MB, built in 3 minutes 28 seconds
```