### PR TITLE
zig: update formula tests

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -32,11 +32,21 @@ class Zig < Formula
     (testpath/"hello.zig").write <<~EOS
       const std = @import("std");
       pub fn main() !void {
-          var stdout_file: std.fs.File = std.io.getStdOut();
-          _ = try stdout_file.write("Hello, world!");
+          const stdout = std.io.getStdOut().writer();
+          try stdout.print("Hello, world!", .{});
       }
     EOS
     system "#{bin}/zig", "build-exe", "hello.zig"
+    assert_equal "Hello, world!", shell_output("./hello")
+
+    (testpath/"hello.c").write <<~EOS
+      #include <stdio.h>
+      int main() {
+        fprintf(stdout, "Hello, world!");
+        return 0;
+      }
+    EOS
+    system "#{bin}/zig", "cc", "hello.c", "-o", "hello"
     assert_equal "Hello, world!", shell_output("./hello")
   end
 end


### PR DESCRIPTION
This commit updates formula's tests to what is currently used in the example `hello.zig`. It also adds an additional smoke test for using zig as a C compiler - compiling and running simple "Hello, world!" in C using zig.

I should note here that having both Zig and C compilation as test cases should flag certain regressions such as this one ziglang/zig#8860 early on and allow us to work on a fix before pushing a potentially broken Zig installation into Homebrew.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
