### PR TITLE
grpcui: fix test for Linux

### DIFF
--- a/Formula/grpcui.rb
+++ b/Formula/grpcui.rb
@@ -21,6 +21,7 @@ class Grpcui < Formula
 
   test do
     host = "no.such.host.dev"
-    assert_match "#{host}: no such host", shell_output("#{bin}/grpcui #{host}:999 2>&1", 1)
+    output = shell_output("#{bin}/grpcui #{host}:999 2>&1", 1)
+    assert_match(/Failed to dial target host "#{Regexp.escape(host)}:999":.*: no such host/, output)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3073742137?check_suite_focus=true
```
==> Testing grpcui
==> /home/linuxbrew/.linuxbrew/Cellar/grpcui/1.1.0/bin/grpcui no.such.host.dev:999 2>&1
Error: grpcui: failed
Error: test failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /no\.such\.host\.dev:\ no\ such\ host/ to match "Failed to dial target host \"no.such.host.dev:999\": dial tcp: lookup no.such.host.dev on 168.63.129.16:53: no such host\n".
```