### PR TITLE
psalm 4.8.1 (new formula)

### DIFF
--- a/Formula/psalm.rb
+++ b/Formula/psalm.rb
@@ -1,0 +1,91 @@
+class Psalm < Formula
+  desc "PHP Static Analysis Tool"
+  homepage "https://psalm.dev"
+  url "https://github.com/vimeo/psalm/releases/download/4.8.1/psalm.phar"
+  sha256 "896246540c669c8d21e62e7c3865bc23cf1e7980caa920cd04b4e38a60354faf"
+  license "MIT"
+
+  # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
+  pour_bottle? do
+    on_macos do
+      reason "The bottle needs to be installed into `#{Homebrew::DEFAULT_PREFIX}` on Intel macOS."
+      satisfy { HOMEBREW_PREFIX.to_s == Homebrew::DEFAULT_PREFIX || Hardware::CPU.arm? }
+    end
+  end
+
+  depends_on "composer" => :test
+
+  uses_from_macos "php"
+
+  def install
+    bin.install "psalm.phar" => "psalm"
+  end
+
+  test do
+    (testpath/"composer.json").write <<~EOS
+      {
+        "name": "homebrew/psalm-test",
+        "description": "Testing if Psalm has been installed properly.",
+        "type": "project",
+        "require": {
+          "php": ">=7.1.3"
+        },
+        "license": "MIT",
+        "autoload": {
+          "psr-4": {
+            "Homebrew\\\\PsalmTest\\\\": "src/"
+          }
+        },
+        "minimum-stability": "stable"
+      }
+    EOS
+
+    (testpath/"src/Email.php").write <<~EOS
+      <?php
+      declare(strict_types=1);
+
+      namespace Homebrew\\PsalmTest;
+
+      final class Email
+      {
+        private string $email;
+
+        private function __construct(string $email)
+        {
+          $this->ensureIsValidEmail($email);
+
+          $this->email = $email;
+        }
+
+        public static function fromString(string $email): self
+        {
+          return new self($email);
+        }
+
+        public function __toString(): string
+        {
+          return $this->email;
+        }
+
+        private function ensureIsValidEmail(string $email): void
+        {
+          if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new \\InvalidArgumentException(
+              sprintf(
+                '"%s" is not a valid email address',
+                $email
+              )
+            );
+          }
+        }
+      }
+    EOS
+
+    system "composer", "install"
+
+    assert_match "Config file created successfully. Please re-run psalm.",
+                 shell_output("#{bin}/psalm --init")
+    assert_match "No errors found!",
+                 shell_output("#{bin}/psalm")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

[Psalm](https://psalm.dev/) is a popular static code analysis tool for PHP, similar to PHPStan which is already included in Homebrew. I use it regularly and think it would make a great addition.