### PR TITLE
wxmac 3.1.5, wxmac@3.0 3.0.5.1 (new formula)

### DIFF
--- a/Aliases/wxmac@3.1
+++ b/Aliases/wxmac@3.1
@@ -1,0 +1,1 @@
+../Formula/wxmac.rb

--- a/Formula/diff-pdf.rb
+++ b/Formula/diff-pdf.rb
@@ -4,6 +4,7 @@ class DiffPdf < Formula
   url "https://github.com/vslavik/diff-pdf/releases/download/v0.5/diff-pdf-0.5.tar.gz"
   sha256 "e7b8414ed68c838ddf6269d11abccdb1085d73aa08299c287a374d93041f172e"
   license "GPL-2.0-only"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "3abff1045972a9a20e5c151ffbb7a0bb9793b39374485987ffd00f8c0c8e9ebd"

--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -5,6 +5,7 @@ class Erlang < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-24.0.2/otp_src_24.0.2.tar.gz"
   sha256 "882e8a93194c32cf8335f62c86489c1850d5a5ec9bdfa35fff55b9317213ab8e"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/erlang@21.rb
+++ b/Formula/erlang@21.rb
@@ -5,6 +5,7 @@ class ErlangAT21 < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-21.3.8.24/otp_src_21.3.8.24.tar.gz"
   sha256 "a82de871d7ba40fd256558b23a3b4c1539e6c7ece7507d6eb2b00330c6135012"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/erlang@22.rb
+++ b/Formula/erlang@22.rb
@@ -5,6 +5,7 @@ class ErlangAT22 < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-22.3.4.20/otp_src_22.3.4.20.tar.gz"
   sha256 "43289f20a7038b6835615a1f68a6e32b9aeec6db38cdb7c97adf78d048d74079"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/erlang@23.rb
+++ b/Formula/erlang@23.rb
@@ -5,6 +5,7 @@ class ErlangAT23 < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-23.3.4.4/otp_src_23.3.4.4.tar.gz"
   sha256 "2d5940762890223ab51e73716ac4f72ed0fd0bad5c3766235b9c47224359682b"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/gambit.rb
+++ b/Formula/gambit.rb
@@ -4,7 +4,7 @@ class Gambit < Formula
   url "https://github.com/gambitproject/gambit/archive/v16.0.1.tar.gz"
   sha256 "56bb86fd17575827919194e275320a5dd498708fd8bb3b20845243d492c10fef"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "45b7d50d9ab796456c5688aabcffa048f39c5d8698e914f2c9d4d308d1f795a9"
@@ -16,9 +16,12 @@ class Gambit < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "wxmac"
+  depends_on "wxmac@3.0"
 
   def install
+    wxmac = Formula["wxmac@3.0"]
+    ENV["WX_CONFIG"] = wxmac.opt_bin/"wx-config-#{wxmac.version.major_minor}"
+
     system "autoreconf", "-fvi"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/homeworlds.rb
+++ b/Formula/homeworlds.rb
@@ -5,6 +5,7 @@ class Homeworlds < Formula
       revision: "917cd7e7e6d0a5cdfcc56cd69b41e3e80b671cde"
   version "20141022"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "4a024da7560148c9d94c347226e325968fd087c09610ee14757c618eaf6d52f1"

--- a/Formula/scummvm-tools.rb
+++ b/Formula/scummvm-tools.rb
@@ -1,9 +1,10 @@
 class ScummvmTools < Formula
   desc "Collection of tools for ScummVM"
   homepage "https://www.scummvm.org/"
-  url "https://www.scummvm.org/frs/scummvm-tools/2.2.0/scummvm-tools-2.2.0.tar.xz"
+  url "https://downloads.scummvm.org/frs/scummvm-tools/2.2.0/scummvm-tools-2.2.0.tar.xz"
   sha256 "1e72aa8f21009c1f7447c755e7f4cf499fe9b8ba3d53db681ea9295666cb48a4"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/scummvm/scummvm-tools.git"
 
   livecheck do
@@ -24,7 +25,7 @@ class ScummvmTools < Formula
   depends_on "libpng"
   depends_on "libvorbis"
   depends_on "mad"
-  depends_on "wxmac"
+  depends_on "wxmac@3.0"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -1,15 +1,14 @@
 class Wxmac < Formula
   desc "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
   homepage "https://www.wxwidgets.org"
-  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5.1/wxWidgets-3.0.5.1.tar.bz2"
-  sha256 "440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807"
+  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.tar.bz2"
+  sha256 "d7b3666de33aa5c10ea41bb9405c40326e1aeb74ee725bb88f90f1d50270a224"
   license "wxWindows"
-  revision 2
   head "https://github.com/wxWidgets/wxWidgets.git"
 
   livecheck do
     url :stable
-    regex(/^v?(\d+\.\d*[02468](?:\.\d+)*)$/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do
@@ -42,8 +41,7 @@ class Wxmac < Formula
       "--enable-std_string",
       "--enable-svg",
       "--enable-unicode",
-      "--enable-webkit",
-      "--enable-webview",
+      "--enable-webviewwebkit",
       "--with-expat",
       "--with-libjpeg",
       "--with-libpng",
@@ -59,6 +57,7 @@ class Wxmac < Formula
       # Set with-macosx-version-min to avoid configure defaulting to 10.5
       args << "--with-macosx-version-min=#{MacOS.version}"
       args << "--with-osx_cocoa"
+      args << "--with-libiconv"
     end
 
     system "./configure", *args
@@ -69,6 +68,10 @@ class Wxmac < Formula
     # using wx-config can find both wxmac and wxpython headers,
     # which are linked to the same place
     inreplace "#{bin}/wx-config", prefix, HOMEBREW_PREFIX
+
+    # Move some files out of the way to prevent conflict with `wxmac-stable`
+    bin.install_symlink "#{bin}/wx-config" => "wx-config-#{version.major_minor}"
+    (share/"wx"/version.major_minor).install share/"aclocal", share/"bakefile"
   end
 
   test do

--- a/Formula/wxmac@3.0.rb
+++ b/Formula/wxmac@3.0.rb
@@ -1,0 +1,89 @@
+class WxmacAT30 < Formula
+  desc "Cross-platform C++ GUI toolkit (wxWidgets for macOS) - Stable Release"
+  homepage "https://www.wxwidgets.org"
+  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5.1/wxWidgets-3.0.5.1.tar.bz2"
+  sha256 "440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807"
+  license "wxWindows"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+\.\d*[02468](?:\.\d+)*)$/i)
+  end
+
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libtiff"
+
+  on_linux do
+    depends_on "pkg-config" => :build
+    depends_on "gtk+"
+    depends_on "libsm"
+    depends_on "mesa-glu"
+  end
+
+  def install
+    args = [
+      "--prefix=#{prefix}",
+      "--enable-clipboard",
+      "--enable-controls",
+      "--enable-dataviewctrl",
+      "--enable-display",
+      "--enable-dnd",
+      "--enable-graphics_ctx",
+      "--enable-std_string",
+      "--enable-svg",
+      "--enable-unicode",
+      "--enable-webkit",
+      "--enable-webview",
+      "--with-expat",
+      "--with-libjpeg",
+      "--with-libpng",
+      "--with-libtiff",
+      "--with-opengl",
+      "--with-zlib",
+      "--disable-precomp-headers",
+      # This is the default option, but be explicit
+      "--disable-monolithic",
+    ]
+
+    on_macos do
+      # Set with-macosx-version-min to avoid configure defaulting to 10.5
+      args << "--with-macosx-version-min=#{MacOS.version}"
+      args << "--with-osx_cocoa"
+      args << "--with-libiconv"
+    end
+
+    system "./configure", *args
+    system "make", "install"
+
+    # wx-config should reference the public prefix, not wxmac's keg
+    # this ensures that Python software trying to locate wxpython headers
+    # using wx-config can find both wxmac and wxpython headers,
+    # which are linked to the same place
+    inreplace "#{bin}/wx-config", prefix, HOMEBREW_PREFIX
+
+    # Move some files out of the way to prevent conflict with `wxmac`
+    bin.install "#{bin}/wx-config" => "wx-config-#{version.major_minor}"
+    (bin/"wxrc").unlink
+    (share/"wx"/version.major_minor).install share/"aclocal", share/"bakefile"
+    Dir.glob(share/"locale/**/*.mo") { |file| add_suffix file, version.major_minor }
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  def caveats
+    <<~EOS
+      To avoid conflicts with the wxmac formula, `wx-config` and `wxrc`
+      have been installed as `wx-config-#{version.major_minor}` and `wxrc-#{version.major_minor}`.
+    EOS
+  end
+
+  test do
+    system bin/"wx-config-#{version.major_minor}", "--libs"
+  end
+end

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -22,5 +22,6 @@
   "pangomm@2.46",
   "pyqt@5",
   "python@3.9",
-  "python-tk@3.9"
+  "python-tk@3.9",
+  "wxmac@3.0"
 ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

### wxmac 3.1.5 970976c467ead53b28e96d0fff223386d650db35

Upstream labels this as a "Development Release", but I believe this is
actually the version we want to package in Homebrew/core. We do the same
for some other formulae (e.g. gnupg).

What upstream mean by "Development Release" is that this is the version
that gets new features. What they call "stable" is probably more
accurately called a long-term support release. [1] Updates to this
branch are bug-fixes only and not new features.

This appears to be the version vendored by `wxpython`, so we should
hopefully be able to use this in place of the bundled one.

[1] The section on the stable release on their downloads page says that
the API for this version has been stable since 11 November 2013.

### wxmac@3.0 3.0.5.1 (new formula) 70af087c201c8aa6f224907d5c68ef8535b21936

This is the long-term support version of wxWidgets. This version is
needed by some formulae that currently depend on `wxmac`.