### PR TITLE
q: add section identifier to manpage contents

### DIFF
--- a/Formula/q.rb
+++ b/Formula/q.rb
@@ -6,7 +6,7 @@ class Q < Formula
   url "https://github.com/harelba/q/archive/2.0.19.tar.gz"
   sha256 "cd4c60923bc40f53d974b54849f76096bf9901407c618cd0a3ccbc322aacc97d"
   license "GPL-3.0-or-later"
-  revision 2
+  revision 3
   head "https://github.com/harelba/q.git"
 
   bottle do
@@ -25,8 +25,8 @@ class Q < Formula
     # broken symlink, fixed in next version
     rm_f "bin/qtextasdata.py"
     virtualenv_install_with_resources
-    system "ronn", "doc/USAGE.markdown"
-    man1.install "doc/USAGE" => "q.1"
+    system "ronn", "--roff", "--section=1", "doc/USAGE.markdown"
+    man1.install "doc/USAGE.1" => "q.1"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Previously manpage was rendered as `Q()` instead of `Q(1)`.