### PR TITLE
clang-format: make keg-only on Linux

### DIFF
--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -36,6 +36,10 @@ class ClangFormat < Formula
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
+  on_linux do
+    keg_only "it conflicts with llvm"
+  end
+
   def install
     if build.head?
       ln_s buildpath/"clang", buildpath/"llvm/tools/clang"


### PR DESCRIPTION
llvm is not keg-only on Linux, so both clang-format binaries will conflict.
On Linux we prioritise llvm, and so clang-format becomes keg-only instead

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
