### PR TITLE
open-zwave: add livecheck

### DIFF
--- a/Formula/open-zwave.rb
+++ b/Formula/open-zwave.rb
@@ -5,6 +5,11 @@ class OpenZwave < Formula
   sha256 "61c4b1857bb80c67b06f83bbeb956275184e30e12401984587dfe79070218d3c"
   license "LGPL-3.0"
 
+  livecheck do
+    url "http://old.openzwave.com/downloads/"
+    regex(/href=.*?openzwave[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "d7ac3272c8e97d579bd7cbf660d0831b282d426344d1c66d1d6273665972c5ac"
     sha256 big_sur:       "ca1c3e4e29bb19f377f169a015112818ebb69320ff76f05de671a857a28a4670"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `open-zwave`. This PR adds a `livecheck` block that checks the download page, which links to `stable` archive files.