### PR TITLE
bash_unit 1.7.2 (new formula)

### DIFF
--- a/Formula/bash_unit.rb
+++ b/Formula/bash_unit.rb
@@ -1,0 +1,24 @@
+class BashUnit < Formula
+  desc "Bash unit testing enterprise edition framework for professionals"
+  homepage "https://github.com/pgrange/bash_unit"
+  url "https://github.com/pgrange/bash_unit/archive/refs/tags/v1.7.2.tar.gz"
+  sha256 "eabb078da18eb4c4eb1db8211d1197bd651e1d837466218338059cc590e33958"
+  license "GPL-3.0-only"
+
+  uses_from_macos "bc" => :test
+
+  def install
+    bin.install "bash_unit"
+    man1.install "docs/man/man1/bash_unit.1"
+  end
+
+  test do
+    (testpath/"test.sh").write <<~EOS
+      test_addition() {
+        RES="$(echo 2+2 | bc)"
+        assert_equals "${RES}" "4"
+      }
+    EOS
+    assert "addition", shell_output("#{bin}/bash_unit test.sh")
+  end
+end


### PR DESCRIPTION
Hello! Hereby suggesting to add [bash_unit](https://github.com/pgrange/bash_unit) for inclusion in homebrew. `bash_unit` is a unit testing framework for bash that produces tap output. It is simple to use and has been around for a few years. I cannot account for the "enterprise" in the description, but it's been working out great for me in a few open source projects and thought that others could benefit from it being in the tree.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
