### PR TITLE
universal_binary_allowlist: add `openjdk{,@11}`

### DIFF
--- a/audit_exceptions/universal_binary_allowlist.json
+++ b/audit_exceptions/universal_binary_allowlist.json
@@ -3,8 +3,10 @@
   "contentful-cli",
   "infer",
   "llvm",
+  "llvm@11",
   "llvm@7",
   "llvm@8",
   "llvm@9",
-  "llvm@11"
+  "openjdk",
+  "openjdk@11"
 ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We copy `JavaNativeFoundation.framework` out of the Xcode SDK, so it's
no surprise that we find a universal binary in the ARM bottle.

I'll work on adding formula methods that will allow us to extract the
arm64 slice in an `install` method.