### PR TITLE
opencc: add support for m1 via rpath. build out of tree

### DIFF
--- a/Formula/opencc.rb
+++ b/Formula/opencc.rb
@@ -15,9 +15,11 @@ class Opencc < Formula
 
   def install
     ENV.cxx11
-    system "cmake", ".", "-DBUILD_DOCUMENTATION:BOOL=OFF", *std_cmake_args
-    system "make"
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", "-DBUILD_DOCUMENTATION:BOOL=OFF", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
+      system "make"
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```

% brew reinstall opencc --build-from-source
==> Downloading https://github.com/BYVoid/OpenCC/archive/ver.1.1.2.tar.gz
Already downloaded: Library/Caches/Homebrew/downloads/4289155b351e74c33bd12449c69e5286240ef0fa4fddca285dd21a199f5726eb--OpenCC-ver.1.1.2.tar.gz
==> Reinstalling opencc 
==> cmake .. -DBUILD_DOCUMENTATION:BOOL=OFF -DCMAKE_INSTALL_RPATH=@loader_path/../lib
==> make
==> make install
🍺  /opt/homebrew/Cellar/opencc/1.1.2: 70 files, 2.0MB, built in 7 seconds
 % brew test opencc                         
==> Testing opencc
==> echo 中国鼠标软件打印机 | /opt/homebrew/Cellar/opencc/1.1.2/bin/opencc
 % brew audit --strict opencc 
 %  

```