### PR TITLE
rdiff-backup: build on ARM

### DIFF
--- a/Formula/rdiff-backup.rb
+++ b/Formula/rdiff-backup.rb
@@ -3,7 +3,7 @@ class RdiffBackup < Formula
   homepage "https://rdiff-backup.net/"
   url "https://github.com/rdiff-backup/rdiff-backup/releases/download/v2.0.5/rdiff-backup-2.0.5.tar.gz"
   sha256 "2bb7837b4a9712b6efaebfa7da8ed6348ffcb02fcecff0e19d8fff732e933b87"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
 
   bottle do
@@ -17,7 +17,6 @@ class RdiffBackup < Formula
   depends_on "python@3.9"
 
   def install
-    ENV["ARCHFLAGS"] = "-arch x86_64"
     system "python3", "setup.py", "build", "--librsync-dir=#{prefix}"
     libexec.install Dir["build/lib.macosx*/rdiff_backup"]
     libexec.install Dir["build/scripts-*/*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Not sure if `ARCHFLAGS` are needed.

Since Homebrew's Python is specific to architecture, I think it should be architecture-specific by default.