### PR TITLE
libgcrypt: enable jitter-based entropy collector

### DIFF
--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -4,6 +4,7 @@ class Libgcrypt < Formula
   url "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.9.3.tar.bz2"
   sha256 "97ebe4f94e2f7e35b752194ce15a0f3c66324e0ff6af26659bbfb5ff2ec328fd"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libgcrypt/"
@@ -27,8 +28,10 @@ class Libgcrypt < Formula
                           "--enable-static",
                           "--prefix=#{prefix}",
                           "--disable-asm",
-                          "--with-libgpg-error-prefix=#{Formula["libgpg-error"].opt_prefix}",
-                          "--disable-jent-support" # Requires ENV.O0, which is unpleasant.
+                          "--with-libgpg-error-prefix=#{Formula["libgpg-error"].opt_prefix}"
+
+    # The jitter entropy collector must be built without optimisations
+    ENV.O0 { system "make", "-C", "random", "rndjent.o", "rndjent.lo" }
 
     # Parallel builds work, but only when run as separate steps
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This enables the jent module, which is included in the default build
configuration. The jent module provides an additional source of entropy
generated from CPU time jitter [1] and should help increase the security
of users who make use of `libgcrypt` particularly in virtualised
environments, server systems, or modern computers which lack spinning
hard disks that can be used as an entropy source.

We previously disabled this because the jent module must be built without
optimisations [2], but our compiler shims provided limited support for
selectively relaxing the optimisation level. This was resolved by
Homebrew/brew#11666.

[1] https://www.chronox.de/jent/doc/CPU-Jitter-NPTRNG.html
[2] #15750

-----

Marking as `do not merge` since this needs Homebrew/brew#11666 to land in a release tag first.