### PR TITLE
mockserver: fix for ARM

### DIFF
--- a/Formula/mockserver.rb
+++ b/Formula/mockserver.rb
@@ -15,6 +15,7 @@ class Mockserver < Formula
   depends_on "openjdk"
 
   def install
+    inreplace "bin/run_mockserver.sh", "/usr/local", HOMEBREW_PREFIX
     libexec.install Dir["*"]
     (bin/"mockserver").write_env_script libexec/"bin/run_mockserver.sh", JAVA_HOME: Formula["openjdk"].opt_prefix
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This fixes `mockserver` test failure on ARM: 
```
Error: Unable to access jarfile /usr/local/lib/mockserver/mockserver-netty-jar-with-dependencies.jar
```

This is currently blocking #72535.
