### PR TITLE
dhcping: use http urls as certificate expired

### DIFF
--- a/Formula/dhcping.rb
+++ b/Formula/dhcping.rb
@@ -1,7 +1,7 @@
 class Dhcping < Formula
   desc "Perform a dhcp-request to check whether a dhcp-server is running"
-  homepage "https://www.mavetju.org/unix/general.php"
-  url "https://www.mavetju.org/download/dhcping-1.2.tar.gz"
+  homepage "http://www.mavetju.org/unix/general.php"
+  url "http://www.mavetju.org/download/dhcping-1.2.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/d/dhcping/dhcping_1.2.orig.tar.gz"
   sha256 "32ef86959b0bdce4b33d4b2b216eee7148f7de7037ced81b2116210bc7d3646a"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3052523899?check_suite_focus=true
```
==> brew audit dhcping --online --git --skip-style
==> FAILED
Error: 2 problems in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
dhcping:
  * The homepage URL is not reachable
  * Stable: The source URL https://www.mavetju.org/download/dhcping-1.2.tar.gz is not reachable
```

<img width="447" alt="Screen Shot 2021-07-13 at 12 48 42 PM" src="https://user-images.githubusercontent.com/20700669/125515763-a272b057-f851-4595-bfba-c1bf916a8eaf.png">