### PR TITLE
sbuild: remove `bottle :unneeded` and unsupported MaxPermSize

### DIFF
--- a/Formula/sbuild.rb
+++ b/Formula/sbuild.rb
@@ -5,13 +5,15 @@ class Sbuild < Formula
   mirror "https://github.com/SBuild-org/SBuild-org.github.io/raw/master/uploads/sbuild/0.7.7/sbuild-0.7.7-dist.zip"
   sha256 "606bc09603707f31d9ca5bc306ba01b171f8400e643261acd28da7a1a24dfb23"
   license "Apache-2.0"
-  revision 1
-
-  bottle :unneeded
+  revision 2
 
   depends_on "openjdk"
 
   def install
+    # Delete unsupported VM option 'MaxPermSize', which is unrecognized in Java 17
+    # Remove this line once upstream removes it from bin/sbuild
+    inreplace "bin/sbuild", /-XX:MaxPermSize=[^ ]*/, ""
+
     libexec.install Dir["*"]
     chmod 0755, libexec/"bin/sbuild"
     (bin/"sbuild").write_env_script libexec/"bin/sbuild", Language::Java.overridable_java_home_env


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

One of extra failures seen in #72535 due to JDK17-ea.
Also try bottling.

For previous JDK, running `brew test sbuild --verbose` would output:
```
OpenJDK 64-Bit Server VM warning: Ignoring option MaxPermSize; support was removed in 8.0
```

With JDK17-ea, it now fails as unrecognized.:
```
❯ brew test sbuild
==> Testing sbuild
==> /opt/homebrew/Cellar/sbuild/0.7.7_1/bin/sbuild --create-stub
Last 15 lines from /Users/cho-m/Library/Logs/Homebrew/sbuild/test.01.sbuild:
2021-05-23 16:10:56 -0700

/opt/homebrew/Cellar/sbuild/0.7.7_1/bin/sbuild
--create-stub

Picked up _JAVA_OPTIONS: -Duser.home=/Users/cho-m/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp
Unrecognized VM option 'MaxPermSize=256m'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
Error: sbuild: failed
```

After removing option, the test passes

---

The resulting diff of `bin/sbuild` is:
```diff
-exec ${JRE} -XX:MaxPermSize=256m ${SBUILD_JAVA_OPTIONS} -cp "${SBUILD_HOME}/lib/scala-library-2.10.4.jar:${SBUILD_HOME}/lib/de.tototec.cmdoption-0.3.2.jar:${SBUILD_HOME}/lib/jansi-1.11.jar:${SBUILD_HOME}/lib/de.tototec.sbuild-0.7.7.jar:${SBUILD_HOME}/lib/de.tototec.sbuild.runner-0.7.7.jar" de.tototec.sbuild.runner.SBuildRunner --sbuild-home "${SBUILD_HOME}" ${SBUILD_OPTS} "$@"
+exec ${JRE}  ${SBUILD_JAVA_OPTIONS} -cp "${SBUILD_HOME}/lib/scala-library-2.10.4.jar:${SBUILD_HOME}/lib/de.tototec.cmdoption-0.3.2.jar:${SBUILD_HOME}/lib/jansi-1.11.jar:${SBUILD_HOME}/lib/de.tototec.sbuild-0.7.7.jar:${SBUILD_HOME}/lib/de.tototec.sbuild.runner-0.7.7.jar" de.tototec.sbuild.runner.SBuildRunner --sbuild-home "${SBUILD_HOME}" ${SBUILD_OPTS} "$@"
```