### PR TITLE
storj-uplink: add livecheck

### DIFF
--- a/Formula/storj-uplink.rb
+++ b/Formula/storj-uplink.rb
@@ -5,6 +5,11 @@ class StorjUplink < Formula
   sha256 "e26d9bbea734245bf63171224b30661c864bafc699cf93ffb268bac25cd74ab5"
   license "AGPL-3.0-only"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "be143d195b4e7dedb904649ed701007d5fbfddddaee168f4ef4d41196a152f07"
     sha256 cellar: :any_skip_relocation, big_sur:       "caa8f81fc92c06e909694ec21ee407fdf9e4a2175d8d810c763a42f42d21a8c6"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `storj-uplink` but it's currently reporting `20190410` as newest (from a `storj_20190410` tag) instead of `1.31.2`. This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`), which omits the old `storj_YYYYMMDD` tags as well as unstable versions like `v1.31.0-rc`, `v1.18.2-rc-2`, etc.