### PR TITLE
afl-fuzz: fix test for Linux and remove 32-bit ELF file

### DIFF
--- a/Formula/afl-fuzz.rb
+++ b/Formula/afl-fuzz.rb
@@ -22,6 +22,9 @@ class AflFuzz < Formula
   def install
     system "make", "PREFIX=#{prefix}", "AFL_NO_X86=1"
     system "make", "install", "PREFIX=#{prefix}", "AFL_NO_X86=1"
+
+    # Delete incompatible elf32-i386 testcase file
+    rm Dir[share/"afl/**/elf/small_exec.elf"]
   end
 
   test do
@@ -34,7 +37,9 @@ class AflFuzz < Formula
       }
     EOS
 
-    system bin/"afl-clang++", "-g", cpp_file, "-o", "test"
+    cmd = "afl-clang++"
+    on_linux { cmd = "afl-g++" }
+    system bin/cmd, "-g", cpp_file, "-o", "test"
     assert_equal "Hello, world!", shell_output("./test")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3049683722?check_suite_focus=true
```
==> brew test --verbose afl-fuzz
==> FAILED
==> Testing afl-fuzz
==> /home/linuxbrew/.linuxbrew/Cellar/afl-fuzz/2.57b_1/bin/afl-clang++ -g /tmp/afl-fuzz-test-20210712-4502-fyx641/main.cpp -o test
25h
[-] PROGRAM ABORT : Oops, failed to execute 'clang++' - check your PATH
         Location : main(), afl-gcc.c:342

Error: afl-fuzz: failed
```