### PR TITLE
libzzip: add zlib dependency for Linux

### DIFF
--- a/Formula/libzzip.rb
+++ b/Formula/libzzip.rb
@@ -18,6 +18,9 @@ class Libzzip < Formula
   depends_on "pkg-config" => :build
   depends_on "python@3.9" => :build
 
+  uses_from_macos "zip" => :test
+  uses_from_macos "zlib"
+
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args, "-DZZIPTEST=OFF", "-DZZIPSDL=OFF", "-DCMAKE_INSTALL_RPATH=#{rpath}"
@@ -28,7 +31,7 @@ class Libzzip < Formula
 
   test do
     (testpath/"README.txt").write("Hello World!")
-    system "/usr/bin/zip", "test.zip", "README.txt"
+    system "zip", "test.zip", "README.txt"
     assert_equal "Hello World!", shell_output("#{bin}/zzcat test/README.txt")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3127614054?check_suite_focus=true
```
==> brew linkage --test libzzip
==> FAILED
Unwanted system libraries:
  /lib/x86_64-linux-gnu/libz.so.1

==> brew install --only-dependencies --include-test libzzip
==> brew test --verbose libzzip
Error: linkage failed, test failed
==> FAILED
==> Testing libzzip
==> /usr/bin/zip test.zip README.txt
Failed to execute: /usr/bin/zip
Error: libzzip: failed
An exception occurred within a child process:
  BuildError: Failed executing: /usr/bin/zip test.zip README.txt
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2249:in `block in system'
```
