### PR TITLE
php@7.2: use disable instead of deprecate

### DIFF
--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -19,7 +19,11 @@ class PhpAT72 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2021-11-30", because: :deprecated_upstream
+  # Unsupported as of 2020-11-30: https://www.php.net/eol.php
+  # The date below is intentionally a year after the EOL date. This gives the
+  # formula a year before being disabled and it will be reported as deprecated
+  # in the interim time.
+  disable! date: "2021-11-30", because: :deprecated_upstream
 
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

PHP 7.2 became unsupported (EOL) on 2020-11-30 but the current date used with `deprecate!` is a year later, so this isn't deprecated right now like it should be. PHP 7.2 is an unsupported version and users should know about this, so they migrate to a supported version.

`php@7.2` originally used `disable! date: "2021-11-30"` but it was switched to `deprecate!` in #77283 without modifying the date. This effectively disabled the deprecation until a year after the actual EOL date, which isn't appropriate. The reason for this change was because `php@7.2` was being skipped in tests due to being deprecated, so undeprecating it would cause it to be tested.

I don't believe that's the correct approach to handle this situation, so this PR restores the original `disable!` setup. If we want certain deprecated formulae to continue to be tested, we should create an allowlist for this, so we can continue to appropriately deprecate formulae.