### PR TITLE
envoy@1.17 1.17.3 (new formula)

### DIFF
--- a/Aliases/envoy@1.18
+++ b/Aliases/envoy@1.18
@@ -1,0 +1,1 @@
+../Formula/envoy.rb

--- a/Formula/envoy@1.17.rb
+++ b/Formula/envoy@1.17.rb
@@ -1,0 +1,52 @@
+class EnvoyAT117 < Formula
+  desc "Cloud-native high-performance edge/middle/service proxy"
+  homepage "https://www.envoyproxy.io"
+  url "https://github.com/envoyproxy/envoy.git",
+      tag:      "v1.17.3",
+      revision: "46bf743b97d0d3f01ff437b2f10cc0bd9cdfe6e4"
+  license "Apache-2.0"
+
+  keg_only :versioned_formula
+  # https://github.com/envoyproxy/envoy/blob/main/RELEASES.md#release-schedule
+  deprecate! date: "2022-01-11", because: :unsupported
+
+  depends_on "automake" => :build
+  depends_on "bazelisk" => :build
+  depends_on "cmake" => :build
+  depends_on "coreutils" => :build
+  depends_on "go" => :build
+  depends_on "libtool" => :build
+  depends_on "ninja" => :build
+  depends_on macos: :catalina
+
+  def install
+    args = %w[
+      -c
+      opt
+      --curses=no
+      --show_task_finish
+      --verbose_failures
+      --action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin
+      --test_output=all
+    ]
+    system Formula["bazelisk"].opt_bin/"bazelisk", "build", *args, "//source/exe:envoy-static"
+    bin.install "bazel-bin/source/exe/envoy-static" => "envoy"
+    pkgshare.install "configs", "examples"
+  end
+
+  test do
+    port = free_port
+
+    cp pkgshare/"configs/envoyproxy_io_proxy.yaml", testpath/"envoy.yaml"
+    inreplace "envoy.yaml" do |s|
+      s.gsub! "port_value: 9901", "port_value: #{port}"
+      s.gsub! "port_value: 10000", "port_value: #{free_port}"
+    end
+
+    fork do
+      exec bin/"envoy", "-c", "envoy.yaml"
+    end
+    sleep 10
+    assert_match "HEALTHY", shell_output("curl -s 127.0.0.1:#{port}/clusters?format=json")
+  end
+end


### PR DESCRIPTION
This adds envoy@1.17 and backfills an alias for 1.18, as that's the current version.

Notably, [Envoy 1.18 changed the config format](https://github.com/envoyproxy/envoy/blob/713b2a6f2b757ff4bea3c51cf89d88f02f56184c/docs/root/version_history/v1.18.0.rst) in an incompatible way with 1.17 which is supported until next year

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`cd Aliases;ln -s ../Formula/envoy.rb 'envoy@1.18'`