### PR TITLE
swi-prolog: fix build for Linux

### DIFF
--- a/Formula/swi-prolog.rb
+++ b/Formula/swi-prolog.rb
@@ -31,6 +31,14 @@ class SwiProlog < Formula
   depends_on "unixodbc"
 
   def install
+    # Remove shim paths from binary files `swipl-ld` and `libswipl.so.*`
+    on_linux do
+      inreplace "cmake/Params.cmake" do |s|
+        s.gsub! "${CMAKE_C_COMPILER}", "\"gcc\""
+        s.gsub! "${CMAKE_CXX_COMPILER}", "\"g++\""
+      end
+    end
+
     mkdir "build" do
       system "cmake", "..", *std_cmake_args,
                       "-DSWIPL_PACKAGES_JAVA=OFF",
@@ -40,13 +48,6 @@ class SwiProlog < Formula
     end
 
     bin.write_exec_script Dir["#{libexec}/bin/*"]
-
-    on_linux do
-      inreplace "libexec/lib/swipl/bin/x86_64-linux/swipl-ld",
-        HOMEBREW_SHIMS_PATH/"linux/super/", "/usr/bin/"
-      inreplace "libexec/lib/swipl/lib/x86_64-linux/libswipl.so.#{version}",
-        HOMEBREW_SHIMS_PATH/"linux/super/", "/usr/bin/"
-    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3093617421?check_suite_focus=true
```
-- Set runtime path of "/home/linuxbrew/.linuxbrew/Cellar/swi-prolog/8.2.4/libexec/lib/swipl/bin/x86_64-linux/swipl-ld" to "/home/linuxbrew/.linuxbrew/Cellar/swi-prolog/8.2.4/libexec/lib/swipl/lib/x86_64-linux"
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory @ rb_sysopen - libexec/lib/swipl/bin/x86_64-linux/swipl-ld
```