### PR TITLE
xml-coreutils: add livecheck

### DIFF
--- a/Formula/xml-coreutils.rb
+++ b/Formula/xml-coreutils.rb
@@ -5,6 +5,11 @@ class XmlCoreutils < Formula
   sha256 "7fb26d57bb17fa770452ccd33caf288deee1d757a0e0a484b90c109610d1b7df"
   license "GPL-3.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?xml-coreutils[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any, arm64_big_sur: "7094a5673f2ab6ba2fa45c587397650f4d9b2ccea1ab66925f58ef776683298d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `xml-coreutils`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

One thing to note is that `xml-coreutils` versions can contain a trailing character (e.g., `0.8a`, `0.8b`, `0.8c`, as seen on the [SourceForge files page](https://sourceforge.net/projects/xml-coreutils/files/)) and the regex accounts for this.