### PR TITLE
erlang@22 22.3.4.18

### DIFF
--- a/Formula/erlang@22.rb
+++ b/Formula/erlang@22.rb
@@ -2,8 +2,8 @@ class ErlangAT22 < Formula
   desc "Programming language for highly scalable real-time systems"
   homepage "https://www.erlang.org/"
   # Download tarball from GitHub; it is served faster than the official tarball.
-  url "https://github.com/erlang/otp/archive/OTP-22.3.4.16.tar.gz"
-  sha256 "92160456fde968208839663d9568a56964c8f0d6220ab57f6bdf078c4c26d854"
+  url "https://github.com/erlang/otp/releases/download/OTP-22.3.4.18/otp_src_22.3.4.18.tar.gz"
+  sha256 "06ca9f9a0de38bae76c3badeab182d694148e79211514a3ee6f0ce798b99f09a"
   license "Apache-2.0"
 
   livecheck do
@@ -20,23 +20,16 @@ class ErlangAT22 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
   depends_on "openssl@1.1"
   depends_on "wxmac" # for GUI apps like observer
 
-  uses_from_macos "m4" => :build
-
   resource "man" do
     url "https://www.erlang.org/download/otp_doc_man_22.3.tar.gz"
-    mirror "https://fossies.org/linux/misc/otp_doc_man_22.3.tar.gz"
     sha256 "43b6d62d9595e1dc51946d55c9528c706c5ae753876b9bf29303b7d11a7ccb16"
   end
 
   resource "html" do
     url "https://www.erlang.org/download/otp_doc_html_22.3.tar.gz"
-    mirror "https://fossies.org/linux/misc/otp_doc_html_22.3.tar.gz"
     sha256 "9b01c61f2898235e7f6643c66215d6419f8706c8fdd7c3e0123e68960a388c34"
   end
 
@@ -45,16 +38,12 @@ class ErlangAT22 < Formula
     # other modules doesn't fail with an unintelligible error.
     %w[LIBS FLAGS AFLAGS ZFLAGS].each { |k| ENV.delete("ERL_#{k}") }
 
-    # Do this if building from a checkout to generate configure
-    system "./otp_build", "autoconf" if File.exist? "otp_build"
-
     args = %W[
       --disable-debug
       --disable-silent-rules
       --prefix=#{prefix}
       --enable-dynamic-ssl-lib
       --enable-hipe
-      --enable-sctp
       --enable-shared-zlib
       --enable-smp-support
       --enable-threads


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Note, I remove resource `mirror` URLs as they weren't working (not sure if there is an alternative):
```console
❯ curl -sI "https://fossies.org/linux/misc/otp_doc_html_22.3.tar.gz" | grep HTTP
HTTP/1.1 410 Gone

❯ curl -sI "https://fossies.org/linux/misc/otp_doc_man_22.3.tar.gz" | grep HTTP
HTTP/1.1 410 Gone
```

Updated to latest version and matched build of v23 and v24.