### PR TITLE
workflows/tests: fix if conditions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
     if: github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
     outputs:
-      run-tests: ${{ steps.check-labels.outputs.run-tests }}
-      skip-arm-tests: ${{ steps.check-labels.outputs.skip-arm-tests }}
+      syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
+      force-arm: ${{ steps.check-labels.outputs.force-arm }}
       test-bot-fail-fast: ${{ steps.check-labels.outputs.test-bot-fail-fast }}
       test-bot-skip-recursive-dependents: ${{ steps.check-labels.outputs.test-bot-skip-recursive-dependents }}
     env:
@@ -64,20 +64,20 @@ jobs:
 
             if (label_names.includes('CI-syntax-only')) {
               console.log('CI-syntax-only label found. Skipping tests.')
-              console.log("::set-output name=run-tests::false");
+              console.log("::set-output name=syntax-only::true");
             }
             else {
               console.log('No CI-syntax-only label found. Running tests.')
-              console.log("::set-output name=run-tests::true");
+              console.log("::set-output name=syntax-only::false");
             }
 
             if (label_names.includes('CI-force-arm')) {
               console.log('CI-force-arm label found. Running ARM builds.')
-              console.log("::set-output name=skip-arm-tests::false");
+              console.log("::set-output name=force-arm::true");
             }
             else {
               console.log('No CI-force-arm label found. Not requiring ARM builds.')
-              console.log("::set-output name=skip-arm-tests::true");
+              console.log("::set-output name=force-arm::false");
             }
 
             if (label_names.includes('CI-test-bot-fail-fast')) {
@@ -100,7 +100,7 @@ jobs:
 
   tests:
     needs: tap_syntax
-    if: github.event_name == 'pull_request' && needs.tap_syntax.outputs.run-tests == 'true'
+    if: github.event_name == 'pull_request' && needs.tap_syntax.outputs.syntax-only == 'false'
     strategy:
       matrix:
         version: ["11-arm64", "11", "10.15", "10.14"]
@@ -115,7 +115,7 @@ jobs:
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
       - name: Check whether ARM tests will be forced
-        if: needs.tap_syntax.outputs.skip-arm-tests == 'true'
+        if: needs.tap_syntax.outputs.force-arm == 'false'
         run: echo 'HOMEBREW_REQUIRE_BOTTLED_ARM=1' >> $GITHUB_ENV
 
       - name: Set up Homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,38 +64,34 @@ jobs:
 
             if (label_names.includes('CI-syntax-only')) {
               console.log('CI-syntax-only label found. Skipping tests.')
-              console.log("::set-output name=syntax-only::true");
-            }
-            else {
+              console.log('::set-output name=syntax-only::true');
+            } else {
               console.log('No CI-syntax-only label found. Running tests.')
-              console.log("::set-output name=syntax-only::false");
+              console.log('::set-output name=syntax-only::false');
             }
 
             if (label_names.includes('CI-force-arm')) {
               console.log('CI-force-arm label found. Running ARM builds.')
-              console.log("::set-output name=force-arm::true");
-            }
-            else {
+              console.log('::set-output name=force-arm::true');
+            } else {
               console.log('No CI-force-arm label found. Not requiring ARM builds.')
-              console.log("::set-output name=force-arm::false");
+              console.log('::set-output name=force-arm::false');
             }
 
             if (label_names.includes('CI-test-bot-fail-fast')) {
               console.log('CI-test-bot-fail-fast label found. Passing --fail-fast to brew test-bot.')
-              console.log("::set-output name=test-bot-fail-fast::--fail-fast");
-            }
-            else {
+              console.log('::set-output name=test-bot-fail-fast::--fail-fast');
+            } else {
               console.log('No CI-test-bot-fail-fast label found. Not passing --fail-fast to brew test-bot.')
-              console.log("::set-output name=test-bot-fail-fast::");
+              console.log('::set-output name=test-bot-fail-fast::');
             }
 
             if (label_names.includes('CI-test-bot-skip-recursive-dependents')) {
               console.log('CI-test-bot-skip-recursive-dependents label found. Passing --skip-recursive-dependents to brew test-bot.')
-              console.log("::set-output name=test-bot-skip-recursive-dependents::--skip-recursive-dependents");
-            }
-            else {
+              console.log('::set-output name=test-bot-skip-recursive-dependents::--skip-recursive-dependents');
+            } else {
               console.log('No CI-test-bot-skip-recursive-dependents label found. Not passing --skip-recursive-dependents to brew test-bot.')
-              console.log("::set-output name=test-bot-skip-recursive-dependents::");
+              console.log('::set-output name=test-bot-skip-recursive-dependents::');
             }
 
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,7 @@ jobs:
 
   tests:
     needs: tap_syntax
-    if: github.event_name == 'pull_request' && needs.tap_syntax.outputs.run-tests
+    if: github.event_name == 'pull_request' && needs.tap_syntax.outputs.run-tests == 'true'
     strategy:
       matrix:
         version: ["11-arm64", "11", "10.15", "10.14"]
@@ -115,7 +115,7 @@ jobs:
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
       - name: Check whether ARM tests will be forced
-        if: needs.tap_syntax.outputs.skip-arm-tests
+        if: needs.tap_syntax.outputs.skip-arm-tests == 'true'
         run: echo 'HOMEBREW_REQUIRE_BOTTLED_ARM=1' >> $GITHUB_ENV
 
       - name: Set up Homebrew


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to https://github.com/Homebrew/homebrew-core/commit/8f1b7cbb7564fa59cef13412018714d3cb412e7a, as it broke the `CI-syntax-only` label functionality (which skips tests).

This happened because [`setOutput`](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#using-workflow-commands-to-access-toolkit-functions) values are strings but the workflow was treating the value like a boolean (from earlier code). Since `'false'` and `'true'` strings are both truthy, `if: needs.tap_syntax.outputs.skip-arm-tests` is always true and tests are run even if the `CI-syntax-only` label is applied to a PR.

[Just to be clear, the value is still a string if you use the `core.setOutput('run-tests', false)` format, as `setOutput` converts a non-string value to a string using `JSON.stringify`.]

---

This PR fixes this issue by modifying related conditions to compare to a string value, like `if: needs.tap_syntax.outputs.run-tests == 'true'`.

In response to feedback, I've renamed `run-tests` to `syntax-only` and `skip-arm-tests` to `force-arm` and adjusted the values/conditions accordingly. This aligns these variables with the `test-bot-fail-fast` and `test-bot-skip-recursive-dependents` variables, which use the same name as their related `CI-` labels. This simplifies the variable setup and makes the workflow logic a little easier to understand.

---

Lastly, this tidies up the style of the JavaScript code:

* This now uses single quotes uniformly, to align with the existing code and prevailing JavaScript norms. This is purely aesthetic and there's no functional difference in JavaScript. Alternatively, we could standardize on double quotes, as this is mostly about using one format instead of a mix.
* I removed the newline before `else`, so it appears on the same line as the preceding closing brace (i.e., `} else {` instead of `}\nelse`). I'm sure there are outliers but this tends to be the norm for JS and I feel like it makes the code easier to read.