### PR TITLE
xctool: deprecate

### DIFF
--- a/Formula/xctool.rb
+++ b/Formula/xctool.rb
@@ -1,16 +1,18 @@
 class Xctool < Formula
   desc "Drop-in replacement for xcodebuild with a few extra features"
-  homepage "https://github.com/facebook/xctool"
-  url "https://github.com/facebook/xctool/archive/0.3.7.tar.gz"
+  homepage "https://github.com/facebookarchive/xctool"
+  url "https://github.com/facebookarchive/xctool/archive/0.3.7.tar.gz"
   sha256 "608522865dc42959a6240010c8295ce01278f4b7a8276d838f21a8973938206d"
   license "Apache-2.0"
-  head "https://github.com/facebook/xctool.git"
+  head "https://github.com/facebookarchive/xctool.git"
 
   bottle do
     sha256 cellar: :any, catalina:    "0cf8c734d095ab97b2d5537b67d3f13e6ff8f38c46503ea02b9eba98ff35942c"
     sha256 cellar: :any, mojave:      "8b116346555e2616619e577d3ce3c69a24d66cb505ee048ba316ab2880736043"
     sha256 cellar: :any, high_sierra: "055172ba606bf94416513e418007f849a08ff24a3b3484fb67c1b4f854123bb9"
   end
+
+  deprecate! date: "2021-05-24", because: :repo_archived
 
   depends_on :macos
   depends_on xcode: "7.0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [facebook/xctool](https://github.com/facebook/xctool/) GitHub repository has been moved to [facebookarchive/xctool](https://github.com/facebookarchive/xctool/) and archived. There isn't any language in the `README`, repository description, etc. that explains this change but I think this makes it clear that `xctool` won't be developed or maintained further. The last commit was on 2019-12-11.

This PR updates the URLs to point to facebookarchive/xctool and deprecates `xctool` accordingly.