### PR TITLE
rmw: update livecheck

### DIFF
--- a/Formula/rmw.rb
+++ b/Formula/rmw.rb
@@ -8,7 +8,7 @@ class Rmw < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^v?(\d+(?:[.-]\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates the `regex` in the existing `livecheck` block for `rmw` to allow for hyphens in versions. The formula version is currently `0.8.0-2`, from an amended tarball from the `v0.8.0` release.

Upstream didn't create a `0.8.0-2` release, so the only way to detect this version would be to check the "latest" release or the first releases page (which we try to avoid, since the information is limited due to pagination). I'm fine continuing to check the Git tags unless/until this issue happens again.

This doesn't fix the current check (`0.8.0` is still reported as newest) but the updated regex allows for the hyphenated version format, in case upstream _does_ create a release like this in the future.