### PR TITLE
haste-client: update resources for Homebrew Ruby on Linux

### DIFF
--- a/Formula/haste-client.rb
+++ b/Formula/haste-client.rb
@@ -29,20 +29,20 @@ class HasteClient < Formula
   depends_on "ruby" if MacOS.version <= :sierra
 
   resource "faraday" do
-    url "https://rubygems.org/gems/faraday-0.12.2.gem"
-    sha256 "6299046a78613ce330b67060e648a132ba7cca4f0ea769bc1d2bbcb22a23ec94"
+    url "https://rubygems.org/gems/faraday-0.17.4.gem"
+    sha256 "11677b5b261fbbfd4d959f702078d81c0bb66006c00ab2f329f32784778e4d9c"
   end
 
   if MacOS.version <= :sierra
     resource "json" do
-      url "https://rubygems.org/gems/json-2.1.0.gem"
-      sha256 "b76fd09b881088c6c64a12721a1528f2f747a1c2ee52fab4c1f60db8af946607"
+      url "https://rubygems.org/gems/json-2.5.1.gem"
+      sha256 "918d8c41dacb7cfdbe0c7bbd6014a5372f0cf1c454ca150e9f4010fe80cc3153"
     end
   end
 
   resource "multipart-post" do
-    url "https://rubygems.org/gems/multipart-post-2.0.0.gem"
-    sha256 "3dc44e50d3df3d42da2b86272c568fd7b75c928d8af3cc5f9834e2e5d9586026"
+    url "https://rubygems.org/gems/multipart-post-2.1.1.gem"
+    sha256 "d2dd7aa957650e0d99e0513cd388401b069f09528441b87d884609c8e94ffcfd"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

At least need to update `faraday` to work with Ruby 2.7+. May need to drop Homebrew Ruby version to 2.x if still has issues.

https://github.com/Homebrew/homebrew-core/runs/3073768959?check_suite_focus=true
```
==> brew test --verbose haste-client
==> FAILED
Error: test failed
==> Testing haste-client
==> /home/linuxbrew/.linuxbrew/Cellar/haste-client/0.2.3_5/bin/haste
/home/linuxbrew/.linuxbrew/Cellar/haste-client/0.2.3_5/libexec/gems/faraday-0.12.2/lib/faraday/options.rb:166:in `new': tried to create Proc object without a block (ArgumentError)
	from /home/linuxbrew/.linuxbrew/Cellar/haste-client/0.2.3_5/libexec/gems/faraday-0.12.2/lib/faraday/options.rb:166:in `memoized'
```
