### PR TITLE
lfe: make emacs a `:build` dependency

### DIFF
--- a/Formula/lfe.rb
+++ b/Formula/lfe.rb
@@ -4,6 +4,7 @@ class Lfe < Formula
   url "https://github.com/lfe/lfe/archive/v2.0.tar.gz"
   sha256 "373ad033bb74679766ed7414bfd6d69fbf6dd0a2337019eb117840384b9fada0"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/lfe/lfe.git", branch: "develop"
 
   bottle do
@@ -13,7 +14,7 @@ class Lfe < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "16d8e8a9f9ab091b1184dac366bb9d83cfccfdb728f79c035362b7b86940a7af"
   end
 
-  depends_on "emacs" if MacOS.version >= :catalina
+  depends_on "emacs" => :build if MacOS.version >= :catalina
   depends_on "erlang"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A better implementation for https://github.com/Homebrew/homebrew-core/pull/79032 that makes sure users don't get a full emacs install attached, just so the build can generate files.