### PR TITLE
sgrep: add livecheck

### DIFF
--- a/Formula/sgrep.rb
+++ b/Formula/sgrep.rb
@@ -5,6 +5,15 @@ class Sgrep < Formula
   mirror "https://fossies.org/linux/misc/old/sgrep-1.94a.tar.gz"
   sha256 "d5b16478e3ab44735e24283d2d895d2c9c80139c95228df3bdb2ac446395faf9"
 
+  # The current formula version (1.94a) is an alpha version, so this regex
+  # has to allow for unstable versions. If/when a new stable version after 0.99
+  # ever appears, the optional `[a-z]?` part of this regex should be removed,
+  # so it will only match stable versions.
+  livecheck do
+    url "https://www.cs.helsinki.fi/pub/Software/Local/Sgrep/"
+    regex(/href=.*?sgrep[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, big_sur:      "fedcff86ec032617015882c5729298bbe1f1fcbda14cdde6167b00ae2af586b8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `sgrep`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The [first-party download page](https://www.cs.helsinki.fi/u/jjaakkol/sgrep/download.html) doesn't link to the version used in the formula (it lists 1.92a as the newest unstable version instead of 1.94a), so we have to check the directory listing page directly.