### PR TITLE
x3270: update livecheck

### DIFF
--- a/Formula/x3270.rb
+++ b/Formula/x3270.rb
@@ -6,7 +6,7 @@ class X3270 < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "http://x3270.bgp.nu/download.html"
+    url "https://x3270.miraheze.org/wiki/Downloads"
     regex(/href=.*?suite3270[._-]v?(\d+(?:\.\d+)+(?:ga\d+)?)(?:-src)?\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` URL redirects from http://x3270.bgp.nu/download.html to https://x3270.miraheze.org/wiki/Downloads. Checking the first-party website, this is the current location of the download page, so this PR updates the URL to avoid the redirection.