### PR TITLE
beast: use java from JAVA_HOME on Linux

### DIFF
--- a/Formula/beast.rb
+++ b/Formula/beast.rb
@@ -24,12 +24,18 @@ class Beast < Formula
   depends_on "openjdk@11"
 
   def install
-    ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix
+    ENV["JAVA_HOME"] = Language::Java.java_home("11")
     system "ant", "linux"
     libexec.install Dir["release/Linux/BEASTv*/*"]
     pkgshare.install_symlink libexec/"examples"
     bin.install Dir[libexec/"bin/*"]
-    bin.env_script_all_files libexec/"bin", JAVA_HOME: ENV["JAVA_HOME"]
+
+    env = Language::Java.overridable_java_home_env("11")
+    on_linux do
+      env["PATH"] = "$JAVA_HOME/bin:$PATH"
+    end
+    bin.env_script_all_files libexec/"bin", env
+    inreplace libexec/"bin/beast", "/usr/local", HOMEBREW_PREFIX
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3206498667?check_suite_focus=true
```
==> brew test --verbose beast
==> FAILED
==> Testing beast
==> /home/linuxbrew/.linuxbrew/Cellar/beast/1.10.4_1/bin/beast testUCRelaxedClockLogNormal.xml
/home/linuxbrew/.linuxbrew/Cellar/beast/1.10.4_1/libexec/bin/beast: 26: /home/linuxbrew/.linuxbrew/Cellar/beast/1.10.4_1/libexec/bin/beast: java: not found
Error: beast: failed
An exception occurred within a child process:
  BuildError: Failed executing: /home/linuxbrew/.linuxbrew/Cellar/beast/1.10.4_1/bin/beast testUCRelaxedClockLogNormal.xml
```

https://github.com/Homebrew/homebrew-core/runs/3206794850
```
==> Testing beast
==> /home/linuxbrew/.linuxbrew/Cellar/beast/1.10.4_1/bin/beast testUCRelaxedClockLogNormal.xml
Picked up _JAVA_OPTIONS: -Duser.home=/home/linuxbrew/.cache/Homebrew/java_cache -Djava.io.tmpdir=/tmp
Failed to load BEAGLE library: no hmsbeagle-jni in java.library.path: [/home/linuxbrew/.linuxbrew/Cellar/beast/1.10.4_1/libexec/lib, /usr/local/lib, .]
```

Link as work item: https://github.com/Homebrew/linuxbrew-core/issues/23986