### PR TITLE
workflows/tests: update skip unbottled ARM ENV

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Check whether ARM tests will be forced
         if: needs.tap_syntax.outputs.force-arm == 'false'
-        run: echo 'HOMEBREW_REQUIRE_BOTTLED_ARM=1' >> $GITHUB_ENV
+        run: echo 'HOMEBREW_SKIP_UNBOTTLED_ARM_TESTS=1' >> $GITHUB_ENV
 
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR renames the `HOMEBREW_REQUIRE_BOTTLED_ARM` environment variable used in the `tests` job to `HOMEBREW_SKIP_UNBOTTLED_ARM_TESTS`, per the [recent discussion](https://github.com/Homebrew/homebrew-core/pull/79458#discussion_r653131335) we had.\

This shouldn't be merged until the test-bot PR that adds support for the name change is merged (Homebrew/homebrew-test-bot#619). After both of these PRs are merged, I'll create a follow-up test-bot PR to remove the old environment variable.