### PR TITLE
cabal-install: add ARM bootstrap artefact

### DIFF
--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -21,8 +21,14 @@ class CabalInstall < Formula
 
   resource "bootstrap" do
     on_macos do
-      url "https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-apple-darwin17.7.0.tar.xz"
-      sha256 "9197c17d2ece0f934f5b33e323cfcaf486e4681952687bc3d249488ce3cbe0e9"
+      if Hardware::CPU.intel?
+        url "https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-apple-darwin17.7.0.tar.xz"
+        sha256 "9197c17d2ece0f934f5b33e323cfcaf486e4681952687bc3d249488ce3cbe0e9"
+      else
+        # Bootstrapped on Homebrew CI. Replace with official upstream artefact when one is available.
+        url "https://github.com/haskell/cabal/files/6617482/cabal-install-3.5-arm64-darwin-11.4-bootstrapped.tar.gz"
+        sha256 "e6f2c70fe8946df3980899bd1c564ffea55630b57238cdac9de851178e644a53"
+      end
     end
     on_linux do
       url "https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This was bootstrapped on Homebrew CI using upstream's bootstrap script.
See haskell/cabal#7433.

-----

Marking this as syntax-only, as this should have no impact on existing bottles/installs. Will dispatch a bottle for this separately.