### PR TITLE
ldapvi: add livecheck

### DIFF
--- a/Formula/ldapvi.rb
+++ b/Formula/ldapvi.rb
@@ -6,6 +6,11 @@ class Ldapvi < Formula
   sha256 "6f62e92d20ff2ac0d06125024a914b8622e5b8a0a0c2d390bf3e7990cbd2e153"
   revision 7
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?ldapvi[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "86cc23b1d8f7bf9b1cf46730d25e0774fa331015e024dfbb5091830c4f73aee0"
     sha256 cellar: :any, big_sur:       "79eefa4e1619324c2573a42e688785d5325c4e2d28ef7366ee24a2586a2dd071"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `ldapvi`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.