### PR TITLE
cadical: add livecheck

### DIFF
--- a/Formula/cadical.rb
+++ b/Formula/cadical.rb
@@ -5,6 +5,11 @@ class Cadical < Formula
   sha256 "b5990bea7aa5df6002b9bfe782323742d786565b9dfee37bbc0dd0f4b8e65141"
   license "MIT"
 
+  livecheck do
+    url :stable
+    regex(/^rel[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c19d4807b7bc2ea2eff3a15fbf25c6ebe4a660bcd84088d0a17ed8de401e715c"
     sha256 cellar: :any_skip_relocation, big_sur:       "780dede4d1880b19f2b5675c2de1dcf92aeff4b03cea584181c9dd52acd4ad62"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `cadical` but it's incorrectly reporting `2021` as the newest version (from an `sc2021` tag) instead of `1.4.0`. This PR addresses the issue by adding a `livecheck` block that restricts matching to release tags with a format like `rel-1.4.0` (not `rel-06w`, `sc17`, `sc2021`, etc.).