### PR TITLE
luajit-openresty: update livecheck

### DIFF
--- a/Formula/luajit-openresty.rb
+++ b/Formula/luajit-openresty.rb
@@ -6,6 +6,11 @@ class LuajitOpenresty < Formula
   license "MIT"
   head "https://github.com/openresty/luajit2.git", branch: "v2.1-agentzh"
 
+  livecheck do
+    url :stable
+    regex(/^v?2\.1[-_.](\d{8})$/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "1206d1abe22d5ce6c2be8899c5829172f25264ea2b888926116c0b5aa21eedbd"
     sha256 cellar: :any, big_sur:       "c4058bf652e63d1fa42b1453a7f1f100f1c8702c874d778693318d2e903ce465"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates the livecheck to only match the date portion of the tag,
and allows livecheck to match the version parsed from the url. The
`v2.1-` prefix is inherited from upstream LuaJIT, and is unlikely to
change in the foreseeable future.