### PR TITLE
taskwarrior-tui: build manpage on ARM

### DIFF
--- a/Formula/taskwarrior-tui.rb
+++ b/Formula/taskwarrior-tui.rb
@@ -18,20 +18,20 @@ class TaskwarriorTui < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "f0f49cec64f7aa6f485cd15eb7f97288e874a86a3f319135a0b14ab2e4744e0e"
   end
 
-  depends_on "pandoc" => :build unless Hardware::CPU.arm?
+  depends_on "pandoc" => :build
   depends_on "rust" => :build
   depends_on "task"
 
   def install
     system "cargo", "install", *std_cargo_args
-    unless Hardware::CPU.arm?
-      args = %w[
-        --standalone
-        --to=man
-      ]
-      system "pandoc", *args, "docs/taskwarrior-tui.1.md", "-o", "taskwarrior-tui.1"
-      man1.install "taskwarrior-tui.1"
-    end
+
+    args = %w[
+      --standalone
+      --to=man
+    ]
+    system "pandoc", *args, "docs/taskwarrior-tui.1.md", "-o", "taskwarrior-tui.1"
+    man1.install "taskwarrior-tui.1"
+
     bash_completion.install "completions/taskwarrior-tui.bash"
     fish_completion.install "completions/taskwarrior-tui.fish"
     zsh_completion.install "completions/_taskwarrior-tui"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since `pandoc` now works on ARM, we can build the manpage. I haven't bumped the `revision` here as I felt it wasn't necessary to force all users to update.