### PR TITLE
obfs4proxy: add livecheck

### DIFF
--- a/Formula/obfs4proxy.rb
+++ b/Formula/obfs4proxy.rb
@@ -5,6 +5,11 @@ class Obfs4proxy < Formula
   sha256 "46f621f1d94d244e7b1d0b93dafea7abadb2428f8b1d0463559426362ea98eae"
   license "BSD-2-Clause"
 
+  livecheck do
+    url :stable
+    regex(/^obfs4proxy[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "4e7ffbf5b299d80b469fc0f4edbf44dcac2c698a7b5ac84f4d78632cc8888ce7"
     sha256 cellar: :any_skip_relocation, big_sur:       "5918cdc41743f14ee4110b132361abe21b20445fb7afd4a60859b4b1e594462a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `obfs4proxy` but it incorrectly reports `4proxy-0.0.11` as the newest version, since the tags use an `obfs4proxy-0.0.11` format. The default behavior of the `Git` strategy when a regex isn't provided in a `livecheck` block is to match the tag text starting at the first digit (so `obfs4proxy-0.0.11` becomes `4proxy-0.0.11`).

This PR adds a `livecheck` block with a regex that accounts for the leading `obfs4proxy-` text in tags and returns correct version strings.