### PR TITLE
Revert "tmuxinator-completion: conflicts with zsh-completions"

### DIFF
--- a/Formula/tmuxinator-completion.rb
+++ b/Formula/tmuxinator-completion.rb
@@ -11,7 +11,6 @@ class TmuxinatorCompletion < Formula
   end
 
   conflicts_with "tmuxinator", because: "the tmuxinator formula includes completion"
-  conflicts_with "zsh-completions", because: "the zsh-completions formula includes zsh completion"
 
   def install
     bash_completion.install "completion/tmuxinator.bash" => "tmuxinator"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is no longer needed after #79372.

This reverts commit 861cfd1019c62359d8d6bc90fc0f438c2987f500.