### PR TITLE
gatsby-cli: fix linux build

### DIFF
--- a/Formula/gatsby-cli.rb
+++ b/Formula/gatsby-cli.rb
@@ -17,6 +17,10 @@ class GatsbyCli < Formula
 
   depends_on "node"
 
+  on_linux do
+    depends_on "libx11"
+  end
+
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]


### PR DESCRIPTION
Signed-off-by: Rui Chen <rui@chenrui.dev>

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
https://github.com/Homebrew/homebrew-core/runs/3052896208?check_suite_focus=true

```
==> brew linkage --test gatsby-cli
==> FAILED
Missing libraries:
  unexpected (libX11.so.6)
```
