### PR TITLE
zmap: fix build for Linux

### DIFF
--- a/Formula/zmap.rb
+++ b/Formula/zmap.rb
@@ -23,6 +23,9 @@ class Zmap < Formula
   depends_on "json-c"
   depends_on "libdnet"
 
+  uses_from_macos "flex" => :build
+  uses_from_macos "libpcap"
+
   # fix json-c 0.14 compat
   # ref PR, https://github.com/zmap/zmap/pull/609
   patch :DATA


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3158638075?check_suite_focus=true
```
[ 26%] Generating lexer.c
make[2]: Entering directory '/tmp/zmap-20210726-5421-1165new/zmap-2.1.1'
cd /tmp/zmap-20210726-5421-1165new/zmap-2.1.1/src && flex -o /tmp/zmap-20210726-5421-1165new/zmap-2.1.1/src/lexer.c --header-file="/tmp/zmap-20210726-5421-1165new/zmap-2.1.1/src/lexer.h" /tmp/zmap-20210726-5421-1165new/zmap-2.1.1/src/lexer.l
/bin/sh: 1: flex: not found
src/CMakeFiles/zmap.dir/build.make:80: recipe for target 'src/lexer.c' failed
make[2]: *** [src/lexer.c] Error 127
make[2]: Leaving directory '/tmp/zmap-20210726-5421-1165new/zmap-2.1.1'
CMakeFiles/Makefile2:174: recipe for target 'src/CMakeFiles/zmap.dir/all' failed
make[1]: *** [src/CMakeFiles/zmap.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```