### PR TITLE
bnfc: revert "fix sphinx-docs 4.0+ man directory"

### DIFF
--- a/Formula/bnfc.rb
+++ b/Formula/bnfc.rb
@@ -33,7 +33,7 @@ class Bnfc < Formula
       system "make", "text", "man", "SPHINXBUILD=#{Formula["sphinx-doc"].bin/"sphinx-build"}"
       cd "_build" do
         doc.install "text" => "manual"
-        man1.install "man/1/bnfc.1" => "bnfc.1"
+        man1.install "man/bnfc.1" => "bnfc.1"
       end
     end
     doc.install %w[README.md examples]


### PR DESCRIPTION
This reverts commit 980ebca602794c7f9d4a56fee186e0c2ec90cfa0.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Seen in CI run from https://github.com/Homebrew/homebrew-core/pull/72535#issuecomment-846722996

Sphinx 4.0.2 reverted behavior on manpage directory structure
https://www.sphinx-doc.org/en/master/changes.html#release-4-0-2-released-may-20-2021
> ### Incompatible changes
> - \# 9217: manpage: Stop creating a section directory on build manpage by default (see man_make_section_directory)