### PR TITLE
go@1.10: workaround permission issues on Linux

### DIFF
--- a/Formula/go@1.10.rb
+++ b/Formula/go@1.10.rb
@@ -47,6 +47,12 @@ class GoAT110 < Formula
   end
 
   def install
+    on_linux do
+      # Fixes: Error: Failure while executing: ../bin/ldd ../line-clang.elf: Permission denied
+      chmod "+x", Dir.glob("src/debug/dwarf/testdata/*.elf")
+      chmod "+x", Dir.glob("src/debug/elf/testdata/*-exec")
+    end
+
     (buildpath/"gobootstrap").install resource("gobootstrap")
     ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"
 


### PR DESCRIPTION
This formula is unsupported but we will add the workaround for
Linux nevertheless, to finalise the core merge

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
