### PR TITLE
gnutls: fix empty trust store

### DIFF
--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -96,7 +96,17 @@ class Gnutls < Formula
         openssl_io.close_write
       end
 
-      $CHILD_STATUS.success?
+      next unless $CHILD_STATUS.success?
+
+      # XXX And drop Kerberos certs which may invalidate the whole trust store
+      # due to bug in gnutls (https://gitlab.com/gnutls/gnutls/-/issues/1255)
+      IO.popen("openssl x509 -inform pem -issuer -noout 2>/dev/null", "r+") do |openssl_io|
+        openssl_io.write(cert)
+        openssl_io.close_write
+        cn = openssl_io.read
+        openssl_io.close_read
+        cn.exclude? "CN=com.apple.kerberos.kdc"
+      end
     end
 
     # Check that the certificate is trusted in keychain


### PR DESCRIPTION
Due to [1] gnutls may drop the whole trust store if there's at least one
certificate with duplicating extensions. I'm not 100% sure but most
likely macOS may have "com.apple.kerberos.kdc" certificate to be of such
kind. So let's filter them out when building trust store.

[1] https://gitlab.com/gnutls/gnutls/-/issues/1255

(#81022)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
