### PR TITLE
sbt@1.3 1.3.13 (new formula)

### DIFF
--- a/Formula/sbt@1.3.rb
+++ b/Formula/sbt@1.3.rb
@@ -1,0 +1,45 @@
+class SbtAT13 < Formula
+  desc "Build tool for Scala projects"
+  homepage "https://www.scala-sbt.org/"
+  url "https://github.com/sbt/sbt/releases/download/v1.3.13/sbt-1.3.13.tgz"
+  sha256 "854154de27a7d8c13b5a0f9a297cd1f254cc13b44588dae507e5d4fb2741bd22"
+  license "Apache-2.0"
+
+  keg_only :versioned_formula
+
+  depends_on "openjdk"
+
+  def install
+    inreplace "bin/sbt" do |s|
+      s.gsub! 'etc_sbt_opts_file="/etc/sbt/sbtopts"', "etc_sbt_opts_file=\"#{etc}/sbtopts\""
+      s.gsub! "/etc/sbt/sbtopts", "#{etc}/sbtopts"
+    end
+
+    libexec.install "bin"
+    etc.install "conf/sbtopts"
+
+    (bin/"sbt").write <<~EOS
+      #!/bin/sh
+      if [ -f "$HOME/.sbtconfig" ]; then
+        echo "Use of ~/.sbtconfig is deprecated, please migrate global settings to #{etc}/sbtopts" >&2
+        . "$HOME/.sbtconfig"
+      fi
+      export JAVA_HOME="${JAVA_HOME:-#{Formula["openjdk"].opt_prefix}}"
+      exec "#{libexec}/bin/sbt" "$@"
+    EOS
+  end
+
+  def caveats
+    <<~EOS
+      You can use $SBT_OPTS to pass additional JVM options to sbt.
+      Project specific options should be placed in .sbtopts in the root of your project.
+      Global settings should be placed in #{etc}/sbtopts
+    EOS
+  end
+
+  test do
+    ENV.append "_JAVA_OPTIONS", "-Dsbt.log.noformat=true"
+    system "#{bin}/sbt", "about"
+    assert_match "[info] #{version}", shell_output("#{bin}/sbt sbtVersion")
+  end
+end


### PR DESCRIPTION
Starting with version 1.4, `sbt` comes with an optional client [`sbtn`](https://www.scala-sbt.org/1.x/docs/sbt-1.4-Release-Notes.html#Native+thin+client) which [cannot be built on apple M1 architecture](https://github.com/sbt/sbtn-dist/releases/tag/v1.4.7). The situation is stalled [until the release of openJdk17](https://github.com/oracle/graal/issues/2666#issuecomment-817834239). Until then, M1 brew users have no possibility to install a recent-ish version of sbt.

The formula is based on c99510bb8873953d655f6fe364f1b845efa97c60, with the mirror url being removed as not reachable anymore.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
