### PR TITLE
blast: update livecheck

### DIFF
--- a/Formula/blast.rb
+++ b/Formula/blast.rb
@@ -8,7 +8,7 @@ class Blast < Formula
 
   livecheck do
     url "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/VERSION"
-    regex(/.+/i)
+    regex(/v?(\d+(?:\.\d+)+)/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `livecheck` block for `blast` was modified in #81449 to check the `VERSION` file. The `regex` used is not strict and can potentially match any text that is included in this file. This PR updates the regex to match version strings using the standard regex.

The change introduced in #81449 deviates from our usual standards of checking the location of the stable URL (and matching version strings from URLs). If we decide that matching within URLs is preferable, I'll update the PR accordingly.