### PR TITLE
libgit2-glib: m1-support add in rpath to build on Apple Silicon

### DIFF
--- a/Formula/libgit2-glib.rb
+++ b/Formula/libgit2-glib.rb
@@ -29,6 +29,7 @@ class Libgit2Glib < Formula
 
   def install
     mkdir "build" do
+      ENV.append "LDFLAGS", "-Wl,-rpath,#{rpath}"
       system "meson", *std_meson_args,
                       "-Dpython=false",
                       "-Dvapi=true",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
