### PR TITLE
Update livecheck for sqlite-related formulae

### DIFF
--- a/Formula/dbhash.rb
+++ b/Formula/dbhash.rb
@@ -7,8 +7,11 @@ class Dbhash < Formula
   license "blessing"
 
   livecheck do
-    url "https://sqlite.org/news.html"
-    regex(%r{v?(\d+(?:\.\d+)+)</h3>}i)
+    url "https://sqlite.org/index.html"
+    regex(%r{href=.*?releaselog/v?(\d+(?:[._]\d+)+)\.html}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match&.first&.gsub("_", ".") }
+    end
   end
 
   bottle do

--- a/Formula/lemon.rb
+++ b/Formula/lemon.rb
@@ -7,8 +7,11 @@ class Lemon < Formula
   license "blessing"
 
   livecheck do
-    url "https://sqlite.org/news.html"
-    regex(%r{v?(\d+(?:\.\d+)+)</h3>}i)
+    url "https://sqlite.org/index.html"
+    regex(%r{href=.*?releaselog/v?(\d+(?:[._]\d+)+)\.html}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match&.first&.gsub("_", ".") }
+    end
   end
 
   bottle do

--- a/Formula/sqldiff.rb
+++ b/Formula/sqldiff.rb
@@ -7,8 +7,11 @@ class Sqldiff < Formula
   license "blessing"
 
   livecheck do
-    url "https://sqlite.org/news.html"
-    regex(%r{v?(\d+(?:\.\d+)+)</h3>}i)
+    url "https://sqlite.org/index.html"
+    regex(%r{href=.*?releaselog/v?(\d+(?:[._]\d+)+)\.html}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match&.first&.gsub("_", ".") }
+    end
   end
 
   bottle do

--- a/Formula/sqlite-analyzer.rb
+++ b/Formula/sqlite-analyzer.rb
@@ -7,8 +7,11 @@ class SqliteAnalyzer < Formula
   license "blessing"
 
   livecheck do
-    url "https://sqlite.org/news.html"
-    regex(%r{v?(\d+(?:\.\d+)+)</h3>}i)
+    url "https://sqlite.org/index.html"
+    regex(%r{href=.*?releaselog/v?(\d+(?:[._]\d+)+)\.html}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match&.first&.gsub("_", ".") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Various `sqlite`-related formulae (`dbhash`, `lemon`, `sqldiff`, `sqlite-analyzer`) use the same `livecheck` block as `sqlite`, as they also use the same `stable` archive. We recently updated the `livecheck` block for `sqlite` in #79685 (as the regex was no longer working) but we forgot to update the other formulae doing the same thing. This PR brings the `livecheck` blocks for related formulae in line with `sqlite`.

In the long term, I would like to add a `formula` method to the `livecheck` block DSL, allowing one formula to use the `livecheck` block from another. In this case, the formulae in this PR would simply use `formula "sqlite"` and we wouldn't have to bother with keeping these in line. There's a fair bit of complexity to implementing it and it will rely on some other features that I have planned, so it's unlikely to be implemented for a while. In the interim time, we simply have to maintain duplicate `livecheck` blocks like these, which isn't a big deal overall.