### PR TITLE
zebra: update stable and livecheck

### DIFF
--- a/Formula/zebra.rb
+++ b/Formula/zebra.rb
@@ -1,14 +1,14 @@
 class Zebra < Formula
   desc "Information management system"
   homepage "https://www.indexdata.com/resources/software/zebra/"
-  url "http://ftp.indexdata.dk/pub/zebra/idzebra-2.2.2.tar.gz"
+  url "https://ftp.indexdata.com/pub/zebra/idzebra-2.2.2.tar.gz"
   sha256 "513c2bf272e12745d4a7b58599ded0bc1292a84e9dc420a32eb53b6601ae0000"
   license "GPL-2.0-or-later"
   revision 2
 
   livecheck do
     url :homepage
-    regex(%r{>Latest:</strong>.*?v?(\d+(?:\.\d+)+)<}i)
+    regex(/href=.*?idzebra[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Thie `stable` URL for `zebra` redirects from `http://ftp.indexdata.dk` to `https://ftp.indexdata.com`. This PR updates the URL to avoid the redirection. The `stable` archive remains the same (the `sha256` is unchanged) and this built/tested fine locally.

This also updates the `livecheck` block regex to match the version from the archive file name, which aligns this check with the other indexdata.com checks. When checking an HTML page, we generally prefer to match versions from archive file names over text on the page, so this also aligns with that idea.