### PR TITLE
dhex: add livecheck

### DIFF
--- a/Formula/dhex.rb
+++ b/Formula/dhex.rb
@@ -4,6 +4,11 @@ class Dhex < Formula
   url "https://www.dettus.net/dhex/dhex_0.69.tar.gz"
   sha256 "52730bcd1cf16bd4dae0de42531be9a4057535ec61ca38c0804eb8246ea6c41b"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?dhex[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "6b2818af033ee41f28f7718a9a310dc32b2b54272f7485934a643571e54b65b9"
     sha256 cellar: :any_skip_relocation, big_sur:       "f9737b2072e10b36cf34973fb1a18fbbdd570bbb4109656b89a51678220fd67e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `dhex`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.