### PR TITLE
getxbook: add livecheck

### DIFF
--- a/Formula/getxbook.rb
+++ b/Formula/getxbook.rb
@@ -3,7 +3,13 @@ class Getxbook < Formula
   homepage "https://njw.name/getxbook"
   url "https://njw.name/getxbook/getxbook-1.2.tar.xz"
   sha256 "7a4b1636ecb6dace814b818d9ff6a68167799b81ac6fc4dca1485efd48cf1c46"
+  license "ISC"
   revision 1
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?getxbook[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "dc9c26a35297ffa8f3b40051b6293104dfb3bc03cb2ceccf56d77e0b8e5d7b6f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `getxbook`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.