### PR TITLE
git: support git-svn by add #{HOMEBREW_PREFIX}/lib/perl5 to git PERLLIB_EXTRA

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -27,6 +27,7 @@ class Git < Formula
   uses_from_macos "curl"
   uses_from_macos "expat"
   uses_from_macos "openssl@1.1"
+  uses_from_macos "perl"
   uses_from_macos "zlib"
 
   on_linux do
@@ -67,15 +68,16 @@ class Git < Formula
     ENV["LIBPCREDIR"] = Formula["pcre2"].opt_prefix
     ENV["V"] = "1" # build verbosely
 
-    perl_version = Utils.safe_popen_read("perl", "--version")[/v(\d+\.\d+)(?:\.\d+)?/, 1]
-
     on_macos do
+      perl_version, perl_short_version = Utils.safe_popen_read("perl", "-e", "print $^V")
+                                              .match(/v((\d+\.\d+)(?:\.\d+))?/).captures
       ENV["PERLLIB_EXTRA"] = %W[
-        #{MacOS.active_developer_dir}
-        /Library/Developer/CommandLineTools
-        /Applications/Xcode.app/Contents/Developer
+        #{HOMEBREW_PREFIX}/lib/perl5/site_perl/#{perl_version}
+        #{MacOS.active_developer_dir}/Library/Perl/#{perl_short_version}
+        /Library/Developer/CommandLineTools/Library/Perl/#{perl_short_version}
+        /Applications/Xcode.app/Contents/Developer/Library/Perl/#{perl_short_version}
       ].uniq.map do |p|
-        "#{p}/Library/Perl/#{perl_version}/darwin-thread-multi-2level"
+        "#{p}/darwin-thread-multi-2level"
       end.join(":")
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I add `#{HOMEBREW_PREFIX}/lib/perl5/site_perl/#{perl_version}/darwin-thread-multi-2level` to `git` `PERLLIB_EXTRA` when building, because of `subversion` also installs its's Perl binding to it. This should fix #52490 when both formulas build with the same Perl. No need to set the environment variable `GITPERLLIB` or `PERL5LIB`.

I also do a little more to remove resource Net::SMTP::SSL when Perl has Net::SMTP newer than 2.34.