### PR TITLE
ghostscript 9.54.0

### DIFF
--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -4,7 +4,7 @@ class Imagemagick < Formula
   url "https://www.imagemagick.org/download/releases/ImageMagick-7.0.11-13.tar.xz"
   sha256 "11797503bc4dd72c7e65e60783e156fd74ec0a551d2f1fe1f41eaa4bd06987a5"
   license "ImageMagick"
-  revision 1
+  revision 2
   head "https://github.com/ImageMagick/ImageMagick.git", branch: "main"
 
   livecheck do

--- a/Formula/imagemagick@6.rb
+++ b/Formula/imagemagick@6.rb
@@ -7,6 +7,7 @@ class ImagemagickAT6 < Formula
   url "https://www.imagemagick.org/download/releases/ImageMagick-6.9.12-13.tar.xz"
   sha256 "a72cb13e79a0878a6fd07f877a61e683c29b646d4fd3ca9ff1ddc042cae846c6"
   license "ImageMagick"
+  revision 1
   head "https://github.com/imagemagick/imagemagick6.git"
 
   livecheck do

--- a/Formula/libgxps.rb
+++ b/Formula/libgxps.rb
@@ -4,6 +4,8 @@ class Libgxps < Formula
   url "https://download.gnome.org/sources/libgxps/0.3/libgxps-0.3.2.tar.xz"
   sha256 "6d27867256a35ccf9b69253eb2a88a32baca3b97d5f4ef7f82e3667fa435251c"
   license "LGPL-2.1-or-later"
+  revision 1
+  head "https://gitlab.gnome.org/GNOME/libgxps.git"
 
   livecheck do
     url :stable
@@ -17,9 +19,7 @@ class Libgxps < Formula
     sha256 cellar: :any, mojave:        "b1d3ce677599e912000eae265d671a8e38f21daefadcb0dd23845b8130665295"
   end
 
-  head do
-    url "https://gitlab.gnome.org/GNOME/libgxps.git"
-  end
+  keg_only "it conflicts with `ghostscript`"
 
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
@@ -36,6 +36,13 @@ class Libgxps < Formula
       system "ninja", "-v"
       system "ninja", "install", "-v"
     end
+  end
+
+  def caveats
+    <<~EOS
+      `ghostscript` now installs a conflicting #{shared_library("libgxps")}.
+      You may need to `brew unlink libgxps` if you have both installed.
+    EOS
   end
 
   test do

--- a/Formula/libspectre.rb
+++ b/Formula/libspectre.rb
@@ -4,7 +4,7 @@ class Libspectre < Formula
   url "https://libspectre.freedesktop.org/releases/libspectre-0.2.9.tar.gz"
   sha256 "49ae9c52b5af81b405455c19fe24089d701761da2c45d22164a99576ceedfbed"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://libspectre.freedesktop.org/releases/"

--- a/Formula/xfig.rb
+++ b/Formula/xfig.rb
@@ -4,6 +4,7 @@ class Xfig < Formula
   url "https://downloads.sourceforge.net/mcj/xfig-3.2.8a.tar.xz"
   sha256 "ba43c0ea85b230d3efa5a951a3239e206d0b033d044c590a56208f875f888578"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Previous attempt: #74225

---

While building on macOS at `make install-so`, there was a `make` failure, which appears due to parallel `mkdir` calls:
```make
mkdir: ./sobin: File exists
mkdir: ./sobin: File exists
make[2]: *** [directories] Error 1
make[2]: *** [directories] Error 1
make[1]: *** [so-only-subtarget] Error 2
make[1]: *** [so-only-subtarget] Error 2
```

I think this is around location Linux is hitting issue, so I consolidated the deparallelize, but may need confirmation from Linux side.

---

Try to replace 9 vendored dependencies:
- `libtiff` - previously added to formula, but never actually used as need `--with-system-libtiff` argument
- Use from Homebrew by deleting source tree:
    - `freetype`
    - `jbig2dec`
    - `jpeg`
    - `libpng`
    - `little-cms2`
    - `openjpeg`
- Use from macOS by deleting source tree:
    - `expat`
    - `zlib`

---

Currently enabled vendored Tesseract/leptonica, but can choose to disable via `--without-tesseract`

When building with Tesseract, hit issues for:
- cstring/etc missing ==> added `-stdlib=libc++` for clang (not sure if needed on GCC)
- hit `<version>` header issue ==> manually deleted file