### PR TITLE
notmuch: allow building with any non-Homebrew emacs

### DIFF
--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -19,8 +19,10 @@ class Notmuch < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "52de489510b6d6c8c905ca6a1c34d4a55a41d8cdee984fa06ce027c145f1107b"
   end
 
+  option "without-brew-emacs", "Build Elisp files with Emacs without requiring the Homebrew Emacs formula"
+
   depends_on "doxygen" => :build
-  depends_on "emacs" => :build
+  depends_on "emacs" => :build unless build.without?("brew-emacs")
   depends_on "libgpg-error" => :build
   depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build

--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -19,10 +19,10 @@ class Notmuch < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "52de489510b6d6c8c905ca6a1c34d4a55a41d8cdee984fa06ce027c145f1107b"
   end
 
-  option "without-brew-emacs", "Build Elisp files with Emacs without requiring the Homebrew Emacs formula"
+  option "with-system-emacs", "Build Elisp files with Emacs without requiring the Homebrew Emacs formula"
 
   depends_on "doxygen" => :build
-  depends_on "emacs" => :build unless build.without?("brew-emacs")
+  depends_on "emacs" => :build unless build.with?("system-emacs")
   depends_on "libgpg-error" => :build
   depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build
@@ -32,6 +32,7 @@ class Notmuch < Formula
   depends_on "talloc"
   depends_on "xapian"
 
+  uses_from_macos "emacs" => :build if build.with?("system-emacs")
   uses_from_macos "zlib", since: :sierra
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I'm terribly sorry, but I don't really understand the use of options according the [Formula Cookbook](https://docs.brew.sh/Formula-Cookbook) and the audit warnings. Is forbidding options too recent to be reflected in the cookbook?

What this PR is basically attempting to achieve is to install the `notmuch` tool and its Elisp files without forcing installation of homebrew Emacs. There's e.g. `emacs-head` formula or other reasons to have emacs built from source outside of Homebrew. As long as `emacs` is in PATH, `notmuch` installation will work. I wanted to reflect that.

Especially on Linux, I think people that care for Emacs at all will have Emacs installed in their favorite flavor already and don't want a homebrew'd copy just to check out HEAD here.

(Please note that the `notmuch` installation also offers an option to skip Elisp files completely. I wanted to add an option to reflect this as well, but since the use of options in formula isn't clear to me, I didn't add that in.)