### PR TITLE
game-music-emu: fix test

### DIFF
--- a/Formula/game-music-emu.rb
+++ b/Formula/game-music-emu.rb
@@ -42,7 +42,8 @@ class GameMusicEmu < Formula
       }
     EOS
 
-    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}",
+    ubsan_libdir = Dir["#{MacOS::CLT::PKG_PATH}/usr/lib/clang/*/lib/darwin"].first
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-Wl,-rpath,#{ubsan_libdir}",
                    "-lgme", "-o", "test", *ENV.cflags.to_s.split
     system "./test"
   end


### PR DESCRIPTION
Fixes test error:
```
dyld: Library not loaded: @rpath/libclang_rt.ubsan_osx_dynamic.dylib
  Referenced from: /usr/local/opt/game-music-emu/lib/libgme.0.dylib
  Reason: image not found
```
In support of #79624.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
