### PR TITLE
clamz: add missing linux dependencies

### DIFF
--- a/Formula/clamz.rb
+++ b/Formula/clamz.rb
@@ -3,6 +3,7 @@ class Clamz < Formula
   homepage "https://code.google.com/archive/p/clamz/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/clamz/clamz-0.5.tar.gz"
   sha256 "5a63f23f15dfa6c2af00ff9531ae9bfcca0facfe5b1aa82790964f050a09832b"
+  license "GPL-3.0-or-later"
   revision 1
 
   bottle do
@@ -18,6 +19,10 @@ class Clamz < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libgcrypt"
+  depends_on "libgpg-error"
+
+  uses_from_macos "curl"
+  uses_from_macos "expat"
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`libgpg-error` is an indirect dependency with linkage (already present in current macOS bottles), `curl` and `expat` provided by macOS but not available on Linux by default.