### PR TITLE
mysql@5.6&5.7: fix C++20 complier loads VERSION

### DIFF
--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -31,6 +31,15 @@ class MysqlAT56 < Formula
       "COMMAND /usr/bin/libtool -static -o ${TARGET_LOCATION}",
       "COMMAND libtool -static -o ${TARGET_LOCATION}"
 
+    # fix C++20 compiler loads VERSION
+    File.rename "VERSION", "MYSQL_VERSION"
+    inreplace "cmake/mysql_version.cmake",
+      "  ${CMAKE_SOURCE_DIR}/VERSION",
+      "  ${CMAKE_SOURCE_DIR}/MYSQL_VERSION"
+    inreplace "cmake/mysql_version.cmake",
+      "   FILE (STRINGS ${CMAKE_SOURCE_DIR}/VERSION str REGEX \"^[ ]*${keyword}=\")",
+      "   FILE (STRINGS ${CMAKE_SOURCE_DIR}/MYSQL_VERSION str REGEX \"^[ ]*${keyword}=\")"
+
     # -DINSTALL_* are relative to `CMAKE_INSTALL_PREFIX` (`prefix`)
     args = %W[
       -DCOMPILATION_COMMENT=Homebrew

--- a/Formula/mysql@5.7.rb
+++ b/Formula/mysql@5.7.rb
@@ -33,6 +33,15 @@ class MysqlAT57 < Formula
   end
 
   def install
+    # fix C++20 compiler loads VERSION
+    File.rename "VERSION", "MYSQL_VERSION"
+    inreplace "cmake/mysql_version.cmake",
+      "  ${CMAKE_SOURCE_DIR}/VERSION",
+      "  ${CMAKE_SOURCE_DIR}/MYSQL_VERSION"
+    inreplace "cmake/mysql_version.cmake",
+      "   FILE (STRINGS ${CMAKE_SOURCE_DIR}/VERSION str REGEX \"^[ ]*${keyword}=\")",
+      "   FILE (STRINGS ${CMAKE_SOURCE_DIR}/MYSQL_VERSION str REGEX \"^[ ]*${keyword}=\")"
+
     # -DINSTALL_* are relative to `CMAKE_INSTALL_PREFIX` (`prefix`)
     args = %W[
       -DCOMPILATION_COMMENT=Homebrew


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
