### PR TITLE
gcc@10: add zstd support

### DIFF
--- a/Formula/gcc@10.rb
+++ b/Formula/gcc@10.rb
@@ -5,6 +5,7 @@ class GccAT10 < Formula
   mirror "https://ftpmirror.gnu.org/gcc/gcc-10.3.0/gcc-10.3.0.tar.xz"
   sha256 "64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
+  revision 1
 
   livecheck do
     url :stable
@@ -26,6 +27,7 @@ class GccAT10 < Formula
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
+  depends_on "zstd"
 
   uses_from_macos "zlib"
 
@@ -66,6 +68,7 @@ class GccAT10 < Formula
       --with-mpfr=#{Formula["mpfr"].opt_prefix}
       --with-mpc=#{Formula["libmpc"].opt_prefix}
       --with-isl=#{Formula["isl"].opt_prefix}
+      --with-zstd=#{Formula["zstd"].opt_prefix}
       --with-pkgversion=#{pkgversion}
       --with-bugurl=#{tap.issues_url}
     ]
@@ -90,6 +93,7 @@ class GccAT10 < Formula
     end
 
     mkdir "build" do
+      ENV.append_to_cflags "-I#{Formula["zstd"].opt_include}"
       system "../configure", *args
 
       # Use -headerpad_max_install_names in the build,


### PR DESCRIPTION
* [x]  Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
* [x]  Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
* [ ]  Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
* [ ]  Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
* [ ]  Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

This enables the use of `zstd` instead of `zlib` for LTO data
compression. Compression with `zstd` is 4-8x faster than with `zlib`. [1]

This is, for practical purposes, part of the default GCC configuration,
since GCC's build system will enable `zstd` support when it discovers
that `zstd` is available in the build environment. We pass the
`--with-zstd` flag anyway to make sure it uses a brewed `zstd` for that.

Same as https://github.com/Homebrew/homebrew-core/pull/77985 but for gcc@10 since it is also affected. [2]

[1] https://gcc.gnu.org/legacy-ml/gcc/2019-06/msg00185.html
[2] https://gcc.gnu.org/gcc-10/changes.html

