### PR TITLE
FUSE formulae: add macOS support info (part 2)

### DIFF
--- a/Formula/archivemount.rb
+++ b/Formula/archivemount.rb
@@ -14,7 +14,7 @@ class Archivemount < Formula
   depends_on "libarchive"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -29,6 +29,18 @@ class Archivemount < Formula
                           "--prefix=#{prefix}"
 
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/avfs.rb
+++ b/Formula/avfs.rb
@@ -16,7 +16,7 @@ class Avfs < Formula
   depends_on "xz"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -36,6 +36,18 @@ class Avfs < Formula
 
     system "./configure", *args
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/bindfs.rb
+++ b/Formula/bindfs.rb
@@ -21,7 +21,7 @@ class Bindfs < Formula
   depends_on "pkg-config" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -42,6 +42,18 @@ class Bindfs < Formula
     end
 
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/btfs.rb
+++ b/Formula/btfs.rb
@@ -18,7 +18,7 @@ class Btfs < Formula
   depends_on "libtorrent-rasterbar"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -34,6 +34,18 @@ class Btfs < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/cryfs.rb
+++ b/Formula/cryfs.rb
@@ -23,7 +23,7 @@ class Cryfs < Formula
   depends_on "openssl@1.1"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -48,6 +48,18 @@ class Cryfs < Formula
 
     system "cmake", ".", *configure_args, *std_cmake_args
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/curlftpfs.rb
+++ b/Formula/curlftpfs.rb
@@ -22,7 +22,7 @@ class Curlftpfs < Formula
   # TODO: depend on specific X11 formulae instead
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -35,5 +35,17 @@ class Curlftpfs < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 end

--- a/Formula/dislocker.rb
+++ b/Formula/dislocker.rb
@@ -10,7 +10,7 @@ class Dislocker < Formula
   depends_on "mbedtls"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -21,6 +21,18 @@ class Dislocker < Formula
     system "cmake", "-DCMAKE_DISABLE_FIND_PACKAGE_Ruby=TRUE", *std_cmake_args
     system "make"
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -22,7 +22,7 @@ class Encfs < Formula
   depends_on "openssl@1.1"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -35,6 +35,18 @@ class Encfs < Formula
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"
+    end
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
     end
   end
 

--- a/Formula/ext2fuse.rb
+++ b/Formula/ext2fuse.rb
@@ -14,7 +14,7 @@ class Ext2fuse < Formula
   depends_on "e2fsprogs"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -31,5 +31,17 @@ class Ext2fuse < Formula
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 end

--- a/Formula/ext4fuse.rb
+++ b/Formula/ext4fuse.rb
@@ -18,7 +18,7 @@ class Ext4fuse < Formula
   depends_on "pkg-config" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -28,5 +28,17 @@ class Ext4fuse < Formula
   def install
     system "make"
     bin.install "ext4fuse"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 end

--- a/Formula/fuse-zip.rb
+++ b/Formula/fuse-zip.rb
@@ -19,7 +19,7 @@ class FuseZip < Formula
   depends_on "libzip"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -28,6 +28,18 @@ class FuseZip < Formula
 
   def install
     system "make", "prefix=#{prefix}", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/gcsfuse.rb
+++ b/Formula/gcsfuse.rb
@@ -15,7 +15,7 @@ class Gcsfuse < Formula
   depends_on "go" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -31,6 +31,18 @@ class Gcsfuse < Formula
     # Use that tool to build gcsfuse itself.
     gcsfuse_version = build.head? ? Utils.git_short_head : version
     system "./build_gcsfuse", buildpath, prefix, gcsfuse_version
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/gitfs.rb
+++ b/Formula/gitfs.rb
@@ -15,7 +15,7 @@ class Gitfs < Formula
   uses_from_macos "libffi"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -68,12 +68,20 @@ class Gitfs < Formula
   end
 
   def caveats
+    on_macos do
+      return <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
+
     <<~EOS
       gitfs clones repos in /var/lib/gitfs. You can either create it with
       sudo mkdir -m 1777 /var/lib/gitfs or use another folder with the
       repo_path argument.
-
-      Also make sure OSXFUSE is properly installed by running brew info osxfuse.
     EOS
   end
 

--- a/Formula/gocryptfs.rb
+++ b/Formula/gocryptfs.rb
@@ -16,7 +16,7 @@ class Gocryptfs < Formula
   depends_on "openssl@1.1"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -30,6 +30,18 @@ class Gocryptfs < Formula
       system "./build.bash"
       bin.install "gocryptfs"
       prefix.install_metafiles
+    end
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
     end
   end
 

--- a/Formula/goofys.rb
+++ b/Formula/goofys.rb
@@ -17,7 +17,7 @@ class Goofys < Formula
   depends_on "go" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -35,6 +35,18 @@ class Goofys < Formula
       system "go", "build", "-o", "goofys", "-ldflags", "-X main.Version=#{Utils.git_head}"
       bin.install "goofys"
       prefix.install_metafiles
+    end
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
     end
   end
 

--- a/Formula/ifuse.rb
+++ b/Formula/ifuse.rb
@@ -21,7 +21,7 @@ class Ifuse < Formula
   depends_on "libplist"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -33,6 +33,18 @@ class Ifuse < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/mp3fs.rb
+++ b/Formula/mp3fs.rb
@@ -18,7 +18,7 @@ class Mp3fs < Formula
   depends_on "libvorbis"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -28,6 +28,18 @@ class Mp3fs < Formula
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/ntfs-3g.rb
+++ b/Formula/ntfs-3g.rb
@@ -34,7 +34,7 @@ class Ntfs3g < Formula
   depends_on "gettext"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -93,6 +93,18 @@ class Ntfs3g < Formula
           "$@" >> /var/log/mount-ntfs-3g.log 2>&1
 
         exit $?;
+      EOS
+    end
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
       EOS
     end
   end

--- a/Formula/rofs-filtered.rb
+++ b/Formula/rofs-filtered.rb
@@ -15,7 +15,7 @@ class RofsFiltered < Formula
   depends_on "cmake" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -26,6 +26,18 @@ class RofsFiltered < Formula
     mkdir "build" do
       system "cmake", "..", "-DCMAKE_INSTALL_SYSCONFDIR=#{etc}", *std_cmake_args
       system "make", "install"
+    end
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
     end
   end
 end

--- a/Formula/s3-backer.rb
+++ b/Formula/s3-backer.rb
@@ -15,7 +15,7 @@ class S3Backer < Formula
   depends_on "openssl@1.1"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -26,6 +26,18 @@ class S3Backer < Formula
     inreplace "configure", "-lfuse", "-losxfuse"
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/s3fs.rb
+++ b/Formula/s3fs.rb
@@ -20,7 +20,7 @@ class S3fs < Formula
   depends_on "nettle"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -31,6 +31,18 @@ class S3fs < Formula
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking", "--with-gnutls", "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/s3ql.rb
+++ b/Formula/s3ql.rb
@@ -22,7 +22,7 @@ class S3ql < Formula
   uses_from_macos "libffi"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -148,6 +148,18 @@ class S3ql < Formula
 
     system libexec/"bin/python3", "setup.py", "build_ext", "--inplace"
     venv.pip_install_and_link buildpath
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/securefs.rb
+++ b/Formula/securefs.rb
@@ -16,7 +16,7 @@ class Securefs < Formula
   depends_on "cmake" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -26,6 +26,18 @@ class Securefs < Formula
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/simple-mtpfs.rb
+++ b/Formula/simple-mtpfs.rb
@@ -18,7 +18,7 @@ class SimpleMtpfs < Formula
   depends_on "libmtp"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -32,6 +32,18 @@ class SimpleMtpfs < Formula
       "LDFLAGS=-L/usr/local/include/osxfuse"
     system "make"
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/squashfuse.rb
+++ b/Formula/squashfuse.rb
@@ -21,7 +21,7 @@ class Squashfuse < Formula
   depends_on "zstd"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -35,9 +35,21 @@ class Squashfuse < Formula
     system "make", "install"
   end
 
-  # Unfortunately, making/testing a squash mount requires sudo privileges, so
-  # just test that squashfuse execs for now.
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
+  end
+
   test do
+    # Unfortunately, making/testing a squash mount requires sudo privileges, so
+    # just test that squashfuse execs for now.
     output = shell_output("#{bin}/squashfuse --version 2>&1", 254)
     assert_match version.to_s, output
   end

--- a/Formula/sshfs.rb
+++ b/Formula/sshfs.rb
@@ -19,7 +19,7 @@ class Sshfs < Formula
   depends_on "libfuse"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   def install
@@ -28,6 +28,18 @@ class Sshfs < Formula
       system "meson", "configure", "--prefix", prefix
       system "ninja", "--verbose"
       system "ninja", "install", "--verbose"
+    end
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
     end
   end
 

--- a/Formula/tup.rb
+++ b/Formula/tup.rb
@@ -15,7 +15,7 @@ class Tup < Formula
   depends_on "pkg-config" => :build
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -29,6 +29,18 @@ class Tup < Formula
     man1.install "tup.1"
     doc.install (buildpath/"docs").children
     pkgshare.install "contrib/syntax"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/wdfs.rb
+++ b/Formula/wdfs.rb
@@ -17,7 +17,7 @@ class Wdfs < Formula
   depends_on "neon"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -28,6 +28,18 @@ class Wdfs < Formula
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do

--- a/Formula/xmount.rb
+++ b/Formula/xmount.rb
@@ -19,7 +19,7 @@ class Xmount < Formula
   depends_on "openssl@1.1"
 
   on_macos do
-    disable! date: "2021-04-08", because: "requires FUSE"
+    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
   end
 
   on_linux do
@@ -31,6 +31,18 @@ class Xmount < Formula
 
     system "cmake", ".", *std_cmake_args
     system "make", "install"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        The reasons for disabling this formula can be found here:
+          https://github.com/Homebrew/homebrew-core/pull/64491
+
+        An external tap may provide a replacement formula. See:
+          https://docs.brew.sh/Interesting-Taps-and-Forks
+      EOS
+    end
   end
 
   test do


### PR DESCRIPTION
Continuing from #80362, this PR updates all the remaining FUSE formulae to show consistent messaging and (hopefully) reduce user confusion when their installations are blocked.

As with the previous PR, this one _only_ addresses the disable messaging. @Homebrew/core, please mark this PR as `CI-syntax-only`, to avoid unnecessary rebuilds. Thanks much!

NOTE: `gitfs` has a hybrid `caveats` section, which I hand-tested on both macOS and Linux to confirm that both sides output correctly:
```sh
# macOS
$ brew info gitfs
gitfs: stable 0.5.2, HEAD
Version controlled file system
https://www.presslabs.com/gitfs
Disabled because it requires closed-source macFUSE!
Not installed
[...]
==> Caveats
The reasons for disabling this formula can be found here:
  https://github.com/Homebrew/homebrew-core/pull/64491

An external tap may provide a replacement formula. See:
  https://docs.brew.sh/Interesting-Taps-and-Forks
[...]

# Linux
$ brew info gitfs
gitfs: stable 0.5.2, HEAD
Version controlled file system
https://www.presslabs.com/gitfs
Not installed
[...]
==> Caveats
gitfs clones repos in /var/lib/gitfs. You can either create it with
sudo mkdir -m 1777 /var/lib/gitfs or use another folder with the
repo_path argument.
[...]
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
