### PR TITLE
iphotoexport: remove `bottle :unneeded`  and deprecate

### DIFF
--- a/Formula/iphotoexport.rb
+++ b/Formula/iphotoexport.rb
@@ -4,17 +4,18 @@ class Iphotoexport < Formula
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/iphotoexport/iphotoexport-1.6.4.zip"
   sha256 "85644b5be1541580a35f1ea6144d832267f1284ac3ca23fe9bcd9eda5aaea5d3"
 
-  bottle :unneeded
+  # Replaced by Phoshare app, which was discontinued on 2012-10-10.
+  # The current version (1.6.4) is from 2010-05-15.
+  deprecate! date: "2021-06-27", because: :deprecated_upstream
 
   depends_on "exiftool"
 
   def install
-    unzip_dir = "#{name}-#{version}"
     # Change hardcoded exiftool path
-    inreplace "#{unzip_dir}/tilutil/exiftool.py", "/usr/bin/exiftool", "exiftool"
+    inreplace "tilutil/exiftool.py", "/usr/bin/exiftool", "exiftool"
 
-    prefix.install Dir["#{unzip_dir}/*"]
-    bin.install_symlink prefix+"iphotoexport.py" => "iphotoexport"
+    prefix.install Dir["*"]
+    bin.install_symlink prefix/"iphotoexport.py" => "iphotoexport"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Extracted from #79998