### PR TITLE
sdl_*: update homepage

### DIFF
--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -1,6 +1,6 @@
 class SdlImage < Formula
   desc "Image file loading library"
-  homepage "https://www.libsdl.org/projects/SDL_image"
+  homepage "https://www.libsdl.org/projects/SDL_image/release-1.2.html"
   url "https://www.libsdl.org/projects/SDL_image/release/SDL_image-1.2.12.tar.gz"
   sha256 "0b90722984561004de84847744d566809dbb9daf732a9e503b91a1b5a84e5699"
   license "Zlib"

--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -1,6 +1,6 @@
 class SdlMixer < Formula
   desc "Sample multi-channel audio mixer library"
-  homepage "https://www.libsdl.org/projects/SDL_mixer/"
+  homepage "https://www.libsdl.org/projects/SDL_mixer/release-1.2.html"
   url "https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-1.2.12.tar.gz"
   sha256 "1644308279a975799049e4826af2cfc787cad2abb11aa14562e402521f86992a"
   license "Zlib"

--- a/Formula/sdl_ttf.rb
+++ b/Formula/sdl_ttf.rb
@@ -1,6 +1,6 @@
 class SdlTtf < Formula
   desc "Library for using TrueType fonts in SDL applications"
-  homepage "https://www.libsdl.org/projects/SDL_ttf/"
+  homepage "https://www.libsdl.org/projects/SDL_ttf/release-1.2.html"
   url "https://www.libsdl.org/projects/SDL_ttf/release/SDL_ttf-2.0.11.tar.gz"
   sha256 "724cd895ecf4da319a3ef164892b72078bd92632a5d812111261cde248ebcdb7"
   revision 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the homepages of various `sdl` formulae to use the `release-1.2.html` page, like `sdl_net` does. The current homepage in these formulae is intended for SDL 2 and the `release-1.2.html` page is the homepage for the SDL 1.2 version.