### PR TITLE
samba: avoid conflicting with /usr/bin/{mdfind,profiles}

### DIFF
--- a/Formula/samba.rb
+++ b/Formula/samba.rb
@@ -7,6 +7,7 @@ class Samba < Formula
   url "https://download.samba.org/pub/samba/stable/samba-4.14.5.tar.gz"
   sha256 "bb6ef5d2f16b85288d823578abc453d9a80514c42e5a2ea2c4e3c60dc42335c3"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "5825541d678648183fe2d19a49a63cb08d1b0686e6834390c39046442b945f52"
@@ -26,6 +27,13 @@ class Samba < Formula
     sha256 "3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5"
   end
 
+  # Workaround for "charset_macosxfs.c:278:4: error: implicit declaration of function 'DEBUG' is invalid in C99"
+  # Can be removed when https://bugzilla.samba.org/show_bug.cgi?id=14680 gets resolved.
+  patch do
+    url "https://attachments.samba.org/attachment.cgi?id=16579"
+    sha256 "86fce5306349d1c8f3732ca978a31065df643c8770114dc9d068b7b4dfa7d282"
+  end
+
   def install
     # avoid `perl module "Parse::Yapp::Driver" not found` error on macOS 10.xx (not required on 11)
     if MacOS.version < :big_sur
@@ -37,9 +45,6 @@ class Samba < Formula
         system "make", "install"
       end
     end
-    # CFLAGS is for avoiding hitting https://bugzilla.samba.org/show_bug.cgi?id=14680 .
-    # Remove this CFLAGS when the patch ( https://attachments.samba.org/attachment.cgi?id=16579 ) gets merged.
-    ENV.append "CFLAGS", "-include #{buildpath}/lib/util/debug.h"
     system "./configure",
            "--disable-cephfs",
            "--disable-cups",
@@ -65,14 +70,20 @@ class Samba < Formula
     on_macos do
       # macOS has its own SMB daemon as /usr/sbin/smbd, so rename our smbd to samba-dot-org-smbd to avoid conflict.
       # samba-dot-org-smbd is used by qemu.rb .
-      mv "#{sbin}/smbd", "#{sbin}/samba-dot-org-smbd"
+      # Rename mdfind and profiles as well to avoid conflicting with /usr/bin/{mdfind,profiles}
+      { sbin => "smbd", bin => "mdfind", bin => "profiles" }.each do |dir, cmd|
+        mv dir/cmd, dir/"samba-dot-org-#{cmd}"
+      end
     end
   end
 
   def caveats
     on_macos do
       <<~EOS
-        macOS has its own SMB daemon as /usr/sbin/smbd, so Samba version of smbd is installed as "#{HOMEBREW_PREFIX}/sbin/samba-dot-org-smbd"
+        To avoid conflicting with macOS system binaries, some files were installed with non-standard name:
+        - smbd:     #{HOMEBREW_PREFIX}/sbin/samba-dot-org-smbd
+        - mdfind:   #{HOMEBREW_PREFIX}/bin/samba-dot-org-mdfind
+        - profiles: #{HOMEBREW_PREFIX}/bin/samba-dot-org-profiles
 
         On macOS, Samba should be executed as a non-root user: https://bugzilla.samba.org/show_bug.cgi?id=8773
       EOS


### PR DESCRIPTION
Rename samba version of `{mdfind,profiles}` to `samba-dot-org-{mdfind,profiles}` to avoid conflicting with macOS systemd binaries `/usr/bin/{mdfind,profiles}`

The "samba-dot-org-" prefix corresponds to `samba-dot-org-smbd`.

Also remove custom `CFLAGS`.

Follow-up to https://github.com/Homebrew/homebrew-core/pull/80171


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
