### PR TITLE
libprelude: use python@3.9

### DIFF
--- a/Formula/libprelude.rb
+++ b/Formula/libprelude.rb
@@ -4,6 +4,7 @@ class Libprelude < Formula
   url "https://www.prelude-siem.org/attachments/download/1395/libprelude-5.2.0.tar.gz"
   sha256 "187e025a5d51219810123575b32aa0b40037709a073a775bc3e5a65aa6d6a66e"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "7b7bd68152744ba511e577cbba513e86155f0b9734ed54591a462482d94c5679"
@@ -16,7 +17,7 @@ class Libprelude < Formula
   depends_on "pkg-config" => :build
   depends_on "gnutls"
   depends_on "libgpg-error"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   def install
     ENV["HAVE_CXX"] = "yes"
@@ -29,7 +30,7 @@ class Libprelude < Formula
       --without-perl
       --without-swig
       --without-python2
-      --with-python3=#{Formula["python@3.8"].opt_bin/"python3"}
+      --with-python3=python#{Formula["python@3.9"].version.major_minor}
       --with-libgnutls-prefix=#{Formula["gnutls"].opt_prefix}
     ]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
See https://copr.fedorainfracloud.org/coprs/g/python/python3.9/package/libprelude/

If `--with-python3` is followed by a path, e.g. /usr/bin/python3 which is python3.8, will fail.