### PR TITLE
jabba: Fix jdk path in test for Linux

### DIFF
--- a/Formula/jabba.rb
+++ b/Formula/jabba.rb
@@ -39,7 +39,8 @@ class Jabba < Formula
 
     system bin/"jabba", "install", jdk_version
     jdk_path = shell_output("#{bin}/jabba which #{jdk_version}").strip
+    on_macos { jdk_path = "#{jdk_path}/Contents/Home" }
     assert_match version_check,
-                 shell_output("#{jdk_path}/Contents/Home/bin/java -version 2>&1")
+                 shell_output("#{jdk_path}/bin/java -version 2>&1")
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
