### PR TITLE
pdal: add livecheck

### DIFF
--- a/Formula/pdal.rb
+++ b/Formula/pdal.rb
@@ -7,6 +7,17 @@ class Pdal < Formula
   revision 4
   head "https://github.com/PDAL/PDAL.git"
 
+  # The upstream GitHub repository sometimes tags a commit with only a
+  # major/minor version (`1.2`) and then uses major/minor/patch (`1.2.3`) for
+  # the release (with downloadable assets). This inconsistency can be a problem
+  # if we need to substitute the version from livecheck in the `stable` URL, so
+  # we use the `GithubLatest` strategy here.
+  livecheck do
+    url :stable
+    regex(/href=.*?PDAL[._-]v?(\d+(?:\.\d+)+)[._-]src\.t/i)
+    strategy :github_latest
+  end
+
   bottle do
     sha256 arm64_big_sur: "9eeb18f3dbf4cde5dcc641be1e06237ddc88d615be7fe95bf9b1f8ac50fa1922"
     sha256 big_sur:       "fcf5c16aaa8e0b03174f97ca817f5da2409b671802532aa619ddc21cda1f1bd8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `pdal` but it's incorrectly reporting an unstable version (`2.3RC1`) as newest instead of `2.3.0`. This PR addresses the issue by adding a `livecheck` block that uses the `GithubLatest` strategy, along with a regex that matches the version from the relevant source tarball in the downloadable assets.

I'm using `GithubLatest` here because using the Git strategy with the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`) gives `2.3` as newest instead of `2.3.0`. This is because upstream sometimes tags a commit with the major/minor version and then tags the same commit with major/minor/patch for the release (which contains the downloadable assets).

Getting the correct release tag in this instance may be important for the future, if/when we substitute the latest version from livecheck in the `stable` URL to create a version bump PR. It's easier to plan for this now instead of waiting for this weird issue to bite us in the future.