### PR TITLE
bibclean: add livecheck block

### DIFF
--- a/Formula/bibclean.rb
+++ b/Formula/bibclean.rb
@@ -5,6 +5,11 @@ class Bibclean < Formula
   sha256 "4fa68bfd97611b0bb27b44a82df0984b300267583a313669c1217983b859b258"
   license "GPL-2.0"
 
+  livecheck do
+    url "https://ftp.math.utah.edu/pub/bibclean/"
+    regex(/href=.*?bibclean[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "1ca564c71ae986472ba45f55cee1dc9c2070513a908b5f3931d4cbd82ed1cd45"
     sha256 big_sur:       "4b273f7061767e8e2a4776863f2da581ab726212ee1ae9b4d512a6bc228a6d7a"

--- a/Formula/bibclean.rb
+++ b/Formula/bibclean.rb
@@ -1,7 +1,7 @@
 class Bibclean < Formula
   desc "BibTeX bibliography file pretty printer and syntax checker"
   homepage "https://www.math.utah.edu/~beebe/software/bibclean/bibclean-03.html#HDR.3"
-  url "http://ftp.math.utah.edu/pub/bibclean/bibclean-3.04.tar.xz"
+  url "https://ftp.math.utah.edu/pub/bibclean/bibclean-3.04.tar.xz"
   sha256 "4fa68bfd97611b0bb27b44a82df0984b300267583a313669c1217983b859b258"
   license "GPL-2.0"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

@samford, could you please confirm that this change is correct?

@Bo98, since you were the last person to edit the `url`, why can't we use `https://`?

After the change:
```
$ brew livecheck bibclean
bibclean : 3.04 ==> 3.04
```

Before the change:
```
$ brew livecheck bibclean
Error: bibclean: Unable to get versions
```