### PR TITLE
autoenv: patch and bottle

### DIFF
--- a/Formula/autoenv.rb
+++ b/Formula/autoenv.rb
@@ -6,7 +6,7 @@ class Autoenv < Formula
   license "MIT"
   head "https://github.com/kennethreitz/autoenv.git"
 
-  bottle :unneeded
+  patch :DATA
 
   def install
     prefix.install "activate.sh"
@@ -25,3 +25,17 @@ class Autoenv < Formula
     assert_match "it works", shell_output(testcmd)
   end
 end
+
+__END__
+diff --git a/activate.sh b/activate.sh
+index 05e908c..091e915 100755
+--- a/activate.sh
++++ b/activate.sh
+@@ -28,6 +28,7 @@ ${_file}"
+ 				fi
+ 			fi
+ 			[ "$(pwd -P)" = "${_mountpoint}" ] && break
++			[ "$(pwd -P)" = "/" ] && break
+ 			command -v chdir >/dev/null 2>&1 && \chdir "$(pwd -P)/.." || builtin cd "$(pwd -P)/.."
+ 		done
+ 	`"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Split from #79993 to handle separately.

Patch is based on upstream pull request (https://github.com/inishchith/autoenv/pull/190) linked to by @cho-m in https://github.com/Homebrew/homebrew-core/pull/79993#issuecomment-868826540, it didn't apply cleanly so I've inlined it with necessary changes.

The test passes for me locally with these changes.