### PR TITLE
cargo-audit: update livecheck

### DIFF
--- a/Formula/cargo-audit.rb
+++ b/Formula/cargo-audit.rb
@@ -8,7 +8,7 @@ class CargoAudit < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(%r{^cargo-audit/v?(\d+(?:\.\d+)+)$}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `cargo-audit` checks the Git tags but it's currently giving an `Unable to get versions` error because the tags include a prefix that the regex doesn't account for (e.g., `cargo-audit/v0.14.1`).

This PR updates the regex to include the `cargo-audit/` prefix, so it matches `cargo-audit` versions again and also avoids matching versions for unrelated tags in the same repository (e.g., `cargo-lock/v7.0.0`, `cvss/v1.0.3`, etc.).