### PR TITLE
aamath: link Homebrew readline on Linux

### DIFF
--- a/Formula/aamath.rb
+++ b/Formula/aamath.rb
@@ -24,6 +24,10 @@ class Aamath < Formula
   uses_from_macos "bison" => :build # for yacc
   uses_from_macos "flex" => :build
 
+  on_linux do
+    depends_on "readline"
+  end
+
   # Fix build on clang; patch by Homebrew team
   # https://github.com/Homebrew/homebrew/issues/23872
   patch do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1016876015
```
==> brew linkage --test aamath
==> FAILED
Missing libraries:
  unexpected (libreadline.so.8)

...

==> Testing aamath
==> /home/linuxbrew/.linuxbrew/Cellar/aamath/0.3/bin/aamath
/home/linuxbrew/.linuxbrew/Cellar/aamath/0.3/bin/aamath: error while loading shared libraries: libreadline.so.8: cannot open shared object file: No such file or directory
Error: aamath: failed
```