### PR TITLE
Envoy: Add production optimized option for build.

### DIFF
--- a/Formula/envoy.rb
+++ b/Formula/envoy.rb
@@ -22,6 +22,8 @@ class Envoy < Formula
 
   def install
     args = %w[
+      -c
+      opt
       --curses=no
       --show_task_finish
       --verbose_failures


### PR DESCRIPTION
The current Envoy binary has around `611.8 M` because the formula is configured to build Envoy with debug info (which is by default without specifying).

So this PR adds `-c opt` flag to Bazel build args in order to produce the production-ready binary. See https://github.com/envoyproxy/envoy/blob/main/bazel/README.md#additional-envoy-build-and-test-options for detail.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

