### PR TITLE
macos-term-size 1.0.0 (new formula)

### DIFF
--- a/Formula/macos-term-size.rb
+++ b/Formula/macos-term-size.rb
@@ -1,0 +1,22 @@
+class MacosTermSize < Formula
+  desc "Get the terminal window size on macOS"
+  homepage "https://github.com/sindresorhus/macos-term-size"
+  url "https://github.com/sindresorhus/macos-term-size/archive/v1.0.0.tar.gz"
+  sha256 "5ec39d49a461e4495f20660609276b0630ef245bf8eb80c8447c090a5fefda3c"
+  license "MIT"
+  head "https://github.com/sindresorhus/macos-term-size.git", branch: "main"
+
+  depends_on :macos
+
+  def install
+    # https://github.com/sindresorhus/macos-term-size/blob/main/build#L6
+    system ENV.cc, "-std=c99", "term-size.c", "-o", "term-size"
+    bin.install "term-size"
+  end
+
+  test do
+    require "pty"
+    out, = PTY.spawn(bin/"term-size")
+    assert_match(/\d+\s+\d+/, out.read.chomp)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula fails our notability criteria, but I suggest we ignore that
because this can be used as a dependency in multiple formulae.

-----

~~Despite the name, I suspect this formula might work on Linux too. So let's try it.~~