### PR TITLE
duckdb: fix build on Linux + repo URL

### DIFF
--- a/Formula/duckdb.rb
+++ b/Formula/duckdb.rb
@@ -1,7 +1,7 @@
 class Duckdb < Formula
   desc "Embeddable SQL OLAP Database Management System"
   homepage "https://www.duckdb.org"
-  url "https://github.com/cwida/duckdb.git",
+  url "https://github.com/duckdb/duckdb.git",
       tag:      "v0.2.7",
       revision: "8bc050d05b25a379efdaa537bd801b712671a83b"
   license "MIT"
@@ -16,7 +16,17 @@ class Duckdb < Formula
   depends_on "cmake" => :build
   depends_on "python@3.9" => :build
 
+  # Upstream PR to fix Linux amalgamation build: https://github.com/duckdb/duckdb/pull/2060
+  # Revisit for removal on next release
+  patch do
+    url "https://github.com/duckdb/duckdb/commit/405c21760dbad0940aa5ea1d9c121ac4cd866ab1.patch?full_index=1"
+    sha256 "184139de9cc7b696d5a0ef28f4f76ef5552f904198473f4e1ed7bdedfd93a535"
+  end
+
   def install
+    on_linux do
+      ENV.deparallelize # amalgamation builds take GBs of RAM
+    end
     mkdir "build/amalgamation"
     system Formula["python@3.9"].opt_bin/"python3", "scripts/amalgamation.py"
     cd "build/amalgamation" do


### PR DESCRIPTION
Amalgamation builds fail on Linux due to missing CMake variable (`CMAKE_DL_LIBS`).

Also ~~switched from Git to tarball sources (no diff between v0.2.7 checkout and v0.2.7 tarball), and~~ fixed base repo URL (old repo redirects to current one). My bad, forgot to rebuild _after_ this change, turns out the amalgamation script requires a Git repo.

NOTE: No revision bump because `CMAKE_DL_LIBS` is empty on macOS, so only Linux builds are affected:
```
linux$ cmake --system-information | grep DL_LIBS
CMAKE_DL_LIBS == "dl"
CMAKE_DL_LIBS "dl"

macos$ cmake --system-information | grep DL_LIBS
CMAKE_DL_LIBS == ""
CMAKE_DL_LIBS ""
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
