### PR TITLE
open-adventure: add livecheck

### DIFF
--- a/Formula/open-adventure.rb
+++ b/Formula/open-adventure.rb
@@ -7,6 +7,11 @@ class OpenAdventure < Formula
   license "BSD-2-Clause"
   head "https://gitlab.com/esr/open-adventure"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?advent[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "3e6e5fe49a6e152e07666b01ef6ce83063f1de437e65970079656e8ae4c2e357"
     sha256 cellar: :any_skip_relocation, big_sur:       "a3ec563817f679d2ed97360b1d32e3fef297eaa3fcaf582044213532a338d217"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `open-adventure`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.