### PR TITLE
clair: update livecheck

### DIFF
--- a/Formula/clair.rb
+++ b/Formula/clair.rb
@@ -7,7 +7,7 @@ class Clair < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `clair` formula is using version `4.1.1` but the existing `livecheck` block uses the `GithubLatest` strategy and is giving `4.0.6` as newest (as it's the "latest" release on GitHub).

`clair` was updated to `4.1.1` in #79430 and it was decided in that PR that `4.1.1` was the correct latest version. Assuming this is true, we shouldn't be using the `GithubLatest` strategy and should simply be checking the Git tags.

With that in mind, this PR removes `strategy :github_latest` and adds the standard regex for Git tags like `1.2.3`/`v1.2.3`. This returns `4.1.1` as the newest version instead.