### PR TITLE
wellington: replace down homepage with GitHub url

### DIFF
--- a/Formula/wellington.rb
+++ b/Formula/wellington.rb
@@ -1,6 +1,6 @@
 class Wellington < Formula
   desc "Project-focused tool to manage Sass and spriting"
-  homepage "https://getwt.io/"
+  homepage "https://github.com/wellington/wellington"
   url "https://github.com/wellington/wellington/archive/v1.0.5.tar.gz"
   sha256 "e2379722849cdd8e5f094849290aacba4b789d4d65c733dec859565c728e7205"
   license "Apache-2.0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Originally seen ~2 weeks ago: https://github.com/Homebrew/homebrew-core/runs/3093722713?check_suite_focus=true
```
==> brew audit wellington --online --git --skip-style
==> FAILED
Error: 1 problem in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
wellington:
  * The homepage URL https://getwt.io/ is not reachable
```

Still down.