### PR TITLE
scamper: update homepage, stable, livecheck urls

### DIFF
--- a/Formula/scamper.rb
+++ b/Formula/scamper.rb
@@ -1,12 +1,12 @@
 class Scamper < Formula
   desc "Advanced traceroute and network measurement utility"
-  homepage "https://www.caida.org/tools/measurement/scamper/"
-  url "https://www.caida.org/tools/measurement/scamper/code/scamper-cvs-20210324.tar.gz"
+  homepage "https://www.caida.org/catalog/software/scamper/"
+  url "https://www.caida.org/catalog/software/scamper/code/scamper-cvs-20210324.tar.gz"
   sha256 "332dce11a707c03045dd3c3faea4daf8b9d5debb8ac122aea8257f6bd2cf4404"
   license "GPL-2.0-only"
 
   livecheck do
-    url "https://www.caida.org/tools/measurement/scamper/code/?C=M&O=D"
+    url "https://www.caida.org/catalog/software/scamper/code/?C=M&O=D"
     regex(/href=.*?scamper(?:-cvs)?[._-]v?(\d{6,8}[a-z]?)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage`, `stable`, and `livecheck` URLs for `scamper` all redirect from `https://www.caida.org/tools/measurement/scamper/` to `https://www.caida.org/catalog/software/scamper/`. This PR updates these URLs to avoid the redirection. The `stable` archived is unchanged (the `sha256` remains the same) and this built fine locally (there is no test).