### PR TITLE
libgnt: fix build for Linux

### DIFF
--- a/Formula/libgnt.rb
+++ b/Formula/libgnt.rb
@@ -3,7 +3,7 @@ class Libgnt < Formula
   homepage "https://keep.imfreedom.org/libgnt/libgnt"
   url "https://downloads.sourceforge.net/project/pidgin/libgnt/2.14.2/libgnt-2.14.2.tar.xz"
   sha256 "61cf74b14eef10868b2d892e975aa78614f094c8f4d30dfd1aaedf52e6120e75"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://sourceforge.net/projects/pidgin/files/libgnt/"
@@ -24,8 +24,19 @@ class Libgnt < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
 
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
+
   def install
-    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
+
+    # Work around for ERROR: Problem encountered: ncurses could not be found!
+    # Issue is build only checks for ncursesw headers under system prefix /usr
+    # Upstream issue: https://issues.imfreedom.org/issue/LIBGNT-15
+    on_linux do
+      inreplace "meson.build", "ncurses_sys_prefix = '/usr'",
+                               "ncurses_sys_prefix = '#{Formula["ncurses"].opt_prefix}'"
+    end
 
     mkdir "build" do
       system "meson", *std_meson_args, ".."


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3094618027?check_suite_focus=true
```
Found pkg-config: /home/linuxbrew/.linuxbrew/opt/pkg-config/bin/pkg-config (0.29.2)
Run-time dependency glib-2.0 found: YES 2.68.3
Run-time dependency gobject-2.0 found: YES 2.68.3
Run-time dependency gmodule-2.0 found: YES 2.68.3
Run-time dependency libxml-2.0 found: YES 2.9.12
Library ncursesw found: YES
Library panelw found: YES
Library tinfow found: NO
Header </usr/include/ncursesw/ncurses.h> has symbol "get_wch" : NO 
Header </usr/include/ncurses.h> has symbol "get_wch" : NO 

../meson.build:127:1: ERROR: Problem encountered: ncurses could not be found!

```