### PR TITLE
aida-header: add livecheck

### DIFF
--- a/Formula/aida-header.rb
+++ b/Formula/aida-header.rb
@@ -5,6 +5,11 @@ class AidaHeader < Formula
   sha256 "882d351bc09e830ae2eb512a2cbf44af5a82ef8efe31fbe0d047363da8314c81"
   license "LGPL-3.0-or-later"
 
+  livecheck do
+    url "https://aida.freehep.org/download.thtml"
+    regex(%r{href=.*?/AIDA/v?(\d+(?:\.\d+)+)/}i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "dbbfb4a01fb14b65b959fe8666c25d894a3b0b0a6e2badb14346c8ba71673bf2"
     sha256 cellar: :any_skip_relocation, big_sur:       "eba4b33299b9ed8ed988c4c17fbffe1e17364a7d284878247c3b0a738fe2b340"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `aida-header`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.