### PR TITLE
Revert "zsh-completions: Install in standard completion path"

### DIFF
--- a/Formula/zsh-completions.rb
+++ b/Formula/zsh-completions.rb
@@ -4,6 +4,7 @@ class ZshCompletions < Formula
   url "https://github.com/zsh-users/zsh-completions/archive/0.33.0.tar.gz"
   sha256 "39452d383d0718aa2c830edba1aa32f0ee1e40002ef6932d88699a888bd58c29"
   license "MIT-Modern-Variant"
+  revision 1
   head "https://github.com/zsh-users/zsh-completions.git"
 
   bottle do
@@ -12,15 +13,19 @@ class ZshCompletions < Formula
 
   def install
     inreplace "src/_ghc", "/usr/local", HOMEBREW_PREFIX
-    zsh_completion.install Dir["src/*"]
+    pkgshare.install Dir["src/_*"]
   end
 
   def caveats
     <<~EOS
       To activate these completions, add the following to your .zshrc:
 
-        autoload -Uz compinit
-        compinit
+        if type brew &>/dev/null; then
+          FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
+
+          autoload -Uz compinit
+          compinit
+        fi
 
       You may also need to force rebuild `zcompdump`:
 
@@ -35,9 +40,10 @@ class ZshCompletions < Formula
 
   test do
     (testpath/"test.zsh").write <<~EOS
+      fpath=(#{pkgshare} $fpath)
       autoload _ack
       which _ack
     EOS
-    assert_match(/^_ack/, shell_output("/bin/zsh -fd test.zsh"))
+    assert_match(/^_ack/, shell_output("/bin/zsh test.zsh"))
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See #79247.

This reverts commit 2fc5e61c5b21e86615cf1079a7a958967de7df24.