### PR TITLE
blastem: add livecheck

### DIFF
--- a/Formula/blastem.rb
+++ b/Formula/blastem.rb
@@ -7,6 +7,11 @@ class Blastem < Formula
   revision 1
   head "https://www.retrodev.com/repos/blastem", using: :hg
 
+  livecheck do
+    url "https://www.retrodev.com/repos/blastem/tags"
+    regex(%r{href=.*?/repos/blastem/rev/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     sha256 cellar: :any, big_sur:     "003bbd7d1f5f9d81fb471d1fff692951c9400a8bf2f1511f0d83c9bea9cb8e63"
     sha256 cellar: :any, catalina:    "7b9652bffa8c28d6f23e1ad88534b5f2bbd49a916566650c3090366a556f11b2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `blastem`. This PR adds a `livecheck` block that checks the upstream repository's version tags, as the `stable` URL is a tag archive from the same source. This isn't a Git repository, so we're checking a webpage that lists the tags.