### PR TITLE
gcc: add zstd support

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -14,6 +14,7 @@ class Gcc < Formula
     sha256 "4c4a6fb8a8396059241c2e674b85b351c26a5d678274007f076957afa1cc9ddf"
   end
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
+  revision 1
   head "https://gcc.gnu.org/git/gcc.git"
 
   livecheck do
@@ -40,6 +41,7 @@ class Gcc < Formula
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
+  depends_on "zstd"
 
   uses_from_macos "zlib"
 
@@ -83,6 +85,7 @@ class Gcc < Formula
       --with-mpfr=#{Formula["mpfr"].opt_prefix}
       --with-mpc=#{Formula["libmpc"].opt_prefix}
       --with-isl=#{Formula["isl"].opt_prefix}
+      --with-zstd=#{Formula["zstd"].opt_prefix}
       --with-pkgversion=#{pkgversion}
       --with-bugurl=#{tap.issues_url}
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This enables the use of `zstd` instead of `zlib` for LTO data
compression. Compression with `zstd` is 4-8x faster than with `zlib`. [1]

This is, for practical purposes, part of the default GCC configuration,
since GCC's build system will enable `zstd` support when it discovers
that `zstd` is available in the build environment. We pass the
`--with-zstd` flag anyway to make sure it uses a brewed `zstd` for that.

Closes Homebrew/linuxbrew-core#22800.

[1] https://gcc.gnu.org/legacy-ml/gcc/2019-06/msg00185.html