### PR TITLE
kpcli: fix build for Linux

### DIFF
--- a/Formula/kpcli.rb
+++ b/Formula/kpcli.rb
@@ -26,6 +26,25 @@ class Kpcli < Formula
 
   uses_from_macos "perl"
 
+  on_macos do
+    resource "Mac::Pasteboard" do
+      url "https://cpan.metacpan.org/authors/id/W/WY/WYANT/Mac-Pasteboard-0.011.tar.gz"
+      sha256 "bd8c4510b1e805c43e4b55155c0beaf002b649fe30b6a7841ff05e7399ba02a9"
+    end
+  end
+
+  on_linux do
+    resource "Clone" do
+      url "https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/Clone-0.45.tar.gz"
+      sha256 "cbb6ee348afa95432e4878893b46752549e70dc68fe6d9e430d1d2e99079a9e6"
+    end
+
+    resource "TermReadKey" do
+      url "https://cpan.metacpan.org/authors/id/J/JS/JSTOWE/TermReadKey-2.38.tar.gz"
+      sha256 "5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290"
+    end
+  end
+
   resource "Module::Build" do
     url "https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-0.4231.tar.gz"
     sha256 "7e0f4c692c1740c1ac84ea14d7ea3d8bc798b2fb26c09877229e04f430b2b717"
@@ -66,11 +85,6 @@ class Kpcli < Formula
     sha256 "886ae43dc8538f9bfc4e07fdbcf09b7fbd6ee59c31f364618c859de14953c58a"
   end
 
-  resource "Mac::Pasteboard" do
-    url "https://cpan.metacpan.org/authors/id/W/WY/WYANT/Mac-Pasteboard-0.011.tar.gz"
-    sha256 "bd8c4510b1e805c43e4b55155c0beaf002b649fe30b6a7841ff05e7399ba02a9"
-  end
-
   resource "Capture::Tiny" do
     url "https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Capture-Tiny-0.48.tar.gz"
     sha256 "6c23113e87bad393308c90a207013e505f659274736638d8c79bac9c67cc3e19"
@@ -80,17 +94,8 @@ class Kpcli < Formula
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
     ENV.prepend_path "PERL5LIB", libexec/"lib"
 
-    resources = [
-      "Module::Build",
-      "File::KeePass",
-      "Crypt::Rijndael",
-      "Sort::Naturally",
-      "Term::ShellUI",
-      "Data::Password",
-      "Mac::Pasteboard",
-      "Capture::Tiny",
-    ]
-    resources.each do |r|
+    res = resources.map(&:name).to_set - ["Clipboard", "Term::Readline::Gnu"]
+    res.each do |r|
       resource(r).stage do
         system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
         system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3033862791?check_suite_focus=true
```
==> make install
cp Password.pm blib/lib/Data/Password.pm
Manifying 1 pod document
Appending installation info to /home/linuxbrew/.linuxbrew/Cellar/kpcli/3.6_1/libexec/lib/perl5/x86_64-linux-thread-multi/perllocal.pod
Installing /home/linuxbrew/.linuxbrew/Cellar/kpcli/3.6_1/libexec/lib/perl5/Data/Password.pm
Installing /home/linuxbrew/.linuxbrew/Cellar/kpcli/3.6_1/libexec/man/man3/Data::Password.3
tar --extract --no-same-owner --file /home/linuxbrew/.cache/Homebrew/downloads/085fc8cbe8a1eaf6b4c9f7fec29de6c2bf96c82eb05c58af706c7df2c3fb681e--Mac-Pasteboard-0.011.tar.gz --directory /tmp/d20210710-4186-wghcbd
cp -pR /tmp/d20210710-4186-wghcbd/Mac-Pasteboard-0.011/. /tmp/kpcli--Mac::Pasteboard-20210710-4186-1u9g0dl/Mac-Pasteboard-0.011
chmod -Rf +w /tmp/d20210710-4186-wghcbd
==> perl Makefile.PL INSTALL_BASE=/home/linuxbrew/.linuxbrew/Cellar/kpcli/3.6_1/libexec
OS unsupported
```
