### PR TITLE
maturin: fix test failure with rust 1.53.0

### DIFF
--- a/Formula/maturin.rb
+++ b/Formula/maturin.rb
@@ -22,6 +22,9 @@ class Maturin < Formula
 
   test do
     system "cargo", "new", "hello_world", "--bin"
+    if File.readlines("hello_world/Cargo.toml").grep(/authors/).empty?
+      inreplace "hello_world/Cargo.toml", "[package]", "[package]\nauthors = [\"test\"]"
+    end
     system "#{bin}/maturin", "build", "-m", "hello_world/Cargo.toml", "-b", "bin", "-o", "dist"
     system "python3", "-m", "pip", "install", "hello_world", "--no-index", "--find-links", testpath/"dist"
     system "python3", "-m", "pip", "uninstall", "-y", "hello_world"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Addresses https://github.com/Homebrew/homebrew-core/pull/79503#issuecomment-864622815