### PR TITLE
libgeotiff: add livecheck

### DIFF
--- a/Formula/libgeotiff.rb
+++ b/Formula/libgeotiff.rb
@@ -6,6 +6,11 @@ class Libgeotiff < Formula
   license "MIT"
   revision 1
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "693599ceb6c27a406ef40a2132fd90736c92e639f09ba9fc73a914a692a7d302"
     sha256 cellar: :any, big_sur:       "d799eaf361b8ae3a149e616376ccc2bd6c165666931d41bea939eb1d60fd84dc"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds a `livecheck` block to `libgeotiff`. Without the block, we use the `Git` strategy but `RC` tags are picked up. Adding the stricter "standard" tag regex prevents this.

Before:
```
Formula:          libgeotiff
Livecheckable?:   No

URL:              https://github.com/OSGeo/libgeotiff/releases/download/1.6.0/libgeotiff-1.6.0.tar.gz
URL (processed):  https://github.com/OSGeo/libgeotiff.git
Strategy:         Git

Matched Versions:
1.4.0, 1.4.1, 1.4.2, 1.4.3, 1.5.0, 1.5.0RC1, 1.5.1, 1.6.0, 1.6.0RC1, 1.7.0RC1
libgeotiff : 1.6.0 ==> 1.7.0RC1
```

After:
```
Formula:          libgeotiff
Livecheckable?:   Yes

URL (stable):     https://github.com/OSGeo/libgeotiff/releases/download/1.6.0/libgeotiff-1.6.0.tar.gz
URL (processed):  https://github.com/OSGeo/libgeotiff.git
Strategy:         Git
Regex:            /^v?(\d+(?:\.\d+)+)$/i

Matched Versions:
1.4.0, 1.4.1, 1.4.2, 1.4.3, 1.5.0, 1.5.1, 1.6.0
libgeotiff : 1.6.0 ==> 1.6.0
```