### PR TITLE
go: don't install incompatible binary file

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -60,6 +60,8 @@ class Go < Formula
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files
     rm_rf Dir[libexec/"src/debug/elf/testdata"]
+    # Binaries built for an incompatible architecture
+    rm_rf Dir[libexec/"src/runtime/pprof/testdata"]
   end
 
   test do


### PR DESCRIPTION
Fixes:
go:
  * Binaries built for an incompatible architecture were installed into go's prefix.
    The offending files are:
      /home/linuxbrew/.linuxbrew/Cellar/go/1.16.6/libexec/src/runtime/pprof/testdata/test32

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
