### PR TITLE
nss: fix build on Linux

### DIFF
--- a/Formula/nss.rb
+++ b/Formula/nss.rb
@@ -49,7 +49,9 @@ class Nss < Formula
     # rather than copying the referenced file.
     cd "../dist"
     bin.mkpath
-    Dir.glob("Darwin*/bin/*") do |file|
+    os = "Darwin"
+    on_linux { os = "Linux" }
+    Dir.glob("#{os}*/bin/*") do |file|
       cp file, bin unless file.include? ".dylib"
     end
 
@@ -59,7 +61,7 @@ class Nss < Formula
 
     lib.mkpath
     libexec.mkpath
-    Dir.glob("Darwin*/lib/*") do |file|
+    Dir.glob("#{os}*/lib/*") do |file|
       if file.include? ".chk"
         cp file, libexec
       else


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1002789112
```make
g++ -o Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/nss_bogo_shim -O2 -fPIC  -m64 -pipe -ffunction-sections -fdata-sections -DHAVE_STRERROR -DLINUX -Dlinux -Wall -Wshadow -Werror -Wsign-compare -DXP_UNIX -DXP_UNIX -UDEBUG -DNDEBUG -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_SOURCE -DSQL_MEASURE_USE_TEMP_DIR -D_REENTRANT -UDEBUG -DNDEBUG -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_SOURCE -DSQL_MEASURE_USE_TEMP_DIR -D_REENTRANT -DNSS_NO_INIT_SUPPORT -DUSE_UTIL_DIRECTLY -DNO_NSPR_10_SUPPORT -DSSL_DISABLE_DEPRECATED_CIPHER_SUITE_NAMES -DNSS_USE_STATIC_LIBS -I../../cpputil -I/home/linuxbrew/.linuxbrew/opt/nspr/include/nspr -I../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/include -I../../../dist/public/nss -I../../../dist/private/nss -I../../../dist/public/nspr -I../../../dist/public/nss -I../../../dist/public/libdbm -I../../../dist/public/cpputil  -I../../lib/ssl Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/config.o Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/nsskeys.o Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/nss_bogo_shim.o -m64 -z noexecstack -m64 -z noexecstack ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libcpputil.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libsectool.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libsmime.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libssl.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libnss.a  ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkcs12.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkcs7.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libcerthi.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libcryptohi.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpk11wrap.a  ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libsoftokn.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libcertdb.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libnsspki.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libnssdev.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libnssb.a  ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libfreebl.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libdbm.a  ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixtop.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixutil.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixsystem.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixcrlsel.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixmodule.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixstore.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixparams.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixchecker.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixpki.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixtop.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixresults.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpkixcertsel.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libnss.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libpk11wrap.a ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib/libcerthi.a   -L../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib -lsqlite3 -L../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/lib -lnssutil3 -L/home/linuxbrew/.linuxbrew/opt/nspr/lib -lplc4 -lplds4 -lnspr4  -lpthread  -ldl -lc
../../coreconf/nsinstall/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/nsinstall -R -m 775 Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/nss_bogo_shim ../../../dist/Linux5.8_x86_64_gcc-5_glibc_PTH_64_OPT.OBJ/bin
make[3]: Leaving directory '/tmp/nss-20210706-3540-1pnotzj/nss-3.67/nss/gtests/nss_bogo_shim'
make[2]: Leaving directory '/tmp/nss-20210706-3540-1pnotzj/nss-3.67/nss/gtests'
make[1]: Leaving directory '/tmp/nss-20210706-3540-1pnotzj/nss-3.67/nss'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/fileutils.rb:128: warning: conflicting chdir during another chdir block
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory @ apply2files - /home/linuxbrew/.linuxbrew/Cellar/nss/3.67/lib/libssl.a
```