### PR TITLE
ccextractor: use brewed libs

### DIFF
--- a/Formula/ccextractor.rb
+++ b/Formula/ccextractor.rb
@@ -3,7 +3,8 @@ class Ccextractor < Formula
   homepage "https://www.ccextractor.org/"
   url "https://github.com/CCExtractor/ccextractor/archive/v0.89.tar.gz"
   sha256 "bbe8d95347d0cf31bd26489b733fd959a7b98c681f14c59309bff54713fd539d"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
+  revision 1
   head "https://github.com/ccextractor/ccextractor.git"
 
   bottle do
@@ -12,20 +13,49 @@ class Ccextractor < Formula
     sha256 cellar: :any_skip_relocation, mojave:   "f389af83990016793f29329e7de8ca7d58c09a25c7faff62bc61d0100d9ee425"
   end
 
+  depends_on "pkg-config" => :build
+  depends_on "freetype"
+  depends_on "gpac"
+  depends_on "leptonica"
+  depends_on "libpng"
+  depends_on "protobuf-c"
+  depends_on "tesseract"
+  depends_on "utf8proc"
+
+  resource "test.mxf" do
+    url "https://raw.githubusercontent.com/alebcay/example-artifacts/5e8d84effab76c4653972ef72513fcee1d00d3c3/mxf/test.mxf"
+    sha256 "e027aca08a2cce64a9fb6623a85306b5481a2f1c3f97a06fd5d3d1b45192b12a"
+  end
+
+  # Patch build script to allow building with Homebrew libs rather than upstream's bundled libs
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/9bc4ef5a88b9a4d55dead30130aa79f8eee5faf7/ccextractor/unbundle-libs.patch"
+    sha256 "b610950e4ae54a8fce3f5952be6d909cb9790a9c46ff356f83e8d8255c7f1ed1"
+  end
+
   def install
-    cd "mac" do
-      system "./build.command"
+    # Multiple source files reference these dependencies with non-standard #include paths
+    ENV["EXTRA_INCLUDE"] = "-I#{Formula["leptonica"].include} -I#{Formula["protobuf-c"].include/"protobuf-c"}"
+
+    platform = "mac"
+    build_script = "./build.command"
+
+    on_linux do
+      platform = "linux"
+      build_script = "./build"
+    end
+
+    cd platform do
+      system build_script, "OCR"
       bin.install "ccextractor"
     end
     (pkgshare/"examples").install "docs/ccextractor.cnf.sample"
   end
 
   test do
-    touch testpath/"test"
-    pid = fork do
-      exec bin/"ccextractor", testpath/"test"
+    resource("test.mxf").stage do
+      system bin/"ccextractor", "test.mxf", "-out=txt"
+      assert_equal "This is a test video.", (Pathname.pwd/"test.txt").read.strip
     end
-    Process.wait(pid)
-    assert_predicate testpath/"test.srt", :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

CCExtractor ships bundled `freetype`, `gpac`, `libpng`, `protobuf-c`, and `utf8proc` and their build script is hardcoded to use them. This PR includes a patch to the build script to allow linkage with system libraries (see #72218) since upstream doesn't want to add the option to allow distributors/packagers to use system dependencies (see https://github.com/CCExtractor/ccextractor/issues/1309).

Another option that I considered was transitioning `ccextractor` to a Cask, but upstream doesn't seem to provide macOS builds on a regular basis.

I've briefly looked over their copies of the five bundled dependencies; most upstream changes seem trivial (removing unused parts of each library, etc.). There is one additional dependency `zvbi` (which Homebrew does not ship anyways) that they've modified more heavily to suit their needs, so I've left that in place.

CCExtractor does provide autotools and CMake-based workflows for building but they seem unmaintained (have some issues) and while fixing them is an option, it would result in a bigger patch, introduce build-time dependencies, and not to mention that upstream docs refer to the build scripts.

With the size of these changes in mind, I've also improved the test with an actual video file that contains CEA-608 closed captions to be extracted (with this test case I've already caught and avoided one potential regression that I wouldn't have otherwise). This file is 7.5 MB (much bigger than our usual test fixtures) and considering its niche use case, I've just made a separate repo to hold it rather than put it in Homebrew/brew test fixtures folder. If it might be more sensible to put this somewhere else, I'm open to ideas here.

Going to try building for ARM and see if that hopefully works now (previously the build failures seemed to be in the bundled libs, not CCExtractor proper). I've also tested this in the brew Docker image, so this _should_ work on Linux.