### PR TITLE
libdshconfig: add livecheck

### DIFF
--- a/Formula/libdshconfig.rb
+++ b/Formula/libdshconfig.rb
@@ -5,6 +5,11 @@ class Libdshconfig < Formula
   sha256 "6f372686c5d8d721820995d2b60d2fda33fdb17cdddee9fce34795e7e98c5384"
   license "GPL-2.0"
 
+  livecheck do
+    url "https://www.netfort.gr.jp/~dancer/software/downloads/"
+    regex(/href=.*?libdshconfig[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any, arm64_big_sur: "7c8ce322c8a67038c0d2eea98640665aad9a4f17dced7d796ac55e271936918a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `libdshconfig`. This PR adds a `livecheck` block that checks the first-party downloads page, which links to the `stable` archive.