### PR TITLE
luajit-openresty: specify `version`

### DIFF
--- a/Formula/luajit-openresty.rb
+++ b/Formula/luajit-openresty.rb
@@ -2,6 +2,7 @@ class LuajitOpenresty < Formula
   desc "OpenResty's Branch of LuaJIT 2"
   homepage "https://github.com/openresty/luajit2"
   url "https://github.com/openresty/luajit2/archive/refs/tags/v2.1-20210510.tar.gz"
+  version "20210510"
   sha256 "1ee6dad809a5bb22efb45e6dac767f7ce544ad652d353a93d7f26b605f69fe3f"
   license "MIT"
   head "https://github.com/openresty/luajit2.git", branch: "v2.1-agentzh"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Homebrew/brew#11491 is causing errors for anyone who tries to install
`luajit-openresty` while on the development branch of `brew`. This fixes
those errors.

Closes #79518.