### PR TITLE
gtk-chtheme: add livecheck

### DIFF
--- a/Formula/gtk-chtheme.rb
+++ b/Formula/gtk-chtheme.rb
@@ -5,6 +5,11 @@ class GtkChtheme < Formula
   sha256 "26f4b6dd60c220d20d612ca840b6beb18b59d139078be72c7b1efefc447df844"
   revision 3
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?gtk-chtheme[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "8db79039412079abddb969b631131eb3a85f4e90edbcda84bffe4505e55f44b7"
     sha256 cellar: :any, big_sur:       "b6255d461ea8c2ce6606170fdfc3d0564cc7d83ad5feeb7243c6dac01a7ba9e1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `gtk-chtheme`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.