### PR TITLE
neopop-sdl: add livecheck

### DIFF
--- a/Formula/neopop-sdl.rb
+++ b/Formula/neopop-sdl.rb
@@ -5,6 +5,11 @@ class NeopopSdl < Formula
   sha256 "2df1b717faab9e7cb597fab834dc80910280d8abf913aa8b0dcfae90f472352e"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?NeoPop-SDL[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, big_sur:     "53e2a47e1f4e3bc4b35a31ea06f757ef62fc11de24347fcca5f4d1799f1adf94"
     sha256 cellar: :any, catalina:    "c4bd22db58945139a07d7c007c546e2edb3be1c3763f2d3f3008b575f30cef84"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `neopop-sdl`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.