### PR TITLE
autoconf@2.69: revision bump (perl shebang fix)

### DIFF
--- a/Formula/autoconf@2.69.rb
+++ b/Formula/autoconf@2.69.rb
@@ -8,6 +8,7 @@ class AutoconfAT269 < Formula
     "GPL-3.0-or-later",
     "GPL-3.0-or-later" => { with: "Autoconf-exception-3.0" },
   ]
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f7b28e5cdf538418baea43d1d5638a1df52161ef0cd198ee1f261cdc61ac6636"


### PR DESCRIPTION
On Catalina, before:
```
$ grep -r /perl5 /usr/local/opt/autoconf@2.69/
/usr/local/opt/autoconf@2.69/bin/autoscan:#!/usr/bin/perl5.30 -w
/usr/local/opt/autoconf@2.69/bin/autom4te:#!/usr/bin/perl5.30 -w
/usr/local/opt/autoconf@2.69/bin/autoupdate:#!/usr/bin/perl5.30 -w
/usr/local/opt/autoconf@2.69/bin/autoreconf:#!/usr/bin/perl5.30 -w
/usr/local/opt/autoconf@2.69/bin/autoheader:#!/usr/bin/perl5.30
/usr/local/opt/autoconf@2.69/bin/ifnames:#!/usr/bin/perl5.30 -w
```
and after:
```
$ grep -r /perl5 /usr/local/opt/autoconf@2.69/
/usr/local/opt/autoconf@2.69/bin/autoscan:#!/usr/bin/perl5.18 -w
/usr/local/opt/autoconf@2.69/bin/autom4te:#!/usr/bin/perl5.18 -w
/usr/local/opt/autoconf@2.69/bin/autoupdate:#!/usr/bin/perl5.18 -w
/usr/local/opt/autoconf@2.69/bin/autoreconf:#!/usr/bin/perl5.18 -w
/usr/local/opt/autoconf@2.69/bin/autoheader:#!/usr/bin/perl5.18
/usr/local/opt/autoconf@2.69/bin/ifnames:#!/usr/bin/perl5.18 -w
```

For some reason, this only needs to be done on Catalina, as `autoconf@2.69` on both Big Sur and Mojave have the correct shebangs.

Addresses #78457, specifically https://github.com/Homebrew/homebrew-core/pull/78457/checks?check_run_id=2715352458#step:7:68:
```
/usr/local/opt/autoconf@2.69/bin/autoconf: /usr/local/Cellar/autoconf@2.69/2.69/bin/autom4te: /usr/bin/perl5.30: bad interpreter: No such file or directory
/usr/local/opt/autoconf@2.69/bin/autoconf: line 505: /usr/local/Cellar/autoconf@2.69/2.69/bin/autom4te: Undefined error: 0
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
