### PR TITLE
opensearch 1.0.0-beta1 (new formula)

### DIFF
--- a/Formula/opensearch.rb
+++ b/Formula/opensearch.rb
@@ -1,0 +1,95 @@
+class Opensearch < Formula
+  desc "Open source distributed and RESTful search engine"
+  homepage "https://github.com/opensearch-project/OpenSearch"
+  url "https://github.com/opensearch-project/OpenSearch/archive/refs/tags/1.0.0-beta1.tar.gz"
+  sha256 "d23385aa42f636049ae270bdb496843dc8d2dfd88bd7f4761e305e8193b76399"
+  license "Apache-2.0"
+
+  depends_on "gradle@6" => :build
+  depends_on "openjdk"
+
+  def install
+    system "gradle", ":distribution:archives:no-jdk-darwin-tar:assemble"
+
+    mkdir "tar" do
+      # Extract the package to the tar directory
+      system "tar", "--strip-components=1", "-xf",
+        Dir["../distribution/archives/no-jdk-darwin-tar/build/distributions/opensearch-*.tar.gz"].first
+
+      # Install into package directory
+      libexec.install "bin", "lib", "modules"
+
+      # Set up Opensearch for local development:
+      inreplace "config/opensearch.yml" do |s|
+        # 1. Give the cluster a unique name
+        s.gsub!(/#\s*cluster\.name: .*/, "cluster.name: opensearch_homebrew")
+
+        # 2. Configure paths
+        s.sub!(%r{#\s*path\.data: /path/to.+$}, "path.data: #{var}/lib/opensearch/")
+        s.sub!(%r{#\s*path\.logs: /path/to.+$}, "path.logs: #{var}/log/opensearch/")
+      end
+
+      inreplace "config/jvm.options", %r{logs/gc.log}, "#{var}/log/opensearch/gc.log"
+
+      # add placeholder to avoid removal of empty directory
+      touch "config/jvm.options.d/.keepme"
+
+      # Move config files into etc
+      (etc/"opensearch").install Dir["config/*"]
+    end
+
+    inreplace libexec/"bin/opensearch-env",
+              "if [ -z \"$OPENSEARCH_PATH_CONF\" ]; then OPENSEARCH_PATH_CONF=\"$OPENSEARCH_HOME\"/config; fi",
+              "if [ -z \"$OPENSEARCH_PATH_CONF\" ]; then OPENSEARCH_PATH_CONF=\"#{etc}/opensearch\"; fi"
+
+    bin.install libexec/"bin/opensearch",
+                libexec/"bin/opensearch-keystore",
+                libexec/"bin/opensearch-plugin",
+                libexec/"bin/opensearch-shard"
+    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Formula["openjdk"].opt_prefix)
+  end
+
+  def post_install
+    # Make sure runtime directories exist
+    (var/"lib/opensearch").mkpath
+    (var/"log/opensearch").mkpath
+    ln_s etc/"opensearch", libexec/"config" unless (libexec/"config").exist?
+    (var/"opensearch/plugins").mkpath
+    ln_s var/"opensearch/plugins", libexec/"plugins" unless (libexec/"plugins").exist?
+    # fix test not being able to create keystore because of sandbox permissions
+    system bin/"opensearch-keystore", "create" unless (etc/"opensearch/opensearch.keystore").exist?
+  end
+
+  def caveats
+    <<~EOS
+      Data:    #{var}/lib/opensearch/
+      Logs:    #{var}/log/opensearch/opensearch_homebrew.log
+      Plugins: #{var}/opensearch/plugins/
+      Config:  #{etc}/opensearch/
+    EOS
+  end
+
+  plist_options manual: "opensearch"
+  service do
+    run opt_bin/"opensearch"
+    working_dir var
+    log_path var/"log/opensearch.log"
+    error_log_path var/"log/opensearch.log"
+  end
+
+  test do
+    port = free_port
+    (testpath/"data").mkdir
+    (testpath/"logs").mkdir
+    fork do
+      exec bin/"opensearch", "-Ehttp.port=#{port}",
+                                "-Epath.data=#{testpath}/data",
+                                "-Epath.logs=#{testpath}/logs"
+    end
+    sleep 20
+    output = shell_output("curl -s -XGET localhost:#{port}/")
+    assert_equal "opensearch", JSON.parse(output)["version"]["distribution"]
+
+    system "#{bin}/opensearch-plugin", "list"
+  end
+end

--- a/audit_exceptions/unstable_allowlist.json
+++ b/audit_exceptions/unstable_allowlist.json
@@ -4,6 +4,7 @@
   "aview": "1.3.0rc",
   "ftgl": "2.1.3-rc",
   "libcaca": "0.99b",
+  "opensearch": "1.0.0-beta",
   "premake": "4.4-beta",
   "pwnat": "0.3-beta",
   "recode": "3.7-beta",


### PR DESCRIPTION
Modified from the `elasticsearch` formula. Builds and passes tests. I realise this is still a beta release but I think we should include it sooner rather than later to give people time to migrate from `elasticsearch`.