### PR TITLE
couchpotatoserver: remove bottle deviations, fix relocatability

### DIFF
--- a/Formula/couchpotatoserver.rb
+++ b/Formula/couchpotatoserver.rb
@@ -15,6 +15,13 @@ class Couchpotatoserver < Formula
 
   def install
     prefix.install_metafiles
+    inreplace_files = %w[
+      couchpotato/core/helpers/variable.py
+      init/freebsd
+      init/synology
+    ]
+    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
+    rm_f "libs/unrar2/unrar" # bundled i386 executable, breaks relocatability
     libexec.install Dir["*"]
     (bin+"couchpotatoserver").write(startup_script)
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The bottle bundles a MachO i386 executable `unrar`. No system we support
can run this, so let's get rid of it. Removing it also makes the Intel
bottles relocatable.