### PR TITLE
smimesign: add `depends_on :macos`

### DIFF
--- a/Formula/smimesign.rb
+++ b/Formula/smimesign.rb
@@ -14,6 +14,7 @@ class Smimesign < Formula
   end
 
   depends_on "go" => :build
+  depends_on :macos
 
   def install
     system "go", "build", *std_go_args, "-ldflags", "-X main.versionString=#{version}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Only for macOS and Windows.
Has dependency on `certstore`: https://github.com/github/certstore/blob/main/certstore_linux.go
```go
// This will hopefully give a compiler error that will hint at the fact that
// this package isn't designed to work on Linux.
func init() {
	CERTSTORE_DOESNT_WORK_ON_LINIX
}
```