### PR TITLE
povray 3.7.0.10

### DIFF
--- a/Formula/povray.rb
+++ b/Formula/povray.rb
@@ -1,8 +1,8 @@
 class Povray < Formula
   desc "Persistence Of Vision RAYtracer (POVRAY)"
   homepage "https://www.povray.org/"
-  url "https://github.com/POV-Ray/povray/archive/v3.7.0.9.tar.gz"
-  sha256 "c273f75864ac98f86b442f58597d842aa8b76e788ea5e9133724296d93fb3e6b"
+  url "https://github.com/POV-Ray/povray/archive/v3.7.0.10.tar.gz"
+  sha256 "7bee83d9296b98b7956eb94210cf30aa5c1bbeada8ef6b93bb52228bbc83abff"
   license "AGPL-3.0-or-later"
   head "https://github.com/POV-Ray/povray.git"
 
@@ -21,12 +21,11 @@ class Povray < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "boost"
+  depends_on "imath"
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
-  # Check whether this can be switched to `openexr` at version bump
-  # Issue ref: https://github.com/POV-Ray/povray/issues/408
-  depends_on "openexr@2"
+  depends_on "openexr"
 
   def install
     ENV.cxx11
@@ -38,7 +37,7 @@ class Povray < Formula
       --prefix=#{prefix}
       --mandir=#{man}
       --with-boost=#{Formula["boost"].opt_prefix}
-      --with-openexr=#{Formula["openexr@2"].opt_prefix}
+      --with-openexr=#{Formula["openexr"].opt_prefix}
       --without-libsdl
       --without-x
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Upstream addressed OpenEXR 3 compatibility in https://github.com/POV-Ray/povray/pull/422. Note that this also adds a dependency on `imath` (which `openexr` already depends on).

The configuration now detects and uses OpenEXR 3 correctly:
```
...
checking whether to use the TIFF library... yes
checking for library containing TIFFGetVersion... -ltiff
checking for tiffio.h... yes
checking for libtiff version >= 3.6.1... 4.3.0, ok
checking whether to use the OpenEXR library... yes
checking for pkg-config... pkg-config
checking for OpenEXR's pkg-config... yes
checking for OpenEXR version >= 1.2... 3.0.5, ok
checking for OpenEXR/ImfCRgbaFile.h... yes
checking for X... disabled
configure: X Window display will be disabled
```

During the test sequence:
```
Support libraries used by POV-Ray:
  ZLib 1.2.11, Copyright 1995-2012 Jean-loup Gailly and Mark Adler
  LibPNG 1.6.37, Copyright 1998-2012 Glenn Randers-Pehrson
  LibJPEG 90, Copyright 1991-2013 Thomas G. Lane, Guido Vollbeding
  LibTIFF 4.3.0, Copyright 1988-1997 Sam Leffler, 1991-1997 SGI
  Boost 1.76, http://www.boost.org/
  OpenEXR 3.0.5 and Imath 3.1.1, Copyright (c) Contributors to the OpenEXR
 Project.
```