### PR TITLE
gpredict: Fix build for Linux

### DIFF
--- a/Formula/gpredict.rb
+++ b/Formula/gpredict.rb
@@ -29,15 +29,24 @@ class Gpredict < Formula
   depends_on "gtk+3"
   depends_on "hamlib"
 
+  uses_from_macos "perl" => :build
   uses_from_macos "curl"
 
   def install
+    # Needed by intltool (xml::parser)
+    on_linux { ENV.prepend_path "PERL5LIB", "#{Formula["intltool"].libexec}/lib/perl5" }
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
   end
 
   test do
+    on_linux do
+      # Gtk-WARNING **: 20:21:55.071: cannot open display
+      return if ENV["HOMEBREW_GITHUB_ACTIONS"]
+    end
+
     assert_match "real-time", shell_output("#{bin}/gpredict -h")
   end
 end


### PR DESCRIPTION
Fixes:
checking for XML::Parser... configure: error: XML::Parser perl module is required for intltool

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
