### PR TITLE
pipx: add shell completions

### DIFF
--- a/Formula/pipx.rb
+++ b/Formula/pipx.rb
@@ -61,6 +61,13 @@ class Pipx < Formula
     (bin/"pipx").write_env_script(libexec/"bin/pipx", PYTHONPATH: ENV["PYTHONPATH"])
     (bin/"register-python-argcomplete").write_env_script(libexec/"bin/register-python-argcomplete",
       PYTHONPATH: ENV["PYTHONPATH"])
+
+    # Install shell completions
+    output = Utils.safe_popen_read(libexec/"bin/register-python-argcomplete", "--shell=bash", "pipx")
+    (bash_completion/"pipx").write output
+
+    output = Utils.safe_popen_read(libexec/"bin/register-python-argcomplete", "--shell=fish", "pipx")
+    (fish_completion/"pipx.fish").write output
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Related to https://github.com/pypa/pipx/issues/330

Note, the `zsh` completions involve a manual step that I added as a caveat, although I'm not sure if that's appropriate (without it, any completion will error with `_pipx:47: command not found: complete`)