### PR TITLE
ipython: fix build for Linux

### DIFF
--- a/Formula/ipython.rb
+++ b/Formula/ipython.rb
@@ -131,7 +131,11 @@ class Ipython < Formula
 
     # install other resources
     ipykernel = resource("ipykernel")
-    (resources - [ipykernel]).each do |r|
+    res = resources - [ipykernel]
+    on_linux do
+      res -= [resource("appnope")]
+    end
+    res.each do |r|
       r.stage do
         system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec/"vendor")
       end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1007131846
```
cp -pR /tmp/d20210707-5746-10dg7ns/appnope-0.1.2/. /tmp/ipython--appnope-20210707-5746-rjmtu3/appnope-0.1.2
chmod -Rf +w /tmp/d20210707-5746-10dg7ns
==> /home/linuxbrew/.linuxbrew/opt/python@3.9/bin/python3 -c import setuptools... --no-user-cfg install --prefix=/home/linuxbrew/.linuxbrew/Cellar/ipython/7.25.0/libexec/vendor --install-scripts=/home/linuxbrew/.linuxbrew/Cellar/ipython/7.25.0/libexec/vendor/bin --single-version-externally-managed --record=installed.txt
Traceback (most recent call last):
  File "<string>", line 3, in <module>
  File "setup.py", line 18, in <module>
    raise ValueError("Only meant for install on macOS >= 10.9")
ValueError: Only meant for install on macOS >= 10.9
```
