### PR TITLE
irrlicht: add license

### DIFF
--- a/Formula/irrlicht.rb
+++ b/Formula/irrlicht.rb
@@ -3,6 +3,9 @@ class Irrlicht < Formula
   homepage "https://irrlicht.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/irrlicht/Irrlicht%20SDK/1.8/1.8.4/irrlicht-1.8.4.zip"
   sha256 "f42b280bc608e545b820206fe2a999c55f290de5c7509a02bdbeeccc1bf9e433"
+  # Irrlicht is available under alternative license terms. See
+  # https://metadata.ftp-master.debian.org/changelogs//main/i/irrlicht/irrlicht_1.8.4+dfsg1-1.1_copyright
+  license "Zlib"
   revision 1
   head "https://svn.code.sf.net/p/irrlicht/code/trunk"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fedora and Arch list the license as `Zlib`. See

https://src.fedoraproject.org/rpms/irrlicht/blob/rawhide/f/irrlicht.spec#_8
https://github.com/archlinux/svntogit-community/blob/01721421aec89a6e6881ff06f1cd5cb2e7ca697a/trunk/PKGBUILD#L14

~~Merge this after #81089 to avoid creating a merge conflict there.~~