### PR TITLE
rails-completion: add livecheck

### DIFF
--- a/Formula/rails-completion.rb
+++ b/Formula/rails-completion.rb
@@ -7,6 +7,10 @@ class RailsCompletion < Formula
   license "MIT"
   head "https://github.com/mernen/completion-ruby.git"
 
+  livecheck do
+    skip "No version information available to check"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "e52f96f415b50192094012cd4678e96b1c5e119c133224d4302e0bf2f6acea0e"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`rails-completion` uses the same repository as `ruby-completion` and `brew livecheck` should skip it for the same reasons (see: Homebrew/homebrew-core#80895). Basically, `completion-ruby` is unversioned and the upstream Git repository doesn't contain any tags. Until there's version information to check, there's no point in checking the Git tags (which livecheck does by default for this formula).