### PR TITLE
raptor: update urls to https

### DIFF
--- a/Formula/raptor.rb
+++ b/Formula/raptor.rb
@@ -1,7 +1,7 @@
 class Raptor < Formula
   desc "RDF parser toolkit"
-  homepage "http://librdf.org/raptor/"
-  url "http://download.librdf.org/source/raptor2-2.0.15.tar.gz"
+  homepage "https://librdf.org/raptor/"
+  url "https://download.librdf.org/source/raptor2-2.0.15.tar.gz"
   sha256 "ada7f0ba54787b33485d090d3d2680533520cd4426d2f7fb4782dd4a6a1480ed"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs in the `raptor` formula are redirecting from HTTP to HTTPS for the `librdf.org` domain. This PR updates these URLs to use HTTPS to avoid the redirection.