### PR TITLE
github/workflows: more test-bot tweaks.

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -99,7 +99,7 @@ jobs:
             docker exec ${{github.sha}} brew test-bot --only-setup
           fi
 
-      - name: Run brew test-bot --keep-old --only-json-tab --only-formulae --skip-dependents ${{github.event.inputs.formula}}
+      - name: Run brew test-bot --only-formulae --keep-old --only-json-tab --skip-dependents ${{github.event.inputs.formula}}
         run: |
           if [ "$RUNNER_OS" = 'macOS' ]; then
             mkdir bottles
@@ -113,9 +113,10 @@ jobs:
         if: always() && runner.os == 'Linux'
         run: docker cp ${{github.sha}}:/tmp/bottles .
 
-      - name: Failures summary for brew test-bot --keep-old --only-json-tab --only-formulae --skip-dependents ${{github.event.inputs.formula}}
+      - name: Failures summary for brew test-bot --only-formulae
         if: always()
         run: |
+          touch bottles/steps_output.txt
           cat bottles/steps_output.txt
           rm bottles/steps_output.txt
 

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -58,7 +58,7 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - name: Run brew test-bot --only-json-tab --only-formulae --skip-dependents
+      - name: Run brew test-bot --only-formulae --only-json-tab --skip-dependents
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
@@ -66,9 +66,10 @@ jobs:
           cd bottles
           brew test-bot --only-json-tab --only-formulae --skip-dependents ${{github.event.inputs.formula}}
 
-      - name: Failures summary for brew test-bot --only-json-tab --only-formulae --skip-dependents
+      - name: Failures summary for brew test-bot --only-formulae
         if: always()
         run: |
+          touch bottles/steps_output.txt
           cat bottles/steps_output.txt
           rm bottles/steps_output.txt
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,15 +113,12 @@ jobs:
 
             const test_bot_dependents_args = ["--only-formulae-dependents", "--junit"]
             test_bot_dependents_args.push('--testing-formulae=${{needs.tap_syntax.outputs.testing_formulae}}')
-            test_bot_dependents_args.push('--added-formulae=${{needs.tap_syntax.outputs.added_formulae}}')
-            test_bot_dependents_args.push('--deleted-formulae=${{needs.tap_syntax.outputs.deleted_formulae}}')
 
             if (label_names.includes('CI-force-arm')) {
               console.log('CI-force-arm label found. Not passing --skip-unbottled-arm to brew test-bot.')
             } else {
               console.log('No CI-force-arm label found. Passing --skip-unbottled-arm to brew test-bot.')
               test_bot_formulae_args.push('--skip-unbottled-arm')
-              test_bot_dependents_args.push('--skip-unbottled-arm')
             }
 
             if (label_names.includes('CI-force-linux')) {
@@ -129,7 +126,6 @@ jobs:
             } else {
               console.log('No CI-force-linux label found. Passing --skip-unbottled-linux to brew test-bot.')
               test_bot_formulae_args.push('--skip-unbottled-linux')
-              test_bot_dependents_args.push('--skip-unbottled-linux')
             }
 
             if (label_names.includes('CI-test-bot-fail-fast')) {
@@ -246,6 +242,7 @@ jobs:
       - name: Failures summary for brew test-bot ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
         if: always()
         run: |
+          touch bottles/steps_output.txt
           cat bottles/steps_output.txt
           rm bottles/steps_output.txt
 
@@ -265,6 +262,7 @@ jobs:
       - name: Failures summary for brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
         if: always()
         run: |
+          touch bottles/steps_output.txt
           cat bottles/steps_output.txt
           rm bottles/steps_output.txt
 


### PR DESCRIPTION
- reorder some arguments
- trim some repeated argument lists
- `touch` file before `cat`ing it (so it doesn't fail)
- remove some no-op test-bot flags