### PR TITLE
chromaprint: support Apple Silicon

### DIFF
--- a/Formula/chromaprint.rb
+++ b/Formula/chromaprint.rb
@@ -16,8 +16,15 @@ class Chromaprint < Formula
   depends_on "ffmpeg"
 
   def install
-    system "cmake", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_TOOLS=ON", ".", *std_cmake_args
-    system "make", "install"
+    args = %W[
+      -DBUILD_TOOLS=ON
+      -DCMAKE_INSTALL_RPATH=#{rpath}
+    ]
+
+    mkdir "build" do
+      system "cmake", "..", *args, *std_cmake_args
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
 % brew reinstall chromaprint --build-from-source
==> Downloading https://github.com/acoustid/chromaprint/releases/download/v1.5.0/chromaprint-1.5.0.tar.gz
Already downloaded: /Users/allenreese/Library/Caches/Homebrew/downloads/3ef157606d26fafffc43525d0216e6ca92f4bcbbc11020a1967121155e3cb8ba--chromaprint-1.5.0.tar.gz
==> Reinstalling chromaprint 
==> cmake .. -DBUILD_TOOLS=ON -DCMAKE_INSTALL_RPATH=@loader_path/../lib
==> make install
🍺  /opt/homebrew/Cellar/chromaprint/1.5.0_6: 11 files, 236.7KB, built in 6 seconds
 % brew test chromaprint                         
==> Testing chromaprint
==> /opt/homebrew/Cellar/chromaprint/1.5.0_6/bin/fpcalc -json -format s16le -rate 44100 -channels 2 -length 10 /dev/zero
 % brew audit --strict chromaprint

chromaprint:
  * Formula chromaprint contains deprecated SPDX licenses: ["LGPL-2.1"].
    You may need to add `-only` or `-or-later` for GNU licenses (e.g. `GPL`, `LGPL`, `AGPL`, `GFDL`).
    For a list of valid licenses check: https://spdx.org/licenses/
Error: 1 problem in 1 formula detected
 % 


```