### PR TITLE
notmuch: add elisp packages to bottle

### DIFF
--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -4,6 +4,7 @@ class Notmuch < Formula
   url "https://notmuchmail.org/releases/notmuch-0.32.1.tar.xz"
   sha256 "a747ca4e8cc919d91feda6cadb97e63b72ff79119491989bbcea79ad47680615"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://git.notmuchmail.org/git/notmuch", using: :git
 
   livecheck do
@@ -19,6 +20,7 @@ class Notmuch < Formula
   end
 
   depends_on "doxygen" => :build
+  depends_on "emacs" => :build
   depends_on "libgpg-error" => :build
   depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build
@@ -52,6 +54,7 @@ class Notmuch < Formula
     system "./configure", *args
     system "make", "V=1", "install"
 
+    elisp.install Dir["emacs/*.el"]
     bash_completion.install "completion/notmuch-completion.bash"
 
     (prefix/"vim/plugin").install "vim/notmuch.vim"


### PR DESCRIPTION
The notmuch project includes emacs-lisp packages in its source releases.
As documented in `notmuch.el`:

```emacs-lisp
;; Note for MELPA users (and others tracking the development version
;; of notmuch-emacs):
;;
;; This emacs package needs a fairly closely matched version of the
;; notmuch program. If you use the MELPA version of notmuch.el (as
;; opposed to MELPA stable), you should be prepared to track the
;; master development branch (i.e. build from git) for the notmuch
;; program as well. Upgrading notmuch-emacs too far beyond the notmuch
;; program can CAUSE YOUR EMAIL TO STOP WORKING.
;;
;; TL;DR: notmuch-emacs from MELPA and notmuch from distro packages is
;; NOT SUPPORTED.
```

i.e. The clients and notmuch program are distributed together because
version mismatches COULD result in unintended behavior.

As such, it seems fitting that the installation of the notmuch package
through Homebrew should also make available the emacs-lisp packages.

Ideally these would be built into the "bottle" distributions of notmuch
and automatically placed on  the host's file system - without the 
_need_ for every consumer of the notmuch package to install
the emacs package. That is my intent here. I add the emacs formula as a
build dependency of notmuch so that notmuch's `./configure` script can
correctly detect that emacs is present - this is what triggers the
notmuch Makefile to generate the emacs-lisp files, without it the Make
process will omit the emacs-lisp client from the build. Given these bits
from the Homebrew Formula Cookbookd[^1] it seems specifying emacs as a
build dependency is the only viable option - whereas an optional
dependency might better fit the use case, but is expressly prohibited:

> :build means that dependency is a build-time only dependency so it can
be skipped when installing from a bottle or when listing missing
dependencies using brew missing... Note: :optional and
:recommended are not allowed in Homebrew/homebrew-core as they are not
tested by CI.

[^1]: https://docs.brew.sh/Formula-Cookbook

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
