### PR TITLE
libxslt: depend on pkg-config for build on Linux

### DIFF
--- a/Formula/libxslt.rb
+++ b/Formula/libxslt.rb
@@ -28,6 +28,10 @@ class Libxslt < Formula
   depends_on "libgcrypt"
   depends_on "libxml2"
 
+  on_linux do
+    depends_on "pkg-config" => :build
+  end
+
   # Fix configure script for libxml2
   # Remove in the next release
   patch do


### PR DESCRIPTION
Fixes:
2021-05-25T19:32:46.5378757Z checking for xml2-config... /home/linuxbrew/.linuxbrew/opt/libxml2/bin/xml2-config
2021-05-25T19:32:46.5380027Z ./configure: line 15402: syntax error near unexpected token `LIBXML,'
2021-05-25T19:32:46.5381168Z ./configure: line 15402: `        PKG_CHECK_MODULES(LIBXML, libxml-2.0 >= $LIBXML_REQUIRED_VERSION,'

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
