### PR TITLE
Use download mirror compatible with macOS `curl` & update livecheck blocks for Xiph.org software

### DIFF
--- a/Formula/cdparanoia.rb
+++ b/Formula/cdparanoia.rb
@@ -2,10 +2,11 @@ class Cdparanoia < Formula
   desc "Audio extraction tool for sampling CDs"
   homepage "https://www.xiph.org/paranoia/"
   url "https://downloads.xiph.org/releases/cdparanoia/cdparanoia-III-10.2.src.tgz"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/cdparanoia/cdparanoia-III-10.2.src.tgz"
   sha256 "005db45ef4ee017f5c32ec124f913a0546e77014266c6a1c50df902a55fe64df"
 
   livecheck do
-    url "https://www.xiph.org/paranoia/down.html"
+    url "https://ftp.osuosl.org/pub/xiph/releases/cdparanoia/?C=M&O=D"
     regex(/href=.*?cdparanoia-III[._-]v?(\d+(?:\.\d+)+)\.src\.t/i)
   end
 

--- a/Formula/ezstream.rb
+++ b/Formula/ezstream.rb
@@ -2,12 +2,13 @@ class Ezstream < Formula
   desc "Client for Icecast streaming servers"
   homepage "https://icecast.org/ezstream/"
   url "https://downloads.xiph.org/releases/ezstream/ezstream-1.0.2.tar.gz"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/ezstream/ezstream-1.0.2.tar.gz"
   sha256 "11de897f455a95ba58546bdcd40a95d3bda69866ec5f7879a83b024126c54c2a"
   license "GPL-2.0-only"
   head "https://gitlab.xiph.org/xiph/ezstream.git"
 
   livecheck do
-    url "https://downloads.xiph.org/releases/ezstream/"
+    url "https://ftp.osuosl.org/pub/xiph/releases/ezstream/?C=M&O=D"
     regex(/href=.*?ezstream[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/flac.rb
+++ b/Formula/flac.rb
@@ -2,10 +2,11 @@ class Flac < Formula
   desc "Free lossless audio codec"
   homepage "https://xiph.org/flac/"
   url "https://downloads.xiph.org/releases/flac/flac-1.3.3.tar.xz"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/flac/flac-1.3.3.tar.xz"
   sha256 "213e82bd716c9de6db2f98bcadbc4c24c7e2efe8c75939a1a84e28539c4e1748"
 
   livecheck do
-    url "https://downloads.xiph.org/releases/flac/"
+    url "https://ftp.osuosl.org/pub/xiph/releases/flac/?C=M&O=D"
     regex(/href=.*?flac[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/icecast.rb
+++ b/Formula/icecast.rb
@@ -2,11 +2,12 @@ class Icecast < Formula
   desc "Streaming MP3 audio server"
   homepage "https://icecast.org/"
   url "https://downloads.xiph.org/releases/icecast/icecast-2.4.4.tar.gz"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/icecast/icecast-2.4.4.tar.gz"
   sha256 "49b5979f9f614140b6a38046154203ee28218d8fc549888596a683ad604e4d44"
   revision 1
 
   livecheck do
-    url "https://downloads.xiph.org/releases/icecast/"
+    url "https://ftp.osuosl.org/pub/xiph/releases/icecast/?C=M&O=D"
     regex(/href=.*?icecast[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/libfishsound.rb
+++ b/Formula/libfishsound.rb
@@ -2,8 +2,14 @@ class Libfishsound < Formula
   desc "Decode and encode audio data using the Xiph.org codecs"
   homepage "https://xiph.org/fishsound/"
   url "https://downloads.xiph.org/releases/libfishsound/libfishsound-1.0.0.tar.gz"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/libfishsound/libfishsound-1.0.0.tar.gz"
   sha256 "2e0b57ce2fecc9375eef72938ed08ac8c8f6c5238e1cae24458f0b0e8dade7c7"
   license "BSD-3-Clause"
+
+  livecheck do
+    url "https://ftp.osuosl.org/pub/xiph/releases/libfishsound/?C=M&O=D"
+    regex(/href=.*?libfishsound[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 1

--- a/Formula/libshout.rb
+++ b/Formula/libshout.rb
@@ -2,11 +2,12 @@ class Libshout < Formula
   desc "Data and connectivity library for the icecast server"
   homepage "https://icecast.org/"
   url "https://downloads.xiph.org/releases/libshout/libshout-2.4.5.tar.gz"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/libshout/libshout-2.4.5.tar.gz"
   sha256 "d9e568668a673994ebe3f1eb5f2bee06e3236a5db92b8d0c487e1c0f886a6890"
   license "LGPL-2.0-or-later"
 
   livecheck do
-    url "https://ftp.osuosl.org/pub/xiph/releases/libshout/"
+    url "https://ftp.osuosl.org/pub/xiph/releases/libshout/?C=M&O=D"
     regex(/href=.*?libshout[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/libvorbis.rb
+++ b/Formula/libvorbis.rb
@@ -2,8 +2,14 @@ class Libvorbis < Formula
   desc "Vorbis General Audio Compression Codec"
   homepage "https://xiph.org/vorbis/"
   url "https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.7.tar.xz"
   sha256 "b33cc4934322bcbf6efcbacf49e3ca01aadbea4114ec9589d1b1e9d20f72954b"
   license "BSD-3-Clause"
+
+  livecheck do
+    url "https://ftp.osuosl.org/pub/xiph/releases/vorbis/?C=M&O=D"
+    regex(/href=.*?libvorbis[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "07ab1118fc6d389a8b0506d0b74a3cfc12026a837c8f2609b2133318c8818c81"

--- a/Formula/libxspf.rb
+++ b/Formula/libxspf.rb
@@ -2,7 +2,13 @@ class Libxspf < Formula
   desc "C++ library for XSPF playlist reading and writing"
   homepage "https://libspiff.sourceforge.io/"
   url "https://downloads.xiph.org/releases/xspf/libxspf-1.2.0.tar.bz2"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/xspf/libxspf-1.2.0.tar.bz2"
   sha256 "ba9e93a0066469b074b4022b480004651ad3aa5b4313187fd407d833f79b43a5"
+
+  livecheck do
+    url "https://ftp.osuosl.org/pub/xiph/releases/xspf/?C=M&O=D"
+    regex(/href=.*?libxspf[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 2

--- a/Formula/oggz.rb
+++ b/Formula/oggz.rb
@@ -2,8 +2,14 @@ class Oggz < Formula
   desc "Command-line tool for manipulating Ogg files"
   homepage "https://www.xiph.org/oggz/"
   url "https://downloads.xiph.org/releases/liboggz/liboggz-1.1.1.tar.gz"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/liboggz/liboggz-1.1.1.tar.gz"
   sha256 "6bafadb1e0a9ae4ac83304f38621a5621b8e8e32927889e65a98706d213d415a"
   license "BSD-3-Clause"
+
+  livecheck do
+    url "https://ftp.osuosl.org/pub/xiph/releases/liboggz/?C=M&O=D"
+    regex(/href=.*?liboggz[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "286192f997ec0e02994b70cdc03d06d0616b10bea980b1aee7f3322f1d58735c"

--- a/Formula/speex.rb
+++ b/Formula/speex.rb
@@ -2,6 +2,7 @@ class Speex < Formula
   desc "Audio codec designed for speech"
   homepage "https://speex.org/"
   url "https://downloads.xiph.org/releases/speex/speex-1.2.0.tar.gz"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/speex/speex-1.2.0.tar.gz"
   sha256 "eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094"
   license "BSD-3-Clause"
 

--- a/Formula/theora.rb
+++ b/Formula/theora.rb
@@ -2,10 +2,11 @@ class Theora < Formula
   desc "Open video compression format"
   homepage "https://www.theora.org/"
   url "https://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.bz2"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-1.1.1.tar.bz2"
   sha256 "b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc"
 
   livecheck do
-    url "https://www.theora.org/downloads/"
+    url "https://ftp.osuosl.org/pub/xiph/releases/theora/?C=M&O=D"
     regex(/href=.*?libtheora[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/vorbis-tools.rb
+++ b/Formula/vorbis-tools.rb
@@ -2,10 +2,11 @@ class VorbisTools < Formula
   desc "Ogg Vorbis CODEC tools"
   homepage "https://github.com/xiph/vorbis-tools"
   url "https://downloads.xiph.org/releases/vorbis/vorbis-tools-1.4.2.tar.gz"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/vorbis/vorbis-tools-1.4.2.tar.gz"
   sha256 "db7774ec2bf2c939b139452183669be84fda5774d6400fc57fde37f77624f0b0"
 
   livecheck do
-    url "https://downloads.xiph.org/releases/vorbis/"
+    url "https://ftp.osuosl.org/pub/xiph/releases/vorbis/?C=M&O=D"
     regex(/href=.*?vorbis-tools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is just a batch update adding download mirrors and altering livecheck blocks in order to ensure:
1. they are compatible with macOS `curl` (ie. do not require TLSv1.3)
2. they all use the same URL pattern https://ftp.osuosl.org/pub/xiph/releases/{{product}}/?C=M&O=D where `?C=M&O=D` part ensures that the latest version gets listed first.