### PR TITLE
jboss-forge: add livecheck

### DIFF
--- a/Formula/jboss-forge.rb
+++ b/Formula/jboss-forge.rb
@@ -4,6 +4,14 @@ class JbossForge < Formula
   url "https://downloads.jboss.org/forge/releases/3.9.8.Final/forge-distribution-3.9.8.Final-offline.zip"
   sha256 "a08387f2d7010ac34e13593707d4d93a135a6e3b42cbe78ebcdae4ef3e5c0bf2"
 
+  # The first-party download page (https://forge.jboss.org/download) uses
+  # JavaScript to render the download links and the version information comes
+  # from the /api/metadata endpoint in JSON format.
+  livecheck do
+    url "https://forge.jboss.org/api/metadata"
+    regex(/["']latestVersion["']:\s*["']([^"']+?)["']/i)
+  end
+
   bottle :unneeded
 
   depends_on "openjdk"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `jboss-forge`. This PR adds a `livecheck` block that checks the `https://forge.jboss.org/api/metadata` endpoint, which contains the version information that's used to render the download links on the [first-party download page](https://forge.jboss.org/download) using JavaScript.