### PR TITLE
abcmidi: fix build for Linux

### DIFF
--- a/Formula/abcmidi.rb
+++ b/Formula/abcmidi.rb
@@ -18,11 +18,6 @@ class Abcmidi < Formula
   end
 
   def install
-    # configure creates a "Makefile" file. A "makefile" file already exist in
-    # the tarball. On case-sensitive file-systems, the "makefile" file won't
-    # be overridden and will be chosen over the "Makefile" file.
-    rm "makefile"
-
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3049646374?check_suite_focus=true
```
==> FAILED
==> Downloading https://ifdo.ca/~seymour/runabc/abcMIDI-2021.06.27.zip
Already downloaded: /home/linuxbrew/.cache/Homebrew/downloads/0a043a2bf43de5306ffc53854a3a420482e0b289f88daae89422b568616febc2--abcMIDI-2021.06.27.zip
==> Verifying checksum for '0a043a2bf43de5306ffc53854a3a420482e0b289f88daae89422b568616febc2--abcMIDI-2021.06.27.zip'
unzip -o /home/linuxbrew/.cache/Homebrew/downloads/0a043a2bf43de5306ffc53854a3a420482e0b289f88daae89422b568616febc2--abcMIDI-2021.06.27.zip -d /tmp/d20210712-2938-y42x8z
cp -pR /tmp/d20210712-2938-y42x8z/abcmidi/. /tmp/abcmidi-20210712-2938-iscv5y/abcmidi
chmod -Rf +w /tmp/d20210712-2938-y42x8z
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory @ apply2files - makefile
```