### PR TITLE
onscripter: add livecheck

### DIFF
--- a/Formula/onscripter.rb
+++ b/Formula/onscripter.rb
@@ -1,10 +1,15 @@
 class Onscripter < Formula
   desc "NScripter-compatible visual novel engine"
-  homepage "https://onscripter.osdn.jp/"
+  homepage "https://onscripter.osdn.jp/onscripter.html"
   url "https://onscripter.osdn.jp/onscripter-20200722.tar.gz"
   sha256 "12e5f4ac336ae3da46bf166ff1d439840be6336b19401a76c7d788994a9cd35e"
   license "GPL-2.0"
   revision 1
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?onscripter[._-]v?(\d+(?:\.\d+)*)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "6bf87dccb1539e34ca53a5d2912937d812d91d5540885a53d7e10e9c334a0f1a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `onscripter`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This updates the `homepage` to https://onscripter.osdn.jp/onscripter.html as it seems more appropriate for this formula (compared to https://onscripter.osdn.jp/) and allows us to simply use `url :homepage` in the `livecheck` block.