### PR TITLE
i2c-tools (new formula), liquidctl: fix build for Linux and use hidapi formula

### DIFF
--- a/Formula/i2c-tools.rb
+++ b/Formula/i2c-tools.rb
@@ -1,0 +1,29 @@
+class I2cTools < Formula
+  desc "Heterogeneous set of I2C tools for Linux"
+  homepage "https://i2c.wiki.kernel.org/index.php/I2C_Tools"
+  url "https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/i2c-tools-4.3.tar.xz"
+  sha256 "1f899e43603184fac32f34d72498fc737952dbc9c97a8dd9467fadfdf4600cf9"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
+
+  livecheck do
+    url "https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/"
+    regex(/href=.*?i2c-tools[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  depends_on "python@3.9" => [:build, :test]
+  depends_on :linux
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}", "EXTRA=eeprog"
+    cd "py-smbus" do
+      system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
+    end
+  end
+
+  test do
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "import smbus"
+    assert_equal "", shell_output("#{sbin}/i2cdetect -l 2>&1").strip
+    assert_match "/dev/i2c/0': No such file or directory", shell_output("#{sbin}/i2cget -y 0 0x08 2>&1", 1)
+    assert_match "No EEPROM found", shell_output("#{bin}/decode-dimms 2>&1")
+  end
+end

--- a/Formula/liquidctl.rb
+++ b/Formula/liquidctl.rb
@@ -6,6 +6,7 @@ class Liquidctl < Formula
   url "https://files.pythonhosted.org/packages/cb/53/6edf9da254d2e80580b116c45a7c50edaf055917bf6d771185a5adf52d2a/liquidctl-1.7.1.tar.gz"
   sha256 "10f650b9486ddac184330940550433685ae0abc70b66fe92d994042491aab356"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/liquidctl/liquidctl.git", branch: "main"
 
   bottle do
@@ -15,8 +16,13 @@ class Liquidctl < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "183f8183b103bab0039f9fc4e6037fba950551ffbf66ce770a4231538c520e75"
   end
 
+  depends_on "hidapi"
   depends_on "libusb"
   depends_on "python@3.9"
+
+  on_linux do
+    depends_on "i2c-tools"
+  end
 
   resource "colorlog" do
     url "https://files.pythonhosted.org/packages/07/d4/ac5127f7d7e022caf740b9f624e5b9fe9a69fefc0f4f9c047b1e9298c87a/colorlog-5.0.1.tar.gz"
@@ -43,13 +49,30 @@ class Liquidctl < Formula
     ENV["DIST_NAME"] = "homebrew"
     ENV["DIST_PACKAGE"] = "liquidctl #{version}"
 
-    virtualenv_install_with_resources
+    venv = virtualenv_create(libexec, "python3")
+
+    resource("hidapi").stage do
+      inreplace "setup.py" do |s|
+        s.gsub! "/usr/include/libusb-1.0", "#{Formula["libusb"].opt_include}/libusb-1.0"
+        s.gsub! "/usr/include/hidapi", "#{Formula["hidapi"].opt_include}/hidapi"
+      end
+      system libexec/"bin/python3", *Language::Python.setup_install_args(libexec), "--with-system-hidapi"
+    end
+
+    venv.pip_install resources.reject { |r| r.name == "hidapi" }
+    venv.pip_install_and_link buildpath
 
     man_page = buildpath/"liquidctl.8"
     # setting the is_macos register to 1 adjusts the man page for macOS
-    inreplace man_page, ".nr is_macos 0", ".nr is_macos 1"
+    on_macos do
+      inreplace man_page, ".nr is_macos 0", ".nr is_macos 1"
+    end
     man.mkpath
     man8.install man_page
+
+    on_linux do
+      (lib/"udev/rules.d").install Dir["extra/linux/*.rules"]
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3041664735?check_suite_focus=true
```
    building 'hid' extension
    creating build
    creating build/temp.linux-x86_64-3.9
    creating build/temp.linux-x86_64-3.9/hidapi
    creating build/temp.linux-x86_64-3.9/hidapi/libusb
    gcc-5 -Wno-unused-result -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -Ihidapi/hidapi -I/usr/include/libusb-1.0 -I/home/linuxbrew/.linuxbrew/include -I/home/linuxbrew/.linuxbrew/opt/openssl@1.1/include -I/home/linuxbrew/.linuxbrew/opt/sqlite/include -I/home/linuxbrew/.linuxbrew/Cellar/liquidctl/1.7.0/libexec/include -I/home/linuxbrew/.linuxbrew/opt/python@3.9/include/python3.9 -c hid.c -o build/temp.linux-x86_64-3.9/hid.o
    gcc-5 -Wno-unused-result -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -Ihidapi/hidapi -I/usr/include/libusb-1.0 -I/home/linuxbrew/.linuxbrew/include -I/home/linuxbrew/.linuxbrew/opt/openssl@1.1/include -I/home/linuxbrew/.linuxbrew/opt/sqlite/include -I/home/linuxbrew/.linuxbrew/Cellar/liquidctl/1.7.0/libexec/include -I/home/linuxbrew/.linuxbrew/opt/python@3.9/include/python3.9 -c hidapi/libusb/hid.c -o build/temp.linux-x86_64-3.9/hidapi/libusb/hid.o
    hidapi/libusb/hid.c:47:20: fatal error: libusb.h: No such file or directory
    compilation terminated.
    error: command '/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/gcc-5' failed with exit code 1
    Running setup.py install for hidapi: finished with status 'error'
ERROR: Command errored out with exit status 1: /home/linuxbrew/.linuxbrew/Cellar/liquidctl/1.7.0/libexec/bin/python3.9 -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-_vuc02rg/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-_vuc02rg/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-g05le9nn/install-record.txt --single-version-externally-managed --compile --install-headers /home/linuxbrew/.linuxbrew/Cellar/liquidctl/1.7.0/libexec/include/site/python3.9/hidapi Check the logs for full command output.
```