### PR TITLE
sn0int: revert change to manpage directory

### DIFF
--- a/Formula/sn0int.rb
+++ b/Formula/sn0int.rb
@@ -34,7 +34,7 @@ class Sn0int < Formula
     (fish_completion/"sn0int.fish").write fish_output
 
     system "make", "-C", "docs", "man"
-    man1.install "docs/_build/man/1/sn0int.1"
+    man1.install "docs/_build/man/sn0int.1"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The manpage location was changed in an earlier PR but now that Sphinx 4.0.2 has landed, that change needs to be reverted. Similar to #78103.