### PR TITLE
libunwind: fix conflict with LLVM

### DIFF
--- a/Formula/libunwind.rb
+++ b/Formula/libunwind.rb
@@ -18,6 +18,15 @@ class Libunwind < Formula
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make"
     system "make", "install"
+
+    # Rename `libunwind.a` to avoid conflict with LLVM's `libunwind.a`
+    mv lib/"libunwind.a", lib/"libunwind-standalone.a"
+  end
+
+  def caveats
+    <<~EOS
+      To avoid conflicts with LLVM, `libunwind.a` has been installed as `libunwind-standalone.a`.
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Both `llvm` and `libunwind` install a `libunwind.a` into `lib`, so let's
rename the one here to avoid a conflicting install.

See also #80883 and #80853.