### PR TITLE
libswiftnav 2.4.2

### DIFF
--- a/Formula/libswiftnav.rb
+++ b/Formula/libswiftnav.rb
@@ -1,9 +1,14 @@
 class Libswiftnav < Formula
   desc "C library implementing GNSS related functions and algorithms"
-  homepage "https://github.com/swift-nav/libswiftnav-legacy"
-  url "https://github.com/swift-nav/libswiftnav-legacy/archive/v0.21.tar.gz"
-  sha256 "087c7264c0d0d735414f8bffbfa52ab44696c500ba14a43262d98d6aa093221f"
-  license "LGPL-3.0"
+  homepage "https://github.com/swift-nav/libswiftnav"
+  url "https://github.com/swift-nav/libswiftnav/archive/v2.4.2.tar.gz"
+  sha256 "9dfe4ce4b4da28ffdb71acad261eef4dd98ad79daee4c1776e93b6f1765fccfa"
+  license "LGPL-3.0-only"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     rebuild 1
@@ -17,18 +22,29 @@ class Libswiftnav < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "pkg-config" => :build
+
+  # Check the `/cmake` directory for a given version tag
+  # (e.g., https://github.com/swift-nav/libswiftnav/tree/v2.4.2/cmake)
+  # to identify the referenced commit hash in the swift-nav/cmake repository.
+  resource "swift-nav/cmake" do
+    url "https://github.com/swift-nav/cmake/archive/fd8c86b87d2b18261691ef8db1f6fd9906911b82.tar.gz"
+    sha256 "7b6995bcc97d001cfe5c4741a8fa3637bc4dc2c3460b908585aef5e7af268798"
+  end
 
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    (buildpath/"cmake/common").install resource("swift-nav/cmake")
+
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
   end
 
   test do
     (testpath/"test.c").write <<~EOS
       #include <stdlib.h>
       #include <stdio.h>
-      #include <libswiftnav/edc.h>
+      #include <swiftnav/edc.h>
 
       const u8 *test_data = (u8*)"123456789";
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The [swift-nav/libswiftnav-legacy](https://github.com/swift-nav/libswiftnav-legacy) GitHub repository has been archived and the `README` reads:

> Please see https://github.com/swift-nav/libswiftnav

This PR modifies the `libswiftnav` formula to use the current repository. As mentioned in #77990, users may need to update their code to reference `swiftnav` (e.g., in `#include` statements) instead of `libswiftnav` (this was necessary to fix the test, at least). This may temporarily break things for existing users but there was support for this approach over others in the aforementioned PR.

This also updates the license from `LGPL-3.0` to `LGPL-3.0-only`, as the source code, `README`, etc. don't use any "or later" language.

Lastly, this adds a `livecheck` block that checks the Git tags using the standard regex for Git tags like `1.2.3`/`v1.2.3` (i.e., `/^v?(\d+(?:\.\d+)+)$/i`). The default check worked fine but I added this `livecheck` block to avoid some unusual tags (e.g., `0.1.6-1-gfc68346`, `2.4.0-branch`) and ensure we're only matching stable releases.