### PR TITLE
bats: deprecate

### DIFF
--- a/Formula/bats.rb
+++ b/Formula/bats.rb
@@ -8,6 +8,8 @@ class Bats < Formula
 
   bottle :unneeded
 
+  deprecate! date: "2021-05-24", because: :repo_archived
+
   conflicts_with "bats-core", because: "both install `bats` executables"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [sstephenson/bats](https://github.com/sstephenson/bats) GitHub repository was archived sometime after 2021-04-18 (the most recent archive.org snapshot). The latest commit is from 2016-02-19, so this would seem to indicate that this won't be maintained or developed further.

For what it's worth, [`bats-core`](https://github.com/bats-core/bats-core) is an actively developed fork and we already have a formula for it.