### PR TITLE
zsync: add livecheck

### DIFF
--- a/Formula/zsync.rb
+++ b/Formula/zsync.rb
@@ -4,6 +4,11 @@ class Zsync < Formula
   url "http://zsync.moria.org.uk/download/zsync-0.6.2.tar.bz2"
   sha256 "0b9d53433387aa4f04634a6c63a5efa8203070f2298af72a705f9be3dda65af2"
 
+  livecheck do
+    url "http://zsync.moria.org.uk/downloads"
+    regex(/href=.*?zsync[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "0ee85fb722fa125e4323e14732d4de448f3751e9445e2ec6933fce0ee38d5a90"
     sha256 cellar: :any_skip_relocation, big_sur:       "1be9e390c02555dbce349a76e0beb63231bc327f4326580b18679ff0307db446"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `zsync`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.