### PR TITLE
vagrant-completion conflicts with zsh-completions

### DIFF
--- a/Formula/vagrant-completion.rb
+++ b/Formula/vagrant-completion.rb
@@ -4,11 +4,14 @@ class VagrantCompletion < Formula
   url "https://github.com/hashicorp/vagrant/archive/v2.2.16.tar.gz"
   sha256 "ab3c60bb12b2da916fd073192849f2b5d3f224f95febf3538212247c4cde28d6"
   license "MIT"
+  revision 1
   head "https://github.com/hashicorp/vagrant.git"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "325bfccadee57150fad636b0ed58536dc47659556fbf34c9ca8ac88dde686e7d"
   end
+
+  conflicts_with "zsh-completions", because: "the zsh-completions formula includes zsh completion"
 
   def install
     bash_completion.install "contrib/bash/completion.sh" => "vagrant"

--- a/Formula/vagrant-completion.rb
+++ b/Formula/vagrant-completion.rb
@@ -4,7 +4,6 @@ class VagrantCompletion < Formula
   url "https://github.com/hashicorp/vagrant/archive/v2.2.16.tar.gz"
   sha256 "ab3c60bb12b2da916fd073192849f2b5d3f224f95febf3538212247c4cde28d6"
   license "MIT"
-  revision 1
   head "https://github.com/hashicorp/vagrant.git"
 
   bottle do


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
