### PR TITLE
bowtie2: fix build on ARM

### DIFF
--- a/Formula/bowtie2.rb
+++ b/Formula/bowtie2.rb
@@ -4,6 +4,7 @@ class Bowtie2 < Formula
   url "https://github.com/BenLangmead/bowtie2/archive/v2.4.4.tar.gz"
   sha256 "ef8272fc1b3e18a30f16cb4b6a4344bf50e1f82fbd3af93dc8194b58e5856f64"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:  "540b354db85c68e4be5276c7a68622b260cf53da5366c11337eeb8e690432b1f"
@@ -11,6 +12,7 @@ class Bowtie2 < Formula
     sha256 cellar: :any_skip_relocation, mojave:   "9341eaa91888215e685123847a3e87f91a2d140612dcb8d1a3850c01c335fc2d"
   end
 
+  depends_on "simde"
   depends_on "tbb"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Attempt to bottle `bowtie2` on ARM. They do have ARM support (although only for Linux, from their repository). Their [`travis.yml`](https://github.com/BenLangmead/bowtie2/blob/e20d2c92d30787cad99758bea0b56ad17dc89637/.travis.yml) does indicate that they're building it on ARM for Linux with the `POPCNT_CAPABILITY=0` argument to `make`. Might also have to set `NO_TBB=1`.