### PR TITLE
x264: update livecheck `url`

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -15,7 +15,7 @@ class X264 < Formula
   # the latest commits in the `stable` Git branch:
   # https://code.videolan.org/videolan/x264/-/commits/stable
   livecheck do
-    url "https://artifacts.videolan.org/x264/release-macos/"
+    url "https://artifacts.videolan.org/x264/release-macos-arm64/"
     regex(%r{href=.*?x264[._-](r\d+)[._-]([\da-z]+)/?["' >]}i)
     strategy :page_match do |page, regex|
       # Match the version and abbreviated commit hash in filenames


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `livecheck` block's `url` for `x264`. It was noted in #79331 that the `release-macos` subfolder has not been updated with the new stable releases, but the `release-macos-x86_64` and `release-macos-arm64` subfolders contain new stable release(s).

I've updated the `url` to check the `release-macos-arm64` subfolder, since that may be supported further than the `x86_64` counterpart. It doesn't seem like the version numbers differ, so checking either one would've been fine.

```
➜ brew livecheck -d x264
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/x264.rb

Formula:          x264
Livecheckable?:   Yes

URL:              https://artifacts.videolan.org/x264/release-macos-arm64/
Strategy:         PageMatch
Regex:            /href=.*?x264[._-](r\d+)[._-]([\da-z]+)\/?["' >]/i

Matched Versions:
r3060, r3059, r3053
x264 : r3049 ==> r3060
```