### PR TITLE
latino 1.4.1

### DIFF
--- a/Formula/latino.rb
+++ b/Formula/latino.rb
@@ -1,10 +1,11 @@
 class Latino < Formula
   desc "Lenguaje de programación de código abierto para latinos y de habla hispana"
   homepage "https://www.lenguajelatino.org/"
-  url "https://github.com/MelvinG24/Latino/archive/v1.3.0.tar.gz"
-  sha256 "28118a047265394ad9a5fcb2c76895d08af4b43a5886f52afce98a0f8cdc86fe"
+  url "https://github.com/lenguaje-latino/latino.git",
+      tag:      "v1.4.1",
+      revision: "3ec6ab29902acb0b353cfe9a7b5d0317785fbd88"
   license "MIT"
-  head "https://github.com/MelvinG24/Latino"
+  head "https://github.com/lenguaje-latino/latino.git"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "dab07196acce245e9876fac1be97127e65d0111ffdbf7e08695cb7468c12b060"
@@ -16,7 +17,6 @@ class Latino < Formula
   depends_on "cmake" => :build
 
   def install
-    mv "logo/Latino-logo.png", "logo/desktop.png"
     system "cmake", ".", *std_cmake_args
     system "make"
     system "make", "install"
@@ -25,15 +25,13 @@ class Latino < Formula
   test do
     (testpath/"test1.lat").write "poner('hola mundo')"
     (testpath/"test2.lat").write <<~EOS
-      i=0
-      repetir
-        poner(i)
-        i++
-      hasta(i>=10)
+      desde (i = 0; i <= 10; i++)
+        escribir(i)
+      fin
     EOS
     output = shell_output("#{bin}/latino test1.lat")
     assert_equal "hola mundo", output.chomp
     output2 = shell_output("#{bin}/latino test2.lat")
-    assert_equal "0\n1\n2\n3\n4\n5\n6\n7\n8\n9", output2.chomp
+    assert_equal "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10", output2.chomp
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR bumps `latino` to `1.4.1` and updates the Formula to pull from the tag, as they've changed their repository structure to use submodules (for their own project and not other/external dependencies).

The project has also moved to another GitHub organisation, so the URLs have been updated accordingly.