### PR TITLE
darcs: add ncurses and zlib dependencies for Linux

### DIFF
--- a/Formula/darcs.rb
+++ b/Formula/darcs.rb
@@ -16,6 +16,9 @@ class Darcs < Formula
   depends_on "ghc" => :build
   depends_on "gmp"
 
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
   def install
     system "cabal", "v2-update"
     system "cabal", "v2-install", *std_cabal_v2_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3157740772?check_suite_focus=true
```
==> brew linkage --test darcs
==> FAILED
Missing libraries:
  unexpected (libncursesw.so.6)
Unwanted system libraries:
  /lib/x86_64-linux-gnu/libz.so.1
```