### PR TITLE
portaudio: add livecheck

### DIFF
--- a/Formula/portaudio.rb
+++ b/Formula/portaudio.rb
@@ -8,6 +8,15 @@ class Portaudio < Formula
   version_scheme 1
   head "https://github.com/PortAudio/portaudio.git"
 
+  livecheck do
+    url "http://files.portaudio.com/download.html"
+    regex(/href=.*?pa[._-]stable[._-]v?(\d+)(?:[._-]\d+)?\.t/i)
+    strategy :page_match do |page, regex|
+      # Modify filename version (190700) to match formula version (19.7.0)
+      page.scan(regex).map { |match| match&.first&.scan(/\d{2}/)&.map(&:to_i)&.join(".") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "50a45425f5c6026788791370b1ba30b0dcc82b6cedacd2240168f57f9abe6484"
     sha256 cellar: :any, big_sur:       "f9ae97164b4101048870c761b15998e46f40da666c3f0e20c33cf6ce2f7319d0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `portaudio` (from the `head` URL) but this is reporting `190600_20161030` as newest instead of `19.7.0`.

This PR adds a `livecheck` block that checks the first-party download page (aligning the check with the `stable` source) and uses a `strategy` block to manipulate the version format used in filenames (e.g., `190700`) into the actual version (e.g., `19.7.0`). This assumes that major/minor/patch versions will never exceed two digits, which hopefully upstream will be careful to maintain if they're not going to use the actual version in the filename.