### PR TITLE
apr: build with autoconf@2.69

### DIFF
--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -16,7 +16,7 @@ class Apr < Formula
 
   keg_only :provided_by_macos, "Apple's CLT provides apr"
 
-  depends_on "autoconf" => :build
+  depends_on "autoconf@2.69" => :build
 
   on_linux do
     depends_on "util-linux"


### PR DESCRIPTION
Fixes:
configure: error: could not determine the string function for int64_t

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
