### PR TITLE
flickcurl: update urls to https

### DIFF
--- a/Formula/flickcurl.rb
+++ b/Formula/flickcurl.rb
@@ -1,7 +1,7 @@
 class Flickcurl < Formula
   desc "Library for the Flickr API"
-  homepage "http://librdf.org/flickcurl/"
-  url "http://download.dajobe.org/flickcurl/flickcurl-1.26.tar.gz"
+  homepage "https://librdf.org/flickcurl/"
+  url "https://download.dajobe.org/flickcurl/flickcurl-1.26.tar.gz"
   sha256 "ff42a36c7c1c7d368246f6bc9b7d792ed298348e5f0f5d432e49f6803562f5a3"
   license any_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3062557940?check_suite_focus=true
```
==> brew audit flickcurl --online --git --skip-style
==> FAILED
Error: 2 problems in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
flickcurl:
  * The homepage URL http://librdf.org/flickcurl/ should use HTTPS rather than HTTP
  * Stable: The source URL http://download.dajobe.org/flickcurl/flickcurl-1.26.tar.gz should use HTTPS rather than HTTP
```