### PR TITLE
Revert "tests: skip unbottled linux reverse dependencies"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -252,7 +252,7 @@ jobs:
             cd bottles
             brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
           else
-            docker exec ${{github.sha}} brew test-bot --skip-unbottled-linux ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
+            docker exec ${{github.sha}} brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
           fi
 
       - name: Copy results from container


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#81004

@iMichka reverting this because this change doesn't do anything. `args.skip_unbottled_linux?` isn't used at all in the dependents step. Perhaps it should be? If so: that'll require a `brew test-bot` change.