### PR TITLE
rzip: add bzip2 dependency for linux

### DIFF
--- a/Formula/rzip.rb
+++ b/Formula/rzip.rb
@@ -3,7 +3,7 @@ class Rzip < Formula
   homepage "https://rzip.samba.org/"
   url "https://rzip.samba.org/ftp/rzip/rzip-2.1.tar.gz"
   sha256 "4bb96f4d58ccf16749ed3f836957ce97dbcff3e3ee5fd50266229a48f89815b7"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "16c1e072a6f596e4bda1fb3bd99a743cdb1ef6c0ec552f1ea33224f24fb28047"
@@ -15,6 +15,8 @@ class Rzip < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:    "4eedb0ca975a72a4591d1e386d1ae01a546fb8401ea4f0b05c0fa71809e159db"
     sha256 cellar: :any_skip_relocation, yosemite:      "170150a7704b270df0a1cce7f1cfde689e245f9a9f628b5f0415df5ceae89e19"
   end
+
+  uses_from_macos "bzip2"
 
   def install
     system "./configure", "--disable-debug",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
As stated on https://rzip.samba.org/,
>  rzip is released under the GNU General Public License version 2 or later. See the COPYING file in the source distribution for details. 