### PR TITLE
ansible@2.8: deprecate

### DIFF
--- a/Formula/ansible@2.8.rb
+++ b/Formula/ansible@2.8.rb
@@ -15,6 +15,8 @@ class AnsibleAT28 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2021-04-12", because: :versioned_formula
+
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "libyaml"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`ansible@2.8` is unmaintained according to https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-release-cycle




