### PR TITLE
libserialport: add livecheck

### DIFF
--- a/Formula/libserialport.rb
+++ b/Formula/libserialport.rb
@@ -5,6 +5,11 @@ class Libserialport < Formula
   sha256 "4a2af9d9c3ff488e92fb75b4ba38b35bcf9b8a66df04773eba2a7bbf1fa7529d"
   license "LGPL-3.0"
 
+  livecheck do
+    url "https://sigrok.org/wiki/Downloads"
+    regex(/href=.*?libserialport[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "cd674d1a466be43b3783028ca9f794d97ee5ce9c90f080cbbdb7c0479094cb26"
     sha256 cellar: :any, big_sur:       "67613224a8f626829329285c5dc904fb25b6dfcbf17e24e35aaeb9fbf33b0f26"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `libserialport`. This PR adds a `livecheck` block that checks the download page, which links to the `stable` archive.