### PR TITLE
minipro: set prefix when building.

### DIFF
--- a/Formula/minipro.rb
+++ b/Formula/minipro.rb
@@ -17,7 +17,7 @@ class Minipro < Formula
   depends_on "srecord"
 
   def install
-    system "make", "CC=clang"
+    system "make", "CC=#{ENV.cc}", "PREFIX=#{prefix}"
     system "make", "PREFIX=#{prefix}", "MANDIR=#{share}", "install"
   end
 


### PR DESCRIPTION
The PREFIX value in the Makefile affects the hard-coded path
minipro uses to find its infoic.xml (see database.c). If we don't
override it, it would defaults to /usr/local which is incorrect for
homebrew not installed in /usr/local.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
