### PR TITLE
libpcl: add livecheck

### DIFF
--- a/Formula/libpcl.rb
+++ b/Formula/libpcl.rb
@@ -5,6 +5,11 @@ class Libpcl < Formula
   sha256 "e7b30546765011575d54ae6b44f9d52f138f5809221270c815d2478273319e1a"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?pcl[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any, big_sur:     "2ed8a2eb0ff0c53cb2a2653991386ceded74a41a8a215e0d641221092917e361"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `libpcl`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.