### PR TITLE
qscintilla2: add head build and update livecheck

### DIFF
--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -4,10 +4,11 @@ class Qscintilla2 < Formula
   url "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.1/QScintilla_src-2.12.1.tar.gz"
   sha256 "a7331c44b5d7320cbf58cb2382c38857e9e9f4fa52c405bd7776c8b6649836c2"
   license "GPL-3.0-only"
+  head "https://github.com/opencor/qscintilla.git"
 
   livecheck do
-    url "https://www.riverbankcomputing.com/software/qscintilla/download"
-    regex(/href=.*?QScintilla(?:[._-](?:gpl|src))?[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
It looks like use the website to do the livecheck would capture the pre-release as wrong result. Hence, updating to use github releases to do the livecheck. 

I also added the head build for the formula as well.

---

relates to #80101 