### PR TITLE
gradle@6 6.9 (new formula)

### DIFF
--- a/Formula/gradle@6.rb
+++ b/Formula/gradle@6.rb
@@ -1,0 +1,38 @@
+class GradleAT6 < Formula
+  desc "Open-source build automation tool based on the Groovy and Kotlin DSL"
+  homepage "https://www.gradle.org/"
+  url "https://services.gradle.org/distributions/gradle-6.9-all.zip"
+  sha256 "5d234488d2cac2ed556dc3c47096e189ad76a63cf304ebf124f756498922cf16"
+  license "Apache-2.0"
+
+  keg_only :versioned_formula
+
+  # gradle@6 does not support Java 16
+  if Hardware::CPU.arm?
+    depends_on "openjdk@11"
+  else
+    depends_on "openjdk"
+  end
+
+  def install
+    rm_f Dir["bin/*.bat"]
+    libexec.install %w[bin docs lib src]
+    env = if Hardware::CPU.arm?
+      Language::Java.overridable_java_home_env("11")
+    else
+      Language::Java.overridable_java_home_env
+    end
+    (bin/"gradle").write_env_script libexec/"bin/gradle", env
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gradle --version")
+
+    (testpath/"settings.gradle").write ""
+    (testpath/"build.gradle").write <<~EOS
+      println "gradle works!"
+    EOS
+    gradle_output = shell_output("#{bin}/gradle build --no-daemon")
+    assert_includes gradle_output, "gradle works!"
+  end
+end


### PR DESCRIPTION
This is needed for `opensearch` (new formula incoming) and `elasticsearch` (deprecated but let's fix it anyway in this PR). 

Also, bung in a quick `elasticsearch@6` cleanup, too.