### PR TITLE
exiftool: use CPAN url and make homepage url mirror

### DIFF
--- a/Formula/exiftool.rb
+++ b/Formula/exiftool.rb
@@ -3,7 +3,8 @@ class Exiftool < Formula
   homepage "https://exiftool.org"
   # Ensure release is tagged production before submitting.
   # https://exiftool.org/history.html
-  url "https://exiftool.org/Image-ExifTool-12.26.tar.gz"
+  url "https://cpan.metacpan.org/authors/id/E/EX/EXIFTOOL/Image-ExifTool-12.26.tar.gz"
+  mirror "https://exiftool.org/Image-ExifTool-12.26.tar.gz"
   sha256 "ed9f3285e263636c713ab52fcfb55cbcf4becd6c6e04bda410c8f240996ece9e"
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Homepage download URL is down and caused Linux bottle attempt to fail
https://github.com/Homebrew/homebrew-core/actions/runs/1014225945
```
==> FAILED
==> Downloading https://exiftool.org/Image-ExifTool-12.26.tar.gz
/usr/bin/curl --disable --globoff --show-error --user-agent Linuxbrew/3.2.1-64-g805f0ba\ \(Linux\;\ x86_64\ Ubuntu\ 16.04.7\ LTS\)\ curl/7.47.0 --header Accept-Language:\ en --fail --silent --retry 3 --location --remote-time --output /home/linuxbrew/.cache/Homebrew/downloads/400fea813b6d2f2b5888e5e2ae00b57b3c0654e7b04c84e365440ac7793e0b1c--Image-ExifTool-12.26.tar.gz.incomplete https://exiftool.org/Image-ExifTool-12.26.tar.gz
curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "exiftool"
Download failed: https://exiftool.org/Image-ExifTool-12.26.tar.gz
```

According to history page https://exiftool.org/history.html, the production version is uploaded to CPAN, so switch to download from CPAN for now and make homepage download into mirror. At least the SHA256 matches.

Can consider switching them on next production release depending on whether homepage or CPAN is better maintained.