### PR TITLE
kumactl 1.2.1 fix missing gitTag

### DIFF
--- a/Formula/kumactl.rb
+++ b/Formula/kumactl.rb
@@ -23,6 +23,7 @@ class Kumactl < Formula
     ldflags = %W[
       -s -w
       -X github.com/kumahq/kuma/pkg/version.version=#{version}
+      -X github.com/kumahq/kuma/pkg/version.gitTag=#{version}
       -X github.com/kumahq/kuma/pkg/version.buildDate=#{Date.today}
     ].join(" ")
 


### PR DESCRIPTION
Fixed formula, as without `github.com/kumahq/kuma/pkg/version.gitTag` kuma didn't know the correct version,
and when trying to install kuma on a k8s cluster using `kumactl install control-plane` it was generating manifests with `unknown` version and images tags, which was wrong as these tags don't exist

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
