### PR TITLE
stockfish: fix build for Linux

### DIFF
--- a/Formula/stockfish.rb
+++ b/Formula/stockfish.rb
@@ -18,6 +18,12 @@ class Stockfish < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "684d804597360a5a7bc70b9392ef51b54627fdd864148eaaa10d6a3ddcbc5f8d"
   end
 
+  on_linux do
+    depends_on "gcc" # For C++17
+  end
+
+  fails_with gcc: 5
+
   def install
     arch = Hardware::CPU.arm? ? "apple-silicon" : "x86-64-modern"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3127460481?check_suite_focus=true
```
/usr/bin/make ARCH=x86-64-modern COMP=gcc all
make[1]: Entering directory '/tmp/stockfish-20210721-2716-1duv2fy/Stockfish-sf_14/src'
g++ -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o benchmark.o benchmark.cpp
g++ -Wall -Wcast-qual -fno-exceptions -std=c++17  -pedantic -Wextra -Wshadow -m64 -DUSE_PTHREADS -DNDEBUG -O3 -DIS_64BIT -msse -msse3 -mpopcnt -DUSE_POPCNT -DUSE_SSE41 -msse4.1 -DUSE_SSSE3 -mssse3 -DUSE_SSE2 -msse2 -flto   -c -o bitbase.o bitbase.cpp
In file included from position.h:28:0,
                 from benchmark.cpp:24:
evaluate.h:23:20: fatal error: optional: No such file or directory
compilation terminated.
<builtin>: recipe for target 'benchmark.o' failed
make[1]: *** [benchmark.o] Error 1
```