### PR TITLE
simg2img: fix build for Linux

### DIFF
--- a/Formula/simg2img.rb
+++ b/Formula/simg2img.rb
@@ -14,6 +14,8 @@ class Simg2img < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "677aa2ecb11b6c0df59eb44cd75b7bc66d7f99607a4a5e0b5f9137d42428efc5"
   end
 
+  uses_from_macos "zlib"
+
   def install
     system "make", "PREFIX=#{prefix}", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3099326199?check_suite_focus=true
```
==> brew linkage --test simg2img
==> FAILED
Unwanted system libraries:
  /lib/x86_64-linux-gnu/libz.so.1

```