### PR TITLE
mpop: add livecheck

### DIFF
--- a/Formula/mpop.rb
+++ b/Formula/mpop.rb
@@ -5,6 +5,11 @@ class Mpop < Formula
   sha256 "b3498466c65b650add1a6e79209b27ba86375673a45c96a5927bed685a327dc1"
   license "GPL-3.0-or-later"
 
+  livecheck do
+    url "https://marlam.de/mpop/download/"
+    regex(/href=.*?mpop[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "a9061a1fd7dfb9f9f73b511a5fd8b476cd57e7336e49c146b999da3afc639753"
     sha256 big_sur:       "8666c6f36ee3f3ed758139f4aceb22128b2c05c9ccaf47a538ef649d6daf598b"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `mpop`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.