### PR TITLE
various ghc-dependent formulae: remove llvm dependency

### DIFF
--- a/Formula/agda.rb
+++ b/Formula/agda.rb
@@ -29,7 +29,6 @@ class Agda < Formula
     end
   end
 
-  depends_on "llvm" => [:build, :test] if Hardware::CPU.arm?
   depends_on "cabal-install"
   depends_on "emacs"
   depends_on "ghc"
@@ -82,8 +81,6 @@ class Agda < Formula
   end
 
   test do
-    ENV.append_path "PATH", Formula["llvm"].opt_bin
-
     simpletest = testpath/"SimpleTest.agda"
     simpletest.write <<~EOS
       module SimpleTest where

--- a/Formula/hadolint.rb
+++ b/Formula/hadolint.rb
@@ -15,7 +15,6 @@ class Hadolint < Formula
 
   depends_on "ghc" => :build
   depends_on "haskell-stack" => :build
-  depends_on "llvm" => :build if Hardware::CPU.arm?
 
   uses_from_macos "xz"
 

--- a/Formula/haskell-stack.rb
+++ b/Formula/haskell-stack.rb
@@ -21,7 +21,6 @@ class HaskellStack < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
-  depends_on "llvm" => :build if Hardware::CPU.arm?
 
   uses_from_macos "zlib"
 

--- a/Formula/hledger.rb
+++ b/Formula/hledger.rb
@@ -22,7 +22,6 @@ class Hledger < Formula
 
   depends_on "ghc" => :build
   depends_on "haskell-stack" => :build
-  depends_on "llvm" => :build if Hardware::CPU.arm?
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"

--- a/Formula/pandoc-plot.rb
+++ b/Formula/pandoc-plot.rb
@@ -14,7 +14,6 @@ class PandocPlot < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
-  depends_on "llvm" => :build if Hardware::CPU.arm?
   depends_on "graphviz" => :test
   depends_on "pandoc"
 

--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -16,7 +16,6 @@ class Pandoc < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
-  depends_on "llvm" => :build if Hardware::CPU.arm?
 
   uses_from_macos "unzip" => :build # for cabal install
   uses_from_macos "zlib"

--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -15,7 +15,6 @@ class Purescript < Formula
 
   depends_on "ghc" => :build
   depends_on "haskell-stack" => :build
-  depends_on "llvm" => :build if Hardware::CPU.arm?
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"

--- a/Formula/shellcheck.rb
+++ b/Formula/shellcheck.rb
@@ -16,7 +16,6 @@ class Shellcheck < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
-  depends_on "llvm" => :build if Hardware::CPU.arm?
   depends_on "pandoc" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is no longer needed. (Cf. #79159)