### PR TITLE
yazpp: update urls, add livecheck

### DIFF
--- a/Formula/yazpp.rb
+++ b/Formula/yazpp.rb
@@ -1,9 +1,14 @@
 class Yazpp < Formula
   desc "C++ API for the Yaz toolkit"
-  homepage "https://www.indexdata.com/yazpp"
-  url "http://ftp.indexdata.dk/pub/yazpp/yazpp-1.7.1.tar.gz"
+  homepage "https://www.indexdata.com/resources/software/yazpp/"
+  url "https://ftp.indexdata.com/pub/yazpp/yazpp-1.7.1.tar.gz"
   sha256 "8cf8b9a84cee6748013beaf8f79a432e4c65b9f04f4c80452bc2f3e93354294a"
   license "BSD-3-Clause"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?yazpp[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "868f7e41ffbd9bcd8c2c59db254182fe5f2fa934ec25c1928fbd0032ee480dd3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `yazpp` formula's  `homepage` redirects from `https://www.indexdata.com/yazpp` to `https://www.indexdata.com/resources/software/yazpp/` and the `stable` URL redirects from `http://ftp.indexdata.dk` to `https://ftp.indexdata.com`. This PR updates these URLs to avoid the redirections.

This also adds a `livecheck` block that checks the homepage, which links to the `stable` archive.