### PR TITLE
fastme: add livecheck

### DIFF
--- a/Formula/fastme.rb
+++ b/Formula/fastme.rb
@@ -5,6 +5,11 @@ class Fastme < Formula
   sha256 "ac05853bc246ccb3d88b8bc075709a82cfe096331b0f4682b639f37df2b30974"
   revision 3
 
+  livecheck do
+    url "https://gite.lirmm.fr/atgc/FastME.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256                               arm64_big_sur: "a63f7a94429ad21604091dbec3fa347d83c81f335a0e112e3a601975c26593f3"
     sha256 cellar: :any,                 big_sur:       "57efef94306e3b9dcbaa2b91289951b545b4ae49cdfe14fb444903e145485a49"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `fastme`. This PR adds a `livecheck` block that checks the Git tags in the repository the `stable` archive is from. I haven't added this URL as `head` because `brew install --HEAD` doesn't seem likely to work, as some of the essential build files are symlinks.

It may be worth noting that there's currently a `fastme-2.1.6.2.tar.gz` file in the `/tarball` directory but `2.1.6.2` wasn't tagged, so I'm leaving it at `2.1.6.1` for now.