### PR TITLE
unittest: add livecheck

### DIFF
--- a/Formula/unittest.rb
+++ b/Formula/unittest.rb
@@ -4,6 +4,11 @@ class Unittest < Formula
   url "https://unittest.red-bean.com/tar/unittest-0.50-62.tar.gz"
   sha256 "9586ef0149b6376da9b5f95a992c7ad1546254381808cddad1f03768974b165f"
 
+  livecheck do
+    url "https://unittest.red-bean.com/tar/"
+    regex(/href=.*?unittest[._-]v?(\d+(?:[.-]\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "2da59f3f0206902816c2dac6c273768858f092eb917b696b0a8b04096ea97007"
     sha256 cellar: :any_skip_relocation, big_sur:       "8f449bf2ba73aaf03dd8316d6057639bd2c3a38ef347157f3721cbabfb60212f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `unittest`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.