### PR TITLE
kite: remove livecheck

### DIFF
--- a/Formula/kite.rb
+++ b/Formula/kite.rb
@@ -6,11 +6,6 @@ class Kite < Formula
   license "BSD-3-Clause"
   revision 3
 
-  livecheck do
-    url "http://www.kite-language.org/files/"
-    regex(/href=.*?kite[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any, big_sur:      "e42d72077eab99bf9765a87691d809c953ab94bd36c65b1dd51a6f681a3962fe"
     sha256 cellar: :any, catalina:     "34c4f01c0b9290e11773e9bd9f971bdefd47dba7d2bd9023aed4fb0b50738184"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`kite` has been deprecated as unmaintained, as the last `kite` version is from 2010-11-23. An LLVM port/rewrite has been in progress since at least 2011 but the [GitHub repository](https://github.com/tmiw/kite-llvm)'s README says it's "not nearly ready for prime time".

If/when the LLVM port stabilizes, this formula can be updated to use it. In the interim time, I don't think there's any point in checking for a new `kite` version. This PR removes the `livecheck` block, so livecheck will automatically skip this formula.