### PR TITLE
composer 2.1.2

### DIFF
--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -1,8 +1,8 @@
 class Composer < Formula
   desc "Dependency Manager for PHP"
   homepage "https://getcomposer.org/"
-  url "https://getcomposer.org/download/2.1.1/composer.phar"
-  sha256 "445a577f3d7966ed2327182380047a38179068ad1292f6b88de4e071920121ce"
+  url "https://getcomposer.org/download/2.1.2/composer.phar"
+  sha256 "2dec01094a6bd571dcc0ed796b6e180aca3833646834b66eb743b7d66787a43d"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 2,252,532 bytes
- formula fetch time: 2.6 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.