### PR TITLE
julia: revision bump, fix test

### DIFF
--- a/Formula/julia.rb
+++ b/Formula/julia.rb
@@ -2,6 +2,7 @@ class Julia < Formula
   desc "Fast, Dynamic Programming Language"
   homepage "https://julialang.org/"
   license all_of: ["MIT", "BSD-3-Clause", "Apache-2.0", "BSL-1.0"]
+  revision 1
   head "https://github.com/JuliaLang/julia.git"
 
   stable do
@@ -164,5 +165,11 @@ class Julia < Formula
   test do
     assert_equal "4", shell_output("#{bin}/julia -E '2 + 2'").chomp
     system bin/"julia", "-e", 'Base.runtests("core")'
+
+    (lib/"julia").children.each do |so|
+      next unless so.symlink?
+
+      assert_predicate so, :exist?, "Broken linkage with #{so.basename}"
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The version bump to `mbedtls` in #80919 broke linkage with
`libmbedcrypto`.

Julia does linkage a bit weirdly, so this wasn't caught in CI. I've
updated the test to help us catch this in the future.