### PR TITLE
exa: build manpages on ARM

### DIFF
--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -18,7 +18,7 @@ class Exa < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "935794d2a1521fc3645f48eaec3035748cde91b183a23bb0c68b069f1187aae9"
   end
 
-  depends_on "pandoc" => :build unless Hardware::CPU.arm?
+  depends_on "pandoc" => :build
   depends_on "rust" => :build
 
   uses_from_macos "zlib"
@@ -45,14 +45,10 @@ class Exa < Formula
       --standalone
       --to=man
     ]
-
-    unless Hardware::CPU.arm?
-      system "pandoc", *args, "man/exa.1.md", "-o", "exa.1"
-      system "pandoc", *args, "man/exa_colors.5.md", "-o", "exa_colors.5"
-
-      man1.install "exa.1"
-      man5.install "exa_colors.5"
-    end
+    system "pandoc", *args, "man/exa.1.md", "-o", "exa.1"
+    system "pandoc", *args, "man/exa_colors.5.md", "-o", "exa_colors.5"
+    man1.install "exa.1"
+    man5.install "exa_colors.5"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since `pandoc` now works on ARM, we can build the manpages. I haven't bumped the revision here as I felt it wasn't necessary to force all users to update.