### PR TITLE
wally-cli 2.0.0 (new formula)

### DIFF
--- a/Formula/wally-cli.rb
+++ b/Formula/wally-cli.rb
@@ -1,0 +1,25 @@
+class WallyCli < Formula
+  desc "Flash your ZSA Keyboard the EZ way"
+  homepage "https://github.com/zsa/wally-cli"
+  url "https://github.com/zsa/wally-cli/archive/refs/tags/2.0.0-osx.tar.gz"
+  sha256 "fd2ae8c12380ecd2ddad6d04351c9e832b8607e795f1f1a17f93c27f697392f6"
+  license "MIT"
+
+  depends_on "go" => :build
+  depends_on "libusb"
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    bin_path = buildpath/"src/github.com/zsa/wally-cli"
+    bin_path.install Dir["*"]
+
+    cd bin_path do
+      system "go", "build", "-o", bin/"wally-cli", "."
+    end
+  end
+
+  test do
+    assert_match "wally-cli v2.0.0", shell_output("#{bin}/wally-cli --version")
+  end
+end


### PR DESCRIPTION
Adding a new formula for wally-cli, a tool for
configuring ZSA keyboards

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I've run the `brew audit --strict wally-cli` and it's failing with the error that the url is providing a binary. I downloaded the tar and decompressed myself to confirm that it is a tar of the source, so I'm not sure what I'm doing wrong.