### PR TITLE
clazy: depend on `llvm@11`

### DIFF
--- a/Formula/clazy.rb
+++ b/Formula/clazy.rb
@@ -4,7 +4,7 @@ class Clazy < Formula
   url "https://download.kde.org/stable/clazy/1.9/src/clazy-1.9.tar.xz"
   sha256 "4c6c2e473e6aa011cc5fab120ebcffec3fc11a9cc677e21ad8c3ea676eb076f8"
   license "LGPL-2.0-or-later"
-  revision 1
+  revision 2
   head "https://invent.kde.org/sdk/clazy.git"
 
   livecheck do
@@ -20,18 +20,15 @@ class Clazy < Formula
   end
 
   depends_on "cmake"   => [:build, :test]
-  depends_on "llvm@11" => [:build, :test]
   depends_on "qt"      => :test
-
   depends_on "coreutils"
+  depends_on "llvm@11"
 
   uses_from_macos "libxml2"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   def install
-    # avoid use llvm libc++
-    ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm@11"].opt_lib
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This still has linkage with `llvm@11` despite the formula going out of
its way to avoid it.

Unfortunately, this gets missed by `brew linkage --test`. See
Homebrew/homebrew-test-bot#611.