### PR TITLE
antlr4-cpp-runtime: fix build for Linux

### DIFF
--- a/Formula/antlr4-cpp-runtime.rb
+++ b/Formula/antlr4-cpp-runtime.rb
@@ -19,6 +19,11 @@ class Antlr4CppRuntime < Formula
 
   depends_on "cmake" => :build
 
+  on_linux do
+    depends_on "pkg-config" => :build
+    depends_on "util-linux"
+  end
+
   def install
     system "cmake", ".", "-DANTLR4_INSTALL=ON", *std_cmake_args
     system "cmake", "--build", ".", "--target", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3153453834?check_suite_focus=true
```
-- Detecting CXX compile features - done
CMake Error at /home/linuxbrew/.linuxbrew/Cellar/cmake/3.21.0/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
Call Stack (most recent call first):
  /home/linuxbrew/.linuxbrew/Cellar/cmake/3.21.0/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /home/linuxbrew/.linuxbrew/Cellar/cmake/3.21.0/share/cmake/Modules/FindPkgConfig.cmake:70 (find_package_handle_standard_args)
  CMakeLists.txt:43 (find_package)
```
