### PR TITLE
spin: add ispin GUI

### DIFF
--- a/Aliases/ispin
+++ b/Aliases/ispin
@@ -1,0 +1,1 @@
+../Formula/spin.rb

--- a/Formula/spin.rb
+++ b/Formula/spin.rb
@@ -13,12 +13,18 @@ class Spin < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "3ffbbe34633fa0e177bd25343b3bbd35d706988ab04c4a617fff530cf3dc542a"
   end
 
+  depends_on "tcl-tk"
+
   uses_from_macos "bison" => :build
 
   def install
     cd "Src" do
       system "make"
       bin.install "spin"
+    end
+
+    cd "optional_gui" do
+      bin.install "ispin.tcl" => "ispin"
     end
 
     man1.install "Man/spin.1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Spin is distributed with the ispin GUI, which is "optional, but highly recommended" to install according to [their readme](http://spinroot.com/spin/Man/README.html). (I've also found that the CLI is difficult to navigate on its own.) As per the acceptable formulae guidelines, I'd say that this satisfies the "GUI is useful and would be widely used" condition, so this PR installs ispin alongside spin in the spin formula. This adds the Tcl/Tk dependency too.

I've tested this formula on Fedora 34, and Ubuntu 20.04 on WSL 2 (both with linuxbrew), as well as a MacBook Air running Homebrew, all with no issues. From the linuxbrew contributor guide, it looks like this belongs more in upstream Homebrew than in linuxbrew since the GUI will work on both OSes.