### PR TITLE
range2cidr: add livecheck

### DIFF
--- a/Formula/range2cidr.rb
+++ b/Formula/range2cidr.rb
@@ -5,6 +5,11 @@ class Range2cidr < Formula
   sha256 "caf6627b361ce690a884ccbb98c229d07dcf73e453af625638b7508113e1b0df"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^range2cidr[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "5afa2bd9b03bf007db38f7dca0b129b0d2094a4309ce983aeb855e0a784119c7"
     sha256 cellar: :any_skip_relocation, big_sur:       "543dde8b3d0ef72d2884e13891a46dda2a9492dc601159efb41380960ebcc054"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Similar to #78346, by default livecheck checks the Git tags for `range2cidr` but it incorrectly reports `2.0.1` as newest (from an `ipinfo-2.0.1` tag) instead of `1.0.0`. In the past, this check has also incorrectly given `2range-1.0.0` as newest (from the `cidr2range-1.0.0` tag), though there's also an incorrect `2cidr-1.0.0` version in the matched versions (from the `range2cidr-1.0.0` tag).

This PR adds a `livecheck` block that resolves both of these issues by using a regex that accounts for the `range2cidr-` tag prefix. This restricts matching to only the `range2cidr` tags, which is important because this repository also contains tags for `cidr2range`, `grepip`, and `ipinfo`. This also ensures that the returned version is `1.0.0` instead of `2range-1.0.0` or `2cidr-1.0.0` (which occur since the `Git` strategy uses the tag string starting at the first digit by default when a regex isn't provided).