### PR TITLE
workflows: set HOMEBREW_ON_DEBIAN7=1 for wheezy

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -60,6 +60,9 @@ jobs:
             # No PATH needed on Linux as set by Docker
             echo 'HOMEBREW_FORCE_HOMEBREW_ON_LINUX=1' >> $GITHUB_ENV
           fi
+          if [ -n ${{github.event.inputs.wheezy}} ]; then
+            echo 'HOMEBREW_ON_DEBIAN7=1' >> $GITHUB_ENV
+          fi
 
       - name: Run Docker container
         if: runner.os == 'Linux'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -185,6 +185,9 @@ jobs:
             # No PATH needed on Linux as set by Docker
             echo 'HOMEBREW_FORCE_HOMEBREW_ON_LINUX=1' >> $GITHUB_ENV
           fi
+          if [ ${{needs.setup_tests.outputs.container}} = 'homebrew/debian7:latest' ]; then
+            echo 'HOMEBREW_ON_DEBIAN7=1' >> $GITHUB_ENV
+          fi
 
       - name: Set up Linux Homebrew Docker container
         if: runner.os == 'Linux'


### PR DESCRIPTION
Since https://github.com/Homebrew/brew/pull/11761,
we need to set this specific env variable for wheezy

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
