### PR TITLE
postgrest: build with `ghc`

### DIFF
--- a/Formula/postgrest.rb
+++ b/Formula/postgrest.rb
@@ -4,6 +4,7 @@ class Postgrest < Formula
   url "https://github.com/PostgREST/postgrest/archive/v8.0.0.tar.gz"
   sha256 "4a930900b59866c7ba25372fd93d2fbab5cdb52fc5fea5e481713b03a2d5e923"
   license "MIT"
+  revision 1
   head "https://github.com/PostgREST/postgrest.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Postgrest < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@8.8" => :build
+  depends_on "ghc" => :build
   depends_on "postgresql"
 
   def install


### PR DESCRIPTION
- [√] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [√] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [√] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [√] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [√] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [v] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I propose building Postgrest against the main ghc (8.10), rather than the older pinned version. 
It builds and runs fine on both intel and arm (Big Sur.) This is a gain, as ghc@8.8 does not run on M1 macs, and thus building Postgrest from source currently fails.
