### PR TITLE
simde 0.7.2 (new formula)

### DIFF
--- a/Formula/simde.rb
+++ b/Formula/simde.rb
@@ -1,0 +1,40 @@
+class Simde < Formula
+  desc "Implementations of SIMD intrinsics for systems which don't natively support them"
+  homepage "https://github.com/simd-everywhere/simde"
+  url "https://github.com/simd-everywhere/simde/archive/v0.7.2.tar.gz"
+  sha256 "366d5e9a342c30f1e40d1234656fb49af5ee35590aaf53b3c79b2afb906ed4c8"
+  license "MIT"
+  head "https://github.com/simd-everywhere/simde.git"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+
+  def install
+    mkdir("build") do
+      system "meson", *std_meson_args, "-Dtests=false", ".."
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <assert.h>
+      #include <simde/arm/neon.h>
+      #include <simde/x86/sse2.h>
+
+      int main() {
+        int64_t a = 1, b = 2;
+        assert(simde_vaddd_s64(a, b) == 3);
+        simde__m128i z = simde_mm_setzero_si128();
+        simde__m128i v = simde_mm_undefined_si128();
+        v = simde_mm_xor_si128(v, v);
+        assert(simde_mm_movemask_epi8(simde_mm_cmpeq_epi8(v, z)) == 0xFFFF);
+        return 0;
+      }
+    EOS
+
+    system ENV.cc, "test.c", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
SIMDe is a header-only library that provides implementations of SIMD
intrinsics on platforms that do not support them natively, such as
calling SSE functions on ARM. The upstream repository is accessible at
https://github.com/simd-everywhere/simde.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This formula, if accepted, could probably be used for `bowtie2` (see #78092), rather than pulling from the tag and using SIMDe as a submodule.