### PR TITLE
curlpp: fix Linux build

### DIFF
--- a/Formula/curlpp.rb
+++ b/Formula/curlpp.rb
@@ -15,11 +15,13 @@ class Curlpp < Formula
 
   depends_on "cmake" => :build
 
+  uses_from_macos "curl"
+
   def install
     ENV.cxx11
     system "cmake", ".", *std_cmake_args
     system "make", "install"
-    inreplace bin/"curlpp-config", "#{HOMEBREW_LIBRARY}/Homebrew/shims/mac/super/clang", "/usr/bin/clang"
+    inreplace bin/"curlpp-config", %r{#{HOMEBREW_SHIMS_PATH}/[^/]+/super/#{ENV.cc}}, ENV.cc.to_s
   end
 
   test do


### PR DESCRIPTION
* add `curl` dependency
* need to match a different shim path in Linux

Linux build/test: https://github.com/Homebrew/linuxbrew-core/pull/23412

No change in macOS build process, so no revision bump.

Fixes https://github.com/Homebrew/discussions/discussions/1607

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
