### PR TITLE
mscgen: add livecheck

### DIFF
--- a/Formula/mscgen.rb
+++ b/Formula/mscgen.rb
@@ -5,6 +5,11 @@ class Mscgen < Formula
   sha256 "3c3481ae0599e1c2d30b7ed54ab45249127533ab2f20e768a0ae58d8551ddc23"
   revision 3
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?mscgen-src[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any, big_sur:     "662b9da17d8c911e9d24be48def9a222e7068386c0b482eca48248d127467e14"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `mscgen`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.