### PR TITLE
git-extras: fix build for Linux

### DIFF
--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -13,6 +13,10 @@ class GitExtras < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "55b4518da5dc0d3f07725c86d64a844b8a98cbcdb28f2a8bd99791c444d1838f"
   end
 
+  on_linux do
+    depends_on "util-linux" # for `column`
+  end
+
   conflicts_with "git-utils",
     because: "both install a `git-pull-request` script"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Linuxbrew upstream fix.

https://github.com/Homebrew/homebrew-core/actions/runs/1013260877
```
==> make PREFIX=/home/linuxbrew/.linuxbrew/Cellar/git-extras/6.2.0 INSTALL_VIA=brew install
Check dependencies before installation
Need to install dependency 'column' before installation
Makefile:29: recipe for target 'check' failed
make: *** [check] Error 1
```