### PR TITLE
carrot2: use versioned gradle@6 as dependency

### DIFF
--- a/Formula/carrot2.rb
+++ b/Formula/carrot2.rb
@@ -13,11 +13,17 @@ class Carrot2 < Formula
     sha256 cellar: :any_skip_relocation, mojave:   "ff58dbebfb493939e5d07f9984fb4a32e34e00cf8b188829703ba6fc04c47658"
   end
 
+  # Switch to `gradle` when carrot2 supports Gradle 7+
+  depends_on "gradle@6" => :build
   depends_on "openjdk"
 
   def install
-    # Remove `./gradlew` and use Homebrew gradle when carrot2 supports Gradle 7+
-    system "./gradlew", "assemble", "--no-daemon"
+    # Make possible to build the formula with the latest available in Homebrew gradle
+    inreplace "gradle/validation/check-environment.gradle",
+      /expectedGradleVersion = '[^']+'/,
+      "expectedGradleVersion = '#{Formula["gradle@6"].version}'"
+
+    system "gradle", "assemble", "--no-daemon"
 
     cd "distribution/build/dist" do
       inreplace "dcs/conf/logging/appender-file.xml", "${dcs:home}/logs", var/"log/carrot2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Revert some of #77587 and switch to using Homebrew's new versioned `gradle@6` (#77591)
