### PR TITLE
daemon 0.8

### DIFF
--- a/Formula/daemon.rb
+++ b/Formula/daemon.rb
@@ -1,9 +1,14 @@
 class Daemon < Formula
   desc "Turn other processes into daemons"
   homepage "http://libslack.org/daemon/"
-  url "http://libslack.org/daemon/download/daemon-0.6.4.tar.gz"
-  sha256 "c4b9ea4aa74d55ea618c34f1e02c080ddf368549037cb239ee60c83191035ca1"
-  license "GPL-2.0"
+  url "http://libslack.org/daemon/download/daemon-0.8.tar.gz"
+  sha256 "74f12e6d4b3c85632489bd08431d3d997bc17264bf57b7202384f2e809cff596"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?daemon[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "a634d876fc4382b34bfd5f3b564a62a251e3eb3b6d07ab03a9c27f25617c44f5"
@@ -16,17 +21,8 @@ class Daemon < Formula
     sha256 cellar: :any_skip_relocation, yosemite:      "f48000af3631f28d47d01d3d89a1f03e7c4f7eac4a81ab7db9c38a1ce9ff66cd"
   end
 
-  # fixes for strlcpy/strlcat: https://trac.macports.org/ticket/42845
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/3323958/daemon/daemon-0.6.4-ignore-strlcpy-strlcat.patch"
-    sha256 "a56e16b0801a13045d388ce7e755b2b4e40288c3731ce0f92ea879d0871782c0"
-  end
-
   def install
-    # Parallel build failure reported to raf@raf.org 27th Feb 2016
-    ENV.deparallelize
-
-    system "./config"
+    system "./configure"
     system "make"
     system "make", "PREFIX=#{prefix}", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates `daemon` to version `0.8` while also updating the license (from `GPL-2.0` to `GPL-2.0-or-later`, referencing the source files) and adding a `livecheck` block. It would be good for someone to check my work in terms of removing the existing patch and `ENV.deparallelize`.

Looking at the `0.8` code, the change to `daemon.c` in the existing patch (adding `#include <config.h>`) could still be applied. The `libslack/str.h` changes seem to have been incorporated in some fashion (i.e., the patch uses `#ifndef HAVE_STRLCPY` and the current code has `#ifndef strlcpy /* This is now a macro on OSX/macOS */` (whereas before there were no related `ifndef` statements on these lines).

The original discussion of the patch references Mac OS X Mavericks (10.9, unsupported as of September 2016), so I'm not sure this patch is something we need to maintain at this point. I can at least say that `daemon` builds fine without it on our currently-supported macOS versions (10.14, 10.15, 11).  If we're fine with removing the patch, I'll create a PR in Homebrew/formula-patches to remove this patch (otherwise I'll update it if we need to keep it around).

Regarding removing `ENV.deparallelize`, I can only say that building the formula from source worked fine for me locally (macOS 11.3.1, Intel) without it and it seems fine on CI but I'm unsure of whether that's a good enough indicator.