### PR TITLE
influxdb: use SOURCE_DATE_EPOCH in build

### DIFF
--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -5,7 +5,7 @@ class Influxdb < Formula
       tag:      "v2.0.7",
       revision: "2a45f0c0375a7d5615835afa6f81a53444df9cea"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/influxdata/influxdb.git"
 
   # The regex below omits a rogue `v9.9.9` tag that breaks version comparison.
@@ -61,7 +61,7 @@ class Influxdb < Formula
       -w
       -X main.version=#{version}
       -X main.commit=#{Utils.git_short_head(length: 10)}
-      -X main.date=#{Time.now.utc.iso8601}
+      -X main.date=#{Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc.iso8601}
     ].join(" ")
 
     system "go", "build", *std_go_args(ldflags: ldflags),


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR follows from conservation in #80579. @bayandin FYI.