### PR TITLE
cpmtools: add livecheck

### DIFF
--- a/Formula/cpmtools.rb
+++ b/Formula/cpmtools.rb
@@ -5,6 +5,11 @@ class Cpmtools < Formula
   sha256 "a0032a17f9350ad1a2b80dea52c94c66cb2b49dfb38e402b5df22bdc2c5029d0"
   license "GPL-3.0-or-later"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?cpmtools[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "15e7282d0aaab6c0fdcba963da488dc134a3a91cdf386f975531ad6cb412eb4d"
     sha256 big_sur:       "72ac1f5c8c685e8a8e9e10ce3ba100883473f9578994752d0bcaab1bb987d27f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `cpmtools`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

One thing to note about this is that there's a `2.22` tarball on the `/~michael/cpmtools/files/` directory listing page but the homepage still only references `2.21`. Only three package managers have updated to version `2.22`, so I'm content to leave this as-is until the homepage is updated for version `2.22`. If that doesn't end up happening or this formula is updated to use version `2.22` in the interim time, we can always update this `livecheck` block to check the directory listing page instead (the regex would continue to work without changes).