### PR TITLE
mongosh 1.0.0

### DIFF
--- a/Formula/mongosh.rb
+++ b/Formula/mongosh.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Mongosh < Formula
   desc "MongoDB Shell to connect, configure, query, and work with your MongoDB database"
   homepage "https://github.com/mongodb-js/mongosh#readme"
-  url "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.15.6.tgz"
-  sha256 "32cb9c1a7453b829071d682a00fc03a86ed28bad1f21515349241c088e1c2ff9"
+  url "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-1.0.0.tgz"
+  sha256 "c94b5f7c8bd31c0a65f4d2066eb1ff56a393a0c86a1285aa0fe2c7041621be2b"
   license "Apache-2.0"
 
   bottle do


### PR DESCRIPTION
This PR was created ~automatically~ (manually this time :D) and bumps `mongosh` to the latest published version `1.0.0`.

For additional details see https://github.com/mongodb-js/mongosh/releases/tag/v1.0.0.