### PR TITLE
languagetool: fix test

### DIFF
--- a/Formula/languagetool.rb
+++ b/Formula/languagetool.rb
@@ -46,6 +46,7 @@ class Languagetool < Formula
     (testpath/"test.txt").write <<~EOS
       Homebrew, this is an test
     EOS
-    assert_match "Message: Use ?a? instead of ?an?", shell_output("#{bin}/languagetool -l en-US test.txt 2>&1")
+    output = shell_output("#{bin}/languagetool -l en-US test.txt 2>&1")
+    assert_match(/Message: Use \Wa\W instead of \Wan\W/, output)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3158614775?check_suite_focus=true
```
==> FAILED
==> Testing languagetool
==> /home/linuxbrew/.linuxbrew/Cellar/languagetool/5.4/bin/languagetool -l en-US test.txt 2>&1
Error: languagetool: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /Message:\ Use\ \?a\?\ instead\ of\ \?an\?/ to match "Picked up _JAVA_OPTIONS: -Duser.home=/home/linuxbrew/.cache/Homebrew/java_cache -Djava.io.tmpdir=/tmp\nExpected text language: English (US)\nWorking on test.txt...\n1.) Line 1, column 19, Rule ID: EN_A_VS_AN prio=-1\nMessage: Use “a” instead of ‘an’ if the following word doesn’t start with a vowel sound, e.g. ‘a sentence’, ‘a university’.\nSuggestion: a\nHomebrew, this is an test \n                  ^^      \nTime: 2897ms for 1 sentences (0.3 sentences/sec)\n".
```