### PR TITLE
libslirp 4.6.1 (Required by QEMU)

### DIFF
--- a/Formula/libslirp.rb
+++ b/Formula/libslirp.rb
@@ -1,8 +1,8 @@
 class Libslirp < Formula
   desc "General purpose TCP-IP emulator"
   homepage "https://gitlab.freedesktop.org/slirp/libslirp"
-  url "https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v4.6.0/libslirp-v4.6.0.tar.gz"
-  sha256 "1fbe79a7402d9617c0e15fd2b946335ed3e71a839cdf02a29f24bc944adb773a"
+  url "https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v4.6.1/libslirp-v4.6.1.tar.gz"
+  sha256 "69ad4df0123742a29cc783b35de34771ed74d085482470df6313b6abeb799b11"
   license "BSD-3-Clause"
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
libslirp is the library used by QEMU for implementing user-mode networking.

DHCP was broken in libslirp 4.6.0: https://gitlab.freedesktop.org/slirp/libslirp/-/issues/48
Fixed in 4.6.1: https://gitlab.freedesktop.org/slirp/libslirp/-/releases/v4.6.1