### PR TITLE
notcurses 2.3.12 (new formula)

### DIFF
--- a/Formula/notcurses.rb
+++ b/Formula/notcurses.rb
@@ -1,0 +1,33 @@
+class Notcurses < Formula
+  desc "Blingful character graphics/TUI library"
+  homepage "https://nick-black.com/dankwiki/index.php/Notcurses"
+  url "https://github.com/dankamongmen/notcurses/archive/refs/tags/v2.3.12.tar.gz"
+  sha256 "ce042908fac11f7df1f9eaa610e46e9c615f53ab036b7c27ae2396292512407b"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "doctest" => :build
+  depends_on "pandoc" => :build
+  depends_on "pkg-config" => :build
+  depends_on "ffmpeg"
+  depends_on "libunistring"
+  depends_on macos: :catalina # requires std::filesystem
+  depends_on "ncurses"
+  depends_on "readline"
+  uses_from_macos "zlib"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    # without the TERM definition, Notcurses is like a small child, lost in a
+    # horrible mall. of course, if the tests are run in some non-xterm
+    # environment, this choice might prove unfortunate.
+    # you have no chance to survive. make your time.
+    ENV["TERM"] = "xterm"
+    assert_match "notcurses", shell_output("#{bin}/notcurses-info")
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
  -**Yes**, including the line
  > We frown on authors submitting their own work unless it is very popular.

  I asked for a clarification regarding this at https://github.com/Homebrew/discussions/discussions/1893, and believe it not to be an issue.
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
  -**Yes**, but I had to do two gross things. I export a `TERM` of `xterm`, as otherwise there is no `TERM`. I ought be pulling in `TERM` from the environment, where it ought always be set. Two, I redirect stdout (*not* stderr) to `/dev/null`, as otherwise the test process blows up (`notcurses-tester` generates a lot of output).
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
  -**No. I get the output `Dependency 'ncurses' is provided by macOS; please replace 'depends_on' with 'uses_from_macos'.`** I want `ncurses` from homebrew, though. Is this the incorrect way to specify that? I'm using `uses_from_macos` for `zlib`, as you can see.
-----
