### PR TITLE
systemd: fix build for linux

### DIFF
--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -18,6 +18,7 @@ class Systemd < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
+  depends_on "rsync" => :build
   depends_on "expat"
   depends_on "libcap"
   depends_on :linux
@@ -25,6 +26,7 @@ class Systemd < Formula
   depends_on "openssl@1.1"
   depends_on "util-linux" # for libmount
   depends_on "xz"
+  depends_on "zstd"
 
   def install
     args = %W[


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1006361660
```
Program rsync found: NO

../man/meson.build:187:0: ERROR: Program 'rsync' not found

A full log can be found at /tmp/systemd-20210707-8935-dxr495/systemd-246/build/meson-logs/meson-log.txt
```