### PR TITLE
monkeysphere: fix runtime error on Big Sur and Linux

### DIFF
--- a/Formula/monkeysphere.rb
+++ b/Formula/monkeysphere.rb
@@ -1,9 +1,10 @@
 class Monkeysphere < Formula
   desc "Use the OpenPGP web of trust to verify ssh connections"
-  homepage "http://web.monkeysphere.info/"
+  homepage "https://web.monkeysphere.info/"
   url "https://deb.debian.org/debian/pool/main/m/monkeysphere/monkeysphere_0.44.orig.tar.gz"
   sha256 "6ac6979fa1a4a0332cbea39e408b9f981452d092ff2b14ed3549be94918707aa"
-  revision 3
+  license "GPL-3.0-or-later"
+  revision 4
   head "git://git.monkeysphere.info/monkeysphere"
 
   livecheck do
@@ -27,18 +28,35 @@ class Monkeysphere < Formula
 
   uses_from_macos "perl"
 
+  on_linux do
+    resource "Crypt::OpenSSL::Guess" do
+      url "https://cpan.metacpan.org/authors/id/A/AK/AKIYM/Crypt-OpenSSL-Guess-0.13.tar.gz"
+      sha256 "87c1dd7f0f80fcd3d1396bce9fd9962e7791e748dc0584802f8d10cc9585e743"
+    end
+  end
+
   resource "Crypt::OpenSSL::Bignum" do
     url "https://cpan.metacpan.org/authors/id/K/KM/KMX/Crypt-OpenSSL-Bignum-0.09.tar.gz"
     sha256 "234e72fb8396d45527e6fd45e43759c5c3f3a208cf8f29e6a22161a996fd42dc"
+  end
+
+  resource "Crypt::OpenSSL::RSA" do
+    url "https://cpan.metacpan.org/authors/id/T/TO/TODDR/Crypt-OpenSSL-RSA-0.31.tar.gz"
+    sha256 "4173403ad4cf76732192099f833fbfbf3cd8104e0246b3844187ae384d2c5436"
   end
 
   def install
     ENV.prepend_path "PATH", Formula["gnu-sed"].libexec/"gnubin"
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
-    resource("Crypt::OpenSSL::Bignum").stage do
-      system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
-      system "make", "install"
+    res = resources
+    on_macos { res = [resource("Crypt::OpenSSL::Bignum")] if MacOS.version <= :catalina }
+
+    res.each do |r|
+      r.stage do
+        system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+        system "make", "install"
+      end
     end
 
     ENV["PREFIX"] = prefix


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Tested on Big Sur.
Haven't tried Linux, so may fail there.

Original formula attempt hit test failure for me on Big Sur:
```make
==> /usr/local/Cellar/monkeysphere/0.44_3/bin/openpgp2pem --help 2>&1
sh: line 1: 29381 Abort trap: 6           /usr/local/Cellar/monkeysphere/0.44_3/bin/openpgp2pem --help 2>&1
Error: monkeysphere: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /We\ need\ at\ least/ to match "dyld: lazy symbol binding failed: Symbol not found: _ERR_load_crypto_strings\n  Referenced from: /System/Library/Perl/Extras/5.30/darwin-thread-multi-2level/auto/Crypt/OpenSSL/RSA/RSA.bundle\n  Expected in: flat namespace\n\ndyld: Symbol not found: _ERR_load_crypto_strings\n  Referenced from: /System/Library/Perl/Extras/5.30/darwin-thread-multi-2level/auto/Crypt/OpenSSL/RSA/RSA.bundle\n  Expected in: flat namespace\n\n".
```