### PR TITLE
freexl: fix test for Linux

### DIFF
--- a/Formula/freexl.rb
+++ b/Formula/freexl.rb
@@ -41,7 +41,7 @@ class Freexl < Formula
           return 0;
       }
     EOS
-    system ENV.cc, "-L#{lib}", "-lfreexl", "test.c", "-o", "test"
+    system ENV.cc, "test.c", "-L#{lib}", "-lfreexl", "-o", "test"
     assert_equal version.to_s, shell_output("./test")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1008961941
```
==> FAILED
==> Testing freexl
==> /usr/bin/gcc-5 -L/home/linuxbrew/.linuxbrew/Cellar/freexl/1.0.6/lib -lfreexl test.c -o test
/tmp/cckCXkMg.o: In function `main':
test.c:(.text+0x5): undefined reference to `freexl_version'
collect2: error: ld returned 1 exit status
Error: freexl: failed
```