### PR TITLE
autojump: fix test for Linux

### DIFF
--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -44,7 +44,7 @@ class Autojump < Formula
     path = testpath/"foo/bar"
     path.mkpath
     output = `
-      source #{etc}/profile.d/autojump.sh
+      . #{etc}/profile.d/autojump.sh
       j -a "#{path.relative_path_from(testpath)}"
       j foo >/dev/null
       pwd


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1007434615
```
==> Testing autojump
sh: 2: source: not found
sh: 3: j: not found
sh: 4: j: not found
Error: autojump: failed
```
