### PR TITLE
icarus-verilog: update license and fix Linux build

### DIFF
--- a/Formula/icarus-verilog.rb
+++ b/Formula/icarus-verilog.rb
@@ -4,7 +4,7 @@ class IcarusVerilog < Formula
   url "https://github.com/steveicarus/iverilog/archive/v11_0.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/i/iverilog/iverilog_11.0.orig.tar.gz"
   sha256 "6327fb900e66b46803d928b7ca439409a0dc32731d82143b20387be0833f1c95"
-  license "LGPL-2.1"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
   head "https://github.com/steveicarus/iverilog.git"
 
   livecheck do
@@ -21,7 +21,10 @@ class IcarusVerilog < Formula
     sha256 high_sierra:   "a92f6fe981238a8c2b9f47b99d77c1e8596bc74235b8f6601835aae8f9ad70a1"
   end
 
-  depends_on "autoconf" => :build
+  # support for autoconf >= 2.70 was added after the current release
+  # switch to `autoconf` in the next release
+  # ref: https://github.com/steveicarus/iverilog/commit/4b3e1099e5517333dd690ba948bce1236466a395
+  depends_on "autoconf@2.69" => :build
   # parser is subtly broken when processed with an old version of bison
   depends_on "bison" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3011637281?check_suite_focus=true
```
checking how to run the C preprocessor... /lib/cpp
configure: error: in `/tmp/icarus-verilog-20210707-5324-uws3fr/iverilog-11_0':
configure: error: C preprocessor "/lib/cpp" fails sanity check
See `config.log' for more details

...

==> brew audit icarus-verilog --online --git --skip-style
==> FAILED
Error: 1 problem in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
icarus-verilog:
  * Formula license ["LGPL-2.1"] does not match GitHub license ["GPL-2.0"].
```