### PR TITLE
archiver: fix test for linux

### DIFF
--- a/Formula/archiver.rb
+++ b/Formula/archiver.rb
@@ -32,8 +32,8 @@ class Archiver < Formula
            "test1", "test2", "test3"
 
     assert_predicate testpath/"test.zip", :exist?
-    assert_match "application/zip",
-                 shell_output("file -bI #{testpath}/test.zip")
+    assert_match "Zip archive data",
+                 shell_output("file -b #{testpath}/test.zip")
 
     output = shell_output("#{bin}/arc ls test.zip")
     names = output.lines.map do |line|


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3037260898?check_suite_focus=true
```
==> file -bI /tmp/archiver-test-20210710-6051-ueogoe/test.zip
file: invalid option -- 'I'
```