### PR TITLE
ipinfo-cli: add livecheck

### DIFF
--- a/Formula/ipinfo-cli.rb
+++ b/Formula/ipinfo-cli.rb
@@ -5,6 +5,11 @@ class IpinfoCli < Formula
   sha256 "86a40d5ea784bbecb1ea570cfaaf3a9924f87b52fda1ef2ef978f2ed95422d67"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^ipinfo[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "aa19540de7e6a5a07401f87df2a3df232c6464171842cc57c7ff0d4f36c9ff27"
     sha256 cellar: :any_skip_relocation, big_sur:       "d9aa10ccd5db7e49054624cd5a48a1a1c8299708c496906302d7d993efa2ba48"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `ipinfo-cli` but it was incorrectly reporting `2range-1.0.0` as the newest version (from a `cidr2range-1.0.0` tag) before version `2.0.1`. We're only interested in the tags like `ipinfo-2.0.1`, so this adds a `livecheck` block with a regex that restricts matching to appropriate tags.