### PR TITLE
opusfile: change stable URL and test resource

### DIFF
--- a/Formula/opusfile.rb
+++ b/Formula/opusfile.rb
@@ -1,7 +1,7 @@
 class Opusfile < Formula
   desc "API for decoding and seeking in .opus files"
   homepage "https://www.opus-codec.org/"
-  url "https://downloads.xiph.org/releases/opus/opusfile-0.12.tar.gz"
+  url "https://ftp.osuosl.org/pub/xiph/releases/opus/opusfile-0.12.tar.gz"
   sha256 "118d8601c12dd6a44f52423e68ca9083cc9f2bfe72da7a8c1acb22a80ae3550b"
   license "BSD-3-Clause"
 
@@ -26,9 +26,9 @@ class Opusfile < Formula
   depends_on "openssl@1.1"
   depends_on "opus"
 
-  resource "music_48kbps.opus" do
-    url "https://www.opus-codec.org/static/examples/samples/music_48kbps.opus"
-    sha256 "64571f56bb973c078ec784472944aff0b88ba0c88456c95ff3eb86f5e0c1357d"
+  resource "sample" do
+    url "https://dl.espressif.com/dl/audio/gs-16b-1c-44100hz.opus"
+    sha256 "f80fabebe4e00611b93019587be9abb36dbc1935cb0c9f4dfdf5c3b517207e1b"
   end
 
   def install
@@ -39,7 +39,7 @@ class Opusfile < Formula
   end
 
   test do
-    testpath.install resource("music_48kbps.opus")
+    resource("sample").stage { testpath.install Pathname.pwd.children(false).first => "sample.opus" }
     (testpath/"test.c").write <<~EOS
       #include <opus/opusfile.h>
       #include <stdlib.h>
@@ -60,6 +60,6 @@ class Opusfile < Formula
                              "-L#{lib}",
                              "-lopusfile",
                              "-o", "test"
-    system "./test", "music_48kbps.opus"
+    system "./test", "sample.opus"
   end
 end

--- a/audit_exceptions/cert_error_allowlist.json
+++ b/audit_exceptions/cert_error_allowlist.json
@@ -6,5 +6,6 @@
   "micropython": "https://www.micropython.org/",
   "minio": "https://min.io",
   "monero": "https://www.getmonero.org/",
+  "opusfile": "https://www.opus-codec.org/",
   "volk": "https://www.libvolk.org/"
 }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR changes the test resource used for `opusfile`, as macOS-provided `curl` errors out when trying to download the currently used resource. See https://github.com/Homebrew/homebrew-core/pull/78711#issuecomment-854929657.

Test output after `brew install opusfile`:
```
➜ brew test --verbose opusfile
==> Testing opusfile
/usr/bin/sandbox-exec -f /private/tmp/homebrew20210606-45624-mznc1r.sb ruby -W1 -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/opusfile.rb --verbose
cp -p /Users/nanda/Library/Caches/Homebrew/downloads/4e5cb2a0e897b5a3fe806f06d08d31eb36131680e023a98448af049ede0e0275--gs-16b-1c-44100hz.opus /private/tmp/opusfile--sample-20210606-45625-1w94tcf/gs-16b-1c-44100hz.opus
==> /usr/bin/clang test.c -I/usr/local/opt/opus/include/opus -L/usr/local/Cellar/opusfile/0.12/lib -lopusfile -o test
==> ./test sample.opus
```