### PR TITLE
libmrss: add head, update homepage and license

### DIFF
--- a/Formula/libmrss.rb
+++ b/Formula/libmrss.rb
@@ -1,9 +1,10 @@
 class Libmrss < Formula
   desc "C library for RSS files or streams"
-  homepage "https://www.autistici.org/bakunin/libmrss/"
+  homepage "https://github.com/bakulf/libmrss"
+  # Update to use an archive from GitHub once there's a release after 0.19.2
   url "https://www.autistici.org/bakunin/libmrss/libmrss-0.19.2.tar.gz"
   sha256 "071416adcae5c1a9317a4a313f2deb34667e3cc2be4487fb3076528ce45b210b"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     rebuild 2
@@ -14,10 +15,24 @@ class Libmrss < Formula
     sha256 cellar: :any, high_sierra:   "234ec50cc4eabdd5433abb2d27f1e359c468db4fda10a36eb2c9278034a4e000"
   end
 
+  head do
+    url "https://github.com/bakulf/libmrss.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "pkg-config" => :build
   depends_on "libnxml"
 
   def install
+    if build.head?
+      mkdir "m4"
+      inreplace "autogen.sh", "libtoolize", "glibtoolize"
+      system "./autogen.sh"
+    end
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR is basically the same as #80617 (same developer, same situation), so I'll replicate that description here with modifications:

The existing [`libmrss` homepage](https://www.autistici.org/bakunin/libmrss/) only contains a message saying, "Moved to github: http://github.com/bakulf/libmrss." With that in mind, this PR updates the homepage to the GitHub repository. In the process, I also updated the `license` from `LGPL-2.1` to `LGPL-2.1-or-later`, as [the license information in code comments uses the "or later" language](https://github.com/bakulf/libmrss/search?q=or+later).

It's worth noting that the GitHub project only provides a tag archive for `0.19.2` (not a release artifact like the one from the website), so I haven't migrated the `stable` URL to GitHub. This is because `libmrss` seemingly needs some modifications to the `autogen.sh` setup to work (i.e., building from the `0.19.2` tag archive didn't work when I tried it).

There are several commits after `0.19.2` that address this but they haven't been included in a release yet and it's probably too many to apply to this formula. The current `stable` archive is still available from the first-party website (though the site doesn't link to it anymore), so I've left it as-is for the moment. Once there's a release after `0.19.2`, we can switch to a GitHub tag archive and I've added a comment above the `stable` URL saying as much.

That said, the point of this PR was simply to get this working with `livecheck`, as it currently gives an `Unable to get versions` error. To do so, I've added a `head` URL, along with conditional logic to allow `brew install --HEAD` to work properly. This approach can be used for `stable` tag archives in the future, if/when a release happens after `0.19.2`.