### PR TITLE
openjdk: ignore missing library

### DIFF
--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -31,6 +31,8 @@ class Openjdk < Formula
   depends_on "autoconf" => :build
   depends_on xcode: :build if Hardware::CPU.arm?
 
+  ignore_missing_libraries "libjvm.so"
+
   on_linux do
     depends_on "pkg-config" => :build
     depends_on "alsa-lib"

--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -31,8 +31,6 @@ class Openjdk < Formula
   depends_on "autoconf" => :build
   depends_on xcode: :build if Hardware::CPU.arm?
 
-  ignore_missing_libraries "libjvm.so"
-
   on_linux do
     depends_on "pkg-config" => :build
     depends_on "alsa-lib"
@@ -47,6 +45,8 @@ class Openjdk < Formula
     depends_on "libxtst"
     depends_on "unzip"
     depends_on "zip"
+
+    ignore_missing_libraries "libjvm.so"
   end
 
   fails_with gcc: "5"


### PR DESCRIPTION
Needed for Linux, should be noop on macOS.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
==> brew linkage --test openjdk
==> FAILED
Missing libraries:
  unexpected (libjvm.so)
```