### PR TITLE
source-to-image: m1-support set arch to arm64 or amd64 depending on H…

### DIFF
--- a/Formula/source-to-image.rb
+++ b/Formula/source-to-image.rb
@@ -22,7 +22,8 @@ class SourceToImage < Formula
     on_linux do
       os = "linux"
     end
-    bin.install "_output/local/bin/#{os}/amd64/s2i"
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    bin.install "_output/local/bin/#{os}/#{arch}/s2i"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
 % brew reinstall source-to-image --build-from-source
==> Cloning https://github.com/openshift/source-to-image.git
Updating /Users/allenreese/Library/Caches/Homebrew/source-to-image--git
==> Checking out tag v1.3.1
HEAD is now at a5a77147 Merge pull request #1055 from adambkaplan/release-vol-mount
HEAD is now at a5a77147 Merge pull request #1055 from adambkaplan/release-vol-mount
==> Reinstalling source-to-image 
==> hack/build-go.sh
🍺  /opt/homebrew/Cellar/source-to-image/1.3.1: 6 files, 18.9MB, built in 10 seconds
 % brew test source-to-image                    
==> Testing source-to-image
==> /opt/homebrew/Cellar/source-to-image/1.3.1/bin/s2i create testimage /private/tmp/source-to-image-test-20210614-67009-5kzpi0
 % brew audit --strict source-to-image
 % 


```