### PR TITLE
tokyo-cabinet: fix build for Linux

### DIFF
--- a/Formula/tokyo-cabinet.rb
+++ b/Formula/tokyo-cabinet.rb
@@ -4,7 +4,7 @@ class TokyoCabinet < Formula
   url "https://fallabs.com/tokyocabinet/tokyocabinet-1.4.48.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/t/tokyocabinet/tokyocabinet_1.4.48.orig.tar.gz"
   sha256 "a003f47c39a91e22d76bc4fe68b9b3de0f38851b160bbb1ca07a4f6441de1f90"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :homepage
@@ -22,6 +22,9 @@ class TokyoCabinet < Formula
     sha256 el_capitan:    "a209fa62fdb84a86784de5eb9699a9a6811c962afab2ebf418b2a712f51852d8"
     sha256 yosemite:      "3267823914e250aff7c8d3a5a686a010f0fc96242a417dbf47bb1502aa020ad6"
   end
+
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

**Note:** Should directly merge and trigger bottle job separately to avoid losing old macOS bottles.

https://github.com/Homebrew/homebrew-core/actions/runs/1009190570
```
checking for bzlib.h... no
configure: error: bzlib.h is required
```