### PR TITLE
fossil: change of official url format

### DIFF
--- a/Formula/fossil.rb
+++ b/Formula/fossil.rb
@@ -1,7 +1,7 @@
 class Fossil < Formula
   desc "Distributed software configuration management"
   homepage "https://www.fossil-scm.org/home/"
-  url "https://www.fossil-scm.org/home/tarball/fossil-src-2.16.tar.gz"
+  url "https://fossil-scm.org/home/tarball/version-2.16/fossil-src-2.16.tar.gz"
   sha256 "fab37e8093932b06b586e99a792bf9b20d00d530764b5bddb1d9a63c8cdafa14"
   license "BSD-2-Clause"
   head "https://www.fossil-scm.org/", using: :fossil


### PR DESCRIPTION
Closes #80994. Upstream confirmed the current URL format in that issue, and it's also reflected in all download URLs published on the upstream website.

No rebuild needed, since the source hasn't changed (verified via `brew fetch -s fossil`).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? _(no change in source code)_
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? _(no change in source code)_
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
