### PR TITLE
jbigkit: add livecheck

### DIFF
--- a/Formula/jbigkit.rb
+++ b/Formula/jbigkit.rb
@@ -7,6 +7,11 @@ class Jbigkit < Formula
   license "GPL-2.0"
   head "https://www.cl.cam.ac.uk/~mgk25/git/jbigkit", using: :git
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?jbigkit[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "cda73dea9c469f1ad380c7fe90b75dfe22d1dcc9ba51593ba59493656cf76c94"
     sha256 cellar: :any_skip_relocation, big_sur:       "568ea0a6734dc1da5d50b5261f43753f7cf1089fae9c786e7859a8ec22562144"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `jbigkit`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.