### PR TITLE
phoronix-test-suite: add php dependency for Linux

### DIFF
--- a/Formula/phoronix-test-suite.rb
+++ b/Formula/phoronix-test-suite.rb
@@ -18,6 +18,8 @@ class PhoronixTestSuite < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "021e080cf334bf2a07774987010e2ea1047e81348f4b020069c4c016522947de"
   end
 
+  uses_from_macos "php"
+
   def install
     ENV["DESTDIR"] = buildpath/"dest"
     system "./install-sh", prefix
@@ -31,7 +33,22 @@ class PhoronixTestSuite < Formula
   end
 
   test do
-    cd pkgshare
-    assert_match version.to_s, shell_output("#{bin}/phoronix-test-suite version")
+    on_macos { cd pkgshare }
+
+    # Work around issue directly running command on Linux CI by using spawn.
+    # Error is "Forked child process failed: pid ##### SIGKILL"
+    require "pty"
+    output = ""
+    PTY.spawn(bin/"phoronix-test-suite", "version") do |r, _w, pid|
+      sleep 2
+      Process.kill "TERM", pid
+      begin
+        r.each_line { |line| output += line }
+      rescue Errno::EIO
+        # GNU/Linux raises EIO when read is done on closed pty
+      end
+    end
+
+    assert_match version.to_s, output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3153395981?check_suite_focus=true
```
==> /home/linuxbrew/.linuxbrew/Cellar/phoronix-test-suite/10.4.0/bin/phoronix-test-suite version
Error: phoronix-test-suite: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /10\.4\.0/ to match "\nPHP must be installed for the Phoronix Test Suite\nThe PHP command-line package is commonly called php-cli, php7-cli, php8-cli, or php.\nFor more information visit: https://www.phoronix-test-suite.com/\n\nThe command to likely run for your operating system is: \n# apt-get install php-cli php-xml\n \n".
```