### PR TITLE
iozone: update livecheck

### DIFF
--- a/Formula/iozone.rb
+++ b/Formula/iozone.rb
@@ -9,6 +9,9 @@ class Iozone < Formula
   livecheck do
     url "https://www.iozone.org/src/current/"
     regex(/href=.*?iozone[._-]?v?(\d+(?:[._]\d+)+)\.t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match&.first&.gsub("_", ".") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `iozone` works properly but the matched versions from filenames are formatted like `3_492` instead of `3.492`. This PR addresses this by adding a `strategy` block that replaces `_` in matched versions with `.`. This doesn't make a functional difference (as `Version` comparison ignores delimiters) and is merely for aesthetic purposes at this point.