### PR TITLE
yarn: make fsevents test macOS specific

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -33,6 +33,9 @@ class Yarn < Formula
   test do
     (testpath/"package.json").write('{"name": "test"}')
     system bin/"yarn", "add", "jquery"
-    system bin/"yarn", "add", "fsevents", "--build-from-source=true"
+    on_macos do
+      # macOS specific package
+      system bin/"yarn", "add", "fsevents", "--build-from-source=true"
+    end
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
