### PR TITLE
druid: force stop zookeeper in test

### DIFF
--- a/Formula/druid.rb
+++ b/Formula/druid.rb
@@ -84,6 +84,8 @@ class Druid < Formula
       assert_match "version", output
     ensure
       system bin/"druid-broker.sh", "stop"
+      # force zookeeper stop since it is sometimes still alive after druid-broker.sh finishes
+      system Formula["zookeeper"].opt_bin/"zkServer", "stop"
       Process.wait pid
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`druid` test sometimes finish with a `zookeeper` process still running, but not every time. The original `pid` couldn't be used because `zookeeper` is a process spawned by `druid-broker.sh`. I've been able to reproduce the issue locally and it didn't reappear with this fix. Spotted in #72535.