### PR TITLE
raylib: fix build to install static and shared libraries

### DIFF
--- a/Formula/raylib.rb
+++ b/Formula/raylib.rb
@@ -26,13 +26,20 @@ class Raylib < Formula
   end
 
   def install
-    system "cmake", ".", "-DSTATIC_RAYLIB=ON",
-                         "-DSHARED_RAYLIB=ON",
+    system "cmake", ".", "-DBUILD_SHARED_LIBS=ON",
                          "-DMACOS_FATLIB=OFF",
                          "-DBUILD_EXAMPLES=OFF",
                          "-DBUILD_GAMES=OFF",
                          *std_cmake_args
     system "make", "install"
+    system "make", "clean"
+    system "cmake", ".", "-DBUILD_SHARED_LIBS=OFF",
+                         "-DMACOS_FATLIB=OFF",
+                         "-DBUILD_EXAMPLES=OFF",
+                         "-DBUILD_GAMES=OFF",
+                         *std_cmake_args
+    system "make"
+    lib.install "raylib/libraylib.a"
   end
 
   test do


### PR DESCRIPTION
As of raylib 3.7.0, brew no longer installs the shared object library (`libraylib.dylib` on MacOS) breaking all `ffi` implementations that using it.

Here's a summary of why:

- Raylib compiles a STATIC object by default, it is no longer possible to flag it
- Raylib updated the SHARED object flag to BUILD_SHARED_LIBS
- Users must now choose between static or shared compilation

See this commit for context: https://github.com/raysan5/raylib/commit/05dfbf3cd42e63f56d978cafec63f22fd7538e9f#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4

--- 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
