### PR TITLE
awf: deprecate

### DIFF
--- a/Formula/awf.rb
+++ b/Formula/awf.rb
@@ -16,6 +16,8 @@ class Awf < Formula
     sha256 cellar: :any, sierra:        "417806f1ab0aa5d1c2e2e0302dd2c3c4cdaaf2957ac18fbfe1f9a2ced72947bd"
   end
 
+  deprecate! date: "2021-05-24", because: :repo_archived
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [valr/awf](https://github.com/valr/awf) repository is archived with the following note in the Status section of the README:

> Warning: it's quite some time I haven't looked at gtk3 to integrate the latest widgets, and I don't plan to work on this tool anymore. AWF was indeed created a long time ago when neither gtk2 nor gtk3 were providing such a tool.
As part of gtk3 there is now [gtk3-widget-factory](https://developer.gnome.org/gtk3/stable/gtk3-widget-factory.html) and gtk4 will provide [gtk4-widget-factory](https://developer.gnome.org/gtk4/stable/gtk4-widget-factory.html).

Since this won't be developed further, this PR deprecates `awf` accordingly.