### PR TITLE
openssl@1.1.1: Build the SSL_trace() function as standard

### DIFF
--- a/Formula/openssl@1.1.rb
+++ b/Formula/openssl@1.1.rb
@@ -50,10 +50,16 @@ class OpensslAT11 < Formula
   # SSLv3 & zlib are off by default with 1.1.0 but this may not
   # be obvious to everyone, so explicitly state it for now to
   # help debug inevitable breakage.
+  #
+  # enable-ssl-trace results in the SSL_trace() function being
+  # built and exposed in ssl.h. SSL_trace() is extremely useful
+  # for debugging handshake issues, and, given the negligable
+  # cost, is worth including by default.
   def configure_args
     args = %W[
       --prefix=#{prefix}
       --openssldir=#{openssldir}
+      enable-ssl-trace
       no-ssl3
       no-ssl3-method
       no-zlib


### PR DESCRIPTION
Even with recent versions of OpenSSL (>= 1.1.1) the public API for displaying handshake information is fairly underdeveloped.  There's simply no easy way print the contents of handshake messages in a humanly readable form.

OpenSSL provides an `SSL_trace()` function which can be called with arguments provided to the `SSL_set_msg_callback` callback.  From there it's about 100 LoC to create a custom BIO to plumb `SSL_trace()` into the logging infrastructure of an application.  After this is done OpenSSL provides reams of useful, humanly readable debug output about the handshake in progress (example below).

Unfortunately OpenSSL does not build the `SSL_trace()` function by default, the code for it being guarded with `#ifndef OPENSSL_NO_SSL_TRACE`. Passing `enable-ssl-trace` to the configure script results in `OPENSSL_NO_SSL_TRACE` not being defined, so `SSL_trace()` is built and exposed as a public function in `ssl.h`.

There are no side effects to enabling `SSL_trace()`. other than `s_client` and `s_server` getting an addition `-trace` argument, and a negligible increase in binary size.

`SSL_trace()` is an extremely useful function, and I'm honestly not sure why the OpenSSL team chose not to build it by default.  With the encrypted handshakes in some types of session resumption and TLS 1.3, Wireshark is fairly useless, and debugging is much more dependent on server/client applications producing good logging output.

Please consider including `SSL_trace()` in the homebrew packages by default.

```
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)        [26] AES128-SHA
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)      >>> send TLS 1.2, handshake[length 65], unknown_handshake_type_0x0002
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)          ServerHello, Length=61
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)            server_version=0x303 (TLS 1.2)
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)            Random:
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              gmt_unix_time=0x1194603F
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              random_bytes (len=28): C955CEE7CCA37F51B68169C1336AAEC477B5BFE2444F574E47524401
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)            session_id (len=0): 
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)            cipher_suite {0xC0, 0x30} TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)            compression_method: No Compression (0x00)
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)            extensions, length = 21
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              extension_type=renegotiate(65281), length=1
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                  <EMPTY>
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              extension_type=ec_point_formats(11), length=4
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                uncompressed (0)
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                ansiX962_compressed_prime (1)
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                ansiX962_compressed_char2 (2)
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              extension_type=session_ticket(35), length=0
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              extension_type=extended_master_secret(23), length=0
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)      
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)      Handshake state [TWSH] - Server SSLv3/TLS write server hello
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)      >>> send TLS 1.2, handshake[length 1397], unknown_handshake_type_0x000b
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)          Certificate, Length=1393
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)            certificate_list, length=1390
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              ASN.1Cert, length=1387
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)      ------details-----
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)      Certificate:
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)          Data:
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              Version: 3 (0x2)
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              Serial Number: 1 (0x1)
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              Signature Algorithm: sha256WithRSAEncryption
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              Issuer: C = FR, ST = Radius, L = Somewhere, O = Example Inc, emailAddress = admin@example.org, CN = Example Certificate Authority
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              Validity
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                  Not Before: May 26 15:40:51 2021 GMT
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                  Not Before: May 26 15:40:51 2021 GMT
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                  Not Before: May 26 15:40:51 2021 GMT
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                  Not After : May 26 15:40:51 2022 GMT
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              Subject: C = FR, ST = Radius, O = Example Inc, CN = Example Server Certificate, emailAddress = admin@example.org
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)              Subject Public Key Info:
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                  Public Key Algorithm: rsaEncryption
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                      RSA Public-Key: (2048 bit)
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                      Modulus:
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                          00:d9:55:1d:fa:eb:53:e8:90:b6:f7:a8:01:7d:d4:
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                          c7:fd:6d:b4:4b:7a:f5:16:80:d5:1e:05:45:e8:1f:
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                          f1:38:d0:a7:76:a8:14:e0:4f:be:74:4f:8e:00:46:
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)                          13:b4:55:d0:34:10:94:48:7f:67:ba:
Sun Jun  6 22:33:49 2021: Debug : ((10,8).0)      Handshake state [TWSC] - Server SSLv3/TLS write certificate
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
