### PR TITLE
wxmac: update livecheck

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -9,7 +9,7 @@ class Wxmac < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+\.\d*[02468](?:\.\d+)*)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `3.1.x` series is not stable (development releases) – see #76311. Going through the previous releases, odd minor versions have been tagged as pre-releases. The website also lists release `2.8.12` as the previous stable along with `3.0.5` (current stable) on the [downloads page](https://www.wxwidgets.org/downloads/).

All these seem to indicate that the project considers odd-numbered minor versions to be unstable.

I've dropped the `strategy :github_latest` here and made the regex stricter, so this now uses the `Git` strategy.