### PR TITLE
less: fix head build

### DIFF
--- a/Formula/less.rb
+++ b/Formula/less.rb
@@ -28,7 +28,7 @@ class Less < Formula
   depends_on "pcre2"
 
   def install
-    system "make", "-f", "Makefile.aut", "dist" if build.head?
+    system "make", "-f", "Makefile.aut", "distfiles" if build.head?
     system "./configure", "--prefix=#{prefix}", "--with-regex=pcre2"
     system "make", "install"
   end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently, `brew install less --HEAD` fails with:

```
if [ ! -d ./release ]; then mkdir ./release; fi
Preparing less-590
Creating release/less-590/590.tar.gz
Signing release/less-590/less-590.tar.gz
/bin/sh: gpg: command not found
make: *** [dist] Error 127
```

The formula uses the `dist` target for the HEAD build, which includes steps for creating and `gpg` signing a tarball of the release.
https://github.com/gwsw/less/blob/fcd5d8f5d2353b8f996bb1f83641f1795ecf23ed/Makefile.aut#L128-L144

The proper target seems to be instead `distfiles`, see https://github.com/gwsw/less/issues/139#issuecomment-832064664.