### PR TITLE
util-linux: disable hardlink

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -12,6 +12,7 @@ class UtilLinux < Formula
     "LGPL-2.1-or-later",
     :public_domain,
   ]
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "922d09f5174a8987fdd7de56103eb6415a561c7490ab149e86bd8959c5832044"
@@ -34,10 +35,10 @@ class UtilLinux < Formula
   def install
     args = std_configure_args + %w[
       --disable-silent-rules
+      --disable-hardlink
     ]
 
     on_macos do
-      args << "--disable-hardlink" # does not build on macOS
       args << "--disable-ipcs" # does not build on macOS
       args << "--disable-ipcrm" # does not build on macOS
       args << "--disable-wall" # already comes with macOS
@@ -76,7 +77,7 @@ class UtilLinux < Formula
       delpart dmesg
       eject
       fallocate fdformat fincore findmnt fsck fsfreeze fstrim
-      hardlink hwclock
+      hwclock
       ionice ipcrm ipcs
       kill
       last ldattach losetup lsblk lscpu lsipc lslocks lslogins lsmem lsns


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It conflicts with hardlink formula, see:
https://github.com/Homebrew/homebrew-core/pull/81717

Debian disables it too and it's reasonable given that this binary is already provided by separate package.