### PR TITLE
tidy-html5: fix sha256 of the release, due to improper retagging of the release…

### DIFF
--- a/Formula/tidy-html5.rb
+++ b/Formula/tidy-html5.rb
@@ -2,7 +2,7 @@ class TidyHtml5 < Formula
   desc "Granddaddy of HTML tools, with support for modern standards"
   homepage "https://www.html-tidy.org/"
   url "https://github.com/htacg/tidy-html5/archive/5.8.0.tar.gz"
-  sha256 "2fc78c4369cde9a80f4ae3961880bd003ac31e8b160f6b9422645bab3be5a6cf"
+  sha256 "59c86d5b2e452f63c5cdb29c866a12a4c55b1741d7025cf2f3ce0cde99b0660e"
   license "Zlib"
   head "https://github.com/htacg/tidy-html5.git", branch: "next"
 


### PR DESCRIPTION
… on our end.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
