### PR TITLE
libusrsctp: fix test for Linux

### DIFF
--- a/Formula/libusrsctp.rb
+++ b/Formula/libusrsctp.rb
@@ -30,7 +30,7 @@ class Libusrsctp < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-L#{lib}", "-lusrsctp", "-o", "test"
+    system ENV.cc, "test.c", "-L#{lib}", "-lusrsctp", "-lpthread", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3148941064?check_suite_focus=true
```
==> /usr/bin/gcc-5 test.c -L/home/linuxbrew/.linuxbrew/Cellar/libusrsctp/0.9.5.0/lib -lusrsctp -o test
/home/linuxbrew/.linuxbrew/Cellar/libusrsctp/0.9.5.0/lib/libusrsctp.a(user_socket.c.o): In function `init_sync':
user_socket.c:(.text+0x18): undefined reference to `pthread_mutexattr_init'
user_socket.c:(.text+0x2d): undefined reference to `pthread_mutexattr_destroy'
/home/linuxbrew/.linuxbrew/Cellar/libusrsctp/0.9.5.0/lib/libusrsctp.a(user_socket.c.o): In function `usrsctp_finish':
user_socket.c:(.text+0x23f6): undefined reference to `pthread_mutex_trylock'
/home/linuxbrew/.linuxbrew/Cellar/libusrsctp/0.9.5.0/lib/libusrsctp.a(sctp_callout.c.o): In function `sctp_stop_timer_thread':
sctp_callout.c:(.text+0x3da): undefined reference to `pthread_join'
/home/linuxbrew/.linuxbrew/Cellar/libusrsctp/0.9.5.0/lib/libusrsctp.a(sctp_output.c.o): In function `sctp_lower_sosend':
sctp_output.c:(.text+0x13357): undefined reference to `pthread_mutex_trylock'
sctp_output.c:(.text+0x14339): undefined reference to `pthread_mutex_trylock'
/home/linuxbrew/.linuxbrew/Cellar/libusrsctp/0.9.5.0/lib/libusrsctp.a(sctp_pcb.c.o): In function `sctp_pcb_init':
```