### PR TITLE
kyoto-cabinet: add livecheck

### DIFF
--- a/Formula/kyoto-cabinet.rb
+++ b/Formula/kyoto-cabinet.rb
@@ -5,6 +5,11 @@ class KyotoCabinet < Formula
   sha256 "67fb1da4ae2a86f15bb9305f26caa1a7c0c27d525464c71fd732660a95ae3e1d"
   license "GPL-3.0-or-later"
 
+  livecheck do
+    url "https://dbmx.net/kyotocabinet/pkg/"
+    regex(/href=.*?kyotocabinet[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "fa9322ae66dc8295d2f60365999a371c6602bcfd98f050e0897992e745c53d93"
     sha256 big_sur:       "8a7873835b5790ece37b54d398daf834e7aa75570202cd7a174ba7e5ebecf6a3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `kyoto-cabinet`. This PR adds a `livecheck` block that checks the first-party directory listing page for "Source Packages of the core library (C/C++)", which links to the `stable` archive. [The homepage simply links to this directory listing page rather than providing a download page or linking to archive files directly.]