### PR TITLE
various formulae: `fails_with gcc:` quotes

### DIFF
--- a/Formula/log4cxx.rb
+++ b/Formula/log4cxx.rb
@@ -21,7 +21,7 @@ class Log4cxx < Formula
     depends_on "gcc"
   end
 
-  fails_with gcc: 5 # needs C++17 or Boost
+  fails_with gcc: "5" # needs C++17 or Boost
 
   def install
     mkdir "build" do

--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -47,7 +47,7 @@ class Mu < Formula
     depends_on "gcc"
   end
 
-  fails_with gcc: 5
+  fails_with gcc: "5"
 
   def install
     system "autoreconf", "-ivf"

--- a/Formula/stockfish.rb
+++ b/Formula/stockfish.rb
@@ -23,7 +23,7 @@ class Stockfish < Formula
     depends_on "gcc" # For C++17
   end
 
-  fails_with gcc: 5
+  fails_with gcc: "5"
 
   def install
     arch = Hardware::CPU.arm? ? "apple-silicon" : "x86-64-modern"

--- a/Formula/tcpflow.rb
+++ b/Formula/tcpflow.rb
@@ -35,7 +35,7 @@ class Tcpflow < Formula
     depends_on "gcc" # For C++17
   end
 
-  fails_with gcc: 5
+  fails_with gcc: "5"
 
   def install
     system "bash", "./bootstrap.sh" if build.head?

--- a/Formula/volk.rb
+++ b/Formula/volk.rb
@@ -25,7 +25,7 @@ class Volk < Formula
     depends_on "gcc"
   end
 
-  fails_with gcc: 5 # https://github.com/gnuradio/volk/issues/375
+  fails_with gcc: "5" # https://github.com/gnuradio/volk/issues/375
 
   resource "Mako" do
     url "https://files.pythonhosted.org/packages/5c/db/2d2d88b924aa4674a080aae83b59ea19d593250bfe5ed789947c21736785/Mako-1.1.4.tar.gz"

--- a/Formula/zeek.rb
+++ b/Formula/zeek.rb
@@ -34,7 +34,7 @@ class Zeek < Formula
     depends_on "gcc" # For C++17
   end
 
-  fails_with gcc: 5
+  fails_with gcc: "5"
 
   def install
     # Remove SDK paths from zeek-config. This breaks usage with other SDKs.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Forgot some quotes in previous PRs for `fails_with gcc: `

Looks like it still worked, but update here to match usage/style from existing formulae.