### PR TITLE
gnutls: depend on autogen at runtime for Linux

### DIFF
--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -31,7 +31,7 @@ class Gnutls < Formula
   depends_on "unbound"
 
   on_linux do
-    depends_on "autogen" => :build
+    depends_on "autogen"
 
     resource "cacert" do
       # homepage "http://curl.haxx.se/docs/caextract.html"


### PR DESCRIPTION
Fixes:
==> brew linkage --test gnutls
==> FAILED
Missing libraries:
unexpected (libopts.so.25)

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
