### PR TITLE
opencsg: add livecheck

### DIFF
--- a/Formula/opencsg.rb
+++ b/Formula/opencsg.rb
@@ -5,6 +5,11 @@ class Opencsg < Formula
   sha256 "d952ec5d3a2e46a30019c210963fcddff66813efc9c29603b72f9553adff4afb"
   revision 3
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?OpenCSG[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "c06e0c8e9ceee5ad621e6f650a289f34f30428bce43f6a9efb95621fc7afdafb"
     sha256 cellar: :any, big_sur:       "f7e6296d4466eea7c516fdca9e382d30fad4194b73969a1158d3d399b59c9381"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `opencsg`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.