### PR TITLE
fabric-completion: add livecheck

### DIFF
--- a/Formula/fabric-completion.rb
+++ b/Formula/fabric-completion.rb
@@ -6,6 +6,10 @@ class FabricCompletion < Formula
   version "1"
   head "https://github.com/kbakulin/fabric-completion.git"
 
+  livecheck do
+    skip "No version information available to check"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "3a73318f4d2d5ef0a1b8f14dd72755ee37273b33e9df402bf0c2b9b825a53f6a"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `fabric-completion` after checking the Git tags. This PR adds a `livecheck` block to `skip` it, as `fabric-completion` is unversioned (i.e., the formula simply uses the newest commit hash from six years ago and the repository doesn't contain any tags).