### PR TITLE
func-e 0.5.0 (new formula)

### DIFF
--- a/Formula/func-e.rb
+++ b/Formula/func-e.rb
@@ -12,7 +12,7 @@ class FuncE < Formula
       -s -w
       -X github.com/tetratelabs/func-e/internal/version.funcE=#{version}
     ]
-    system "go", "build", "-trimpath", "-ldflags", ldflags.join(" "), "-o", bin/"func-e"
+    system "go", "build", *std_go_args(ldflags: ldflags.join(" "))
   end
 
   test do

--- a/Formula/func-e.rb
+++ b/Formula/func-e.rb
@@ -1,5 +1,5 @@
 class FuncE < Formula
-  desc "Easily run Envoy®"
+  desc "Easily run Envoy"
   homepage "https://func-e.io"
   url "https://github.com/tetratelabs/func-e/archive/v0.5.0.tar.gz"
   sha256 "17fc6c5c0f7bea8ce59e0bfb315198cc9f9ecfda98d51909149d42ffd125d72f"

--- a/Formula/func-e.rb
+++ b/Formula/func-e.rb
@@ -16,6 +16,20 @@ class FuncE < Formula
   end
 
   test do
-    system "#{bin}/func-e", "-v"
+    func_e_home = testpath/".func-e"
+    ENV["FUNC_E_HOME"] = func_e_home
+
+    # While this says "--version", this is a legitimate test as the --version is interpreted by Envoy.
+    # Specifically, func-e downloads and installs Envoy. Finally, it runs `envoy --version`
+    run_output = shell_output("#{bin}/func-e run --version")
+
+    # We intentionally aren't choosing an Envoy version, so we need to read the version file to figure it out.
+    installed_envoy_version = (func_e_home/"version").read
+    envoy_bin = "#{func_e_home}/versions/#{installed_envoy_version}/bin/envoy"
+    assert_path_exists envoy_bin
+
+    # Test output from the `envoy --version`. This uses a regex because we won't know the commit etc used. Ex.
+    # envoy  version: 98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Modified/RELEASE/BoringSSL
+    assert_match %r{envoy +version: [a-f0-9]{40}/#{installed_envoy_version}/}, run_output
   end
 end

--- a/Formula/func-e.rb
+++ b/Formula/func-e.rb
@@ -1,0 +1,21 @@
+class FuncE < Formula
+  desc "Easily run Envoy®"
+  homepage "https://func-e.io"
+  url "https://github.com/tetratelabs/func-e/archive/v0.5.0.tar.gz"
+  sha256 "17fc6c5c0f7bea8ce59e0bfb315198cc9f9ecfda98d51909149d42ffd125d72f"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/tetratelabs/func-e/internal/version.funcE=#{version}
+    ]
+    system "go", "build", "-trimpath", "-ldflags", ldflags.join(" "), "-o", bin/"func-e"
+  end
+
+  test do
+    system "#{bin}/func-e", "-v"
+  end
+end


### PR DESCRIPTION
While this is a new name, the project is older (formerly named
getenvoy). Now's a good time to make it official!

This obviates the tap https://github.com/tetratelabs/homebrew-getenvoy

Signed-off-by: Adrian Cole <adrian@tetrate.io>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
