### PR TITLE
cminpack: set lib folder for Linux, fix test for Linux

### DIFF
--- a/Formula/cminpack.rb
+++ b/Formula/cminpack.rb
@@ -18,6 +18,7 @@ class Cminpack < Formula
   def install
     system "cmake", ".", "-DBUILD_SHARED_LIBS=ON",
                          "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
+                         "-DCMINPACK_LIB_INSTALL_DIR=lib",
                          *std_cmake_args
     system "make", "install"
 
@@ -27,8 +28,8 @@ class Cminpack < Formula
   end
 
   test do
-    system ENV.cc, pkgshare/"thybrdc.c", "-o", "test",
-                   "-I#{include}/cminpack-1", "-L#{lib}", "-lcminpack", "-lm"
+    system ENV.cc, "-I#{include}/cminpack-1", pkgshare/"thybrdc.c",
+                   "-L#{lib}", "-lcminpack", "-lm", "-o", "test"
     assert_match "number of function evaluations", shell_output("./test")
   end
 end


### PR DESCRIPTION
Prevents the installation in a lib64 folder
on some platforms

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
