### PR TITLE
log4cxx: fix build for Linux

### DIFF
--- a/Formula/log4cxx.rb
+++ b/Formula/log4cxx.rb
@@ -16,6 +16,12 @@ class Log4cxx < Formula
   depends_on "cmake" => :build
   depends_on "apr-util"
 
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: 5 # needs C++17 or Boost
+
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args, "-DBUILD_SHARED_LIBS=ON"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3148918703?check_suite_focus=true
```
/tmp/log4cxx-20210724-5519-jfjlou/apache-log4cxx-0.12.0/src/main/include/log4cxx/rolling/action.h:51:8: error: ‘mutex’ in namespace ‘std’ does not name a type
   std::mutex mutex;
        ^
```