### PR TITLE
gcc: update livecheck

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -17,12 +17,10 @@ class Gcc < Formula
   revision 1
   head "https://gcc.gnu.org/git/gcc.git"
 
+  # We can't use `url :stable` here due to the ARM-specific branch above.
   livecheck do
-    # Should be
-    # url :stable
-    # but that does not work with the ARM-specific branch above
-    url "https://ftp.gnu.org/gnu/gcc/gcc-11.1.0"
-    regex(%r{href=.*?gcc[._-]v?(\d+(?:\.\d+)+)(?:/?["' >]|\.t)}i)
+    url "https://ftp.gnu.org/gnu/gcc/"
+    regex(%r{href=["']?gcc[._-]v?(\d+(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `livecheck` block URL to make it clear that we're checking the `/gnu/gcc/` directory and not the `gcc-11.1.0` subdirectory. The `Gnu` strategy converts either URL to `http://ftp.gnu.org/gnu/gcc/?C=M&O=D`, so they work the same and this just helps to avoid confusion.

This also slightly modifies the regex (to use `href=["']?` instead of `href=.*?`), to better align with typical regexes where we're matching versioned directories.

Lastly, this condenses the explanatory comment and moves it directly before the `livecheck` block, which is the normal place where we put this type of comment.