### PR TITLE
jnettop: fix build for Linux

### DIFF
--- a/Formula/jnettop.rb
+++ b/Formula/jnettop.rb
@@ -3,6 +3,7 @@ class Jnettop < Formula
   homepage "https://web.archive.org/web/20161127214942/jnettop.kubs.info/wiki/"
   url "https://downloads.sourceforge.net/project/jnettop/jnettop/0.13/jnettop-0.13.0.tar.gz"
   sha256 "a005d6fa775a85ff9ee91386e25505d8bdd93bc65033f1928327c98f5e099a62"
+  license "GPL-2.0-or-later"
   revision 2
 
   livecheck do
@@ -21,10 +22,18 @@ class Jnettop < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
 
+  uses_from_macos "libpcap"
+
   def install
     # Work around "-Werror,-Wimplicit-function-declaration" issues with
     # configure scripts on Xcode 12:
     ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
+    # Fix undefined reference to `g_thread_init'
+    on_linux do
+      inreplace "Makefile.in", "$(jnettop_LDFLAGS) $(jnettop_OBJECTS)",
+                               "$(jnettop_OBJECTS) $(AM_LDFLAGS) $(LDFLAGS) $(jnettop_LDFLAGS)"
+    end
 
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3041556217?check_suite_focus=true
```
checking pcap.h usability... no
checking pcap.h presence... no
checking for pcap.h... no
configure: error: Header file pcap.h not found.
```
