### PR TITLE
spidermonkey 89.0

### DIFF
--- a/Formula/couchdb.rb
+++ b/Formula/couchdb.rb
@@ -5,7 +5,7 @@ class Couchdb < Formula
   mirror "https://archive.apache.org/dist/couchdb/source/3.1.1/apache-couchdb-3.1.1.tar.gz"
   sha256 "8ffe766bba2ba39a7b49689a0732afacf69caffdf8e2d95447e82fb173c78ca3"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any, big_sur:  "a5f39bc7837033ef94ce64bd004ab640d0dbcc36723048a5eecbf0fe7f79b83e"
@@ -19,14 +19,39 @@ class Couchdb < Formula
   depends_on "erlang@22" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "gcc"
   depends_on "icu4c"
   depends_on "openssl@1.1"
-  depends_on "spidermonkey"
+  depends_on "spidermonkey@78"
 
   conflicts_with "ejabberd", because: "both install `jiffy` lib"
 
+  fails_with :clang # c++20 support
+
+  # resolve rejections of patches below
+  patch :DATA
+
+  # feat(couchjs): add support for SpiderMonkey 86
+  patch do
+    url "https://github.com/apache/couchdb/commit/a411fe220f94be73b9364fc0e923b8401d4e73ff.patch?full_index=1"
+    sha256 "1bc52ae8f602701a27262a4174006306fa1d357d41944d82b3061bf7b541639b"
+  end
+
+  # Add support for Spidermonkey 78
+  patch do
+    url "https://github.com/apache/couchdb/commit/37b5eed5024b9a57a134260794ea80032a1149f8.patch?full_index=1"
+    sha256 "caf4a73d6e0c7edbe508be94d9ca47da3cc65bf3900cb22151c2094bba7ba9cb"
+  end
+
   def install
-    system "./configure"
+    spidermonkey = Formula["spidermonkey@78"]
+    inreplace "src/couch/rebar.config.script",
+              "/usr/local/include/mozjs-#{spidermonkey.version.major}",
+              "#{spidermonkey.opt_include}/mozjs-#{spidermonkey.version.major}"
+    inreplace "src/couch/rebar.config.script",
+              "-L/usr/local/lib -std=c++20 -lmozjs-78 -lm",
+              "-L#{spidermonkey.opt_lib} -std=c++20 -lmozjs-78 -lm"
+    system "./configure", "--spidermonkey-version", spidermonkey.version.major
     system "make", "release"
     # setting new database dir
     inreplace "rel/couchdb/etc/default.ini", "./data", "#{var}/couchdb/data"
@@ -92,3 +117,89 @@ class Couchdb < Formula
     assert_equal "Welcome", output["couchdb"]
   end
 end
+
+__END__
+--- a/src/couch/rebar.config.script
++++ b/src/couch/rebar.config.script
+@@ -76,7 +76,7 @@ ConfigH = [
+     {"JSSCRIPT_TYPE", "JSObject*"},
+     {"COUCHJS_NAME", "\"" ++ CouchJSName++ "\""},
+     {"PACKAGE", "\"apache-couchdb\""},
+-    {"PACKAGE_BUGREPORT", "\"https://issues.apache.org/jira/browse/COUCHDB\""},
++    {"PACKAGE_BUGREPORT", "\"https://github.com/apache/couchdb/issues\""},
+     {"PACKAGE_NAME", "\"Apache CouchDB\""},
+     {"PACKAGE_STRING", "\"Apache CouchDB " ++ Version ++ "\""},
+     {"PACKAGE_VERSION", "\"" ++ Version ++ "\""}
+@@ -123,38 +123,15 @@ end.
+     {unix, _} when SMVsn == "60" ->
+         {
+             "-DXP_UNIX -I/usr/include/mozjs-60 -I/usr/local/include/mozjs-60 -std=c++14 -Wno-invalid-offsetof",
+-            "-L/usr/local/lib -std=c++14 -lmozjs-60 -lm"
++            "-L/usr/local/lib -std=c++14 -lmozjs-60 -lm -lstdc++"
+         };
+     {unix, _} when SMVsn == "68" ->
+         {
+             "-DXP_UNIX -I/usr/include/mozjs-68 -I/usr/local/include/mozjs-68 -std=c++14 -Wno-invalid-offsetof",
+-            "-L/usr/local/lib -std=c++14 -lmozjs-68 -lm"
++            "-L/usr/local/lib -std=c++14 -lmozjs-68 -lm -lstdc++"
+         }
+ end.
+ 
+-{CURL_CFLAGS, CURL_LDFLAGS} = case lists:keyfind(with_curl, 1, CouchConfig) of
+-    {with_curl, true} ->
+-        case os:type() of
+-            {win32, _} ->
+-                {
+-                    "/DHAVE_CURL",
+-                    "/DHAVE_CURL libcurl.lib"
+-                };
+-            {unix, freebsd} ->
+-                {
+-                    "-DHAVE_CURL -I/usr/local/include",
+-                    "-DHAVE_CURL -lcurl"
+-                };
+-            _ ->
+-                {
+-                    "-DHAVE_CURL",
+-                    "-DHAVE_CURL -lcurl"
+-                }
+-        end;
+-    _ ->
+-        {"", ""}
+-end.
+-
+ CouchJSSrc = case SMVsn of
+     "1.8.5" -> ["priv/couch_js/1.8.5/*.c"];
+     "60" -> ["priv/couch_js/60/*.cpp"];
+@@ -164,13 +141,13 @@ end.
+ CouchJSEnv = case SMVsn of
+     "1.8.5" ->
+         [
+-            {"CFLAGS", JS_CFLAGS ++ " " ++ CURL_CFLAGS},
+-            {"LDFLAGS", JS_LDFLAGS ++ " " ++ CURL_LDFLAGS}
++            {"CFLAGS", JS_CFLAGS},
++            {"LDFLAGS", JS_LDFLAGS}
+         ];
+     _ ->
+         [
+-            {"CXXFLAGS", JS_CFLAGS ++ " " ++ CURL_CFLAGS},
+-            {"LDFLAGS", JS_LDFLAGS ++ " " ++ CURL_LDFLAGS}
++            {"CXXFLAGS", JS_CFLAGS},
++            {"LDFLAGS", JS_LDFLAGS}
+         ]
+ end.
+ 
+@@ -237,5 +214,10 @@ AddConfig = [
+ ].
+ 
+ lists:foldl(fun({K, V}, CfgAcc) ->
+-    lists:keystore(K, 1, CfgAcc, {K, V})
+-end, CONFIG, AddConfig).
++    case lists:keyfind(K, 1, CfgAcc) of
++        {K, Existent} when is_list(Existent) andalso is_list(V) ->
++            lists:keystore(K, 1, CfgAcc, {K, Existent ++ V});
++        false ->
++            lists:keystore(K, 1, CfgAcc, {K, V})
++    end
++end, CONFIG, AddConfig).
+\ No newline at end of file

--- a/Formula/narwhal.rb
+++ b/Formula/narwhal.rb
@@ -8,7 +8,6 @@ class Narwhal < Formula
 
   bottle :unneeded
 
-  conflicts_with "spidermonkey", because: "both install a js binary"
   conflicts_with "elixir-build", because: "both install `json` binaries"
 
   def install

--- a/Formula/spidermonkey@78.rb
+++ b/Formula/spidermonkey@78.rb
@@ -1,0 +1,60 @@
+class SpidermonkeyAT78 < Formula
+  desc "JavaScript-C Engine"
+  homepage "https://spidermonkey.dev/"
+  # NOTE: fetch source from here: https://treeherder.mozilla.org/jobs?repo=mozilla-release
+  # click on the first SM(pkg) link you see, then navigate to `Artifacts` sheet
+  # download the `mozjs-<version>.tar.xz`
+  url "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/RPc3WnqfRfK_CQdBKL8N_g/runs/0/artifacts/public/build/mozjs-78.11.0.tar.bz2"
+  sha256 "cb418f21cb02b0d08cb6244af10c89110b1412b8e382809f6bf66984aee5e462"
+  license "MPL-1.1"
+
+  keg_only :versioned_formula
+
+  depends_on "autoconf@2.13" => :build
+  depends_on "pkg-config"    => :build
+  depends_on "python@3.9"    => :build
+  depends_on "rust"          => :build
+  depends_on arch: :x86_64
+
+  depends_on "icu4c"
+  depends_on "nspr"
+
+  uses_from_macos "libedit"
+
+  def install
+    inreplace "build/moz.configure/toolchain.configure",
+                "sdk_max_version = Version('10.15.4')",
+                "sdk_max_version = Version('11.99')"
+
+    inreplace "config/rules.mk",
+              "-install_name $(_LOADER_PATH)/$(SHARED_LIBRARY) ",
+              "-install_name #{lib}/$(SHARED_LIBRARY) "
+
+    args = %W[
+      --prefix=#{prefix}
+      --enable-optimize
+      --enable-readline
+      --enable-release
+      --enable-shared-js
+      --disable-jemalloc
+      --with-intl-api
+      --with-system-icu
+      --with-system-nspr
+      --with-system-zlib
+    ]
+
+    cd "js/src"
+    mkdir "brew_build" do
+      system "../configure", *args
+      system "make"
+      system "make", "install"
+      rm lib/"libjs_static.ajs"
+    end
+  end
+
+  test do
+    path = testpath/"test.js"
+    path.write "print('hello');"
+    assert_equal "hello", shell_output("#{bin}/js#{version.major} #{path}").strip
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
From https://archive.mozilla.org/pub/spidermonkey/README.txt
> We have stopped uploading specific releases. SpiderMonkey source packages are
not an official Mozilla product, though we do try to keep them working.
https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples is the
best source of information for these releases, though you will also want to
visit the main SpiderMonkey documentation page at https://spidermonkey.dev/
 The easiest way to fetch the version corresponding to the current Firefox
release is to visit the treeherder page for the release repository and click on
the first SM(pkg) link you see. That will open a small window in the bottom
left with a line like
    `artifact uploaded: mozjs-86.0.1.tar.xz`
 where the 'mozjs-*.tar.xz' part will be a link to the actual file.
 For the SpiderMonkey package corresponding to the current Firefox release:
  https://treeherder.mozilla.org/#/jobs?repo=mozilla-release&filter-searchStr=spidermonkey-sm-package
 For the SpiderMonkey package corresponding to the latest ESR (Extended Support
Release), select "Repos" from the above page and choose the latest
"mozilla-esrNN" repository, then follow the instructions above. For example,
for esr78 that would take you to:
 https://treeherder.mozilla.org/jobs?repo=mozilla-esr78&filter-searchStr=spidermonkey-sm-package
 Build instructions are in a toplevel INSTALL file.
 To contact us via various mechanisms (realtime chat, forum, mailing list, etc.)
see the "Where to find us" section at https://spidermonkey.dev/

The version number here follows firefox.

remove `libjs_static.ajs` because https://www.linuxfromscratch.org/blfs/view/svn/general/js78.html
