### PR TITLE
httping: deprecate

### DIFF
--- a/Formula/httping.rb
+++ b/Formula/httping.rb
@@ -16,6 +16,8 @@ class Httping < Formula
     sha256 cellar: :any, sierra:        "9d0b6368e6fa4e2b4fb618c7ba3893a5b3b47471b366305026ee75b44d6ce91e"
   end
 
+  deprecate! date: "2021-05-20", because: "Upstream website has disappeared"
+
   depends_on "gettext"
   depends_on "openssl@1.1"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The upstream webpage for `httping` (https://www.vanheusden.com/httping/) has been removed and this applies to all the formulae that reference www.vanheusden.com (`genstats`, `httping`, `multitail`, `rsstail`, `truncate`). Most of these formulae also had GitHub repositories but the related [flok99 account](https://github.com/flok99) has been pretty much wiped clean, so it's unlikely this software will be maintained.