### PR TITLE
global: add license

### DIFF
--- a/Formula/global.rb
+++ b/Formula/global.rb
@@ -6,6 +6,7 @@ class Global < Formula
   url "https://ftp.gnu.org/gnu/global/global-6.6.6.tar.gz"
   mirror "https://ftpmirror.gnu.org/global/global-6.6.6.tar.gz"
   sha256 "758078afff98d4c051c58785c7ada3ed1977fabb77f8897ff657b71cc62d4d5d"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 arm64_big_sur: "f96368bfa6146b1e1ab6df7fa7a830edac7a733e5e5b166da466279cd95f7f24"


### PR DESCRIPTION
`COPYING` is the GPL-3.0 boilerplate, and most source headers with a
license annotation contain the phrase "at your option".

See also https://metadata.ftp-master.debian.org/changelogs//main/g/global/global_6.6.5-1_copyright.

~~Merge this after #77920 to avoid introducing a merge conflict there.~~

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?