### PR TITLE
pastel: fix build and add head

### DIFF
--- a/Formula/pastel.rb
+++ b/Formula/pastel.rb
@@ -1,9 +1,21 @@
 class Pastel < Formula
   desc "Command-line tool to generate, analyze, convert and manipulate colors"
   homepage "https://github.com/sharkdp/pastel"
-  url "https://github.com/sharkdp/pastel/archive/v0.8.0.tar.gz"
-  sha256 "603dc63d6aa261f159178dffeb389471a845c1a5d62187a275a3d33a66fe9a69"
   license "Apache-2.0"
+  head "https://github.com/sharkdp/pastel.git"
+
+  # Remove stable block on next release with merged patch
+  stable do
+    url "https://github.com/sharkdp/pastel/archive/v0.8.0.tar.gz"
+    sha256 "603dc63d6aa261f159178dffeb389471a845c1a5d62187a275a3d33a66fe9a69"
+
+    # Fix lexical-core build error on newer Rust with updated dependencies
+    # Remove in the next release
+    patch do
+      url "https://github.com/sharkdp/pastel/commit/00fb2e5d52011903ddb5c33f4dfe1018d692ab3e.patch?full_index=1"
+      sha256 "39dfc577e36645c693cf6d56e505d87d02450b313cdfc6a1acd59e1c5890247c"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "5063fbbdfeae431e7522f8a66d48999e5ef0dc3d7dae922ffc088a227b90e1c4"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Previously seen failure in Rust bump.
Also seen while trying to bottle Linux.

Added updated Cargo.lock file.
Cargo.toml hasn't changed since 0.8.0 release, so hopefully no issues introduced due to unreleased commits.