### PR TITLE
`PULL_REQUEST_TEMPLATE.md`: make some steps explicit

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,8 @@
 - [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
+- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
 - [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
 - [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
 - [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
-- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
+- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
 
 -----


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This PR proposes some minor modifications to the PR template, in the hope of making some instructions more noticeable to those who may have missed them, either in the guidelines for contributing or after `brew create` (if they're creating a new formula).

Proposed changes:
* Add an explicit step asking contributors if they have followed the commit style guide. This is very frequently missed and a maintainer often responds with a request to change the commit message, in situations where `autosquash` doesn't work as well as we'd like it to (yet).
* Ask contributors if they have run `brew audit --new <formula>` if the PR is for a new formula submission. For now, this has been added to the final step in the checklist rather than as a separate step. We have had over 30 PRs fail the notability audit, quite a few in the last few weeks, despite the instruction being present in the contributing guidelines and also being shown after `brew create`.
* Minor change: Tweak the install command used in the last step to be consistent with the previous step (`--build-from-source`).