### PR TITLE
wxwidgets wxwidgets@3.0: use gtk+3 on Linux

### DIFF
--- a/Aliases/wxmac@3.1
+++ b/Aliases/wxmac@3.1
@@ -1,1 +1,0 @@
-../Formula/wxmac.rb

--- a/Aliases/wxwidgets
+++ b/Aliases/wxwidgets
@@ -1,1 +1,0 @@
-../Formula/wxmac.rb

--- a/Aliases/wxwidgets@3.0
+++ b/Aliases/wxwidgets@3.0
@@ -1,1 +1,0 @@
-../Formula/wxmac@3.0.rb

--- a/Aliases/wxwidgets@3.1
+++ b/Aliases/wxwidgets@3.1
@@ -1,0 +1,1 @@
+../Formula/wxwidgets.rb

--- a/Formula/diff-pdf.rb
+++ b/Formula/diff-pdf.rb
@@ -4,7 +4,7 @@ class DiffPdf < Formula
   url "https://github.com/vslavik/diff-pdf/releases/download/v0.5/diff-pdf-0.5.tar.gz"
   sha256 "e7b8414ed68c838ddf6269d11abccdb1085d73aa08299c287a374d93041f172e"
   license "GPL-2.0-only"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "1a8643c9b3c96ce72d46ba82acb0fa764dc930fced4b3172a42d3578019f775d"
@@ -19,7 +19,7 @@ class DiffPdf < Formula
   depends_on "pkg-config" => :build
   depends_on "cairo"
   depends_on "poppler"
-  depends_on "wxmac"
+  depends_on "wxwidgets"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -5,6 +5,7 @@ class Erlang < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-24.0.4/otp_src_24.0.4.tar.gz"
   sha256 "34d1f17425ed75add154261a9df2caeddb408b269b43275e5231c44f4fe5658b"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -27,7 +28,7 @@ class Erlang < Formula
   end
 
   depends_on "openssl@1.1"
-  depends_on "wxmac" # for GUI apps like observer
+  depends_on "wxwidgets" # for GUI apps like observer
 
   resource "html" do
     url "https://www.erlang.org/download/otp_doc_html_24.0.tar.gz"

--- a/Formula/erlang@21.rb
+++ b/Formula/erlang@21.rb
@@ -5,7 +5,7 @@ class ErlangAT21 < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-21.3.8.24/otp_src_21.3.8.24.tar.gz"
   sha256 "a82de871d7ba40fd256558b23a3b4c1539e6c7ece7507d6eb2b00330c6135012"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -25,7 +25,7 @@ class ErlangAT21 < Formula
   depends_on "libtool" => :build
   depends_on arch: :x86_64
   depends_on "openssl@1.1"
-  depends_on "wxmac" # for GUI apps like observer
+  depends_on "wxwidgets" # for GUI apps like observer
 
   resource "man" do
     url "https://www.erlang.org/download/otp_doc_man_21.3.tar.gz"

--- a/Formula/erlang@22.rb
+++ b/Formula/erlang@22.rb
@@ -5,7 +5,7 @@ class ErlangAT22 < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-22.3.4.20/otp_src_22.3.4.20.tar.gz"
   sha256 "43289f20a7038b6835615a1f68a6e32b9aeec6db38cdb7c97adf78d048d74079"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -22,7 +22,7 @@ class ErlangAT22 < Formula
   keg_only :versioned_formula
 
   depends_on "openssl@1.1"
-  depends_on "wxmac" # for GUI apps like observer
+  depends_on "wxwidgets" # for GUI apps like observer
 
   resource "man" do
     url "https://www.erlang.org/download/otp_doc_man_22.3.tar.gz"

--- a/Formula/erlang@23.rb
+++ b/Formula/erlang@23.rb
@@ -5,6 +5,7 @@ class ErlangAT23 < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-23.3.4.5/otp_src_23.3.4.5.tar.gz"
   sha256 "f3698a686045787ea10fddd89a7e27663c3ae53cc07f75285d412beb829a25f0"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,7 +22,7 @@ class ErlangAT23 < Formula
   keg_only :versioned_formula
 
   depends_on "openssl@1.1"
-  depends_on "wxmac" # for GUI apps like observer
+  depends_on "wxwidgets" # for GUI apps like observer
 
   resource "html" do
     url "https://www.erlang.org/download/otp_doc_html_23.3.tar.gz"

--- a/Formula/gambit.rb
+++ b/Formula/gambit.rb
@@ -4,7 +4,7 @@ class Gambit < Formula
   url "https://github.com/gambitproject/gambit/archive/v16.0.1.tar.gz"
   sha256 "56bb86fd17575827919194e275320a5dd498708fd8bb3b20845243d492c10fef"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "8baa71e381f33562fc0580da41d111451900d28d20e162d0d86b82d10a8e21a8"
@@ -16,11 +16,11 @@ class Gambit < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "wxmac@3.0"
+  depends_on "wxwidgets@3.0"
 
   def install
-    wxmac = Formula["wxmac@3.0"]
-    ENV["WX_CONFIG"] = wxmac.opt_bin/"wx-config-#{wxmac.version.major_minor}"
+    wxwidgets = Formula["wxwidgets@3.0"]
+    ENV["WX_CONFIG"] = wxwidgets.opt_bin/"wx-config-#{wxwidgets.version.major_minor}"
 
     system "autoreconf", "-fvi"
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/homeworlds.rb
+++ b/Formula/homeworlds.rb
@@ -5,7 +5,7 @@ class Homeworlds < Formula
       revision: "917cd7e7e6d0a5cdfcc56cd69b41e3e80b671cde"
   version "20141022"
   license "BSD-2-Clause"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "c094bde41b9eeccc8c9d62b2e7e808f4ca9addfeb19f81a2e2e41f26f3871363"
@@ -14,7 +14,7 @@ class Homeworlds < Formula
     sha256 cellar: :any, mojave:        "85ac4667ac133f9a45870166c29a7c0dc1ed7cbb51216db987fb8601a001ebf6"
   end
 
-  depends_on "wxmac"
+  depends_on "wxwidgets"
 
   def install
     system "make"

--- a/Formula/scummvm-tools.rb
+++ b/Formula/scummvm-tools.rb
@@ -4,7 +4,7 @@ class ScummvmTools < Formula
   url "https://downloads.scummvm.org/frs/scummvm-tools/2.2.0/scummvm-tools-2.2.0.tar.xz"
   sha256 "1e72aa8f21009c1f7447c755e7f4cf499fe9b8ba3d53db681ea9295666cb48a4"
   license "GPL-2.0-or-later"
-  revision 2
+  revision 3
   head "https://github.com/scummvm/scummvm-tools.git"
 
   livecheck do
@@ -24,17 +24,17 @@ class ScummvmTools < Formula
   depends_on "libpng"
   depends_on "libvorbis"
   depends_on "mad"
-  depends_on "wxmac@3.0"
+  depends_on "wxwidgets@3.0"
 
   def install
-    # configure will happily carry on even if it can't find wxmac,
+    # configure will happily carry on even if it can't find wxwidgets,
     # so let's make sure the install method keeps working even when
-    # the wxmac dependency version changes
-    wxmac = deps.find { |dep| dep.name.match?(/^wxmac(@\d+(\.\d+)?)?$/) }
-                .to_formula
+    # the wxwidgets dependency version changes
+    wxwidgets = deps.find { |dep| dep.name.match?(/^wxwidgets(@\d+(\.\d+)?)?$/) }
+                    .to_formula
 
     # The configure script needs a little help finding our wx-config
-    wxconfig = "wx-config-#{wxmac.version.major_minor}"
+    wxconfig = "wx-config-#{wxwidgets.version.major_minor}"
     inreplace "configure", /^_wxconfig=wx-config$/, "_wxconfig=#{wxconfig}"
 
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/spatialite-gui.rb
+++ b/Formula/spatialite-gui.rb
@@ -4,7 +4,7 @@ class SpatialiteGui < Formula
   url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/spatialite_gui-1.7.1.tar.gz"
   sha256 "cb9cb1ede7f83a5fc5f52c83437e556ab9cb54d6ace3c545d31b317fd36f05e4"
   license "GPL-3.0-or-later"
-  revision 8
+  revision 9
 
   livecheck do
     url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/"
@@ -25,7 +25,7 @@ class SpatialiteGui < Formula
   depends_on "libspatialite"
   depends_on "proj@7"
   depends_on "sqlite"
-  depends_on "wxmac@3.0"
+  depends_on "wxwidgets@3.0"
 
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/85fa66a9/spatialite-gui/1.7.1.patch"
@@ -33,8 +33,8 @@ class SpatialiteGui < Formula
   end
 
   def install
-    wxmac = Formula["wxmac@3.0"]
-    ENV["WX_CONFIG"] = wxmac.opt_bin/"wx-config-#{wxmac.version.major_minor}"
+    wxwidgets = Formula["wxwidgets@3.0"]
+    ENV["WX_CONFIG"] = wxwidgets.opt_bin/"wx-config-#{wxwidgets.version.major_minor}"
 
     # Link flags for sqlite don't seem to get passed to make, which
     # causes builds to fatally error out on linking.

--- a/Formula/wxmaxima.rb
+++ b/Formula/wxmaxima.rb
@@ -4,7 +4,7 @@ class Wxmaxima < Formula
   url "https://github.com/wxMaxima-developers/wxmaxima/archive/Version-21.05.2.tar.gz"
   sha256 "4d2d486a24090ace2f64ceccb026210e2e6299a32cb348d43134ef80440bcf01"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/wxMaxima-developers/wxmaxima.git", branch: "main"
 
   bottle do
@@ -18,7 +18,7 @@ class Wxmaxima < Formula
   depends_on "gettext" => :build
   depends_on "ninja" => :build
   depends_on "maxima"
-  depends_on "wxmac"
+  depends_on "wxwidgets"
 
   def install
     mkdir "build-wxm" do

--- a/Formula/wxwidgets.rb
+++ b/Formula/wxwidgets.rb
@@ -1,5 +1,5 @@
-class Wxmac < Formula
-  desc "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
+class Wxwidgets < Formula
+  desc "Cross-platform C++ GUI toolkit"
   homepage "https://www.wxwidgets.org"
   url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.tar.bz2"
   sha256 "d7b3666de33aa5c10ea41bb9405c40326e1aeb74ee725bb88f90f1d50270a224"
@@ -11,21 +11,13 @@ class Wxmac < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  bottle do
-    sha256 cellar: :any,                 arm64_big_sur: "9080b4b039c1267c300977b6a1bab583717f0829f6858eeec580a55473e25a2f"
-    sha256 cellar: :any,                 big_sur:       "a4ca829d8774407a89b727677286788c2088c7f5814e4e21b07cd339453f6950"
-    sha256 cellar: :any,                 catalina:      "1b1e632388b899230f8728e21ac2336e741b8233094bf572e9b5e93e9028efe1"
-    sha256 cellar: :any,                 mojave:        "1be251946ba9b3c4f5acf14a1c3a99f9a5d06360dce108d62ba495c84594159c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4e1acbd860a4b0225c8a3e26f938ca5cb2ed281c03b3fae23be99a3e4ea0ca20"
-  end
-
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
 
   on_linux do
     depends_on "pkg-config" => :build
-    depends_on "gtk+"
+    depends_on "gtk+3"
     depends_on "libsm"
     depends_on "mesa-glu"
   end
@@ -64,13 +56,13 @@ class Wxmac < Formula
     system "./configure", *args
     system "make", "install"
 
-    # wx-config should reference the public prefix, not wxmac's keg
+    # wx-config should reference the public prefix, not wxwidgets's keg
     # this ensures that Python software trying to locate wxpython headers
-    # using wx-config can find both wxmac and wxpython headers,
+    # using wx-config can find both wxwidgets and wxpython headers,
     # which are linked to the same place
     inreplace "#{bin}/wx-config", prefix, HOMEBREW_PREFIX
 
-    # For consistency with the versioned wxmac formulae
+    # For consistency with the versioned wxwidgets formulae
     bin.install_symlink "#{bin}/wx-config" => "wx-config-#{version.major_minor}"
     (share/"wx"/version.major_minor).install share/"aclocal", share/"bakefile"
   end

--- a/Formula/wxwidgets@3.0.rb
+++ b/Formula/wxwidgets@3.0.rb
@@ -1,5 +1,5 @@
-class WxmacAT30 < Formula
-  desc "Cross-platform C++ GUI toolkit (wxWidgets for macOS) - Stable Release"
+class WxwidgetsAT30 < Formula
+  desc "Cross-platform C++ GUI toolkit - Stable Release"
   homepage "https://www.wxwidgets.org"
   url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5.1/wxWidgets-3.0.5.1.tar.bz2"
   sha256 "440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807"
@@ -10,21 +10,13 @@ class WxmacAT30 < Formula
     regex(/^v?(\d+\.\d*[02468](?:\.\d+)*)$/i)
   end
 
-  bottle do
-    sha256 cellar: :any,                 arm64_big_sur: "781881c92fcaadcfea66e7d33a36ae1d9b55d26839738f44248f39d187f46a3c"
-    sha256 cellar: :any,                 big_sur:       "42385ebead8045f2f4b1ac40f13f15c18b84b78ffa7110d69ebf8a798cd29dc0"
-    sha256 cellar: :any,                 catalina:      "d3d18b83d84b79735bda4497ebd92f763ed7cf4200c8ce8d651070ccd1b2719d"
-    sha256 cellar: :any,                 mojave:        "319f6ca3509265ace16fae3aaab777ae932130b741ba51d99702c0391da7833f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7c20b17371eaf47ea6da7f6754d35d539f335bec8ce11f3d0c6c41a113ffbbe8"
-  end
-
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
 
   on_linux do
     depends_on "pkg-config" => :build
-    depends_on "gtk+"
+    depends_on "gtk+3"
     depends_on "libsm"
     depends_on "mesa-glu"
   end
@@ -64,13 +56,13 @@ class WxmacAT30 < Formula
     system "./configure", *args
     system "make", "install"
 
-    # wx-config should reference the public prefix, not wxmac's keg
+    # wx-config should reference the public prefix, not wxwidgets's keg
     # this ensures that Python software trying to locate wxpython headers
-    # using wx-config can find both wxmac and wxpython headers,
+    # using wx-config can find both wxwidgets and wxpython headers,
     # which are linked to the same place
     inreplace "#{bin}/wx-config", prefix, HOMEBREW_PREFIX
 
-    # Move some files out of the way to prevent conflict with `wxmac`
+    # Move some files out of the way to prevent conflict with `wxwidgets`
     bin.install "#{bin}/wx-config" => "wx-config-#{version.major_minor}"
     (bin/"wxrc").unlink
     (share/"wx"/version.major_minor).install share/"aclocal", share/"bakefile"
@@ -86,7 +78,7 @@ class WxmacAT30 < Formula
 
   def caveats
     <<~EOS
-      To avoid conflicts with the wxmac formula, `wx-config` and `wxrc`
+      To avoid conflicts with the wxwidgets formula, `wx-config` and `wxrc`
       have been installed as `wx-config-#{version.major_minor}` and `wxrc-#{version.major_minor}`.
     EOS
   end

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -24,5 +24,5 @@
   "pyqt@5",
   "python@3.9",
   "python-tk@3.9",
-  "wxmac@3.0"
+  "wxwidgets@3.0"
 ]

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -143,5 +143,6 @@
   "weboob": "woob",
   "wires": "geckodriver",
   "wpcli-completion": "wp-cli-completion",
+  "wxmac": "wxwidgets",
   "xu4": "scummvm"
 }

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -144,5 +144,6 @@
   "wires": "geckodriver",
   "wpcli-completion": "wp-cli-completion",
   "wxmac": "wxwidgets",
+  "wxmac@3.0": "wxwidgets@3.0",
   "xu4": "scummvm"
 }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

GTK+3 is the default.

Alternatively, may be possible to use GTK4 via `--with-gtk=4`, but not sure how stable.