### PR TITLE
asdf: Don't symlink lib and bin files

### DIFF
--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -4,6 +4,7 @@ class Asdf < Formula
   url "https://github.com/asdf-vm/asdf/archive/v0.8.1.tar.gz"
   sha256 "6ca280287dcb687ec12f0c37e4e193de390cdab68f2b2a0e271e3a4f1e20bd2e"
   license "MIT"
+  revision 1
   head "https://github.com/asdf-vm/asdf.git"
 
   bottle do
@@ -19,19 +20,37 @@ class Asdf < Formula
   depends_on "readline"
   depends_on "unixodbc"
 
-  conflicts_with "homeshick",
-    because: "asdf and homeshick both install files in lib/commands"
-
   def install
     bash_completion.install "completions/asdf.bash"
     fish_completion.install "completions/asdf.fish"
     zsh_completion.install "completions/_asdf"
-    libexec.install "bin/private"
-    prefix.install Dir["*"]
-    touch prefix/"asdf_updates_disabled"
+    libexec.install Dir["*"]
+    touch libexec/"asdf_updates_disabled"
+
+    # TODO: Remove these placeholders on 31 August 2022
+    bin.write_exec_script libexec/"bin/asdf"
+    (prefix/"asdf.sh").write ". #{libexec}/asdf.sh\n"
+    (prefix/"asdf.fish").write "source #{libexec}/asdf.fish\n"
+    (lib/"asdf.sh").write ". #{libexec}/lib/asdf.sh\n"
+    (lib/"asdf.fish").write "source #{libexec}/lib/asdf.fish\n"
+  end
+
+  def caveats
+    s = "To use asdf, add the following line to your #{shell_profile}:\n"
+
+    s += if preferred == :fish
+      "  source #{opt_libexec}/asdf.fish\n\n"
+    else
+      "  . #{opt_libexec}/asdf.sh\n\n"
+    end
+
+    s += "Restart your terminal for the settings to take effect."
+
+    s
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/asdf version")
     output = shell_output("#{bin}/asdf plugin-list 2>&1", 1)
     assert_match "No plugins installed", output
     assert_match "Update command disabled.", shell_output("#{bin}/asdf update", 42)

--- a/Formula/homeshick.rb
+++ b/Formula/homeshick.rb
@@ -10,9 +10,6 @@ class Homeshick < Formula
     sha256 cellar: :any_skip_relocation, all: "61abfc0f6d5e42bf58f6b15eaeb155e867094b5d3cd33f88223d0ec7882106fa"
   end
 
-  conflicts_with "asdf",
-    because: "asdf and homeshick both install files in lib/commands"
-
   def install
     inreplace "bin/homeshick", /^homeshick=.*/, "homeshick=#{opt_prefix}"
 


### PR DESCRIPTION
because asdf will only partially work if the `ASDF_DIR` is resolved to `/usr/local/`. E.g. just running `asdf` will print

    cat: /usr/local/VERSION: No such file or directory
    version:

    cat: /usr/local/help.txt: No such file or directory

    PLUGIN direnv
      asdf direnv
      asdf direnv hook asdf

    "Late but latest"
    -- Rajinikanth

instead of the version and the complete help message.

It should be installed as the instructions in https://asdf-vm.com/#/core-manage-asdf?id=add-to-your-shell as the `ASDF_DIR` is resolved in https://github.com/asdf-vm/asdf/blob/ccf76dd7e60de8a3de03cd3574f570dc1f9dbc55/lib/utils.bash#L24-L29 after utils.bash is sourced in https://github.com/asdf-vm/asdf/blob/ccf76dd7e60de8a3de03cd3574f570dc1f9dbc55/bin/asdf#L4

So to resolve the `ASDF_DIR` correctly as `/usr/local/opt/asdf`, the `/usr/local/opt/asdf/bin/asdf` script must be directly executed.

If lib and bin files were symlinked instead, then `/usr/local/bin/asdf` would be executed, resolving the `ASDF_DIR` incorrectly to `/usr/local`.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
