### PR TITLE
ncurses: avoid linkage against terminfo dirs.

### DIFF
--- a/Formula/ncurses.rb
+++ b/Formula/ncurses.rb
@@ -23,15 +23,21 @@ class Ncurses < Formula
   end
 
   def install
-    system "./configure", "--prefix=#{prefix}",
-                          "--enable-pc-files",
-                          "--with-pkg-config-libdir=#{lib}/pkgconfig",
-                          "--enable-sigwinch",
-                          "--enable-symlinks",
-                          "--enable-widec",
-                          "--with-shared",
-                          "--with-gpm=no",
-                          "--without-ada"
+    args = [
+      "--prefix=#{prefix}",
+      "--enable-pc-files",
+      "--with-pkg-config-libdir=#{lib}/pkgconfig",
+      "--enable-sigwinch",
+      "--enable-symlinks",
+      "--enable-widec",
+      "--with-shared",
+      "--with-gpm=no",
+      "--without-ada",
+    ]
+    on_linux do
+      args << "--with-terminfo-dirs=#{share}/terminfo:/etc/terminfo:/lib/terminfo:/usr/share/terminfo"
+    end
+    system "./configure", *args
     system "make", "install"
     make_libncurses_symlinks
 


### PR DESCRIPTION
Fixes (on Linux):
2021-06-29T18:04:03.7021571Z [34m==>[0m [1mDetecting if ncurses--6.2.x86_64_linux.bottle.tar.gz is relocatable...[0m
2021-06-29T18:04:03.7024568Z [33mWarning:[0m String '/home/linuxbrew/.linuxbrew/Homebrew' still exists in these files:
2021-06-29T18:04:03.7026932Z [31m/home/linuxbrew/.linuxbrew/Cellar/ncurses/6.2/lib/libncursesw_g.a[0m
2021-06-29T18:04:03.7029684Z  [1m-->[0m match '/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/current/share/terminfo' at offset [1m0xb52a6[0m
2021-06-29T18:04:03.7032940Z [31m/home/linuxbrew/.linuxbrew/Cellar/ncurses/6.2/lib/libncursesw.so.6.2[0m
2021-06-29T18:04:03.7035795Z  [1m-->[0m match '/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/current/share/terminfo' at offset [1m0x5bd08[0m
2021-06-29T18:04:03.7039060Z [31mError:[0m Bottle contains non-relocatable reference to /home/linuxbrew/.linuxbrew/Homebrew!
2021-06-29T18:04:03.7042352Z [31m/home/linuxbrew/.linuxbrew/Cellar/ncurses/6.2/lib/libncursesw.a[0m
2021-06-29T18:04:03.7046498Z  [1m-->[0m match '/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/current/share/terminfo' at offset [1m0x84d26[0m

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
