### PR TITLE
x264: update livecheck

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -23,11 +23,11 @@ class X264 < Formula
 
       # Fetch the `stable` Git branch Atom feed
       stable_page_data = Homebrew::Livecheck::Strategy.page_content("https://code.videolan.org/videolan/x264/-/commits/stable?format=atom")
-      return [] if stable_page_data[:content] && stable_page_data[:content].empty?
+      next [] if stable_page_data[:content].blank?
 
       # Extract commit hashes from the feed content
       commit_hashes = stable_page_data[:content].scan(%r{/commit/([\da-z]+)}i).flatten
-      return [] if commit_hashes.empty?
+      next [] if commit_hashes.blank?
 
       # Only keep versions with a matching commit hash in the `stable` branch
       matches.map do |match|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Similar to #79384 and #79387, this PR updates the existing `livecheck` block for `x264` to replace use of `return` in the `strategy` block with `next`. `return` can't be used in a block for an early return and `next` must be used instead.

This also replaces the `stable_page_data[:content] && stable_page_data[:content].empty?` return condition with `stable_page_data[:content].blank?`. Basically, this should have been `!stable_page_data[:content] || stable_page_data[:content].empty?` and that can be accounted for by simply using `#blank?`.