### PR TITLE
sdl_gfx: update homepage

### DIFF
--- a/Formula/sdl_gfx.rb
+++ b/Formula/sdl_gfx.rb
@@ -1,6 +1,6 @@
 class SdlGfx < Formula
   desc "Graphics drawing primitives and other support functions"
-  homepage "https://www.ferzkopp.net/joomla/content/view/19/14/"
+  homepage "https://www.ferzkopp.net/wordpress/2016/01/02/sdl_gfx-sdl2_gfx/"
   url "https://www.ferzkopp.net/Software/SDL_gfx-2.0/SDL_gfx-2.0.26.tar.gz"
   sha256 "7ceb4ffb6fc63ffba5f1290572db43d74386cd0781c123bc912da50d34945446"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` for `sdl_gfx` redirects from `https://www.ferzkopp.net/joomla/content/view/19/14/` to `https://www.ferzkopp.net/wordpress/2016/01/02/sdl_gfx-sdl2_gfx/`. This PR updates the `homepage` URL to avoid the redirection. For what it's worth, the `sdl2_gfx` homepage has already been updated to the current URL.