### PR TITLE
pcre2: patch JIT issue that breaks PHP regex

### DIFF
--- a/Formula/pcre2.rb
+++ b/Formula/pcre2.rb
@@ -1,10 +1,20 @@
 class Pcre2 < Formula
   desc "Perl compatible regular expressions library with a new API"
   homepage "https://www.pcre.org/"
-  url "https://ftp.pcre.org/pub/pcre/pcre2-10.37.tar.bz2"
-  sha256 "4d95a96e8b80529893b4562be12648d798b957b1ba1aae39606bbc2ab956d270"
   license "BSD-3-Clause"
+  revision 1
   head "svn://vcs.exim.org/pcre2/code/trunk"
+
+  # remove stable block on next release with merged patch
+  stable do
+    url "https://ftp.pcre.org/pub/pcre/pcre2-10.37.tar.bz2"
+    sha256 "4d95a96e8b80529893b4562be12648d798b957b1ba1aae39606bbc2ab956d270"
+
+    # fix invalid single character repetition issues in JIT
+    # upstream revision: https://vcs.pcre.org/pcre2?view=revision&revision=1315
+    # remove in the next release
+    patch :DATA
+  end
 
   livecheck do
     url "https://ftp.pcre.org/pub/pcre/"
@@ -44,3 +54,52 @@ class Pcre2 < Formula
     system bin/"pcre2grep", "regular expression", prefix/"README"
   end
 end
+
+__END__
+--- a/src/pcre2_jit_compile.c
++++ b/src/pcre2_jit_compile.c
+@@ -1236,15 +1236,16 @@ start:
+ 
+ return: current number of iterators enhanced with fast fail
+ */
+-static int detect_early_fail(compiler_common *common, PCRE2_SPTR cc, int *private_data_start, sljit_s32 depth, int start)
++static int detect_early_fail(compiler_common *common, PCRE2_SPTR cc, int *private_data_start,
++   sljit_s32 depth, int start, BOOL fast_forward_allowed)
+ {
+ PCRE2_SPTR begin = cc;
+ PCRE2_SPTR next_alt;
+ PCRE2_SPTR end;
+ PCRE2_SPTR accelerated_start;
++BOOL prev_fast_forward_allowed;
+ int result = 0;
+ int count;
+-BOOL fast_forward_allowed = TRUE;
+ 
+ SLJIT_ASSERT(*cc == OP_ONCE || *cc == OP_BRA || *cc == OP_CBRA);
+ SLJIT_ASSERT(*cc != OP_CBRA || common->optimized_cbracket[GET2(cc, 1 + LINK_SIZE)] != 0);
+@@ -1476,6 +1477,7 @@ do
+       case OP_CBRA:
+       end = cc + GET(cc, 1);
+ 
++      prev_fast_forward_allowed = fast_forward_allowed;
+       fast_forward_allowed = FALSE;
+       if (depth >= 4)
+         break;
+@@ -1484,7 +1486,7 @@ do
+       if (*end != OP_KET || (*cc == OP_CBRA && common->optimized_cbracket[GET2(cc, 1 + LINK_SIZE)] == 0))
+         break;
+ 
+-      count = detect_early_fail(common, cc, private_data_start, depth + 1, count);
++      count = detect_early_fail(common, cc, private_data_start, depth + 1, count, prev_fast_forward_allowed);
+ 
+       if (PRIVATE_DATA(cc) != 0)
+         common->private_data_ptrs[begin - common->start] = 1;
+@@ -13657,7 +13659,7 @@ memset(common->private_data_ptrs, 0, total_length * sizeof(sljit_s32));
+ private_data_size = common->cbra_ptr + (re->top_bracket + 1) * sizeof(sljit_sw);
+ 
+ if ((re->overall_options & PCRE2_ANCHORED) == 0 && (re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0 && !common->has_skip_in_assert_back)
+-  detect_early_fail(common, common->start, &private_data_size, 0, 0);
++  detect_early_fail(common, common->start, &private_data_size, 0, 0, TRUE);
+ 
+ set_private_data_ptrs(common, &private_data_size, ccend);
+ 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Not sure if there is a way to apply patch from VCS.

From revision https://vcs.pcre.org/pcre2?view=revision&revision=1315, I tried patch file https://vcs.pcre.org/pcre2/code/trunk/src/pcre2_jit_compile.c?view=patch&r1=1315&r2=1314&pathrev=1315, but the trunk directory structure doesn't work well with current patch method

---

Goal is to apply upstream patch to fix #80695 and fix #78635