### PR TITLE
proj 8.0.1

### DIFF
--- a/Aliases/proj@8
+++ b/Aliases/proj@8
@@ -1,0 +1,1 @@
+../Formula/proj.rb

--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -4,6 +4,7 @@ class Gdal < Formula
   url "https://download.osgeo.org/gdal/3.3.0/gdal-3.3.0.tar.xz"
   sha256 "190c8f4b56afc767f43836b2a5cd53cc52ee7fdc25eb78c6079c5a244e28efa7"
   license "MIT"
+  revision 1
 
   livecheck do
     url "https://download.osgeo.org/gdal/CURRENT/"
@@ -45,7 +46,7 @@ class Gdal < Formula
   depends_on "openjpeg"
   depends_on "pcre"
   depends_on "poppler"
-  depends_on "proj"
+  depends_on "proj@7"
   depends_on "python@3.9"
   depends_on "sqlite" # To ensure compatibility with SpatiaLite
   depends_on "unixodbc" # macOS version is not complete enough
@@ -91,7 +92,7 @@ class Gdal < Formula
       "--with-png=#{Formula["libpng"].opt_prefix}",
       "--with-spatialite=#{Formula["libspatialite"].opt_prefix}",
       "--with-sqlite3=#{Formula["sqlite"].opt_prefix}",
-      "--with-proj=#{Formula["proj"].opt_prefix}",
+      "--with-proj=#{Formula["proj@7"].opt_prefix}",
       "--with-zstd=#{Formula["zstd"].opt_prefix}",
       "--with-liblzma=yes",
       "--with-cfitsio=#{Formula["cfitsio"].opt_prefix}",

--- a/Formula/libgaiagraphics.rb
+++ b/Formula/libgaiagraphics.rb
@@ -3,7 +3,7 @@ class Libgaiagraphics < Formula
   homepage "https://www.gaia-gis.it/fossil/libgaiagraphics/index"
   url "https://www.gaia-gis.it/gaia-sins/gaiagraphics-sources/libgaiagraphics-0.5.tar.gz"
   sha256 "ccab293319eef1e77d18c41ba75bc0b6328d0fc3c045bb1d1c4f9d403676ca1c"
-  revision 7
+  revision 8
 
   livecheck do
     url "https://www.gaia-gis.it/gaia-sins/gaiagraphics-sources/"
@@ -23,7 +23,7 @@ class Libgaiagraphics < Formula
   depends_on "jpeg"
   depends_on "libgeotiff"
   depends_on "libpng"
-  depends_on "proj"
+  depends_on "proj@7"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/libgeotiff.rb
+++ b/Formula/libgeotiff.rb
@@ -4,6 +4,7 @@ class Libgeotiff < Formula
   url "https://github.com/OSGeo/libgeotiff/releases/download/1.6.0/libgeotiff-1.6.0.tar.gz"
   sha256 "9311017e5284cffb86f2c7b7a9df1fb5ebcdc61c30468fb2e6bca36e4272ebca"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "a670b1daf400c747f5993a97888a8910a126a6e4668ddf3aa78e4f259db9246b"
@@ -23,7 +24,7 @@ class Libgeotiff < Formula
 
   depends_on "jpeg"
   depends_on "libtiff"
-  depends_on "proj"
+  depends_on "proj@7"
 
   def install
     system "./autogen.sh" if build.head?

--- a/Formula/librasterlite.rb
+++ b/Formula/librasterlite.rb
@@ -4,7 +4,7 @@ class Librasterlite < Formula
   url "https://www.gaia-gis.it/gaia-sins/librasterlite-sources/librasterlite-1.1g.tar.gz"
   sha256 "0a8dceb75f8dec2b7bd678266e0ffd5210d7c33e3d01b247e9e92fa730eebcb3"
   license any_of: ["MPL-1.1", "GPL-2.0-or-later", "LGPL-2.1-or-later"]
-  revision 7
+  revision 8
 
   livecheck do
     skip "No longer developed"

--- a/Formula/libspatialite.rb
+++ b/Formula/libspatialite.rb
@@ -6,6 +6,7 @@ class Libspatialite < Formula
   mirror "https://www.mirrorservice.org/sites/ftp.netbsd.org/pub/pkgsrc/distfiles/libspatialite-5.0.1.tar.gz"
   sha256 "eecbc94311c78012d059ebc0fae86ea5ef6eecb13303e6e82b3753c1b3409e98"
   license any_of: ["MPL-1.1", "GPL-2.0-or-later", "LGPL-2.1-or-later"]
+  revision 1
 
   livecheck do
     url "https://www.gaia-gis.it/gaia-sins/libspatialite-sources/"
@@ -32,7 +33,7 @@ class Libspatialite < Formula
   depends_on "librttopo"
   depends_on "libxml2"
   depends_on "minizip"
-  depends_on "proj"
+  depends_on "proj@7"
   depends_on "sqlite"
 
   def install

--- a/Formula/mapnik.rb
+++ b/Formula/mapnik.rb
@@ -4,7 +4,7 @@ class Mapnik < Formula
   url "https://github.com/mapnik/mapnik/releases/download/v3.1.0/mapnik-v3.1.0.tar.bz2"
   sha256 "43d76182d2a975212b4ad11524c74e577576c11039fdab5286b828397d8e6261"
   license "LGPL-2.1-or-later"
-  revision 3
+  revision 4
   head "https://github.com/mapnik/mapnik.git"
 
   livecheck do
@@ -30,7 +30,7 @@ class Mapnik < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "postgresql"
-  depends_on "proj"
+  depends_on "proj@7"
   depends_on "webp"
 
   def install

--- a/Formula/mapserver.rb
+++ b/Formula/mapserver.rb
@@ -4,7 +4,7 @@ class Mapserver < Formula
   url "https://download.osgeo.org/mapserver/mapserver-7.6.3.tar.gz"
   sha256 "0e0db478dabddee50498cd89669340f160a0437fed5a9f823022b19e2f150365"
   license "MIT"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://mapserver.org/download.html"
@@ -29,7 +29,7 @@ class Mapserver < Formula
   depends_on "giflib"
   depends_on "libpng"
   depends_on "postgresql"
-  depends_on "proj"
+  depends_on "proj@7"
   depends_on "protobuf-c"
   depends_on "python@3.9"
 

--- a/Formula/osm2pgsql.rb
+++ b/Formula/osm2pgsql.rb
@@ -4,6 +4,7 @@ class Osm2pgsql < Formula
   url "https://github.com/openstreetmap/osm2pgsql/archive/1.4.2.tar.gz"
   sha256 "fc68283930ccd468ed9b28685150741b16083fec86800a4b011884ae22eb061c"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/openstreetmap/osm2pgsql.git"
 
   bottle do
@@ -18,7 +19,7 @@ class Osm2pgsql < Formula
   depends_on "geos"
   depends_on "luajit-openresty"
   depends_on "postgresql"
-  depends_on "proj"
+  depends_on "proj@7"
 
   def install
     # This is essentially a CMake disrespects superenv problem

--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -4,7 +4,7 @@ class Postgis < Formula
   url "https://download.osgeo.org/postgis/source/postgis-3.1.1.tar.gz"
   sha256 "0e96afef586db6939d48fb22fbfbc9d0de5e6bc1722d6d553d63bb41441a2a7d"
   license "GPL-2.0-or-later"
-  revision 2
+  revision 3
 
   livecheck do
     url "https://download.osgeo.org/postgis/source/"
@@ -33,7 +33,7 @@ class Postgis < Formula
   depends_on "json-c" # for GeoJSON and raster handling
   depends_on "pcre"
   depends_on "postgresql"
-  depends_on "proj"
+  depends_on "proj@7"
   depends_on "protobuf-c" # for MVT (map vector tiles) support
   depends_on "sfcgal" # for advanced 2D/3D functions
 
@@ -41,7 +41,7 @@ class Postgis < Formula
     ENV.deparallelize
 
     args = [
-      "--with-projdir=#{Formula["proj"].opt_prefix}",
+      "--with-projdir=#{Formula["proj@7"].opt_prefix}",
       "--with-jsondir=#{Formula["json-c"].opt_prefix}",
       "--with-pgconfig=#{Formula["postgresql"].opt_bin}/pg_config",
       "--with-protobufdir=#{Formula["protobuf-c"].opt_bin}",

--- a/Formula/proj.rb
+++ b/Formula/proj.rb
@@ -1,8 +1,8 @@
 class Proj < Formula
   desc "Cartographic Projections Library"
   homepage "https://proj.org/"
-  url "https://github.com/OSGeo/PROJ/releases/download/7.2.1/proj-7.2.1.tar.gz"
-  sha256 "b384f42e5fb9c6d01fe5fa4d31da2e91329668863a684f97be5d4760dbbf0a14"
+  url "https://github.com/OSGeo/PROJ/releases/download/8.0.1/proj-8.0.1.tar.gz"
+  sha256 "e0463a8068898785ca75dd49a261d3d28b07d0a88f3b657e8e0089e16a0375fa"
   license "MIT"
 
   bottle do

--- a/Formula/proj@7.rb
+++ b/Formula/proj@7.rb
@@ -1,0 +1,50 @@
+class ProjAT7 < Formula
+  desc "Cartographic Projections Library"
+  homepage "https://proj.org/"
+  url "https://github.com/OSGeo/PROJ/releases/download/7.2.1/proj-7.2.1.tar.gz"
+  sha256 "b384f42e5fb9c6d01fe5fa4d31da2e91329668863a684f97be5d4760dbbf0a14"
+  license "MIT"
+
+  keg_only :versioned_formula
+
+  deprecate! date: "2020-03-01", because: :unsupported
+
+  depends_on "pkg-config" => :build
+  depends_on "libtiff"
+
+  uses_from_macos "curl"
+  uses_from_macos "sqlite"
+
+  skip_clean :la
+
+  # The datum grid files are required to support datum shifting
+  resource "datumgrid" do
+    url "https://download.osgeo.org/proj/proj-datumgrid-1.8.zip"
+    sha256 "b9838ae7e5f27ee732fb0bfed618f85b36e8bb56d7afb287d506338e9f33861e"
+  end
+
+  def install
+    (buildpath/"nad").install resource("datumgrid")
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test").write <<~EOS
+      45d15n 71d07w Boston, United States
+      40d40n 73d58w New York, United States
+      48d51n 2d20e Paris, France
+      51d30n 7'w London, England
+    EOS
+    match = <<~EOS
+      -4887590.49\t7317961.48 Boston, United States
+      -5542524.55\t6982689.05 New York, United States
+      171224.94\t5415352.81 Paris, France
+      -8101.66\t5707500.23 London, England
+    EOS
+
+    output = shell_output("#{bin}/proj +proj=poly +ellps=clrk66 -r #{testpath}/test")
+    assert_equal match, output
+  end
+end

--- a/Formula/spatialite-gui.rb
+++ b/Formula/spatialite-gui.rb
@@ -3,8 +3,8 @@ class SpatialiteGui < Formula
   homepage "https://www.gaia-gis.it/fossil/spatialite_gui/index"
   url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/spatialite_gui-1.7.1.tar.gz"
   sha256 "cb9cb1ede7f83a5fc5f52c83437e556ab9cb54d6ace3c545d31b317fd36f05e4"
-  license "GPL-3.0"
-  revision 6
+  license "GPL-3.0-or-later"
+  revision 7
 
   livecheck do
     url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/"
@@ -24,7 +24,7 @@ class SpatialiteGui < Formula
   depends_on "geos"
   depends_on "libgaiagraphics"
   depends_on "libspatialite"
-  depends_on "proj"
+  depends_on "proj@7"
   depends_on "sqlite"
   depends_on "wxmac"
 
@@ -37,9 +37,12 @@ class SpatialiteGui < Formula
     # Link flags for sqlite don't seem to get passed to make, which
     # causes builds to fatally error out on linking.
     # https://github.com/Homebrew/homebrew/issues/44003
+    #
+    # spatialite-gui uses `proj` (instead of `proj@7`) if installed
     sqlite = Formula["sqlite"]
-    ENV.prepend "LDFLAGS", "-L#{sqlite.opt_lib} -lsqlite3"
-    ENV.prepend "CFLAGS", "-I#{sqlite.opt_include}"
+    proj = Formula["proj@7"]
+    ENV.prepend "LDFLAGS", "-L#{sqlite.opt_lib} -lsqlite3 -L#{proj.opt_lib}"
+    ENV.prepend "CFLAGS", "-I#{sqlite.opt_include} -I#{proj.opt_include}"
 
     # Use Proj 6.0.0 compatibility headers
     # https://www.gaia-gis.it/fossil/spatialite_gui/tktview?name=8349866db6

--- a/Formula/spatialite-tools.rb
+++ b/Formula/spatialite-tools.rb
@@ -4,6 +4,7 @@ class SpatialiteTools < Formula
   url "https://www.gaia-gis.it/gaia-sins/spatialite-tools-sources/spatialite-tools-5.0.1.tar.gz"
   sha256 "9604c205e87f037789bc52302c66ccd1371c3e98c74e8ec4e29b0752de35171c"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.gaia-gis.it/gaia-sins/spatialite-tools-sources/"


### PR DESCRIPTION
Continuation of https://github.com/Homebrew/homebrew-core/pull/72680

Switched to `proj@7` because doesn't support `proj` 8:
- `libgaiagraphics` 
- `spatialite-gui`
- `osm2pgsql`
- `postgis`(will work with `proj` 8 in the next release (3.1.2) https://lists.osgeo.org/pipermail/postgis-users/2021-April/044833.html)


Switched to `proj@7` to prevent mixing `proj` with `proj@7` in (recursive) dependencies (but support `proj` 8 themself):
- `gdal`
- `libgeotiff`
- `libspatialite`
- `mapnik`
- `mapserver`

Also, there's a note regarding [`proj`](https://proj.org/download.html#current-release):
>  The proj-datumgrid packages have been deprecated with PROJ 7.0.0. The proj-data package should be used with PROJ 7.0.0 and newer

We have bundled in `proj-datumgrid`, so it should be replaced with `proj-data`, but the size of `proj-data` is about 555MB (https://download.osgeo.org/proj/).