### PR TITLE
dolt: align homepage with stable URL

### DIFF
--- a/Formula/dolt.rb
+++ b/Formula/dolt.rb
@@ -1,6 +1,6 @@
 class Dolt < Formula
   desc "Git for Data"
-  homepage "https://github.com/liquidata-inc/dolt"
+  homepage "https://github.com/dolthub/dolt"
   url "https://github.com/dolthub/dolt/archive/v0.26.8.tar.gz"
   sha256 "d408ac7e41bf3b68a0a7732b1053bad8c4b93f658c500cfc2f726e23d7861ad6"
   license "Apache-2.0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR aligns `dolt`'s homepage with the repository used in the stable URL. https://github.com/liquidata-inc/dolt redirects to https://github.com/dolthub/dolt.