### PR TITLE
just: update 0.9.8 sha256

### DIFF
--- a/Formula/just.rb
+++ b/Formula/just.rb
@@ -2,8 +2,10 @@ class Just < Formula
   desc "Handy way to save and run project-specific commands"
   homepage "https://github.com/casey/just"
   url "https://github.com/casey/just/archive/0.9.8.tar.gz"
-  sha256 "dbb0bec2ccda354e07d25eb5bdd98151edb84ca7a763a2cfb885841b7578f0a4"
+  sha256 "0c464c3a06d40e68e1014e583ec1733aa16bca5796fb42874438dec9f4a464a4"
   license "CC0-1.0"
+  revision 1
+  head "https://github.com/casey/just.git"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "89f93b8233efe610afbfd20e42bc016b7c2d142b6d98035f7137d00efafdfc27"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See upstream comment from repo owner https://github.com/casey/just/issues/899#issuecomment-875083398

> Sorry for the inconvenience! There was an issue with the 0.9.8 GitHub release, and I had to delete and recreate the release. Linuxbrew must have picked up the release before I deleted it, and still has the hash of the older version.
> 
> I was going to open an issue in Linuxbrew, but the issue template requires a bunch of output from the brew command, which I can't provide because I don't have a linux box.