### PR TITLE
sdl*: deprecate

### DIFF
--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -46,11 +46,6 @@ class Sdl < Formula
     end
   end
 
-  livecheck do
-    url "https://www.libsdl.org/release/"
-    regex(/href=.*?SDL[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "c3fda7b3047ffff537ba6f2a5711fd03f50fa776546d7788f42a4df325944fcf"
     sha256 cellar: :any,                 big_sur:       "d97aac056338f24b09ff065d8a80c6f5e9b6e16aed93003764054f6703093ecd"
@@ -66,6 +61,9 @@ class Sdl < Formula
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
+
+  # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
+  deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   def install
     # we have to do this because most build scripts assume that all sdl modules

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -6,11 +6,6 @@ class SdlImage < Formula
   license "Zlib"
   revision 7
 
-  livecheck do
-    url "https://www.libsdl.org/projects/SDL_image/release/"
-    regex(/href=.*?SDL_image[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "9720413694ba49519d1d1c5213607dbdf177939ae0ee081c03ab2c1d478e2fe3"
     sha256 cellar: :any,                 big_sur:       "67495888095b02d6716cc51f5a522f2a872c29de418f19210ecd586d23684b81"
@@ -22,6 +17,9 @@ class SdlImage < Formula
     sha256 cellar: :any,                 yosemite:      "3403edd53a6776bad8dc4390ef8204479f3af7c485e8a7a1f81f86f43b4a7b5c"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "7d8a3d6067fce20c398a6cfbe5ba87136f9d5968569a613b8a29e3bc3eef4817"
   end
+
+  # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
+  deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "jpeg"

--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -6,11 +6,6 @@ class SdlMixer < Formula
   license "Zlib"
   revision 4
 
-  livecheck do
-    url "https://www.libsdl.org/projects/SDL_mixer/release/"
-    regex(/href=.*?SDL_mixer[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any, arm64_big_sur: "20d1beb530df525f4aa8d5e4716eb9acf5a54330076c6ba3c1784b88a9e9e3f8"
     sha256 cellar: :any, big_sur:       "0bd16f40744f277701a46fda52b3df4aecff40371e3ae84b09556ec3e2a3bc63"
@@ -18,6 +13,9 @@ class SdlMixer < Formula
     sha256 cellar: :any, mojave:        "dd69b75165f502ff2540c6e6fa72645049b8bc25ed1794b36d3757a8bc74eb97"
     sha256 cellar: :any, high_sierra:   "a6e0ff3e96a41f88892cf1fcee7d8c21fd816094f48d376640f77184a8c78e06"
   end
+
+  # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
+  deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "flac"

--- a/Formula/sdl_net.rb
+++ b/Formula/sdl_net.rb
@@ -4,11 +4,6 @@ class SdlNet < Formula
   url "https://www.libsdl.org/projects/SDL_net/release/SDL_net-1.2.8.tar.gz"
   sha256 "5f4a7a8bb884f793c278ac3f3713be41980c5eedccecff0260411347714facb4"
 
-  livecheck do
-    url "https://www.libsdl.org/projects/SDL_net/release/"
-    regex(/href=.*?SDL_net[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "99b9b5259989971316f1ab7d1c785949868b329abe2e73b0034bdfe5f447eeb8"
     sha256 cellar: :any,                 big_sur:       "53bf15367d717f52383f6221a46c2103ed88beb591830f7d6269b9ae993521f7"
@@ -20,6 +15,9 @@ class SdlNet < Formula
     sha256 cellar: :any,                 yosemite:      "fe6b8eda1d640db450ed12f79feb731d49a62263c4b83601d69659498d697538"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "2ebc10f3cf5bb91fe6e4a336d6cb615b54436bd07e4a07d084d4a97c85a530f3"
   end
+
+  # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
+  deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "sdl"

--- a/Formula/sdl_rtf.rb
+++ b/Formula/sdl_rtf.rb
@@ -16,6 +16,9 @@ class SdlRtf < Formula
     sha256 cellar: :any, yosemite:      "8dd89df32c9ea02bcab36932c2f22bcb6de58d6002bd6fb9e95f9bbfe5ccf41e"
   end
 
+  # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
+  deprecate! date: "2013-08-17", because: :deprecated_upstream
+
   depends_on "sdl"
 
   def install

--- a/Formula/sdl_sound.rb
+++ b/Formula/sdl_sound.rb
@@ -6,11 +6,6 @@ class SdlSound < Formula
   sha256 "3999fd0bbb485289a52be14b2f68b571cb84e380cc43387eadf778f64c79e6df"
   revision 1
 
-  livecheck do
-    url "https://icculus.org/SDL_sound/downloads/"
-    regex(/href=.*?SDL_sound[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any, arm64_big_sur: "2da102c4035e6cd0138668695cbee5eed9f730077a78e7221e73cb2a047d915c"
     sha256 cellar: :any, big_sur:       "8a2c07271bbc94a345cd8951ed897e9d12edda47d713c247a77e3186780247fc"
@@ -29,6 +24,9 @@ class SdlSound < Formula
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
+
+  # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
+  deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "libogg"

--- a/Formula/sdl_ttf.rb
+++ b/Formula/sdl_ttf.rb
@@ -5,11 +5,6 @@ class SdlTtf < Formula
   sha256 "724cd895ecf4da319a3ef164892b72078bd92632a5d812111261cde248ebcdb7"
   revision 1
 
-  livecheck do
-    url "https://www.libsdl.org/projects/SDL_ttf/release/"
-    regex(/href=.*?SDL_ttf[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any, arm64_big_sur: "5e82bcaa6cc1cb3ec449c957678e71f23681f7bc998e16b3f39dd39baf5cd8ad"
     sha256 cellar: :any, big_sur:       "6fa67e2282123689e1391faec02d41a1cda527f9cb0b89f9c0e4bd0dd7ee5407"
@@ -20,6 +15,9 @@ class SdlTtf < Formula
     sha256 cellar: :any, el_capitan:    "981960db1d2539b57bc42deb12ab59e163214d881612c1fffea72e4927e1c82a"
     sha256 cellar: :any, yosemite:      "cea0e7f2cb248778bc3af4cab3f3ddd7469d4b24d72780891d2cd54dbc9d7216"
   end
+
+  # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
+  deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "freetype"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Looking back at snapshots of the libsdl.org website on archive.org, SDL 1.2 has been deprecated since SDL 2.0 was released around 2013-08-17. A 2013-08-24 snapshot of the Wiki ["Support" page](https://web.archive.org/web/20130825065205/http://wiki.libsdl.org/Support) states:

> SDL 1.2 is deprecated and not recommended for new projects.

The [historic download page for 1.2](https://www.libsdl.org/download-1.2.php) also states:

> SDL 1.2 has been superceded by SDL 2.0.
>
> SDL 1.2 is no longer supported and no longer works on many modern systems, but the source code is available for historic purposes on [GitHub](https://github.com/libsdl-org/SDL-1.2)

This PR deprecates the `sdl`-related formulae and removes any `livecheck` blocks, so livecheck will automatically skip them. There hasn't been a new 1.2 release since around 2012-01 and upstream won't be releasing new versions in the future, so there's no point in checking.

That said, though this PR deprecates these formulae, we should continue to keep them around as `sdl` still has a substantial install count (30 days: 4,333, 90 days: 14,358, 365 days: 85,483). This is primarily intended to ensure that users get a warning about `sdl` being deprecated and that livecheck will skip these formulae.