### PR TITLE
monitoring-plugins: add livecheck

### DIFF
--- a/Formula/monitoring-plugins.rb
+++ b/Formula/monitoring-plugins.rb
@@ -4,6 +4,11 @@ class MonitoringPlugins < Formula
   url "https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz"
   sha256 "f56eb84871983fd719247249e3532228b37e2efaae657a3979bd14ac1f84a35b"
 
+  livecheck do
+    url "https://www.monitoring-plugins.org/download.html"
+    regex(/href=.*?monitoring-plugins[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "5044511cc0f5a64f3424d4507559b6ca316669121f4b15d58ef6b9cec5bba3f8"
     sha256 cellar: :any, big_sur:       "a49576ad287d073c67e0da12be686ba737abe34e5f61813a2e308cd44c427017"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `monitoring-plugins`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.