### PR TITLE
depends on openjdk when using `bin.write_jar_script`

### DIFF
--- a/Formula/apgdiff.rb
+++ b/Formula/apgdiff.rb
@@ -12,6 +12,8 @@ class Apgdiff < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     jar = "apgdiff-#{version}.jar"
 

--- a/Formula/briss.rb
+++ b/Formula/briss.rb
@@ -6,6 +6,8 @@ class Briss < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     libexec.install Dir["*.jar"]
     bin.write_jar_script libexec/"briss-#{version}.jar", "briss"

--- a/Formula/calabash.rb
+++ b/Formula/calabash.rb
@@ -9,6 +9,7 @@ class Calabash < Formula
     sha256 cellar: :any_skip_relocation, all: "b35fca9a2745fa7bea9a71a9eec85071eba850af9d7df2c8132b81152f1ca6ce"
   end
 
+  depends_on "openjdk"
   depends_on "saxon"
 
   def install

--- a/Formula/davmail.rb
+++ b/Formula/davmail.rb
@@ -7,6 +7,8 @@ class Davmail < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     libexec.install Dir["*"]
     bin.write_jar_script libexec/"davmail.jar", "davmail", "-Djava.awt.headless=true"

--- a/Formula/epubcheck.rb
+++ b/Formula/epubcheck.rb
@@ -7,6 +7,8 @@ class Epubcheck < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     jarname = "epubcheck.jar"
     libexec.install jarname, "lib"

--- a/Formula/htmlcompressor.rb
+++ b/Formula/htmlcompressor.rb
@@ -6,6 +6,8 @@ class Htmlcompressor < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     libexec.install "htmlcompressor-#{version}.jar"
     bin.write_jar_script libexec/"htmlcompressor-#{version}.jar", "htmlcompressor"

--- a/Formula/ivy.rb
+++ b/Formula/ivy.rb
@@ -8,6 +8,8 @@ class Ivy < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     libexec.install Dir["ivy*"]
     doc.install Dir["doc/*"]

--- a/Formula/jslint4java.rb
+++ b/Formula/jslint4java.rb
@@ -6,6 +6,8 @@ class Jslint4java < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     doc.install Dir["docs/*"]
     libexec.install Dir["*.jar"]

--- a/Formula/rhino.rb
+++ b/Formula/rhino.rb
@@ -13,12 +13,14 @@ class Rhino < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk@11"
+
   conflicts_with "nut", because: "both install `rhino` binaries"
 
   def install
     rhino_jar = "rhino-#{version}.jar"
     libexec.install "lib/#{rhino_jar}"
-    bin.write_jar_script libexec/rhino_jar, "rhino"
+    bin.write_jar_script libexec/rhino_jar, "rhino", java_version: "11"
     doc.install Dir["docs/*"]
   end
 

--- a/Formula/scalariform.rb
+++ b/Formula/scalariform.rb
@@ -17,6 +17,8 @@ class Scalariform < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   def install
     if build.head?
       system "sbt", "project cli", "assembly"

--- a/Formula/scalastyle.rb
+++ b/Formula/scalastyle.rb
@@ -13,6 +13,8 @@ class Scalastyle < Formula
 
   bottle :unneeded
 
+  depends_on "openjdk"
+
   resource "default_config" do
     url "https://raw.githubusercontent.com/scalastyle/scalastyle/v1.0.0/lib/scalastyle_config.xml"
     sha256 "6ce156449609a375d973cc8384a17524e4538114f1747efc2295cf4ca473d04e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Many formulae are using `bin.write_jar_script` but didn't depend on any version of java. Some of them failed in #79448.
