### PR TITLE
nicovideo-dl: add livecheck

### DIFF
--- a/Formula/nicovideo-dl.rb
+++ b/Formula/nicovideo-dl.rb
@@ -8,6 +8,11 @@ class NicovideoDl < Formula
   sha256 "886980d154953bc5ff5d44758f352ce34d814566a83ceb0b412b8d2d51f52197"
   revision 2
 
+  livecheck do
+    url "https://osdn.net/projects/nicovideo-dl/releases/"
+    regex(%r{value=.*?/rel/nicovideo-dl/v?(\d+(?:\.\d+)+)["']}i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "5c4b76aa62fa658eed10b7224c5f53e25e8b29f764766a9ab4a7d80b9ff79850"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `nicovideo-dl`. This PR adds a `livecheck` block that checks the releases page for the project, which links to the `stable` archive. Unfortunately, the archive links aren't available in the HTML but we can identify versions from release URLs that are present in the HTML.