### PR TITLE
chart-testing: fix configuration file search path

### DIFF
--- a/Formula/chart-testing.rb
+++ b/Formula/chart-testing.rb
@@ -5,6 +5,7 @@ class ChartTesting < Formula
       tag:      "v3.4.0",
       revision: "68a43ac09699ef9473266457e893a7ddd7ef6b5b"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/helm/chart-testing.git"
 
   bottle do
@@ -18,6 +19,8 @@ class ChartTesting < Formula
   depends_on "yamllint" => :test
 
   def install
+    # Fix default search path for configuration files, needed for ARM
+    inreplace "pkg/config/config.go", "/usr/local/etc", etc
     ldflags = %W[
       -X github.com/helm/chart-testing/v#{version.major}/ct/cmd.Version=#{version}
       -X github.com/helm/chart-testing/v#{version.major}/ct/cmd.GitCommit=#{Utils.git_head}


### PR DESCRIPTION
This should hopefully allow bottling on ARM. They check some specific paths for the `lintconf.yaml` file so specifying the path with `--lint-conf` should fix the ARM test failure.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?