### PR TITLE
kakoune: fix build with GCC

### DIFF
--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -1,10 +1,21 @@
 class Kakoune < Formula
   desc "Selection-based modal text editor"
   homepage "https://github.com/mawww/kakoune"
-  url "https://github.com/mawww/kakoune/releases/download/v2020.09.01/kakoune-2020.09.01.tar.bz2"
-  sha256 "861a89c56b5d0ae39628cb706c37a8b55bc289bfbe3c72466ad0e2757ccf0175"
   license "Unlicense"
   head "https://github.com/mawww/kakoune.git"
+
+  # Remove stable block in next release with merged patch
+  stable do
+    url "https://github.com/mawww/kakoune/releases/download/v2020.09.01/kakoune-2020.09.01.tar.bz2"
+    sha256 "861a89c56b5d0ae39628cb706c37a8b55bc289bfbe3c72466ad0e2757ccf0175"
+
+    # Fix build for GCC: error: 'numeric_limits' is not a member of 'std'
+    # Remove in the next release
+    patch do
+      url "https://github.com/mawww/kakoune/commit/a0c23ccb720cb10469c4dfd77342524d6f607a9c.patch?full_index=1"
+      sha256 "01608c5bee3afb00593bddb1289fdec25d4e236aa00c0997a99c3c66ff7bb04d"
+    end
+  end
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1009183996
```
regex_impl.cc: In member function 'Kakoune::RegexParser::NodeIndex Kakoune::RegexParser::new_node(Kakoune::ParsedRegex::Op, Kakoune::Codepoint, Kakoune::ParsedRegex::Quantifier)':
regex_impl.cc:608:41: error: 'numeric_limits' is not a member of 'std'
  608 |         constexpr auto max_nodes = std::numeric_limits<int16_t>::max();
      |                                         ^~~~~~~~~~~~~~
regex_impl.cc:608:63: error: expected primary-expression before '>' token
  608 |         constexpr auto max_nodes = std::numeric_limits<int16_t>::max();
      |                                                               ^
regex_impl.cc:608:66: error: '::max' has not been declared; did you mean 'std::max'?
  608 |         constexpr auto max_nodes = std::numeric_limits<int16_t>::max();
      |                                                                  ^~~
      |                                                                  std::max
```