### PR TITLE
composer: add php dependency for Linux

### DIFF
--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -25,6 +25,8 @@ class Composer < Formula
     end
   end
 
+  uses_from_macos "php"
+
   def install
     bin.install "composer.phar" => "composer"
   end
@@ -49,7 +51,7 @@ class Composer < Formula
       }
     EOS
 
-    (testpath/"src/HelloWorld/greetings.php").write <<~EOS
+    (testpath/"src/HelloWorld/Greetings.php").write <<~EOS
       <?php
 
       namespace HelloWorld;


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
==> /home/linuxbrew/.linuxbrew/Cellar/composer/2.1.3/bin/composer install
Last 15 lines from /root/.cache/Homebrew/Logs/composer/test.01.composer:
2021-07-19 13:59:49 +0000

/home/linuxbrew/.linuxbrew/Cellar/composer/2.1.3/bin/composer
install

/usr/bin/env: ‘php’: No such file or directory
Error: composer: failed
```