### PR TITLE
gitversion: remove non-native binaries for Linux

### DIFF
--- a/Formula/gitversion.rb
+++ b/Formula/gitversion.rb
@@ -15,16 +15,21 @@ class Gitversion < Formula
   depends_on "dotnet"
 
   def install
-    system "dotnet", "publish",
+    os = "osx"
+    on_linux do
+      os = "linux"
+    end
+
+    system "dotnet", "publish", "src/GitVersion.App/GitVersion.App.csproj",
            "--configuration", "Release",
            "--framework", "net#{Formula["dotnet"].version.major_minor}",
            "--output", libexec,
-           "src/GitVersion.App/GitVersion.App.csproj"
+           "--runtime", "#{os}-x64",
+           "--self-contained", "false",
+           "/p:PublishSingleFile=true"
 
-    (bin/"gitversion").write <<~EOS
-      #!/bin/sh
-      exec "#{Formula["dotnet"].opt_bin}/dotnet" "#{libexec}/gitversion.dll" "$@"
-    EOS
+    env = { DOTNET_ROOT: "${DOTNET_ROOT:-#{Formula["dotnet"].opt_libexec}}" }
+    (bin/"gitversion").write_env_script libexec/"gitversion", env
   end
 
   test do

--- a/audit_exceptions/universal_binary_allowlist.json
+++ b/audit_exceptions/universal_binary_allowlist.json
@@ -3,6 +3,7 @@
   "babel",
   "contentful-cli",
   "gatsby-cli",
+  "gitversion",
   "infer",
   "llvm",
   "llvm@11",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3177403114?check_suite_focus=true
```
==> FAILED
Error: 1 problem in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
gitversion:
  * Binaries built for a non-native architecture were installed into gitversion's prefix.
    The offending files are:
      /home/linuxbrew/.linuxbrew/Cellar/gitversion/5.6.11/libexec/runtimes/linux-arm/native/libgit2-6777db8.so	(arm)
      /home/linuxbrew/.linuxbrew/Cellar/gitversion/5.6.11/libexec/runtimes/linux-arm64/native/libgit2-6777db8.so	(arm64)

...

==> brew linkage --test gitversion
==> FAILED
Missing libraries:
  unexpected (libc.musl-x86_64.so.1)

```
