### PR TITLE
frobtads: add curl and ncurses as Linux runtime dependencies

### DIFF
--- a/Formula/frobtads.rb
+++ b/Formula/frobtads.rb
@@ -14,7 +14,8 @@ class Frobtads < Formula
     sha256 el_capitan:    "cff84f9389281d4ca9c9aae8ece93384aec506ea9601e1c3d637df82776afce3"
   end
 
-  uses_from_macos "curl" => :build
+  uses_from_macos "curl"
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3208026790?check_suite_focus=true
```
==> brew linkage --test frobtads
==> FAILED
Missing libraries:
  unexpected (libcurl.so.4)
  unexpected (libncursesw.so.6)
```