### PR TITLE
bdw-gc: add to `make_check_allowlist`

### DIFF
--- a/style_exceptions/make_check_allowlist.json
+++ b/style_exceptions/make_check_allowlist.json
@@ -1,5 +1,6 @@
 [
   "beecrypt",
+  "bdw-gc",
   "ccrypt",
   "git",
   "gmp",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is used as a library by formulae like `gnutls`, so we probably 
want to be able to do `make check` in its install method, which it
currently does.