### PR TITLE
dieharder: add livecheck

### DIFF
--- a/Formula/dieharder.rb
+++ b/Formula/dieharder.rb
@@ -1,9 +1,14 @@
 class Dieharder < Formula
   desc "Random number test suite"
-  homepage "https://www.phy.duke.edu/~rgb/General/dieharder.php"
-  url "https://www.phy.duke.edu/~rgb/General/dieharder/dieharder-3.31.1.tgz"
+  homepage "https://webhome.phy.duke.edu/~rgb/General/dieharder.php"
+  url "https://webhome.phy.duke.edu/~rgb/General/dieharder/dieharder-3.31.1.tgz"
   sha256 "6cff0ff8394c553549ac7433359ccfc955fb26794260314620dfa5e4cd4b727f"
   revision 3
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?dieharder[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "e0650468410dbd840acddb2cebc9e28e7bdd0293d5c442abb8c95d50c8524735"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

By default, livecheck gives an `Unable to get versions` error for `dieharder`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This PR also updates the `homepage` and `stable` URLs to avoid redirecting from `www.phy.duke.edu` to `physics.duke.edu` to `webhome.phy.duke.edu`.