### PR TITLE
openshift-cli: caveats for version issue

### DIFF
--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -52,6 +52,14 @@ class OpenshiftCli < Formula
     end
   end
 
+  def caveats
+    <<~EOS
+      The version reported by the "oc version --client" command is known to be incorrect.
+      Nevertheless the correct version matching the formula was installed.
+      For more information see: https://github.com/openshift/oc/issues/740
+    EOS
+  end
+
   test do
     (testpath/"kubeconfig").write ""
     system "KUBECONFIG=#{testpath}/kubeconfig #{bin}/oc config set-context foo 2>&1"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The version problem with the `oc version` command was recently reported in #76968 and #66476.

Here is an explanation about this problem: https://github.com/openshift/oc/issues/774#issuecomment-849736677