### PR TITLE
libident: add livecheck

### DIFF
--- a/Formula/libident.rb
+++ b/Formula/libident.rb
@@ -4,6 +4,11 @@ class Libident < Formula
   url "https://www.remlab.net/files/libident/libident-0.32.tar.gz"
   sha256 "8cc8fb69f1c888be7cffde7f4caeb3dc6cd0abbc475337683a720aa7638a174b"
 
+  livecheck do
+    url "https://www.remlab.net/files/libident/"
+    regex(/href=.*?libident[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any, big_sur:     "50e093a609acac219853ba89a884408bebcddd23b7ae23faad9476618649cbe7"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `libident`. This PR adds a `livecheck` block that checks the directory listing page where the the `stable` archive is found. The current `homepage` redirects to the directory listing page, so this is as close to a first-party download page as we can find.