### PR TITLE
couchpotatoserver: remove `bottle :unneeded` and use service

### DIFF
--- a/Formula/couchpotatoserver.rb
+++ b/Formula/couchpotatoserver.rb
@@ -6,41 +6,14 @@ class Couchpotatoserver < Formula
   license "GPL-3.0"
   head "https://github.com/CouchPotato/CouchPotatoServer.git"
 
-  bottle :unneeded
-
   def install
     prefix.install_metafiles
     libexec.install Dir["*"]
     (bin+"couchpotatoserver").write(startup_script)
   end
 
-  def caveats
-    "CouchPotatoServer defaults to port 5050."
-  end
-
-  plist_options manual: "couchpotatoserver"
-
-  def plist
-    <<~EOS
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/couchpotatoserver</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>--quiet</string>
-            <string>--daemon</string>
-          </array>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>UserName</key>
-          <string>#{`whoami`.chomp}</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"couchpotatoserver", "--quiet"]
   end
 
   def startup_script


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Extracted from #79995 to independently check on audit failure.