### PR TITLE
ttfautohint: update livecheck

### DIFF
--- a/Formula/ttfautohint.rb
+++ b/Formula/ttfautohint.rb
@@ -5,7 +5,7 @@ class Ttfautohint < Formula
   sha256 "87bb4932571ad57536a7cc20b31fd15bc68cb5429977eb43d903fa61617cf87e"
 
   livecheck do
-    url :stable
+    url "https://sourceforge.net/projects/freetype/rss?path=/ttfautohint"
     regex(%r{url=.*?/ttfautohint[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `ttfautohint` uses the `Sourceforge` strategy to check the `stable` URL. However, the `freetype` SourceForge project contains more than just `ttfautohint` and the latest version has been pushed out of the main RSS feed. Previously, we weren't able to manually specify the URL for a SourceForge RSS feed but I made this possible in Homebrew/brew#11746.

This PR returns the check to a working state by updating the `livecheck` block URL to check the RSS feed for the `/ttfautohint` directory, so it will only contain related information.