### PR TITLE
pangomm: fix build for Linux

### DIFF
--- a/Formula/pangomm.rb
+++ b/Formula/pangomm.rb
@@ -19,6 +19,12 @@ class Pangomm < Formula
   depends_on "glibmm"
   depends_on "pango"
 
+  on_linux do
+    depends_on "gcc" => :build
+  end
+
+  fails_with gcc: "5"
+
   def install
     ENV.cxx11
 
@@ -28,6 +34,7 @@ class Pangomm < Formula
       system "ninja", "install"
     end
   end
+
   test do
     (testpath/"test.cpp").write <<~EOS
       #include <pangomm.h>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3173215443?check_suite_focus=true
```
In file included from /home/linuxbrew/.linuxbrew/Cellar/glibmm/2.68.1/include/glibmm-2.68/glibmm.h:103:0,
                 from ../untracked/pango/pangomm/cairofontmap.cc:4:
/home/linuxbrew/.linuxbrew/Cellar/glibmm/2.68.1/include/glibmm-2.68/glibmm/binding.h:27:20: fatal error: optional: No such file or directory
compilation terminated.
```