### PR TITLE
kakoune: use linux-headers@4.4

### DIFF
--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -38,7 +38,7 @@ class Kakoune < Formula
 
   on_linux do
     depends_on "binutils" => :build
-    depends_on "linux-headers" => :build
+    depends_on "linux-headers@4.4" => :build
     depends_on "pkg-config" => :build
     depends_on "gcc"
   end


### PR DESCRIPTION
Fixes:
Dependency 'linux-headers' was renamed; use new name 'linux-headers@4.4'.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
