### PR TITLE
buildpulse-test-reporter 0.15.0 (new formula)

### DIFF
--- a/Formula/buildpulse-test-reporter.rb
+++ b/Formula/buildpulse-test-reporter.rb
@@ -1,0 +1,27 @@
+class BuildpulseTestReporter < Formula
+  desc "Connect your CI to BuildPulse to detect, track, and rank flaky tests"
+  homepage "https://buildpulse.io"
+  url "https://github.com/buildpulse/test-reporter/archive/refs/tags/v0.15.0.tar.gz"
+  sha256 "5119c189341bec12531fa85ac504a3c88b5ca08f090f2ee92d6cef667d66684d"
+  license "MIT"
+  head "https://github.com/buildpulse/test-reporter.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    goldflags = %W[
+      -s -w
+      -X main.Version=#{version}
+      -X main.Commit=#{tap.user}
+    ].join(" ")
+    system "go", "build", *std_go_args(ldflags: goldflags), "./cmd/test-reporter"
+  end
+
+  test do
+    binary = bin/name
+    assert_match version.to_s, shell_output("#{binary} --version")
+
+    fake_dir = "im-not-real"
+    assert_match "Received args: #{fake_dir}", shell_output("#{binary} submit #{fake_dir}", 1)
+  end
+end

--- a/Formula/buildpulse-test-reporter.rb
+++ b/Formula/buildpulse-test-reporter.rb
@@ -18,7 +18,7 @@ class BuildpulseTestReporter < Formula
   end
 
   test do
-    binary = bin/name
+    binary = bin/"buildpulse-test-reporter"
     assert_match version.to_s, shell_output("#{binary} --version")
 
     fake_dir = "im-not-real"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula fails the audit, but we may have need of it in
Homebrew/brew (cf. Homebrew/brew#11578), so I think this will still be
useful to add to homebrew-core.