### PR TITLE
Remove unnecessary versions

### DIFF
--- a/Formula/bandcamp-dl.rb
+++ b/Formula/bandcamp-dl.rb
@@ -10,7 +10,6 @@ class BandcampDl < Formula
   stable do
     url "https://github.com/iheanyi/bandcamp-dl/archive/v0.0.8-12.tar.gz"
     sha256 "3252f52780f280ba18818d40cda1c89bdb99ee33d7911320ec2ce4c374df2d6b"
-    version "0.0.8-12"
     # upstream hotfix, https://github.com/iheanyi/bandcamp-dl/pull/167
     # remove this in next release
     patch do

--- a/Formula/jnethack.rb
+++ b/Formula/jnethack.rb
@@ -8,7 +8,6 @@ class Jnethack < Formula
   url "https://scm.osdn.net/gitroot/jnethack/source.git",
       tag:      "v3.6.6-0.2",
       revision: "1dff0026832d47d3c93ff263afad233cced3a387"
-  version "3.6.6-0.2"
   license "NGPL"
   head "https://github.com/jnethack/jnethack-alpha.git", branch: "develop"
 

--- a/Formula/redir.rb
+++ b/Formula/redir.rb
@@ -2,7 +2,6 @@ class Redir < Formula
   desc "Port redirector"
   homepage "https://web.archive.org/web/20190817033513/sammy.net/~sammy/hacks/"
   url "https://github.com/TracyWebTech/redir/archive/2.2.1-9.tar.gz"
-  version "2.2.1-9"
   sha256 "7e6612a0eee1626a0e7d9888de49b9c0fa4b7f75c5c4caca7804bf73d73f01fe"
   license "GPL-2.0"
 

--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -2,7 +2,6 @@ class YoutubeDlc < Formula
   desc "Media downloader supporting various sites such as youtube"
   homepage "https://github.com/blackjack4494/yt-dlc"
   url "https://github.com/blackjack4494/yt-dlc/archive/2020.11.11-3.tar.gz"
-  version "2020.11.11-3"
   sha256 "649f8ba9a6916ca45db0b81fbcec3485e79895cec0f29fd25ec33520ffffca84"
   license "Unlicense"
   head "https://github.com/blackjack4494/yt-dlc.git"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to Homebrew/brew#11491, which fixed `Version` parsing for certain hyphenated version formats. The formulae in this PR no longer need a manually-specified `version`, as the version is now correctly parsed.