### PR TITLE
dwarfutils: fix build for Linux

### DIFF
--- a/Formula/dwarfutils.rb
+++ b/Formula/dwarfutils.rb
@@ -17,9 +17,15 @@ class Dwarfutils < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "f072dac053dee574c279956d1b072aeeb591a078d207d2d963a745e3553fab26"
   end
 
-  depends_on "libelf" => :build
-
   uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "libelf" => :build
+  end
+
+  on_linux do
+    depends_on "libelf"
+  end
 
   def install
     system "./configure"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3033761256?check_suite_focus=true
```
==> brew linkage --test dwarfutils
==> FAILED
Missing libraries:
  unexpected (libelf.so.0)

==> brew install --only-dependencies --include-test dwarfutils
==> brew test --verbose dwarfutils
==> FAILED
==> Testing dwarfutils
==> /home/linuxbrew/.linuxbrew/Cellar/dwarfutils/20210528/bin/dwarfdump -V
/home/linuxbrew/.linuxbrew/Cellar/dwarfutils/20210528/bin/dwarfdump: error while loading shared libraries: libelf.so.0: cannot open shared object file: No such file or directory
```