### PR TITLE
hyperspec: add livecheck

### DIFF
--- a/Formula/hyperspec.rb
+++ b/Formula/hyperspec.rb
@@ -5,6 +5,14 @@ class Hyperspec < Formula
   version "7.0"
   sha256 "1ac1666a9dc697dbd8881262cad4371bcd2e9843108b643e2ea93472ba85d7c3"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?HyperSpec[._-]v?(\d+(?:[.-]\d+)+)\.t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match&.first&.gsub("-", ".") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "f97fdd5f56b2c8d2ea223a0ce5950c225c198e3e1157d7bd8c7d691c65773404"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `hyperspec`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.