### PR TITLE
sonic: fix build on Linux

### DIFF
--- a/Formula/sonic.rb
+++ b/Formula/sonic.rb
@@ -14,6 +14,9 @@ class Sonic < Formula
 
   depends_on "rust" => :build
 
+  uses_from_macos "llvm" => :build
+  uses_from_macos "netcat" => :test
+
   def install
     system "cargo", "install", *std_cargo_args
     inreplace "config.cfg", "./", var/"sonic/"
@@ -58,7 +61,7 @@ class Sonic < Formula
     port = free_port
 
     cp etc/"sonic.cfg", testpath/"config.cfg"
-    inreplace "config.cfg", ":1491", ":#{port}"
+    inreplace "config.cfg", "[::1]:1491", "0.0.0.0:#{port}"
     inreplace "config.cfg", "#{var}/sonic", "."
 
     fork { exec bin/"sonic" }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1003269816
```
   Compiling librocksdb-sys v6.7.4
The following warnings were emitted during compilation:

warning: couldn't execute `llvm-config --prefix` (error: No such file or directory (os error 2))
warning: set the LLVM_CONFIG_PATH environment variable to the full path to a valid `llvm-config` executable (including the executable itself)

error: failed to run custom build command for `librocksdb-sys v6.7.4`

Caused by:
  process didn't exit successfully: `/tmp/sonic-20210706-8151-hwwm9p/sonic-1.3.0/target/release/build/librocksdb-sys-99f90673e6ba75e6/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=build.rs
  cargo:warning=couldn't execute `llvm-config --prefix` (error: No such file or directory (os error 2))
  cargo:warning=set the LLVM_CONFIG_PATH environment variable to the full path to a valid `llvm-config` executable (including the executable itself)

  --- stderr
  thread 'main' panicked at 'Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', /home/linuxbrew/.cache/Homebrew/cargo_cache/registry/src/github.com-1ecc6299db9ec823/bindgen-0.53.3/src/lib.rs:1956:31
```