### PR TITLE
xa: add livecheck

### DIFF
--- a/Formula/xa.rb
+++ b/Formula/xa.rb
@@ -5,6 +5,11 @@ class Xa < Formula
   sha256 "32f2164c99e305218e992970856dd8e2309b5cb6ac4758d7b2afe3bfebc9012d"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href\s*?=.*?xa[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e17d657560922230517dfecf5d6600f0aae85c17bb86108a9c6c935be3a1bde7"
     sha256 cellar: :any_skip_relocation, big_sur:       "0f45f1bf0cd1d43ff2135c305ec836301dcc6d58d1ebc0f7fdbe9d9b9fb747a7"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `xa`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

The `regex` in this `livecheck` block is slightly different than the usual regex for matching a version from a filename in an `href` attribute on an HTML page. This page contains whitespace around the equals sign for attributes (e.g., `href = "something"`), so it was necessary to use `href\s*?=.*?` instead of the usual `href=.*?`.