### PR TITLE
pbzip2: fix build for Linux

### DIFF
--- a/Formula/pbzip2.rb
+++ b/Formula/pbzip2.rb
@@ -16,6 +16,8 @@ class Pbzip2 < Formula
     sha256 cellar: :any_skip_relocation, yosemite:      "ad103aef3e2d72293cfed3fcc42999afee9b4fc332f8319e3c079758215411c9"
   end
 
+  uses_from_macos "bzip2"
+
   def install
     system "make", "PREFIX=#{prefix}",
                    "CC=#{ENV.cxx}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1018959432
```
==> make PREFIX=/home/linuxbrew/.linuxbrew/Cellar/pbzip2/1.1.13 CC=g++-5 CFLAGS= PREFIX=/home/linuxbrew/.linuxbrew/Cellar/pbzip2/1.1.13 install
g++-5 -O2 -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -DUSE_STACKSIZE_CUSTOMIZATION -pthread -D_POSIX_PTHREAD_SEMANTICS  pbzip2.cpp BZ2StreamScanner.cpp ErrorContext.cpp -o pbzip2 -lbz2 -lpthread
pbzip2.cpp:33:19: fatal error: bzlib.h: No such file or directory
compilation terminated.
Makefile:70: recipe for target 'pbzip2' failed
```