### PR TITLE
adns: use https url for head

### DIFF
--- a/Formula/adns.rb
+++ b/Formula/adns.rb
@@ -4,7 +4,7 @@ class Adns < Formula
   url "https://www.chiark.greenend.org.uk/~ian/adns/ftp/adns-1.6.0.tar.gz"
   sha256 "fb427265a981e033d1548f2b117cc021073dc8be2eaf2c45fd64ab7b00ed20de"
   license all_of: ["GPL-3.0-or-later", "LGPL-2.0-or-later"]
-  head "git://git.chiark.greenend.org.uk/~ianmdlvl/adns.git"
+  head "https://www.chiark.greenend.org.uk/ucgi/~ianmdlvl/githttp/adns.git"
 
   livecheck do
     url "https://www.chiark.greenend.org.uk/~ian/adns/ftp/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Bottle attempt failed due to head URL in audit
https://github.com/Homebrew/homebrew-core/actions/runs/1014220480
```
==> brew audit adns --online --git --skip-style
==> FAILED
Error: 1 problem in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
adns:
  * HEAD: The URL git://git.chiark.greenend.org.uk/~ianmdlvl/adns.git is not a valid git URL
```