### PR TITLE
Fix julia build on linux

### DIFF
--- a/Formula/julia.rb
+++ b/Formula/julia.rb
@@ -80,8 +80,14 @@ class Julia < Formula
       LIBLAPACKNAME=libopenblas
       USE_BLAS64=0
       PYTHON=python3
-      MACOSX_VERSION_MIN=#{MacOS.version}
     ]
+    on_macos { args << "MACOSX_VERSION_MIN=#{MacOS.version}" }
+    on_linux do
+      ENV.llvm_clang
+      # FIXME: Testing behavior if building a bundled libc++
+      args << "USECLANG=1"
+      args << "BUILD_CUSTOM_LIBCXX=1"
+    end
 
     # ARM gcc does not provide `libquadmath`
     args << "USE_SYSTEM_CSL=1" unless Hardware::CPU.arm?

--- a/Formula/libunwind.rb
+++ b/Formula/libunwind.rb
@@ -4,10 +4,13 @@ class Libunwind < Formula
   url "https://download.savannah.nongnu.org/releases/libunwind/libunwind-1.5.0.tar.gz"
   sha256 "90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "01d88381315b99c187e8351a10764ff2e38872bd178fe51bf3ddedba3d6418ee"
   end
+
+  keg_only "it conflicts with `llvm`"
 
   depends_on :linux
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Testing out some changes to try to build Julia on Linux.

Currently, `julia` build failures on Linux. It may be due to conflict between `llvm` and `libunwind`.
https://github.com/Homebrew/homebrew-core/runs/3024024869?check_suite_focus=true
```
Could not symlink lib/libunwind.a
Target /home/linuxbrew/.linuxbrew/lib/libunwind.a
is a symlink belonging to llvm. You can unlink it:
  brew unlink llvm

...

In file included from /tmp/julia-20210708-13518-11vlje7/julia-1.6.1/src/runtime_ccall.cpp:11:0:
/tmp/julia-20210708-13518-11vlje7/julia-1.6.1/src/julia_internal.h:884:25: fatal error: libunwind.h: No such file or directory
compilation terminated.
Makefile:170: recipe for target 'runtime_ccall.o' failed
make[2]: *** [runtime_ccall.o] Error 1
```

Not sure which is better to make keg_only here. `llvm` is already keg_only on macOS while `libunwind` is less-used based on analytics & as only dependency in `julia`/`gperftools`.