### PR TITLE
sqlcipher: fix build for Linux

### DIFF
--- a/Formula/sqlcipher.rb
+++ b/Formula/sqlcipher.rb
@@ -15,6 +15,10 @@ class Sqlcipher < Formula
 
   depends_on "openssl@1.1"
 
+  # Build scripts require tclsh. `--disable-tcl` only skips building extension
+  uses_from_macos "tcl-tk" => :build
+  uses_from_macos "sqlite"
+
   def install
     args = %W[
       --prefix=#{prefix}
@@ -34,6 +38,10 @@ class Sqlcipher < Formula
       -DSQLITE_ENABLE_COLUMN_METADATA
     ].join(" ")
     args << "CFLAGS=#{cflags}"
+
+    on_linux do
+      args << "LIBS=-lm"
+    end
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1016764768
```make
/tmp/sqlcipher-20210709-2962-yoe2qv/sqlcipher-4.4.3/src/sqlite3ext.h:20:21: fatal error: sqlite3.h: No such file or directory
compilation terminated.
Makefile:1215: recipe for target 'json1.lo' failed
make: *** [json1.lo] Error 1
make: *** Waiting for unfinished jobs....
cp /tmp/sqlcipher-20210709-2962-yoe2qv/sqlcipher-4.4.3/tool/lempar.c .
```