### PR TITLE
hamlib: use gcc for Linux

### DIFF
--- a/Formula/hamlib.rb
+++ b/Formula/hamlib.rb
@@ -19,6 +19,12 @@ class Hamlib < Formula
   depends_on "libtool"
   depends_on "libusb-compat"
 
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5"
+
   def install
     system "./bootstrap" if build.head?
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
Fixes:
In file included from rotclass.cc:36:0:
../include/hamlib/rotclass.h:42:20: error: expected ',' or '...' before '&&' token
     Rotator(Rotator&&) = default;

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
