### PR TITLE
pypi_formula_mappings: add wxpython

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -204,6 +204,9 @@
   "twarc": {
     "exclude_packages": ["six"]
   },
+  "wxpython": {
+    "exclude_packages": ["numpy", "pillow", "six"]
+  },
   "xdot": {
     "extra_packages": ["graphviz"]
   },


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`wxpython` will depend on the `six` and `pillow` formulae, so let's
exclude them from `update-python-resources`.

See #79759.