### PR TITLE
genstats: deprecate

### DIFF
--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -15,6 +15,8 @@ class Genstats < Formula
     sha256 cellar: :any_skip_relocation, yosemite:      "91737ec825ed346716fddcedc4e075b195f214dfb22586a33d46f7ec5ea3a17e"
   end
 
+  deprecate! date: "2021-05-20", because: "Upstream website has disappeared"
+
   def install
     # Tried to make this a patch.  Applying the patch hunk would
     # fail, even though I used "git diff | pbcopy". Tried messing


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The upstream webpage for `genstats` (https://www.vanheusden.com/genstats/) has been removed and this applies to all the formulae that reference www.vanheusden.com (`genstats`, `httping`, `multitail`, `rsstail`, `truncate`). Most of these formulae also had GitHub repositories but the related [flok99 account](https://github.com/flok99) has been pretty much wiped clean, so it's unlikely this software will be maintained.