### PR TITLE
poco: set rpath for m1 support

### DIFF
--- a/Formula/poco.rb
+++ b/Formula/poco.rb
@@ -25,7 +25,8 @@ class Poco < Formula
     mkdir "build" do
       system "cmake", "..", *std_cmake_args,
                             "-DENABLE_DATA_MYSQL=OFF",
-                            "-DENABLE_DATA_ODBC=OFF"
+                            "-DENABLE_DATA_ODBC=OFF",
+                            "-DCMAKE_INSTALL_RPATH=#{rpath}"
       system "make", "install"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
```
 % brew reinstall poco --build-from-source
==> Downloading https://pocoproject.org/releases/poco-1.10.1/poco-1.10.1-all.tar.gz
Already downloaded: Library/Caches/Homebrew/downloads/3f8d009f5c8967b591068a112216d12451697594c6bd78520d7fad95a25fe1dc--poco-1.10.1-all.tar.gz
==> Reinstalling poco 
==> cmake .. -DENABLE_DATA_MYSQL=OFF -DENABLE_DATA_ODBC=OFF -DCMAKE_INSTALL_RPATH=@loader_path/../lib
==> make install
🍺  /opt/homebrew/Cellar/poco/1.10.1: 886 files, 14.3MB, built in 50 seconds
 % brew test poco                         
==> Testing poco
==> /opt/homebrew/Cellar/poco/1.10.1/bin/cpspc -h
 % brew audit --strict poco
 %

```