### PR TITLE
archi-steam-farm: add livecheck

### DIFF
--- a/Formula/archi-steam-farm.rb
+++ b/Formula/archi-steam-farm.rb
@@ -7,6 +7,11 @@ class ArchiSteamFarm < Formula
   license "Apache-2.0"
   head "https://github.com/JustArchiNET/ArchiSteamFarm.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:  "16bc55a12a0957f01360d26ba97cf3e8970a11ae7563bc0ccda5f26b2a09f3c9"
     sha256 cellar: :any_skip_relocation, catalina: "8b6857a931593bcb24aee55236fbb7a9ecf5d5331ab732ca9530892206911ac8"


### PR DESCRIPTION
archi-steam-farm: add livecheck to avoid pre-release tag, `5.1.1.1`

![image](https://user-images.githubusercontent.com/1580956/124050217-1ef5d700-d9e8-11eb-96f6-a00025da57b6.png)
