### PR TITLE
fleetctl: use GO111MODULE=auto to fix build

### DIFF
--- a/Formula/fleetctl.rb
+++ b/Formula/fleetctl.rb
@@ -23,6 +23,7 @@ class Fleetctl < Formula
 
   def install
     ENV["GOPATH"] = buildpath
+    ENV["GO111MODULE"] = "auto"
     system "./build"
     bin.install "bin/fleetctl"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3062557098?check_suite_focus=true
```
==> ./build
Building fleetd...
no required module provides package github.com/coreos/fleet: go.mod file not found in current directory or any parent directory; see 'go help modules'
```
