### PR TITLE
workflows/tests: enable use of a `CI-force-dependents-tests` label

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,14 @@ jobs:
               core.setOutput('fail-fast', 'true')
             }
 
+            if (label_names.includes('CI-force-dependents-tests')) {
+              console.log('CI-force-dependents-tests label found. Testing dependents despite failing tests for any modified formulae.')
+              core.setOutput('force-dependents-tests', 'true')
+            } else {
+              console.log('No CI-force-dependents-tests label found. Skipping dependents if any test for a modified formula fails.')
+              core.setOutput('force-dependents-tests', 'false')
+            }
+
             if (label_names.includes('CI-long-timeout')) {
               console.log('CI-long-timeout label found. Setting long GitHub Actions timeout.')
               core.setOutput('timeout-minutes', '4320')
@@ -247,6 +255,7 @@ jobs:
           rm bottles/steps_output.txt
 
       - name: Run brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
+        if: success() || ${{ fromJson(needs.setup_tests.outputs.force-dependents-tests) }}
         run: |
           if [ "$RUNNER_OS" = 'macOS' ]; then
             cd bottles


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently, CI skips dependents if the formula tests fail for any reason.
This can be undesirable in PRs which require a large number of revision
bumps (e.g. `icu4c`, `boost`, or `libffi`), or when failures are due to
transient networks issues or other issues that can be more easily
addressed in separate PRs (e.g. some `livecheck` failures).

This should allow us to make use of a label that will force CI to
continue attempting to test dependents even when the tests of the
modified formula fails.

-----

Not sure if this does what I intend this to yet, but if this change makes sense I can test it out to check.