### PR TITLE
various: use dotnet publish instead of build

### DIFF
--- a/Formula/archi-steam-farm.rb
+++ b/Formula/archi-steam-farm.rb
@@ -5,6 +5,7 @@ class ArchiSteamFarm < Formula
     tag:      "5.1.0.9",
     revision: "31a06a8af36360c0f2afaf1bc3e41fdec6d2831b"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/JustArchiNET/ArchiSteamFarm.git"
 
   livecheck do
@@ -21,7 +22,7 @@ class ArchiSteamFarm < Formula
   depends_on "dotnet"
 
   def install
-    system "dotnet", "build", "ArchiSteamFarm",
+    system "dotnet", "publish", "ArchiSteamFarm",
            "--configuration", "Release",
            "--framework", "net#{Formula["dotnet"].version.major_minor}",
            "--output", libexec

--- a/Formula/gitversion.rb
+++ b/Formula/gitversion.rb
@@ -4,6 +4,7 @@ class Gitversion < Formula
   url "https://github.com/GitTools/GitVersion/archive/5.6.10.tar.gz"
   sha256 "5a4cdca526241f322e51fc307a5be2ef236281b6c5cca833fa04bc8eecd9f725"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any, big_sur:  "5e99b09d02ac3aa3074a179782ad8fcca9ca6c93a9188d83e5f6e1a05abbb985"
@@ -14,13 +15,11 @@ class Gitversion < Formula
   depends_on "dotnet"
 
   def install
-    system "dotnet", "build",
+    system "dotnet", "publish",
            "--configuration", "Release",
            "--framework", "net#{Formula["dotnet"].version.major_minor}",
-           "--output", "out",
+           "--output", libexec,
            "src/GitVersion.App/GitVersion.App.csproj"
-
-    libexec.install Dir["out/*"]
 
     (bin/"gitversion").write <<~EOS
       #!/bin/sh


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is follow-up from #81786 since that PR cannot be re-opened. I also welcome and expect there to be further investigation and discussion here if needed.

To summarize findings from that PR, Microsoft recommends `dotnet publish` as the way to prepare a package for distribution. Some formula upstreams have reported that `dotnet publish` instead of `dotnet build` fixes issues reported to upstream by end users installing the software in question via Homebrew.

From the Homebrew side, there were concerns raised about `dotnet publish` also bundling dependencies, because the output from `dotnet publish` also includes ["the application's dependencies, which are copied from the NuGet cache into the output folder"](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-publish). However, it's worth noting that these dependencies also seem to be included when we do `dotnet build` anyways (the output files include DLLs of dependencies), so I don't believe changing `dotnet build` to `dotnet publish` will change anything in this regard.

The `dafny` formula also depends on `dotnet` and their Makefile (which we invoke) calls `dotnet build`. I'm not planning to patch that/inquire upstream unless someone actually reports issues with their usage of `dotnet build`.