### PR TITLE
kube-no-trouble 0.4.0 (new formula)

### DIFF
--- a/Formula/kube-no-trouble.rb
+++ b/Formula/kube-no-trouble.rb
@@ -1,6 +1,3 @@
-# Documentation: https://docs.brew.sh/Formula-Cookbook
-#                https://rubydoc.brew.sh/Formula
-# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
 class KubeNoTrouble < Formula
   desc "Easily check your cluster for use of deprecated APIs"
   homepage "https://www.doit-intl.com"

--- a/Formula/kube-no-trouble.rb
+++ b/Formula/kube-no-trouble.rb
@@ -1,0 +1,20 @@
+# Documentation: https://docs.brew.sh/Formula-Cookbook
+#                https://rubydoc.brew.sh/Formula
+# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
+class KubeNoTrouble < Formula
+  desc "Easily check your cluster for use of deprecated APIs"
+  homepage "https://www.doit-intl.com"
+  url "https://github.com/doitintl/kube-no-trouble/archive/refs/tags/0.4.0.tar.gz"
+  sha256 "b9d63f41ae1b64b9dd161c1eaa3a0de4f35b5c0030793f491342d1c2058b042d"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args, "-o", bin/"kubent", "cmd/kubent/main.go"
+  end
+
+  test do
+    system bin/"kubent", "-h"
+  end
+end


### PR DESCRIPTION
Easily check your Kubernetes cluster for use of deprecated APIs

- [v] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [v] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [v] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [v] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [v] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [v] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
