### PR TITLE
gnupg: disable-ccid for scdaemon on macos

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -4,6 +4,7 @@ class Gnupg < Formula
   url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.3.1.tar.bz2"
   sha256 "c498db346a9b9a4b399e514c8f56dfc0a888ce8f327f10376ff984452cd154ec"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gnupg/"
@@ -49,11 +50,21 @@ class Gnupg < Formula
     system "make"
     system "make", "check"
     system "make", "install"
+
+    # Configure scdaemon as recommended by upstream developers
+    # https://dev.gnupg.org/T5415#145864
+    on_macos do
+      # write to buildpath then install to ensure existing files are not clobbered
+      (buildpath/"scdaemon.conf").write <<~EOS
+        disable-ccid
+      EOS
+      pkgetc.install "scdaemon.conf"
+    end
   end
 
   def post_install
     (var/"run").mkpath
-    quiet_system "killall", "gpg-agent"
+    quiet_system "gpgconf", "--reload", "all"
   end
 
   test do


### PR DESCRIPTION
Fixes "Operation not supported by device" bug for smart cards on macos:
https://dev.gnupg.org/T5409

This was a breaking change in gnupg 2.3.1 and the gnupg devs consider it
working as designed. Their recommendation:

> [...] - better tell the macOS folks to put disable-ccid into /etc/gnupg/scdaemon.conf

https://dev.gnupg.org/T5415#145864
