### PR TITLE
pazpar2: update homepage, stable, livecheck urls and license

### DIFF
--- a/Formula/pazpar2.rb
+++ b/Formula/pazpar2.rb
@@ -1,13 +1,13 @@
 class Pazpar2 < Formula
   desc "Metasearching middleware webservice"
-  homepage "https://www.indexdata.com/pazpar2"
-  url "http://ftp.indexdata.dk/pub/pazpar2/pazpar2-1.14.0.tar.gz"
+  homepage "https://www.indexdata.com/resources/software/pazpar2/"
+  url "https://ftp.indexdata.com/pub/pazpar2/pazpar2-1.14.0.tar.gz"
   sha256 "3b0012450c66d6932009ac0decb72436690cc939af33e2ad96c0fec85863d13d"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 4
 
   livecheck do
-    url "http://ftp.indexdata.dk/pub/pazpar2/"
+    url :homepage
     regex(/href=.*?pazpar2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `pazpar2` formula contains a couple indexdata.dk URLs that redirect to indexdata.com. The `homepage` was using indexdata.com but the path redirects from `/pazpar2` to `/resources/software/pazpar2/`.

This PR updates related URLs to avoid these redirections. The `stable` archive is unchanged (the `sha256` remains the same) and it built/tested fine locally.

This also updates the `license` from `GPL-2.0` to `GPL-2.0-or-later`, as the source files use the "or...later" language in the license comments.