### PR TITLE
vmdktool: add livecheck

### DIFF
--- a/Formula/vmdktool.rb
+++ b/Formula/vmdktool.rb
@@ -4,6 +4,11 @@ class Vmdktool < Formula
   url "https://people.freebsd.org/~brian/vmdktool/vmdktool-1.4.tar.gz"
   sha256 "981eb43d3db172144f2344886040424ef525e15c85f84023a7502b238aa7b89c"
 
+  livecheck do
+    url "https://people.freebsd.org/~brian/vmdktool/"
+    regex(/href=.*?vmdktool[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "2a19ea885fcf69d6929cb155489aab52543b1b1f456eedf9f49f3f6eebf51ec9"
     sha256 cellar: :any_skip_relocation, big_sur:       "9f3f1adccbe9d28c54b0009c00866636ab7872914ff6587ccf206f15cb08ac68"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `vmdktool`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found (as there isn't a first-party site for this formula).