### PR TITLE
pdftk-java: pin to openjdk@11 version for M1 support see: https://git…

### DIFF
--- a/Formula/pdftk-java.rb
+++ b/Formula/pdftk-java.rb
@@ -4,7 +4,7 @@ class PdftkJava < Formula
   url "https://gitlab.com/pdftk-java/pdftk/-/archive/v3.2.2/pdftk-v3.2.2.tar.gz"
   sha256 "b284e413dd43fe440152360eccbc5cb9ffd8978be8313ffc060bfebb74d14bf1"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
   head "https://gitlab.com/pdftk-java/pdftk.git"
 
   livecheck do
@@ -20,12 +20,12 @@ class PdftkJava < Formula
   end
 
   depends_on "gradle" => :build
-  depends_on "openjdk"
+  depends_on "openjdk@11"
 
   def install
     system "gradle", "shadowJar", "--no-daemon"
     libexec.install "build/libs/pdftk-all.jar"
-    bin.write_jar_script libexec/"pdftk-all.jar", "pdftk"
+    bin.write_jar_script libexec/"pdftk-all.jar", "pdftk", java_version: "11"
   end
 
   test do


### PR DESCRIPTION
…hub.com/Homebrew/homebrew-core/pull/72535

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See: https://github.com/Homebrew/homebrew-core/pull/78021
There was a suggestion to use openjdk@11, so I'm opening this just in case that is well founded.