### PR TITLE
stubby: fix test for Linux

### DIFF
--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -18,6 +18,10 @@ class Stubby < Formula
   depends_on "getdns"
   depends_on "libyaml"
 
+  on_linux do
+    depends_on "bind" => :test
+  end
+
   def install
     system "cmake", "-DCMAKE_INSTALL_RUNSTATEDIR=#{HOMEBREW_PREFIX}/var/run/", \
                     "-DCMAKE_INSTALL_SYSCONFDIR=#{HOMEBREW_PREFIX}/etc", ".", *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3206393853?check_suite_focus=true
```
==> dig @127.0.0.1 -p 5553 getdnsapi.net
Killing child processes...
Error: stubby: failed
An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - dig
```

https://github.com/Homebrew/linuxbrew-core/issues/23986