### PR TITLE
luajit-openresty: add version_scheme, livecheck

### DIFF
--- a/Formula/luajit-openresty.rb
+++ b/Formula/luajit-openresty.rb
@@ -2,10 +2,21 @@ class LuajitOpenresty < Formula
   desc "OpenResty's Branch of LuaJIT 2"
   homepage "https://github.com/openresty/luajit2"
   url "https://github.com/openresty/luajit2/archive/refs/tags/v2.1-20210510.tar.gz"
-  version "20210510"
   sha256 "1ee6dad809a5bb22efb45e6dac767f7ce544ad652d353a93d7f26b605f69fe3f"
   license "MIT"
+  version_scheme 1
   head "https://github.com/openresty/luajit2.git", branch: "v2.1-agentzh"
+
+  # The latest LuaJIT release is unstable (2.1.0-beta3, from 2017-05-01) and
+  # OpenResty is making releases using the latest LuaJIT Git commits. With this
+  # in mind, the regex below is very permissive and will match any tags
+  # starting with a numeric version, ensuring that we match unstable versions.
+  # We should consider restricting the regex to stable versions if it ever
+  # becomes feasible in the future.
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:[.-]\d+)+[^{}]*)/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "1206d1abe22d5ce6c2be8899c5829172f25264ea2b888926116c0b5aa21eedbd"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Homebrew/brew#11491 will add a `Version` parser that accounts for filenames which don't include a leading software name (e.g., `brew-1.2.3.tar.gz` vs. `v2.1-20210510.tar.gz` here). As described in that PR, the parsed version for `luajit-openresty` only includes the trailing date (`20210510`) instead of the full version (`2.1-20210510`). This occurs because the existing `Version` parsers assume that anything before the hyphen in a filename like `v2.1-20210510.tar.gz` is the leading software name and omits it. This isn't true for `luajit-openresty` and the brew PR accounts for this type of filename format.

The aforementioned brew PR will lead to the full version (`2.1-20210510`) being used for `luajit-openresty`, so this PR bumps `version_scheme`.

This also adds a `livecheck` block with a permissive regex that can match unstable versions (since the latest LuaJIT version [from 2017] is a beta). We can revisit this if the regex ends up being too loose over time (matching something we don't want) but I feel that it's better to be permissive in this particular instance, since the formula is technically using unstable versions.

---

For context on this, see #78791 and Homebrew/brew#11491, where we discussed the appropriateness and benefits/detriments of using only the date as the version or using the full version that OpenResty provides.

The arguments for only using the date as the version are: LuaJIT will never make another release (people have asked and it won't happen), the `2.1-` prefix is just noise (it will never change), and we would need to bump `version_scheme` for this to work (as seen in this PR).

My arguments for using the full version can be summarized as follows:

* Upstream uses a tag format like `v2.1-20210510` and it's not our place to say that the `v2.1-` prefix isn't a meaningful part of the version simply because it's unlikely to change. [Other package managers use the full version](https://repology.org/project/luajit-openresty/versions) but we're the lone exception and this is only because of a shortcoming in our `Version` parser. We should use the version format that upstream has provided and this is in keeping with how we handle this type of situation in other formulae.
* LuaJIT is an actively-developed project and even if they've said that they won't make a new release, I don't see any reason why we should encode this assumption into how we handle the `luajit-openresty` version (see previous point). It doesn't seem unreasonable to me that LuaJIT could reverse course and make a new release sometime in the future (people change their mind, the composition of the development team and/or leadership could change, etc.).
* Using the full version (`2.1-20210510`) will work both now and in the future for foreseeable potentialities (e.g., if LuaJIT ever released a `2.2.0` version). If we only use the date as the version, `20210510` would be erroneously treated as newer than a version like `2.2.0`. A date version only works if OpenResty uses the `2.1-20210510` format forever. This isn't a given, as the repository used tags like `v2.0.5` in the past and switched to the date-based format after `v2.1.0-beta3` because LuaJIT stopped making releases. It's not unreasonable to believe that OpenResty could return to a format like `v2.2.0` if LuaJIT made such a release.

Basically, using the full version that upstream provides is appropriate here but it would also adapt better to potential version changes in the future (however unlikely they are). We bump `version_scheme` once here and we should be good for the foreseeable future, unless something really unexpected happens upstream (which we would need to address regardless).