### PR TITLE
cidr2range: add livecheck

### DIFF
--- a/Formula/cidr2range.rb
+++ b/Formula/cidr2range.rb
@@ -5,6 +5,11 @@ class Cidr2range < Formula
   sha256 "81540e845b567fe64e192ee1ec3f1476c7d2bb035a4680c2d26e144f48916b2c"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^cidr2range[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "43859c5789d878bd51444ce5d13dd36013b83818f85d93c051019b124e8690cf"
     sha256 cellar: :any_skip_relocation, big_sur:       "d201dff9f15ac4300b94749621506bf270d403db91c4bfa6dd4937d233ae0511"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck checks the Git tags for `cidr2range` but it incorrectly reports `2.0.1` as newest (from an `ipinfo-2.0.1` tag) instead of `1.0.0`. In the past, this check has also incorrectly given `2range-1.0.0` as newest (from the `cidr2range-1.0.0` tag), though there's also an incorrect `2cidr-1.0.0` version in the matched versions (from the `range2cidr-1.0.0` tag).

This PR adds a `livecheck` block that resolves both of these issues by using a regex that accounts for the `cidr2range-` tag prefix. This restricts matching to only the `cidr2range` tags, which is important because this repository also contains tags for `grepip`, `ipinfo`, and `range2cidr`. This also ensures that the returned version is `1.0.0` instead of `2range-1.0.0` or `2cidr-1.0.0` (which occur since the `Git` strategy uses the tag string starting at the first digit by default when a regex isn't provided).