### PR TITLE
argus-clients: add livecheck

### DIFF
--- a/Formula/argus-clients.rb
+++ b/Formula/argus-clients.rb
@@ -1,9 +1,14 @@
 class ArgusClients < Formula
   desc "Audit Record Generation and Utilization System clients"
-  homepage "https://qosient.com/argus/"
+  homepage "https://openargus.org"
   url "https://qosient.com/argus/src/argus-clients-3.0.8.2.tar.gz"
   sha256 "32073a60ddd56ea8407a4d1b134448ff4bcdba0ee7399160c2f801a0aa913bb1"
   revision 4
+
+  livecheck do
+    url "https://openargus.org/getting-argus"
+    regex(/href=.*?argus-clients[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "399217b0dc94900b41013e73be7ac85cccf52d9046d42d960f0461d07657739c"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `argus-clients`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.

This PR also updates the homepage, as the existing homepage only contains a redirect to `openargus.org` at this point:

```
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">
  <head>
    <meta HTTP-EQUIV="REFRESH" content="0; url=https://openargus.org">
  </head>
</html>
```