### PR TITLE
encfs: depend on libfuse@2 for Linux

### DIFF
--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -26,7 +26,7 @@ class Encfs < Formula
   end
 
   on_linux do
-    depends_on "libfuse"
+    depends_on "libfuse@2"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3037317347?check_suite_focus=true
```
-- Detecting CXX compile features - done
CMake Error at /home/linuxbrew/.linuxbrew/Cellar/cmake/3.20.5/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find FUSE (missing: FUSE_INCLUDE_DIR FUSE_LIBRARIES)
Call Stack (most recent call first):
  /home/linuxbrew/.linuxbrew/Cellar/cmake/3.20.5/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  cmake/FindFUSE.cmake:29 (find_package_handle_standard_args)
  CMakeLists.txt:98 (find_package)
```
