### PR TITLE
libnxml: add head, update homepage and license

### DIFF
--- a/Formula/libnxml.rb
+++ b/Formula/libnxml.rb
@@ -1,9 +1,10 @@
 class Libnxml < Formula
   desc "C library for parsing, writing, and creating XML files"
-  homepage "https://www.autistici.org/bakunin/libnxml/"
+  homepage "https://github.com/bakulf/libnxml"
+  # Update to use an archive from GitHub once there's a release after 0.18.3
   url "https://www.autistici.org/bakunin/libnxml/libnxml-0.18.3.tar.gz"
   sha256 "0f9460e3ba16b347001caf6843f0050f5482e36ebcb307f709259fd6575aa547"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     rebuild 1
@@ -17,7 +18,21 @@ class Libnxml < Formula
     sha256 cellar: :any, yosemite:      "7c2bff9c49c93ef6a3901050212671c60e0cb4e72f2faf968eb4ae57f3d6fbeb"
   end
 
+  head do
+    url "https://github.com/bakulf/libnxml.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   def install
+    if build.head?
+      mkdir "m4"
+      inreplace "autogen.sh", "libtoolize", "glibtoolize"
+      system "./autogen.sh"
+    end
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing [`libnxml` homepage](https://www.autistici.org/bakunin/libnxml/) only contains a message saying, "Moved to github: http://github.com/bakulf/libnxml." With that in mind, this PR updates the homepage to the GitHub repository. In the process, I also updated the `license` from `LGPL-2.1` to `LGPL-2.1-or-later`, as [the license information in code comments uses the "or later" language](https://github.com/bakulf/libnxml/search?q=or+later).

It's worth noting that the GitHub project only provides a tag archive for `0.18.3` (not a release artifact like the one from the website), so I haven't migrated the `stable` URL to GitHub. This is because `libnxml` seemingly needs some modifications to the `autogen.sh` setup to work (i.e., building from the `0.18.3` tag archive didn't work when I tried it).

There are several commits after `0.18.3` that address this but they haven't been included in a release yet and it's probably too many to apply to this formula. The current `stable` archive is still available from the first-party website (though the site doesn't link to it anymore), so I've left it as-is for the moment. Once there's a release after `0.18.3`, we can switch to a GitHub tag archive and I've added a comment above the `stable` URL saying as much.

That said, the point of this PR was simply to get this working with `livecheck`, as it currently gives an `Unable to get versions` error. To do so, I've added a `head` URL, along with conditional logic to allow `brew install --HEAD` to work properly. This approach can be used for `stable` tag archives in the future, if/when a release happens after `0.18.3`.