### PR TITLE
docker-completion: update upstream source

### DIFF
--- a/Formula/docker-completion.rb
+++ b/Formula/docker-completion.rb
@@ -1,9 +1,9 @@
 class DockerCompletion < Formula
   desc "Bash, Zsh and Fish completion for Docker"
   homepage "https://www.docker.com/"
-  url "https://github.com/docker/docker-ce.git",
-      tag:      "v19.03.15",
-      revision: "99e3ed89195c4e551e87aad1e7453b65456b03ad"
+  url "https://github.com/docker/cli.git",
+      tag:      "v20.10.7",
+      revision: "f0df35096d5f5e6b559b42c7fde6c65a2909f7c5"
   license "Apache-2.0"
 
   bottle do
@@ -14,9 +14,9 @@ class DockerCompletion < Formula
     because: "docker already includes these completion scripts"
 
   def install
-    bash_completion.install "components/cli/contrib/completion/bash/docker"
-    fish_completion.install "components/cli/contrib/completion/fish/docker.fish"
-    zsh_completion.install "components/cli/contrib/completion/zsh/_docker"
+    bash_completion.install "contrib/completion/bash/docker"
+    fish_completion.install "contrib/completion/fish/docker.fish"
+    zsh_completion.install "contrib/completion/zsh/_docker"
   end
 
   test do


### PR DESCRIPTION
https://github.com/docker/docker-ce is deprecated.

Replaces #78722.