### PR TITLE
jc: update man page location

### DIFF
--- a/Formula/jc.rb
+++ b/Formula/jc.rb
@@ -39,7 +39,7 @@ class Jc < Formula
 
   def install
     virtualenv_install_with_resources
-    man1.install "jc/man/jc.1.gz"
+    man1.install "man/jc.1"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`jc/man/jc.1.gz` is [deprecated](https://github.com/Homebrew/homebrew-core/pull/81601#issuecomment-884310597), so update the man page location in preparation for the next release

cc @kellyjonbrazil 