### PR TITLE
coccinelle: add missing pcre dependency and fix revision hash

### DIFF
--- a/Formula/coccinelle.rb
+++ b/Formula/coccinelle.rb
@@ -3,7 +3,7 @@ class Coccinelle < Formula
   homepage "http://coccinelle.lip6.fr/"
   url "https://github.com/coccinelle/coccinelle.git",
       tag:      "1.1.0",
-      revision: "e84d3ddc7d4131b7e7e70c29d49eca09d35fabb6"
+      revision: "25e7cee77b4b6efbabf60ffaa8bccd72500ba8bd"
   license "GPL-2.0-only"
   revision 1
   head "https://github.com/coccinelle/coccinelle.git"
@@ -25,7 +25,9 @@ class Coccinelle < Formula
   depends_on "hevea" => :build
   depends_on "ocaml-findlib" => :build
   depends_on "opam" => :build
+  depends_on "pkg-config" => :build
   depends_on "ocaml"
+  depends_on "pcre"
 
   # Bootstap resource for Ocaml 4.12 compatibility.
   # Remove when Coccinelle supports Ocaml 4.12 natively


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix failures from #75169

Minor re-tag due to version number / changelog commit:
https://github.com/coccinelle/coccinelle/compare/e84d3ddc7d4131b7e7e70c29d49eca09d35fabb6...25e7cee77b4b6efbabf60ffaa8bccd72500ba8bd

`pcre` is a build/runtime dependency:
- Build:
  ```
  checking for libpcre... yes
  configure: configuring package pcre
  ```
- Test:
  ```
  dyld: Library not loaded: /usr/local/opt/pcre/lib/libpcre.1.dylib
    Referenced from: /usr/local/Cellar/coccinelle/1.1.0_1/bin/spatch
    Reason: image not found
  Error: coccinelle: failed
  ```


`pkg-config` is optional (fallback is used if unavailable), but might as well add since recommended:
https://github.com/coccinelle/coccinelle/blob/master/install.txt
> pkg-config (optional, but strongly recommended)