### PR TITLE
pybind11: fix test for Linux

### DIFF
--- a/Formula/pybind11.rb
+++ b/Formula/pybind11.rb
@@ -58,7 +58,7 @@ class Pybind11 < Formula
     site_packages = "lib/python#{version}/site-packages"
 
     python_flags = `#{Formula["python@3.9"].opt_bin}/python3-config --cflags --ldflags --embed`.split
-    system ENV.cxx, "-O3", "-shared", "-std=c++11", *python_flags, "example.cpp", "-o", "example.so"
+    system ENV.cxx, "-shared", "-fPIC", "-O3", "-std=c++11", "example.cpp", "-o", "example.so", *python_flags
     system Formula["python@3.9"].opt_bin/"python3", "example.py"
 
     test_module = shell_output("#{Formula["python@3.9"].opt_bin/"python3"} -m pybind11 --includes")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3034026467?check_suite_focus=true
```
==> Testing pybind11
==> /usr/bin/g++-5 -O3 -shared -std=c++11 -I/home/linuxbrew/.linuxbrew/opt/python@3.9/include/python3.9 -I/home/linuxbrew/.linuxbrew/opt/python@3.9/include/python3.9 -Wno-unused-result -Wsign-compare -DNDEBUG -g -O3 -Wall -L/home/linuxbrew/.linuxbrew/opt/python@3.9/lib -lpython3.9 -lcrypt -lpthread -ldl -lutil -lm -lm example.cpp -o example.so
/usr/bin/ld: /tmp/cchOsqKL.o: relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a shared object; recompile with -fPIC
/tmp/cchOsqKL.o: error adding symbols: Bad value
```