### PR TITLE
ftjam: fix build for Linux

### DIFF
--- a/Formula/ftjam.rb
+++ b/Formula/ftjam.rb
@@ -3,6 +3,7 @@ class Ftjam < Formula
   homepage "https://www.freetype.org/jam/"
   url "https://downloads.sourceforge.net/project/freetype/ftjam/2.5.2/ftjam-2.5.2.tar.bz2"
   sha256 "e89773500a92912de918e9febffabe4b6bce79d69af194435f4e032b8a6d66a3"
+  license :cannot_represent
 
   # We check the "ftjam" directory page since versions aren't present in the
   # RSS feed as of writing.
@@ -21,6 +22,8 @@ class Ftjam < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:  "f94287203827dea6ac5031e695c217a48b1b69e939dcd68a489c8477b4100447"
     sha256 cellar: :any_skip_relocation, yosemite:    "95490ead99e537713d8c26d1c1bea72b31ea06153a405867ffe83c044593caa0"
   end
+
+  uses_from_macos "bison" => :build
 
   conflicts_with "jam", because: "both install a `jam` binary"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3062567638?check_suite_focus=true
```
Cc bin.unix/fileunix.o 
Cc bin.unix/pathunix.o 
Yacc1 jamgram.c jamgram.h 
/bin/sh: 2: yacc: not found

yacc -d jamgram.y

...failed Yacc1 jamgram.c jamgram.h ...
```