### PR TITLE
haskell-language-server: generate binary name with patch version

### DIFF
--- a/Formula/haskell-language-server.rb
+++ b/Formula/haskell-language-server.rb
@@ -43,8 +43,10 @@ class HaskellLanguageServer < Formula
     ghcs.each do |ghc|
       system "cabal", "v2-install", "-w", ghc.bin/"ghc", *std_cabal_v2_args
 
-      bin.install bin/"haskell-language-server" => "haskell-language-server-#{ghc.version.major_minor}"
-      rm bin/"haskell-language-server-wrapper" unless ghc == newest_ghc
+      hls = "haskell-language-server"
+      bin.install bin/hls => "#{hls}-#{ghc.version}"
+      bin.install_symlink "#{hls}-#{ghc.version}" => "#{hls}-#{ghc.version.major_minor}"
+      rm bin/"#{hls}-wrapper" unless ghc == newest_ghc
     end
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
Tool versions found on the $PATH
cabal:		3.4.0.0
stack:		Not found
ghc:		8.10.5


Consulting the cradle to get project GHC version...
Project GHC version: 8.10.5
haskell-language-server exe candidates: ["haskell-language-server-8.10.5","haskell-language-server"]
Cannot find any haskell-language-server exe, looked for: haskell-language-server-8.10.5, haskell-language-server
```

`haskell-language-server-wrapper` expect binary's name with patch part of version


