### PR TITLE
gradle-profiler: remove `bottle :unneeded` and downgrade to openjdk@11

### DIFF
--- a/Formula/gradle-profiler.rb
+++ b/Formula/gradle-profiler.rb
@@ -4,15 +4,17 @@ class GradleProfiler < Formula
   url "https://repo.gradle.org/gradle/ext-releases-local/org/gradle/profiler/gradle-profiler/0.16.0/gradle-profiler-0.16.0.zip"
   sha256 "f376581ed7b788d9d3d640a2ddde88747ce2e8a0e297991a77b98e6b7a257fbb"
   license "Apache-2.0"
+  revision 1
 
-  bottle :unneeded
-
-  depends_on "openjdk"
+  # gradle currently does not support Java 17 (ARM)
+  # gradle@6 is still default gradle-version, but does not support Java 16
+  # Switch to `openjdk` once above situations are no longer true
+  depends_on "openjdk@11"
 
   def install
     rm_f Dir["bin/*.bat"]
     libexec.install %w[bin lib]
-    env = Language::Java.overridable_java_home_env
+    env = Language::Java.overridable_java_home_env("11")
     (bin/"gradle-profiler").write_env_script libexec/"bin/gradle-profiler", env
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

One of extra failures from #72535 due to Gradle7 not supporting JDK17.
Also try to bottle.

---

When `gradle-profiler` is run without `--gradle-version` argument, it uses Gradle v6.6.1, which is not compatible with Java 16.

Also, `gradle@6` is still commonly used by various projects. So, dropping down to `openjdk@11` will allow users to not be required to use Gradle v7 during transition period.