### PR TITLE
circleci: fix build for ARM

### DIFF
--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -6,6 +6,7 @@ class Circleci < Formula
       tag:      "v0.1.15338",
       revision: "850f9acdbf24e4222bd4b36035e20c182e7db385"
   license "MIT"
+  revision 1
   head "https://github.com/CircleCI-Public/circleci-cli.git"
 
   bottle do
@@ -15,25 +16,18 @@ class Circleci < Formula
   end
 
   depends_on "go" => :build
+  depends_on "packr" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
+    system "packr2", "--ignore-imports", "-v"
 
-    dir = buildpath/"src/github.com/CircleCI-Public/circleci-cli"
-    dir.install buildpath.children
-
-    cd dir do
-      ldflags = %W[
-        -s -w
-        -X github.com/CircleCI-Public/circleci-cli/version.packageManager=homebrew
-        -X github.com/CircleCI-Public/circleci-cli/version.Version=#{version}
-        -X github.com/CircleCI-Public/circleci-cli/version.Commit=#{Utils.git_short_head}
-      ]
-      system "make", "pack"
-      system "go", "build", "-ldflags", ldflags.join(" "),
-             "-o", bin/"circleci"
-      prefix.install_metafiles
-    end
+    ldflags = %W[
+      -s -w
+      -X github.com/CircleCI-Public/circleci-cli/version.packageManager=homebrew
+      -X github.com/CircleCI-Public/circleci-cli/version.Version=#{version}
+      -X github.com/CircleCI-Public/circleci-cli/version.Commit=#{Utils.git_short_head}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags.join(" "))
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should hopefully get `circleci` built on ARM. I tried (for a few hours 😅) to remove `GOPATH` and get this built with our usual `std_go_args`, but it fails. Some observations:
* `packr` doesn't seem to be compatible with the `-trimpath` flag, although I'm not too familiar with any of this.
* Even without using `-trimpath`, removing `GOPATH` results in a binary that fails to work, with an error message indicating that `data.yml` couldn't be found (this is the resource that `packr` is used to handle).

I'm attaching a patch with one of my approaches, hopefully it helps someone more experienced debug the issue: [circleci.patch.txt](https://github.com/Homebrew/homebrew-core/files/6634568/circleci.patch.txt).