### PR TITLE
llvm: Collapse runtimes and projects being configured.

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -53,8 +53,6 @@ class Llvm < Formula
       openmp
       polly
       mlir
-    ]
-    runtimes = %w[
       compiler-rt
       libcxx
       libcxxabi
@@ -79,7 +77,6 @@ class Llvm < Formula
     # in a non-default prefix
     args = %W[
       -DLLVM_ENABLE_PROJECTS=#{projects.join(";")}
-      -DLLVM_ENABLE_RUNTIMES=#{runtimes.join(";")}
       -DLLVM_POLLY_LINK_INTO_TOOLS=ON
       -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON
       -DLLVM_LINK_LLVM_DYLIB=ON


### PR DESCRIPTION
Using the separate lists here isn't the documented way of building LLVM,
nor what is used by the upstream packagers. It results in different
directory layouts on different Linux distributions that don't work as
well with Clang and other instructions (and don't match the layout on
Mac). It also caused some other problems when porting to linuxbrew that
resulted in disabling things there.

Switching to the simpler all-projects configuration, which is the
documented and recommended way of building LLVM, these problems go away
and the predictable and usable. This causes the tests to pass, etc.

Everything also continues to work on Mac, and this really seems to be
the canonical and preferred way to build LLVM. I have built LLVM from
source with this on my Mac and ensured the tests pass and the resulting
toolchain works.

I also have tested a version of this in Linuxbrew on both a Debian
testing and Ubuntu 16.04 (the distro baseline where historical problems
occurred) and it works well and passes all tests.

If anyone hits issues with LLVM builds in Homebrew, I'm happy to help
debug and help maintain the LLVM build here. I'm a very long time LLVM
developer and user with lots of experience with the build system.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
