### PR TITLE
nacl: add livecheck

### DIFF
--- a/Formula/nacl.rb
+++ b/Formula/nacl.rb
@@ -5,6 +5,14 @@ class Nacl < Formula
   mirror "https://deb.debian.org/debian/pool/main/n/nacl/nacl_20110221.orig.tar.bz2"
   sha256 "4f277f89735c8b0b8a6bbd043b3efb3fa1cc68a9a5da6a076507d067fc3b3bf8"
 
+  # On an HTML page, we typically match versions from file URLs in `href`
+  # attributes. This "Installation" page only provides the archive URL in text,
+  # so this regex is a bit different.
+  livecheck do
+    url "https://nacl.cr.yp.to/install.html"
+    regex(%r{https?://[^\n]+?/nacl[._-]v?(\d+{6,8})\.t}i)
+  end
+
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, big_sur:     "89574694f733c8aa852e09e3828f10dd6ce2ece4219bd825e5f6c18253bddb28"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `nacl`. This PR adds a `livecheck` block that checks the first-party "Installation" page, which provides the `stable` archive URL in a set of instructions. Since the URL isn't in a link, this regex is a bit different than our typical ones for HTML pages, where we identify versions from URLs in `href` attributes.