### PR TITLE
xmlformat: add livecheck

### DIFF
--- a/Formula/xmlformat.rb
+++ b/Formula/xmlformat.rb
@@ -4,6 +4,11 @@ class Xmlformat < Formula
   url "http://www.kitebird.com/software/xmlformat/xmlformat-1.04.tar.gz"
   sha256 "71a70397e44760d67645007ad85fea99736f4b6f8679067a3b5f010589fd8fef"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?xmlformat[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle :unneeded
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `xmlformat`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.