### PR TITLE
dmalloc: add livecheck

### DIFF
--- a/Formula/dmalloc.rb
+++ b/Formula/dmalloc.rb
@@ -5,6 +5,11 @@ class Dmalloc < Formula
   sha256 "480e3414ab6cedca837721c756b7d64b01a84d2d0e837378d98444e2f63a7c01"
   license "ISC"
 
+  livecheck do
+    url "https://dmalloc.com/releases/"
+    regex(/href=.*?dmalloc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c8e1beff8a66f4a5d7a90fa8c5f9836ed79b9241ab642966d82550916a3af5c1"
     sha256 cellar: :any_skip_relocation, big_sur:       "300f9e7b54c15071bc36fb861cc6b75ef671052c8be6096a99314b1ca0077565"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `dmalloc`. This PR adds a `livecheck` block that checks the first-party "Releases" page, which links to the `stable` archive.