### PR TITLE
autobench: add livecheck

### DIFF
--- a/Formula/autobench.rb
+++ b/Formula/autobench.rb
@@ -5,6 +5,11 @@ class Autobench < Formula
   sha256 "d8b4d30aaaf652df37dff18ee819d8f42751bc40272d288ee2a5d847eaf0423b"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?autobench[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c475644370c0f887d23d5fb77b4c3e24fc31ab21366e35395a8c1214c3f91143"
     sha256 cellar: :any_skip_relocation, big_sur:       "dde390cbcb35b87f2cf565a59e11ae4997400a37170abd9b276696460f81dbc4"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `autobench`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.