### PR TITLE
multi-git-status 2.0 (new formula)

### DIFF
--- a/Formula/multi-git-status.rb
+++ b/Formula/multi-git-status.rb
@@ -13,6 +13,10 @@ class MultiGitStatus < Formula
   end
 
   test do
-    system "#{bin}/mgitstatus", "--version"
+    Dir.mkdir("test-repo")
+    Dir.chdir("test-repo"){
+      system "git", "init"
+    }
+    assert_match "./test-repo: Uncommitted changes", shell_output("#{bin}/mgitstatus 2>&1")
   end
 end

--- a/Formula/multi-git-status.rb
+++ b/Formula/multi-git-status.rb
@@ -13,10 +13,9 @@ class MultiGitStatus < Formula
   end
 
   test do
-    Dir.mkdir("test-repo")
-    Dir.chdir("test-repo"){
+    mkdir "test-repo" do
       system "git", "init"
-    }
+    end
     assert_match "./test-repo: Uncommitted changes", shell_output("#{bin}/mgitstatus 2>&1")
   end
 end

--- a/Formula/multi-git-status.rb
+++ b/Formula/multi-git-status.rb
@@ -1,0 +1,18 @@
+class MultiGitStatus < Formula
+  desc "Show uncommitted, untracked and unpushed changes for multiple Git repos"
+  homepage "https://github.com/fboender/multi-git-status"
+  url "https://github.com/fboender/multi-git-status/archive/refs/tags/2.0.tar.gz"
+  sha256 "13ce21fc087354cd7e0fd16f332bcff7e8c42c0315d3f27803159926aff3360f"
+  license "MIT"
+
+  def install
+    # This is what the included 'install.sh' script does, except that
+    # we use Homebrew's preferred location for 'man1'.
+    bin.install "mgitstatus"
+    man1.install "mgitstatus.1"
+  end
+
+  test do
+    system "#{bin}/mgitstatus", "--version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula consists of one (very useful) shell script and one man page.  I would love to get it as a formula because otherwise the installation process is a bit goofy, and I'd like to be able to tell my colleagues "just do `brew install multi-git-status`".