### PR TITLE
sql-lint 0.0.19 (new formula)

### DIFF
--- a/Formula/sql-lint.rb
+++ b/Formula/sql-lint.rb
@@ -1,0 +1,24 @@
+require "language/node"
+
+class SqlLint < Formula
+  desc "SQL linter to do sanity checks on your queries and bring errors back from the DB"
+  homepage "https://github.com/joereynolds/sql-lint"
+  url "https://registry.npmjs.org/sql-lint/-/sql-lint-0.0.19.tgz"
+  sha256 "af38df9ffdea1647fa677b1fae1897c91c787455b1be8654f07c6866da09798e"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    (testpath/"pg-enum.sql").write("CREATE TYPE status AS ENUM ('to-do', 'in-progress', 'done');")
+    output = shell_output("#{bin}/sql-lint -d postgres pg-enum.sql", 0)
+    (testpath/"invalid-delete.sql").write("DELETE FROM table-epbdlrsrkx;")
+    output = shell_output("#{bin}/sql-lint invalid-delete.sql", 1)
+    assert_match "missing-where", output
+  end
+end

--- a/Formula/sql-lint.rb
+++ b/Formula/sql-lint.rb
@@ -16,7 +16,8 @@ class SqlLint < Formula
 
   test do
     (testpath/"pg-enum.sql").write("CREATE TYPE status AS ENUM ('to-do', 'in-progress', 'done');")
-    output = shell_output("#{bin}/sql-lint -d postgres pg-enum.sql", 0)
+    output = shell_output("#{bin}/sql-lint -d postgres pg-enum.sql")
+    assert_equal "", output
     (testpath/"invalid-delete.sql").write("DELETE FROM table-epbdlrsrkx;")
     output = shell_output("#{bin}/sql-lint invalid-delete.sql", 1)
     assert_match "missing-where", output


### PR DESCRIPTION
Enable install of the sql-lint tool.

sql-lint will do sanity checks on your queries
as well as bring errors back from the DB.

Tests:

- test that a postgres enum creation is valid
- test that a syntactically invalid statement exits > 0

Closes https://github.com/joereynolds/sql-lint/issues/94.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
