### PR TITLE
baidupcs-go 3.8.1 (new formula)

### DIFF
--- a/Formula/baidupcs-go.rb
+++ b/Formula/baidupcs-go.rb
@@ -1,0 +1,19 @@
+class BaidupcsGo < Formula
+  desc "Terminal utility for Baidu Network Disk"
+  homepage "https://github.com/qjfoidnh/BaiduPCS-Go"
+  url "https://github.com/qjfoidnh/BaiduPCS-Go/archive/v3.8.1.tar.gz"
+  sha256 "265f14e110e836195d230fcea26a27c440c1ae710d9a2fd9d664a603a89fd5c9"
+  license "Apache-2.0"
+  head "https://github.com/qjfoidnh/BaiduPCS-Go.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    system bin/"baidupcs-go", "run", "touch", "test.txt"
+    assert_predicate testpath/"test.txt", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes qjfoidnh/BaiduPCS-Go#81

Previously it was removed due to [the upstream repo removal](https://github.com/Homebrew/homebrew-core/pull/55695).
