### PR TITLE
unnethack: add livecheck

### DIFF
--- a/Formula/unnethack.rb
+++ b/Formula/unnethack.rb
@@ -5,6 +5,11 @@ class Unnethack < Formula
   sha256 "a32a2c0e758eb91842033d53d43f718f3bc719a346e993d9b23bac06f0ac9004"
   head "https://github.com/UnNetHack/UnNetHack.git"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+(?:[._-]\d{6,8})?)$/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "5b4386eee78f20075e693b6ad437df496c8c914518161d8901991c1c4a6ee1f9"
     sha256 big_sur:       "45d58053580ccdf9b65510768136206b71453b3457f23240a6dc592f817a6145"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR adds a `livecheck` block to `unnethack`, which is necessary to exclude pre-release tags (as seen in #77951 and #78288).

I've included the date portion of the tag within the capture group (so it would be part of the version), but I'm unsure whether or not we need to do this. In the past, we have had versions with and without the date included in them such as `5.1.0-20131208`, `5.2.0`, etc.