### PR TITLE
cifer: fix build for Linux

### DIFF
--- a/Formula/cifer.rb
+++ b/Formula/cifer.rb
@@ -3,7 +3,7 @@ class Cifer < Formula
   homepage "https://code.google.com/p/cifer/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/cifer/cifer-1.2.0.tar.gz"
   sha256 "436816c1f9112b8b80cf974596095648d60ffd47eca8eb91fdeb19d3538ea793"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "5f826a8dc0534a56e2c372abeba0f05124f79e96502243d1c89548777d2156b2"
@@ -14,6 +14,13 @@ class Cifer < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "875e676d7866fd3ba2c8b70806838068775ffbc1102c56ca52d041155b2ade43"
     sha256 cellar: :any_skip_relocation, el_capitan:    "86cbc00f11a5818f48ee67bdc0fa5f2692cc7f37ae6c2c5eb237338c7dc6919b"
     sha256 cellar: :any_skip_relocation, yosemite:      "bde7d97d9ef2a07c481ff8c5ec717fb2ec455fdef864db2a1a7b3056aa1934d2"
+  end
+
+  on_linux do
+    depends_on "readline"
+
+    # Fix order of linker flags for GCC
+    patch :DATA
   end
 
   def install
@@ -28,3 +35,16 @@ class Cifer < Formula
     assert_match version.to_s, pipe_output("#{bin}/cifer")
   end
 end
+
+__END__
+--- a/Makefile
++++ b/Makefile
+@@ -54,7 +54,7 @@ allfiles := $(wildcard *)
+ all : cifer
+ 
+ cifer : $(objects)
+-	$(CC) $(CFLAGS) $(LINKLIBS) -o $@ $(objects)
++	$(CC) $(CFLAGS) -o $@ $(objects) $(LINKLIBS)
+ 
+ src/%.o : src/%.c $(headers)
+ 	$(CC) $(DEFS) -c $(CFLAGS) $< -o $@


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3153451007?check_suite_focus=true
```
==> make prefix=/home/linuxbrew/.linuxbrew/Cellar/cifer/1.2.0 CC=gcc-5 CFLAGS= LDFLAGS= install
[ -d /home/linuxbrew/.linuxbrew/Cellar/cifer/1.2.0/share/man/man1 ] || install -d /home/linuxbrew/.linuxbrew/Cellar/cifer/1.2.0/share/man/man1
gcc-5 -DVERSION="\"1.2.0\"" -c  src/polybius.c -o src/polybius.o
gcc-5 -DVERSION="\"1.2.0\"" -c  src/actions_io.c -o src/actions_io.o
In file included from src/polybius.c:19:0:
src/stdinc.h:39:31: fatal error: readline/readline.h: No such file or directory
compilation terminated.
Makefile:60: recipe for target 'src/polybius.o' failed
make: *** [src/polybius.o] Error 1
make: *** Waiting for unfinished jobs....
In file included from src/actions_io.c:19:0:
src/stdinc.h:39:31: fatal error: readline/readline.h: No such file or directory
compilation terminated.
Makefile:60: recipe for target 'src/actions_io.o' failed
make: *** [src/actions_io.o] Error 1
```