### PR TITLE
pnpm: add livecheck

### DIFF
--- a/Formula/pnpm.rb
+++ b/Formula/pnpm.rb
@@ -7,6 +7,11 @@ class Pnpm < Formula
   sha256 "11311440f52a8770fa18fdc0e95d8627b06c1a0ef89f9a7f8f7a24a5a6d217d5"
   license "MIT"
 
+  livecheck do
+    url "https://registry.npmjs.org/pnpm/latest"
+    regex(/["']version["']:\s*?["']([^"']+)["']/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "5e39cef7fd1b8e8715d678470b119052843d59fd7421c407fcdff24af3011044"
     sha256 cellar: :any_skip_relocation, big_sur:       "cbb69e29ac9cd2b924e9e1e8768a22798465e35ec48e0da244df1c8d57d4ddf6"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #81966, where livecheck was using the `Npm` strategy by default to obtain version information for `pnpm` but the newest version from livecheck (`6.11.0`) was above the "latest" version reported on npm (`6.10.3`). This PR adds a `livecheck` block that checks the `/latest` JSON endpoint for the `pnpm` package on `registry.npmjs.org` and identifies the "latest" version from the `version` field. With this change, livecheck gives `6.10.3` instead of `6.11.0` as the newest version.

---

I checked the other formulae using the `Npm` strategy and the only other formula where the "latest" version differs from the newest version given by livecheck is `cdk8s`. However, in the case of `cdk8s`, the `Npm` strategy provides the correct latest version and checking the `/latest` endpoint fails because the "latest" version is unstable and livecheck filters the version out (leading to an `Unable to get versions` error).

Looking to the future, it would be nice to add configuration options to the `Npm` strategy that make it easy to select the behavior of the strategy (e.g., using the current approach or, alternatively, checking the `/latest` endpoint) but I need to create a PR for related livecheck work first to be able to implement this idea. This would allow us to check `/latest` when it's appropriate while also allowing us to use the current behavior when that's better (e.g., with `cdk8s`).