### PR TITLE
dgraph: remove livecheck

### DIFF
--- a/Formula/dgraph.rb
+++ b/Formula/dgraph.rb
@@ -8,11 +8,6 @@ class Dgraph < Formula
   license "Apache-2.0"
   head "https://github.com/dgraph-io/dgraph.git"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "28d00b7cc12ab6eb34da4240b7075ee322ff51cd94223d7a8892c823f91bf5cc"
     sha256 cellar: :any_skip_relocation, big_sur:       "9e2da2c025d3b8f89d4716be724942f7c284c9d0ac70c77fed7c287a31abdb56"


### PR DESCRIPTION
Should have included this in Homebrew/homebrew-core#79070, since we don't plan to update this formula. Apologies for the oversight. I don't think we can make `audit` or `style` fail though, because we do update (and intentionally have) `livecheck` blocks for some deprecated formulae – unless of course we have an allowlist as suggested in #62032.

(Adding a brief explanation here: future updates of `dgraph` do not support macOS, so I believe `livecheck` is unnecessary as this formula will not be updated in the future.)

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?