### PR TITLE
chipmunk: fix test for Linux

### DIFF
--- a/Formula/chipmunk.rb
+++ b/Formula/chipmunk.rb
@@ -39,8 +39,8 @@ class Chipmunk < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "-pthread", "-I#{include}/chipmunk", "-L#{lib}", "-lchipmunk",
-           testpath/"test.c", "-o", testpath/"test"
+    system ENV.cc, testpath/"test.c", "-o", testpath/"test", "-pthread",
+                   "-I#{include}/chipmunk", "-L#{lib}", "-lchipmunk"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3052442411?check_suite_focus=true
```
==> FAILED
==> Testing chipmunk
==> /usr/bin/gcc-5 -pthread -I/home/linuxbrew/.linuxbrew/Cellar/chipmunk/7.0.3/include/chipmunk -L/home/linuxbrew/.linuxbrew/Cellar/chipmunk/7.0.3/lib -lchipmunk /tmp/chipmunk-test-20210713-5906-48z38u/test.c -o /tmp/chipmunk-test-20210713-5906-48z38u/test
/tmp/ccPa49oS.o: In function `main':
test.c:(.text+0x76): undefined reference to `cpSpaceNew'
test.c:(.text+0x98): undefined reference to `cpSpaceSetGravity'
test.c:(.text+0xa4): undefined reference to `cpSpaceFree'
collect2: error: ld returned 1 exit status
```