### PR TITLE
mbedtls 3.0.0, mbedtls@2 2.27 (new formula)

### DIFF
--- a/Formula/dislocker.rb
+++ b/Formula/dislocker.rb
@@ -4,7 +4,7 @@ class Dislocker < Formula
   url "https://github.com/Aorimn/dislocker/archive/v0.7.1.tar.gz"
   sha256 "742fb5c1b3ff540368ced54c29eae8b488ae5a5fcaca092947e17c2d358a6762"
   license "GPL-2.0-only"
-  revision 5
+  revision 6
 
   bottle do
     rebuild 1
@@ -12,7 +12,7 @@ class Dislocker < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "mbedtls"
+  depends_on "mbedtls@2"
 
   on_macos do
     disable! date: "2021-04-08", because: "requires closed-source macFUSE"

--- a/Formula/gauche.rb
+++ b/Formula/gauche.rb
@@ -4,7 +4,7 @@ class Gauche < Formula
   url "https://github.com/shirok/Gauche/releases/download/release0_9_10/Gauche-0.9.10.tgz"
   sha256 "0f39df1daec56680b542211b085179cb22e8220405dae15d9d745c56a63a2532"
   license "BSD-3-Clause"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -19,7 +19,7 @@ class Gauche < Formula
     sha256 mojave:        "44dac5484933886fc49e0e3e02140c44e6189ae65c7ab32f2f3ad24521740ec8"
   end
 
-  depends_on "mbedtls"
+  depends_on "mbedtls@2"
 
   uses_from_macos "zlib"
 

--- a/Formula/hashlink.rb
+++ b/Formula/hashlink.rb
@@ -4,7 +4,7 @@ class Hashlink < Formula
   url "https://github.com/HaxeFoundation/hashlink/archive/1.11.tar.gz"
   sha256 "b087ded7b93c7077f5b093b999f279a37aa1e31df829d882fa965389b5ad1aea"
   license "MIT"
-  revision 3
+  revision 4
   head "https://github.com/HaxeFoundation/hashlink.git"
 
   bottle do
@@ -19,7 +19,7 @@ class Hashlink < Formula
   depends_on "libpng"
   depends_on "libuv"
   depends_on "libvorbis"
-  depends_on "mbedtls"
+  depends_on "mbedtls@2"
   depends_on "openal-soft"
   depends_on "sdl2"
 

--- a/Formula/haxe.rb
+++ b/Formula/haxe.rb
@@ -2,7 +2,7 @@ class Haxe < Formula
   desc "Multi-platform programming language"
   homepage "https://haxe.org/"
   license all_of: ["GPL-2.0-or-later", "MIT"]
-  revision 1
+  revision 2
   head "https://github.com/HaxeFoundation/haxe.git", branch: "development"
 
   stable do
@@ -33,7 +33,7 @@ class Haxe < Formula
   depends_on "ocaml" => :build
   depends_on "opam" => :build
   depends_on "pkg-config" => :build
-  depends_on "mbedtls"
+  depends_on "mbedtls@2"
   depends_on "neko"
   depends_on "pcre"
 

--- a/Formula/julia.rb
+++ b/Formula/julia.rb
@@ -4,6 +4,7 @@ class Julia < Formula
   url "https://github.com/JuliaLang/julia/releases/download/v1.6.2/julia-1.6.2.tar.gz"
   sha256 "d56422ac75cbd00a9f69ca9ffd5b6b35c8aeded8312134ef45ffbba828918b5e"
   license all_of: ["MIT", "BSD-3-Clause", "Apache-2.0", "BSL-1.0"]
+  revision 1
   head "https://github.com/JuliaLang/julia.git"
 
   bottle do
@@ -22,7 +23,7 @@ class Julia < Formula
   depends_on "libgit2"
   depends_on "libssh2"
   depends_on "llvm"
-  depends_on "mbedtls"
+  depends_on "mbedtls@2"
   depends_on "mpfr"
   depends_on "nghttp2"
   depends_on "openblas"

--- a/Formula/mbedtls.rb
+++ b/Formula/mbedtls.rb
@@ -1,8 +1,8 @@
 class Mbedtls < Formula
   desc "Cryptographic & SSL/TLS library"
   homepage "https://tls.mbed.org/"
-  url "https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.27.0.tar.gz"
-  sha256 "4f6a43f06ded62aa20ef582436a39b65902e1126cbbe2fb17f394e9e9a552767"
+  url "https://github.com/ARMmbed/mbedtls/archive/mbedtls-3.0.0.tar.gz"
+  sha256 "377d376919be19f07c7e7adeeded088a525be40353f6d938a78e4f986bce2ae0"
   license "Apache-2.0"
   head "https://github.com/ARMmbed/mbedtls.git", branch: "development"
 
@@ -24,7 +24,7 @@ class Mbedtls < Formula
   depends_on "python@3.9" => :build
 
   def install
-    inreplace "include/mbedtls/config.h" do |s|
+    inreplace "include/mbedtls/mbedtls_config.h" do |s|
       # enable pthread mutexes
       s.gsub! "//#define MBEDTLS_THREADING_PTHREAD", "#define MBEDTLS_THREADING_PTHREAD"
       # allow use of mutexes within mbed TLS
@@ -32,8 +32,9 @@ class Mbedtls < Formula
     end
 
     system "cmake", "-DUSE_SHARED_MBEDTLS_LIBRARY=On",
-      "-DPython3_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3",
-      *std_cmake_args
+                    "-DPython3_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    *std_cmake_args
     system "make"
     system "make", "install"
 

--- a/Formula/mbedtls@2.rb
+++ b/Formula/mbedtls@2.rb
@@ -1,0 +1,48 @@
+class MbedtlsAT2 < Formula
+  desc "Cryptographic & SSL/TLS library"
+  homepage "https://tls.mbed.org/"
+  url "https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.27.0.tar.gz"
+  sha256 "4f6a43f06ded62aa20ef582436a39b65902e1126cbbe2fb17f394e9e9a552767"
+  license "Apache-2.0"
+  head "https://github.com/ARMmbed/mbedtls.git", branch: "development_2.x"
+
+  livecheck do
+    url :stable
+    regex(/^v?(2(?:\.\d+)+)$/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "python@3.9" => :build
+
+  def install
+    inreplace "include/mbedtls/config.h" do |s|
+      # enable pthread mutexes
+      s.gsub! "//#define MBEDTLS_THREADING_PTHREAD", "#define MBEDTLS_THREADING_PTHREAD"
+      # allow use of mutexes within mbed TLS
+      s.gsub! "//#define MBEDTLS_THREADING_C", "#define MBEDTLS_THREADING_C"
+    end
+
+    system "cmake", "-DUSE_SHARED_MBEDTLS_LIBRARY=On",
+                    "-DPython3_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3",
+                    *std_cmake_args
+    system "make"
+    system "make", "install"
+
+    # Why does Mbedtls ship with a "Hello World" executable. Let's remove that.
+    rm_f bin/"hello"
+    # Rename benchmark & selftest, which are awfully generic names.
+    mv bin/"benchmark", bin/"mbedtls-benchmark"
+    mv bin/"selftest", bin/"mbedtls-selftest"
+    # Demonstration files shouldn't be in the main bin
+    libexec.install bin/"mpi_demo"
+  end
+
+  test do
+    (testpath/"testfile.txt").write("This is a test file")
+    # Don't remove the space between the checksum and filename. It will break.
+    expected_checksum = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0ff81339148249  testfile.txt"
+    assert_equal expected_checksum, shell_output("#{bin}/generic_sum SHA256 testfile.txt").strip
+  end
+end

--- a/Formula/neko.rb
+++ b/Formula/neko.rb
@@ -4,7 +4,7 @@ class Neko < Formula
   url "https://github.com/HaxeFoundation/neko/archive/v2-3-0/neko-2.3.0.tar.gz"
   sha256 "850e7e317bdaf24ed652efeff89c1cb21380ca19f20e68a296c84f6bad4ee995"
   license "MIT"
-  revision 5
+  revision 6
   head "https://github.com/HaxeFoundation/neko.git"
 
   bottle do
@@ -18,7 +18,7 @@ class Neko < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "bdw-gc"
-  depends_on "mbedtls"
+  depends_on "mbedtls@2"
   depends_on "openssl@1.1"
   depends_on "pcre"
 

--- a/Formula/ortp.rb
+++ b/Formula/ortp.rb
@@ -4,7 +4,7 @@ class Ortp < Formula
   url "https://gitlab.linphone.org/BC/public/ortp/-/archive/4.5.22/ortp-4.5.22.tar.bz2"
   sha256 "c30fd72e7847b32b5aaa31dc5a82c92856c59ca8cb8128d50b3c0e38104d6376"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://gitlab.linphone.org/BC/public/ortp.git"
 
   bottle do
@@ -16,7 +16,7 @@ class Ortp < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "mbedtls"
+  depends_on "mbedtls@2"
 
   # bctoolbox appears to follow ortp's version. This can be verified at the GitHub mirror:
   # https://github.com/BelledonneCommunications/bctoolbox

--- a/Formula/shadowsocks-libev.rb
+++ b/Formula/shadowsocks-libev.rb
@@ -4,7 +4,7 @@ class ShadowsocksLibev < Formula
   url "https://github.com/shadowsocks/shadowsocks-libev/releases/download/v3.3.5/shadowsocks-libev-3.3.5.tar.gz"
   sha256 "cfc8eded35360f4b67e18dc447b0c00cddb29cc57a3cec48b135e5fb87433488"
   license "GPL-3.0-or-later"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "e168d22c62b27ff0eb6645471ffc44dd9a01fce3dafaeb86565f5d88b23eef7d"
@@ -27,7 +27,7 @@ class ShadowsocksLibev < Formula
   depends_on "c-ares"
   depends_on "libev"
   depends_on "libsodium"
-  depends_on "mbedtls"
+  depends_on "mbedtls@2"
   depends_on "pcre"
 
   def install

--- a/audit_exceptions/versioned_head_spec_allowlist.json
+++ b/audit_exceptions/versioned_head_spec_allowlist.json
@@ -1,4 +1,5 @@
 [
   "bash-completion@2",
-  "imagemagick@6"
+  "imagemagick@6",
+  "mbedtls@2"
 ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Continuation of #80727. This also adds an `mbedtls@2` formula, since all existing formulae that use `mbedtls` do not work with 3.0. The 2.x branch of MbedTLS is still being maintained. See https://lists.trustedfirmware.org/pipermail/mbed-tls-announce/2021-April/000011.html.