### PR TITLE
tika: add a mirror for resource server

### DIFF
--- a/Formula/tika.rb
+++ b/Formula/tika.rb
@@ -11,7 +11,8 @@ class Tika < Formula
   depends_on "openjdk"
 
   resource "server" do
-    url "https://downloads.apache.org/tika/tika-server-1.26.jar"
+    url "https://www.apache.org/dyn/closer.lua?path=tika/tika-server-1.26.jar"
+    mirror "https://archive.apache.org/dist/tika/tika-server-1.26.jar"
     sha256 "18b5ec5b8a7f80a3ce253cf93c5ea5f031a3c17bc83e88ab0d29a516e8e73d95"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`tika-server-1.26.jar` is not available anymore at `https://downloads.apache.org/tika`. I changed the url and added a mirror. Spotted in #72535.