### PR TITLE
debianutils: fix exponential backtracking in livecheck regex

### DIFF
--- a/Formula/debianutils.rb
+++ b/Formula/debianutils.rb
@@ -7,7 +7,7 @@ class Debianutils < Formula
 
   livecheck do
     url "https://packages.qa.debian.org/d/debianutils.html"
-    regex(/href=.*?debianutils[._-]v?(\d+(?:.\d+)+).dsc/i)
+    regex(/href=.*?debianutils[._-]v?(\d+(?:\.\d+)+).dsc/i)
   end
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

If the URL were to start serving up HTML with certain strings, the regex could take a very long time to match:

```
irb(main):001:0> measure
TIME is added.
=> nil
irb(main):002:0> /href=.*?debianutils[._-]v?(\d+(?:.\d+)+).dsc/i =~ 'href="...debianutils_00000000000000000000000000000000000000"'
processing time: 3.912238s
=> nil
irb(main):003:0> /href=.*?debianutils[._-]v?(\d+(?:.\d+)+).dsc/i =~ 'href="...debianutils_0000000000000000000000000000000000000000000"'
processing time: 39.323560s
=> nil
irb(main):004:0> /href=.*?debianutils[._-]v?(\d+(?:.\d+)+).dsc/i =~ 'href="...debianutils_000000000000000000000000000000000000000000000"'
processing time: 99.694848s
=> nil
```

With a string containing hundreds of zeroes, it could take years to test against the regex.

What happens is that each `0` could match either `.` or `\d+`, so the regex engine tries one of them. When the end of the string doesn't match the regex, the engine backtracks and tries each other possible option. The number of steps it tries is exponential in the length of the string.

My fix here replaces `.` with `\.` to match only a dot character. I believe this was the original intention: it still matches every string matched by the old regex for the HTML currently served at that URL, and matches the [example given in the Homebrew documentation](https://docs.brew.sh/Brew-Livecheck#regex-guidelines).

With this, the regex test finishes almost instantly, even with many more zeroes:

```
irb(main):005:0> /href=.*?debianutils[._-]v?(\d+(?:\.\d+)+).dsc/i =~ 'href="...debianutils_00000000000000000000000000000000000000000000000000000000000000000"'
processing time: 0.000048s
```