### PR TITLE
geph2: deprecate

### DIFF
--- a/Formula/geph2.rb
+++ b/Formula/geph2.rb
@@ -13,6 +13,9 @@ class Geph2 < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "392a4199771a8ff4c5aa1c45bd3225640d9949aa1e2a9af915e488093fe84ff9"
   end
 
+  # Geph has been rewritten in Rust: https://github.com/geph-official/geph4
+  deprecate! date: "2020-04-24", because: :repo_archived
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [geph-official/geph2](https://github.com/geph-official/geph2) GitHub repository is archived and the README was last updated on 2021-02-10 to read:

> This repository is now obsolete. Geph has been rewritten in Rust at https://github.com/geph-official/geph4

We already have a `geph4` formula and this PR deprecates `geph2` accordingly.