### PR TITLE
log4shib: fix test for Linux

### DIFF
--- a/Formula/log4shib.rb
+++ b/Formula/log4shib.rb
@@ -27,7 +27,7 @@ class Log4shib < Formula
 
   test do
     cp_r (pkgshare/"test").children, testpath
-    system ENV.cxx, "-I#{include}", "-L#{lib}", "-llog4shib", "testConfig.cpp", "-o", "test"
+    system ENV.cxx, "testConfig.cpp", "-I#{include}", "-L#{lib}", "-llog4shib", "-o", "test", "-pthread"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3089340311?check_suite_focus=true
```
==> FAILED
==> Testing log4shib
==> /usr/bin/g++-5 -I/home/linuxbrew/.linuxbrew/Cellar/log4shib/2.0.0/include -L/home/linuxbrew/.linuxbrew/Cellar/log4shib/2.0.0/lib -llog4shib testConfig.cpp -o test
/tmp/ccwWn2vL.o: In function `main':
testConfig.cpp:(.text+0x18e): undefined reference to `log4shib::SimpleConfigurator::configure(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
testConfig.cpp:(.text+0x19f): undefined reference to `log4shib::Category::getRoot()'
testConfig.cpp:(.text+0x1d9): undefined reference to `log4shib::Category::getInstance(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
testConfig.cpp:(.text+0x22e): undefined reference to `log4shib::Category::getInstance(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
```