### PR TITLE
pillow 8.2.0 (new formula)

### DIFF
--- a/Formula/pillow.rb
+++ b/Formula/pillow.rb
@@ -1,0 +1,67 @@
+class Pillow < Formula
+  desc "Friendly PIL fork (Python Imaging Library)"
+  homepage "https://python-pillow.org"
+  url "https://files.pythonhosted.org/packages/21/23/af6bac2a601be6670064a817273d4190b79df6f74d8012926a39bc7aa77f/Pillow-8.2.0.tar.gz"
+  sha256 "a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1"
+  license "HPND"
+  head "https://github.com/python-pillow/Pillow.git"
+
+  depends_on "pkg-config" => :build
+  depends_on "python@3.7" => [:build, :test] unless Hardware::CPU.arm?
+  depends_on "python@3.8" => [:build, :test]
+  depends_on "python@3.9" => [:build, :test]
+  depends_on "jpeg"
+  depends_on "libimagequant"
+  depends_on "libraqm"
+  depends_on "libtiff"
+  depends_on "little-cms2"
+  depends_on "openjpeg"
+  depends_on "tcl-tk"
+  depends_on "webp"
+
+  uses_from_macos "zlib"
+
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/python@\d\.\d+/) }
+        .map(&:opt_bin)
+        .map { |bin| bin/"python3" }
+  end
+
+  def install
+    pre_args = %w[
+      --enable-tiff
+      --enable-freetype
+      --enable-lcms
+      --enable-webp
+      --enable-xcb
+    ]
+
+    post_args = %W[
+      --prefix=#{prefix}
+      --install-scripts=#{bin}
+      --single-version-externally-managed
+      --record=installed.txt
+    ]
+
+    ENV["MAX_CONCURRENCY"] = ENV.make_jobs.to_s
+    ENV.prepend "CPPFLAGS", "-I#{Formula["tcl-tk"].opt_include}"
+    ENV.prepend "LDFLAGS", "-L#{Formula["tcl-tk"].opt_lib}"
+
+    pythons.each do |python|
+      system python, "setup.py", "build_ext", *pre_args, "install", *post_args
+    end
+  end
+
+  test do
+    (testpath/"test.py").write <<~EOS
+      from PIL import Image
+      im = Image.open("#{test_fixtures("test.jpg")}")
+      print(im.format, im.size, im.mode)
+    EOS
+
+    pythons.each do |python|
+      assert_equal "JPEG (1, 1) RGB", shell_output("#{python} test.py").chomp
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a Python library, but it has no Python dependencies, and could
be useful for other formulae.

This formula fails the new formula audit because of the `tcl-tk`
dependency. However, some formulae that use Pillow also depend on
`tcl-tk`, and we don't want to have a mixed-version dependency when we
switch those formulae to depend on this one.

Partially addresses #79562. See also #73875.