### PR TITLE
wxmaxima: use main branch for `head`

### DIFF
--- a/Formula/wxmaxima.rb
+++ b/Formula/wxmaxima.rb
@@ -4,7 +4,7 @@ class Wxmaxima < Formula
   url "https://github.com/wxMaxima-developers/wxmaxima/archive/Version-21.05.2.tar.gz"
   sha256 "4d2d486a24090ace2f64ceccb026210e2e6299a32cb348d43134ef80440bcf01"
   license "GPL-2.0-or-later"
-  head "https://github.com/wxMaxima-developers/wxmaxima.git"
+  head "https://github.com/wxMaxima-developers/wxmaxima.git", branch: "main"
 
   bottle do
     sha256 arm64_big_sur: "68314ebcebe36aaa5eacdac464c9e0be072845025badf0415645c5a7bcb84ad6"


### PR DESCRIPTION
Installing mxmaxima from head with command `brew install --HEAD wxmaxima` currently fails with `fatal: Remote branch master not found in upstream origin` as the branch is now `main`.  This PR updates the formula to specify the correct branch.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
