### PR TITLE
redis-leveldb: disable due to no license

### DIFF
--- a/Formula/redis-leveldb.rb
+++ b/Formula/redis-leveldb.rb
@@ -17,6 +17,9 @@ class RedisLeveldb < Formula
     sha256 cellar: :any, yosemite:      "4cf802ff434be42c86043c45f539cfdb0f137cfd37df4815560e3495da5f9d1b"
   end
 
+  # https://github.com/KDr2/redis-leveldb/issues/17
+  disable! date: "2021-06-19", because: :no_license
+
   depends_on "gmp"
   depends_on "leveldb"
   depends_on "libev"


### PR DESCRIPTION
redis-leveldb: disable due to no license

---

relates to KDr2/redis-leveldb#17

