### PR TITLE
multitail: deprecate

### DIFF
--- a/Formula/multitail.rb
+++ b/Formula/multitail.rb
@@ -14,6 +14,8 @@ class Multitail < Formula
     sha256 cellar: :any, high_sierra:   "57526de43035b0d5d2520d54b252d29c20a4efb146c019ac044ad5067be5351a"
   end
 
+  deprecate! date: "2021-05-20", because: "Upstream website has disappeared"
+
   depends_on "pkg-config" => :build
   depends_on "ncurses"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The upstream webpage for `multitail` (https://vanheusden.com/multitail/) has been removed and this applies to all the formulae that reference www.vanheusden.com (`genstats`, `httping`, `multitail`, `rsstail`, `truncate`). Most of these formulae also had GitHub repositories but the related [flok99 account](https://github.com/flok99) has been pretty much wiped clean, so it's unlikely this software will be maintained.