### PR TITLE
redland: add livecheck

### DIFF
--- a/Formula/redland.rb
+++ b/Formula/redland.rb
@@ -1,9 +1,14 @@
 class Redland < Formula
   desc "RDF Library"
-  homepage "http://librdf.org/"
-  url "http://download.librdf.org/source/redland-1.0.17.tar.gz"
+  homepage "https://librdf.org/"
+  url "https://download.librdf.org/source/redland-1.0.17.tar.gz"
   sha256 "de1847f7b59021c16bdc72abb4d8e2d9187cd6124d69156f3326dd34ee043681"
   revision 1
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?redland[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 arm64_big_sur: "f54c731eecd682be899b7b8b5ab3424db134a1a48fe7076f0113deedb9a7f057"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `redland`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

Additionally, this updates the `homepage` and `stable` URLs to use HTTPS, as they are currently redirecting from HTTP to HTTPS.