### PR TITLE
ghc: fix doc build

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -4,6 +4,7 @@ class Ghc < Formula
   url "https://downloads.haskell.org/~ghc/8.10.5/ghc-8.10.5-src.tar.xz"
   sha256 "f10941f16e4fbd98580ab5241b9271bb0851304560c4d5ca127e3b0e20e3076f"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url "https://www.haskell.org/ghc/download.html"
@@ -17,8 +18,8 @@ class Ghc < Formula
   end
 
   depends_on "python@3.9" => :build
+  depends_on "sphinx-doc" => :build
   depends_on "llvm" if Hardware::CPU.arm?
-  depends_on macos: :catalina
 
   resource "gmp" do
     url "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz"
@@ -33,8 +34,9 @@ class Ghc < Formula
   resource "binary" do
     on_macos do
       if Hardware::CPU.intel?
-        url "https://downloads.haskell.org/~ghc/8.10.5/ghc-8.10.5-x86_64-apple-darwin.tar.xz"
-        sha256 "ef0f47eff8962d58fa447123636cf8ef31c1e5b2d0ae90177d3388861ddf4a22"
+        # We intentionally bootstrap with 8.10.4 on Intel, as 8.10.5 leads to build failure on Mojave
+        url "https://downloads.haskell.org/~ghc/8.10.4/ghc-8.10.4-x86_64-apple-darwin.tar.xz"
+        sha256 "725ecf6543e63b81a3581fb8c97afd21a08ae11bc0fa4f8ee25d45f0362ef6d5"
       else
         url "https://downloads.haskell.org/ghc/8.10.5/ghc-8.10.5-aarch64-apple-darwin.tar.xz"
         sha256 "03684e70ff03d041b9a4e0f84c177953a241ab8ec7a028c72fa21ac67e66cb09"
@@ -48,6 +50,13 @@ class Ghc < Formula
   end
 
   def install
+    # Fix doc build error. Remove at version bump.
+    # https://gitlab.haskell.org/ghc/ghc/-/issues/19962
+    inreplace "docs/users_guide/conf.py" do |s|
+      s.gsub! "'preamble': '''", "'preamble': r'''"
+      s.gsub! "\\setlength{\\\\tymin}{45pt}", "\\setlength{\\tymin}{45pt}"
+    end
+
     ENV["CC"] = ENV.cc
     ENV["LD"] = "ld"
     ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
@@ -79,7 +88,7 @@ class Ghc < Formula
     end
 
     system "./configure", "--prefix=#{prefix}", *args
-    system "make", "BUILD_SPHINX_HTML=NO"
+    system "make"
 
     ENV.deparallelize { system "make", "install" }
     Dir.glob(lib/"*/package.conf.d/package.cache") { |f| rm f }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This restores the `sphinx-build` dependency, and ~makes `llvm` a
build-only dependency~ bootstraps with 8.10.4 on Intel.

See https://gitlab.haskell.org/ghc/ghc/-/issues/19962.