### PR TITLE
jam: deprecate

### DIFF
--- a/Formula/jam.rb
+++ b/Formula/jam.rb
@@ -12,6 +12,13 @@ class Jam < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "2927cebface8a3cbc00a23e7badb9e1676fda9bae282e78a1772b99aafba5014"
   end
 
+  # The "Jam Documentation" page has a banner stating:
+  # "Perforce is no longer actively contributing to the Jam Open Source project.
+  # The last Perforce release of Jam was version 2.6 in August of 2014. We will
+  # keep the Perforce-controlled links and information posted here available
+  # until further notice."
+  deprecate! date: "2021-07-10", because: :unmaintained
+
   conflicts_with "ftjam", because: "both install a `jam` binary"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The ["Jam Documentation" page](https://www.perforce.com/documentation/jam-documentation) (used as the homepage in this formula) contains a banner that states:

> Please Note: Perforce is no longer actively contributing to the Jam Open Source project. The last Perforce release of Jam was version 2.6 in August of 2014. We will keep the Perforce-controlled links and information posted here available until further notice.

This PR deprecates the formula as `:unmaintained`, as [there hasn't been any activity in the project in two years](https://swarm.workshop.perforce.com/projects/perforce_software-jam/activity/) and it doesn't seem likely that will change.