### PR TITLE
dartsim: Add m1/Apple Silicon support

### DIFF
--- a/Formula/dartsim.rb
+++ b/Formula/dartsim.rb
@@ -38,8 +38,10 @@ class Dartsim < Formula
       args << "-DGLUT_glut_LIBRARY=#{glut_lib}"
     end
 
-    system "cmake", ".", *args
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", *args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
+      system "make", "install"
+    end
 
     # Clean up the build file garbage that has been installed.
     rm_r Dir["#{share}/doc/dart/**/CMakeFiles/"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
% brew reinstall dartsim --build-from-source
==> Downloading https://github.com/dartsim/dart/archive/v6.10.1.tar.gz
Already downloaded: Library/Caches/Homebrew/downloads/27d4de7ba6a046b94844ab6172d26767d59d1cf6b1f27f698cdb40fbcce1b7fc--dart-6.10.1.tar.gz
==> Reinstalling dartsim 
==> cmake .. -DGLUT_glut_LIBRARY=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/GLUT.framework -DCMAKE_INSTALL_RPATH=@loader_path/../lib
==> make install
🍺  /opt/homebrew/Cellar/dartsim/6.10.1_2: 1,031 files, 46.7MB, built in 1 minute 28 seconds
  % brew test dartsim                         
==> Testing dartsim
==> /usr/bin/clang++ test.cpp -I/opt/homebrew/opt/eigen/include/eigen3 -I/opt/homebrew/Cellar/dartsim/6.10.1_2/include -L/opt/homebrew/Cellar/dartsim/6.10.1_2/lib -ldart -L/opt/homebrew/opt/assimp/lib -lassimp -L/opt/homebrew/opt/
==> ./test
  % brew audit --strict dartsim
  % 


```