### PR TITLE
gawk: skip make check if no cmp command is installed

### DIFF
--- a/Formula/gawk.rb
+++ b/Formula/gawk.rb
@@ -28,7 +28,11 @@ class Gawk < Formula
                           "--without-libsigsegv-prefix"
 
     system "make"
-    system "make", "check"
+    if which "cmp"
+      system "make", "check"
+    else
+      opoo "Skipping `make check` due to unavailable `cmp`"
+    end
     system "make", "install"
 
     (libexec/"gnubin").install_symlink bin/"gawk" => "awk"


### PR DESCRIPTION
We have a few users on Linux who compile from source,
and did not have cmp installed on their system.
As gawk is quite low in the dependency tree, it's important
to be able to install it. The tests can be skipped locally,
they are still run on macOS and Linux CI, where cmp is installed

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
