### PR TITLE
telegram-cli: Add Apple Silicon support by supporting the --sysconfdi…

### DIFF
--- a/Formula/telegram-cli.rb
+++ b/Formula/telegram-cli.rb
@@ -16,6 +16,10 @@ class TelegramCli < Formula
     sha256 high_sierra: "410b56cc04620c7a1f495b500b41fa61339cc68444c1c65939bb4fb0c4cc96ef"
   end
 
+  # "This project is deprecated and is no longer being maintained.
+  # Last commit was in 2016
+  deprecate! date: "2021-06-30", because: :unmaintained
+
   depends_on "pkg-config" => :build
   depends_on "jansson"
   depends_on "libconfig"
@@ -38,6 +42,15 @@ class TelegramCli < Formula
     sha256 "eb6243e1861c0b1595e8bdee705d1acdd2678e854f0919699d4b26c159e30b5e"
   end
 
+  # Patch to make telegram-cli use sysconfdir for Apple Silicon support
+  # This patch does not apply cleanly to 1.3.1, but applies cleanly to head.
+  # using inline patch for the tag this is checking out.
+  # patch do
+  #   url "https://github.com/vysheng/tg/commit/63b85c3ca1b335daf783d6e9ae80c076e7406e39.patch?full_index=1"
+  #   sha256 "cbc37bd03b7456a43dbedeb5c8dd17294e016d8e8bb36f236f42f74bde4d7a71"
+  # end
+  patch :DATA
+
   def install
     args = %W[
       --prefix=#{prefix}
@@ -45,6 +58,7 @@ class TelegramCli < Formula
       CPPFLAGS=-I#{Formula["readline"].include}
       LDFLAGS=-L#{Formula["readline"].lib}
       --disable-liblua
+      --sysconfdir=#{etc}
     ]
 
     system "./configure", *args
@@ -58,3 +72,40 @@ class TelegramCli < Formula
     assert_match "messages_allocated", shell_output("echo stats | #{bin}/telegram")
   end
 end
+__END__
+diff --git a/Makefile.in b/Makefile.in
+index e1989ab..78d84d0 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -2,7 +2,7 @@ srcdir=@srcdir@
+
+ CFLAGS=@CFLAGS@
+ LDFLAGS=@LDFLAGS@ @OPENSSL_LDFLAGS@
+-CPPFLAGS=@CPPFLAGS@ @OPENSSL_INCLUDES@
++CPPFLAGS=@CPPFLAGS@ @OPENSSL_INCLUDES@  -DSYSCONFDIR='"@sysconfdir@"'
+ DEFS=@DEFS@
+ COMPILE_FLAGS=${CFLAGS} ${CPFLAGS} ${CPPFLAGS} ${DEFS} -Wall -Wextra -Werror -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter -fPIC
+
+diff --git a/main.c b/main.c
+index 9498b0b..ba97e36 100644
+--- a/main.c
++++ b/main.c
+@@ -927,8 +927,16 @@ int main (int argc, char **argv) {
+   running_for_first_time ();
+   parse_config ();
+
+-  #if defined(__FreeBSD__) || (defined(__APPLE__) && defined(__MACH__))
+-  tgl_set_rsa_key (TLS, "/usr/local/etc/" PROG_NAME "/server.pub");
++  #if defined(__FreeBSD__)
++  /* at the time of adding --sysconfdir to configure I do not know if FreeBSD has it set to /usr/local/etc */
++  #undef SYSCONFDIR
++  #define SYSCONFDIR "/usr/local/etc"
++  #endif
++
++  #if defined(SYSCONFDIR)
++  /* if --sysconfdir was provided to configure use it, not touching FreeBSD as I'm not sure if
++     the default is correct there */
++  tgl_set_rsa_key (TLS, SYSCONFDIR "/" PROG_NAME "/server.pub");
+   #else
+   tgl_set_rsa_key (TLS, "/etc/" PROG_NAME "/server.pub");
+   #endif


### PR DESCRIPTION
…r option of configure

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This one is a little odd:

The upstream fix is here:
https://github.com/vysheng/tg/pull/1714

However, it doesn't apply cleanly, so attached one in the data section.

I need to look again, as I think there is a way to do this when building against HEAD, I'll have to look at other formula and come back



