### PR TITLE
vcprompt: fix build by using older autconf@2.69

### DIFF
--- a/Formula/vcprompt.rb
+++ b/Formula/vcprompt.rb
@@ -18,7 +18,8 @@ class Vcprompt < Formula
     sha256 cellar: :any, mojave:        "8be8d7b1126e40a72a85f707b07f922132769cb2c6c26f768fe57ccb9c542fa5"
   end
 
-  depends_on "autoconf" => :build
+  # Check if `autoconf` works when updating to the next release
+  depends_on "autoconf@2.69" => :build
   depends_on "sqlite"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Shouldn't impact previous macOS bottles as they were probably built on older `autoconf` before update to v2.71.

Alternative solution is `autoreconf -fvi` with `automake` dependency:
```
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force 
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: /usr/local/Cellar/autoconf/2.71/bin/autoconf --force
configure.ac:18: warning: The macro `AC_PROG_CC_C99' is obsolete.
configure.ac:18: You should run autoupdate.
./lib/autoconf/c.m4:1659: AC_PROG_CC_C99 is expanded from...
configure.ac:18: the top level
autoreconf: running: /usr/local/Cellar/autoconf/2.71/bin/autoheader --force
autoreconf: configure.ac: not using Automake
autoreconf: './config.sub' is created
autoreconf: './config.guess' is created
autoreconf: Leaving directory '.'
```

https://github.com/Homebrew/homebrew-core/actions/runs/1009137235
```
==> autoconf
configure.ac:18: warning: The macro `AC_PROG_CC_C99' is obsolete.
configure.ac:18: You should run autoupdate.
./lib/autoconf/c.m4:1659: AC_PROG_CC_C99 is expanded from...
configure.ac:18: the top level
==> ./configure --disable-dependency-tracking --prefix=/home/linuxbrew/.linuxbrew/Cellar/vcprompt/1.2.1
configure: WARNING: unrecognized options: --disable-dependency-tracking
configure: error: cannot find required auxiliary files: config.guess config.sub
```
