### PR TITLE
pandoc 2.14

### DIFF
--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -1,8 +1,8 @@
 class Pandoc < Formula
   desc "Swiss-army knife of markup format conversion"
   homepage "https://pandoc.org/"
-  url "https://hackage.haskell.org/package/pandoc-2.13/pandoc-2.13.tar.gz"
-  sha256 "30bfbadcd34f9c44090d744599c82f129375518cc8f2c1dd0b88e3afd62ae2b8"
+  url "https://hackage.haskell.org/package/pandoc-2.14/pandoc-2.14.tar.gz"
+  sha256 ""
   license "GPL-2.0-or-later"
   head "https://github.com/jgm/pandoc.git"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 0 bytes
- formula fetch time: 0.6 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.