### PR TITLE
cspice: add livecheck

### DIFF
--- a/Formula/cspice.rb
+++ b/Formula/cspice.rb
@@ -5,6 +5,13 @@ class Cspice < Formula
   version "66"
   sha256 "f5d48c4b0d558c5d71e8bf6fcdf135b0943210c1ff91f8191dfc447419a6b12e"
 
+  # The `stable` tarball is unversioned, so we have to identify the latest
+  # version from text on the homepage.
+  livecheck do
+    url :homepage
+    regex(/current SPICE Toolkit version is (?:<[^>]+?>)?N0*(\d+)/im)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, catalina:    "a8674cfcd5ef55ec8061890728960dd910aa23533c2c4868e93915c77b6e5c8c"
     sha256 cellar: :any_skip_relocation, mojave:      "a08696e53b60d3255a28ca8c52fc6ba992d95f345f31dea6506a64227d10ceac"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `cspice`. This PR adds a `livecheck` block that checks the homepage and matches the version from the `The current SPICE Toolkit version is <b>N0066` text. This is necessary because the `stable` archive is unversioned (`cspice.tar.Z`), so we can't obtain the version from the filename.