### PR TITLE
glab: build with cgo in order to use macOS's native dns resolver

### DIFF
--- a/Formula/glab.rb
+++ b/Formula/glab.rb
@@ -4,6 +4,7 @@ class Glab < Formula
   url "https://github.com/profclems/glab/archive/v1.18.1.tar.gz"
   sha256 "ce10c93268eb58fa6d277ebd4ed6de254e4365a1a332122f597e295cc11496c3"
   license "MIT"
+  revision 1
   head "https://github.com/profclems/glab.git", branch: "trunk"
 
   bottle do
@@ -16,6 +17,8 @@ class Glab < Formula
   depends_on "go" => :build
 
   def install
+    on_macos { ENV["CGO_ENABLED"] = "1" }
+
     system "make", "GLAB_VERSION=#{version}"
     bin.install "bin/glab"
     (bash_completion/"glab").write Utils.safe_popen_read(bin/"glab", "completion", "--shell=bash")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It is required to build binaries for macOS using `CGO_ENABLED=1` in order to use macOS's native DNS/hostname resolving. See https://github.com/golang/go/issues/12524. This is of special importance for corporate networks with GitLab instances running in a VPN.

Same issue as, e. g., over here: https://github.com/Homebrew/homebrew-core/blob/9085445f116056632a04a08f31f829d8b44bdbc0/Formula/terraform.rb 