### PR TITLE
sntop: use sourceforge archive, add livecheck

### DIFF
--- a/Formula/sntop.rb
+++ b/Formula/sntop.rb
@@ -1,9 +1,14 @@
 class Sntop < Formula
   desc "Curses-based utility that polls hosts to determine connectivity"
   homepage "https://sntop.sourceforge.io/"
-  url "https://pkg.freebsd.org/ports-distfiles/sntop-1.4.3.tar.gz"
+  url "https://downloads.sourceforge.net/project/sntop/sntop/1.4.3/sntop-1.4.3.tar.gz"
   sha256 "943a5af1905c3ae7ead064e531cde6e9b3dc82598bbda26ed4a43788d81d6d89"
   license "GPL-2.0"
+
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/sntop[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `stable` URL for `sntop` to use a tarball from SourceForge, as the homepage directs folks to the SourceForge project. Looking back at the history of this formula, I didn't see any reason given as to why this uses a tarball from FreeBSD. The tarball from both sources is the same, so it makes more sense to me to use what appears to be the more canonical source.

That said, this adds a `livecheck` block that uses the `SourceForge` formula to check the `stable` URL. It's necessary to use a regex that restricts matching to tarballs, otherwise the latest version is incorrectly given as `1.4.3-1` (from an `rpm` file in the RSS feed).