### PR TITLE
leptonica: fix test for Linux

### DIFF
--- a/Formula/leptonica.rb
+++ b/Formula/leptonica.rb
@@ -43,7 +43,7 @@ class Leptonica < Formula
       #include <leptonica/allheaders.h>
 
       int main(int argc, char **argv) {
-          std::fprintf(stdout, "%d.%d.%d", LIBLEPT_MAJOR_VERSION, LIBLEPT_MINOR_VERSION, LIBLEPT_PATCH_VERSION);
+          fprintf(stdout, "%d.%d.%d", LIBLEPT_MAJOR_VERSION, LIBLEPT_MINOR_VERSION, LIBLEPT_PATCH_VERSION);
           return 0;
       }
     EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1007248986
```make
==> /usr/bin/g++-5 test.cpp -I/home/linuxbrew/.linuxbrew/Cellar/leptonica/1.81.1/include/leptonica -Os -w -pipe -march=native
test.cpp: In function ‘int main(int, char**)’:
test.cpp:5:5: error: ‘fprintf’ is not a member of ‘std’
     std::fprintf(stdout, "%d.%d.%d", LIBLEPT_MAJOR_VERSION, LIBLEPT_MINOR_VERSION, LIBLEPT_PATCH_VERSION);
     ^
test.cpp:5:5: note: suggested alternative:
In file included from /usr/include/stdio.h:936:0,
                 from /home/linuxbrew/.linuxbrew/opt/leptonica/include/leptonica/alltypes.h:31,
                 from /home/linuxbrew/.linuxbrew/opt/leptonica/include/leptonica/allheaders.h:35,
                 from test.cpp:2:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:95:1: note:   ‘fprintf’
 fprintf (FILE *__restrict __stream, const char *__restrict __fmt, ...)
 ^
Error: leptonica: failed
```