### PR TITLE
ntl: add license

### DIFF
--- a/Formula/ntl.rb
+++ b/Formula/ntl.rb
@@ -3,6 +3,7 @@ class Ntl < Formula
   homepage "https://libntl.org"
   url "https://libntl.org/ntl-11.5.1.tar.gz"
   sha256 "210d06c31306cbc6eaf6814453c56c776d9d8e8df36d74eb306f6a523d1c6a8a"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url "https://libntl.org/download.html"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

license change ref
<p><hr><p>
<h3>
2016.10.08: Changes between NTL 9.11.0 and 10.0.0
</h3>

<ul>
<li> <b>New License: LGPLv2.1+</b>

<ul>
<li>
With the permission of all relevant contributors,
NTL is now licensed under 
LGPLv2.1+ (the Lesser GNU Public License version 2.1 or later).

<li>
Previously, NTL was licensed under the GPL.
This new, less restrictive licensing should hopefully increase the 
impact of NTL.
</ul>