### PR TITLE
libusbmuxd: fix test for Linux

### DIFF
--- a/Formula/libusbmuxd.rb
+++ b/Formula/libusbmuxd.rb
@@ -3,7 +3,7 @@ class Libusbmuxd < Formula
   homepage "https://www.libimobiledevice.org/"
   url "https://github.com/libimobiledevice/libusbmuxd/archive/2.0.2.tar.gz"
   sha256 "8ae3e1d9340177f8f3a785be276435869363de79f491d05d8a84a59efc8a8fdc"
-  license "LGPL-2.1"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
   head "https://github.com/libimobiledevice/libusbmuxd.git"
 
   bottle do
@@ -21,6 +21,8 @@ class Libusbmuxd < Formula
   depends_on "libplist"
   depends_on "libusb"
 
+  uses_from_macos "netcat" => :test
+
   def install
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
@@ -33,7 +35,7 @@ class Libusbmuxd < Formula
     source = free_port
     dest = free_port
     fork do
-      exec bin/"iproxy", "#{source}:#{dest}"
+      exec bin/"iproxy", "-s", "localhost", "#{source}:#{dest}"
     end
 
     sleep(2)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Probably will need an additional fix to get test to work as there were 2 issues on previous run.

https://github.com/Homebrew/homebrew-core/runs/3034016255?check_suite_focus=true
```make
==> FAILED
==> Testing libusbmuxd
bind(): Cannot assign requested address
Error creating socket for listen port 38479: Invalid argument
Creating listening port 38479 for device port 43491
Error: test failed
==> nc -z localhost 38479
Failed to execute: nc
Killing child processes...
Error: libusbmuxd: failed
```