### PR TITLE
uniutils: add livecheck

### DIFF
--- a/Formula/uniutils.rb
+++ b/Formula/uniutils.rb
@@ -5,6 +5,11 @@ class Uniutils < Formula
   sha256 "c662a9215a3a67aae60510f679135d479dbddaf90f5c85a3c5bab1c89da61596"
   license "GPL-3.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?uniutils[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "8cb5a86b69e6efe758a353744ac48a0ec1777f3b1ed814848906d6365ad7ba81"
     sha256 cellar: :any_skip_relocation, big_sur:       "df42759537263cec13ae2662eac1de96d0692b34e146eff756dbb52b79c7c5d7"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `uniutils`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.