### PR TITLE
libvorbis: update 1.3.7 bottle.

### DIFF
--- a/Formula/libvorbis.rb
+++ b/Formula/libvorbis.rb
@@ -12,11 +12,12 @@ class Libvorbis < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_big_sur: "07ab1118fc6d389a8b0506d0b74a3cfc12026a837c8f2609b2133318c8818c81"
-    sha256 cellar: :any, big_sur:       "05e639c274f52924cbf31fb4337888ab51554a66597486aeed8e5942d267c586"
-    sha256 cellar: :any, catalina:      "432eb21045d9dfac3ef879648d845d894cc828862f5498448fe98c0141ef5cd0"
-    sha256 cellar: :any, mojave:        "59509a351e88352f01512b54cc5cb849c2551623f7d6dcd6679d38b5e96032ed"
-    sha256 cellar: :any, high_sierra:   "3e6609520d0ffd7179f721c23c1291f2735b70384d56d1c1dd10185ae355c4b2"
+    sha256 cellar: :any,                 arm64_big_sur: "07ab1118fc6d389a8b0506d0b74a3cfc12026a837c8f2609b2133318c8818c81"
+    sha256 cellar: :any,                 big_sur:       "05e639c274f52924cbf31fb4337888ab51554a66597486aeed8e5942d267c586"
+    sha256 cellar: :any,                 catalina:      "432eb21045d9dfac3ef879648d845d894cc828862f5498448fe98c0141ef5cd0"
+    sha256 cellar: :any,                 mojave:        "59509a351e88352f01512b54cc5cb849c2551623f7d6dcd6679d38b5e96032ed"
+    sha256 cellar: :any,                 high_sierra:   "3e6609520d0ffd7179f721c23c1291f2735b70384d56d1c1dd10185ae355c4b2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c205523df9d4dd5f8ee71b26018419b9cf5bbca73c64eec36f5cbe5f2db6bbbd"
   end
 
   head do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Tried uploading `libvorbis` via `brew pr-upload --keep-old --verbose` from run
 https://github.com/Homebrew/homebrew-core/actions/runs/1036519909
Which only had audit failure due to XIPH:
```
==> FAILED
Error: 2 problems in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
libvorbis:
  * The homepage URL https://xiph.org/vorbis/ is not reachable
  * Stable: The source URL https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz is not reachable

...

==> brew uninstall --force libogg xz
Error: 1 failed step!
brew audit libvorbis --online --git --skip-style
Error: Process completed with exit code 1.
```

---

Probably should find alternative way to update XIPH formulae.
Since this was already uploaded, creating PR to finish update.

Locally tested:
```console
$ git checkout libvorbis-bottle
Switched to branch 'libvorbis-bottle'
Your branch is up to date with 'cho-m/libvorbis-bottle'.

$ brew install libvorbis
Updating Homebrew...
==> Downloading https://ghcr.io/v2/homebrew/core/libogg/manifests/1.3.5
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/libogg/blobs/sha256:db517cc6e922b1d3a7c845bad5dd4c78d48b170aa94187d6281
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:db517cc6e922b1d3a7c845bad5dd4c78d48
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/libvorbis/manifests/1.3.7
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/libvorbis/blobs/sha256:c205523df9d4dd5f8ee71b26018419b9cf5bbca73c64eec3
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:c205523df9d4dd5f8ee71b26018419b9cf5
######################################################################## 100.0%
==> Installing dependencies for libvorbis: libogg
==> Installing libvorbis dependency: libogg
==> Pouring libogg--1.3.5.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/libogg/1.3.5: 98 files, 529.9KB
==> Installing libvorbis
==> Pouring libvorbis--1.3.7.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/libvorbis/1.3.7: 160 files, 2.6MB
```