### PR TITLE
osm: add build date to binary

### DIFF
--- a/Formula/osm.rb
+++ b/Formula/osm.rb
@@ -17,7 +17,7 @@ class Osm < Formula
 
   def install
     ENV["VERSION"] = "v"+version
-    ENV["BUILD_DATE"] = "$$(date +%Y-%m-%d-%H:%M)"
+    ENV["BUILD_DATE"] = Time.now.utc.strftime("%Y-%m-%d-%H:%M")
     system "make", "build-osm"
     bin.install "bin/osm"
   end

--- a/Formula/osm.rb
+++ b/Formula/osm.rb
@@ -17,6 +17,7 @@ class Osm < Formula
 
   def install
     ENV["VERSION"] = "v"+version
+    ENV["BUILD_DATE"] = "$$(date +%Y-%m-%d-%H:%M)"
     system "make", "build-osm"
     bin.install "bin/osm"
   end


### PR DESCRIPTION
OSM recently made a change that removes the build date string that was
compiled into each binary by default. This change sets the build date to
its previous default.

ref: https://github.com/openservicemesh/osm/pull/3377

All OSM versions installable from brew thus far already have the build
date compiled in and this change is a no-op. Only future OSM releases
require this change.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
