### PR TITLE
spdlog: remove manual external fmt tweak

### DIFF
--- a/Formula/spdlog.rb
+++ b/Formula/spdlog.rb
@@ -19,8 +19,6 @@ class Spdlog < Formula
   def install
     ENV.cxx11
 
-    inreplace "include/spdlog/tweakme.h", "// #define SPDLOG_FMT_EXTERNAL", "#define SPDLOG_FMT_EXTERNAL"
-
     mkdir "spdlog-build" do
       args = std_cmake_args + %W[
         -Dpkg_config_libdir=#{lib}
@@ -56,7 +54,8 @@ class Spdlog < Formula
       }
     EOS
 
-    system ENV.cxx, "-std=c++11", "test.cpp", "-I#{include}", "-L#{Formula["fmt"].opt_lib}", "-lfmt", "-o", "test"
+    system ENV.cxx, "-std=c++11", "test.cpp", "-DSPDLOG_FMT_EXTERNAL", "-I#{include}", +
+    "-L#{Formula["fmt"].opt_lib}", "-lfmt", "-o", "test"
     system "./test"
     assert_predicate testpath/"basic-log.txt", :exist?
     assert_match "Test", (testpath/"basic-log.txt").read


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The spdlog formula manually forces an entry in `tweakme.h` for `SPDLOG_FMT_EXTERNAL` which causes a compiler warning for build systems that use `pkg-config`, because `pkg-config --cflags spdlog` already correctly adds the required define.

A simple Meson example is at https://github.com/kklobe/brew-spdlog-fix-demo.git. The warning produced is:

```
The Meson build system
Version: 0.58.1
Source dir: /Users/xxxxxx/scratch/src/slt
Build dir: /Users/xxxxxx/scratch/src/slt/build
Build type: native build
Project name: spdlog_test
Project version: undefined
C++ compiler for the host machine: ccache c++ (clang 12.0.5 "Apple clang version 12.0.5 (clang-1205.0.22.9)")
C++ linker for the host machine: c++ ld64 650.9
Host machine cpu family: aarch64
Host machine cpu: arm64
Found pkg-config: /opt/homebrew/bin/pkg-config (0.29.2)
Run-time dependency spdlog found: YES 1.8.5
Build targets in project: 1

Found ninja-1.10.2 at /opt/homebrew/bin/ninja
➜  slt meson compile -C build
ninja: Entering directory `build'
[1/2] Compiling C++ object spdlog_test.p/spdlog_test.cpp.o
In file included from ../spdlog_test.cpp:1:
In file included from /opt/homebrew/Cellar/spdlog/1.8.5/include/spdlog/spdlog.h:12:
In file included from /opt/homebrew/Cellar/spdlog/1.8.5/include/spdlog/common.h:6:
/opt/homebrew/Cellar/spdlog/1.8.5/include/spdlog/tweakme.h:74:9: warning: 'SPDLOG_FMT_EXTERNAL' macro redefined [-Wmacro-redefined]
#define SPDLOG_FMT_EXTERNAL
        ^
<command line>:3:9: note: previous definition is here
#define SPDLOG_FMT_EXTERNAL 1
        ^
1 warning generated.
[2/2] Linking target spdlog_test
```
The proposed fix remove the system-wide `tweakme.h` override and leaves the responsibility to the user's build process.