### PR TITLE
brew-gem: add livecheck

### DIFF
--- a/Formula/brew-gem.rb
+++ b/Formula/brew-gem.rb
@@ -6,6 +6,14 @@ class BrewGem < Formula
   license "MIT"
   head "https://github.com/sportngin/brew-gem.git"
 
+  # Until versions exceed 2.2, the leading `v` in this regex isn't optional, as
+  # we need to avoid an older `2.2` tag (a typo) while continuing to match
+  # newer tags like `v1.1.1` and allowing for a future `v2.2.0` version.
+  livecheck do
+    url :stable
+    regex(/^v(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "fc319ba05f5f17b0f516292f5fb2d55eccb6c03a11cacc438b1c2c2fb5ccb0db"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `brew-gem` but it's reporting `2.2` as newest (from a `2.2` tag) instead of `1.1.1` (from a `v1.1.1` tag).

This PR adds a `livecheck` block with a regex that restricts matching to tags like `v1.2`, `v1.2.3`, etc. Usually we make the leading `v` optional (i.e., `v?`) but in this case it needs to be required to avoid matching the `2.2` tag until the version exceeds `2.2.0`. I've taken this approach instead of specifically omitting `2.2`, as it allows us to potentially match a `v2.2` tag in the future (though it would likely be `v2.2.0` in practice).