### PR TITLE
gradle: downgrade to openjdk@11 for ARM (upcoming jdk17-ea)

### DIFF
--- a/Formula/gradle.rb
+++ b/Formula/gradle.rb
@@ -4,7 +4,7 @@ class Gradle < Formula
   url "https://services.gradle.org/distributions/gradle-7.0.2-all.zip"
   sha256 "13bf8d3cf8eeeb5770d19741a59bde9bd966dd78d17f1bbad787a05ef19d1c2d"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://services.gradle.org/distributions/"
@@ -15,12 +15,22 @@ class Gradle < Formula
     sha256 cellar: :any_skip_relocation, all: "0d659be86c309f4ac28003a0593d366f3c0fd9e85eb14d34542e6c7545fe5a6a"
   end
 
-  depends_on "openjdk"
+  # gradle currently does not support Java 17
+  if Hardware::CPU.arm?
+    depends_on "openjdk@11"
+  else
+    depends_on "openjdk"
+  end
 
   def install
     rm_f Dir["bin/*.bat"]
     libexec.install %w[bin docs lib src]
-    (bin/"gradle").write_env_script libexec/"bin/gradle", Language::Java.overridable_java_home_env
+    env = if Hardware::CPU.arm?
+      Language::Java.overridable_java_home_env("11")
+    else
+      Language::Java.overridable_java_home_env
+    end
+    (bin/"gradle").write_env_script libexec/"bin/gradle", env
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Need to revert changes from #77590 as upcoming `openjdk` update #72535 will use JDK17-ea for ARM, which is again incompatible with latest `gradle`.

Not sure how this impacts bottles though as ARM and Intel will end up different.

Locally built upcoming `openjdk` formula on ARM (so JDK17-ea).
With current `gradle` formula, test error occurs:
```console
==> Testing gradle
==> /opt/homebrew/Cellar/gradle/7.0.2_1/bin/gradle --version
Picked up _JAVA_OPTIONS: -Duser.home=/Users/cho-m/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp
==> /opt/homebrew/Cellar/gradle/7.0.2_1/bin/gradle build --no-daemon
Picked up _JAVA_OPTIONS: -Duser.home=/Users/cho-m/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp

FAILURE: Build failed with an exception.

* Where:
Build file '/private/tmp/gradle-test-20210522-47145-ho72qt/build.gradle'

* What went wrong:
Could not compile build file '/private/tmp/gradle-test-20210522-47145-ho72qt/build.gradle'.
> startup failed:
  General error during conversion: Unsupported class file major version 61

  java.lang.IllegalArgumentException: Unsupported class file major version 61
  	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:189)
  	at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:170)
```

With reverted `openjdk@11` version:
```console
❯ brew test gradle
==> Testing gradle
==> /opt/homebrew/Cellar/gradle/7.0.2_2/bin/gradle --version
Picked up _JAVA_OPTIONS: -Duser.home=/Users/cho-m/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp
==> /opt/homebrew/Cellar/gradle/7.0.2_2/bin/gradle build --no-daemon
Picked up _JAVA_OPTIONS: -Duser.home=/Users/cho-m/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp

❯ echo $?
0
```