### PR TITLE
gitfs: fix build for Linux

### DIFF
--- a/Formula/gitfs.rb
+++ b/Formula/gitfs.rb
@@ -44,8 +44,8 @@ class Gitfs < Formula
   end
 
   resource "pygit2" do
-    url "https://files.pythonhosted.org/packages/1d/c4/e0ba65178512a724a86b39565d7f9286c16d7f8e45e2f665973065c4a495/pygit2-1.1.1.tar.gz"
-    sha256 "9255d507d5d87bf22dfd57997a78908010331fc21f9a83eca121a53f657beb3c"
+    url "https://files.pythonhosted.org/packages/6b/23/a8c5b726a58282fe2cadcc63faaddd4be147c3c8e0bd38b233114adf98fd/pygit2-1.6.1.tar.gz"
+    sha256 "c3303776f774d3e0115c1c4f6e1fc35470d15f113a7ae9401a0b90acfa1661ac"
   end
 
   resource "six" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`gitfs` actually has an old `pygit2` dependency of v0.28.2. There appears to be strict version requirements for `gitfs` with `libgit2` (major+minor version), so trying to update to newer version.

May also need to drop from `libfuse` v3 to v2.

https://github.com/Homebrew/homebrew-core/runs/3037319907?check_suite_focus=true
```
  gcc-5 -Wno-unused-result -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/usr/local/include -I/home/linuxbrew/.linuxbrew/include -I/home/linuxbrew/.linuxbrew/opt/openssl@1.1/include -I/home/linuxbrew/.linuxbrew/opt/sqlite/include -I/home/linuxbrew/.linuxbrew/Cellar/gitfs/0.5.2_5/libexec/include -I/home/linuxbrew/.linuxbrew/opt/python@3.9/include/python3.9 -c src/blob.c -o build/temp.linux-x86_64-3.9/src/blob.o
  In file included from src/blob.h:34:0,
                   from src/blob.c:30:
  src/types.h:36:2: error: #error You need a compatible libgit2 version (0.99.x or 1.0.x)
   #error You need a compatible libgit2 version (0.99.x or 1.0.x)
    ^
```