### PR TITLE
dgraph: deprecate

### DIFF
--- a/Formula/dgraph.rb
+++ b/Formula/dgraph.rb
@@ -20,6 +20,8 @@ class Dgraph < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "57fa2f974e4e0313fb58f7e35e2d9547a4d43319af7e84a4fc6619238e862885"
   end
 
+  deprecate! date: "2021-06-10", because: :unsupported
+
   depends_on "go" => :build
   depends_on "jemalloc"
 


### PR DESCRIPTION
Installing `dgraph` on macOS is unsupported for newer versions, i.e.,
21.03.0 and newer. They suggest using Docker instead, and have removed
build instructions for macOS from their README.

See:
* https://dgraph.io/docs/dgraph-overview/#get-started-with-self-managed-dgraph
* https://github.com/dgraph-io/dgraph/pull/7685

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?