### PR TITLE
re2: fix test for Linux

### DIFF
--- a/Formula/re2.rb
+++ b/Formula/re2.rb
@@ -49,8 +49,8 @@ class Re2 < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "-std=c++11", "-I#{include}", "-L#{lib}", "-lre2",
-           "test.cpp", "-o", "test"
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test",
+                    "-I#{include}", "-L#{lib}", "-lre2"
     system "./test"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1002472484

```make
==> Testing re2
==> /usr/bin/g++-5 -std=c++11 -I/home/linuxbrew/.linuxbrew/Cellar/re2/20210601/include -L/home/linuxbrew/.linuxbrew/Cellar/re2/20210601/lib -lre2 test.cpp -o test
/tmp/ccmCnVtn.o: In function `main':
test.cpp:(.text+0x2b): undefined reference to `re2::RE2::RE2(char const*)'
test.cpp:(.text+0x84): undefined reference to `re2::RE2::~RE2()'
test.cpp:(.text+0x98): undefined reference to `re2::RE2::RE2(char const*)'
test.cpp:(.text+0xf1): undefined reference to `re2::RE2::~RE2()'
test.cpp:(.text+0x119): undefined reference to `re2::RE2::~RE2()'
test.cpp:(.text+0x136): undefined reference to `re2::RE2::~RE2()'
/tmp/ccmCnVtn.o: In function `bool re2::RE2::FullMatch<>(re2::StringPiece const&, re2::RE2 const&)':
test.cpp:(.text._ZN3re23RE29FullMatchIJEEEbRKNS_11StringPieceERKS0_DpOT_[_ZN3re23RE29FullMatchIJEEEbRKNS_11StringPieceERKS0_DpOT_]+0x26): undefined reference to `re2::RE2::FullMatchN(re2::StringPiece const&, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/tmp/ccmCnVtn.o: In function `bool re2::RE2::PartialMatch<>(re2::StringPiece const&, re2::RE2 const&)':
test.cpp:(.text._ZN3re23RE212PartialMatchIJEEEbRKNS_11StringPieceERKS0_DpOT_[_ZN3re23RE212PartialMatchIJEEEbRKNS_11StringPieceERKS0_DpOT_]+0x26): undefined reference to `re2::RE2::PartialMatchN(re2::StringPiece const&, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
collect2: error: ld returned 1 exit status
```