### PR TITLE
opencascade: update livecheck

### DIFF
--- a/Formula/opencascade.rb
+++ b/Formula/opencascade.rb
@@ -6,9 +6,17 @@ class Opencascade < Formula
   sha256 "3a43d8b50df78ade72786fa63bc8808deac6380189333663e7b4ef8558ae7739"
   license "LGPL-2.1-only"
 
+  # The first-party download page (https://dev.opencascade.org/release)
+  # references version 7.5.0 and hasn't been updated for later maintenance
+  # releases (e.g., 7.5.1, 7.5.2), so we check the Git tags instead. Release
+  # information is posted at https://dev.opencascade.org/forums/occt-releases
+  # but the text varies enough that we can't reliably match versions from it.
   livecheck do
-    url "https://dev.opencascade.org/release"
-    regex(/href=.*?opencascade[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://git.dev.opencascade.org/repos/occt.git"
+    regex(/^v?(\d+(?:[._]\d+)+(?:p\d+)?)$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.gsub("_", ".") }.compact
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `opencascade` checks the [first-party download page](https://dev.opencascade.org/release) but this gives `7.5.0` as the newest release and doesn't list the later maintenance releases (e.g., `7.5.1`, `7.5.2`) posted on the [OCCT Releases](https://dev.opencascade.org/forums/occt-releases) part of the forum.

The text on the OCCT Releases forum page isn't standardized, so we can't check that for versions. This PR checks the Git tags from the repository where the `stable` tag archive comes from (converting the `1_2_3` tag format to the `1.2.3` formula version format in the `strategy` block).

If the download page starts being reliably updated in the future we can consider checking that again but the updated `livecheck` block in this PR seems to align with our current approach to updating this formula (seeing as we've updated to the `7.5.1` maintenance release and attempted to update to the `7.5.2` maintenance release).