### PR TITLE
h2spec: fix description

### DIFF
--- a/Formula/h2spec.rb
+++ b/Formula/h2spec.rb
@@ -1,5 +1,5 @@
 class H2spec < Formula
-  desc "Fast website link checker in Go"
+  desc "A conformance testing tool for HTTP/2 implementation"
   homepage "https://github.com/summerwind/h2spec"
   url "https://github.com/summerwind/h2spec.git",
     tag:      "v2.6.0",

--- a/Formula/h2spec.rb
+++ b/Formula/h2spec.rb
@@ -1,5 +1,5 @@
 class H2spec < Formula
-  desc "A conformance testing tool for HTTP/2 implementation"
+  desc "Conformance testing tool for HTTP/2 implementation"
   homepage "https://github.com/summerwind/h2spec"
   url "https://github.com/summerwind/h2spec.git",
     tag:      "v2.6.0",


### PR DESCRIPTION
The description seems to have been inadvertently copied from `muffet.rb`. This updates the description to match the GitHub page (without trailing period).

Closes https://github.com/Homebrew/homebrew-core/issues/80733.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?

-----
