### PR TITLE
john-jumbo: fix build for Linux

### DIFF
--- a/Formula/john-jumbo.rb
+++ b/Formula/john-jumbo.rb
@@ -25,12 +25,9 @@ class JohnJumbo < Formula
   depends_on "gmp"
   depends_on "openssl@1.1"
 
-  conflicts_with "john", because: "both install the same binaries"
+  uses_from_macos "zlib"
 
-  # https://github.com/magnumripper/JohnTheRipper/blob/bleeding-jumbo/doc/INSTALL#L133-L143
-  fails_with :gcc do
-    cause "Upstream have a hacky workaround for supporting gcc that we can't use."
-  end
+  conflicts_with "john", because: "both install the same binaries"
 
   # Fixed setup `-mno-sse4.1` for some machines.
   # See details for example from here: https://github.com/magnumripper/JohnTheRipper/pull/4100


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3096302693?check_suite_focus=true
```
==> Verifying checksum for '714a1380551e0c210360cc833149bfa24a17bbfcbcc260b4898645b2f79e38ba--john-1.9.0-jumbo-1.tar.xz'
Error: An exception occurred within a child process:
  CompilerSelectionError: john-jumbo cannot be built with any available compilers.
Install Clang or run `brew install gcc`.
```

Due to `fails_with :gcc`