### PR TITLE
audit_exceptions: add `universal_binary_allowlist`

### DIFF
--- a/audit_exceptions/universal_binary_allowlist.json
+++ b/audit_exceptions/universal_binary_allowlist.json
@@ -1,0 +1,10 @@
+[
+  "babel",
+  "contentful-cli",
+  "infer",
+  "llvm",
+  "llvm@7",
+  "llvm@8",
+  "llvm@9",
+  "llvm@11"
+]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The LLVM formulae build universal binaries for compiler-rt. This is why
these formulae use `ENV.permit_arch_flags`. Infer vendors its own clang,
and so also has its own compiler-rt.

`babel` and `contentful-cli` both install the npm package `fsevents`,
which installs a universal native module `fsevents.node`. I suggest
adding them to the allowlist for now so we have a list that keeps track
of them. (It would be nice if JSON files allowed comments though.)

I have changes in mind for `brew` that will allow us to easily extract
the native slices from these binaries, but I'd like to see it needed by
more formulae before we add it to `brew`. This list should help us keep
track of the number of formulae that would need this.

This commit unblocks #81556 and #81582.

See Homebrew/brew#11737 for context.