### PR TITLE
onelogin 0.1 (new formula)

### DIFF
--- a/Formula/onelogin.rb
+++ b/Formula/onelogin.rb
@@ -1,0 +1,35 @@
+class Onelogin < Formula
+  desc "CLI for Using OneLogin"
+  homepage "https://github.com/onelogin/onelogin"
+  url "https://github.com/onelogin/onelogin/archive/refs/tags/v0.1.14.tar.gz"
+  sha256 "d25d41b51f4a1464675b88e7de8026331d2a1ac2611674a9064535ccd5001ba5"
+  license "Apache-2.0"
+  head "https://github.com/onelogin/onelogin.git"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  bottle :unneeded
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    bin_path = buildpath/"src/github.com/onelogin/onelogin"
+    # Copy all files from their current location (GOPATH root)
+    # to $GOPATH/src/github.com/onelogin/onelogin
+    bin_path.install Dir["*"]
+    cd bin_path do
+      # Install the compiled binary into Homebrew's `bin` - a pre-existing
+      # global variable
+      system "go", "build", "-o", bin/"onelogin", "."
+    end
+  end
+
+  test do
+    # "2>&1" redirects standard error to stdout. The "2" at the end means "the
+    # exit code should be 2".
+    assert_match "Welcome to OneLogin", shell_output("#{bin}/onelogin 2>&1")
+  end
+end


### PR DESCRIPTION
This commit adds the formula for building and installing the OneLogin CLI. The OneLogin CLI is a command line tool for managing your OneLogin account from the command line.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
