### PR TITLE
task: use linux-headers@4.4

### DIFF
--- a/Formula/task.rb
+++ b/Formula/task.rb
@@ -4,6 +4,7 @@ class Task < Formula
   url "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v2.5.3/task-2.5.3.tar.gz"
   sha256 "7243d75e0911d9e2c9119ad94a61a87f041e4053e197f7280c42410aa1ee963b"
   license "MIT"
+  revision 1
   head "https://github.com/GothenburgBitFactory/taskwarrior.git", branch: "2.6.0"
 
   livecheck do
@@ -23,7 +24,7 @@ class Task < Formula
   depends_on "gnutls"
 
   on_linux do
-    depends_on "linux-headers"
+    depends_on "linux-headers@4.4"
     depends_on "readline"
     depends_on "util-linux"
   end


### PR DESCRIPTION
Fixes:
Dependency 'linux-headers' was renamed; use new name 'linux-headers@4.4'.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
