### PR TITLE
influxdb-cli 2.1.0 (new formula)

### DIFF
--- a/Formula/influxdb-cli.rb
+++ b/Formula/influxdb-cli.rb
@@ -1,0 +1,62 @@
+class InfluxdbCli < Formula
+  desc "CLI for managing resources in InfluxDB v2"
+  homepage "https://influxdata.com/time-series-platform/influxdb/"
+  url "https://github.com/influxdata/influx-cli.git",
+      tag:      "v2.1.0",
+      revision: "e6cad1b4aa05a801e1206496c3369246794555e0"
+  license "MIT"
+  head "https://github.com/influxdata/influx-cli.git"
+
+  livecheck do
+    url :stable
+    regex(/^v?((?!9\.9\.9)\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "go" => :build
+  depends_on "influxdb" => :test
+
+  def install
+    ldflags = %W[
+      -s
+      -w
+      -X main.version=#{version}
+      -X main.commit=#{Utils.git_short_head(length: 10)}
+      -X main.date=#{time.iso8601}
+    ].join(" ")
+
+    system "go", "build", *std_go_args(ldflags: ldflags),
+           "-o", bin/"influx", "./cmd/influx"
+  end
+
+  test do
+    # Boot a test server.
+    influxd_port = free_port
+    influxd = fork do
+      exec "influxd", "--bolt-path=#{testpath}/influxd.bolt",
+                      "--engine-path=#{testpath}/engine",
+                      "--http-bind-address=:#{influxd_port}",
+                      "--log-level=error"
+    end
+    sleep 30
+
+    # Configure the CLI for the test env.
+    influx_host = "http://localhost:#{influxd_port}"
+    cli_configs_path = "#{testpath}/influx-configs"
+    ENV["INFLUX_HOST"] = influx_host
+    ENV["INFLUX_CONFIGS_PATH"] = cli_configs_path
+
+    # Check that the CLI can connect to the server.
+    assert_match "OK", shell_output("#{bin}/influx ping")
+
+    # Perform initial DB setup.
+    system "#{bin}/influx", "setup", "-u", "usr", "-p", "fakepassword", "-b", "bkt", "-o", "org", "-f"
+
+    # Assert that initial resources show in CLI output.
+    assert_match "usr", shell_output("#{bin}/influx user list")
+    assert_match "bkt", shell_output("#{bin}/influx bucket list")
+    assert_match "org", shell_output("#{bin}/influx org list")
+  ensure
+    Process.kill("TERM", influxd)
+    Process.wait influxd
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We've moved the `influx` CLI into its own GitHub repository, so it can be installed on its own / so we can release fixes and features to it more frequently. This creates a new `influxdb-cli` formula, removes the CLI from the existing `influxdb` formula, and updates `influxdb` to depend on `influxdb-cli`.

Closes influxdata/influx-cli#211