### PR TITLE
entr: add patch to prevent segfault

### DIFF
--- a/Formula/entr.rb
+++ b/Formula/entr.rb
@@ -4,6 +4,7 @@ class Entr < Formula
   url "https://eradman.com/entrproject/code/entr-4.9.tar.gz"
   sha256 "e256a4d2fbe46f6132460833ba447e65d7f35ba9d0b265e7c4150397cc4405a2"
   license "ISC"
+  revision 1
   head "https://github.com/eradman/entr.git"
 
   livecheck do
@@ -17,6 +18,10 @@ class Entr < Formula
     sha256 cellar: :any_skip_relocation, catalina:      "9e8c9239cf071087ff47cfcd1ab0a729a77e5a9e7284a038d1790a81eebd70a3"
     sha256 cellar: :any_skip_relocation, mojave:        "810b1d21eef7e39c5194296c0717bdb200c2d5f1edf2c64d24093d4df95d4bf2"
   end
+
+  # Fix v4.9 segfault on the Mac: https://github.com/eradman/entr/issues/74
+  # TODO: remove in next release
+  patch :DATA
 
   def install
     ENV["PREFIX"] = prefix
@@ -35,3 +40,18 @@ class Entr < Formula
     assert_equal "New File", pipe_output("#{bin}/entr -n -p -d echo 'New File'", testpath).strip
   end
 end
+
+__END__
+diff --git a/entr.c b/entr.c
+index ebe535a2dc18baf1cc58db3d96a20db6822c61e7..e137919d4c11051ffa0b87691bb771f681c43b72 100644
+--- a/entr.c
++++ b/entr.c
+@@ -164,6 +164,8 @@ main(int argc, char *argv[]) {
+ 	if (open_max == 0)
+ 		open_max = 65536;
+ #elif defined(_MACOS_PORT)
++	if (getrlimit(RLIMIT_NOFILE, &rl) == -1)
++		err(1, "getrlimit");
+ 	/* guard against unrealistic replies */
+ 	open_max = min(65536, (unsigned)rl.rlim_cur);
+ 	if (open_max == 0)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
The 4.9 release of `entr` segfaults when installed on the Mac via Homebrew ([discussed here](https://github.com/Homebrew/discussions/discussions/1542)) because of an uninitialized struct that accidentally got introduced upstream ([upstream issue 74](https://github.com/eradman/entr/issues/74)). 

The main branch of upstream has been fixed in (https://github.com/eradman/entr/commit/468d77d45925abba826bb1dcda01487dbe37eb33) and the fix will go out in a future upstream release, but in the meantime `entr` installs are probably failing on most Macs so it would be good to push out this temporary fix.

This is my first Homebrew PR, so I'm guessing that we'll need to bump the `revision` here to cause new bottles to be published, and I added `revision 1` to this patch. But I could be wrong about that. 