### PR TITLE
editorconfig: m1-support add rpath and build out of tree

### DIFF
--- a/Formula/editorconfig.rb
+++ b/Formula/editorconfig.rb
@@ -17,8 +17,10 @@ class Editorconfig < Formula
   depends_on "pcre2"
 
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  % brew reinstall editorconfig --build-from-source                                    
==> Downloading https://github.com/editorconfig/editorconfig-core-c/archive/v0.12.4.tar.gz
Already downloaded: Library/Caches/Homebrew/downloads/baf0cc1867a4485cbde09cd0d393415c2802a4c52fe37a4ece0311131f9b9239--editorconfig-core-c-0.12.4.tar.gz
==> Reinstalling editorconfig 
==> cmake .. -DCMAKE_INSTALL_RPATH=@loader_path/../lib
==> make install
🍺  /opt/homebrew/Cellar/editorconfig/0.12.4: 22 files, 193.6KB, built in 4 seconds
  % brew test editorconfig
Fetching gem metadata from https://rubygems.org/.........
Using concurrent-ruby 1.1.9
Using minitest 5.14.4
Using zeitwerk 2.4.2
Using public_suffix 4.0.6
Using ast 2.4.2
Using bindata 2.4.8
Using msgpack 1.4.2
Using bundler 1.17.3
Using byebug 11.1.3
Using connection_pool 2.2.5
Using diff-lcs 1.4.4
Using docile 1.3.5
Using unf_ext 0.0.7.7
Using hpricot 0.8.6
Using mime-types-data 3.2021.0225
Using net-http-digest_auth 1.4.1
Using mini_portile2 2.5.3
Using racc 1.5.2
Using rubyntlm 0.6.3
Using webrick 1.7.0
Using webrobots 0.1.2
Using mustache 1.1.1
Using parallel 1.20.1
Using plist 3.6.0
Using rack 2.2.3
Using rainbow 3.0.0
Using rdiscount 2.2.0.2
Using regexp_parser 2.1.1
Using rexml 3.2.5
Using rspec-support 3.10.2
Using ruby-progressbar 1.11.0
Using unicode-display_width 2.0.0
Using ruby-macho 2.5.1
Using simplecov-html 0.12.3
Using simplecov_json_formatter 0.1.2
Using sorbet-runtime-stub 0.2.0
Using warning 1.2.0
Using i18n 1.8.10
Using tzinfo 2.0.4
Using addressable 2.7.0
Using elftools 1.1.3
Using mime-types 3.3.1
Using bootsnap 1.7.5
Using nokogiri 1.11.7 (x86_64-darwin)
Using parallel_tests 3.7.0
Using parser 3.0.1.1
Using ronn 0.7.3
Using rspec-core 3.10.1
Using rspec-expectations 3.10.1
Using rspec-mocks 3.10.2
Using simplecov 0.21.2
Using activesupport 6.1.3.2
Using patchelf 1.3.0
Using unf 0.1.4
Using net-http-persistent 4.0.1
Using domain_name 0.5.20190701
Using rspec 3.10.0
Using rspec-github 2.3.1
Using rspec-its 1.3.0
Using rspec-retry 0.6.2
Using rubocop-ast 1.7.0
Using simplecov-cobertura 1.4.2
Using http-cookie 1.0.3
Using rspec-wait 0.0.9
Fetching rubocop 1.16.1
Using mechanize 2.8.1
Installing rubocop 1.16.1
Using rubocop-performance 1.11.3
Using rubocop-sorbet 0.6.2
Fetching rubocop-rspec 2.4.0
Using rubocop-rails 2.10.1
Installing rubocop-rspec 2.4.0
Bundle complete! 31 Gemfile dependencies, 70 gems now installed.
Bundled gems are installed into `../../../../Homebrew/vendor/bundle`
Removing tapioca (0.4.23)
Removing sorbet-runtime (0.5.6274)
Removing coderay (1.1.3)
Removing highline (2.0.3)
Removing parlour (6.0.0)
Removing thor (1.1.0)
Removing sorbet-static-0.5.6274-universal-darwin (20)
Removing pry (0.14.1)
Removing spoom (1.0.9)
Removing method_source (1.0.0)
Removing commander (4.6.0)
Removing colorize (0.8.1)
Removing rspec-sorbet (1.8.0)
Removing sorbet (0.5.6274)
Removing rubocop-rspec (2.3.0)
Removing rubocop (1.16.0)
==> Testing editorconfig
==> /opt/homebrew/Cellar/editorconfig/0.12.4/bin/editorconfig --version
  % brew audit --strict editorconfig
  % 
```