### PR TITLE
bnd: add livecheck

### DIFF
--- a/Formula/bnd.rb
+++ b/Formula/bnd.rb
@@ -4,6 +4,11 @@ class Bnd < Formula
   url "https://search.maven.org/remotecontent?filepath=biz/aQute/bnd/biz.aQute.bnd/5.3.0/biz.aQute.bnd-5.3.0.jar"
   sha256 "f02cd3406b054da1840795c3cecc11c4226a8563aa74a67acc05f3d9aeaa9b85"
 
+  livecheck do
+    url "https://search.maven.org/remotecontent?filepath=biz/aQute/bnd/biz.aQute.bnd/maven-metadata.xml"
+    regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "89dd0195cf90dfc4bd45fa72d6d772e5b98a085c7fc4f1f385282cb5ada76049"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `bnd`. This PR adds a `livecheck` block that checks Maven's `maven-metadata.xml` file, which contains version information.

It's also possible to get version information from the first-party website's [/releases/index.json](https://bnd.bndtools.org/releases/index.json) file or the [GitHub repository](https://github.com/bndtools/bnd) but I opted to check the `stable` source, so livecheck doesn't report a new version before it's available from Maven.