### PR TITLE
arpoison: fix build for Linux

### DIFF
--- a/Formula/arpoison.rb
+++ b/Formula/arpoison.rb
@@ -21,6 +21,7 @@ class Arpoison < Formula
   depends_on "libnet"
 
   def install
+    on_linux { inreplace "Makefile", /gcc -lnet (.*)/, "gcc \\1 -lnet" }
     system "make"
     bin.install "arpoison"
     man8.install "arpoison.8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3148940561?check_suite_focus=true
```
==> make
gcc -lnet -o arpoison `libnet-config --defines` -I/opt/local/include -L/opt/local/lib arpoison.c
/tmp/ccW4PUSA.o: In function `main':
arpoison.c:(.text.startup+0x218): undefined reference to `libnet_init'
arpoison.c:(.text.startup+0x264): undefined reference to `libnet_build_arp'
arpoison.c:(.text.startup+0x28e): undefined reference to `libnet_build_ethernet'
arpoison.c:(.text.startup+0x2f6): undefined reference to `libnet_write'
arpoison.c:(.text.startup+0x316): undefined reference to `libnet_destroy'
collect2: error: ld returned 1 exit status
Makefile:5: recipe for target 'arpoison' failed
make: *** [arpoison] Error 1
```
