### PR TITLE
luarocks: set `variables.UNZIP` on Linux

### DIFF
--- a/Formula/luarocks.rb
+++ b/Formula/luarocks.rb
@@ -26,6 +26,12 @@ class Luarocks < Formula
                           "--sysconfdir=#{etc}",
                           "--rocks-tree=#{HOMEBREW_PREFIX}"
     system "make", "install"
+
+    on_linux do
+      File.open(pkgetc/"config-#{Formula["lua"].version.major_minor}.lua", "a") do |f|
+        f.write "variables.UNZIP = \"#{Formula["unzip"].opt_bin}/unzip -n\";"
+      end
+    end
   end
 
   def caveats

--- a/Formula/vis.rb
+++ b/Formula/vis.rb
@@ -4,6 +4,7 @@ class Vis < Formula
   url "https://github.com/martanne/vis/archive/v0.7.tar.gz"
   sha256 "359ebb12a986b2f4e2a945567ad7587eb7d354301a5050ce10d51544570635eb"
   license "ISC"
+  revision 1
   head "https://github.com/martanne/vis.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes a bottling [failure](https://github.com/Homebrew/homebrew-core/runs/3042316459?check_suite_focus=true#step:8:56) for `vis`:

    Error: Failed unpacking rock file: /tmp/luarocks_luarocks-rock-lpeg-1.0.2-1-Z3e4AW/lpeg-1.0.2-1.src.rock: 'unzip -n' program not found. Make sure unzip is installed and is available in your PATH (or you may want to edit the 'variables.UNZIP' value in file '/home/linuxbrew/.linuxbrew/etc/luarocks/config-5.4.lua')

This should also make the following workaround unnecessary:

https://github.com/Homebrew/homebrew-core/blob/4e3ff58f979e93e5d03a03852eb7e707809ce8a6/Formula/neovim.rb#L31