### PR TITLE
ffmpegthumbnailer: add support for m1 via rpath. build out of tree

### DIFF
--- a/Formula/ffmpegthumbnailer.rb
+++ b/Formula/ffmpegthumbnailer.rb
@@ -23,10 +23,13 @@ class Ffmpegthumbnailer < Formula
     args = std_cmake_args
     args << "-DENABLE_GIO=ON"
     args << "-DENABLE_THUMBNAILER=ON"
+    args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
 
-    system "cmake", *args
-    system "make"
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make"
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  % brew reinstall ffmpegthumbnailer --build-from-source
==> Downloading https://github.com/dirkvdb/ffmpegthumbnailer/archive/2.2.2.tar.gz
Already downloaded: Library/Caches/Homebrew/downloads/be7cb91dc9ca232dbb2aa1d527aaef92a650dfff9a16cf8fa974cfa9cd528034--ffmpegthumbnailer-2.2.2.tar.gz
==> Reinstalling ffmpegthumbnailer 
==> cmake .. -DENABLE_GIO=ON -DENABLE_THUMBNAILER=ON -DCMAKE_INSTALL_RPATH=@loader_path/../lib
==> make
==> make install
🍺  /opt/homebrew/Cellar/ffmpegthumbnailer/2.2.2_5: 22 files, 377.3KB, built in 9 seconds
  % brew test ffmpegthumbnailer               
==> Testing ffmpegthumbnailer
==> /opt/homebrew/opt/ffmpeg/bin/ffmpeg -loop 1 -i /opt/homebrew/Library/Homebrew/test/support/fixtures/test.png -c:v libx264 -t 30 -pix_fmt yuv420p v.mp4
==> /opt/homebrew/Cellar/ffmpegthumbnailer/2.2.2_5/bin/ffmpegthumbnailer -i v.mp4 -o out.jpg
  % brew audit --strict ffmpegthumbnailer 
ffmpegthumbnailer:
  * Formula ffmpegthumbnailer contains deprecated SPDX licenses: ["GPL-2.0"].
    You may need to add `-only` or `-or-later` for GNU licenses (e.g. `GPL`, `LGPL`, `AGPL`, `GFDL`).
    For a list of valid licenses check: https://spdx.org/licenses/
Error: 1 problem in 1 formula detected
  % 
```