### PR TITLE
rubberband: update livecheck

### DIFF
--- a/Formula/rubberband.rb
+++ b/Formula/rubberband.rb
@@ -8,7 +8,7 @@ class Rubberband < Formula
 
   livecheck do
     url :homepage
-    regex(/Rubber Band Library v?(\d+(?:\.\d+)+) released/i)
+    regex(/href=.*?rubberband[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `rubberband` checks the homepage for text like `Rubber Band Library v1.9.2 released!`. This PR updates the regex to identify the version from the link to the `stable` archive instead, which is more in line with common checks. This `livecheck` block is an older one, so this brings it up to our current standards.