### PR TITLE
ykclient: deprecate

### DIFF
--- a/Formula/ykclient.rb
+++ b/Formula/ykclient.rb
@@ -31,6 +31,12 @@ class Ykclient < Formula
     depends_on "libtool" => :build
   end
 
+  # "This project is deprecated and is no longer being maintained. For more
+  # information and guidance on how to implement Yubico OTP support in
+  # applications, see
+  # https://status.yubico.com/2021/04/15/one-api-yubico-com-one-http-get/."
+  deprecate! date: "2021-05-24", because: :repo_archived
+
   depends_on "help2man" => :build
   depends_on "pkg-config" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [Yubico/yubico-c-client](https://github.com/Yubico/yubico-c-client/) GitHub repository has been archived and the `README` contains the following note at the top:

> This project is deprecated and is no longer being maintained. For more information and guidance on how to implement Yubico OTP support in applications, see https://status.yubico.com/2021/04/15/one-api-yubico-com-one-http-get/.

This PR deprecates `ykclient` accordingly.