### PR TITLE
pbc: add livecheck

### DIFF
--- a/Formula/pbc.rb
+++ b/Formula/pbc.rb
@@ -6,6 +6,11 @@ class Pbc < Formula
   license "LGPL-3.0"
   head "https://repo.or.cz/pbc.git"
 
+  livecheck do
+    url "https://crypto.stanford.edu/pbc/download.html"
+    regex(/href=.*?pbc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any, arm64_big_sur: "ac722f3534f9cf0679f2c999353a524d822d4068d8f9877a5967fe6fbcef9f04"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `pbc`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.