### PR TITLE
pup: fix arm64 binary

### DIFF
--- a/Formula/pup.rb
+++ b/Formula/pup.rb
@@ -27,14 +27,15 @@ class Pup < Formula
     dir = buildpath/"src/github.com/ericchiang/pup"
     dir.install buildpath.children
 
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
     os = "darwin"
     on_linux do
       os = "linux"
     end
 
     cd dir do
-      system "gox", "-arch", "amd64", "-os", os, "./..."
-      bin.install "pup_#{os}_amd64" => "pup"
+      system "gox", "-arch", arch, "-os", os, "./..."
+      bin.install "pup_#{os}_#{arch}" => "pup"
     end
 
     prefix.install_metafiles dir


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Not sure if worth adding `revision 1` and impacting older macOS bottles.

The issue is that previous `arm64_big_sur` bottle binary was compiled for x86_64:
```console
❯ file /opt/homebrew/bin/pup
/opt/homebrew/bin/pup: Mach-O 64-bit executable x86_64
```

Adding `arm64` arch allows compiling for correct architecture:
```console
❯ brew install pup --build-from-source
==> Downloading https://github.com/ericchiang/pup/archive/v0.4.0.tar.gz
==> Downloading from https://codeload.github.com/ericchiang/pup/tar.gz/v0.4.0
  # #=O=#   #
==> gox -arch arm64 -os darwin ./...
🍺  /opt/homebrew/Cellar/pup/0.4.0: 5 files, 3.8MB, built in 5 seconds

❯ file /opt/homebrew/bin/pup
/opt/homebrew/bin/pup: Mach-O 64-bit executable arm64
```