### PR TITLE
rdate: add livecheck

### DIFF
--- a/Formula/rdate.rb
+++ b/Formula/rdate.rb
@@ -5,6 +5,11 @@ class Rdate < Formula
   sha256 "6e800053eaac2b21ff4486ec42f0aca7214941c7e5fceedd593fa0be99b9227d"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?rdate[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b3606f3683c8c1465c87a5c3fe427c4e067420f7de3ff4abdabb61871105e190"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `rdate`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.