### PR TITLE
tokyo-cabinet: update homepage and stable urls

### DIFF
--- a/Formula/tokyo-cabinet.rb
+++ b/Formula/tokyo-cabinet.rb
@@ -1,7 +1,7 @@
 class TokyoCabinet < Formula
   desc "Lightweight database library"
-  homepage "https://fallabs.com/tokyocabinet/"
-  url "https://fallabs.com/tokyocabinet/tokyocabinet-1.4.48.tar.gz"
+  homepage "https://dbmx.net/tokyocabinet/"
+  url "https://dbmx.net/tokyocabinet/tokyocabinet-1.4.48.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/t/tokyocabinet/tokyocabinet_1.4.48.orig.tar.gz"
   sha256 "a003f47c39a91e22d76bc4fe68b9b3de0f38851b160bbb1ca07a4f6441de1f90"
   license "LGPL-2.1-or-later"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs redirect from fallabs.com to dbmx.net, so this PR updates the URLs to avoid the redirection. Looking at archive.org, the website content is the same and this has been redirecting since at least 2020-07.