### PR TITLE
grt: add to `github_prerelease_allowlist`

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -3,6 +3,7 @@
   "get-flash-videos": "1.25.99.03",
   "gitless": "0.8.8",
   "gron": "all",
+  "grt": "0.2.4",
   "riff": "0.5.0",
   "telegram-cli": "1.3.1",
   "thrift@0.9": "all"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The version we currently ship is labelled a GitHub pre-release, and it
looks like this is what is preventing it from being bottled on Big Sur.