### PR TITLE
gcc@4.9: remove livecheck

### DIFF
--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -6,11 +6,6 @@ class GccAT49 < Formula
   sha256 "6c11d292cd01b294f9f84c9a59c230d80e9e4a47e5c6355f046bb36d4f358092"
   revision 2
 
-  livecheck do
-    url :stable
-    regex(%r{href=.*?gcc[._-]v?(4\.9(?:\.\d+)*)(?:/?["' >]|\.t)}i)
-  end
-
   bottle do
     sha256 high_sierra: "cb153d98245bcbe4809dc19adf688f642285154b19fe907c7de3cb71652b0ec6"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [upstream page for GCC 4.9](https://gcc.gnu.org/gcc-4.9/) has a parenthetical note at the top saying "This release series is no longer supported." and this formula is deprecated at this point. As such, this PR removes the `livecheck` block, so this formula will be automatically skipped due to being deprecated.