### PR TITLE
marp-cli 1.1.1 (new formula)

### DIFF
--- a/Formula/marp-cli.rb
+++ b/Formula/marp-cli.rb
@@ -1,0 +1,40 @@
+require "language/node"
+
+class MarpCli < Formula
+  desc "Easily convert Marp Markdown files into static HTML/CSS, PDF, PPT and images"
+  homepage "https://github.com/marp-team/marp-cli"
+  url "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-1.1.1.tgz"
+  sha256 "62711d9298f96a9634020d31a05561ad076e59e06749b0be643a20ccb8533770"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    (testpath/"deck.md").write <<~EOS
+      ---
+      theme: uncover
+      ---
+
+      # Hello, Homebrew!
+
+      ---
+
+      <!-- backgroundColor: blue -->
+
+      # <!--fit--> :+1:
+    EOS
+
+    system "marp", testpath/"deck.md", "-o", testpath/"deck.html"
+    assert_predicate testpath/"deck.html", :exist?
+    content = (testpath/"deck.html").read
+    assert_match "theme:uncover", content
+    assert_match "<h1>Hello, Homebrew!</h1>", content
+    assert_match "background-color:blue", content
+    assert_match "👍", content
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Retry of #77628, this PR adds a new `marp-cli` Formula. The tool converts Markdown slide decks into HTML/CSS, PDF and other formats.

CC @yhatt @MarcinKonowalczyk