### PR TITLE
mytop: bump rev to match system perl

### DIFF
--- a/Formula/mytop.rb
+++ b/Formula/mytop.rb
@@ -4,7 +4,7 @@ class Mytop < Formula
   url "https://web.archive.org/web/20150602163826/www.mysqlfanboy.com/mytop-3/mytop-1.9.1.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/m/mytop/mytop_1.9.1.orig.tar.gz"
   sha256 "179d79459d0013ab9cea2040a41c49a79822162d6e64a7a85f84cdc44828145e"
-  revision 8
+  revision 9
 
   livecheck do
     skip "Upstream is gone and the formula uses archive.org URLs"
@@ -76,7 +76,7 @@ class Mytop < Formula
     end
 
     system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}"
-    system "make", "test", "install"
+    system "make", "install"
     share.install prefix/"man"
     bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
   end


### PR DESCRIPTION
Addresses test error `Expected /username\ you\ specified/ to match "ListUtil.c: loadable library and perl binaries are mismatched (got handshake key 0xc500080, needed 0xc400080)\n".`

Also removed `make test` per `brew audit` complaint:
```
$ brew audit --strict --online --git --fix mytop
mytop:
  * 79: col 5: Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
```

In support of #79624.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
