### PR TITLE
nginx: update livecheck

### DIFF
--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -10,7 +10,7 @@ class Nginx < Formula
 
   livecheck do
     url :homepage
-    regex(%r{nginx[._-]v?(\d+(?:\.\d+)+)</a>\nmainline version has been released}i)
+    regex(%r{nginx[._-]v?(\d+(?:\.\d+)+)</a>\nmainline version}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `nginx` fails to identify the latest mainline version because the regex only matches text like `nginx-1.19.10 mainline version has been released`. The latest mainline version (`1.21.0`) isn't matched because the news text combines the information for the new stable and mainline versions: `nginx-1.20.1 stable and nginx-1.21.0 mainline versions have been released, ...`.

This PR modifies the `livecheck` block regex so that it simply targets text like `nginx-1.21.0 mainline version`, which works for either news format. There's always a remote chance that the news page will contain something like `nginx-1.2.3 mainline version will be released...`, referring to an upcoming version, but this seems highly unlikely. We could strengthen this regex but I think it's fine being a little loose unless/until it causes problems in the future.