### PR TITLE
bltool: depend on openjdk

### DIFF
--- a/Formula/bltool.rb
+++ b/Formula/bltool.rb
@@ -12,6 +12,8 @@ class Bltool < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     if build.head?
       system "lein", "uberjar"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`bltool` is based on a jar script but didn't depend on `openjdk`. Its test failed in #79448 because java wasn't found.