### PR TITLE
c-kermit: update livecheck

### DIFF
--- a/Formula/c-kermit.rb
+++ b/Formula/c-kermit.rb
@@ -6,8 +6,10 @@ class CKermit < Formula
   sha256 "0d5f2cd12bdab9401b4c836854ebbf241675051875557783c332a6a40dac0711"
   license "BSD-3-Clause"
 
+  # C-Kermit archive file names only contain the patch version and the full
+  # version has to be obtained from text on the project page.
   livecheck do
-    url "http://www.kermitproject.org/ck90.html"
+    url "https://www.kermitproject.org/ckermit.html"
     regex(/The current C-Kermit release is v?(\d+(?:\.\d+)+) /i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `c-kermit` checks the `ck90.html` page, which is the "C-Kermit" page on www.kermitproject.org. This PR updates the URL for the `livecheck` block to check the generic `ckermit.html` page (linked from various parts of the site), which currently redirects to `ck90.html`.

In general, it's best to avoid redirections when we can but the `ckermit.html` URL may be preferable here, as the redirection could be automatically updated if/when a new major/minor version appears. If we checked the `ck90.html` page directly, this check may quietly fail to surface a new version like `9.1` or `10.0` (e.g., if upstream moves to a `ck91.html` or `ck100.html` page).