### PR TITLE
qtfaststart: deprecate

### DIFF
--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -15,7 +15,7 @@ class Libav < Formula
   end
 
   # See: https://lists.libav.org/pipermail/libav-devel/2020-April/086589.html
-  deprecate! date: "2019-04-16", because: :unmaintained
+  deprecate! date: "2020-04-16", because: :unmaintained
 
   depends_on "pkg-config" => :build
   # manpages won't be built without texi2html

--- a/Formula/qtfaststart.rb
+++ b/Formula/qtfaststart.rb
@@ -5,11 +5,6 @@ class Qtfaststart < Formula
   sha256 "115b659022dd387f662e26fbc5bc0cc14ec18daa100003ffd34f4da0479b272e"
   license "LGPL-2.1"
 
-  livecheck do
-    url "https://libav.org/releases/"
-    regex(/href=.*?libav[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e9190e060b5e58f6e294576e87607b43e6f9f6399ae350ba48fb3f522a511c0c"
@@ -18,6 +13,9 @@ class Qtfaststart < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "2fac027c66defdafcbaee5b346fd5c5e6c11b5e9a267de40d604b8e837f5d2c4"
     sha256 cellar: :any_skip_relocation, high_sierra:   "073794a6af64b0fe9f2bc22480b4c605f9497c5ae9087d26fa8e51bdc0230b00"
   end
+
+  # See: https://lists.libav.org/pipermail/libav-devel/2020-April/086589.html
+  deprecate! date: "2020-04-16", because: :unmaintained
 
   resource "mov" do
     url "https://github.com/van7hu/fanca/raw/master/examples/kmplayer/samples/H264_test4_Talkingheadclipped_mov_480x320.mov"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR deprecates the `qtfaststart` formula, as it uses the same source as `libav`, which is deprecated due to being unmaintained. I've used the date of the [message confirming that the project is dead](https://lists.libav.org/pipermail/libav-devel/2020-April/086589.html) (2020-04-16) and this also updates the `libav` deprecation date to the same date (instead of the date of the last commit to the upstream `master` branch, 2019-04-16).