### PR TITLE
tcpdump: fix test for Linux

### DIFF
--- a/Formula/tcpdump.rb
+++ b/Formula/tcpdump.rb
@@ -30,12 +30,17 @@ class Tcpdump < Formula
 
   test do
     output = shell_output("#{bin}/tcpdump --help 2>&1")
-
     assert_match "tcpdump version #{version}", output
     assert_match "libpcap version #{Formula["libpcap"].version}", output
     assert_match "OpenSSL #{Formula["openssl@1.1"].version}", output
 
-    assert_match "tcpdump: (cannot open BPF device) /dev/bpf0: Operation not permitted",
-      shell_output("#{bin}/tcpdump ipv6 2>&1", 1)
+    match = "tcpdump: (cannot open BPF device) /dev/bpf0: Operation not permitted"
+    on_linux do
+      match = <<~EOS
+        tcpdump: eth0: You don't have permission to capture on that device
+        (socket: Operation not permitted)
+      EOS
+    end
+    assert_match match, shell_output("#{bin}/tcpdump ipv6 2>&1", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3096313902?check_suite_focus=true
```
==> Testing tcpdump
==> /home/linuxbrew/.linuxbrew/Cellar/tcpdump/4.99.1/bin/tcpdump --help 2>&1
==> /home/linuxbrew/.linuxbrew/Cellar/tcpdump/4.99.1/bin/tcpdump ipv6 2>&1
Error: test failed
Error: tcpdump: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /tcpdump:\ \(cannot\ open\ BPF\ device\)\ \/dev\/bpf0:\ Operation\ not\ permitted/ to match "tcpdump: eth0: You don't have permission to capture on that device\n(socket: Operation not permitted)\n".
```