### PR TITLE
widelands 1.0

### DIFF
--- a/Formula/widelands.rb
+++ b/Formula/widelands.rb
@@ -1,14 +1,13 @@
 class Widelands < Formula
   desc "Free real-time strategy game like Settlers II"
   homepage "https://www.widelands.org/"
-  url "https://launchpad.net/widelands/build21/build21/+download/widelands-build21-source.tar.gz"
-  version "21"
-  sha256 "601e0e4c6f91b3fb0ece2cd1b83ecfb02344a1b9194fbb70ef3f70e06994e357"
-  revision 7
+  url "https://github.com/widelands/widelands/archive/v1.0.tar.gz"
+  sha256 "1dab0c4062873cc72c5e0558f9e9620b0ef185f1a78923a77c4ce5b9ed76031a"
+  version_scheme 1
 
   livecheck do
     url :stable
-    regex(%r{<div class="version">\s*Latest version is [^<]*?v?(\d+(?:\.\d+)*)\s*</div>}i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates `widelands` from the latest beta (i.e., `build21`) to `1.0`, which is the first stable release.

It may be worth noting that the `stable` tarball in this PR comes from GitHub. The [first-party download page](https://www.widelands.org/wiki/Download/) links to GitHub for source archives, so this updates the formula to follow suit. This page says "Older versions of Widelands are available from Launchpad (Build 15 and newer) and Sourceforge (older builds)". Source files for 1.0 aren't available from Launchpad (dmg files are), so GitHub is the only option anyway.

This PR also updates the `livecheck` block to check the GitHub repository tags, to correspond with the new `stable` source.