### PR TITLE
tbb@2020: fix build for Linux

### DIFF
--- a/Formula/tbb@2020.rb
+++ b/Formula/tbb@2020.rb
@@ -31,7 +31,7 @@ class TbbAT2020 < Formula
   def install
     compiler = (ENV.compiler == :clang) ? "clang" : "gcc"
     system "make", "tbb_build_prefix=BUILDPREFIX", "compiler=#{compiler}"
-    lib.install Dir["build/BUILDPREFIX_release/*.dylib"]
+    lib.install Dir["build/BUILDPREFIX_release/#{shared_library("*")}"]
 
     # Build and install static libraries
     system "make", "tbb_build_prefix=BUILDPREFIX", "compiler=#{compiler}",
@@ -41,12 +41,18 @@ class TbbAT2020 < Formula
 
     cd "python" do
       ENV["TBBROOT"] = prefix
+      on_linux do
+        system "make", "-C", "rml", "compiler=#{compiler}", "CPATH=#{include}"
+        lib.install Dir["rml/libirml.so*"]
+      end
       system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
     end
 
+    os = "Darwin"
+    on_linux { os = "Linux" }
     system "cmake", *std_cmake_args,
                     "-DINSTALL_DIR=lib/cmake/TBB",
-                    "-DSYSTEM_NAME=Darwin",
+                    "-DSYSTEM_NAME=#{os}",
                     "-DTBB_VERSION_FILE=#{include}/tbb/tbb_stddef.h",
                     "-P", "cmake/tbb_config_installer.cmake"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3158618308?check_suite_focus=true
```
g++-5 -shared build/temp.linux-x86_64-3.9/tbb/api_wrap.o -L/tmp/tbbA2020-20210726-5206-c0scxk/oneTBB-2020.3/python -L/home/linuxbrew/.linuxbrew/Cellar/tbb@2020/2020_U3/lib/intel64/gcc4.8 -L/home/linuxbrew/.linuxbrew/Cellar/tbb@2020/2020_U3/lib -L/home/linuxbrew/.linuxbrew/Cellar/tbb@2020/2020_U3/lib/intel64/vc_mt -L/home/linuxbrew/.linuxbrew/lib -L/home/linuxbrew/.linuxbrew/opt/openssl@1.1/lib -L/home/linuxbrew/.linuxbrew/opt/sqlite/lib -L/home/linuxbrew/.linuxbrew/opt/python@3.9/lib -ltbb -lirml -o build/lib.linux-x86_64-3.9/tbb/_api.cpython-39-x86_64-linux-gnu.so
/usr/bin/ld: cannot find -lirml
collect2: error: ld returned 1 exit status
error: command '/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/g++-5' failed with exit code 1
```
