### PR TITLE
cgit: add livecheck

### DIFF
--- a/Formula/cgit.rb
+++ b/Formula/cgit.rb
@@ -5,6 +5,11 @@ class Cgit < Formula
   sha256 "5a5f12d2f66bd3629c8bc103ec8ec2301b292e97155d30a9a61884ea414a6da4"
   license "GPL-2.0-only"
 
+  livecheck do
+    url "https://git.zx2c4.com/cgit/refs/tags"
+    regex(/href=.*?cgit[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "1d94a449229b9550a5d76b9d1f0140ea6b267fcd982539d6537fce21447aae12"
     sha256 big_sur:       "43d5a3249276dc89f9b8730b775fab358f9a04adac63fc18dc1257cecb0de2a8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `cgit`. This PR adds a `livecheck` block that checks the repository website's tags page, which links to the `stable` archive.