### PR TITLE
randomize-lines: add livecheck

### DIFF
--- a/Formula/randomize-lines.rb
+++ b/Formula/randomize-lines.rb
@@ -5,6 +5,11 @@ class RandomizeLines < Formula
   sha256 "1cfca23d6a14acd190c5a6261923757d20cb94861c9b2066991ec7a7cae33bc8"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?rl[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c107eea0fba80096a370db46e622320bdb9ea825b837280e46ad236b3a37bbd4"
     sha256 cellar: :any_skip_relocation, big_sur:       "05b5f772ee8d86ef341e30e91194b0a4b0cdbe5d3e16c8e319ed5e74a901e806"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `randomize-lines`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.