### PR TITLE
net-tools: fix non-interactive configuration step

### DIFF
--- a/Formula/net-tools.rb
+++ b/Formula/net-tools.rb
@@ -5,12 +5,14 @@ class NetTools < Formula
   sha256 "b262435a5241e89bfa51c3cabd5133753952f7a7b7b93f32e08cb9d96f580d69"
   license "GPL-2.0-or-later"
 
-  depends_on "gettext" => :build
   depends_on "libdnet"
   depends_on :linux
 
   def install
-    system "yes '' | make config"
+    # Support non-interactive configuration
+    inreplace "configure.sh", "IFS='@' read ans || exit 1", ""
+
+    system "make", "config"
     system "make"
     system "make", "DESTDIR=#{prefix}", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The bashism in the existing formula doesn't work. We can work around this by patching the configure script to work non-interactively.

Also remove `gettext` as a build dependency, because the default configuration for `net-tools` is without Gettext support.