### PR TITLE
wp-cli: add php dependency for Linux

### DIFF
--- a/Formula/wp-cli.rb
+++ b/Formula/wp-cli.rb
@@ -17,6 +17,8 @@ class WpCli < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "67acd9816806eef402f59f1904fcebd2e23e6d6cb7657604430e299cf21bd300"
   end
 
+  uses_from_macos "php"
+
   def install
     bin.install "wp-cli-#{version}.phar" => "wp"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1009182080
```
==> FAILED
==> Testing wp-cli
==> /home/linuxbrew/.linuxbrew/Cellar/wp-cli/2.5.0/bin/wp core download --path=wptest
/usr/bin/env: ‘php’: No such file or directory

```