### PR TITLE
stp: add livecheck

### DIFF
--- a/Formula/stp.rb
+++ b/Formula/stp.rb
@@ -6,6 +6,11 @@ class Stp < Formula
   license "MIT"
   head "https://github.com/stp/stp.git"
 
+  livecheck do
+    url :stable
+    regex(/^(?:stp[._-])?v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "c85797a1bcf17ff2ee089ca7deffb73cb366073342c80805fb5d96f01b6862a8"
     sha256 cellar: :any, big_sur:       "67c02fd361c644c8b084a169780a08b3a784dc9be52c9526f43c46eedd43fa8b"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `stp` but it's incorrectly reporting `2020` as newest, from an `smtcomp2020` tag. This tag is listed as the "latest" release on GitHub but it's unclear whether this is also intended for users.

Erring on the side of this probably not being a release that should be used (i.e., wait for the next normal release), this PR adds a `livecheck` block that restricts matching to tags like `1.2.3`/`v1.2.3` (the prevailing tag format) or `stp-1.2.3` (there's one tag with this format). This gives `2.3.3` as newest, as it's the newest version before the `smtcomp2020` tag.