### PR TITLE
libffcall: update license

### DIFF
--- a/Formula/libffcall.rb
+++ b/Formula/libffcall.rb
@@ -4,7 +4,7 @@ class Libffcall < Formula
   url "https://ftp.gnu.org/gnu/libffcall/libffcall-2.3.tar.gz"
   mirror "https://ftpmirror.gnu.org/gnu/libffcall/libffcall-2.3.tar.gz"
   sha256 "81e7e9862e342053b62004e1788b49e80defaa3186d0352cccf6e6b77c823ef2"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any, big_sur:  "bb1f926fad9495f329bf5c6145621cb03102588514955cb05e715fb9ac840dd6"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Code headers:
```
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or
 * (at your option) any later version.
```
Note: The project homepage [mentions GPL 3 or later](https://www.gnu.org/software/libffcall/#license). However, the code headers and README from the source archive are up-to-date (the copyright year in the README, for instance, was modified to 2021 in this release) and all mention the GPL 2 license. The COPYING file included contains the GPL 2 license text.