### PR TITLE
adwaita-icon-theme: update livecheck

### DIFF
--- a/Formula/adwaita-icon-theme.rb
+++ b/Formula/adwaita-icon-theme.rb
@@ -5,6 +5,11 @@ class AdwaitaIconTheme < Formula
   sha256 "0b6c436ed6ad9887a88ada1f72a0197b1eb73b020d8d344abab4c7fa7250f8f6"
   license any_of: ["LGPL-3.0-or-later", "CC-BY-SA-3.0"]
 
+  livecheck do
+    url :stable
+    regex(/adwaita-icon-theme-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?|\d{2,}(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "3d32ff160b977a5f9f37d096199199e3503bfa73c19556ec1260559f1af48def"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It seems that `adwaita-icon-theme` is now using the new GNOME versioning scheme, a description of which is available at https://discourse.gnome.org/t/new-gnome-versioning-scheme/4235. The package was updated from `3.38.x` to `40.0` a while back, and is now at `40.1.1`.

I couldn't find any explicit mention of this change (for the package specifically) yet, so I'll update this comment if I do. Also, the regex may not be perfect but I'm sure it could be improved, if required.

It's unclear whether this new scheme will be adopted by all packages/libraries, and the discussion I linked to does mention that libraries are not expected to change their versioning scheme – so larger changes to the `Gnome` strategy may not be required.