### PR TITLE
fswatch: add livecheck

### DIFF
--- a/Formula/fswatch.rb
+++ b/Formula/fswatch.rb
@@ -5,6 +5,11 @@ class Fswatch < Formula
   sha256 "95ece85eb01af71e99afef0173755fcedb737b639163f8efc7fed674f6f5372f"
   license all_of: ["GPL-3.0-or-later", "Apache-2.0"]
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "a9857b4d1cc1320e967edcc5ba5c61bd9215fac591204bc005bc89223f107228"
     sha256 cellar: :any, big_sur:       "f930656cf465723b282216767a932555efdfd6b75d0404cd904c52005fad53ac"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `fswatch` but it's currently reporting a `1.16.0+cmake` tag as newest instead of `1.16.0` (as used in the formula). This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`), which will omit tags with a suffix.