### PR TITLE
regex-opt: add livecheck

### DIFF
--- a/Formula/regex-opt.rb
+++ b/Formula/regex-opt.rb
@@ -5,6 +5,11 @@ class RegexOpt < Formula
   sha256 "128c8ba9570b1fd8a6a660233de2f5a4022740bc5ee300300709c3894413883f"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?regex-opt[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "0d8b19c7d0c896626944d9affc850e42f0073ecbfe82b6380f0ed494c13bc759"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `regex-opt`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.