### PR TITLE
irrlicht: m1-support check the correct cpu arch in the test

### DIFF
--- a/Formula/irrlicht.rb
+++ b/Formula/irrlicht.rb
@@ -73,7 +73,7 @@ class Irrlicht < Formula
 
   test do
     on_macos do
-      assert_match "x86_64", shell_output("lipo -info #{lib}/libIrrlicht.a")
+      assert_match Hardware::CPU.arch.to_s, shell_output("lipo -info #{lib}/libIrrlicht.a")
     end
     on_linux do
       cp_r Dir["#{pkgshare}/examples/01.HelloWorld/*"], testpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  % brew reinstall irrlicht --build-from-source
==> Downloading https://downloads.sourceforge.net/project/irrlicht/Irrlicht%20SDK/1.8/1.8.4/irrlicht-1.8.4.zip
Already downloaded: Library/Caches/Homebrew/downloads/818339be7248823d503f78d68414692daa70377607966825c53c0e118f622404--irrlicht-1.8.4.zip
==> Reinstalling irrlicht 
==> xcodebuild -project source/Irrlicht/MacOSX/MacOSX.xcodeproj -configuration Release -target libIrrlicht.a SYMROOT=build
🍺  /opt/homebrew/Cellar/irrlicht/1.8.4: 187 files, 10.6MB, built in 20 seconds
  % brew test irrlicht                         
==> Testing irrlicht
==> lipo -info /opt/homebrew/Cellar/irrlicht/1.8.4/lib/libIrrlicht.a
  % brew audit --strict irrlicht
  % 
```