### PR TITLE
darkstat: add livecheck

### DIFF
--- a/Formula/darkstat.rb
+++ b/Formula/darkstat.rb
@@ -4,6 +4,11 @@ class Darkstat < Formula
   url "https://unix4lyfe.org/darkstat/darkstat-3.0.719.tar.bz2"
   sha256 "aeaf909585f7f43dc032a75328fdb62114e58405b06a92a13c0d3653236dedd7"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?darkstat[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f118133e9435512691870171effd65220c2340328860a7b22ae32ad1ba3c369e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `darkstat`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.