### PR TITLE
mecab-unidic: add livecheck

### DIFF
--- a/Formula/mecab-unidic.rb
+++ b/Formula/mecab-unidic.rb
@@ -5,6 +5,11 @@ class MecabUnidic < Formula
   url "https://dotsrc.dl.osdn.net/osdn/unidic/58338/unidic-mecab-2.1.2_src.zip"
   sha256 "6cce98269214ce7de6159f61a25ffc5b436375c098cc86d6aa98c0605cbf90d4"
 
+  livecheck do
+    url "https://osdn.net/projects/unidic/releases/"
+    regex(%r{value=.*?/rel/unidic/unidic-mecab/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e2268e16ea3e293eface41c4f3693340dd784c15963ddc3693f3d48586e323d3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `mecab-unidic`. This PR adds a `livecheck` block that checks the OSDN releases page for the project. This page links to the `stable` archive but those links are produced client-side using JavaScript, so this `livecheck` block obtains version information from URLs that are present in the HTML.