### PR TITLE
libu2f-host: remove livecheck

### DIFF
--- a/Formula/libu2f-host.rb
+++ b/Formula/libu2f-host.rb
@@ -6,11 +6,6 @@ class Libu2fHost < Formula
   license "GPL-3.0"
   revision 1
 
-  livecheck do
-    url "https://developers.yubico.com/libu2f-host/Releases/"
-    regex(/href=.*?libu2f-host[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any, arm64_big_sur: "052b140ee60b38b731fe05d9d4bd0ba81765e9bac7ccc25125ba93596534fe14"
     sha256 cellar: :any, big_sur:       "4c6f6729349bce13f6710e5edf040411b78c36e6815258f54a4c8c52f907109b"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [`libu2f-host` GitHub repository](https://github.com/Yubico/libu2f-host) is archived with the following note:

> This project is deprecated and is no longer being maintained. [libfido2](https://developers.yubico.com/libfido2/) is a new project with support for U2F and FIDO2.

This formula is deprecated and this removes the `livecheck` block, so that it will be automatically skipped.