### PR TITLE
hiredis: fix test for Linux

### DIFF
--- a/Formula/hiredis.rb
+++ b/Formula/hiredis.rb
@@ -28,8 +28,8 @@ class Hiredis < Formula
   test do
     # running `./test` requires a database to connect to, so just make
     # sure it compiles
-    system ENV.cc, "-I#{include}/hiredis", "-L#{lib}", "-lhiredis",
-           pkgshare/"examples/example.c", "-o", testpath/"test"
+    system ENV.cc, pkgshare/"examples/example.c", "-o", testpath/"test",
+                   "-I#{include}/hiredis", "-L#{lib}", "-lhiredis"
     assert_predicate testpath/"test", :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3073781163?check_suite_focus=true
```
==> brew test --verbose hiredis
==> FAILED
==> Testing hiredis
==> /usr/bin/gcc-5 -I/home/linuxbrew/.linuxbrew/Cellar/hiredis/1.0.0/include/hiredis -L/home/linuxbrew/.linuxbrew/Cellar/hiredis/1.0.0/lib -lhiredis /home/linuxbrew/.linuxbrew/Cellar/hiredis/1.0.0/share/hiredis/examples/example.c -o /tmp/hiredis-test-20210715-4594-1imqblp/test
/tmp/ccIAxnoy.o: In function `main':
example.c:(.text+0xef): undefined reference to `redisConnectUnixWithTimeout'
example.c:(.text+0x10f): undefined reference to `redisConnectWithTimeout'
example.c:(.text+0x152): undefined reference to `redisFree'
```