### PR TITLE
tmpwatch: add livecheck

### DIFF
--- a/Formula/tmpwatch.rb
+++ b/Formula/tmpwatch.rb
@@ -4,6 +4,15 @@ class Tmpwatch < Formula
   url "https://releases.pagure.org/tmpwatch/tmpwatch-2.11.tar.bz2"
   sha256 "93168112b2515bc4c7117e8113b8d91e06b79550d2194d62a0c174fe6c2aa8d4"
   license "GPL-2.0-only"
+  head "https://pagure.io/tmpwatch.git"
+
+  livecheck do
+    url :head
+    regex(/^(?:r|tmpwatch|v)[._-]?(\d+(?:[._-]\d+)+)$/i)
+    strategy :git do |tags|
+      tags.map { |tag| tag[regex, 1]&.gsub(/[_-]/, ".") }.compact
+    end
+  end
 
   bottle do
     rebuild 2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `tmpwatch`. This PR adds a `livecheck` block that checks the upstream Git repository tags, which aligns with the stable source.

For what it's worth, I couldn't get this to successfully build using `brew install --HEAD tmpwatch`. I figured I would add the Git repository as `head` anyway and someone else can fix the `head` build if they need it in the future.