### PR TITLE
mmctl: revert upgrade to 6.0.0

### DIFF
--- a/Formula/mmctl.rb
+++ b/Formula/mmctl.rb
@@ -13,10 +13,10 @@ class Mmctl < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "37dd0cbcff879356df7b9c98a2f240d1dbf98ba1ba0120ccc09e02c4d6426dc9"
-    sha256 cellar: :any_skip_relocation, big_sur:       "3d49102a68b99a00da3e3889be2f2e2fcad95320d708560f209d3ec0897fb440"
-    sha256 cellar: :any_skip_relocation, catalina:      "a66045beaebefb112620b20d9c5e15bb09ae8360b08dd2e8228c3c5db9139e94"
-    sha256 cellar: :any_skip_relocation, mojave:        "28dd9de0d2774ae089b267e677194014614453be8bea52fa9e396b2f1b87564c"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "2100b6ed7798a993f34233c4b6b58759c83ce0f96b3c39a66d192d6a89c3d570"
+    sha256 cellar: :any_skip_relocation, big_sur:       "1e14c73707eb41c21ad5b9b6aea1850b56b71b79dd7fa6e8ccd8ec48e888c162"
+    sha256 cellar: :any_skip_relocation, catalina:      "9c7223fc02910173dabd773352af3617e92e1cfacc37337e43f5606cfeeef13d"
+    sha256 cellar: :any_skip_relocation, mojave:        "4db09ecf5831227464cf41b6bd512e37a079406c124d32ec93b4ce14987772cd"
   end
 
   depends_on "go" => :build

--- a/Formula/mmctl.rb
+++ b/Formula/mmctl.rb
@@ -2,8 +2,8 @@ class Mmctl < Formula
   desc "Remote CLI tool for Mattermost server"
   homepage "https://github.com/mattermost/mmctl"
   url "https://github.com/mattermost/mmctl.git",
-      tag:      "v6.0.0",
-      revision: "0ac724fa8ce75c42b0257453ed3f0f3df9fb8790"
+      tag:      "v5.36.0",
+      revision: "a3c6ff14a9f44dc847fa629a9e8ab516b8b883ec"
   license "Apache-2.0"
   head "https://github.com/mattermost/mmctl.git"
 


### PR DESCRIPTION
Downgrade and bump the version scheme.

See: https://github.com/Homebrew/homebrew-core/pull/79078.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

The `mmctl` formula was bumped to `6.0.0` by an automated GitHub Action that uses `livecheck` to determine the latest version (see: [workflow](https://github.com/dawidd6/ba-bump/blob/master/.github/workflows/bump.yml) and [particular run](https://github.com/dawidd6/ba-bump/runs/2795485911?check_suite_focus=true)). However, a user pointed out in #79078 that `6.0.0` was a pre-release.

The formula uses the `GithubLatest` strategy, so the automated bump would not have occurred unless `6.0.0` was the latest at some point, after which it was marked as a pre-release.

I've added a comment above the `version_scheme` with a link to the bump PR and an explanation for its addition.