### PR TITLE
clusterctl: update livecheck

### DIFF
--- a/Formula/clusterctl.rb
+++ b/Formula/clusterctl.rb
@@ -5,9 +5,15 @@ class Clusterctl < Formula
   sha256 "af60c8aa1b21eccc7f272c0135ffaf1a8e0ecdffb4173075efac52509ce0eeb0"
   license "Apache-2.0"
 
+  # Upstream creates releases on GitHub for the two most recent major/minor
+  # versions (e.g., 0.3.x, 0.4.x), so the "latest" release can be incorrect. We
+  # don't check the Git tags because, for this project, a version may not be
+  # considered released until the GitHub release is created. The first-party
+  # website doesn't clearly list the latest version and we have to isolate it
+  # from a GitHub URL used in a curl command in the installation instructions.
   livecheck do
-    url :stable
-    strategy :github_latest
+    url "https://cluster-api.sigs.k8s.io/user/quick-start.html"
+    regex(%r{/cluster-api/releases/download/v?(\d+(?:\.\d+)+)/}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `clusterctl` uses the `GithubLatest` strategy but the "latest" version in the GitHub project is `0.3.20` instead of `0.4.0`. Upstream regularly [maintains the two most recent releases](https://cluster-api.sigs.k8s.io/reference/versions.html) (e.g., `0.3.x`, `0.4.x`) and this can cause the "latest" release on GitHub to point to a release for the lower version, depending on when releases are created. This issue occurred because the `0.3.20` release was created after `0.4.0`.

As was mentioned in #75297, we don't want to check the Git tags for this project because a version isn't considered released until the GitHub release is created. I've chosen to check the first-party website in this `livecheck` block but, unfortunately, the site doesn't clearly indicate the latest version. Instead, I'm isolating the version from a GitHub release URL that's used in a `curl` command in the install instructions. This is a little fragile but I don't see any better alternatives with these constraints, so we'll just have to adjust this if it breaks over time.