### PR TITLE
saxon: update livecheck

### DIFF
--- a/Formula/saxon.rb
+++ b/Formula/saxon.rb
@@ -8,6 +8,9 @@ class Saxon < Formula
   livecheck do
     url :stable
     regex(%r{url=.*?/SaxonHE(\d+(?:[.-]\d+)+)J?\.(?:t|zip)}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map { |match| match&.first&.gsub("-", ".") }
+    end
   end
 
   bottle :unneeded


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `saxon` correctly identifies the latest version but the filenames use a `1-2` version format instead of `1.2`. This adds a `strategy` block that replaces `-` in matched version text with `.`, to massage the version format.

It's worth noting that this is only aesthetic at this point and doesn't produce a functional difference, as delimiters (e.g., `.`, `-`) are ignored when it comes to `Version` comparison (i.e., `1.2` and `1-2` are treated as equal).