### PR TITLE
growly: disable due to removed dependency

### DIFF
--- a/Formula/growly.rb
+++ b/Formula/growly.rb
@@ -7,6 +7,8 @@ class Growly < Formula
 
   bottle :unneeded
 
+  disable! date: "2021-06-27", because: "depends on growlnotify which has been removed"
+
   def install
     bin.install "growly"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See: https://github.com/Homebrew/homebrew-core/pull/79997#issuecomment-869077499

Currently, `brew test growly` fails due to missing `growlnotify`:
```console
❯ brew test growly
==> Testing growly
==> /usr/local/Cellar/growly/0.2.0/bin/growly echo Hello, world!
Last 15 lines from /Users/cho-m/Library/Logs/Homebrew/growly/test.01.growly:
2021-06-27 10:05:49 -0700

/usr/local/Cellar/growly/0.2.0/bin/growly
echo Hello, world!

/usr/local/Cellar/growly/0.2.0/bin/growly: line 64: growlnotify: command not found
Error: growly: failed
An exception occurred within a child process:
  BuildError: Failed executing: /usr/local/Cellar/growly/0.2.0/bin/growly echo\ Hello,\ world!
/usr/local/Homebrew/Library/Homebrew/formula.rb:2218:in `block in system'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2154:in `open'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2154:in `system'
```

`growlnotify` was removed from Homebrew back in 2011: Homebrew/legacy-homebrew#8316

---

Also, project is unmaintained with last commit in 2013.

Growl itself is a retired project: https://growl.github.io/growl/