### PR TITLE
ssss: add livecheck

### DIFF
--- a/Formula/ssss.rb
+++ b/Formula/ssss.rb
@@ -5,6 +5,11 @@ class Ssss < Formula
   sha256 "5d165555105606b8b08383e697fc48cf849f51d775f1d9a74817f5709db0f995"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?ssss[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "c1656cbcd114f1e8269d54fa5b525ceababe178d0fddec508fdb568d747035f0"
     sha256 cellar: :any, big_sur:       "5ff50aef8004346c9cf21eb9aecae18ce2b7d4032c7460284b6c1903dc244d6f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `ssss`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.