### PR TITLE
qscintilla2: update livecheck

### DIFF
--- a/Formula/qscintilla2.rb
+++ b/Formula/qscintilla2.rb
@@ -5,9 +5,14 @@ class Qscintilla2 < Formula
   sha256 "a7331c44b5d7320cbf58cb2382c38857e9e9f4fa52c405bd7776c8b6649836c2"
   license "GPL-3.0-only"
 
+  # The downloads page also lists pre-release versions, which use the same file
+  # name format as stable versions. The only difference is that files for
+  # stable versions are kept in corresponding version subdirectories and
+  # pre-release files are in the parent QScintilla directory. The regex below
+  # omits pre-release versions by only matching tarballs in a version directory.
   livecheck do
     url "https://www.riverbankcomputing.com/software/qscintilla/download"
-    regex(/href=.*?QScintilla(?:[._-](?:gpl|src))?[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=.*?QScintilla/v?\d+(?:\.\d+)+/QScintilla(?:[._-](?:gpl|src))?[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `qscintilla2` checks the first-party [Download page](https://www.riverbankcomputing.com/software/qscintilla/download) and matches versions from tarball filenames like `QScintilla_src-2.12.1.tar.gz`.

However, livecheck is currently reporting a pre-release version, `2.13.0`, as newest (see #80101). This is because the filename format for pre-release versions is the same as stable versions (e.g., `QScintilla_src-2.13.0.tar.gz`). The only difference is that stable versions are found in a corresponding version directory (e.g., `/static/Downloads/QScintilla/2.12.1/QScintilla_src-2.12.1.tar.gz`) and pre-release versions are kept in the parent directory (e.g., `/static/Downloads/QScintilla/QScintilla_src-2.13.0.tar.gz`).

With that in mind, this PR updates the `livecheck` block regex to only match versions from tarball filenames that are found in a version directory. This omits the `2.13.0` prerelease version and livecheck correctly gives `2.12.1` as the newest stable version.