### PR TITLE
goffice: fix test for Linux

### DIFF
--- a/Formula/goffice.rb
+++ b/Formula/goffice.rb
@@ -62,7 +62,7 @@ class Goffice < Formula
           return 0;
       }
     EOS
-    libxml2 = MacOS.sdk_path/"usr/include/libxml2"
+    libxml2 = "#{MacOS.sdk_path}/usr/include/libxml2"
     on_linux do
       libxml2 = Formula["libxml2"].opt_include/"libxml2"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3063414943?check_suite_focus=true
```
==> Testing goffice
Error: goffice: failed
An exception occurred within a child process:
  NoMethodError: undefined method `/' for nil:NilClass
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/goffice.rb:66:in `block in <class:Goffice>'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2043:in `block (3 levels) in run_test'
```