### PR TITLE
osi: update livecheck

### DIFF
--- a/Formula/osi.rb
+++ b/Formula/osi.rb
@@ -7,8 +7,7 @@ class Osi < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
-    regex(%r{href=.*?/tag/(?:releases%2F)?v?(\d+(?:\.\d+)+)["' >]}i)
+    regex(%r{^releases/v?(\d+(?:\.\d+)+)$}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `osi` is giving an `Unable to get versions` error because it's using the `GithubLatest` strategy but the "latest" release is `test-tag`.

The `Git` strategy can correctly identify the latest version if supplied with a regex that accounts for the `releases/` prefix for release tags. As such, the `GithubLatest` strategy is neither correct nor necessary and we shouldn't be using it for this formula.

This PR updates the `livecheck` block to remove `strategy :github_latest` and to add an appropriate regex to use with the `Git` strategy. This correctly identifies the latest version as `0.108.6`.