### PR TITLE
libzt: disable

### DIFF
--- a/Formula/libzt.rb
+++ b/Formula/libzt.rb
@@ -13,6 +13,8 @@ class Libzt < Formula
     sha256 cellar: :any, high_sierra:   "19554cc555c087797403049615b0145cec80dc3c49a5a70167b2fad75a0729ce"
   end
 
+  disable! date: "2021-05-31", because: "has an incompatible license"
+
   depends_on "cmake" => :build
 
   def install


### PR DESCRIPTION
Disable `libzt` because it has an incompatible license (BUSL-1.1). See
Homebrew/homebrew-core#76788.

Closes Homebrew/homebrew-core#76788.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?