### PR TITLE
physfs: use `#rpath`

### DIFF
--- a/Formula/physfs.rb
+++ b/Formula/physfs.rb
@@ -3,6 +3,7 @@ class Physfs < Formula
   homepage "https://icculus.org/physfs/"
   url "https://icculus.org/physfs/downloads/physfs-3.0.2.tar.bz2"
   sha256 "304df76206d633df5360e738b138c94e82ccf086e50ba84f456d3f8432f9f863"
+  license "Zlib"
   head "https://hg.icculus.org/icculus/physfs/", using: :hg
 
   livecheck do
@@ -30,7 +31,7 @@ class Physfs < Formula
     mkdir "macbuild" do
       args = std_cmake_args
       args << "-DPHYSFS_BUILD_TEST=TRUE"
-      args << "-DCMAKE_INSTALL_RPATH=#{lib}"
+      args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
       args << "-DPHYSFS_BUILD_WX_TEST=FALSE" unless build.head?
       system "cmake", "..", *args
       system "make", "install"


### PR DESCRIPTION
See #75458.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?