### PR TITLE
go@1.14: remove livecheck

### DIFF
--- a/Formula/go@1.14.rb
+++ b/Formula/go@1.14.rb
@@ -6,11 +6,6 @@ class GoAT114 < Formula
   sha256 "7ed13b2209e54a451835997f78035530b331c5b6943cdcd68a3d815fdc009149"
   license "BSD-3-Clause"
 
-  livecheck do
-    url "https://golang.org/dl/"
-    regex(/href=.*?go[._-]?v?(1\.14(?:\.\d+)*)[._-]src\.t/i)
-  end
-
   bottle do
     sha256 big_sur:  "faf9dc9e47037a6676239fe00904c43822c622f40f0a7e6d524b1a6b770292b8"
     sha256 catalina: "896c37117ef621d065878a9a97f20ebc5ad5485188cff533db398edf744fb59a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Each major Go release is supported until there are two newer major releases and that's the case for 1.14. The `go@1.14` formula is deprecated and this PR removes the `livecheck` block, so it will be automatically skipped.