### PR TITLE
libmobi 0.6 (new formula)

### DIFF
--- a/Formula/libmobi.rb
+++ b/Formula/libmobi.rb
@@ -1,0 +1,28 @@
+class Libmobi < Formula
+  desc "C library for handling Kindle (MOBI) formats of ebook documents"
+  homepage "https://github.com/bfabiszewski/libmobi/"
+  url "https://github.com/bfabiszewski/libmobi/releases/download/v0.6/libmobi-0.6.tar.gz"
+  sha256 "c35bd44279575bf8b102d23eba482805bfc1e5a49df8414d851507e8ea811c5d"
+  license "LGPL-3.0-only"
+
+  def install
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <mobi.h>
+      int main() {
+        MOBIData *m = mobi_init();
+        if (m == NULL) {
+          return 1;
+        }
+        mobi_free(m);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.cpp", "-L#{lib}", "-lmobi", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/libmobi.rb
+++ b/Formula/libmobi.rb
@@ -3,7 +3,7 @@ class Libmobi < Formula
   homepage "https://github.com/bfabiszewski/libmobi/"
   url "https://github.com/bfabiszewski/libmobi/releases/download/v0.6/libmobi-0.6.tar.gz"
   sha256 "c35bd44279575bf8b102d23eba482805bfc1e5a49df8414d851507e8ea811c5d"
-  license "LGPL-3.0-only"
+  license "LGPL-3.0-or-later"
 
   def install
     system "./configure", *std_configure_args, "--disable-silent-rules"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds [libmobi](https://github.com/bfabiszewski/libmobi). There was a [PR for this 4 years ago](https://github.com/Homebrew/homebrew-core/pull/10473) but it was abandoned.