### PR TITLE
minizip: use workaround only on macOS to fix Linux build

### DIFF
--- a/Formula/minizip.rb
+++ b/Formula/minizip.rb
@@ -34,11 +34,13 @@ class Minizip < Formula
     system "make"
 
     cd "contrib/minizip" do
-      # edits to statically link to libz.a
-      inreplace "Makefile.am" do |s|
-        s.sub! "-L$(zlib_top_builddir)", "$(zlib_top_builddir)/libz.a"
-        s.sub! "-version-info 1:0:0 -lz", "-version-info 1:0:0"
-        s.sub! "libminizip.la -lz", "libminizip.la"
+      on_macos do
+        # edits to statically link to libz.a
+        inreplace "Makefile.am" do |s|
+          s.sub! "-L$(zlib_top_builddir)", "$(zlib_top_builddir)/libz.a"
+          s.sub! "-version-info 1:0:0 -lz", "-version-info 1:0:0"
+          s.sub! "libminizip.la -lz", "libminizip.la"
+        end
       end
       system "autoreconf", "-fi"
       system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
