### PR TITLE
nzbget: fix ncurses paths, disable workaround on Linux

### DIFF
--- a/Formula/nzbget.rb
+++ b/Formula/nzbget.rb
@@ -28,9 +28,16 @@ class Nzbget < Formula
 
     # Fix "ncurses library not found"
     # Reported 14 Aug 2016: https://github.com/nzbget/nzbget/issues/264
-    (buildpath/"brew_include").install_symlink MacOS.sdk_path/"usr/include/ncurses.h"
-    ENV["ncurses_CFLAGS"] = "-I#{buildpath}/brew_include"
-    ENV["ncurses_LIBS"] = "-L/usr/lib -lncurses"
+    on_macos do
+      (buildpath/"brew_include").install_symlink MacOS.sdk_path/"usr/include/ncurses.h"
+      ENV["ncurses_CFLAGS"] = "-I#{buildpath}/brew_include"
+      ENV["ncurses_LIBS"] = "-L/usr/lib -lncurses"
+    end
+
+    on_linux do
+      ENV["ncurses_CFLAGS"] = "-I#{Formula["ncurses"].opt_include}"
+      ENV["ncurses_LIBS"] = "-L#{Formula["ncurses"].opt_lib} -lncurses"
+    end
 
     # Tell configure to use OpenSSL
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
@@ -43,8 +50,10 @@ class Nzbget < Formula
 
     # Set upstream's recommended values for file systems without
     # sparse-file support (e.g., HFS+); see Homebrew/homebrew-core#972
-    inreplace "nzbget.conf", "DirectWrite=yes", "DirectWrite=no"
-    inreplace "nzbget.conf", "ArticleCache=0", "ArticleCache=700"
+    on_macos do
+      inreplace "nzbget.conf", "DirectWrite=yes", "DirectWrite=no"
+      inreplace "nzbget.conf", "ArticleCache=0", "ArticleCache=700"
+    end
 
     etc.install "nzbget.conf"
   end
@@ -89,10 +98,10 @@ class Nzbget < Formula
   test do
     (testpath/"downloads/dst").mkpath
     # Start nzbget as a server in daemon-mode
-    system "#{bin}/nzbget", "-D"
+    system "#{bin}/nzbget", "-D", "-c", etc/"nzbget.conf"
     # Query server for version information
-    system "#{bin}/nzbget", "-V"
+    system "#{bin}/nzbget", "-V", "-c", etc/"nzbget.conf"
     # Shutdown server daemon
-    system "#{bin}/nzbget", "-Q"
+    system "#{bin}/nzbget", "-Q", "-c", etc/"nzbget.conf"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
