### PR TITLE
less: switch pcre to pcre2

### DIFF
--- a/Formula/less.rb
+++ b/Formula/less.rb
@@ -4,6 +4,7 @@ class Less < Formula
   url "https://www.greenwoodsoftware.com/less/less-581.2.tar.gz"
   sha256 "ce34b47caf20a99740672bf560fc48d5d663c5e78e67bc254e616b9537d5d83b"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url :homepage
@@ -24,11 +25,11 @@ class Less < Formula
   end
 
   depends_on "ncurses"
-  depends_on "pcre"
+  depends_on "pcre2"
 
   def install
     system "make", "-f", "Makefile.aut", "dist" if build.head?
-    system "./configure", "--prefix=#{prefix}", "--with-regex=pcre"
+    system "./configure", "--prefix=#{prefix}", "--with-regex=pcre2"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`less` added support for PCRE2 in https://github.com/gwsw/less/commit/5393f049df0791039cc68dad983e9421e4772a02 (released in [v548][1]). It's picked by default by `configure` so seems reasonable to switch the formula to use PCRE2 instead of PCRE as well.

[1]: http://greenwoodsoftware.com/less/news.548.html