### PR TITLE
cross-arch tools: install in arch-specific dirs

### DIFF
--- a/Formula/arm-linux-gnueabihf-binutils.rb
+++ b/Formula/arm-linux-gnueabihf-binutils.rb
@@ -5,6 +5,7 @@ class ArmLinuxGnueabihfBinutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.36.1.tar.xz"
   sha256 "e81d9edf373f193af428a0f256674aea62a9d74dfe93f65192d4eae030b0f3b0"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "d88da4f91a77063ddb2a8bdf717c0b0ffdf552111660b1af59448d61ab465fa8"
@@ -21,12 +22,15 @@ class ArmLinuxGnueabihfBinutils < Formula
     # Avoid build failure: https://sourceware.org/bugzilla/show_bug.cgi?id=23424
     ENV.append "CXXFLAGS", "-Wno-c++11-narrowing"
 
+    target = "arm-linux-gnueabihf"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--enable-deterministic-archives",
                           "--prefix=#{prefix}",
+                          "--libdir=#{lib}/#{target}",
+                          "--infodir=#{info}/#{target}",
                           "--disable-werror",
-                          "--target=arm-linux-gnueabihf",
+                          "--target=#{target}",
                           "--enable-gold=yes",
                           "--enable-ld=yes",
                           "--enable-interwork",

--- a/Formula/i686-elf-binutils.rb
+++ b/Formula/i686-elf-binutils.rb
@@ -5,6 +5,7 @@ class I686ElfBinutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.36.1.tar.xz"
   sha256 "e81d9edf373f193af428a0f256674aea62a9d74dfe93f65192d4eae030b0f3b0"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "1250e2e488a22f422b981a5b38602b1269568020c167c491894a7d984a3fbea8"
@@ -14,9 +15,11 @@ class I686ElfBinutils < Formula
   end
 
   def install
-    system "./configure", "--target=i686-elf",
+    target = "i686-elf"
+    system "./configure", "--target=#{target}",
                           "--prefix=#{prefix}",
-                          "--infodir=#{info}/i686-elf-binutils",
+                          "--libdir=#{lib}/#{target}",
+                          "--infodir=#{info}/#{target}",
                           "--disable-nls"
     system "make"
     system "make", "install"

--- a/Formula/i686-elf-gcc.rb
+++ b/Formula/i686-elf-gcc.rb
@@ -5,6 +5,7 @@ class I686ElfGcc < Formula
   mirror "https://ftpmirror.gnu.org/gcc/gcc-11.1.0/gcc-11.1.0.tar.xz"
   sha256 "4c4a6fb8a8396059241c2e674b85b351c26a5d678274007f076957afa1cc9ddf"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
+  revision 1
 
   bottle do
     rebuild 1
@@ -29,10 +30,11 @@ class I686ElfGcc < Formula
   end
 
   def install
+    target = "i686-elf"
     mkdir "i686-elf-gcc-build" do
-      system "../configure", "--target=i686-elf",
+      system "../configure", "--target=#{target}",
                              "--prefix=#{prefix}",
-                             "--infodir=#{info}/i686-elf-gcc",
+                             "--infodir=#{info}/#{target}",
                              "--disable-nls",
                              "--without-isl",
                              "--without-headers",

--- a/Formula/x86_64-elf-binutils.rb
+++ b/Formula/x86_64-elf-binutils.rb
@@ -5,6 +5,7 @@ class X8664ElfBinutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.36.1.tar.xz"
   sha256 "e81d9edf373f193af428a0f256674aea62a9d74dfe93f65192d4eae030b0f3b0"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "a5584ba07f4f488096061f8f11c5d2fad72b87f42526aae902ba24b2dded7e13"
@@ -16,9 +17,11 @@ class X8664ElfBinutils < Formula
   uses_from_macos "texinfo"
 
   def install
-    system "./configure", "--target=x86_64-elf",
+    target = "x86_64-elf"
+    system "./configure", "--target=#{target}",
                           "--prefix=#{prefix}",
-                          "--infodir=#{info}/x86_64-elf-binutils",
+                          "--libdir=#{lib}/#{target}",
+                          "--infodir=#{info}/#{target}",
                           "--disable-nls"
     system "make"
     system "make", "install"

--- a/Formula/x86_64-elf-gcc.rb
+++ b/Formula/x86_64-elf-gcc.rb
@@ -5,6 +5,7 @@ class X8664ElfGcc < Formula
   mirror "https://ftpmirror.gnu.org/gcc/gcc-11.1.0/gcc-11.1.0.tar.xz"
   sha256 "4c4a6fb8a8396059241c2e674b85b351c26a5d678274007f076957afa1cc9ddf"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
+  revision 1
 
   bottle do
     rebuild 1
@@ -29,10 +30,11 @@ class X8664ElfGcc < Formula
   end
 
   def install
+    target = "x86_64-elf"
     mkdir "x86_64-elf-gcc-build" do
-      system "../configure", "--target=x86_64-elf",
+      system "../configure", "--target=#{target}",
                              "--prefix=#{prefix}",
-                             "--infodir=#{info}/x86_64-elf-gcc",
+                             "--infodir=#{info}/#{target}",
                              "--disable-nls",
                              "--without-isl",
                              "--without-headers",

--- a/Formula/x86_64-elf-gdb.rb
+++ b/Formula/x86_64-elf-gdb.rb
@@ -5,6 +5,7 @@ class X8664ElfGdb < Formula
   mirror "https://ftpmirror.gnu.org/gdb/gdb-10.2.tar.xz"
   sha256 "aaa1223d534c9b700a8bec952d9748ee1977513f178727e1bee520ee000b4f29"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://sourceware.org/git/binutils-gdb.git"
 
   bottle do
@@ -29,10 +30,14 @@ class X8664ElfGdb < Formula
   end
 
   def install
+    target = "x86_64-elf"
     args = %W[
-      --target=x86_64-elf
+      --target=#{target}
       --prefix=#{prefix}
-      --datarootdir=#{share}/x86_64-elf-gdb
+      --datarootdir=#{share}/#{target}
+      --includedir=#{include}/#{target}
+      --infodir=#{info}/#{target}
+      --mandir=#{man}
       --disable-debug
       --disable-dependency-tracking
       --with-lzma
@@ -47,8 +52,6 @@ class X8664ElfGdb < Formula
 
       system "make", "install-gdb"
     end
-
-    mv include/"gdb", include/"x86_64-elf-gdb"
   end
 
   test do


### PR DESCRIPTION
Ensures no `binutils` instance clashes with any other, even with the main `binutils` (even though it's keg-only, knowledgable users may need to `brew link` it for reasons). Primary issue:
```
Error: The `brew link` step did not complete successfully
/usr/local/lib/bfd-plugins/libdep.so -> /usr/local/Cellar/i686-elf-binutils/2.36.1/lib/bfd-plugins/libdep.so
```
This PR creates the following build product/symlink instead:
```
/usr/local/lib/i686-elf/bfd-plugins/libdep.so -> /usr/local/Cellar/i686-elf-binutils/2.36.1/lib/i686-elf/bfd-plugins/libdep.so
```

Addresses https://github.com/Homebrew/homebrew-core/issues/78849#issuecomment-856387840 and #79624.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
