### PR TITLE
lfe: remove emacs dependency

### DIFF
--- a/Formula/lfe.rb
+++ b/Formula/lfe.rb
@@ -13,18 +13,15 @@ class Lfe < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "16d8e8a9f9ab091b1184dac366bb9d83cfccfdb728f79c035362b7b86940a7af"
   end
 
-  depends_on "emacs" if MacOS.version >= :catalina
   depends_on "erlang"
 
   def install
     system "make"
     system "make", "MANINSTDIR=#{man}", "install-man"
-    system "make", "emacs"
     libexec.install "bin", "ebin"
     bin.install_symlink (libexec/"bin").children
     doc.install Dir["doc/*.txt"]
     pkgshare.install "dev", "examples", "test"
-    elisp.install Dir["emacs/*.elc"]
   end
 
   test do


### PR DESCRIPTION
Emacs isn't a dependency for LFE and having Emacs as a dependency causes installation issues when emacs-plus
is present.

Fixes #79031 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
