### PR TITLE
crystal: update to (patched) llvm@11

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -2,7 +2,7 @@ class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   stable do
     url "https://github.com/crystal-lang/crystal/archive/1.0.0.tar.gz"
@@ -37,9 +37,7 @@ class Crystal < Formula
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libevent"
   depends_on "libyaml"
-  # NOTE: Using llvm@11 is possible but compiling in release mode
-  #       has currently a known issue https://github.com/crystal-lang/crystal/issues/10359
-  depends_on "llvm@9"
+  depends_on "llvm@11"
   depends_on "openssl@1.1" # std uses it but it's not linked
   depends_on "pcre"
   depends_on "pkg-config" # @[Link] will use pkg-config if available
@@ -62,7 +60,7 @@ class Crystal < Formula
     ENV.append_path "PATH", "boot/bin"
     ENV.append_path "CRYSTAL_LIBRARY_PATH", Formula["bdw-gc"].opt_lib
     ENV.append_path "CRYSTAL_LIBRARY_PATH", ENV["HOMEBREW_LIBRARY_PATHS"]
-    ENV.append_path "LLVM_CONFIG", Formula["llvm@9"].opt_bin/"llvm-config"
+    ENV.append_path "LLVM_CONFIG", Formula["llvm@11"].opt_bin/"llvm-config"
 
     # Build crystal
     crystal_build_opts = []

--- a/Formula/llvm@11.rb
+++ b/Formula/llvm@11.rb
@@ -5,7 +5,7 @@ class LlvmAT11 < Formula
   sha256 "74d2529159fd118c3eac6f90107b5611bccc6f647fdea104024183e8d5e25831"
   # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
   license "Apache-2.0" => { with: "LLVM-exception" }
-  revision 1
+  revision 2
 
   livecheck do
     url :homepage
@@ -61,6 +61,11 @@ class LlvmAT11 < Formula
   patch do
     url "https://github.com/llvm/llvm-project/commit/c4d7536136b331bada079b2afbb2bd09ad8296bf.patch?full_index=1"
     sha256 "2b894cbaf990510969bf149697882c86a068a1d704e749afa5d7b71b6ee2eb9f"
+  end
+
+  patch do
+    url "https://github.com/llvm/llvm-project/commit/c997867dc084a1bcf631816f964b3ff49a297ba3.patch?full_index=1"
+    sha256 "a215925cb872406fe770369ef3adfef1170c6ffbd65f1de44358a240307faab1"
   end
 
   # Upstream ARM patch for OpenMP runtime, remove in next version


### PR DESCRIPTION
Finally, the reason why crystal was not compatible with llvm@11 was found. The underlying reason can be read at https://llvm.discourse.group/t/bug-or-feature-freeze-instruction/3639

This PR:

- includes the upstream patch in llvm@11
- bumps crystal to use llvm@11
- ~~includes the upstream patch in llvm[@12]~~

~~The last step is not strictly necessary but it will help to update later crystal to llvm@12. This patch [might be included in llvm 12.0.1](https://bugs.llvm.org/show_bug.cgi?id=50695).~~

Having crystal with llvm@11 will bring back some debug stories that were present in llvm@10, that were lost since that is not available in brew and will allow community to move forward with M1 support that requires llvm@11.

cc: @maxfierke / @carlocab you might be interested in this update.