### PR TITLE
hadolint: build with brewed GHC

### DIFF
--- a/Formula/hadolint.rb
+++ b/Formula/hadolint.rb
@@ -13,6 +13,7 @@ class Hadolint < Formula
 
   depends_on "ghc" => :build
   depends_on "haskell-stack" => :build
+  depends_on "llvm" => :build if Hardware::CPU.arm?
 
   uses_from_macos "xz"
 
@@ -25,8 +26,14 @@ class Hadolint < Formula
     jobs = ENV.make_jobs
     ENV.deparallelize
 
-    system "stack", "-j#{jobs}", "build"
-    system "stack", "-j#{jobs}", "--local-bin-path=#{bin}", "install"
+    ghc_args = [
+      "--system-ghc",
+      "--no-install-ghc",
+      "--skip-ghc-check",
+    ]
+
+    system "stack", "-j#{jobs}", "build", *ghc_args
+    system "stack", "-j#{jobs}", "--local-bin-path=#{bin}", "install", *ghc_args
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The formula declares a build dependency on GHC, but doesn't actually
make use of it. Instead, `stack` downloads its own GHC at build time. [1]

Let's fix that by using Homebrew GHC instead. This should hopefully
allow us to build this on ARM, and likely also removes the need for the
`gmp` dependency on Linux. (CC @Homebrew/linux)

[1] Attempting to bottle this on ARM without the changes here produces
the error:

    I don't know how to install GHC for (OSX,AArch64), please install manually