### PR TITLE
tmuxinator: fix test for Linux

### DIFF
--- a/Formula/tmuxinator.rb
+++ b/Formula/tmuxinator.rb
@@ -55,7 +55,7 @@ class Tmuxinator < Formula
     version_output = shell_output("#{bin}/tmuxinator version")
     assert_match "tmuxinator #{version}", version_output
 
-    completion = shell_output("source #{bash_completion}/tmuxinator && complete -p tmuxinator")
+    completion = shell_output("bash -c 'source #{bash_completion}/tmuxinator && complete -p tmuxinator'")
     assert_match "-F _tmuxinator", completion
 
     commands = shell_output("#{bin}/tmuxinator commands")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3034032371?check_suite_focus=true
```
==> Testing tmuxinator
==> /home/linuxbrew/.linuxbrew/Cellar/tmuxinator/3.0.1/bin/tmuxinator version
==> source /home/linuxbrew/.linuxbrew/Cellar/tmuxinator/3.0.1/etc/bash_completion.d/tmuxinator && complete -p tmuxinator
sh: 1: source: not found
```