### PR TITLE
rdiff-backup: add livecheck

### DIFF
--- a/Formula/rdiff-backup.rb
+++ b/Formula/rdiff-backup.rb
@@ -6,6 +6,11 @@ class RdiffBackup < Formula
   license "GPL-2.0-or-later"
   revision 1
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "8ca9789a8e2456096ab851fe8277004201bc2f9ca66adf6934a6a942f9eaf3d3"
     sha256 cellar: :any, big_sur:       "da5cbef995206de251e217fbfb1a0594d3222c26c20c003df78a8aad6e855b8f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, `livecheck` checks the Git tags for `rdiff-backup` but it's reporting an unstable version (`2.1.0a1`) as newest instead of `2.0.5`. This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which omits unstable tags like `v1.4.0.beta`, `v1.9.0b0`, `v1.9.2rc0`, `v2.1.0a0`, `v2.1.0a1`, etc. At the moment, it's not necessary to use the `GithubLatest` strategy, as checking the Git tags with this regex correctly provides the latest version.