### PR TITLE
snapcraft: update livecheck

### DIFF
--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -11,7 +11,7 @@ class Snapcraft < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `snapcraft` uses the `GithubLatest` strategy to identify the newest version but this is failing because the "latest" release on GitHub is an `untagged-09e019302ffaf6f7c3e1` tag with a `4.8.1` title. A `4.8.1` tag was added after this that references the same commit but it's not treated as the "latest" release. `snapcraft` has a habit of periodically creating these `untagged-...` tags which cause problems for livecheck.

This PR replaces `strategy :github_latest` with the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`), which doesn't match the `untagged-...` tags. The newest version from the `Git` strategy is the correct latest version (`4.8.1`), so the `GithubLatest` strategy doesn't seem to be necessary for now.