### PR TITLE
mdbtools: fix SQL support when building from source

### DIFF
--- a/Formula/mdbtools.rb
+++ b/Formula/mdbtools.rb
@@ -4,6 +4,7 @@ class Mdbtools < Formula
   url "https://github.com/mdbtools/mdbtools/releases/download/v0.9.3/mdbtools-0.9.3.tar.gz"
   sha256 "bf4b297a9985e82bc64c8a620adc00e2e3483371a7d280e81249b294fe0e6619"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "e9bd349e7979d818b4b45de5cfc26ca64f357188eb63651560821940df39179b"
@@ -15,6 +16,7 @@ class Mdbtools < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "bison" => :build
   depends_on "gawk" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
@@ -25,7 +27,6 @@ class Mdbtools < Formula
   def install
     system "autoreconf", "-fvi"
     system "./configure", "--prefix=#{prefix}",
-                          "--enable-sql",
                           "--enable-man"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`--enable-sql` does nothing when compiling mdbtools 0.9.x. Instead, SQL support is automatically enabled when bison 3+
is present.

See: https://github.com/mdbtools/mdbtools/issues/273

As a side note, the bottles should be regenerated, since they are currently lacking SQL support.