### PR TITLE
jumanpp: update homepage to use https

### DIFF
--- a/Formula/jumanpp.rb
+++ b/Formula/jumanpp.rb
@@ -1,6 +1,6 @@
 class Jumanpp < Formula
   desc "Japanese Morphological Analyzer based on RNNLM"
-  homepage "http://nlp.ist.i.kyoto-u.ac.jp/EN/index.php?JUMAN%2B%2B"
+  homepage "https://nlp.ist.i.kyoto-u.ac.jp/EN/index.php?JUMAN%2B%2B"
   url "https://lotus.kuee.kyoto-u.ac.jp/nl-resource/jumanpp/jumanpp-1.02.tar.xz"
   sha256 "01fa519cb1b66c9cccc9778900a4048b69b718e190a17e054453ad14c842e690"
   license "Apache-2.0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` for `jumanpp` redirects from HTTP to HTTPS. This PR updates the URL to use HTTPS, to avoid the redirection.