### PR TITLE
theora: fix download

### DIFF
--- a/Formula/theora.rb
+++ b/Formula/theora.rb
@@ -1,8 +1,16 @@
 class Theora < Formula
   desc "Open video compression format"
   homepage "https://www.theora.org/"
-  url "https://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.bz2"
-  sha256 "b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc"
+  license "BSD-3-Clause"
+
+  stable do
+    url "https://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.bz2"
+    sha256 "b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc"
+
+    depends_on "curl" => :build
+
+    ENV["HOMEBREW_CURL"] = "#{Formula["curl"].opt_bin}/curl"
+  end
 
   livecheck do
     url "https://www.theora.org/downloads/"


### PR DESCRIPTION
We need to use curl with support for TLSv1.3 or newer to download from https://downloads.xiph.org, use our built in curl instead of the system curl as it is newer and supports TLSv1.3.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
