### PR TITLE
FUSE formulae: add macOS support info

### DIFF
--- a/Formula/afuse.rb
+++ b/Formula/afuse.rb
@@ -17,7 +17,7 @@ class Afuse < Formula
   depends_on "pkg-config" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -27,6 +27,18 @@ class Afuse < Formula
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do


### PR DESCRIPTION
Add macOS-only caveat that points to the FUSE deprecation PR, and instructions for finding a replacement. Followup from #77289.

NOTES:
1. License updates will be addressed in a separate PR.
2. I'm adding one formula first, then once the final changes are confirmed, I'll add commits for all the other formulae.

@Homebrew/core, please mark this PR as `CI-syntax-only`, to avoid unnecessary rebuilds. Thanks much!

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? (`CI-syntax-only`)
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? (`CI-syntax-only`)
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
