### PR TITLE
autopano-sift-c: disable due to license issues

### DIFF
--- a/Formula/autopano-sift-c.rb
+++ b/Formula/autopano-sift-c.rb
@@ -22,10 +22,20 @@ class AutopanoSiftC < Formula
     sha256 cellar: :any, yosemite:    "f38fa9a0dc3b30352155bafdad91f18b01ddc11db7c27c164d23def252ec7513"
   end
 
+  # Upstream dropped support due to unclear licensing terms.  See:
+  #   https://groups.google.com/g/hugin-ptx/c/85yJ6SSd7Eo/m/SkxWF3hGBQAJ
+  # Last update was in 2009
+  disable! date: "2021-03-28", because: :no_license
+
   depends_on "cmake" => :build
   depends_on "libpano"
 
   def install
+    # libpano includes Carbon.h which on Big Sur indirectly includes CarbonCore/Components.h
+    # This defines a typedef named "Component" which causes a conflict with a typedef used
+    # internally by this package
+    inreplace %w[APSCpp/APSCpp_main.c MatchKeys.c AutoPanoSift.h AutoPano.c APSCmain.c],
+              /\bComponent\b/, "Pano_Component"
     system "cmake", ".", *std_cmake_args
     system "make", "install"
   end


### PR DESCRIPTION
(and also general staleness, since it was last updated in 2009)

This is a very lightly-installed formula which has never been bottled for Big Sur.  Until a couple weeks ago this had been
blocked on libpano not building, and my previous build fixes for that were initially rejected for being too complicated (#68086)  Recently, however, libpano has gotten a version bump which sorted out its previous Big Sur issues (#77125)  Therefore I thought I'd take a look at this formula.

It still did not build.  The underlying problem is that libpano `#include`s Carbon.h which then indirectly `#include`s CarbonCore/Components.h (via Carbon.h -> CoreServices.h -> CarbonCore.h)  This system header contains this typedef:
```
typedef ComponentRecord *               Component;
```
This causes a conflict with another typedef internal to autopano-sift-c.  It's a little ugly but by renaming the typedef here it seems to build OK.

I looked for a place to upstream a bug report for this package but it seems that it only was ever supported via the "hugin-ptx" Google Group.  Searching around there I found a thread from 2016 where a FreeBSD ports maintainer asked a question about the status of this package.  The answer from @StefanPeter is basically that it had potential licensing issues and they said it should be removed from FreeBSD ports entirely:
  https://groups.google.com/g/hugin-ptx/c/85yJ6SSd7Eo/m/SkxWF3hGBQAJ

I assume this would apply to Homebrew as well.

Therefore, let's at least mark the formula as `disabled!` -- since the underlying issue is one of licensing I think its best to skip the normal deprecation period.

I did leave my Big Sur build fix in-place as well in the unlikely case that this formula ever needs to be reanimated... at least nobody will have to re-do that work.