### PR TITLE
ckan: add reason for `depends_on arch: :x86_64`

### DIFF
--- a/Formula/ckan.rb
+++ b/Formula/ckan.rb
@@ -14,7 +14,7 @@ class Ckan < Formula
     sha256 cellar: :any_skip_relocation, all: "ef445fe525dcb9ddece0844663621a439e6cf159889d00005aa86e7ab1c20583"
   end
 
-  depends_on arch: :x86_64
+  depends_on arch: :x86_64 # Remove this when `mono` is bottled for ARM
   depends_on "mono"
 
   def install


### PR DESCRIPTION
Add a comment indicating that the `depends_on arch: :x86_64` must be
removed when `mono` is bottled for ARM.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?