### PR TITLE
midicsv: add livecheck

### DIFF
--- a/Formula/midicsv.rb
+++ b/Formula/midicsv.rb
@@ -1,8 +1,13 @@
 class Midicsv < Formula
   desc "Convert MIDI audio files to human-readable CSV format"
-  homepage "https://www.fourmilab.ch/webtools/midicsv"
+  homepage "https://www.fourmilab.ch/webtools/midicsv/"
   url "https://www.fourmilab.ch/webtools/midicsv/midicsv-1.1.tar.gz"
   sha256 "7c5a749ab5c4ebac4bd7361df0af65892f380245be57c838e08ec6e4ac9870ef"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?midicsv[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b4786091a3131f6ffafe70a561bc2a0ffcbab3ed7c651393bb1908e1bd00bad7"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `midicsv`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This also updates the `homepage` to include a trailing forward slash, to avoid an unnecessary redirection.