### PR TITLE
solr@7.7: update livecheck

### DIFF
--- a/Formula/solr@7.7.rb
+++ b/Formula/solr@7.7.rb
@@ -9,9 +9,9 @@ class SolrAT77 < Formula
 
   # Remove the `livecheck` block (so the check is automatically skipped) once
   # the 7.7.x series is reported as EOL on the first-party downloads page:
-  # https://lucene.apache.org/solr/downloads.html#about-versions-and-support
+  # https://solr.apache.org/downloads.html#about-versions-and-support
   livecheck do
-    url "https://lucene.apache.org/solr/downloads.html"
+    url "https://solr.apache.org/downloads.html"
     regex(/href=.*?solr[._-]v?(7(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `livecheck` block URL to avoid the redirection from `lucene.apache.org/solr` to `solr.apache.org`. The `homepage` has already been updated, so this simply aligns the `livecheck` block.