### PR TITLE
zig: update install fn to force LLVM static linking

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -24,7 +24,7 @@ class Zig < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", ".", *std_cmake_args, "-DZIG_STATIC_LLVM=ON"
     system "make", "install"
   end
 


### PR DESCRIPTION
This short commit updates the Zig formula to always prefer static
linking of LLVM via `ZIG_STATIC_LLVM` CMake flag.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Closes #78025 

Closes https://github.com/ziglang/zig/issues/8860

cc @Bo98 