### PR TITLE
tcpreplay: fix build on ARM and Linux

### DIFF
--- a/Formula/tcpreplay.rb
+++ b/Formula/tcpreplay.rb
@@ -17,16 +17,35 @@ class Tcpreplay < Formula
   depends_on "libtool" => :build
   depends_on "libdnet"
 
+  uses_from_macos "libpcap"
+
   def install
-    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
     args = %W[
       --disable-debug
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
       --enable-dynamic-link
-      --with-macosx-sdk=#{MacOS.version}
     ]
+
+    on_macos do
+      ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
+      args << "--with-macosx-sdk=#{MacOS.version}"
+
+      # The SDK is currently found using `xcrun --sdk macosx<V>` starting with
+      # input `--with-macosx-sdk=<V>` and then going from older 10.8 onward.
+      # On ARM, for Big Sur 11.4 the correct SDK is 11.3 (as of 2021-07-11);
+      # however, the logic picks 10.15, which causes configure failure.
+      # As a workaround, we remove all 10.x versions from SDK detection logic.
+      #
+      # Check in next release if the workaround can be removed.
+      # Upstream issue: https://github.com/appneta/tcpreplay/issues/668
+      inreplace "configure.ac", /(\$with_macosx_sdk\s+)(?:10\.\d+\s+)+/, "\\1" if Hardware::CPU.arm?
+    end
+
+    on_linux do
+      args << "--with-libpcap=#{Formula["libpcap"].opt_prefix}"
+    end
 
     system "./autogen.sh"
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For ARM, the previous commit was for ARM-support (#79327); however, even though CI had `CI-force-arm`, it didn't actually build a bottle:
```
==> Running Formulae#formula!(tcpreplay)
Warning: tcpreplay has not yet been bottled on ARM!
==> SKIPPED tcpreplay
```

Locally attempted and saw failure:
```
checking for gcc... /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -m64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk
checking whether the C compiler works... no
configure: error: in `/private/tmp/tcpreplay-20210711-59319-1tuq123/tcpreplay-4.3.4':
configure: error: C compiler cannot create executables
See `config.log' for more details
```

So, just added workaround to try to fix.

Probably need to add details to upstream issue https://github.com/appneta/tcpreplay/issues/668

The problematic logic is https://github.com/appneta/tcpreplay/blob/v4.3.4/configure.ac#L80-L81
```sh
        for _macosx_sdk in $with_macosx_sdk 10.8 10.9 10.10 10.11 10.12 10.13 10.14 10.15 10.16 10.17 10.18 10.19 10.20 11.0 11.1 11.2 11.3 11.4 11.5; do
            MACOSX_SDK_PATH=$(xcrun --sdk macosx${_macosx_sdk} --show-sdk-path 2> /dev/null)
```

On my system, `macosx10.15` and `macosx11.3` are valid.

---

Also trying to fix Linux build.
https://github.com/Homebrew/homebrew-core/runs/3033943366?check_suite_focus=true
```
checking for libpcap... no
configure: error: libpcap not found
```