### PR TITLE
calicoctl 3.19.1

### DIFF
--- a/Formula/calicoctl.rb
+++ b/Formula/calicoctl.rb
@@ -2,10 +2,15 @@ class Calicoctl < Formula
   desc "Calico CLI tool"
   homepage "https://www.projectcalico.org"
   url "https://github.com/projectcalico/calicoctl.git",
-      tag:      "v3.18.3",
-      revision: "528c58600dcb1ab40eaf99135c8113fc049514dd"
+      tag:      "v3.19.1",
+      revision: "6fc0db96a3d2df7bd2eb0929f9c3d327380b0ed0"
   license "Apache-2.0"
   head "https://github.com/projectcalico/calicoctl.git"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "622d966ce5503d359a68fb9095840e193e46157d518916fd00e7fe352872edd8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates `calicoctl` to 3.19.1, which is reported as the latest version on the first-party [releases page](https://docs.projectcalico.org/releases).

This also adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`. This addresses an issue where livecheck was reporting `96a22c18af1c6ae56331` as newest (from a `untagged-96a22c18af1c6ae56331` tag) instead of `v3.19.1`.

The `GithubLatest` strategy isn't necessary here (since we can obtain the correct latest version using the `Git` strategy and a regex) but it's worth mentioning that the "latest" version on GitHub is incorrectly given as `v3.18.4` at the moment, as it was tagged after `v3.19.1`. If checking the Git tags ends up being insufficient in the future, we should check the previously-mentioned first-party releases page instead (i.e., we can't rely on `GithubLatest`).