### PR TITLE
ceylon: add livecheck

### DIFF
--- a/Formula/ceylon.rb
+++ b/Formula/ceylon.rb
@@ -5,6 +5,14 @@ class Ceylon < Formula
   sha256 "4ec1f1781043ee369c3e225576787ce5518685f2206eafa7d2fd5cfe6ac9923d"
   revision 2
 
+  livecheck do
+    url "https://ceylon-lang.org/download/"
+    regex(%r{href=.*?/download/dist/v?(\d+(?:[._]\d+)+)["' >]}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match&.first&.gsub("_", ".") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "d221a5e146fd8e9150edd4803370fa057f2181c85b5ad670478ad0e489115b3f"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `ceylon`. This PR adds a `livecheck` block that checks the first-party download page, which contains a link like `/download/dist/1_3_3` that redirects to the `stable` archive.