### PR TITLE
drg 0.5.1 (new formula)

### DIFF
--- a/Formula/drg.rb
+++ b/Formula/drg.rb
@@ -1,0 +1,17 @@
+class Drg < Formula
+  desc "Command-line tool for managing apps and devices in drogue cloud"
+  homepage "https://drogue.io"
+  url "https://github.com/drogue-iot/drg/archive/refs/tags/v0.5.1.tar.gz"
+  sha256 "29f8d8adb014da9a47b1e68d485dedc180621844e7af228bc88a2cfb34baca63"
+  license "Apache-2.0"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    system "#{bin}/drg", "--version"
+  end
+end


### PR DESCRIPTION
Adds the Drogue Cloud CLI for managing apps and devices.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
