### PR TITLE
spidermonkey: update homepage, livecheck

### DIFF
--- a/Formula/spidermonkey.rb
+++ b/Formula/spidermonkey.rb
@@ -1,6 +1,6 @@
 class Spidermonkey < Formula
   desc "JavaScript-C Engine"
-  homepage "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey"
+  homepage "https://spidermonkey.dev"
   url "https://archive.mozilla.org/pub/mozilla.org/js/js185-1.0.0.tar.gz"
   version "1.8.5"
   sha256 "5d12f7e1f5b4a99436685d97b9b7b75f094d33580227aa998c406bbae6f2a687"
@@ -8,9 +8,11 @@ class Spidermonkey < Formula
   revision 4
   head "https://hg.mozilla.org/mozilla-central", using: :hg
 
+  # Spidermonkey versions use the same versions as Firefox, so we simply check
+  # Firefox release versions.
   livecheck do
-    url "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Releases"
-    regex(%r{href=.*?Releases/v?(\d+(?:\.\d+)*)["' >]}i)
+    url "https://www.mozilla.org/en-US/firefox/releases/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/releasenotes/?["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey` site has seemingly been removed, so the `url` for the existing `livecheck` block now gives a 404 (not found) response. I wasn't able to find an alternative location for `spidermonkey` release information (spidermonkey.dev doesn't list them) but it seems like it simply follows Firefox versions these days. This updates the `livecheck` block to simply check Firefox versions from the [Firefox Releases](https://www.mozilla.org/en-US/firefox/releases/) page.

Just for good measure, this also updates the `homepage` to the current website, as the existing `homepage` also gives a 404. The alternative is to use the [last archive.org snapshot of this page](https://web.archive.org/web/20210601152810/https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey) but that seems like the worse option.