### PR TITLE
glooctl 1.7.8

### DIFF
--- a/Formula/glooctl.rb
+++ b/Formula/glooctl.rb
@@ -2,10 +2,15 @@ class Glooctl < Formula
   desc "Envoy-Powered API Gateway"
   homepage "https://docs.solo.io/gloo/latest/"
   url "https://github.com/solo-io/gloo.git",
-      tag:      "v1.7.7",
-      revision: "309aa1e49999348b65d82f5304977e271ba8f914"
+      tag:      "v1.7.8",
+      revision: "faf4c222fe951e99fefde46e55f2a8c2a7669b1a"
   license "Apache-2.0"
   head "https://github.com/solo-io/gloo.git"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "9a0745ee80c106625df8e3c96a93f31ee76fe0b33dc29c260b1c45a2113ebdd3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates `glooctl` to the latest version (`1.7.8`).

This also adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, so that the latest version is correctly identified (e.g., avoiding `v1.7.8-patch1`, which is older than the `v1.7.8` tag). This approach correctly identifies the latest version and it's not necessary to use the `GithubLatest` strategy at this time.