### PR TITLE
klavaro: depend on adwaita-icon-theme

### DIFF
--- a/Formula/klavaro.rb
+++ b/Formula/klavaro.rb
@@ -4,6 +4,7 @@ class Klavaro < Formula
   url "https://downloads.sourceforge.net/project/klavaro/klavaro-3.11.tar.bz2"
   sha256 "fc64d3bf9548a5d55af1ba72912024107883a918b95ae60cda95706116567de6"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -20,6 +21,7 @@ class Klavaro < Formula
 
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
+  depends_on "adwaita-icon-theme"
   depends_on "gtk+3"
 
   def install


### PR DESCRIPTION
When Klavaro is installed on Homebrew there are may warnings seen in the console such as:

(klavaro:30266): Gtk-WARNING **: 17:29:19.474: Error loading theme icon 'dialog-information' for stock: Icon 'dialog-information' not present in theme Adwaita
(klavaro:30266): Gtk-WARNING **: 17:31:14.465: Error loading theme icon 'edit-delete' for stock: Icon 'edit-delete' not present in theme Adwaita
(klavaro:30266): Gtk-WARNING **: 17:31:14.465: Error loading theme icon 'window-close' for stock: Icon 'window-close' not present in theme Adwaita
(klavaro:30266): Gtk-WARNING **: 17:31:14.594: Error loading theme icon 'edit-clear' for stock: 

Adding the missing adwaita theme (default theme for GKT3) causes the warnings to cease

