### PR TITLE
tbb: add `onetbb` alias

### DIFF
--- a/Aliases/onetbb
+++ b/Aliases/onetbb
@@ -1,0 +1,1 @@
+../Formula/tbb.rb


### PR DESCRIPTION
The project was renamed to oneTBB [1]. Everyone else still seems to call
it `tbb` [2], so keeping the existing name probably makes more sense.
However, an alias may still be useful.

[1] https://github.com/oneapi-src/oneTBB
[2] https://repology.org/project/onetbb/versions

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?