### PR TITLE
earthly: disable

### DIFF
--- a/Formula/earthly.rb
+++ b/Formula/earthly.rb
@@ -19,6 +19,8 @@ class Earthly < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "78f6b33643db61f1944ceaf27d27ad001f8ba7a865b358a040cf1374fd618a96"
   end
 
+  disable! date: "2021-07-15", because: "has an incompatible license"
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
-------------

#### Debug data

PR generated by the [Earthly build](https://github.com/earthly/earthly/blob/main/release/Earthfile) (target +release-homebrew)

* `RELEASE_TAG=v0.5.18`

* `GIT_USERNAME=griswoldthecat`

* `NEW_URL=https://github.com/earthly/earthly/archive/v0.5.18.tar.gz`

* `NEW_SHA256=b7679ae11f76536033de59c27c22ea6ca426d3e876fa61aa389d0710ac639c81`

* `TAGS=dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork`

* `LDFLAGS=-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} -X main.GitSha=0cb24b0a8bbe4253e96990b7947e18f684918298 `

* `LDFLAGS1=-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} `

* `LDFLAGS2=-X main.GitSha=0cb24b0a8bbe4253e96990b7947e18f684918298 `