### PR TITLE
hopenpgp-tools: add zlib dependency for Linux

### DIFF
--- a/Formula/hopenpgp-tools.rb
+++ b/Formula/hopenpgp-tools.rb
@@ -19,6 +19,8 @@ class HopenpgpTools < Formula
   depends_on "pkg-config" => :build
   depends_on "nettle"
 
+  uses_from_macos "zlib"
+
   resource "homebrew-key.gpg" do
     url "https://gist.githubusercontent.com/zmwangx/be307671d11cd78985bd3a96182f15ea/raw/c7e803814efc4ca96cc9a56632aa542ea4ccf5b3/homebrew-key.gpg"
     sha256 "994744ca074a3662cff1d414e4b8fb3985d82f10cafcaadf1f8342f71f36b233"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3127431911?check_suite_focus=true
```
==> brew install ./hopenpgp-tools--0.23.6.x86_64_linux.bottle.1.tar.gz
==> brew linkage --test hopenpgp-tools
==> FAILED
Unwanted system libraries:
  /lib/x86_64-linux-gnu/libz.so.1
```