### PR TITLE
sysbench: make it build on ARM.

### DIFF
--- a/Formula/sysbench.rb
+++ b/Formula/sysbench.rb
@@ -4,6 +4,7 @@ class Sysbench < Formula
   url "https://github.com/akopytov/sysbench/archive/1.0.20.tar.gz"
   sha256 "e8ee79b1f399b2d167e6a90de52ccc90e52408f7ade1b9b7135727efe181347f"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/akopytov/sysbench.git"
 
   bottle do
@@ -17,6 +18,7 @@ class Sysbench < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "luajit-openresty"
   depends_on "mysql-client"
   depends_on "openssl@1.1"
 
@@ -24,14 +26,7 @@ class Sysbench < Formula
 
   def install
     system "./autogen.sh"
-
-    # Fix for luajit build breakage.
-    # Per https://luajit.org/install.html: If MACOSX_DEPLOYMENT_TARGET
-    # is not set then it's forced to 10.4, which breaks compile on Mojave.
-    # https://github.com/LuaJIT/LuaJIT/issues/518: set to 10.14 to build on Catalina.
-    ENV["MACOSX_DEPLOYMENT_TARGET"] = (DevelopmentTools.clang_build_version >= 1100) ? "10.14" : MacOS.version
-
-    system "./configure", "--prefix=#{prefix}", "--with-mysql"
+    system "./configure", "--prefix=#{prefix}", "--with-mysql", "--with-system-luajit"
     system "make", "install"
   end
 


### PR DESCRIPTION
Luajit has not released a version for macOS ARM yet. Therefore, we
use luajit-openresty fork like some other formulas and add the flag
--with-system-luajit to not use luajit vendored in sysbench.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
