### PR TITLE
six: remove `include Language::Python::Virtualenv`

### DIFF
--- a/Formula/six.rb
+++ b/Formula/six.rb
@@ -1,6 +1,4 @@
 class Six < Formula
-  include Language::Python::Virtualenv
-
   desc "Python 2 and 3 compatibility utilities"
   homepage "https://github.com/benjaminp/six"
   url "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"


### PR DESCRIPTION
It's not being used in the formula.

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?