### PR TITLE
scheme48: add livecheck

### DIFF
--- a/Formula/scheme48.rb
+++ b/Formula/scheme48.rb
@@ -5,6 +5,11 @@ class Scheme48 < Formula
   sha256 "9c4921a90e95daee067cd2e9cc0ffe09e118f4da01c0c0198e577c4f47759df4"
   license "BSD-3-Clause"
 
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/download\.html}i)
+  end
+
   bottle do
     rebuild 1
     sha256 arm64_big_sur: "5a2ff16cfe2c0cad8648b4057552a19f3389408d3e90b884c0b4d4f3c4116d30"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `scheme48`. This PR adds a `livecheck` block that checks the homepage, which lists the current version. The various pages/files linked from the homepage are kept in a versioned subdirectory (e.g., `1.9.2/download.html`) and this `livecheck` block obtains the version from the subdirectory name.