### PR TITLE
topgrade: fix test for Linux

### DIFF
--- a/Formula/topgrade.rb
+++ b/Formula/topgrade.rb
@@ -33,7 +33,7 @@ class Topgrade < Formula
     assert_match version.to_s, shell_output("#{bin}/topgrade --version")
 
     output = shell_output("#{bin}/topgrade -n --only brew_formula")
-    assert_match "Dry running: #{HOMEBREW_PREFIX}/bin/brew upgrade", output
+    assert_match %r{Dry running: (?:#{HOMEBREW_PREFIX}/bin/)?brew upgrade}o, output
     refute_match(/\sSelf update\s/, output)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3034018962?check_suite_focus=true
```
Error: topgrade: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /Dry\ running:\ \/home\/linuxbrew\/\.linuxbrew\/bin\/brew\ upgrade/ to match "―― 02:00:18 - Brew ――\nDry running: brew update\nDry running: brew upgrade --ignore-pinned --formula\n―― 02:00:18 - Summary ――\nBrew: OK\n".
```