### PR TITLE
libnice: fix test for Linux

### DIFF
--- a/Formula/libnice.rb
+++ b/Formula/libnice.rb
@@ -76,7 +76,7 @@ class Libnice < Formula
     on_macos do
       flags << "-lintl"
     end
-    system ENV.cc, *flags, "test.c", "-o", "test"
+    system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3033892278?check_suite_focus=true
```
==> FAILED
==> Testing libnice
Error: test failed
==> /usr/bin/gcc-5 -I/home/linuxbrew/.linuxbrew/opt/gettext/include -I/home/linuxbrew/.linuxbrew/opt/glib/include/glib-2.0 -I/home/linuxbrew/.linuxbrew/opt/glib/lib/glib-2.0/include -I/home/linuxbrew/.linuxbrew/Cellar/libnice/0.1.18/include/nice -D_REENTRANT -L/home/linuxbrew/.linuxbrew/opt/gettext/lib -L/home/linuxbrew/.linuxbrew/opt/glib/lib -L/home/linuxbrew/.linuxbrew/Cellar/libnice/0.1.18/lib -lgio-2.0 -lglib-2.0 -lgobject-2.0 -lnice test.c -o test
/tmp/cchfr40V.o: In function `main':
test.c:(.text+0x1a): undefined reference to `g_main_loop_new'
test.c:(.text+0x2a): undefined reference to `g_main_loop_get_context'

```