### PR TITLE
bear, grpc, mavsdk, pdnsrec: check for compiler version instead of OS version

### DIFF
--- a/Formula/bear.rb
+++ b/Formula/bear.rb
@@ -29,7 +29,7 @@ class Bear < Formula
   uses_from_macos "llvm" => :test
 
   on_macos do
-    depends_on "llvm" if MacOS.version <= :mojave
+    depends_on "llvm" if DevelopmentTools.clang_build_version <= 1100
   end
 
   on_linux do
@@ -48,7 +48,7 @@ class Bear < Formula
 
   def install
     on_macos do
-      ENV.llvm_clang if MacOS.version <= :mojave
+      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1100
     end
 
     args = std_cmake_args + %w[

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -35,7 +35,7 @@ class Grpc < Formula
   uses_from_macos "zlib"
 
   on_macos do
-    depends_on "llvm" => :build if MacOS.version <= :mojave
+    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
   end
 
   fails_with :clang do
@@ -46,7 +46,7 @@ class Grpc < Formula
   def install
     ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
     on_macos do
-      ENV.llvm_clang if MacOS.version <= :mojave
+      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1100
     end
     mkdir "cmake/build" do
       args = %W[

--- a/Formula/mavsdk.rb
+++ b/Formula/mavsdk.rb
@@ -38,7 +38,7 @@ class Mavsdk < Formula
   uses_from_macos "zlib"
 
   on_macos do
-    depends_on "llvm" if MacOS.version <= :mojave
+    depends_on "llvm" if DevelopmentTools.clang_build_version <= 1100
   end
 
   fails_with :clang do
@@ -71,7 +71,7 @@ class Mavsdk < Formula
 
   def install
     on_macos do
-      ENV.llvm_clang if MacOS.version <= :mojave
+      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1100
     end
 
     # Install protoc-gen-mavsdk deps

--- a/Formula/pdnsrec.rb
+++ b/Formula/pdnsrec.rb
@@ -23,7 +23,7 @@ class Pdnsrec < Formula
   depends_on "openssl@1.1"
 
   on_macos do
-    depends_on "llvm" => :build if MacOS.version <= :mojave
+    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
   end
 
   on_linux do
@@ -44,7 +44,7 @@ class Pdnsrec < Formula
     ENV.cxx11
     ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
     on_macos do
-      ENV.llvm_clang if MacOS.version <= :mojave
+      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1100
     end
 
     args = %W[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This check is more consistent with the `fails_with` stanza, which changes the compiler from system Clang when the installed CLT is old enough. I imagine this could technically apply to Catalina too.