### PR TITLE
enscript: fix test issue with double escaped characters

### DIFF
--- a/Formula/enscript.rb
+++ b/Formula/enscript.rb
@@ -4,6 +4,7 @@ class Enscript < Formula
   url "https://ftp.gnu.org/gnu/enscript/enscript-1.6.6.tar.gz"
   mirror "https://ftpmirror.gnu.org/enscript/enscript-1.6.6.tar.gz"
   sha256 "6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb"
+  license "GPL-3.0-or-later"
   revision 1
   head "https://git.savannah.gnu.org/git/enscript.git"
 
@@ -27,7 +28,6 @@ class Enscript < Formula
   end
 
   test do
-    assert_match "GNU Enscript #{Regexp.escape(version)}",
-                 shell_output("#{bin}/enscript -V")
+    assert_match "GNU Enscript #{version}", shell_output("#{bin}/enscript -V")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Caused issue on Linux bottle attempt https://github.com/Homebrew/homebrew-core/actions/runs/1014247905

Before:
```console
❯ brew test enscript; echo $?
==> Testing enscript
==> /usr/local/Cellar/enscript/1.6.6_1/bin/enscript -V
Error: enscript: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /GNU\ Enscript\ 1\\\.6\\\.6/ to match "GNU Enscript 1.6.6\nCopyright (C) 1995-2003, 2007, 2008, 2009, 2010 Free Software Foundation, Inc.\nGNU Enscript comes with NO WARRANTY, to the extent permitted by law.\nYou may redistribute copies of GNU Enscript under the terms of the GNU\nGeneral Public License, version 3 or, at your option, any later version.\nFor more information about these matters, see the files named COPYING.\n".
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/minitest-5.14.4/lib/minitest/assertions.rb:183:in `assert'
...
/usr/local/Homebrew/Library/Homebrew/test.rb:48:in `<main>'
1
```

After:
```console
❯ brew test enscript; echo $?
==> Testing enscript
==> /usr/local/Cellar/enscript/1.6.6_1/bin/enscript -V
0
```