### PR TITLE
xorgproto: update livecheck

### DIFF
--- a/Formula/xorgproto.rb
+++ b/Formula/xorgproto.rb
@@ -5,6 +5,11 @@ class Xorgproto < Formula
   sha256 "0f5157030162844b398e7ce69b8bb967c2edb8064b0a9c9bb5517eb621459fbf"
   license "MIT"
 
+  livecheck do
+    url :stable
+    regex(/href=.*?xorgproto[._-]v?(\d+\.\d+(?:\.([0-8]\d*?)?\d(?:\.\d+)*)?)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "e7e892aa9dfd101f067d5c3e298ccc65bb37c2a7889a0f50ef4e4610b030e00c"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR updates the `livecheck` block for `xorgproto` to exclude development releases. The `2021.4.99.x` releases are development releases (see https://github.com/Homebrew/homebrew-core/pull/77433).

The regex I've used is probably a little more complex than it should be, so please do suggest improvements (I may have gotten confused beyond a certain point). The logic I've used:
* There must be a major and a minor version, and these may be any `\d+`.
* Patch versions may not be present, but if they are, they must be less than 90.
* The version beyond the third `.` may take any `\d+` if it is present.