### PR TITLE
gnuradio: add livecheck

### DIFF
--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -8,6 +8,11 @@ class Gnuradio < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/gnuradio/gnuradio.git"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any, big_sur:  "11134e43fc66f713045e669118d4c9dcdfe19468bff503a0c362166f6e32dae7"
     sha256 cellar: :any, catalina: "2e2fc2e22252fe5b5ee6f95636eaf021d041d69bca3352bfcafe7f3c03639b3e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `gnuradio` but it's incorrectly reporting `3.10.0.0git` as newest instead of `3.9.1.0`. This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which omits the `3.10.0.0git` tag and correctly reports the latest version. [We can obtain the correct latest version from the Git tags, so it isn't necessary to use the `GithubLatest` strategy at this time.]