### PR TITLE
kallisto: fix build with autoconf@2.69

### DIFF
--- a/Formula/kallisto.rb
+++ b/Formula/kallisto.rb
@@ -13,7 +13,7 @@ class Kallisto < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "8491424ec8d4f8e170315e13c5f3bb92895b608c9c7108f260459e06bbbf73f9"
   end
 
-  depends_on "autoconf" => :build
+  depends_on "autoconf@2.69" => :build
   depends_on "automake" => :build
   depends_on "cmake" => :build
   depends_on "hdf5"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3153334757?check_suite_focus=true
```
checking build system type... x86_64-pc-linux-gnu
checking host system type... Invalid configuration `unknown-Linux': machine `unknown-unknown' not recognized
configure: error: /bin/bash ./config.sub unknown-Linux failed
CMakeFiles/htslib.dir/build.make:94: recipe for target 'ext/htslib/src/htslib-stamp/htslib-configure' failed
make[3]: *** [ext/htslib/src/htslib-stamp/htslib-configure] Error 1
make[3]: Leaving directory '/tmp/kallisto-20210725-6100-6rj05i/kallisto-0.46.2'
CMakeFiles/Makefile2:104: recipe for target 'CMakeFiles/htslib.dir/all' failed
make[2]: *** [CMakeFiles/htslib.dir/all] Error 2
make[2]: Leaving directory '/tmp/kallisto-20210725-6100-6rj05i/kallisto-0.46.2'
CMakeFiles/Makefile2:111: recipe for target 'CMakeFiles/htslib.dir/rule' failed
make[1]: *** [CMakeFiles/htslib.dir/rule] Error 2
make[1]: Leaving directory '/tmp/kallisto-20210725-6100-6rj05i/kallisto-0.46.2'
Makefile:172: recipe for target 'htslib' failed
make: *** [htslib] Error 2
```