### PR TITLE
libsigc++: remove workaround, this is not needed anymore

### DIFF
--- a/Formula/libsigc++.rb
+++ b/Formula/libsigc++.rb
@@ -52,10 +52,6 @@ class Libsigcxx < Formula
       }
     EOS
 
-    on_linux do
-      ENV["CXX"] = Formula["gcc"].opt_bin/"c++-10"
-    end
-
     system ENV.cxx, "-std=c++17", "test.cpp",
                    "-L#{lib}", "-lsigc-3.0", "-I#{include}/sigc++-3.0", "-I#{lib}/sigc++-3.0/include", "-o", "test"
     assert_match "hello world", shell_output("./test")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
