### PR TITLE
qbe 1.0.0 (new formula)

### DIFF
--- a/Formula/qbe.rb
+++ b/Formula/qbe.rb
@@ -1,0 +1,18 @@
+class Qbe < Formula
+  desc "Compiler Backend"
+  homepage "https://c9x.me/compile/"
+  url "git://c9x.me/qbe.git",
+    revision: "6d9ee1389572ae985f6a39bb99dbd10cdf42c123"
+  version "1.0.0"
+  license "MIT"
+
+  def install
+    system "make", "PREFIX=#{prefix}"
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    system "#{bin}/qbe", "-h"
+  end
+end
+


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds a formula for the QBE compiler backend. 

The audit does not pass since it expects a git tag:

```
Formulae in homebrew/core should specify a tag for git URLs
```

The problem here is that QBE does not utilize Git tags in their workflow.
Another thing to note is that QBE does not use versions that could reliably be referenced. Any help is greatly appreciated!
