### PR TITLE
cityhash: fix test on linux

### DIFF
--- a/Formula/cityhash.rb
+++ b/Formula/cityhash.rb
@@ -24,16 +24,17 @@ class Cityhash < Formula
   test do
     (testpath/"test.cpp").write <<~EOS
       #include <stdio.h>
+      #include <inttypes.h>
       #include <city.h>
 
       int main() {
         const char* a = "This is my test string";
         uint64_t result = CityHash64(a, sizeof(a));
-        printf("result: %llx\\n", result);
-        return result != 0xab7a556ed7598b04LL;
+        printf("%" PRIx64 "\\n", result);
+        return 0;
       }
     EOS
-    system ENV.cxx, "-L#{lib}", "-lcityhash", "test.cpp", "-o", "test"
-    system "./test"
+    system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-lcityhash", "-o", "test"
+    assert_equal "ab7a556ed7598b04", shell_output("./test").chomp
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Move test for expected hash value out of the C++ into our test code instead, and make the test code slightly more portable while we're here.