### PR TITLE
growly: remove `bottle :unneeded`

### DIFF
--- a/Formula/growly.rb
+++ b/Formula/growly.rb
@@ -5,8 +5,6 @@ class Growly < Formula
   sha256 "3e803207aa15e3a1ee33fc388a073bd84230dce2c579295ce26b857987e78a79"
   head "https://github.com/ryankee/growly.git"
 
-  bottle :unneeded
-
   disable! date: "2021-06-27", because: "depends on growlnotify which has been removed"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Didn't realize we were also removing `bottle :unneeded` from disabled formulae.

I should have done it in #80146, but for now using separate PR as follow-up.

Not sure if this is a syntax-only change or if actual bottles are built, so will let CI run with force-arm in case.