### PR TITLE
docker-machine-driver-hyperkit: deprecate as it is unmaintained

### DIFF
--- a/Formula/docker-machine-driver-hyperkit.rb
+++ b/Formula/docker-machine-driver-hyperkit.rb
@@ -15,6 +15,8 @@ class DockerMachineDriverHyperkit < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:  "92bef33ec9ad5fbdfb887fcabe550603c886065c8ec3c677732a55f84a4c7520"
   end
 
+  deprecate! date: "2021-07-29", because: :unmaintained
+  
   depends_on "dep" => :build
   depends_on "go" => :build
   depends_on "docker-machine"

--- a/Formula/docker-machine-driver-hyperkit.rb
+++ b/Formula/docker-machine-driver-hyperkit.rb
@@ -17,7 +17,6 @@ class DockerMachineDriverHyperkit < Formula
 
   deprecate! date: "2021-07-29", because: :unmaintained
 
-  depends_on "dep" => :build
   depends_on "go" => :build
   depends_on "docker-machine"
 
@@ -29,7 +28,8 @@ class DockerMachineDriverHyperkit < Formula
     dir.install buildpath.children
 
     cd dir do
-      system "dep", "ensure", "-vendor-only"
+      system "go", "mod", "init", "github.com/machine-drivers/docker-machine-driver-hyperkit"
+      system "go", "mod", "tidy"
       system "go", "build", "-o", "#{bin}/docker-machine-driver-hyperkit",
              "-ldflags", "-X main.version=#{version}"
       prefix.install_metafiles

--- a/Formula/docker-machine-driver-hyperkit.rb
+++ b/Formula/docker-machine-driver-hyperkit.rb
@@ -16,7 +16,7 @@ class DockerMachineDriverHyperkit < Formula
   end
 
   deprecate! date: "2021-07-29", because: :unmaintained
-  
+
   depends_on "dep" => :build
   depends_on "go" => :build
   depends_on "docker-machine"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
