### PR TITLE
dvd+rw-tools: add livecheck

### DIFF
--- a/Formula/dvd+rw-tools.rb
+++ b/Formula/dvd+rw-tools.rb
@@ -5,6 +5,11 @@ class DvdxrwTools < Formula
   sha256 "f8d60f822e914128bcbc5f64fbe3ed131cbff9045dca7e12c5b77b26edde72ca"
   license "GPL-2.0"
 
+  livecheck do
+    url "http://fy.chalmers.se/~appro/linux/DVD+RW/tools/"
+    regex(/href=.*?dvd\+rw-tools[._-]v?(\d+(?:[.-]\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "11ec6e949911cca76b2c3a940e362aff334523a7018dfd3bdcd232acb7b741d1"
     sha256 cellar: :any_skip_relocation, big_sur:       "c3d9ab88096123bd36acbad9f27cc21c07fd881f00ac45b49605f18de03262b1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `dvd+rw-tools`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.