### PR TITLE
micronaut: update livecheck

### DIFF
--- a/Formula/micronaut.rb
+++ b/Formula/micronaut.rb
@@ -7,7 +7,7 @@ class Micronaut < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The existing `livecheck` block for `micronaut` uses the `GithubLatest` strategy but it's currently giving an `Unable to get versions` error because the "latest" release on GitHub is `v3.0.0-M1` and the default regex doesn't match it. This is an unstable version, so the `GithubLatest` strategy isn't providing the correct latest [stable] version.

This PR removes `strategy :github_latest` (so livecheck falls back to the `Git` strategy) and adds the standard regex for Git tags like `1.2.3`/`v1.2.3`. This accurately identifies the latest stable version (`2.5.4`), so it also isn't necessary to use the `GithubLatest` strategy.