### PR TITLE
newt: update stable and livecheck urls

### DIFF
--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -1,12 +1,12 @@
 class Newt < Formula
   desc "Library for color text mode, widget based user interfaces"
   homepage "https://pagure.io/newt"
-  url "https://pagure.io/releases/newt/newt-0.52.21.tar.gz"
+  url "https://releases.pagure.org/newt/newt-0.52.21.tar.gz"
   sha256 "265eb46b55d7eaeb887fca7a1d51fe115658882dfe148164b6c49fccac5abb31"
   license "LGPL-2.0"
 
   livecheck do
-    url "https://pagure.io/releases/newt/"
+    url "https://releases.pagure.org/newt/"
     regex(/href=.*?newt[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `pagure.io/releases/` URLs in the `newt` formula are redirecting to `releases.pagure.org`, so this PR updates the `stable` and `livecheck` URLs to avoid the redirection. I built/tested this locally and the `stable` archive is the same as the existing one (`sha256` is unchanged).