### PR TITLE
Deprecate formulae with an archived GitHub repository

### DIFF
--- a/Formula/codemod.rb
+++ b/Formula/codemod.rb
@@ -18,6 +18,8 @@ class Codemod < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "b7b6b35729c1e0e990f4dc2d09c197d6c07cd8fbdacaa3d81decfe16e8856cb3"
   end
 
+  deprecate! date: "2021-07-13", because: :repo_archived
+
   depends_on "python@3.9"
 
   def install

--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -7,11 +7,6 @@ class Inlets < Formula
   license "MIT"
   head "https://github.com/inlets/inlets.git"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "55fdb93d26dacaca8cbb42cc68b9387423e3b618220e57f9de67855209132eeb"
     sha256 cellar: :any_skip_relocation, big_sur:       "5d6d55f2b32adc41a92f908ee15b263f9090dad596d137bf448d0d224288f365"
@@ -19,6 +14,8 @@ class Inlets < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "f87a32ce9f00b128379a23e83e62e2d9e4c811303c1b760cdde9cad16a599e99"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "fc3dc0b39ea492fd4d00bef8ff4b5019567eb1e5fda0db6e7d7b276f46de4b4a"
   end
+
+  deprecate! date: "2021-07-11", because: :repo_archived
 
   depends_on "go" => :build
 

--- a/Formula/libevhtp.rb
+++ b/Formula/libevhtp.rb
@@ -14,6 +14,8 @@ class Libevhtp < Formula
     sha256 cellar: :any, high_sierra:   "72be53d01a0ab668255e9ab605c4d7b6c16e4ca1a3f68b026c3c9ae1fe77af50"
   end
 
+  deprecate! date: "2021-07-13", because: :repo_removed
+
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "libevent"

--- a/Formula/saltwater.rb
+++ b/Formula/saltwater.rb
@@ -13,6 +13,8 @@ class Saltwater < Formula
     sha256 cellar: :any_skip_relocation, high_sierra: "da2e7d1937a9e47c96329261c76a3cc3ec445b0826b92115d3c48ab6885ca8a1"
   end
 
+  deprecate! date: "2021-06-02", because: :repo_archived
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These formulae have had their related GitHub repositories archived since the last time I checked. This deprecates these formulae as `:repo_archived`.