### PR TITLE
rdkit 2021.03.2

### DIFF
--- a/Formula/rdkit.rb
+++ b/Formula/rdkit.rb
@@ -1,11 +1,18 @@
 class Rdkit < Formula
   desc "Open-source chemoinformatics library"
   homepage "https://rdkit.org/"
-  url "https://github.com/rdkit/rdkit/archive/Release_2021_03_1.tar.gz"
-  sha256 "9495f797a54ac70b3b6e12776de7d82acd7f7b5d5f0cc1f168c763215545610b"
+  url "https://github.com/rdkit/rdkit/archive/Release_2021_03_2.tar.gz"
+  sha256 "9907a745405cc915c65504046e446199f8ad03d870714de57c27d3738f330fe4"
   license "BSD-3-Clause"
-  revision 1
   head "https://github.com/rdkit/rdkit.git"
+
+  livecheck do
+    url :stable
+    regex(/^Release[._-](\d+(?:[._]\d+)+)$/i)
+    strategy :git do |tags|
+      tags.map { |tag| tag[regex, 1]&.gsub("_", ".") }.compact
+    end
+  end
 
   bottle do
     sha256 arm64_big_sur: "4517bab8a0cbf87d593d4da115beef2f5df826eb5f876f57178099fe6007b8fa"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This updates `rdkit` to the latest version (`2021.03.2`).

This also adds a `livecheck` block with a regex that restricts matching to tags like `Release_2021_03_2` (not `Release_2010_12_1beta1`, `Release_2013_09_1pre`, `Release_2016_03_1b1`, etc.) and a `strategy` block that replaces `_` with `.` to massage the matched versions into the `2021.03.2` format.

This fixes an issue where, by default, livecheck was checking the Git tags and reporting `42009_1` as the newest version, from an old `Release_Q42009_1` tag. Only matching the current version format avoids this issue, so it was the path of least resistance. [There's also an even older version format like `Release_April2007_1` and some unrelated tags that we avoid as well.]