### PR TITLE
teleconsole: deprecate

### DIFF
--- a/Formula/teleconsole.rb
+++ b/Formula/teleconsole.rb
@@ -15,6 +15,8 @@ class Teleconsole < Formula
     sha256 cellar: :any_skip_relocation, sierra:      "c74fa8ac5e92c39a3f0d869b9e8bd44d32ab67ed0748b5548a0700287dfbe817"
   end
 
+  deprecate! date: "2021-05-24", because: :repo_archived
+
   depends_on "go" => :build
 
   go_resource "github.com/Sirupsen/logrus" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [gravitational/teleconsole](https://github.com/gravitational/teleconsole/) GitHub repository has been archived and the `README` reads:

> We are temporary shutting down teleconsole service.
>
> We hope to release a better and free version using Teleport Cloud - a new platform we are working on.
>
> Thank you.

This PR deprecates `teleconsole` accordingly.