### PR TITLE
nu-smv: add livecheck

### DIFF
--- a/Formula/nu-smv.rb
+++ b/Formula/nu-smv.rb
@@ -4,6 +4,13 @@ class NuSmv < Formula
   url "https://nusmv.fbk.eu/distrib/NuSMV-2.6.0.tar.gz"
   sha256 "dba953ed6e69965a68cd4992f9cdac6c449a3d15bf60d200f704d3a02e4bbcbb"
 
+  # The download page is behind a CAPTCHA, so we identify new versions from the
+  # the version announce links on the homepage.
+  livecheck do
+    url :homepage
+    regex(/href=.*?announce-NuSMV[._-]v?(\d+(?:\.\d+)+)\.txt/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:     "93b0188158e38160632863ca61c3e6809e2524fc46f93dacbe6d8c07a1693432"
     sha256 cellar: :any_skip_relocation, catalina:    "90dad1b30d80ee7ddba984d6ad2536fff08896e79cf1a26a083a5e9990fc3c43"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `nu-smv`. This PR adds a `livecheck` block that checks the homepage, identifying versions from the version announce links. We have to approach the `livecheck` block in this manner, as the download page is behind a CAPTCHA.