### PR TITLE
workflows/triage: restrict self-hosted Linux labelling

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -125,7 +125,7 @@ jobs:
                     "keep_if_no_match": true
                 }, {
                     "label": "CI-linux-self-hosted",
-                    "path": "Formula/(gdbm|go|openssl|python|rust|sqlite)(@[0-9.]+)?.rb",
+                    "path": "Formula/(gdbm|go|openssl@1.1|python@3.9|rust|sqlite).rb",
                     "keep_if_no_match": true
                 }, {
                     "label": "bump-formula-pr",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We only need these to run for `openssl@1.1` and `python@3.9`, and not
any other version (e.g. `python@3.8`).

The existing code will run `python@3.8` PRs on the self-hosted Linux
runner, and these will end up waiting ages for no good reason if they
come in shortly after a `python@3.9` PR.