### PR TITLE
argo: update stable url

### DIFF
--- a/Formula/argo.rb
+++ b/Formula/argo.rb
@@ -1,7 +1,7 @@
 class Argo < Formula
   desc "Get stuff done with container-native workflows for Kubernetes"
   homepage "https://argoproj.io"
-  url "https://github.com/argoproj/argo.git",
+  url "https://github.com/argoproj/argo-workflows.git",
       tag:      "v3.1.1",
       revision: "a245fe67db56d2808fb78c6079d08404cbee91aa"
   license "Apache-2.0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The argoproj/argo repository was seemingly renamed to argo-workflows. The old URL correctly redirected for a while (as seen in the last [archive.org snapshot](https://web.archive.org/web/20210217134807/https://github.com/argoproj/argo) from 2021-02-17) but it now points to a different repository. This PR updates the stable URL accordingly.