### PR TITLE
sratoolkit 2.11.1

### DIFF
--- a/Formula/sratoolkit.rb
+++ b/Formula/sratoolkit.rb
@@ -1,10 +1,26 @@
 class Sratoolkit < Formula
   desc "Data tools for INSDC Sequence Read Archive"
   homepage "https://github.com/ncbi/sra-tools"
-  url "https://github.com/ncbi/sra-tools/archive/2.11.0.tar.gz"
-  sha256 "10ac0a4d1fafc274bc107de811891d3e803d0713a247581dece4448231883810"
   license all_of: [:public_domain, "GPL-3.0-or-later", "MIT"]
-  head "https://github.com/ncbi/sra-tools.git", branch: "master"
+
+  stable do
+    url "https://github.com/ncbi/sra-tools/archive/2.11.1.tar.gz"
+    sha256 "725b368562217c145e6e1e062560617fb5f8099d09e64470dffc0873f43636a1"
+
+    resource "ngs-sdk" do
+      url "https://github.com/ncbi/ngs/archive/2.11.1.tar.gz"
+      sha256 "f39c56bbfdb0bdacdd5e86b5d3b65c448df17e419f3f533b1a0168e99f532553"
+    end
+
+    resource "ncbi-vdb" do
+      url "https://github.com/ncbi/ncbi-vdb/archive/2.11.1.tar.gz"
+      sha256 "21b802205f14a00b084b3fde0984dfb3789def8562b32f8cd09b27547c7b0548"
+
+      # Fix Linux error in vdb3/interfaces/memory/MemoryManagerItf.hpp:155:13:
+      # error: 'ptrdiff_t' does not name a type
+      patch :DATA
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:  "87602a3b77c5d58a037bf2e93423e6cb925bd586fe424680035885894359aeb0"
@@ -12,29 +28,46 @@ class Sratoolkit < Formula
     sha256 cellar: :any_skip_relocation, mojave:   "b9b36c564d65e79d3726e4de473e18d892f109221f45dbb91768ecac5758df59"
   end
 
-  depends_on "hdf5"
+  head do
+    url "https://github.com/ncbi/sra-tools.git", branch: "master"
+
+    resource "ngs-sdk" do
+      url "https://github.com/ncbi/ngs.git", branch: "master"
+    end
+
+    resource "ncbi-vdb" do
+      url "https://github.com/ncbi/ncbi-vdb.git", branch: "master"
+    end
+  end
+
+  depends_on "cmake" => :build
+  # Failed to build with `hdf5` at ncbi-vdb-source/libs/hdf5/hdf5dir.c:295:89:
+  # error: too few arguments to function call, expected 5, have 4
+  # herr_t h5e = H5Oget_info_by_name( self->hdf5_handle, buffer, &obj_info, H5P_DEFAULT );
+  # Try updating to `hdf5` on future release.
+  depends_on "hdf5@1.10"
   depends_on "libmagic"
 
+  uses_from_macos "perl" => :build
   uses_from_macos "libxml2"
-  uses_from_macos "perl"
-
-  resource "ngs-sdk" do
-    url "https://github.com/ncbi/ngs/archive/2.11.0.tar.gz"
-    sha256 "5fde50784760c00b403c2cc42ead15a4e9477697ee439f0a16edb4de3f52dfcc"
-  end
-
-  resource "ncbi-vdb" do
-    url "https://github.com/ncbi/ncbi-vdb/archive/2.11.0.tar.gz"
-    sha256 "9a65e3885b9ae1ebecbec871f04ce3162ac3764fb556ecdc8c1e61993e2164aa"
-  end
 
   def install
+    libxml2_prefix = if OS.mac?
+      MacOS.sdk_path/"usr"
+    else
+      Formula["libxml2"].opt_prefix
+    end
+    with_formula_args = %W[
+      --with-hdf5-prefix=#{Formula["hdf5@1.10"].opt_prefix}
+      --with-magic-prefix=#{Formula["libmagic"].opt_prefix}
+      --with-xml2-prefix=#{libxml2_prefix}
+    ]
+
     ngs_sdk_prefix = buildpath/"ngs-sdk-prefix"
     resource("ngs-sdk").stage do
       cd "ngs-sdk" do
-        system "./configure",
-          "--prefix=#{ngs_sdk_prefix}",
-          "--build=#{buildpath}/ngs-sdk-build"
+        system "./configure", "--prefix=#{ngs_sdk_prefix}",
+                              "--build=#{buildpath}/ngs-sdk-build"
         system "make"
         system "make", "install"
       end
@@ -44,10 +77,18 @@ class Sratoolkit < Formula
     ncbi_vdb_build = buildpath/"ncbi-vdb-build"
     ncbi_vdb_source.install resource("ncbi-vdb")
     cd ncbi_vdb_source do
-      system "./configure",
-        "--prefix=#{buildpath/"ncbi-vdb-prefix"}",
-        "--with-ngs-sdk-prefix=#{ngs_sdk_prefix}",
-        "--build=#{ncbi_vdb_build}"
+      # Fix detection of hdf5 library on macOS as Apple Clang linker doesn't
+      # allow mixing static (-Wl,-Bstatic) and dynamic (-Wl,-Bdynamic) libraries
+      inreplace "setup/konfigure.perl", "-Wl,-Bstatic -lhdf5 -Wl,-Bdynamic", "-lhdf5" if OS.mac?
+
+      # Fix Linux error: `pshufb' is not supported on `generic64.aes'
+      # Upstream ref: https://github.com/ncbi/ncbi-vdb/issues/14
+      inreplace "libs/krypto/Makefile", "-Wa,-march=generic64+aes", "" if OS.linux?
+
+      system "./configure", "--prefix=#{buildpath}/ncbi-vdb-prefix",
+                            "--build=#{ncbi_vdb_build}",
+                            "--with-ngs-sdk-prefix=#{ngs_sdk_prefix}",
+                            *with_formula_args
       ENV.deparallelize { system "make" }
     end
 
@@ -55,13 +96,24 @@ class Sratoolkit < Formula
     # Upstream PR: https://github.com/ncbi/sra-tools/pull/105
     inreplace "tools/copycat/Makefile", "-smagic-static", "-smagic"
 
-    system "./configure",
-      "--prefix=#{prefix}",
-      "--with-ngs-sdk-prefix=#{ngs_sdk_prefix}",
-      "--with-ncbi-vdb-sources=#{ncbi_vdb_source}",
-      "--with-ncbi-vdb-build=#{ncbi_vdb_build}",
-      "--build=#{buildpath}/sra-tools-build"
+    # Fix detection of hdf5 library on macOS as Apple Clang linker doesn't
+    # allow mixing static (-Wl,-Bstatic) and dynamic (-Wl,-Bdynamic) libraries
+    inreplace "setup/konfigure.perl", "-Wl,-Bstatic -lhdf5 -Wl,-Bdynamic", "-lhdf5" if OS.mac?
 
+    # Fix the error: utf8proc.o: linker input file unused because linking not done
+    # Upstream issue: https://github.com/ncbi/sra-tools/issues/283
+    if OS.linux?
+      inreplace "tools/driver-tool/utf8proc/Makefile",
+                "$(CC) $(LDFLAGS) -shared",
+                "#{ENV.cc} $(LDFLAGS) -shared"
+    end
+
+    system "./configure", "--prefix=#{prefix}",
+                          "--build=#{buildpath}/sra-tools-build",
+                          "--with-ngs-sdk-prefix=#{ngs_sdk_prefix}",
+                          "--with-ncbi-vdb-sources=#{ncbi_vdb_source}",
+                          "--with-ncbi-vdb-build=#{ncbi_vdb_build}",
+                          *with_formula_args
     system "make", "install"
 
     # Remove non-executable files.
@@ -79,3 +131,17 @@ class Sratoolkit < Formula
     assert_match "@SRR000001.1 EM7LVYS02FOYNU length=284", File.read("SRR000001.fastq")
   end
 end
+
+__END__
+diff --git a/vdb3/interfaces/memory/MemoryManagerItf.hpp b/vdb3/interfaces/memory/MemoryManagerItf.hpp
+index d802ba79..84a88aa5 100644
+--- a/vdb3/interfaces/memory/MemoryManagerItf.hpp
++++ b/vdb3/interfaces/memory/MemoryManagerItf.hpp
+@@ -26,6 +26,7 @@
+ #pragma once
+ 
+ #include <memory>
++#include <stddef.h>
+ 
+ namespace VDB3
+ {


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3079982031?check_suite_focus=true
```
gcc -c  -std=c11  -DNDEBUG -m64   -DLINUX -DUNIX -D_GNU_SOURCE -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DPKGNAME=linux64 -D_ARCH_BITS=__SIZEOF_POINTER__*__CHAR_BIT__ -DLIBPREFIX=lib -DSHLIBEXT=so  -I/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/interfaces/override -I/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/libs/krypto/linux -I/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/libs/krypto/unix -I/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/libs/krypto -I/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/interfaces -I/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/interfaces/cc/gcc/x86_64 -I/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/interfaces/cc/gcc -I/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/interfaces/os/linux -I/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/interfaces/os/unix -I/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/interfaces/ext -I/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ngs-sdk-prefix/include -I. -MD -o aes-ncbi.aes-ni.pic.o -fPIC -O3 -Wno-variadic-macros -fno-strict-aliasing -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -fstack-protector -Wa,--noexecstack -Wall -D_LIBRARY -DUSEVEC -DUSEVECREG -DUSEAESNI -funsafe-math-optimizations -mmmx -msse -msse2 -msse3 -mssse3 -msse4.1 -maes -Wa,-march=generic64+aes -Wa,-ahlms=/tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/libs/krypto/aes-ncbi.aes-ni.pic.o.list /tmp/sratoolkit-20210715-6122-g2ajls/sra-tools-2.11.0/ncbi-vdb-source/libs/krypto/aes-ncbi.c
{standard input}: Assembler messages:
{standard input}:131: Error: `pshufb' is not supported on `generic64.aes'
{standard input}:135: Error: `pshufb' is not supported on `generic64.aes'
```
