### PR TITLE
bitrise: add rsync at runtime for Linux

### DIFF
--- a/Formula/bitrise.rb
+++ b/Formula/bitrise.rb
@@ -13,7 +13,8 @@ class Bitrise < Formula
   end
 
   depends_on "go" => :build
-  uses_from_macos "rsync" => :build
+
+  uses_from_macos "rsync"
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3041652116?check_suite_focus=true
```
==> Testing bitrise
==> /home/linuxbrew/.linuxbrew/Cellar/bitrise/1.47.2/bin/bitrise setup

...

Downloading plugin binary...
Setup failed, error: Failed to do Plugins setup, error: Plugin (step) failed to install: Failed to install plugin, error: failed to copy plugin from (/tmp/plugin-src-tmp038650756) to (/tmp/__plugin__056942867/src), error: exec: "rsync": executable file not found in $PATH
Error: bitrise: failed
```