### PR TITLE
libu2f-host: deprecate

### DIFF
--- a/Formula/libu2f-host.rb
+++ b/Formula/libu2f-host.rb
@@ -19,6 +19,9 @@ class Libu2fHost < Formula
     sha256 cellar: :any, high_sierra:   "376aa8fc3a98d4aab29ba7d284a58bf07308fda51aa30da72e068f8a6206505e"
   end
 
+  # See: https://github.com/Yubico/libu2f-host
+  deprecate! date: "2021-05-25", because: :repo_archived
+
   depends_on "pkg-config" => :build
   depends_on "hidapi"
   depends_on "json-c"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See: https://github.com/Yubico/libu2f-host
> This project is deprecated and is no longer being maintained. libfido2 is a new project with support for U2F and FIDO2.