### PR TITLE
procenv 0.56 (new formula)

### DIFF
--- a/Formula/procenv.rb
+++ b/Formula/procenv.rb
@@ -1,0 +1,36 @@
+class Procenv < Formula
+  desc "Command-line utility to show process environment"
+  homepage "https://github.com/jamesodhunt/procenv"
+  url "https://github.com/jamesodhunt/procenv/archive/refs/tags/0.56.tar.gz"
+  sha256 "ffd186f479aa33194ef6070555011b356526c18bf4c2bce6c65f3ada4eebce5d"
+  license "GPL-3.0-or-later"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+
+  def install
+    system "autoreconf", "-fi"
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    output = pipe_output("#{bin}/procenv")
+
+    assert_match(/^compiler:$/, output)
+    assert_match(/^cpu:$/, output)
+
+    assert_match(/^environment:$/, output)
+    assert_match(/^\s+HOME: #{ENV['HOME']}/, output)
+    assert_match(/^\s+USER: #{ENV['USER']}/, output)
+
+    assert_match(/^memory:$/, output)
+    assert_match(/^meta:$/, output)
+    assert_match(/^process:$/, output)
+    assert_match(/^sysconf:$/, output)
+    assert_match(/^tty:$/, output)
+    assert_match(/^uname:$/, output)
+  end
+end


### PR DESCRIPTION
Add a new formula for the `procenv` CLI tool which shows everything possible about the environment it is running in:

* https://github.com/jamesodhunt/procenv

Signed-off-by: James O. D. Hunt <jamesodhunt@gmail.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I'm afraid I'm not sure what to do about this message (should I be insulted? :smile:)

```bash
$rew audit --new-formula procenv
procenv:
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 formula detected
```

This is the first proper version of `procenv` for OSX (but hopefully the first of many). The tool was first introduced in the following blogpost:

- https://ifdeflinux.blogspot.com/2012/10/procenv-and-process-environment.html

A potentially useful feature on OSX is that it outputs lots of memory details in a parseable format (`procenv --mem` for example). This would allow a trivial shell script to be written to simulate the GNU `free(1)` command.