### PR TITLE
rsstail: deprecate

### DIFF
--- a/Formula/rsstail.rb
+++ b/Formula/rsstail.rb
@@ -6,11 +6,6 @@ class Rsstail < Formula
   license "GPL-2.0"
   head "https://github.com/flok99/rsstail.git"
 
-  livecheck do
-    url :homepage
-    regex(/Latest release.*href=.*?rsstail[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any, arm64_big_sur: "6316d9202a28175cb6e2f8451402db38f9d11a581145459ce6e10a49a2096e1c"
@@ -19,6 +14,8 @@ class Rsstail < Formula
     sha256 cellar: :any, mojave:        "b6f2a222c1bc903a5d0179331398ced65980798d694d186bd52e0b54239d9dfd"
     sha256 cellar: :any, high_sierra:   "29b1cd5b6cbfbd66d250586450e2e24e5706da80b03aa1b54834bd0c01e73202"
   end
+
+  deprecate! date: "2021-05-20", because: "Upstream website has disappeared"
 
   depends_on "libmrss"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The upstream webpage for `rsstail` (https://www.vanheusden.com/rsstail/) has been removed and this applies to all the formulae that reference www.vanheusden.com (`genstats`, `httping`, `multitail`, `rsstail`, `truncate`). Most of these formulae also had GitHub repositories but the related [flok99 account](https://github.com/flok99) has been pretty much wiped clean, so it's unlikely this software will be maintained.

This PR also removes the existing `livecheck` block, so this formula will be automatically skipped due to being deprecated.