### PR TITLE
amap: update homepage, stable, livecheck urls

### DIFF
--- a/Formula/amap.rb
+++ b/Formula/amap.rb
@@ -1,15 +1,15 @@
 class Amap < Formula
   desc "Perform application protocol detection"
-  homepage "https://github.com/vanhauser-thc/THC-Archive"
-  url "https://github.com/vanhauser-thc/THC-Archive/raw/master/Tools/amap-5.4.tar.gz"
+  homepage "https://github.com/hackerschoice/THC-Archive"
+  url "https://github.com/hackerschoice/THC-Archive/raw/master/Tools/amap-5.4.tar.gz"
   mirror "https://downloads.sourceforge.net/project/slackbuildsdirectlinks/amap/amap-5.4.tar.gz"
   sha256 "a75ea58de75034de6b10b0de0065ec88e32f9e9af11c7d69edbffc4da9a5b059"
   revision 3
 
   livecheck do
-    url "https://github.com/vanhauser-thc/THC-Archive/tree/master/Tools/"
-    strategy :page_match
+    url "https://github.com/hackerschoice/THC-Archive/tree/master/Tools/"
     regex(%r{href=.*?/amap[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `vanhauser-thc/THC-archive` GitHub repository has moved to `hackerschoice/THC-archive`, so this PR updates the `homepage`, `stable` and `livecheck` URLs accordingly.