### PR TITLE
tcpreplay: m1-support  Pass --with-macosx-sdk=MacOS.latest_sdk_version to find the MacOSX 11.3 SDK on Apple Silicon

### DIFF
--- a/Formula/tcpreplay.rb
+++ b/Formula/tcpreplay.rb
@@ -11,14 +11,25 @@ class Tcpreplay < Formula
     sha256 cellar: :any, mojave:   "f55a4af6cbc64fcf75fd5967ae13f9babd24472c4f1ce659beeaa8754a317fda"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "libdnet"
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--enable-dynamic-link"
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --enable-dynamic-link
+      --with-macosx-sdk=#{MacOS.version}
+    ]
+
+    system "./autogen.sh"
+    system "./configure", *args
+
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  % brew reinstall tcpreplay --build-from-source
==> Downloading https://github.com/appneta/tcpreplay/releases/download/v4.3.4/tcpreplay-4.3.4.tar.gz
==> Downloading from https://github-releases.githubusercontent.com/14542959/c36ca300-aaa3-11eb-88f7-0ac424a43361?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20210614%2Fus-east-1%2Fs3%2Faws4_request&X-A
######################################################################## 100.0%
==> Reinstalling tcpreplay 
==> ./configure --prefix=/opt/homebrew/Cellar/tcpreplay/4.3.4 --enable-dynamic-link --with-macosx-sdk=11.1
==> make install
🍺  /opt/homebrew/Cellar/tcpreplay/4.3.4: 14 files, 1.8MB, built in 19 seconds
Removing: Library/Caches/Homebrew/tcpreplay--4.3.3.tar.gz... (3.6MB)
  % brew test tcpreplay                    
==> Testing tcpreplay
==> /opt/homebrew/Cellar/tcpreplay/4.3.4/bin/tcpreplay --version
  % brew audit --strict tcpreplay
  % 

```