### PR TITLE
wasm-pack: depend on `binaryen`, `openssl@1.1`

### DIFF
--- a/Formula/wasm-pack.rb
+++ b/Formula/wasm-pack.rb
@@ -4,6 +4,7 @@ class WasmPack < Formula
   url "https://github.com/rustwasm/wasm-pack/archive/v0.10.0.tar.gz"
   sha256 "1b89ebb73853b749fdb2bc49474e17cca5658edd3b40723405a6a6cc3e3927fd"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/rustwasm/wasm-pack.git"
 
   bottle do
@@ -13,9 +14,13 @@ class WasmPack < Formula
   end
 
   depends_on "rust" => :build
+  depends_on "binaryen"
+  depends_on "openssl@1.1"
   depends_on "rustup-init"
 
   def install
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
+
     system "cargo", "install", *std_cargo_args
   end
 
@@ -24,6 +29,7 @@ class WasmPack < Formula
 
     system "#{Formula["rustup-init"].bin}/rustup-init", "-y", "--no-modify-path"
     ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
+    ENV.prepend_path "PATH", Formula["binaryen"].opt_bin
 
     system bin/"wasm-pack", "new", "hello-wasm"
     system bin/"wasm-pack", "build", "hello-wasm"


### PR DESCRIPTION
* Add `binaryen` dependency for `wasm-opt` command.
* Add `openssl@1.1` dependency, set `OPENSSL_DIR` to help find it.
* Try to build on ARM.

See: [failed bottle job logs](https://github.com/Homebrew/homebrew-core/actions/runs/994692495).

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?