### PR TITLE
infer: depend on patchelf on Linux

### DIFF
--- a/Formula/infer.rb
+++ b/Formula/infer.rb
@@ -36,6 +36,10 @@ class Infer < Formula
   uses_from_macos "xz"
   uses_from_macos "zlib"
 
+  on_linux do
+    depends_on "patchelf" => :build
+  end
+
   def install
     # needed to build clang
     ENV.permit_arch_flags
@@ -51,6 +55,9 @@ class Infer < Formula
     ENV["OPAMROOT"] = opamroot
     ENV["OPAMYES"] = "1"
     ENV["OPAMVERBOSE"] = "1"
+    on_linux do
+      ENV["PATCHELF"] = Formula["patchelf"].opt_bin/"patchelf"
+    end
 
     system "opam", "init", "--no-setup", "--disable-sandboxing"
 


### PR DESCRIPTION
Fixes:
echo "ERROR: ldd (Linux?) found but not patchelf, please install patchelf" >&2; exit 1
ERROR: ldd (Linux?) found but not patchelf, please install patchelf
Makefile:673: recipe for target 'install-with-libs' failed
make: *** [install-with-libs] Error 1

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
