### PR TITLE
libtensorflow@1: deprecate

### DIFF
--- a/Formula/libtensorflow@1.rb
+++ b/Formula/libtensorflow@1.rb
@@ -15,6 +15,8 @@ class LibtensorflowAT1 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2021-01-06", because: :versioned_formula
+
   depends_on "bazel" => :build
   depends_on "python@3.9" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

From https://github.com/tensorflow/tensorflow/releases/tag/v1.15.5
> Note that this is the last patch release for the TensorFlow 1.x series.

