### PR TITLE
cdb: add livecheck

### DIFF
--- a/Formula/cdb.rb
+++ b/Formula/cdb.rb
@@ -4,6 +4,11 @@ class Cdb < Formula
   url "https://cr.yp.to/cdb/cdb-0.75.tar.gz"
   sha256 "1919577799a50c080a8a05a1cbfa5fa7e7abc823d8d7df2eeb181e624b7952c5"
 
+  livecheck do
+    url "https://cr.yp.to/cdb/install.html"
+    regex(/href=.*?cdb[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c9136d67f3a62785add35b9b205169b9ace86da2c86edf4fe1c16cb833465bf5"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `cdb`. This PR adds a `livecheck` block that checks the "How to install cdb" page, which links to the `stable` archive.