### PR TITLE
git-now: fix build for Linux

### DIFF
--- a/Formula/git-now.rb
+++ b/Formula/git-now.rb
@@ -1,11 +1,20 @@
 class GitNow < Formula
   desc "Light, temporary commits for git"
   homepage "https://github.com/iwata/git-now"
-  url "https://github.com/iwata/git-now.git",
-      tag:      "v0.1.1.0",
-      revision: "a07a05893b9ddf784833b3d4b410c843633d0f71"
   license "GPL-2.0"
   head "https://github.com/iwata/git-now.git"
+
+  stable do
+    url "https://github.com/iwata/git-now.git",
+        tag:      "v0.1.1.0",
+        revision: "a07a05893b9ddf784833b3d4b410c843633d0f71"
+
+    # Fix error on Linux due to /bin/sh using dash
+    patch do
+      url "https://github.com/iwata/git-now/commit/be74736cb95e8213cd06cc6fe85f467e26b9a3c2.patch?full_index=1"
+      sha256 "6f13e7baeb0160e937221e51cd5736fabc57e3b8ba9309b88a8b17b5d14bb767"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "cbebffb09635dd83022c86c6317b6af0e795914942f968e62aafccdcca171364"
@@ -22,12 +31,7 @@ class GitNow < Formula
 
   def install
     system "make", "prefix=#{libexec}", "install"
-
-    (bin/"git-now").write <<~EOS
-      #!/bin/sh
-      PATH=#{Formula["gnu-getopt"].opt_bin}:$PATH #{libexec}/bin/git-now "$@"
-    EOS
-
+    (bin/"git-now").write_env_script libexec/"bin/git-now", PATH: "#{Formula["gnu-getopt"].opt_bin}:$PATH"
     zsh_completion.install "etc/_git-now"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3011610153?check_suite_focus=true
```
==> /home/linuxbrew/.linuxbrew/Cellar/git-now/0.1.1.0/bin/git-now
/home/linuxbrew/.linuxbrew/Cellar/git-now/0.1.1.0/libexec/bin/git-now: 17: /home/linuxbrew/.linuxbrew/Cellar/git-now/0.1.1.0/libexec/bin/git-now-add: Syntax error: "(" unexpected (expecting "fi")
Error: git-now: failed
An exception occurred within a child process:
  BuildError: Failed executing: /home/linuxbrew/.linuxbrew/Cellar/git-now/0.1.1.0/bin/git-now
```

Upstream: https://github.com/iwata/git-now/issues/2

Also simplify install with `write_env_script`.

I think changes only modify `/bin/sh -> /bin/bash`, so shouldn't impact macOS.
Probably can avoid rebuilding bottles and keep support for older macOS.