### PR TITLE
gcc@5: depend on glibc if any version installed

### DIFF
--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -31,6 +31,7 @@ class GccAT5 < Formula
 
   on_linux do
     depends_on "binutils"
+    depends_on "glibc" if Formula["glibc"].any_version_installed?
   end
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib


### PR DESCRIPTION
This is only needed for gcc@5 as this is the first compiler
that needs to be built on older systems. In this case
we also need to ship and use our own glibc.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
