### PR TITLE
exa: fix head completion install

### DIFF
--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -30,9 +30,16 @@ class Exa < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    bash_completion.install "completions/completions.bash" => "exa"
-    zsh_completion.install  "completions/completions.zsh"  => "_exa"
-    fish_completion.install "completions/completions.fish" => "exa.fish"
+    if build.head?
+      bash_completion.install "completions/bash/exa"      => "exa"
+      zsh_completion.install  "completions/zsh/_exa"      => "_exa"
+      fish_completion.install "completions/fish/exa.fish" => "exa.fish"
+    else
+      # Remove after >0.10.1 build
+      bash_completion.install "completions/completions.bash" => "exa"
+      zsh_completion.install  "completions/completions.zsh"  => "_exa"
+      fish_completion.install "completions/completions.fish" => "exa.fish"
+    end
 
     args = %w[
       --standalone

--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -31,9 +31,9 @@ class Exa < Formula
     system "cargo", "install", *std_cargo_args
 
     if build.head?
-      bash_completion.install "completions/bash/exa"      => "exa"
-      zsh_completion.install  "completions/zsh/_exa"      => "_exa"
-      fish_completion.install "completions/fish/exa.fish" => "exa.fish"
+      bash_completion.install "completions/bash/exa"
+      zsh_completion.install  "completions/zsh/_exa"
+      fish_completion.install "completions/fish/exa.fish"
     else
       # Remove after >0.10.1 build
       bash_completion.install "completions/completions.bash" => "exa"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
exa recently moved completions from the completions directory into shell-specific subdirectories and standardized the names (https://github.com/ogham/exa/pull/860). 0.10.1 will still need to install completions from the previous locations, but HEAD installs will need to install completions from the new ones. This fix checks if we're installing from head to see where to install completions from.

@ariasuni 