### PR TITLE
freediameter: add livecheck

### DIFF
--- a/Formula/freediameter.rb
+++ b/Formula/freediameter.rb
@@ -6,6 +6,11 @@ class Freediameter < Formula
   license "BSD-3-Clause"
   head "http://www.freediameter.net/hg/freeDiameter", using: :hg
 
+  livecheck do
+    url "http://www.freediameter.net/hg/freeDiameter/json-tags"
+    regex(/["']tag["']:\s*?["']v?(\d+(?:\.\d+)+)["']/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "a2fd2271af79fd86ec7162e0af3adbaf611f280563a84dc2a98af96b7b3a3a4d"
     sha256 cellar: :any, big_sur:       "2c99cc840e0daebf52793d55e91ec616416c7fc7c4f4a8c332c6fe8c52fd181d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `freediameter`. This PR adds a `livecheck` block that checks the Mercurial repository tags, as the `stable` URL is a tag archive from the same source.