### PR TITLE
volta: add caveats

### DIFF
--- a/Formula/volta.rb
+++ b/Formula/volta.rb
@@ -37,6 +37,13 @@ class Volta < Formula
     (fish_completion/"volta.fish").write fish_output
   end
 
+  def caveats
+    <<~EOS
+      If you have already installed tools using Volta, you need to migrate them manually:
+        volta setup
+    EOS
+  end
+
   test do
     system "#{bin}/volta", "install", "node@12.16.1"
     node = shell_output("#{bin}/volta which node").chomp


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Per the discussion in https://github.com/volta-cli/volta/issues/927

Volta installs tools in $VOLTA_HOME (~/.volta by default).
Those tools may need to be migrated after upgrading Volta.