### PR TITLE
morse: add livecheck

### DIFF
--- a/Formula/morse.rb
+++ b/Formula/morse.rb
@@ -6,6 +6,11 @@ class Morse < Formula
   license "BSD-2-Clause"
   revision 2
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?morse[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "cb06d8049d00c1b52a2c6538ea10918a7623541df2304c1f9c154e042fde868d"
     sha256 cellar: :any, big_sur:       "a956bb32257136228025435a70344d3322b621be1c932e1f61be3fbc1db3b000"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `more`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.