### PR TITLE
ammonite-repl: add version

### DIFF
--- a/Formula/ammonite-repl.rb
+++ b/Formula/ammonite-repl.rb
@@ -2,6 +2,7 @@ class AmmoniteRepl < Formula
   desc "Ammonite is a cleanroom re-implementation of the Scala REPL"
   homepage "https://ammonite.io/"
   url "https://github.com/lihaoyi/Ammonite/releases/download/2.3.8/2.13-2.3.8"
+  version "2.3.8"
   sha256 "e7af76416202ff02b8faece785740d957e3ca6351f8d56cf69a749ec4d25484b"
   license "MIT"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`ammonite-repl` is one of a number of formulae that use a filename format that contains a Scala version followed by a hyphen and the actual version. In the current filename (`2.13-2.3.8`), `2.13` is the Scala version and the `ammonite-repl` version is `2.3.8` (as seen on the [GitHub releases page](https://github.com/com-lihaoyi/Ammonite/releases)).

This currently isn't an issue because the version is parsed from the filename as `2.3.8`. However, it's merely a coincidence that `Version` is isolating `2.3.8` here and it's not intentional behavior.

`Version` doesn't parse the full version from filenames like `2.13-2.3.8` because it assumes that `2.13-` is a leading software name (e.g., `openssl-`) and omits it from the version capture group. Homebrew/brew#11491 will fix this behavior for filenames that don't include a leading software name and `ammonite-repl` is the one formula that's negatively affected.

It's arguably best for `Version` to correctly parse the full version by default and for us to use `version` in a formula/cask to account for unusual filenames. This works for the majority and we only have to address the outliers.

As such, this PR adds `version "2.3.8"` to `ammonite-repl` in anticipation of Homebrew/brew#11491. This will fail CI due to `version` not being necessary at the present moment (i.e., `Stable: version 2.3.8 is redundant with version scanned from URL`).