### PR TITLE
agda, cabal-install, allureofthestars: depend on GHC on Mojave

### DIFF
--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -2,7 +2,7 @@ class Agda < Formula
   desc "Dependently typed functional programming language"
   homepage "https://wiki.portal.chalmers.se/agda/"
   license "BSD-3-Clause"
-  revision 2
+  revision 3
 
   stable do
     url "https://hackage.haskell.org/package/Agda-2.6.1.3/Agda-2.6.1.3.tar.gz"
@@ -28,14 +28,12 @@ class Agda < Formula
     end
   end
 
+  depends_on "llvm" => [:build, :test] if Hardware::CPU.arm?
   depends_on "cabal-install"
   depends_on "emacs"
-  depends_on "ghc" if MacOS.version >= :catalina
+  depends_on "ghc"
 
   uses_from_macos "zlib"
-
-  on_macos { depends_on "ghc@8.8" if MacOS.version <= :mojave }
-  on_linux { depends_on "ghc" }
 
   resource "alex" do
     url "https://hackage.haskell.org/package/alex-3.2.6/alex-3.2.6.tar.gz"
@@ -80,13 +78,11 @@ class Agda < Formula
 
     # Clean up references to Homebrew shims
     rm_rf "#{lib}/agda/dist-newstyle/cache"
-
-    on_macos do
-      bin.env_script_all_files libexec/"bin", PATH: "$PATH:#{Formula["ghc@8.8"].opt_bin}" if MacOS.version <= :mojave
-    end
   end
 
   test do
+    ENV.append_path "PATH", Formula["llvm"].opt_bin
+
     simpletest = testpath/"SimpleTest.agda"
     simpletest.write <<~EOS
       module SimpleTest where

--- a/Formula/allureofthestars.rb
+++ b/Formula/allureofthestars.rb
@@ -4,7 +4,7 @@ class Allureofthestars < Formula
   url "https://hackage.haskell.org/package/Allure-0.10.2.0/Allure-0.10.2.0.tar.gz"
   sha256 "fcb9f38ea543d3277fa90eee004f7624d1168bf7f2c17902cda1870293b7c2f4"
   license all_of: ["AGPL-3.0-or-later", "GPL-2.0-or-later", "OFL-1.1", "MIT", :cannot_represent]
-  revision 1
+  revision 2
   head "https://github.com/AllureOfTheStars/Allure.git"
 
   bottle do
@@ -15,12 +15,9 @@ class Allureofthestars < Formula
 
   depends_on "cabal-install" => :build
   depends_on "pkg-config" => :build
-  depends_on "ghc" if MacOS.version >= :catalina
+  depends_on "ghc"
   depends_on "gmp"
   depends_on "sdl2_ttf"
-
-  on_macos { depends_on "ghc@8.8" if MacOS.version <= :mojave }
-  on_linux { depends_on "ghc" }
 
   def install
     system "cabal", "v2-update"

--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -4,7 +4,7 @@ class CabalInstall < Formula
   url "https://hackage.haskell.org/package/cabal-install-3.4.0.0/cabal-install-3.4.0.0.tar.gz"
   sha256 "1980ef3fb30001ca8cf830c4cae1356f6065f4fea787c7786c7200754ba73e97"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://github.com/haskell/cabal.git", branch: "3.4"
 
   bottle do
@@ -15,11 +15,8 @@ class CabalInstall < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "72d1e5df19c428e987f7bee160c05eda1cc75af427d2962242750b3d4f29952a"
   end
 
-  depends_on "ghc" if MacOS.version >= :catalina
+  depends_on "ghc"
   uses_from_macos "zlib"
-
-  on_macos { depends_on "ghc@8.8" if MacOS.version <= :mojave }
-  on_linux { depends_on "ghc" }
 
   resource "bootstrap" do
     on_macos do
@@ -44,7 +41,6 @@ class CabalInstall < Formula
   end
 
   def install
-    cabal = buildpath/"cabal"
     if Hardware::CPU.intel?
       resource("bootstrap").stage buildpath
     else
@@ -58,17 +54,11 @@ class CabalInstall < Formula
       buildpath.install "bootdir/_build/bin/cabal"
     end
 
+    cabal = buildpath/"cabal"
     cd "cabal-install" if build.head?
     system cabal, "v2-update"
     system cabal, "v2-install", *std_cabal_v2_args
     bash_completion.install "bash-completion/cabal"
-
-    on_macos do
-      if MacOS.version <= :mojave
-        (libexec/"bin").install bin/"cabal"
-        (bin/"cabal").write_env_script libexec/"bin/cabal", PATH: "$PATH:#{Formula["ghc@8.8"].opt_bin}"
-      end
-    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also, let's try to build `agda` and `allureofthestars` on ARM.