### PR TITLE
kube-linter: update build

### DIFF
--- a/Formula/kube-linter.rb
+++ b/Formula/kube-linter.rb
@@ -1,9 +1,8 @@
 class KubeLinter < Formula
   desc "Static analysis tool for Kubernetes YAML files and Helm charts"
   homepage "https://github.com/stackrox/kube-linter"
-  url "https://github.com/stackrox/kube-linter.git",
-      tag:      "0.2.2",
-      revision: "2d8dff014dda8cd6a7ea10bf665ec421c9350b5c"
+  url "https://github.com/stackrox/kube-linter/archive/0.2.2.tar.gz"
+  sha256 "5600cf6f0a518073ae8bfa914fd34fd5b9d15aa6316abf21269bcd73870be7c3"
   license "Apache-2.0"
   head "https://github.com/stackrox/kube-linter.git"
 
@@ -16,8 +15,9 @@ class KubeLinter < Formula
   depends_on "go" => :build
 
   def install
-    system "make", "build"
-    bin.install ".gobin/kube-linter"
+    ENV["CGO_ENABLED"] = "0"
+    ldflags = "-s -w -X golang.stackrox.io/kube-linter/internal/version.version=#{version}"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/kube-linter"
   end
 
   test do
@@ -47,5 +47,6 @@ class KubeLinter < Formula
 
     # Lint pod.yaml for default errors
     assert_match "No lint errors found!", shell_output("#{bin}/kube-linter lint pod.yaml 2>&1").chomp
+    assert_equal version.to_s, shell_output("#{bin}/kube-linter version").chomp
   end
 end


### PR DESCRIPTION
This should fix the build on ARM.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Running `make build` builds binaries for Darwin, Linux and Windows and I could not find any method to build only for a single OS. This fails when trying to build Windows ARM64 binaries, while the Darwin build step is actually successful.

This PR updates the build to use `go build` instead with the necessary arguments. Upstream does not seem to have explicit instructions for this (they only mention `make build`), so I put this together from their various build scripts.