### PR TITLE
graphql-cli: add livecheck

### DIFF
--- a/Formula/graphql-cli.rb
+++ b/Formula/graphql-cli.rb
@@ -7,6 +7,14 @@ class GraphqlCli < Formula
   sha256 "c52d62ac108d4a3f711dbead0939bd02e3e2d0c82f8480fd76fc28f285602f5c"
   license "MIT"
 
+  # The Npm page is nearly 2 MB compressed (due to there being thousands
+  # of pre-release versions of the package) and livecheck can time out, so we
+  # check the Git tags in this instance.
+  livecheck do
+    url :homepage
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "2da205bbd5c76588be334a84b52dacfac9062045d605ed3f8298b7cb7b9b84a7"
     sha256 big_sur:       "02d60908557d5dedf63fffe66a51f5829807abd910b5460a2ae44d7b8d208142"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck uses the `Npm` strategy on the `stable` URL to identify the latest version from the `graphql-cli` package. This currently works but it will start to time out when livecheck is switched from `open-uri` to `Utils::Curl` in the near future. This may be because the npm page is nearly 2 MB compressed (8 MB uncompressed), as there are thousands of pre-release versions of the package.

Either way, we don't really want to be downloading 2 MB for one check, so this PR adds a `livecheck` block that checks the Git tags instead. We generally prefer to keep the check aligned with the `stable` source (npm) but this is an exceptional situation.

Depending on how upstream does releases, there may be some latency between when a tag is created on GitHub and the related tarball is available on npm, so we may need to revisit this if it becomes a problem.

---

The main alternative I see is fetching the npm JSON information for the package (https://registry.npmjs.org/graphql-cli) and restricting the request to the first X bytes using the `Range` header (e.g., `Range: bytes=0-1000`). The `latest` version information is near the beginning of the JSON data, so we only need the first KB or so and wouldn't need to fetch all 2 MB (and growing!) here.

This isn't technically possible in livecheck at the moment but I have some local in-progress work which allows for client/request configuration (in a `livecheck` block or `Strategy`) and I'll create a PR for that sometime after I've finished the open livecheck/curl PRs in Homebrew/brew. After that, we should be able to modify the `Npm` strategy to use this approach by default and it would speed things up (avoiding this timeout) and avoid transferring a lot of unnecessary data.