### PR TITLE
libfuse@2 2.9.9 (new formula)

### DIFF
--- a/Aliases/libfuse@3
+++ b/Aliases/libfuse@3
@@ -1,0 +1,1 @@
+../Formula/libfuse.rb

--- a/Formula/libfuse@2.rb
+++ b/Formula/libfuse@2.rb
@@ -1,0 +1,36 @@
+class LibfuseAT2 < Formula
+  desc "Reference implementation of the Linux FUSE interface"
+  homepage "https://github.com/libfuse/libfuse"
+  url "https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz"
+  sha256 "d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5"
+  license any_of: ["LGPL-2.1-only", "GPL-2.0-only"]
+
+  keg_only :versioned_formula
+
+  depends_on :linux
+
+  def install
+    ENV["INIT_D_PATH"] = etc/"init.d"
+    ENV["UDEV_RULES_PATH"] = etc/"udev/rules.d"
+    ENV["MOUNT_FUSE_PATH"] = bin
+    system "./configure", *std_configure_args, "--enable-lib", "--enable-util", "--disable-example"
+    system "make"
+    system "make", "install"
+    (pkgshare/"doc").install "doc/kernel.txt"
+  end
+
+  test do
+    (testpath/"fuse-test.c").write <<~EOS
+      #define FUSE_USE_VERSION 21
+      #include <fuse/fuse.h>
+      #include <stdio.h>
+      int main() {
+        printf("%d%d\\n", FUSE_MAJOR_VERSION, FUSE_MINOR_VERSION);
+        printf("%d\\n", fuse_version());
+        return 0;
+      }
+    EOS
+    system ENV.cc, "fuse-test.c", "-L#{lib}", "-I#{include}", "-D_FILE_OFFSET_BITS=64", "-lfuse", "-o", "fuse-test"
+    system "./fuse-test"
+  end
+end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula is Linux-only and it might be needed for a lot of formulae which now depend on `libfuse` but they can't be built as they expect libfuse2 and we shove libfuse3 to them.

@cho-m @iMichka what do you think guys? Should we provide the formula or try to hack those formulae?

Debian and Arch seem to deliver this lib.

https://github.com/Homebrew/homebrew-core/runs/3036286189?check_suite_focus=true
https://github.com/Homebrew/homebrew-core/runs/3036285825?check_suite_focus=true