### PR TITLE
sdl*: add head

### DIFF
--- a/Formula/sdl2_image.rb
+++ b/Formula/sdl2_image.rb
@@ -19,6 +19,14 @@ class Sdl2Image < Formula
     sha256 cellar: :any, sierra:        "e3c9cf45d97099e818c667d23af8352e6d1bba0e3b609cdddee654f2a9da80cf"
   end
 
+  head do
+    url "https://github.com/libsdl-org/SDL_image.git", branch: "main"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "pkg-config" => :build
   depends_on "jpeg"
   depends_on "libpng"
@@ -28,6 +36,8 @@ class Sdl2Image < Formula
 
   def install
     inreplace "SDL2_image.pc.in", "@prefix@", HOMEBREW_PREFIX
+
+    system "./autogen.sh" if build.head?
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/sdl2_net.rb
+++ b/Formula/sdl2_net.rb
@@ -21,11 +21,21 @@ class Sdl2Net < Formula
     sha256 cellar: :any, yosemite:      "2e2bcc1e1aac84b37ebb44398e463d9004764aa369489926cd07bb97cb9f60c4"
   end
 
+  head do
+    url "https://github.com/libsdl-org/SDL_net.git", branch: "main"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "pkg-config" => :build
   depends_on "sdl2"
 
   def install
     inreplace "SDL2_net.pc.in", "@prefix@", HOMEBREW_PREFIX
+
+    system "./autogen.sh" if build.head?
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--disable-sdltest"

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -1,10 +1,21 @@
 class SdlImage < Formula
   desc "Image file loading library"
   homepage "https://www.libsdl.org/projects/SDL_image/release-1.2.html"
-  url "https://www.libsdl.org/projects/SDL_image/release/SDL_image-1.2.12.tar.gz"
-  sha256 "0b90722984561004de84847744d566809dbb9daf732a9e503b91a1b5a84e5699"
   license "Zlib"
   revision 7
+
+  stable do
+    url "https://www.libsdl.org/projects/SDL_image/release/SDL_image-1.2.12.tar.gz"
+    sha256 "0b90722984561004de84847744d566809dbb9daf732a9e503b91a1b5a84e5699"
+
+    # Fix graphical glitching
+    # https://github.com/Homebrew/homebrew-python/issues/281
+    # https://trac.macports.org/ticket/37453
+    patch :p0 do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/41996822/sdl_image/IMG_ImageIO.m.patch"
+      sha256 "c43c5defe63b6f459325798e41fe3fdf0a2d32a6f4a57e76a056e752372d7b09"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "9720413694ba49519d1d1c5213607dbdf177939ae0ee081c03ab2c1d478e2fe3"
@@ -18,6 +29,14 @@ class SdlImage < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "7d8a3d6067fce20c398a6cfbe5ba87136f9d5968569a613b8a29e3bc3eef4817"
   end
 
+  head do
+    url "https://github.com/libsdl-org/SDL_image.git", branch: "SDL-1.2"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
   deprecate! date: "2013-08-17", because: :deprecated_upstream
 
@@ -28,16 +47,10 @@ class SdlImage < Formula
   depends_on "sdl"
   depends_on "webp"
 
-  # Fix graphical glitching
-  # https://github.com/Homebrew/homebrew-python/issues/281
-  # https://trac.macports.org/ticket/37453
-  patch :p0 do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/41996822/sdl_image/IMG_ImageIO.m.patch"
-    sha256 "c43c5defe63b6f459325798e41fe3fdf0a2d32a6f4a57e76a056e752372d7b09"
-  end
-
   def install
     inreplace "SDL_image.pc.in", "@prefix@", HOMEBREW_PREFIX
+
+    system "./autogen.sh" if build.head?
 
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking",

--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -14,6 +14,14 @@ class SdlMixer < Formula
     sha256 cellar: :any, high_sierra:   "a6e0ff3e96a41f88892cf1fcee7d8c21fd816094f48d376640f77184a8c78e06"
   end
 
+  head do
+    url "https://github.com/libsdl-org/SDL_mixer.git", branch: "SDL-1.2"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
   deprecate! date: "2013-08-17", because: :deprecated_upstream
 
@@ -32,6 +40,8 @@ class SdlMixer < Formula
 
   def install
     inreplace "SDL_mixer.pc.in", "@prefix@", HOMEBREW_PREFIX
+
+    system "./autogen.sh" if build.head?
 
     args = %W[
       --prefix=#{prefix}

--- a/Formula/sdl_net.rb
+++ b/Formula/sdl_net.rb
@@ -16,6 +16,14 @@ class SdlNet < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "2ebc10f3cf5bb91fe6e4a336d6cb615b54436bd07e4a07d084d4a97c85a530f3"
   end
 
+  head do
+    url "https://github.com/libsdl-org/SDL_net.git", branch: "SDL-1.2"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
   deprecate! date: "2013-08-17", because: :deprecated_upstream
 
@@ -23,6 +31,8 @@ class SdlNet < Formula
   depends_on "sdl"
 
   def install
+    system "./autogen.sh" if build.head?
+
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--disable-sdltest"
     system "make", "install"

--- a/Formula/sdl_ttf.rb
+++ b/Formula/sdl_ttf.rb
@@ -1,9 +1,19 @@
 class SdlTtf < Formula
   desc "Library for using TrueType fonts in SDL applications"
   homepage "https://www.libsdl.org/projects/SDL_ttf/release-1.2.html"
-  url "https://www.libsdl.org/projects/SDL_ttf/release/SDL_ttf-2.0.11.tar.gz"
-  sha256 "724cd895ecf4da319a3ef164892b72078bd92632a5d812111261cde248ebcdb7"
   revision 1
+
+  stable do
+    url "https://www.libsdl.org/projects/SDL_ttf/release/SDL_ttf-2.0.11.tar.gz"
+    sha256 "724cd895ecf4da319a3ef164892b72078bd92632a5d812111261cde248ebcdb7"
+
+    # Fix broken TTF_RenderGlyph_Shaded()
+    # https://bugzilla.libsdl.org/show_bug.cgi?id=1433
+    patch do
+      url "https://gist.githubusercontent.com/tomyun/a8d2193b6e18218217c4/raw/8292c48e751c6a9939db89553d01445d801420dd/sdl_ttf-fix-1433.diff"
+      sha256 "4c2e38bb764a23bc48ae917b3abf60afa0dc67f8700e7682901bf9b03c15be5f"
+    end
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "5e82bcaa6cc1cb3ec449c957678e71f23681f7bc998e16b3f39dd39baf5cd8ad"
@@ -16,6 +26,14 @@ class SdlTtf < Formula
     sha256 cellar: :any, yosemite:      "cea0e7f2cb248778bc3af4cab3f3ddd7469d4b24d72780891d2cd54dbc9d7216"
   end
 
+  head do
+    url "https://github.com/libsdl-org/SDL_ttf.git", branch: "SDL-1.2"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
   deprecate! date: "2013-08-17", because: :deprecated_upstream
 
@@ -23,15 +41,10 @@ class SdlTtf < Formula
   depends_on "freetype"
   depends_on "sdl"
 
-  # Fix broken TTF_RenderGlyph_Shaded()
-  # https://bugzilla.libsdl.org/show_bug.cgi?id=1433
-  patch do
-    url "https://gist.githubusercontent.com/tomyun/a8d2193b6e18218217c4/raw/8292c48e751c6a9939db89553d01445d801420dd/sdl_ttf-fix-1433.diff"
-    sha256 "4c2e38bb764a23bc48ae917b3abf60afa0dc67f8700e7682901bf9b03c15be5f"
-  end
-
   def install
     inreplace "SDL_ttf.pc.in", "@prefix@", HOMEBREW_PREFIX
+
+    system "./autogen.sh" if build.head?
 
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds `head` for `sdl`/`sdl2`-related formulae that don't already have it.

Adding `head` to the various `sdl` formulae may be useful for some folks, as the `SDL-1.2` branches are sometimes updated but there won't be a new 1.2 release. These formulae still have a substantial install count despite SDL 1.2 being deprecated, so I figured it wouldn't hurt to give them some attention.

I've built/tested all of these formulae locally using `brew install --build-from-source` and `brew install --HEAD` and both worked fine.