### PR TITLE
exim: update livecheck

### DIFF
--- a/Formula/exim.rb
+++ b/Formula/exim.rb
@@ -16,11 +16,11 @@ class Exim < Formula
       versions = page.scan(regex).flatten.uniq
 
       # Return versions if a `fixes` subdirectory isn't present
-      return versions if page.match(%r{href=["']?fixes/?["' >]}i).blank?
+      next versions if page.match(%r{href=["']?fixes/?["' >]}i).blank?
 
       # Fetch the page for the `fixes` directory
       fixes_page = Homebrew::Livecheck::Strategy.page_content(URI.join(@url, "fixes").to_s)
-      return versions if fixes_page[:content].blank?
+      next versions if fixes_page[:content].blank?
 
       # Match maintenance releases and add them to the versions array
       versions += fixes_page[:content].scan(regex).flatten


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Similar change to #79384, in short: use `next` instead of `return` when returning early from the block.