### PR TITLE
httrack: add zlib dependency for Linux

### DIFF
--- a/Formula/httrack.rb
+++ b/Formula/httrack.rb
@@ -23,6 +23,8 @@ class Httrack < Formula
 
   depends_on "openssl@1.1"
 
+  uses_from_macos "zlib"
+
   def install
     ENV.deparallelize
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3073808712?check_suite_focus=true
```
==> brew linkage --test httrack
==> FAILED
Unwanted system libraries:
  /lib/x86_64-linux-gnu/libz.so.1
```