### PR TITLE
jabba: openjdk@14 doesn't exist for Apple Silicon in the upstream jab…

### DIFF
--- a/Formula/jabba.rb
+++ b/Formula/jabba.rb
@@ -32,10 +32,14 @@ class Jabba < Formula
   end
 
   test do
+    jdk_version = "zulu@1.16.0-0"
+    version_check ='openjdk version "16'
+
     ENV["JABBA_HOME"] = testpath/"jabba_home"
-    system bin/"jabba", "install", "openjdk@1.14.0"
-    jdk_path = shell_output("#{bin}/jabba which openjdk@1.14.0").strip
-    assert_match 'openjdk version "14',
+
+    system bin/"jabba", "install", jdk_version
+    jdk_path = shell_output("#{bin}/jabba which #{jdk_version}").strip
+    assert_match version_check,
                  shell_output("#{jdk_path}/Contents/Home/bin/java -version 2>&1")
   end
 end


### PR DESCRIPTION
…ba repo, so use zulu@16 instead when on arm

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
