### PR TITLE
pigz: fix test for Linux

### DIFF
--- a/Formula/pigz.rb
+++ b/Formula/pigz.rb
@@ -39,7 +39,7 @@ class Pigz < Formula
     assert (testpath/"example.gz").file?
     system bin/"unpigz", testpath/"example.gz"
     assert_equal test_data, (testpath/"example").read
-    system "/bin/dd", "if=/dev/random", "of=foo.bin", "bs=1m", "count=10"
+    system "/bin/dd", "if=/dev/random", "of=foo.bin", "bs=1024k", "count=10"
     system bin/"pigz", "foo.bin"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3034031848?check_suite_focus=true
```
==> /bin/dd if=/dev/random of=foo.bin bs=1m count=10
/bin/dd: invalid number: ‘1m’
Error: pigz: failed
```