### PR TITLE
blueutil: add `depends_on :macos`

### DIFF
--- a/Formula/blueutil.rb
+++ b/Formula/blueutil.rb
@@ -14,6 +14,7 @@ class Blueutil < Formula
   end
 
   depends_on xcode: :build
+  depends_on :macos
 
   def install
     # Set to build with SDK=macosx10.6, but it doesn't actually need 10.6


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Uses macOS APIs.