### PR TITLE
nrg2iso: add livecheck

### DIFF
--- a/Formula/nrg2iso.rb
+++ b/Formula/nrg2iso.rb
@@ -4,6 +4,14 @@ class Nrg2iso < Formula
   url "http://gregory.kokanosky.free.fr/v4/linux/nrg2iso-0.4.tar.gz"
   sha256 "25049d864680ec12bbe31b20597ce8c1ba3a4fe7a7f11e25742b83e2fda94aa3"
 
+  # The latest version reported on the English page (nrg2iso.en.html) and the
+  # main French page (nrg2iso.html) can differ, so we may want to keep an eye
+  # on this to make sure we don't miss any versions.
+  livecheck do
+    url :homepage
+    regex(/href=.*?nrg2iso[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "4b1896503c9c1944672f043adebe206ec236d51253f4c2057fcb83694477434b"
     sha256 cellar: :any_skip_relocation, big_sur:       "de13076ac7730d2b664fbdfe4128b17f0c61fc458c9bfd82b5fbf638ec526702"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `nrg2iso`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

One thing to note is that the latest reported version differs between the [main French page](http://gregory.kokanosky.free.fr/v4/linux/nrg2iso.html) (`0.4`) and the [English page](http://gregory.kokanosky.free.fr/v4/linux/nrg2iso.en.html) (`0.4.1`). As reported in #76715, the `0.4.1` release only modifies `nrg2iso.c` to update the license comment at the top of the file and `CHANGELOG` to mention the change (`29/04/2021 v0.4.1 update to GPL v3`). I added a comment before the `livecheck` block to explain the situation, in case it becomes more of an issue in the future.