### PR TITLE
wxmaxima: revision bump

### DIFF
--- a/Formula/wxmaxima.rb
+++ b/Formula/wxmaxima.rb
@@ -4,6 +4,7 @@ class Wxmaxima < Formula
   url "https://github.com/wxMaxima-developers/wxmaxima/archive/Version-21.05.2.tar.gz"
   sha256 "4d2d486a24090ace2f64ceccb026210e2e6299a32cb348d43134ef80440bcf01"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/wxMaxima-developers/wxmaxima.git", branch: "main"
 
   bottle do


### PR DESCRIPTION
This rebuilds `wxmaxima` with the updates to `wxmac` in https://github.com/Homebrew/homebrew-core/pull/79278.