### PR TITLE
sonar-scanner: fix OpenJDK dependency

### DIFF
--- a/Formula/sonar-scanner.rb
+++ b/Formula/sonar-scanner.rb
@@ -4,13 +4,14 @@ class SonarScanner < Formula
   url "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.6.2.2472.zip"
   sha256 "344bfeff44b09a11082b4a4646b1ed14f213feb00a5cd6d01c86f3767cb32471"
   license "LGPL-3.0-or-later"
+  revision 1
   head "https://github.com/SonarSource/sonar-scanner-cli.git"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "06bb168ce2572d35e6db64466fa5e0eb0e5f94aac94cd70e41fad709ee523992"
   end
 
-  depends_on "openjdk"
+  depends_on "openjdk@11"
 
   def install
     rm_rf Dir["bin/*.bat"]
@@ -18,7 +19,7 @@ class SonarScanner < Formula
     bin.install libexec/"bin/sonar-scanner"
     etc.install libexec/"conf/sonar-scanner.properties"
     ln_s etc/"sonar-scanner.properties", libexec/"conf/sonar-scanner.properties"
-    bin.env_script_all_files libexec/"bin/", SONAR_SCANNER_HOME: libexec, JAVA_HOME: Formula["openjdk"].opt_prefix
+    bin.env_script_all_files libexec/"bin/", SONAR_SCANNER_HOME: libexec, JAVA_HOME: Formula["openjdk@11"].opt_prefix
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Current formula depends on the latest OpenJDK version and was running fine until the latest 16.x update (due to illegal access issues, see https://github.com/Homebrew/homebrew-core/issues/78468).

This fix downgrades the OpenJDK dependency to version 11 (LTS), as expected by `sonar-scanner`, until the issue is fixed upstream.
