### PR TITLE
dmagnetic: add livecheck

### DIFF
--- a/Formula/dmagnetic.rb
+++ b/Formula/dmagnetic.rb
@@ -5,6 +5,11 @@ class Dmagnetic < Formula
   sha256 "1a0356f04d3a5e252225b0fd38b9047957f292f67338ba83579958b46f184139"
   license "BSD-2-Clause"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?dMagnetic[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "cf25009d9eff9196c36d27402aebae7e7ecf90a5a8029162ec6f33d6457ce9ed"
     sha256 cellar: :any_skip_relocation, big_sur:       "5e7d9d39d36fbeb673598c7974ee8dbf6fc542ea00e73eeed6253db6c0fc67bf"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `dmagnetic`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.