### PR TITLE
packer: set PACKER_PLUGIN_PATH to prefix

### DIFF
--- a/Formula/packer.rb
+++ b/Formula/packer.rb
@@ -31,6 +31,9 @@ class Packer < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
 
+    # Allow packer to find plugins in Homebrew prefix
+    bin.env_script_all_files libexec/"bin", PACKER_PLUGIN_PATH: "$PACKER_PLUGIN_PATH:#{HOMEBREW_PREFIX/"bin"}"
+
     zsh_completion.install "contrib/zsh-completion/_packer"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Set `PACKER_PLUGIN_PATH` to our prefix so `packer` can find any brewed packer plugins, cause right now it can't.
Reference: https://www.packer.io/docs/plugins#installing-plugins

Currently there are no packer plugins available in Homebrew, but after this change, there might be.

This change should not have any impact on existing installations.

```
➜  ~/packer  sudo PACKER_LOG=1 packer build rpi2-ubuntu.json
2021/07/17 00:21:21 [INFO] Packer version: 1.7.3 [go1.16.5 linux amd64]
2021/07/17 00:21:21 [TRACE] discovering plugins in /home/linuxbrew/.linuxbrew/Cellar/packer/1.7.3/libexec/bin
2021/07/17 00:21:21 [TRACE] discovering plugins in /root/.packer.d/plugins
2021/07/17 00:21:21 [TRACE] discovering plugins in .
2021/07/17 00:21:21 [TRACE] discovering plugins in 
2021/07/17 00:21:21 [TRACE] discovering plugins in /home/linuxbrew/.linuxbrew/bin
2021/07/17 00:21:21 [DEBUG] Discovered plugin: arm-image = /home/linuxbrew/.linuxbrew/bin/packer-builder-arm-image
2021/07/17 00:21:21 [INFO] using external builders: [arm-image]
```