### PR TITLE
zsh-completions: conflicts with tmuxinator-completion, vagrant-completion

### DIFF
--- a/Formula/zsh-completions.rb
+++ b/Formula/zsh-completions.rb
@@ -10,6 +10,10 @@ class ZshCompletions < Formula
     sha256 cellar: :any_skip_relocation, all: "2579cab8a4d96ce2a7d179bf36fb2898d4f3611823c6392f5eac2014ff4d7d1f"
   end
 
+  conflicts_with "vagrant-completion", because: "the vagrant-completion formula includes zsh completion for vagrant"
+  conflicts_with "tmuxinator-completion",
+    because: "the tmuxinator-completion formula includes zsh completion for tmuxinator"
+
   def install
     inreplace "src/_ghc", "/usr/local", HOMEBREW_PREFIX
     zsh_completion.install Dir["src/*"]


### PR DESCRIPTION
Symmetric change according to #79247 and #79298.

Co-authored-by: Alexander Bayandin <a.bayandin@gmail.com>
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
