### PR TITLE
truncate: deprecate

### DIFF
--- a/Formula/truncate.rb
+++ b/Formula/truncate.rb
@@ -17,6 +17,8 @@ class Truncate < Formula
     sha256 cellar: :any_skip_relocation, yosemite:      "a9d1c87d6cfec42674f0e7db25b786ba100a04c8c0da318fd5f6299a7418843f"
   end
 
+  deprecate! date: "2021-05-20", because: :repo_removed
+
   conflicts_with "coreutils", because: "both install `truncate` binaries"
   conflicts_with "uutils-coreutils", because: "both install `truncate` binaries"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The GitHub repository for `truncate` has been removed and, looking at the [most recent snapshot on archive.org](https://web.archive.org/web/20201120180343/https://github.com/flok99/truncate), it hadn't been updated since 2016 anyway. This PR deprecates the formula accordingly.

I'm currently looking through the other formulae that reference www.vanheusden.com, as that website has also disappeared.