### PR TITLE
tree-sitter: skip WASM module build on Linux

### DIFF
--- a/Formula/tree-sitter.rb
+++ b/Formula/tree-sitter.rb
@@ -15,28 +15,33 @@ class TreeSitter < Formula
     sha256 cellar: :any, mojave:        "1bf537d6e22c72586f41cc75cb0f9a496243c5daab3f406f4849e69851ba09fd"
   end
 
-  depends_on "emscripten" => [:build, :test]
   depends_on "node" => [:build, :test]
   depends_on "rust" => :build
+
+  on_macos { depends_on "emscripten" => [:build, :test] }
 
   def install
     system "make", "AMALGAMATED=1"
     system "make", "install", "PREFIX=#{prefix}"
 
-    # NOTE: This step needs to be done *before* `cargo install`
-    cd "lib/binding_web" do
-      system "npm", "install", *Language::Node.local_npm_install_args
+    on_macos do
+      # NOTE: This step needs to be done *before* `cargo install`
+      cd "lib/binding_web" do
+        system "npm", "install", *Language::Node.local_npm_install_args
+      end
+      system "script/build-wasm"
     end
-    system "script/build-wasm"
 
     cd "cli" do
       system "cargo", "install", *std_cargo_args
     end
 
-    # Install the wasm module into the prefix.
-    # NOTE: This step needs to be done *after* `cargo install`.
-    %w[tree-sitter.js tree-sitter-web.d.ts tree-sitter.wasm package.json].each do |file|
-      (lib/"binding_web").install "lib/binding_web/#{file}"
+    on_macos do
+      # Install the wasm module into the prefix.
+      # NOTE: This step needs to be done *after* `cargo install`.
+      %w[tree-sitter.js tree-sitter-web.d.ts tree-sitter.wasm package.json].each do |file|
+        (lib/"binding_web").install "lib/binding_web/#{file}"
+      end
     end
   end
 
@@ -102,8 +107,10 @@ class TreeSitter < Formula
     system ENV.cc, "test_program.c", "-L#{lib}", "-ltree-sitter", "-o", "test_program"
     assert_equal "tree creation failed", shell_output("./test_program")
 
-    # test `tree-sitter build-wasm`
-    ENV.delete "CPATH"
-    system bin/"tree-sitter", "build-wasm"
+    on_macos do
+      # test `tree-sitter build-wasm`
+      ENV.delete "CPATH"
+      system bin/"tree-sitter", "build-wasm"
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The WASM module needs `emscripten` to build, but we're currently unable
to bottle this on Linux. See Homebrew/linuxbrew-core#22225.

This should allow the bottling of `tree-sitter` and `neovim` on Linux.