### PR TITLE
openfpgaloader 0.4.0 (new formula)

### DIFF
--- a/Formula/openfpgaloader.rb
+++ b/Formula/openfpgaloader.rb
@@ -2,7 +2,7 @@ class Openfpgaloader < Formula
   desc "Universal utility for programming FPGA"
   homepage "https://github.com/trabucayre/openFPGALoader"
   url "https://github.com/trabucayre/openFPGALoader/archive/v0.4.0.tar.gz"
-  sha256 "ab29cc5cc758a5edf26944e7578a47a7887a70b87494ad516ef4b8241e6b481f"
+  sha256 "f2a67761a6fc66b5f1ba61618ea73852e3d4d7ea7166f32ea0a3274a908c6d11"
   license "Apache-2.0"
   head "https://github.com/trabucayre/openFPGALoader.git"
 

--- a/Formula/openfpgaloader.rb
+++ b/Formula/openfpgaloader.rb
@@ -1,0 +1,26 @@
+class Openfpgaloader < Formula
+  desc "Universal utility for programming FPGA"
+  homepage "https://github.com/trabucayre/openFPGALoader"
+  url "https://github.com/trabucayre/openFPGALoader.git",
+    tag:      "v0.4.0",
+    revision: "1dbbd34420e00070bd0f58e0a91a653e12a87b97"
+  license "Apache-2.0"
+  revision 1
+  head "https://github.com/trabucayre/openFPGALoader.git"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libftdi"
+  depends_on "libusb"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    version_output = shell_output("#{bin}/openFPGALoader -V 2>&1")
+    assert_match "openFPGALoader v#{version}", version_output
+  end
+end

--- a/Formula/openfpgaloader.rb
+++ b/Formula/openfpgaloader.rb
@@ -1,11 +1,9 @@
 class Openfpgaloader < Formula
   desc "Universal utility for programming FPGA"
   homepage "https://github.com/trabucayre/openFPGALoader"
-  url "https://github.com/trabucayre/openFPGALoader.git",
-    tag:      "v0.4.0",
-    revision: "1dbbd34420e00070bd0f58e0a91a653e12a87b97"
+  url "https://github.com/trabucayre/openFPGALoader/archive/v0.4.0.tar.gz"
+  sha256 "ab29cc5cc758a5edf26944e7578a47a7887a70b87494ad516ef4b8241e6b481f"
   license "Apache-2.0"
-  revision 1
   head "https://github.com/trabucayre/openFPGALoader.git"
 
   depends_on "cmake" => :build
@@ -22,5 +20,8 @@ class Openfpgaloader < Formula
   test do
     version_output = shell_output("#{bin}/openFPGALoader -V 2>&1")
     assert_match "openFPGALoader v#{version}", version_output
+
+    error_output = shell_output("#{bin}/openFPGALoader --detect 2>&1 >/dev/null", 1)
+    assert_includes error_output, "JTAG init failed"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hi everyone, I've created a formula for [openFPGALoader](https://github.com/trabucayre/openFPGALoader) to make its installation easier on macOS.

**Disclaimer:** openFPGALoader features FPGA bitstreams ("FPGA firmwares" if you will) inside its source tree and which must be copied onto the target computer. These FPGA bitstreams provide important functionnality ("spi-over-JTAG") for openFPGALoader.

Even though the sources files for generating these bitstreams are available in the source tree, these bitstream can't be generated easily through Homebrew's CI. FPGA toolchains are bloated (tens of GBs), take ages to run, have complicated licensing issues (license files tied to network interfaces or sometimes worse) and won't run on macOS.