### PR TITLE
universal-ctags: add livecheck

### DIFF
--- a/Formula/universal-ctags.rb
+++ b/Formula/universal-ctags.rb
@@ -7,6 +7,11 @@ class UniversalCtags < Formula
   license "GPL-2.0-only"
   head "https://github.com/universal-ctags/ctags.git"
 
+  livecheck do
+    url :stable
+    regex(/^(p\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "48182f751f5f6efaa9516d4ed948e59b440b4e7fb0ad7b3ed654cbb7e2f4f44b"
     sha256 cellar: :any, big_sur:       "40e0a5ebd29473d1233c7e147e85ef84a01af9019c773816adb55a4fed9fd9d1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `universal-ctags` but it reports `5.9.20210523.0`, which is incorrectly treated as newer than `p5.9.20210523.0` since it doesn't have the same leading `p`.

This PR adds a `livecheck` block that uses a version of the standard regex for Git tags like `1.2.3` that has been modified to include the leading `p` in the capture group. This causes `livecheck` to correctly return versions like `p5.9.20210523.0` (matching the formula version) and fixes the aforementioned version comparison issue.