### PR TITLE
lean, mathlibtools: fix tests for large CI jobs

### DIFF
--- a/Formula/lean.rb
+++ b/Formula/lean.rb
@@ -36,6 +36,12 @@ class Lean < Formula
   end
 
   test do
+    # A bug in test-bot unlinks `coreutils` in PRs that test
+    # a large number of formulae without re-linking it for this
+    # one, causing a failure. As a temporary fix, make sure
+    # `coreutils` can always be found in PATH.
+    ENV.prepend_path "PATH", Formula["coreutils"].opt_bin
+
     (testpath/"hello.lean").write <<~EOS
       def id' {α : Type} (x : α) : α := x
 

--- a/Formula/mathlibtools.rb
+++ b/Formula/mathlibtools.rb
@@ -138,6 +138,12 @@ class Mathlibtools < Formula
   end
 
   test do
+    # A bug in test-bot unlinks `coreutils` in PRs that test
+    # a large number of formulae without re-linking it for this
+    # one, causing a failure. As a temporary fix, make sure
+    # `coreutils` can always be found in PATH.
+    ENV.prepend_path "PATH", Formula["coreutils"].opt_bin
+
     system bin/"leanproject", "new", "my_project"
     project_toml = testpath/"my_project/leanpkg.toml"
     assert_predicate project_toml, :exist?, "leanpkg.toml should have been created"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A bug in test-bot unlinks `coreutils` in PRs that test a large number of
formulae without re-linking it before testing `lean` or `mathlibtools`. 
This causes a test failure. [1]

As a temporary fix, let's make sure `coreutils` can always be found in
`PATH` for the appropriate tests.

[1] In #80052, for example:
https://github.com/Homebrew/homebrew-core/pull/80052/checks?check_run_id=2919543779#step:8:4093
https://github.com/Homebrew/homebrew-core/pull/80052/checks?check_run_id=2919543779#step:8:6465

Also occurred in #79624 and #79585.

------

This is, admittedly, not a proper fix. However, a proper fix takes work that I'm not able to put in at the moment, and this bug has existed for a while. Homebrew/homebrew-test-bot#544.
