### PR TITLE
slurm: add ncurses dependency for Linux

### DIFF
--- a/Formula/slurm.rb
+++ b/Formula/slurm.rb
@@ -3,7 +3,7 @@ class Slurm < Formula
   homepage "https://github.com/mattthias/slurm"
   url "https://github.com/mattthias/slurm/archive/upstream/0.4.3.tar.gz"
   sha256 "b960c0d215927be1d02c176e1b189321856030226c91f840284886b727d3a3ac"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "0568e6cdfc383e2ad89668439afbae2a0f9bf7f7061e3b721dc16cb4fbecc77a"
@@ -17,6 +17,8 @@ class Slurm < Formula
   end
 
   depends_on "cmake" => :build
+
+  uses_from_macos "ncurses"
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3033821551?check_suite_focus=true
```
==> brew linkage --test slurm
==> FAILED
Missing libraries:
  unexpected (libncursesw.so.6)
```