### PR TITLE
mpck: add livecheck

### DIFF
--- a/Formula/mpck.rb
+++ b/Formula/mpck.rb
@@ -5,6 +5,11 @@ class Mpck < Formula
   sha256 "a27b4843ec06b069a46363836efda3e56e1daaf193a73a4da875e77f0945dd7a"
   license "GPL-2.0"
 
+  livecheck do
+    url "https://checkmate.gissen.nl/download.php"
+    regex(/href=.*?checkmate[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f963c58102f58169a5ea1d6264f3ea1093a62fd6461332d5e70d0e1ad9aa5d79"
     sha256 cellar: :any_skip_relocation, big_sur:       "215f2f66b6567409359c6a0f784702df9fcc2e0c86edcab52fc40f91b6911bb9"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `mpck`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.