### PR TITLE
ncmpc: needs gcc on Linux

### DIFF
--- a/Formula/ncmpc.rb
+++ b/Formula/ncmpc.rb
@@ -25,6 +25,12 @@ class Ncmpc < Formula
   depends_on "libmpdclient"
   depends_on "pcre"
 
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5"
+
   def install
     mkdir "build" do
       system "meson", *std_meson_args, "-Dcolors=false", "-Dnls=disabled", ".."


### PR DESCRIPTION
Fixes:
../src/util/IntrusiveList.hxx:110:61: error: expected string-literal before ')' token
../src/util/IntrusiveList.hxx: In static member function 'static constexpr const IntrusiveListHook& IntrusiveList<T>::ToHook(const T&)':
../src/util/IntrusiveList.hxx:115:61: error: expected ',' before ')' token
   static_assert(std::is_base_of<IntrusiveListHook, T>::value);
                                                             ^
../src/util/IntrusiveList.hxx:115:61: error: expected string-literal before ')' token
In file included from ../src/mpdclient.hxx:26:0,
                 from ../src/OutputsPage.cxx:29:
../src/event/FineTimerEvent.hxx: At global scope:
../src/event/FineTimerEvent.hxx:77:17: error: enclosing class of constexpr non-static member function 'auto FineTimerEvent::GetDue() const' is not a literal type
  constexpr auto GetDue() const noexcept {
                 ^
../src/event/FineTimerEvent.hxx:53:7: note: 'FineTimerEvent' is not literal because:
 class FineTimerEvent final
       ^
../src/event/FineTimerEvent.hxx:53:7: note:   'FineTimerEvent' has a non-trivial destructor
ninja: build stopped: subcommand failed.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
