### PR TITLE
cliclick: add `depends_on :macos`

### DIFF
--- a/Formula/cliclick.rb
+++ b/Formula/cliclick.rb
@@ -13,6 +13,8 @@ class Cliclick < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "7ff1aa3722085a9bbcdbd3fe496a84dcef9774a75b0374c0c3f404517aa79eca"
   end
 
+  depends_on :macos
+
   def install
     system "make"
     bin.install "cliclick"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

macOS CLI tool in Objective-C