### PR TITLE
getxbook: update homepage

### DIFF
--- a/Formula/getxbook.rb
+++ b/Formula/getxbook.rb
@@ -1,6 +1,6 @@
 class Getxbook < Formula
   desc "Tools to download ebooks from various sources"
-  homepage "https://njw.name/getxbook"
+  homepage "https://njw.name/getxbook/"
   url "https://njw.name/getxbook/getxbook-1.2.tar.xz"
   sha256 "7a4b1636ecb6dace814b818d9ff6a68167799b81ac6fc4dca1485efd48cf1c46"
   license "ISC"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` for `getxbook` redirects from `https://njw.name/getxbook` to the same URL with a trailing forward slash. This PR updates the `homepage` URL to avoid the redirection.