### PR TITLE
google-java-format: support Java 16

### DIFF
--- a/Formula/google-java-format.rb
+++ b/Formula/google-java-format.rb
@@ -11,7 +11,15 @@ class GoogleJavaFormat < Formula
 
   def install
     libexec.install "google-java-format-#{version}-all-deps.jar" => "google-java-format.jar"
-    bin.write_jar_script libexec / "google-java-format.jar", "google-java-format"
+
+    java_opts = <<~JAVA_OPTS.gsub(/\s+/, " ").strip
+      --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+      --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+      --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+      --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+      --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+    JAVA_OPTS
+    bin.write_jar_script libexec / "google-java-format.jar", "google-java-format", java_opts
   end
 
   test do


### PR DESCRIPTION
Java 16 by default no longer expose internal APIs that this formula relies upon.
Thus additional flags have to be added for Java 16 to work.
See https://github.com/google/google-java-format#jdk-16.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
