### PR TITLE
libpipeline: add livecheck

### DIFF
--- a/Formula/libpipeline.rb
+++ b/Formula/libpipeline.rb
@@ -1,9 +1,14 @@
 class Libpipeline < Formula
   desc "C library for manipulating pipelines of subprocesses"
   homepage "http://libpipeline.nongnu.org/"
-  url "https://download.savannah.gnu.org/releases/libpipeline/libpipeline-1.5.3.tar.gz"
+  url "https://download.savannah.nongnu.org/releases/libpipeline/libpipeline-1.5.3.tar.gz"
   sha256 "5dbf08faf50fad853754293e57fd4e6c69bb8e486f176596d682c67e02a0adb0"
   license "GPL-3.0-or-later"
+
+  livecheck do
+    url "https://download.savannah.nongnu.org/releases/libpipeline/"
+    regex(/href=.*?libpipeline[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "0a398cdb65f5321e356e7035a3bc2352dd3b92e2f37632d85a64fbdd0510d41d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `libpipeline`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.

This also updates the `stable` URL to use `download.savannah.nongnu.org` instead of `download.savannah.gnu.org`, as this is where the homepage links. The `sha256` is unchanged and the formula built fine locally when I tested it.