### PR TITLE
erlang@23 23.3.4 (new formula)

### DIFF
--- a/Formula/erlang@23.rb
+++ b/Formula/erlang@23.rb
@@ -1,0 +1,98 @@
+class ErlangAT23 < Formula
+  desc "Programming language for highly scalable real-time systems"
+  homepage "https://www.erlang.org/"
+  # Download tarball from GitHub; it is served faster than the official tarball.
+  url "https://github.com/erlang/otp/releases/download/OTP-23.3.4/otp_src_23.3.4.tar.gz"
+  sha256 "e19e6e0eebcee3b6165db33a8f7cea7d70c5b98ea41bd336a6fe26ddf775a2bb"
+  license "Apache-2.0"
+
+  livecheck do
+    url :stable
+    regex(/^OTP[._-]v?(23(?:\.\d+)+)$/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "openssl@1.1"
+  depends_on "wxmac" # for GUI apps like observer
+
+  resource "html" do
+    url "https://www.erlang.org/download/otp_doc_html_23.3.tar.gz"
+    mirror "https://fossies.org/linux/misc/otp_doc_html_23.3.tar.gz"
+    sha256 "03d86ac3e71bb58e27d01743a9668c7a1265b573541d4111590f0f3ec334383e"
+  end
+
+  def install
+    # Unset these so that building wx, kernel, compiler and
+    # other modules doesn't fail with an unintelligible error.
+    %w[LIBS FLAGS AFLAGS ZFLAGS].each { |k| ENV.delete("ERL_#{k}") }
+
+    args = %W[
+      --disable-debug
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --enable-dynamic-ssl-lib
+      --enable-hipe
+      --enable-shared-zlib
+      --enable-smp-support
+      --enable-threads
+      --enable-wx
+      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
+      --without-javac
+    ]
+
+    on_macos do
+      args << "--enable-darwin-64bit"
+      args << "--enable-kernel-poll" if MacOS.version > :el_capitan
+      args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Build the doc chunks (manpages are also built by default)
+    system "make", "docs", "DOC_TARGETS=chunks"
+    system "make", "install-docs"
+
+    doc.install resource("html")
+  end
+
+  def caveats
+    <<~EOS
+      Man pages can be found in:
+        #{opt_lib}/erlang/man
+
+      Access them with `erl -man`, or add this directory to MANPATH.
+    EOS
+  end
+
+  test do
+    system "#{bin}/erl", "-noshell", "-eval", "crypto:start().", "-s", "init", "stop"
+    (testpath/"factorial").write <<~EOS
+      #!#{bin}/escript
+      %% -*- erlang -*-
+      %%! -smp enable -sname factorial -mnesia debug verbose
+      main([String]) ->
+          try
+              N = list_to_integer(String),
+              F = fac(N),
+              io:format("factorial ~w = ~w\n", [N,F])
+          catch
+              _:_ ->
+                  usage()
+          end;
+      main(_) ->
+          usage().
+
+      usage() ->
+          io:format("usage: factorial integer\n").
+
+      fac(0) -> 1;
+      fac(N) -> N * fac(N-1).
+    EOS
+    chmod 0755, "factorial"
+    assert_match "usage: factorial integer", shell_output("./factorial")
+    assert_match "factorial 42 = 1405006117752879898543142606244511569936384000000000", shell_output("./factorial 42")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

With `erlang` updated to 24.0, `erlang@23` is only recent version missing
(given there is `erlang@21`, `erlang@22`, and `erlang@24 == erlang`)

Formula based on recent updates in `erlang` formula (#77620) and using some syntax/format from previous `erlang@22`.