### PR TITLE
dotnet + dependent formulae: add `depends_on arch: :x86_64`

### DIFF
--- a/Formula/archi-steam-farm.rb
+++ b/Formula/archi-steam-farm.rb
@@ -17,6 +17,7 @@ class ArchiSteamFarm < Formula
     sha256 cellar: :any_skip_relocation, all: "10439853b50da7d457721024536f97d522703684da732e256ff73faf4f9a9b51"
   end
 
+  depends_on arch: :x86_64 # dotnet does not support ARM
   depends_on "dotnet"
 
   def install

--- a/Formula/dafny.rb
+++ b/Formula/dafny.rb
@@ -18,6 +18,7 @@ class Dafny < Formula
 
   depends_on "gradle" => :build
   depends_on "nuget" => :build
+  depends_on arch: :x86_64 # dotnet does not support ARM
   depends_on "dotnet"
   depends_on "openjdk@11"
 

--- a/Formula/dotnet.rb
+++ b/Formula/dotnet.rb
@@ -21,6 +21,7 @@ class Dotnet < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on xcode: :build
+  depends_on arch: :x86_64
   depends_on "curl"
   depends_on "icu4c"
   depends_on "openssl@1.1"

--- a/Formula/gitversion.rb
+++ b/Formula/gitversion.rb
@@ -11,6 +11,7 @@ class Gitversion < Formula
     sha256 cellar: :any, mojave:   "85042a5e5f3791e1b07e9ee944c8a1217f3403836e7bac14793d1b37bb1fa906"
   end
 
+  depends_on arch: :x86_64 # dotnet does not support ARM
   depends_on "dotnet"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These formulae are being tested on ARM (e.g. #82025), causing spurious failures. Making as syntax-only, since this change has no impact on the built bottles.