### PR TITLE
libfox: compile with c++11

### DIFF
--- a/Formula/libofx.rb
+++ b/Formula/libofx.rb
@@ -20,6 +20,8 @@ class Libofx < Formula
   depends_on "open-sp"
 
   def install
+    ENV.cxx11
+
     opensp = Formula["open-sp"]
     system "./configure", "--disable-dependency-tracking",
                           "--with-opensp-includes=#{opensp.opt_include}/OpenSP",


### PR DESCRIPTION
Fixes:
2021-06-20T10:49:41.2440650Z ofx_utilities.cpp: In function ‘time_t ofxdate_to_time_t(const string&)’:
2021-06-20T10:49:41.2441563Z ofx_utilities.cpp:151:38: error: ‘nullptr’ was not declared in this scope
2021-06-20T10:49:41.2442666Z std::time_t temptime = std::time(nullptr);

This is needed on Linux for gcc-5, but I enabled it for mac too,
as this should do no harm there

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
