### PR TITLE
dug 0.0.76 (new formula)

### DIFF
--- a/Formula/dug.rb
+++ b/Formula/dug.rb
@@ -1,8 +1,8 @@
 class Dug < Formula
     desc "Global DNS progagation checker that gives pretty output"
     homepage "https://dug.unfrl.com"
-    url "https://github.com/unfrl/dug/releases/download/0.0.75/dug.0.0.75.osx-x64.tar.gz"
-    version "0.0.75"
+    url "https://github.com/unfrl/dug/releases/download/0.0.76/dug.0.0.76.osx-x64.tar.gz"
+    version "0.0.76"
     sha256 "8a8f355cd5972a32b250028340659a9633ac936615fc7e4bbb5ae4234738e29e"
     license :cannot_represent
   
@@ -14,7 +14,7 @@ class Dug < Formula
     end
   
     test do
-      assert_equal "0.0.75", shell_output("#{bin}/dug --version").strip
+      assert_equal "0.0.76", shell_output("#{bin}/dug --version").strip
     end
   end
   

--- a/Formula/dug.rb
+++ b/Formula/dug.rb
@@ -1,0 +1,20 @@
+class Dug < Formula
+    desc "Global DNS progagation checker that gives pretty output"
+    homepage "https://dug.unfrl.com"
+    url "https://github.com/unfrl/dug/releases/download/0.0.75/dug.0.0.75.osx-x64.tar.gz"
+    version "0.0.75"
+    sha256 "8a8f355cd5972a32b250028340659a9633ac936615fc7e4bbb5ae4234738e29e"
+    license :cannot_represent
+  
+    def install
+      libexec.install Dir["*"]
+      bin.write_exec_script (libexec/"dug")
+  
+      bottle :unneeded
+    end
+  
+    test do
+      assert_equal "0.0.75", shell_output("#{bin}/dug --version").strip
+    end
+  end
+  


### PR DESCRIPTION
dug is a global DNS propagation checker that is lightweight, fast, and supports formatting the output data so it can be piped into other applications.
For more information visit dug.unfrl.com

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
