### PR TITLE
pcre2: enable jit for aarch64

### DIFF
--- a/Formula/pcre2.rb
+++ b/Formula/pcre2.rb
@@ -29,10 +29,8 @@ class Pcre2 < Formula
       --enable-pcre2-32
       --enable-pcre2grep-libz
       --enable-pcre2grep-libbz2
+      --enable-jit
     ]
-
-    # JIT not currently supported for Apple Silicon
-    args << "--enable-jit" unless Hardware::CPU.arm?
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This depends on https://github.com/zherczeg/sljit/pull/105 and a pcre2 release. I have a patched mirror [here](https://github.com/b8591340/pcre2-mirror/tree/release/10.37_aarch64) and it works on macOS 12 aarch64 (i.e. `url "https://github.com/b8591340/pcre2-mirror/archive/refs/heads/release/10.37_aarch64.zip”`).
