### PR TITLE
redis: stop specifying daemon status in service

### DIFF
--- a/Formula/redis.rb
+++ b/Formula/redis.rb
@@ -37,7 +37,7 @@ class Redis < Formula
   end
 
   service do
-    run [opt_bin/"redis-server", etc/"redis.conf", "--deamonize no"]
+    run [opt_bin/"redis-server", etc/"redis.conf"]
     keep_alive true
     error_log_path var/"log/redis.log"
     log_path var/"log/redis.log"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fixes an issue with the redis service.