### PR TITLE
jbig2dec: update livecheck

### DIFF
--- a/Formula/jbig2dec.rb
+++ b/Formula/jbig2dec.rb
@@ -5,10 +5,14 @@ class Jbig2dec < Formula
   sha256 "279476695b38f04939aa59d041be56f6bade3422003a406a85e9792c27118a37"
   license "AGPL-3.0-or-later"
 
+  # Not every GhostPDL release contains a jbig2dec archive, so we have to check
+  # the GitHub releases page instead (which we otherwise avoid). This is
+  # necessary because the jbig2dec homepage hasn't been updated to link to
+  # versions after 0.17.
   livecheck do
-    url :stable
-    strategy :github_latest
+    url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases"
     regex(%r{href=.*?/jbig2dec[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `jbig2dec` uses the `GithubLatest` strategy, as `jbig2dec` versions (e.g., `0.19`) don't correspond to GhostPDL versions (e.g., `9.53.3`). As a result, it's necessary to check a release page to obtain the `jbig2dec` version from the tarball in the release artifacts.

However, this check is currently broken because the "latest" GhostPDL release doesn't provide a `jbig2dec` artifact. As a result, we have to check the GitHub releases page itself and hope that there's always a GhostPDL release with a `jbig2dec` tarball on the first page.

If this ends up being unreliable over time, we can check their non-GitHub Git repository for tags (http://git.ghostscript.com/jbig2dec.git). The reason why I'm not doing that here is because it may be useful to have the full URL for the tarball on GitHub, as this can be used to update the `stable` URL in the future if we pursue an automated version bump PR solution.

As an aside, it's necessary to check the GitHub releases because the [`jbig2dec` homepage](https://jbig2dec.com/) hasn't been updated for versions after 0.17, so we can't rely on it for version information.