### PR TITLE
ps2eps: add livecheck

### DIFF
--- a/Formula/ps2eps.rb
+++ b/Formula/ps2eps.rb
@@ -4,6 +4,11 @@ class Ps2eps < Formula
   url "https://www.tm.uka.de/~bless/ps2eps-1.70.tar.gz"
   sha256 "3a6681c3177af9ae326459c57e84fe90829d529d247fc32ae7f66e8839e81b11"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?ps2eps[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "cb048bafbe5b44a17151bc81c5743045f3f4963d6f3cf2adf38685bba82c8c67"
     sha256 cellar: :any_skip_relocation, big_sur:       "91e08e8ced4f5394ad3f4990a092fa61a547cce4264127350f97912c50dda5f3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `ps2eps`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.