### PR TITLE
aces_container: fix test for Linux

### DIFF
--- a/Formula/aces_container.rb
+++ b/Formula/aces_container.rb
@@ -15,6 +15,7 @@ class AcesContainer < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
 
   def install
     mkdir "build" do
@@ -33,7 +34,7 @@ class AcesContainer < Formula
           return 0;
       }
     EOS
-    system ENV.cxx, "-L#{lib}", "-lacescontainer", "test.cpp", "-o", "test"
+    system ENV.cxx, "test.cpp", "-L#{lib}", "-lAcesContainer", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1016875622
```
==> FAILED
==> Testing aces_container
==> /usr/bin/g++-5 -L/home/linuxbrew/.linuxbrew/Cellar/aces_container/1.0.2/lib -lacescontainer test.cpp -o test
/usr/bin/ld: cannot find -lacescontainer
collect2: error: ld returned 1 exit status
```