### PR TITLE
gotop: apply patch for ARM

### DIFF
--- a/Formula/gotop.rb
+++ b/Formula/gotop.rb
@@ -13,6 +13,12 @@ class Gotop < Formula
 
   depends_on "go" => :build
 
+  # Apply https://github.com/xxxserxxx/gotop/pull/183 to build on M1
+  patch do
+    url "https://github.com/xxxserxxx/gotop/commit/5efc6ec054a65c3ec63ed5eb67631ca3becdeb50.patch?full_index=1"
+    sha256 "1dd66fc5e25d49396c2be000f35f2b7fe57083a63e093f54d3565a6d43467771"
+  end
+
   def install
     time = `date +%Y%m%dT%H%M%S`.chomp
     system "go", "build", *std_go_args, "-ldflags",


### PR DESCRIPTION
Apply https://github.com/xxxserxxx/gotop/pull/183 to allow gotop build on Apple Silicon

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
```
% brew reinstall gotop --build-from-source
==> Downloading https://ghcr.io/v2/homebrew/core/go/manifests/1.16.5
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/go/blobs/sha256:dde21eedfa67da23db70cf977ae82c0cadd5acf2a326cb91853ff54d0cf5886f
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:dde21eedfa67da23db70cf977ae82c0cadd5acf2a326cb91853ff54d0cf5886f?se=2021-06-14T16%3A55%3A00Z&sig=aIVp9g286ZJQR1%2BI6GtYLmTBH96B4NBS5IoLsCCCsG4%3D
######################################################################## 100.0%
==> Downloading https://github.com/xxxserxxx/gotop/commit/5efc6ec054a65c3ec63ed5eb67631ca3becdeb50.patch?full_index=1
Already downloaded: Library/Caches/Homebrew/downloads/2e0cd961672db69cf6972efaa4b5a83c57e3db8918a959a554bb8ea41bd3fd24--5efc6ec054a65c3ec63ed5eb67631ca3becdeb50.patch
==> Downloading https://github.com/xxxserxxx/gotop/archive/v4.1.1.tar.gz
Already downloaded: Library/Caches/Homebrew/downloads/7c53cb944c8954dec37437d9451e35e83cdbeebd84054c52c1c3d9ccc1f9bb2c--gotop-4.1.1.tar.gz
==> Reinstalling gotop 
==> Installing dependencies for gotop: go
==> Installing gotop dependency: go
==> Pouring go--1.16.5.arm64_big_sur.bottle.tar.gz
🍺  /opt/homebrew/Cellar/go/1.16.5: 9,957 files, 505.0MB
==> Installing gotop
==> Patching
==> Applying 5efc6ec054a65c3ec63ed5eb67631ca3becdeb50.patch
patching file logging/logging_arm64.go
patching file logging/logging_other.go
==> go build -ldflags -X main.Version=4.1.1 -X main.BuildDate=20210614T094816 ./cmd/gotop
🍺  /opt/homebrew/Cellar/gotop/4.1.1: 6 files, 8MB, built in 11 seconds
% brew test gotop                         
==> Testing gotop
==> /opt/homebrew/Cellar/gotop/4.1.1/bin/gotop --version
==> /opt/homebrew/Cellar/gotop/4.1.1/bin/gotop --write-config
% brew audit --strict gotop
% 
```