### PR TITLE
libgweather: fix test for Linux

### DIFF
--- a/Formula/libgweather.rb
+++ b/Formula/libgweather.rb
@@ -98,10 +98,12 @@ class Libgweather < Formula
       -lgobject-2.0
       -lgtk-3
       -lgweather-3
-      -lintl
       -lpango-1.0
       -lpangocairo-1.0
     ]
+    on_macos do
+      flags << "-lintl"
+    end
     system ENV.cc, "-DGWEATHER_I_KNOW_THIS_IS_UNSTABLE=1", "test.c", "-o", "test", *flags
     system "./test"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3177370360?check_suite_focus=true
```
==> /usr/bin/gcc-5 -DGWEATHER_I_KNOW_THIS_IS_UNSTABLE=1 test.c -o test -I/home/linuxbrew/.linuxbrew/opt/atk/include/atk-1.0 -I/home/linuxbrew/.linuxbrew/opt/cairo/include/cairo -I/home/linuxbrew/.linuxbrew/opt/fontconfig/include -I/home/linuxbrew/.linuxbrew/opt/freetype/include/freetype2 -I/home/linuxbrew/.linuxbrew/opt/gdk-pixbuf/include/gdk-pixbuf-2.0 -I/home/linuxbrew/.linuxbrew/opt/gettext/include -I/home/linuxbrew/.linuxbrew/opt/glib/include/gio-unix-2.0/ -I/home/linuxbrew/.linuxbrew/opt/glib/include/glib-2.0 -I/home/linuxbrew/.linuxbrew/opt/glib/lib/glib-2.0/include -I/home/linuxbrew/.linuxbrew/opt/gtk+3/include/gtk-3.0 -I/home/linuxbrew/.linuxbrew/opt/harfbuzz/include/harfbuzz -I/home/linuxbrew/.linuxbrew/Cellar/libgweather/40.0/include/libgweather-3.0 -I/home/linuxbrew/.linuxbrew/opt/libepoxy/include -I/home/linuxbrew/.linuxbrew/opt/libpng/include/libpng16 -I/home/linuxbrew/.linuxbrew/opt/libsoup/include/libsoup-2.4 -I/home/linuxbrew/.linuxbrew/opt/pango/include/pango-1.0 -I/home/linuxbrew/.linuxbrew/opt/pixman/include/pixman-1 -D_REENTRANT -L/home/linuxbrew/.linuxbrew/opt/atk/lib -L/home/linuxbrew/.linuxbrew/opt/cairo/lib -L/home/linuxbrew/.linuxbrew/opt/gdk-pixbuf/lib -L/home/linuxbrew/.linuxbrew/opt/gettext/lib -L/home/linuxbrew/.linuxbrew/opt/glib/lib -L/home/linuxbrew/.linuxbrew/opt/gtk+3/lib -L/home/linuxbrew/.linuxbrew/Cellar/libgweather/40.0/lib -L/home/linuxbrew/.linuxbrew/opt/pango/lib -latk-1.0 -lcairo -lcairo-gobject -lgdk-3 -lgdk_pixbuf-2.0 -lgio-2.0 -lglib-2.0 -lgobject-2.0 -lgtk-3 -lgweather-3 -lintl -lpango-1.0 -lpangocairo-1.0
Error: test failed
/home/linuxbrew/.linuxbrew/bin/ld: cannot find -lintl
collect2: error: ld returned 1 exit status
Error: libgweather: failed
```