### PR TITLE
ledger: update patch for Boost 1.76

### DIFF
--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -4,7 +4,7 @@ class Ledger < Formula
   url "https://github.com/ledger/ledger/archive/v3.2.1.tar.gz"
   sha256 "92bf09bc385b171987f456fe3ee9fa998ed5e40b97b3acdd562b663aa364384a"
   license "BSD-3-Clause"
-  revision 5
+  revision 6
   head "https://github.com/ledger/ledger.git"
 
   livecheck do
@@ -29,7 +29,11 @@ class Ledger < Formula
 
   # Compatibility with Boost 1.76
   # https://github.com/ledger/ledger/issues/2030
-  patch :DATA
+  # https://github.com/ledger/ledger/pull/2036
+  patch do
+    url "https://github.com/ledger/ledger/commit/e60717ccd78077fe4635315cb2657d1a7f539fca.patch?full_index=1"
+    sha256 "edba1dd7bde707f510450db3197922a77102d5361ed7a5283eb546fbf2221495"
+  end
 
   def install
     ENV.cxx11
@@ -67,56 +71,3 @@ class Ledger < Formula
     assert_equal 0, $CHILD_STATUS.exitstatus
   end
 end
-
-__END__
-diff --git a/src/expr.cc b/src/expr.cc
-index c8945d3..136fc97 100644
---- a/src/expr.cc
-+++ b/src/expr.cc
-@@ -34,6 +34,7 @@
- #include "expr.h"
- #include "parser.h"
- #include "scope.h"
-+#include <memory>
-
- namespace ledger {
-
-@@ -278,7 +279,7 @@ value_t expr_value(expr_t::ptr_op_t op)
- value_t source_command(call_scope_t& args)
- {
-   std::istream * in = NULL;
--  scoped_ptr<ifstream> stream;
-+  std::unique_ptr<ifstream> stream;
-   string pathname;
-
-   if (args.has(0)) {
-diff --git a/src/format.h b/src/format.h
-index 15431cf..c12f1c9 100644
---- a/src/format.h
-+++ b/src/format.h
-@@ -44,6 +44,7 @@
-
- #include "expr.h"
- #include "unistring.h"
-+#include <memory>
-
- namespace ledger {
-
-@@ -65,7 +66,7 @@ class format_t : public expr_base_t<string>, public noncopyable
-     std::size_t                  min_width;
-     std::size_t                  max_width;
-     variant<string, expr_t>      data;
--    scoped_ptr<struct element_t> next;
-+    std::unique_ptr<struct element_t> next;
-
-     element_t() throw()
-       : supports_flags<>(), type(STRING), min_width(0), max_width(0) {
-@@ -103,7 +104,7 @@ class format_t : public expr_base_t<string>, public noncopyable
-     void dump(std::ostream& out) const;
-   };
-
--  scoped_ptr<element_t> elements;
-+  std::unique_ptr<element_t> elements;
-
- public:
-   static enum elision_style_t {


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The newer patch has a much smaller scope than the original one. This is
also the patched used by Gentoo.

See ledger/ledger#2036.