### PR TITLE
newlisp: add livecheck

### DIFF
--- a/Formula/newlisp.rb
+++ b/Formula/newlisp.rb
@@ -4,6 +4,11 @@ class Newlisp < Formula
   url "http://www.newlisp.org/downloads/newlisp-10.7.5.tgz"
   sha256 "dc2d0ff651c2b275bc4af3af8ba59851a6fb6e1eaddc20ae75fb60b1e90126ec"
 
+  livecheck do
+    url "http://www.newlisp.org/index.cgi?Downloads"
+    regex(/href=.*?newlisp[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "24b3c02002fa7c832d9a817c552b19bd520ae06f82ab526b8e993ae0a3d77d99"
     sha256 big_sur:       "509f6892a0eabf53cebe424f2f2163ded090b7942e8fe8e43047f43781b0535e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `newlisp`. This PR adds a `livecheck` block that checks the first-party downloads page, which links to the `stable` archive.