### PR TITLE
universal-ctags p5.9.20210523.0 (new formula)

### DIFF
--- a/Formula/universal-ctags.rb
+++ b/Formula/universal-ctags.rb
@@ -1,0 +1,47 @@
+class UniversalCtags < Formula
+  desc "Maintained ctags implementation"
+  homepage "https://github.com/universal-ctags/ctags"
+  url "https://github.com/universal-ctags/ctags/archive/refs/tags/p5.9.20210523.0.tar.gz"
+  version "p5.9.20210523.0"
+  sha256 "00e5493454c7c013b996a24019b8f8cbd75968e1993fb56f7e2737b7309cc684"
+  license "GPL-2.0-only"
+  head "https://github.com/universal-ctags/ctags.git"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "docutils" => :build
+  depends_on "pkg-config" => :build
+  depends_on "jansson"
+  depends_on "libyaml"
+
+  uses_from_macos "libxml2"
+
+  conflicts_with "ctags", because: "this formula installs the same executable as the ctags formula"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", *std_configure_args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include <stdlib.h>
+
+      void func()
+      {
+        printf("Hello World!");
+      }
+
+      int main()
+      {
+        func();
+        return 0;
+      }
+    EOS
+    system bin/"ctags", "-R", "."
+    assert_match(/func.*test\.c/, File.read("tags"))
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Copied from https://github.com/universal-ctags/homebrew-universal-ctags since universal-ctags has releases now (see https://github.com/universal-ctags/homebrew-universal-ctags/issues/58).