### PR TITLE
scummvm-tools: fix linkage with `wxmac@3.0`

### DIFF
--- a/Formula/scummvm-tools.rb
+++ b/Formula/scummvm-tools.rb
@@ -4,7 +4,7 @@ class ScummvmTools < Formula
   url "https://downloads.scummvm.org/frs/scummvm-tools/2.2.0/scummvm-tools-2.2.0.tar.xz"
   sha256 "1e72aa8f21009c1f7447c755e7f4cf499fe9b8ba3d53db681ea9295666cb48a4"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/scummvm/scummvm-tools.git"
 
   livecheck do
@@ -27,7 +27,19 @@ class ScummvmTools < Formula
   depends_on "wxmac@3.0"
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    # configure will happily carry on even if it can't find wxmac,
+    # so let's make sure the install method keeps working even when
+    # the wxmac dependency version changes
+    wxmac = deps.find { |dep| dep.name.match?(/^wxmac(@\d+(\.\d+)?)?$/) }
+                .to_formula
+
+    # The configure script needs a little help finding our wx-config
+    wxconfig = "wx-config-#{wxmac.version.major_minor}"
+    inreplace "configure", /^_wxconfig=wx-config$/, "_wxconfig=#{wxconfig}"
+
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-debug",
+                          "--enable-verbose-build"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing bottle reports no linkage with `wxmac@3.0`. This is because
its `configure` script isn't able to find our versioned `wx-config-3.0`,
and assumes that wxWidgets is not available.

This is a regression that was introduced in #79798, so let's fix that
up.