### PR TITLE
libscrypt: add linux install support

### DIFF
--- a/Formula/libscrypt.rb
+++ b/Formula/libscrypt.rb
@@ -17,8 +17,17 @@ class Libscrypt < Formula
   end
 
   def install
-    system "make", "install-osx", "PREFIX=#{prefix}", "LDFLAGS=", "CFLAGS_EXTRA="
-    system "make", "check", "LDFLAGS=", "CFLAGS_EXTRA="
+    on_macos do
+      system "make", "install-osx", "PREFIX=#{prefix}", "LDFLAGS=", "CFLAGS_EXTRA="
+      system "make", "check", "LDFLAGS=", "CFLAGS_EXTRA="
+    end
+    on_linux do
+      system "make"
+      system "make", "check"
+      lib.install "libscrypt.a", "libscrypt.so", "libscrypt.so.0"
+      include.install "libscrypt.h"
+      prefix.install "libscrypt.version"
+    end
   end
 
   test do


### PR DESCRIPTION
There is no install step in the documentation for Linux,
but one of our contributors came up with this and we
have been shipping these files with success for some time now.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
