### PR TITLE
fakeroot: remove livecheck

### DIFF
--- a/Formula/fakeroot.rb
+++ b/Formula/fakeroot.rb
@@ -5,11 +5,6 @@ class Fakeroot < Formula
   sha256 "2e045b3160370b8ab4d44d1f8d267e5d1d555f1bb522d650e7167b09477266ed"
   license "GPL-3.0"
 
-  livecheck do
-    url "https://deb.debian.org/debian/pool/main/f/fakeroot/"
-    regex(/href=.*?fakeroot[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any, catalina:    "c72ae187158b6cce73311fee527ba8bf8d2f0e18340bd66eef57b50b3d45c275"
     sha256 cellar: :any, mojave:      "6c23e4c601af569c2de802cac685de5d18e6ebafcb53e6c53107aa3feb3d1527"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`fakeroot` will be disabled on 2022-03-28, since it does not build and it hasn't been updated since 2013. This PR removes the `livecheck` block, so livecheck will automatically skip the formula.