### PR TITLE
namebench: deprecate

### DIFF
--- a/Formula/namebench.rb
+++ b/Formula/namebench.rb
@@ -16,6 +16,10 @@ class Namebench < Formula
     sha256 cellar: :any_skip_relocation, yosemite:      "8d400aed171038f248e9d91718fb42625fc1f278df538b34259f26918b245f66"
   end
 
+  deprecate! date: "2021-07-05", because: :unmaintained
+
+  depends_on :macos # Due to Python 2
+
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
 


### PR DESCRIPTION
The project has been unmaintained since 2011 and only supports Python 2

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See https://github.com/Homebrew/homebrew-core/pull/80580 for related discussion and suggestion to deprecate and depend on macOS.
