### PR TITLE
color-code: add license, livecheck

### DIFF
--- a/Formula/color-code.rb
+++ b/Formula/color-code.rb
@@ -3,7 +3,13 @@ class ColorCode < Formula
   homepage "http://colorcode.laebisch.com/"
   url "http://colorcode.laebisch.com/download/ColorCode-0.8.5.tar.gz"
   sha256 "7c128db12af6ab11439eb710091b4a448100553a4d11d3a7c8dafdfbc57c1a85"
+  license "GPL-3.0-or-later"
   revision 2
+
+  livecheck do
+    url "http://colorcode.laebisch.com/download"
+    regex(/href=.*?ColorCode[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "8e7c81eca9f900ce20df5013b24120a39732113506ca72db063c52dec64fb028"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `color-code`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.

This also sets `license` to `GPL-3.0-or-later`, as the `COPYING` file is GPL 3 and the source files contain "or...later" language in the license comments.