### PR TITLE
eigen: add livecheck

### DIFF
--- a/Formula/eigen.rb
+++ b/Formula/eigen.rb
@@ -6,6 +6,11 @@ class Eigen < Formula
   license "MPL-2.0"
   head "https://gitlab.com/libeigen/eigen.git"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e03d900e18903478875f1c354ee169373be0fdc49996da784e4a55f7b3c3594a"
     sha256 cellar: :any_skip_relocation, big_sur:       "c3305d00c64e0bd6f53e45858b92be3d72827c02b2e2f71d4edd01f1efaa1080"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

It was reported in https://github.com/Homebrew/homebrew-core/issues/75472 that `eigen 3.4` was a pre-release; `livecheck` was identifying a tag named `before-3.4` as the latest (using the `Git` strategy).

This PR adds a `livecheck` block to check the homepage, which links to the latest stable archive. An alternative would be to check the `git` tags with the stricter `/^v?(\d+(?:\.\d+)+)$/i` regex.