### PR TITLE
workflows/tests: fix syntax-only condition

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,7 +162,7 @@ jobs:
 
   tests:
     needs: setup_tests
-    if: github.event_name == 'pull_request' && ${{fromJson(needs.setup_tests.outputs.syntax-only)}}
+    if: ${{github.event_name == 'pull_request' && fromJson(needs.setup_tests.outputs.syntax-only) == false}}
     strategy:
       matrix:
         runner: ${{fromJson(needs.setup_tests.outputs.runners)}}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

#80808 introduced a number of modifications to workflows, one of which involved a change to the `syntax-only` condition. Unfortunately, this change has broken the `CI-syntax-only` label's functionality.

The workflow is currently running tests when `syntax-only` is `true`, whereas it should be running tests when `syntax-only` is `false`. The condition previously compared the `syntax-only` value to `'false'` and this was omitted when the condition was updated to use `fromJson()` to parse the value as a boolean. This PR updates the condition to compare the value to `false`, which should restore the `CI-syntax-only` label's expected behavior.

---

One thing to note here is that [it's important to use the `${{ ... }}` syntax around the entire condition](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#about-contexts-and-expressions) when using an expression that contains an [operator](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#operators) (e.g., `==`, `>`, `<=`, etc.). When I initially updated this to compare the value from `fromJson()` to `false` (i.e., `github.event_name == 'pull_request' && ${{fromJson(needs.setup_tests.outputs.syntax-only) == false}}`), it didn't work as expected. This syntax was incorrect and it's necessary to use `${{ ... }}` around the entire condition for it to work properly.

For what it's worth, I think we should simply standardize on using `${{ ... }}` around an `if` condition, regardless of whether it's technically necessary or not. This will help us to avoid this weird type of situation and make it easy to update an expression that didn't previously use an operator to include one (e.g., `if: ${{ something }}` -> `if: ${{ something == false }}`). Additionally, it would be nice to try to standardize the formatting to use a space after the opening bracket and before the closing one.

[I had some in-progress work that updated all the workflow files to incorporate these changes but it's not useful now, as there have been many changes in the interim time. Anyone's free to work on this if they want, otherwise I'll get around to it in time.]