### PR TITLE
yaz: update homepage, stable, livecheck urls

### DIFF
--- a/Formula/yaz.rb
+++ b/Formula/yaz.rb
@@ -1,12 +1,12 @@
 class Yaz < Formula
   desc "Toolkit for Z39.50/SRW/SRU clients/servers"
-  homepage "https://www.indexdata.com/yaz"
-  url "http://ftp.indexdata.dk/pub/yaz/yaz-5.31.0.tar.gz"
+  homepage "https://www.indexdata.com/resources/software/yaz/"
+  url "https://ftp.indexdata.com/pub/yaz/yaz-5.31.0.tar.gz"
   sha256 "864d4476d1578ac132782b3d4e2eb96391bd88f7ae3040ddcb1556aba6fe0d15"
   license "BSD-3-Clause"
 
   livecheck do
-    url "http://ftp.indexdata.dk/pub/yaz/"
+    url :homepage
     regex(/href=.*?yaz[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `yaz` formula contains a couple indexdata.dk URLs that redirect to indexdata.com. The `homepage` was using indexdata.com but the path redirects from `/yaz` to `/resources/software/yaz/`.

This PR updates related URLs to avoid these redirections. The `stable` archive is unchanged (the `sha256` remains the same) and it built/tested fine locally.