### PR TITLE
sdl*: update repository references

### DIFF
--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -37,11 +37,11 @@ class Sdl < Formula
     end
 
     # Fix audio initialization issues on Big Sur, upstream patch
-    # http://hg.libsdl.org/SDL/rev/45055c672931
+    # https://github.com/libsdl-org/SDL-1.2/commit/a2047dc403ffb58b89b717929637352045699743
     if MacOS.version >= :big_sur
       patch do
-        url "http://hg.libsdl.org/SDL/raw-rev/45055c672931"
-        sha256 "4bc838bcfe8f671e016d22d9319cb39ca94052b86ad45b805d9b4d32564ef836"
+        url "https://github.com/libsdl-org/SDL-1.2/commit/a2047dc403ffb58b89b717929637352045699743.patch?full_index=1"
+        sha256 "7684a923dfd0c13f1a78e09ca0cea2632850e4d41023867b504707946ec495d4"
       end
     end
   end
@@ -55,7 +55,7 @@ class Sdl < Formula
   end
 
   head do
-    url "https://hg.libsdl.org/SDL", branch: "SDL-1.2", using: :hg
+    url "https://github.com/libsdl-org/SDL-1.2.git", branch: "main"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/Formula/sdl2_mixer.rb
+++ b/Formula/sdl2_mixer.rb
@@ -5,7 +5,6 @@ class Sdl2Mixer < Formula
   sha256 "b4cf5a382c061cd75081cf246c2aa2f9df8db04bdda8dcdc6b6cca55bede2419"
   license "Zlib"
   revision 1
-  head "https://hg.libsdl.org/SDL_mixer", using: :hg
 
   livecheck do
     url :homepage
@@ -19,6 +18,14 @@ class Sdl2Mixer < Formula
     sha256 cellar: :any, mojave:        "6d797207e602091ecee25168556e27f03665f5a9cb5d759152689b62e114f58b"
   end
 
+  head do
+    url "https://github.com/libsdl-org/SDL_mixer.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "pkg-config" => :build
   depends_on "flac"
   depends_on "libmodplug"
@@ -27,6 +34,11 @@ class Sdl2Mixer < Formula
 
   def install
     inreplace "SDL2_mixer.pc.in", "@prefix@", HOMEBREW_PREFIX
+
+    if build.head?
+      mkdir "build"
+      system "./autogen.sh"
+    end
 
     args = %W[
       --prefix=#{prefix}

--- a/Formula/sdl2_ttf.rb
+++ b/Formula/sdl2_ttf.rb
@@ -4,7 +4,6 @@ class Sdl2Ttf < Formula
   url "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.15.tar.gz"
   sha256 "a9eceb1ad88c1f1545cd7bd28e7cbc0b2c14191d40238f531a15b01b1b22cd33"
   license "Zlib"
-  head "https://hg.libsdl.org/SDL_ttf", using: :hg
 
   livecheck do
     url :homepage
@@ -20,12 +19,22 @@ class Sdl2Ttf < Formula
     sha256 cellar: :any, high_sierra:   "1867ff73485eaa12fc00def01be8e388443ac6c226065218bb435558fdb8bb22"
   end
 
+  head do
+    url "https://github.com/libsdl-org/SDL_ttf.git", branch: "main"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "pkg-config" => :build
   depends_on "freetype"
   depends_on "sdl2"
 
   def install
     inreplace "SDL2_ttf.pc.in", "@prefix@", HOMEBREW_PREFIX
+
+    system "./autogen.sh" if build.head?
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -34,7 +34,7 @@ class SdlMixer < Formula
 
   # Source file for sdl_mixer example
   resource "playwave" do
-    url "https://hg.libsdl.org/SDL_mixer/raw-file/a4e9c53d9c30/playwave.c"
+    url "https://github.com/libsdl-org/SDL_mixer/raw/1a14d94ed4271e45435ecb5512d61792e1a42932/playwave.c"
     sha256 "92f686d313f603f3b58431ec1a3a6bf29a36e5f792fb78417ac3d5d5a72b76c9"
   end
 

--- a/Formula/sdl_rtf.rb
+++ b/Formula/sdl_rtf.rb
@@ -3,7 +3,6 @@ class SdlRtf < Formula
   homepage "https://www.libsdl.org/projects/SDL_rtf/"
   url "https://www.libsdl.org/projects/SDL_rtf/release/SDL_rtf-0.1.0.tar.gz"
   sha256 "3dc0274b666e28010908ced24844ca7d279e07b66f673c990d530d4ea94b757e"
-  head "https://hg.libsdl.org/SDL_rtf", using: :hg
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "9d08d7ff2342e161defb1160668e96414902afd78756e4ab3824915385574546"
@@ -16,12 +15,22 @@ class SdlRtf < Formula
     sha256 cellar: :any, yosemite:      "8dd89df32c9ea02bcab36932c2f22bcb6de58d6002bd6fb9e95f9bbfe5ccf41e"
   end
 
+  head do
+    url "https://github.com/libsdl-org/SDL_rtf.git", branch: "SDL-1.2"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
   deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   depends_on "sdl"
 
   def install
+    system "./autogen.sh" if build.head?
+
     system "./configure", "--prefix=#{prefix}", "--disable-sdltest"
     system "make", "install"
   end

--- a/Formula/sdl_sound.rb
+++ b/Formula/sdl_sound.rb
@@ -18,7 +18,7 @@ class SdlSound < Formula
   end
 
   head do
-    url "https://hg.icculus.org/icculus/SDL_sound", using: :hg
+    url "https://github.com/icculus/SDL_sound.git", branch: "stable-1.0"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -34,16 +34,12 @@ class SdlSound < Formula
   depends_on "sdl"
 
   def install
-    if build.head?
-      inreplace "bootstrap", "/usr/bin/glibtoolize", "#{Formula["libtool"].opt_bin}/glibtoolize"
-      system "./bootstrap"
-    end
+    system "./autogen.sh" if build.head?
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-sdltest"
     system "make"
-    system "make", "check"
     system "make", "install"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing URLs that use the previous SDL Mercurial repository now redirect to the GitHub repository, so this PR updates these URLs accordingly. This also updates the steps for `head` builds, where necessary. `sdl2_mixer` is an odd case, as it needed `mkdir "build"` for the `head` build to succeed.

I've built/tested this locally using `brew install --build-from-source` and `brew install --HEAD` and both work fine.

I'll be adding `head` URLs for other SDL-related formulae in a separate PR.

---

The only other thing to note is that I've modified the `playwave` test resource URL in the `sdl_mixer` formula to use the commit hash for the `release-1.2.12` tag, to align with the `stable` archive. There's no difference in the file, so the `sha256` remains the same.