### PR TITLE
neofetch: remove optional dependencies

### DIFF
--- a/Formula/neofetch.rb
+++ b/Formula/neofetch.rb
@@ -11,7 +11,6 @@ class Neofetch < Formula
     sha256 cellar: :any_skip_relocation, all: "3e914c528b75e3057342e16b096aec7ea835347cba55c045d9d8f6ec288c7ab6"
   end
 
-  depends_on "imagemagick"
   depends_on "screenresolution"
 
   def install


### PR DESCRIPTION
First time contributor here, please let me know if I did something wrong :)

The dependencies are optional. Optional dependencies should not be
listed in homebrew.

Source:
- [image: Remove imagemagick dependency and draw images
  directly.](https://github.com/dylanaraps/neofetch/pull/956)
- system_profiler is used as fallback (link to code):
  https://github.com/dylanaraps/neofetch/blob/a980dc8e8be54e57a1c64518fb68c166b84cbd2c/neofetch#L3007-L3014

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
