### PR TITLE
libtecla: add livecheck

### DIFF
--- a/Formula/libtecla.rb
+++ b/Formula/libtecla.rb
@@ -1,8 +1,13 @@
 class Libtecla < Formula
   desc "Command-line editing facilities similar to the tcsh shell"
-  homepage "https://www.astro.caltech.edu/~mcs/tecla/index.html"
-  url "https://www.astro.caltech.edu/~mcs/tecla/libtecla-1.6.3.tar.gz"
+  homepage "https://sites.astro.caltech.edu/~mcs/tecla/"
+  url "https://sites.astro.caltech.edu/~mcs/tecla/libtecla-1.6.3.tar.gz"
   sha256 "f2757cc55040859fcf8f59a0b7b26e0184a22bece44ed9568a4534a478c1ee1a"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?libtecla[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, big_sur:     "d0f28c06cf9d2d1669298104439c4e194d21df65fc17e9b95e9dec0383aa7fef"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `libtecla`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This also updates the `homepage` and `stable` URLs to avoid redirecting from `www.astro.caltech.edu` to `sites.astro.caltech.edu`. I built this from source locally and the `sha256` remains unchanged.