### PR TITLE
rasqal: add livecheck

### DIFF
--- a/Formula/rasqal.rb
+++ b/Formula/rasqal.rb
@@ -1,8 +1,13 @@
 class Rasqal < Formula
   desc "RDF query library"
-  homepage "http://librdf.org/rasqal/"
-  url "http://download.librdf.org/source/rasqal-0.9.33.tar.gz"
+  homepage "https://librdf.org/rasqal/"
+  url "https://download.librdf.org/source/rasqal-0.9.33.tar.gz"
   sha256 "6924c9ac6570bd241a9669f83b467c728a322470bf34f4b2da4f69492ccfd97c"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?rasqal[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "36d9d4a210921573c1cad68bc17bf0d0fced251de091855ce1b61cefc64a37c8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `rasqal`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

Additionally, this updates the `homepage` and `stable` URL to use HTTPS (avoiding a redirection for the homepage).