### PR TITLE
picat: port Linux changes + update sha256

### DIFF
--- a/Formula/picat.rb
+++ b/Formula/picat.rb
@@ -3,8 +3,9 @@ class Picat < Formula
   homepage "http://picat-lang.org/"
   url "http://picat-lang.org/download/picat31_src.tar.gz"
   version "3.1"
-  sha256 "093ca00f74a67a70ed8c5e42f3e3e29a43b761daa3cf9ca7d6bb216c401f4e72"
+  sha256 "c1ae1491d56e643693aa806c08c221d2cf0d59de1ddd8c31bcff1c917c979542"
   license "MPL-2.0"
+  revision 1
 
   livecheck do
     url "http://picat-lang.org/download.html"
@@ -18,7 +19,12 @@ class Picat < Formula
   end
 
   def install
-    system "make", "-C", "emu", "-f", "Makefile.mac64"
+    makefile = "Makefile.mac64"
+    on_linux do
+      ENV.cxx11
+      makefile = "Makefile.linux64"
+    end
+    system "make", "-C", "emu", "-f", makefile
     bin.install "emu/picat" => "picat"
     prefix.install "lib" => "pi_lib"
     doc.install Dir["doc/*"]


### PR DESCRIPTION
Revision bump because upstream made changes to the source tarball that also change the macOS bottles: https://groups.google.com/g/picat-lang/c/mfSyN9thVCE/m/efgJM2Y2AgAJ

Supporting Homebrew/linuxbrew-core#23986

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
