### PR TITLE
autopano-sift-c: remove livecheck

### DIFF
--- a/Formula/autopano-sift-c.rb
+++ b/Formula/autopano-sift-c.rb
@@ -5,14 +5,6 @@ class AutopanoSiftC < Formula
   sha256 "9a9029353f240b105a9c0e31e4053b37b0f9ef4bd9166dcb26be3e819c431337"
   revision 1
 
-  # We check the "autopano-sift-C" directory page since versions aren't present
-  # in the RSS feed as of writing.
-  livecheck do
-    url "https://sourceforge.net/projects/hugin/files/autopano-sift-C/"
-    strategy :page_match
-    regex(%r{href=.*?autopano-sift-C[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
-  end
-
   bottle do
     sha256 cellar: :any, catalina:    "6c95b627cbba417827b7955d6292a9c74d3993ccbcd60be4999765b2be4ac17e"
     sha256 cellar: :any, mojave:      "4ccc74538e6f6b01fd42c659991d0ba67e2544eb135f130d052dd1d2688070d8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`autopano-sift-c` has been disabled due to unclear licensing terms and the software hasn't been updated since 2009, so it doesn't seem like this will change anytime soon. This PR removes the `livecheck` block, so livecheck will automatically skip this formula.