### PR TITLE
lsof: update homepage

### DIFF
--- a/Formula/lsof.rb
+++ b/Formula/lsof.rb
@@ -1,6 +1,6 @@
 class Lsof < Formula
   desc "Utility to list open files"
-  homepage "https://people.freebsd.org/~abe/"
+  homepage "https://github.com/lsof-org/lsof"
   url "https://github.com/lsof-org/lsof/archive/4.94.0.tar.gz"
   sha256 "a9865eeb581c3abaac7426962ddb112ecfd86a5ae93086eb4581ce100f8fa8f4"
   license "Zlib"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream was changed in #41840 but homepage still points to the old site. See https://github.com/lsof-org/lsof/blob/master/README.md#lsof-org-at-github:

> Many texts in the source tree still refers purdue.edu as the home of lsof development. It should be `https://github.com/lsof-org/lsof`, the new home. The updating is in progress.