### PR TITLE
gsar 1.51

### DIFF
--- a/Formula/gsar.rb
+++ b/Formula/gsar.rb
@@ -1,10 +1,18 @@
 class Gsar < Formula
   desc "General Search And Replace on files"
   homepage "http://tjaberg.com/"
-  url "http://tjaberg.com/gsar121.zip"
-  version "1.21"
-  sha256 "05fb9583c970aba4eb0ffae2763d7482b0697c65fda1632a247a0153d7db65a9"
-  license "GPL-2.0"
+  url "http://tjaberg.com/gsar151.zip"
+  version "1.51"
+  sha256 "72908ae302d2293de5218fd4da0b98afa2ce8890a622e709360576e93f5e8cc8"
+  license "GPL-2.0-only"
+
+  # gsar archive file names don't include a version string with dots (e.g., 123
+  # instead of 1.23), so we identify versions from the text of the "Changes"
+  # section.
+  livecheck do
+    url :homepage
+    regex(/gsar v?(\d+(?:\.\d+)+) released/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "422050c4abb86641242bd8649dc39b83bf9a0bff0b2f57c0011d59baefaa87ac"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `gsar` to the latest version, `1.51`.

Additionally, this adds a `livecheck` block that checks the homepage and identifies versions from text like `gsar 1.51 released`, as found in the "Changes" section. This is necessary because `gsar` archive file names omit dots in the version text (e.g., `gsar151.zip`). If this `livecheck` block breaks in the future (due to relying on a specific text format), we can technically take the version numbers from the archive file and insert a dot after the first digit but it's preferable to not guess at creating a version from numbers without dots.

Lastly, this updates the `license` from `GPL-2.0` to `GPL-2.0-only`. Neither the website nor the source files contain any "or later" language, so this appears to be `GPL-2.0-only` by default.