### PR TITLE
libtecla: add automake as build dependency for ARM support

### DIFF
--- a/Formula/libtecla.rb
+++ b/Formula/libtecla.rb
@@ -19,10 +19,19 @@ class Libtecla < Formula
     sha256 cellar: :any, yosemite:    "836d6100343197540f079ea7f6b9e5641fd8efc4e331d3492f8be4cd41ced6e9"
   end
 
+  # Added automake as a build dependency to update config files for ARM support.
+  # Please remove in the future if there is a patch upstream which recognises aarch64 macOS.
+  depends_on "automake" => :build
+
   uses_from_macos "ncurses"
 
   def install
     ENV.deparallelize
+
+    %w[config.guess config.sub].each do |fn|
+      cp "#{Formula["automake"].opt_prefix}/share/automake-#{Formula["automake"].version.major_minor}/#{fn}", fn
+    end
+
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

There haven't been any releases to `libtecla` since 2014, ~so I took some _inspiration_ from the `tecla` port over at MacPorts~ so we're using `automake` as a build dependency to update the outdated configure files.