### PR TITLE
libunwind: make keg-only

### DIFF
--- a/Formula/libunwind.rb
+++ b/Formula/libunwind.rb
@@ -10,6 +10,8 @@ class Libunwind < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "5b802d128e935893e9e70e6125ba525e663d0f941b8128e939a9b677e36381e4"
   end
 
+  keg_only "libunwind conflicts with LLVM"
+
   depends_on :linux
 
   uses_from_macos "xz"
@@ -19,15 +21,6 @@ class Libunwind < Formula
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make"
     system "make", "install"
-
-    # Rename `libunwind.a` to avoid conflict with LLVM's `libunwind.a`
-    mv lib/"libunwind.a", lib/"libunwind-standalone.a"
-  end
-
-  def caveats
-    <<~EOS
-      To avoid conflicts with LLVM, `libunwind.a` has been installed as `libunwind-standalone.a`.
-    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Unfortunately, #80915 wasn't enough to resolve the conflict. I missed
that both `llvm` and `libunwind` also install a `libunwind.so`.

Merge this before #80883.