### PR TITLE
iozone: tarball fixes, sha256 change

### DIFF
--- a/Formula/iozone.rb
+++ b/Formula/iozone.rb
@@ -2,8 +2,9 @@ class Iozone < Formula
   desc "File system benchmark tool"
   homepage "https://www.iozone.org/"
   url "https://www.iozone.org/src/current/iozone3_491.tgz"
-  sha256 "057d310cc0c16fcb35ac6de25bee363d54503377cbd93a6122797f8277aab6f0"
+  sha256 "efeea0e84ccd9b92920c60e2668caf6ef595c5d95e6cea89760a62eb64365df8"
   license :cannot_represent
+  revision 1
 
   livecheck do
     url "https://www.iozone.org/src/current/"


### PR DESCRIPTION
Upstream confirmed changes to the Makefile:

> The change was to the "makefile".  It was a recommended change the compile and link phases so that it would build more cleanly on Fedora releases.
> There was no functionality change to Iozone.  Just the makefile.

but there were also unexpected Linux binary artifacts in the revised tarball, which break the formula build when Homebrew tries to link against them:

> The objects and pre-built binaries in iozone3_491.tar and iozone3_491.tgz were not intended.  I have repackaged and uploaded the new tar balls.

I've verified that the current (revised^2) tarball no longer includes those artifacts, and builds/tests fine locally. Closes #77494. 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
