### PR TITLE
geeqie: update urls, license, livecheck

### DIFF
--- a/Formula/geeqie.rb
+++ b/Formula/geeqie.rb
@@ -1,13 +1,13 @@
 class Geeqie < Formula
   desc "Lightweight Gtk+ based image viewer"
-  homepage "http://www.geeqie.org/"
-  url "http://www.geeqie.org/geeqie-1.6.tar.xz"
+  homepage "https://www.geeqie.org/"
+  url "https://github.com/BestImageViewer/geeqie/releases/download/v1.6/geeqie-1.6.tar.xz"
   sha256 "48f8a4474454d182353100e43878754b76227f3b8f30cfc258afc9d90a4e1920"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
-    url :homepage
-    regex(/href=.*?geeqie[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR is primarily intended to fix the existing `livecheck` block for `geeqie`, as it's currently giving an `Unable to get versions` error due to the homepage not linking to a tarball anymore. The `stable` tarball has also been removed from the first-party website (it now gives a 404), so it's not just a removal of the link. The homepage links to a bunch of different compiled options but no source tarball, unfortunately.

The related [GitHub project](https://github.com/BestImageViewer/geeqie) provides the same `geeqie-1.6.tar.xz` tarball as a [release artifact](https://github.com/BestImageViewer/geeqie/releases/tag/v1.6) (same `sha256`) and I've updated the `stable` URL (and `livecheck` block) accordingly. I couldn't find this tarball anywhere else, so it seems like this may the place to check now.

For what it's worth, they also run their own Git repository (http://geeqie.org/cgi-bin/gitweb.cgi?p=geeqie.git;a=summary). The [snapshot tarball for the `v1.6` tag commit](http://geeqie.org/cgi-bin/gitweb.cgi?p=geeqie.git;a=snapshot;h=8030a220a9f6bc12b1da57dd9d6ab7fb1b597697;sf=tgz) has a different `sha256` than the existing tarball, though the files inside are identical. This would be harder to upgrade (and potentially less reliable) than using the GitHub release tarball, so I only mention this for the sake of completeness.

Beyond that, this also updates the `homepage` to use HTTPS, to address an audit error. Additionally, this updates the `license` from `GPL-2.0` to `GPL-2.0-or-later`, referencing the [source files](https://github.com/BestImageViewer/geeqie/search?q=or+later), which use "or later" language in the license information comments.