### PR TITLE
makeicns: use Macports mirror

### DIFF
--- a/Formula/makeicns.rb
+++ b/Formula/makeicns.rb
@@ -3,6 +3,7 @@ class Makeicns < Formula
   homepage "http://www.amnoid.de/icns/makeicns.html"
   url "https://distfiles.macports.org/makeicns/makeicns-1.4.10a.tar.bz2"
   sha256 "10e44b8d84cb33ed8d92b9c2cfa42f46514586d2ec11ae9832683b69996ddeb8"
+  license "MIT"
 
   bottle do
     sha256 cellar: :any_skip_relocation, catalina:    "c2a5afff3eee709316951ad70c8244fe5c628ae98fdb2e15ea607c7638733d63"

--- a/Formula/makeicns.rb
+++ b/Formula/makeicns.rb
@@ -1,9 +1,8 @@
 class Makeicns < Formula
   desc "Create icns files from the command-line"
-  homepage "https://bitbucket.org/mkae/makeicns"
-  url "https://bitbucket.org/mkae/makeicns/downloads/makeicns-1.4.10a.tar.bz2"
+  homepage "http://www.amnoid.de/icns/makeicns.html"
+  url "https://distfiles.macports.org/makeicns/makeicns-1.4.10a.tar.bz2"
   sha256 "10e44b8d84cb33ed8d92b9c2cfa42f46514586d2ec11ae9832683b69996ddeb8"
-  head "https://bitbucket.org/mkae/makeicns", using: :hg
 
   bottle do
     sha256 cellar: :any_skip_relocation, catalina:    "c2a5afff3eee709316951ad70c8244fe5c628ae98fdb2e15ea607c7638733d63"
@@ -13,8 +12,6 @@ class Makeicns < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:  "96f91bccf728f040931c2816156a7c5de739ae91e63191795cd108d0a46370ac"
     sha256 cellar: :any_skip_relocation, yosemite:    "40c3d4befe2d4625d7013ea40f307b4f5b26e122a6dad51706a25bb22734f075"
   end
-
-  disable! date: "2020-12-08", because: :repo_removed
 
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/e59da9d/makeicns/patch-IconFamily.m.diff"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This restores the `makeicns` build by using Macports's distfiles copy of the release tarball.