### PR TITLE
llvm: use `install` instead of `install/strip` target

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -167,7 +167,7 @@ class Llvm < Formula
       # Workaround for CMake Error: failed to create symbolic link
       ENV.deparallelize if Hardware::CPU.arm?
       system "cmake", "--build", "."
-      system "cmake", "--build", ".", "--target", "install/strip"
+      system "cmake", "--build", ".", "--target", "install"
       system "cmake", "--build", ".", "--target", "install-xcode-toolchain" if MacOS::Xcode.installed?
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Using the `install/strip` target seems to have broken LLVM 11 on Apple
Silicon (cf. #79466). Stripping results in just a modest decrease in
bottle size, so it seems better to play it safe here and stick with the
`install` target.

-----

Marking this as syntax-only, since we have a few long-running PRs going, and this exact configuration has been tested quite a few times already previously (some quite recently). This change does not need new bottles, since the existing bottles are still built from the `install` target.