### PR TITLE
bindfs 1.15.1

### DIFF
--- a/Formula/bindfs.rb
+++ b/Formula/bindfs.rb
@@ -1,9 +1,9 @@
 class Bindfs < Formula
   desc "FUSE file system for mounting to another location"
   homepage "https://bindfs.org/"
-  url "https://bindfs.org/downloads/bindfs-1.14.8.tar.gz"
-  sha256 "e5ca5aff55204b993a025a77c3f8c0e2ee901ba8059d71bea11de2cc685ec497"
-  license "GPL-2.0"
+  url "https://bindfs.org/downloads/bindfs-1.15.1.tar.gz"
+  sha256 "04dd3584a6cdf9af4344d403c62185ca9fab31ce3ae5a25d0101bc10936c68ab"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any, catalina:    "bf4fb90d788651299973a3f48300824ae6b4ec4ce1441dd94d544180f54379bd"
@@ -13,6 +13,7 @@ class Bindfs < Formula
 
   head do
     url "https://github.com/mpartel/bindfs.git"
+
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Previous version failing with FUSE3:
https://github.com/Homebrew/homebrew-core/actions/runs/1018647176

But homepage mentions it has been tested (https://bindfs.org/):
> bindfs is developed and tested primarily on Linux with FUSE 2 and 3

So hopefully version bump will help.