### PR TITLE
pkcrack: add livecheck

### DIFF
--- a/Formula/pkcrack.rb
+++ b/Formula/pkcrack.rb
@@ -4,6 +4,11 @@ class Pkcrack < Formula
   url "https://www.unix-ag.uni-kl.de/~conrad/krypto/pkcrack/pkcrack-1.2.2.tar.gz"
   sha256 "4d2dc193ffa4342ac2ed3a6311fdf770ae6a0771226b3ef453dca8d03e43895a"
 
+  livecheck do
+    url "https://www.unix-ag.uni-kl.de/~conrad/krypto/pkcrack/download1.html"
+    regex(/href=.*?pkcrack[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f4ee4c3916070396ad7bd3fdcf550cd150f33359381a177784015a06a4fed9e8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `pkcrack`. This PR adds a `livecheck` block that checks the first-party download page for source archives, which links to the `stable` archive.