### PR TITLE
ttyd: improve test, bump revision

### DIFF
--- a/Formula/ttyd.rb
+++ b/Formula/ttyd.rb
@@ -4,7 +4,7 @@ class Ttyd < Formula
   url "https://github.com/tsl0922/ttyd/archive/1.6.3.tar.gz"
   sha256 "1116419527edfe73717b71407fb6e06f46098fc8a8e6b0bb778c4c75dc9f64b9"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/tsl0922/ttyd.git"
 
   bottle do
@@ -32,6 +32,12 @@ class Ttyd < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/ttyd --version")
+    port = free_port
+    fork do
+      system "#{bin}/ttyd", "--port", port.to_s, "bash"
+    end
+    sleep 5
+
+    system "curl", "-sI", "http://localhost:#{port}"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See #81149. This PR improves the test and bumps the revision. I confirmed that the test fails with the current (`revision 1`) bottle for the formula, while it passes when rebuilt from source.