### PR TITLE
smlpkg: make mlkit a build-only dependency

### DIFF
--- a/Formula/smlpkg.rb
+++ b/Formula/smlpkg.rb
@@ -12,7 +12,7 @@ class Smlpkg < Formula
     sha256 cellar: :any_skip_relocation, mojave:   "6e7e55cdf218da273d5184d411a7a1491b1e52941859bbf08ab610b470b824c4"
   end
 
-  depends_on "mlkit"
+  depends_on "mlkit" => :build
 
   def install
     system "make", "-C", "src", "smlpkg"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`mlkit` (a compiler) does not need to be installed when this formula is installed as a bottle. [ref](https://github.com/diku-dk/smlpkg/issues/2#issuecomment-890157469)