### PR TITLE
qprint: add livecheck

### DIFF
--- a/Formula/qprint.rb
+++ b/Formula/qprint.rb
@@ -1,8 +1,13 @@
 class Qprint < Formula
   desc "Encoder and decoder for quoted-printable encoding"
-  homepage "https://www.fourmilab.ch/webtools/qprint"
+  homepage "https://www.fourmilab.ch/webtools/qprint/"
   url "https://www.fourmilab.ch/webtools/qprint/qprint-1.1.tar.gz"
   sha256 "ffa9ca1d51c871fb3b56a4bf0165418348cf080f01ff7e59cd04511b9665019c"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?qprint[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "05903a905caebf80944f4705898c5377849b7a411cf234614205b3136dba4a38"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `qprint`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This also updates the `homepage` URL to include a trailing forward slash, as the existing homepage was redirecting to the same URL with a trailing forward slash.