### PR TITLE
mrtg: add livecheck

### DIFF
--- a/Formula/mrtg.rb
+++ b/Formula/mrtg.rb
@@ -4,6 +4,11 @@ class Mrtg < Formula
   url "https://oss.oetiker.ch/mrtg/pub/mrtg-2.17.7.tar.gz"
   sha256 "9b94cb268fb15b0304ad3bb3ec92b9a8a16dacfcee72baac19298224a2c332c3"
 
+  livecheck do
+    url "https://oss.oetiker.ch/mrtg/pub/"
+    regex(/href=.*?mrtg[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "a1b3746893c8a50b75735a622cecdea8ae87d0ed4adaa18a9aadd473238fe271"
     sha256 cellar: :any, big_sur:       "657438ce4eea4830cd467cc64bd8f653b9a025e8052b6c1b5e8811bbd837cc91"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `mrtg`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found (as the download page simply links to the directory listing page).