### PR TITLE
workflows: use system bash to fix post cleanup

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -30,6 +30,9 @@ jobs:
   bottle:
     runs-on: ${{github.event.inputs.runner}}
     timeout-minutes: 4320
+    defaults:
+      run:
+        shell: /bin/bash -e {0}
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,6 +127,9 @@ jobs:
       fail-fast: false
     runs-on: ${{matrix.runner}}
     timeout-minutes: 4320
+    defaults:
+      run:
+        shell: /bin/bash -e {0}
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

### Issue/Reason
Trying to fix CI **Post cleanup** failures in #80227 and #80296 when Homebrew `bash` is installed in a previous step.

This results in runner using Homebrew's `bash` during **Post cleanup** and has chance of failing due to deleting `bash` executable being used.

### Comments
Currently `bash` arguments are based on existing CI output, but may need to see if other flags are needed.

From https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell:
The command run internally shown to be `bash --noprofile --norc -eo pipefail {0}`
So, may want to add these extra args to make sure error code is returned and no unexpected behavior from loading profile/rc files.

Can also configure the `shell` for all jobs, or restricted to particular step.

### Some alternatives:
- Split `brew test-bot --only-cleanup-after` and `rm -rvf bottles` into separate steps.
  This was the previous behavior. Possible cons:
  - Some CI overhead of setting up another step
  - Not exactly sure, but there may still be a small risk of the first command deleting `bash` before finishing.
- Change order of `PATH`, though may cause side-effects.
- Uninstall `bash` if installed at the end of test step. Would need to make sure no breakages.