### PR TITLE
pdftk-java:  Relax JDK version for M1 support

### DIFF
--- a/Formula/pdftk-java.rb
+++ b/Formula/pdftk-java.rb
@@ -4,6 +4,7 @@ class PdftkJava < Formula
   url "https://gitlab.com/pdftk-java/pdftk/-/archive/v3.2.2/pdftk-v3.2.2.tar.gz"
   sha256 "b284e413dd43fe440152360eccbc5cb9ffd8978be8313ffc060bfebb74d14bf1"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://gitlab.com/pdftk-java/pdftk.git"
 
   livecheck do
@@ -18,12 +19,12 @@ class PdftkJava < Formula
   end
 
   depends_on "gradle" => :build
-  depends_on "openjdk@8"
+  depends_on "openjdk"
 
   def install
     system "gradle", "shadowJar", "--no-daemon"
     libexec.install "build/libs/pdftk-all.jar"
-    bin.write_jar_script libexec/"pdftk-all.jar", "pdftk", java_version: "1.8"
+    bin.write_jar_script libexec/"pdftk-all.jar", "pdftk"
   end
 
   test do


### PR DESCRIPTION
…n m1

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
```
homebrew-core % patch -p1 < pdftk-java.patch 
patching file Formula/pdftk-java.rb
homebrew-core % git diff master
diff --git a/Formula/pdftk-java.rb b/Formula/pdftk-java.rb
index 61771fb208..e1e15bf2fb 100644
--- a/Formula/pdftk-java.rb
+++ b/Formula/pdftk-java.rb
@@ -18,12 +18,12 @@ class PdftkJava < Formula
   end
 
   depends_on "gradle" => :build
-  depends_on "openjdk@8"
+  depends_on "openjdk"
 
   def install
     system "gradle", "shadowJar", "--no-daemon"
     libexec.install "build/libs/pdftk-all.jar"
-    bin.write_jar_script libexec/"pdftk-all.jar", "pdftk", java_version: "1.8"
+    bin.write_jar_script libexec/"pdftk-all.jar", "pdftk"
   end
 
   test do
homebrew-core % brew install pdftk-java --build-from-source
==> Downloading https://ghcr.io/v2/homebrew/core/openjdk/11/manifests/11.0.10
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/openjdk/11/blobs/sha256:cf3697acc905957c78e2255bea96bd807c29329a8d5dd4cd22603585875c7c8f
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:cf3697acc905957c78e2255bea96bd807c29329a8d5dd4cd22603585875c7c8f?se=2021-05-25T19%3A40%3A00Z&sig=nBmqBLtxa1bJ3OxBOnjVkXXivu4UK4qP2vNB7SLvfEk%3D&s
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/gradle/manifests/7.0.2_2
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/gradle/blobs/sha256:4b3b39dd6943031660b05d88972179aaf57d18227077c49b3590a5174501240f
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:4b3b39dd6943031660b05d88972179aaf57d18227077c49b3590a5174501240f?se=2021-05-25T19%3A40%3A00Z&sig=GitAg699MnAFVwIQTzVZeEPtK0C%2FNOKn3R66tBRWASM%3D
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/openjdk/manifests/15.0.2
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/openjdk/blobs/sha256:063189cdbad2c9ef5ab5e7dc34cea1d2fe68a5405b3728eb87765d6c1b9a3a64
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:063189cdbad2c9ef5ab5e7dc34cea1d2fe68a5405b3728eb87765d6c1b9a3a64?se=2021-05-25T19%3A45%3A00Z&sig=MAU4kdSmUfJyBUrjjQDnqjAGpjMBW%2B%2F%2BvvMndEgrqg
######################################################################## 100.0%
==> Downloading https://gitlab.com/pdftk-java/pdftk/-/archive/v3.2.2/pdftk-v3.2.2.tar.gz
 #-#O=#   #                                                                   
==> Installing dependencies for pdftk-java: openjdk@11, gradle and openjdk
==> Installing pdftk-java dependency: openjdk@11
==> Pouring openjdk@11--11.0.10.arm64_big_sur.bottle.tar.gz
🍺  /opt/homebrew/Cellar/openjdk@11/11.0.10: 645 files, 272.6MB
==> Installing pdftk-java dependency: gradle
==> Pouring gradle--7.0.2_2.arm64_big_sur.bottle.tar.gz
🍺  /opt/homebrew/Cellar/gradle/7.0.2_2: 10,864 files, 260.6MB
==> Installing pdftk-java dependency: openjdk
==> Pouring openjdk--15.0.2.arm64_big_sur.bottle.tar.gz
🍺  /opt/homebrew/Cellar/openjdk/15.0.2: 613 files, 305.5MB
==> Installing pdftk-java
==> gradle shadowJar --no-daemon
🍺  /opt/homebrew/Cellar/pdftk-java/3.2.2: 7 files, 5.4MB, built in 28 seconds
homebrew-core % brew test pdftk-java                       
==> Installing 'bundler' gem
Fetching bundler-1.17.3.gem
Fetching gem metadata from https://rubygems.org/.........
Fetching zeitwerk 2.4.2
Fetching concurrent-ruby 1.1.8
Fetching minitest 5.14.4
Installing zeitwerk 2.4.2
Fetching public_suffix 4.0.6
Installing minitest 5.14.4
Fetching ast 2.4.2
Installing concurrent-ruby 1.1.8
Installing ast 2.4.2
Fetching bindata 2.4.8
Installing public_suffix 4.0.6
Fetching msgpack 1.4.2
Using bundler 1.17.3
Fetching byebug 11.1.3
Installing bindata 2.4.8
Installing msgpack 1.4.2 with native extensions
Fetching coderay 1.1.3
Installing byebug 11.1.3 with native extensions
Installing coderay 1.1.3
Fetching colorize 0.8.1
Installing colorize 0.8.1
Fetching highline 2.0.3
Installing highline 2.0.3
Fetching connection_pool 2.2.5
Installing connection_pool 2.2.5
Fetching diff-lcs 1.4.4
Installing diff-lcs 1.4.4
Fetching docile 1.3.5
Installing docile 1.3.5
Fetching unf_ext 0.0.7.7
Installing unf_ext 0.0.7.7 with native extensions
Fetching hpricot 0.8.6
Installing hpricot 0.8.6 with native extensions
Fetching mime-types-data 3.2021.0225
Installing mime-types-data 3.2021.0225
Fetching net-http-digest_auth 1.4.1
Installing net-http-digest_auth 1.4.1
Fetching mini_portile2 2.5.1
Installing mini_portile2 2.5.1
Fetching racc 1.5.2
Fetching rubyntlm 0.6.3
Installing racc 1.5.2 with native extensions
Installing rubyntlm 0.6.3
Fetching webrick 1.7.0
Installing webrick 1.7.0
Fetching webrobots 0.1.2
Installing webrobots 0.1.2
Fetching method_source 1.0.0
Installing method_source 1.0.0
Fetching mustache 1.1.1
Fetching parallel 1.20.1
Installing parallel 1.20.1
Fetching rainbow 3.0.0
Installing mustache 1.1.1
Fetching sorbet-runtime 0.5.6274
Installing rainbow 3.0.0
Fetching plist 3.6.0
Installing sorbet-runtime 0.5.6274
Fetching rack 2.2.3
Installing plist 3.6.0
Fetching rdiscount 2.2.0.2
Installing rdiscount 2.2.0.2 with native extensions
Installing rack 2.2.3
Fetching regexp_parser 2.1.1
Installing regexp_parser 2.1.1
Fetching rexml 3.2.5
Installing rexml 3.2.5
Fetching rspec-support 3.10.2
Installing rspec-support 3.10.2
Fetching sorbet-static 0.5.6274 (universal-darwin-20)
Installing sorbet-static 0.5.6274 (universal-darwin-20)
Fetching ruby-progressbar 1.11.0
Installing ruby-progressbar 1.11.0
Fetching unicode-display_width 2.0.0
Installing unicode-display_width 2.0.0
Fetching ruby-macho 2.5.1
Installing ruby-macho 2.5.1
Fetching simplecov-html 0.12.3
Installing simplecov-html 0.12.3
Fetching simplecov_json_formatter 0.1.2
Installing simplecov_json_formatter 0.1.2
Fetching sorbet-runtime-stub 0.2.0
Installing sorbet-runtime-stub 0.2.0
Fetching thor 1.1.0
Installing thor 1.1.0
Fetching warning 1.2.0
Installing warning 1.2.0
Fetching parser 3.0.1.1
Installing parser 3.0.1.1
Fetching addressable 2.7.0
Installing addressable 2.7.0
Fetching i18n 1.8.10
Installing i18n 1.8.10
Fetching tzinfo 2.0.4
Installing tzinfo 2.0.4
Fetching elftools 1.1.3
Installing elftools 1.1.3
Fetching commander 4.6.0
Installing commander 4.6.0
Fetching net-http-persistent 4.0.1
Installing net-http-persistent 4.0.1
Fetching bootsnap 1.7.5
Installing bootsnap 1.7.5 with native extensions
Fetching mime-types 3.3.1
Installing mime-types 3.3.1
Fetching unf 0.1.4
Installing unf 0.1.4
Fetching nokogiri 1.11.5 (x86_64-darwin)
Installing nokogiri 1.11.5 (x86_64-darwin)
Fetching pry 0.14.1
Installing pry 0.14.1
Fetching parallel_tests 3.7.0
Fetching rspec-core 3.10.1
Fetching rspec-expectations 3.10.1
Installing parallel_tests 3.7.0
Fetching rspec-mocks 3.10.2
Installing rspec-expectations 3.10.1
Installing rspec-core 3.10.1
Fetching sorbet 0.5.6274
Installing rspec-mocks 3.10.2
Fetching simplecov 0.21.2
Fetching rubocop-ast 1.5.0
Installing sorbet 0.5.6274
Fetching activesupport 6.1.3.2
Installing simplecov 0.21.2
Installing rubocop-ast 1.5.0
Fetching patchelf 1.3.0
Fetching parlour 6.0.0
Installing patchelf 1.3.0
Fetching domain_name 0.5.20190701
Installing activesupport 6.1.3.2
Installing parlour 6.0.0
Fetching ronn 0.7.3
Installing domain_name 0.5.20190701
Fetching rspec-github 2.3.1
Fetching rspec-its 1.3.0
Installing ronn 0.7.3
Fetching rspec-retry 0.6.2
Installing rspec-github 2.3.1
Fetching rspec 3.10.0
Installing rspec-its 1.3.0
Fetching rspec-sorbet 1.8.0
Installing rspec-retry 0.6.2
Fetching spoom 1.0.9
Installing rspec 3.10.0
Fetching simplecov-cobertura 1.4.2
Installing spoom 1.0.9
Installing simplecov-cobertura 1.4.2
Fetching rubocop 1.15.0
Installing rspec-sorbet 1.8.0
Fetching http-cookie 1.0.3
Fetching rspec-wait 0.0.9
Installing http-cookie 1.0.3
Installing rspec-wait 0.0.9
Fetching tapioca 0.4.22
Fetching mechanize 2.8.1
Installing tapioca 0.4.22
Installing mechanize 2.8.1
Installing rubocop 1.15.0
Fetching rubocop-performance 1.11.3
Fetching rubocop-rails 2.10.1
Fetching rubocop-rspec 2.3.0
Installing rubocop-performance 1.11.3
Installing rubocop-rspec 2.3.0
Installing rubocop-rails 2.10.1
Fetching rubocop-sorbet 0.6.1
Installing rubocop-sorbet 0.6.1
Bundle complete! 31 Gemfile dependencies, 84 gems now installed.
Bundled gems are installed into `../../../Homebrew/vendor/bundle`
Post-install message from sorbet:

  Thanks for installing Sorbet! To use it in your project, first run:

    bundle exec srb init

  which will get your project ready to use with Sorbet.
  After that whenever you want to typecheck your code, run:

    bundle exec srb tc

  For more docs see: https://sorbet.org/docs/adopting
==> Testing pdftk-java
==> /opt/homebrew/Cellar/pdftk-java/3.2.2/bin/pdftk /opt/homebrew/Library/Homebrew/test/support/fixtures/test.pdf /opt/homebrew/Library/Homebrew/test/support/fixtures/test.pdf cat output /private/tmp/pdftk-java-test-20210525-12376
homebrew-core % brew audit --strict pdftk-java 
homebrew-core %
```