### PR TITLE
gbdfed: add livecheck

### DIFF
--- a/Formula/gbdfed.rb
+++ b/Formula/gbdfed.rb
@@ -5,6 +5,11 @@ class Gbdfed < Formula
   sha256 "8042575d23a55a3c38192e67fcb5eafd8f7aa8d723012c374acb2e0a36022943"
   revision 3
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?gbdfed[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "636d528318fa5e5fc90bdc61665ca3e3dc220a5c034bb478bedda854017de83d"
     sha256 cellar: :any,                 big_sur:       "0c060efda560aa9ab6addc8087cad336ca01f420b280f0e41b2460f4d74b06aa"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `gbdfed`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.