### PR TITLE
x86_64-elf-gdb, i386-elf-gdb: Fix ELF file support

### DIFF
--- a/Formula/i386-elf-gdb.rb
+++ b/Formula/i386-elf-gdb.rb
@@ -1,9 +1,9 @@
 class I386ElfGdb < Formula
   desc "GNU debugger for i386-elf cross development"
   homepage "https://www.gnu.org/software/gdb/"
-  url "https://ftp.gnu.org/gnu/gdb/gdb-10.1.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gdb/gdb-10.1.tar.xz"
-  sha256 "f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0"
+  url "https://ftp.gnu.org/gnu/gdb/gdb-10.2.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gdb/gdb-10.2.tar.xz"
+  sha256 "aaa1223d534c9b700a8bec952d9748ee1977513f178727e1bee520ee000b4f29"
   license "GPL-3.0-or-later"
   head "https://sourceware.org/git/binutils-gdb.git"
 
@@ -15,20 +15,30 @@ class I386ElfGdb < Formula
     sha256 high_sierra:   "f97095dfc0fc75cfdfa67f9cc8ef4402c7b8d4f24a0a522281f1d5c93c3ee4b3"
   end
 
+  depends_on "i686-elf-gcc" => :test
   depends_on "python@3.9"
   depends_on "xz" # required for lzma support
 
-  conflicts_with "gdb", because: "both install include/gdb, share/gdb and share/info"
-  conflicts_with "x86_64-elf-gdb", because: "both install include/gdb, share/gdb and share/info"
+  uses_from_macos "zlib"
+
+  # Fix for https://sourceware.org/bugzilla/show_bug.cgi?id=26949#c8
+  # Remove when upstream includes this commit
+  # https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=b413232211bf
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/242630de4b54d6c57721e12ce88988a0f4e41202/gdb/gdb-10.2.patch"
+    sha256 "36652e9d97037266650a3b31f9f39539c4b376d31016fa4fc325dc0aa7930acc"
+  end
 
   def install
     args = %W[
       --target=i386-elf
       --prefix=#{prefix}
+      --datarootdir=#{share}/i386-elf-gdb
       --disable-debug
       --disable-dependency-tracking
       --with-lzma
       --with-python=#{Formula["python@3.9"].opt_bin}/python3
+      --with-system-zlib
       --disable-binutils
     ]
 
@@ -39,9 +49,14 @@ class I386ElfGdb < Formula
       # Don't install bfd or opcodes, as they are provided by binutils
       system "make", "install-gdb"
     end
+
+    mv include/"gdb", include/"i386-elf-gdb"
   end
 
   test do
-    system "#{bin}/i386-elf-gdb", "#{bin}/i386-elf-gdb", "-configuration"
+    (testpath/"test.c").write "void _start(void) {}"
+    system "#{Formula["i686-elf-gcc"].bin}/i686-elf-gcc", "-g", "-nostdlib", "test.c"
+    assert_match "Symbol \"_start\" is a function at address 0x",
+          shell_output("#{bin}/i386-elf-gdb -batch -ex 'info address _start' a.out")
   end
 end

--- a/Formula/x86_64-elf-gdb.rb
+++ b/Formula/x86_64-elf-gdb.rb
@@ -1,9 +1,9 @@
 class X8664ElfGdb < Formula
-  desc "GNU debugger for i386-elf cross development"
+  desc "GNU debugger for x86_64-elf cross development"
   homepage "https://www.gnu.org/software/gdb/"
-  url "https://ftp.gnu.org/gnu/gdb/gdb-10.1.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gdb/gdb-10.1.tar.xz"
-  sha256 "f82f1eceeec14a3afa2de8d9b0d3c91d5a3820e23e0a01bbb70ef9f0276b62c0"
+  url "https://ftp.gnu.org/gnu/gdb/gdb-10.2.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gdb/gdb-10.2.tar.xz"
+  sha256 "aaa1223d534c9b700a8bec952d9748ee1977513f178727e1bee520ee000b4f29"
   license "GPL-3.0-or-later"
   head "https://sourceware.org/git/binutils-gdb.git"
 
@@ -15,20 +15,30 @@ class X8664ElfGdb < Formula
     sha256 high_sierra:   "bc725f791779a9400ab2b11d485ebba7e71aced9e6cef3365db614dbb273205c"
   end
 
+  depends_on "x86_64-elf-gcc" => :test
   depends_on "python@3.9"
   depends_on "xz"
 
-  conflicts_with "gdb", because: "both install include/gdb, share/gdb and share/info"
-  conflicts_with "i386-elf-gdb", because: "both install include/gdb, share/gdb and share/info"
+  uses_from_macos "zlib"
+
+  # Fix for https://sourceware.org/bugzilla/show_bug.cgi?id=26949#c8
+  # Remove when upstream includes this commit
+  # https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=b413232211bf
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/242630de4b54d6c57721e12ce88988a0f4e41202/gdb/gdb-10.2.patch"
+    sha256 "36652e9d97037266650a3b31f9f39539c4b376d31016fa4fc325dc0aa7930acc"
+  end
 
   def install
     args = %W[
       --target=x86_64-elf
       --prefix=#{prefix}
+      --datarootdir=#{share}/x86_64-elf-gdb
       --disable-debug
       --disable-dependency-tracking
       --with-lzma
       --with-python=#{Formula["python@3.9"].opt_bin}/python3
+      --with-system-zlib
       --disable-binutils
     ]
 
@@ -38,9 +48,14 @@ class X8664ElfGdb < Formula
 
       system "make", "install-gdb"
     end
+
+    mv include/"gdb", include/"x86_64-elf-gdb"
   end
 
   test do
-    system "#{bin}/x86_64-elf-gdb", "#{bin}/x86_64-elf-gdb", "-configuration"
+    (testpath/"test.c").write "void _start(void) {}"
+    system "#{Formula["x86_64-elf-gcc"].bin}/x86_64-elf-gcc", "-g", "-nostdlib", "test.c"
+    assert_match "Symbol \"_start\" is a function at address 0x",
+          shell_output("#{bin}/x86_64-elf-gdb -batch -ex 'info address _start' a.out")
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
gdb is currently unable to load ELF files on Big Sur.  See https://sourceware.org/bugzilla/show_bug.cgi?id=26949

```
$ echo 'void _start() {}' | x86_64-elf-gcc -g -xc -nostdlib -
$ /opt/homebrew/Cellar/x86_64-elf-gdb/10.1/bin/x86_64-elf-gdb -batch a.out
I'm sorry, Dave, I can't do that.  Symbol format `elf64-x86-64' unknown.
```

This PR
* updates gdb to 10.2 and includes a patch to fix ELF file loading.  The patch is adapted from https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=b413232211bf
* updates the test to ensure that ELF files can be read
* adjusts paths to avoid conflicts