### PR TITLE
bumpversion: script has different flags on Linux

### DIFF
--- a/Formula/bumpversion.rb
+++ b/Formula/bumpversion.rb
@@ -25,7 +25,12 @@ class Bumpversion < Formula
 
   test do
     ENV["COLUMNS"] = "80"
-    assert_includes shell_output("script -q /dev/null #{bin}/bumpversion --help"), "bumpversion: v#{version}"
+    on_macos do
+      assert_includes shell_output("script -q /dev/null #{bin}/bumpversion --help"), "bumpversion: v#{version}"
+    end
+    on_linux do
+      assert_includes shell_output("script -q /dev/null -c \"#{bin}/bumpversion --help\""), "bumpversion: v#{version}"
+    end
     version_file = testpath/"VERSION"
     version_file.write "0.0.0"
     system bin/"bumpversion", "--current-version", "0.0.0", "minor", version_file


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
