### PR TITLE
bwfmetaedit: add livecheck

### DIFF
--- a/Formula/bwfmetaedit.rb
+++ b/Formula/bwfmetaedit.rb
@@ -5,6 +5,11 @@ class Bwfmetaedit < Formula
   sha256 "273600425521d27aa3babd5d564e7c7a8c71bbf359e0bdebeac4761fc753149b"
   license "0BSD"
 
+  livecheck do
+    url "https://mediaarea.net/BWFMetaEdit/Download/Source"
+    regex(/href=.*?bwfmetaedit[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "3e74719411cb950866e9eec2b40fb5404238b6036a4a401785eb4cd1db220a9e"
     sha256 cellar: :any_skip_relocation, big_sur:       "1dbda1bf33cccd0b42ce0833f84c7f0a6a03162adde2650ecbd55cde00a89a8f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `bwfmetaedit`. This PR adds a `livecheck` block that checks the first-party download page for source files. This links to a slightly different tarball than the one used as `stable` but I couldn't find a download link on the website for the current `stable` tarball (outside of the directory listing page where it's located). Either way, this works fine for identifying the latest version.