### PR TITLE
pillow: fix linkage for Linux

### DIFF
--- a/Formula/pillow.rb
+++ b/Formula/pillow.rb
@@ -14,7 +14,6 @@ class Pillow < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.7" => [:build, :test] unless Hardware::CPU.arm?
   depends_on "python@3.8" => [:build, :test]
   depends_on "python@3.9" => [:build, :test]
   depends_on "jpeg"
@@ -27,6 +26,10 @@ class Pillow < Formula
   depends_on "webp"
 
   uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "python@3.7" => [:build, :test] unless Hardware::CPU.arm?
+  end
 
   def pythons
     deps.map(&:to_formula)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Work item from https://github.com/Homebrew/linuxbrew-core/issues/23986

Pillow on Python 3.7 has dynamic linkage
https://github.com/Homebrew/homebrew-core/runs/3033531687?check_suite_focus=true
```
==> brew linkage --test pillow
==> FAILED
Missing libraries:
  unexpected (libpython3.7m.so.1.0)
```

```console
# objdump -p /home/linuxbrew/.linuxbrew/Cellar/pillow/8.3.1/lib/python3.7/site-packages/PIL/_imagingtk.cpython-37m-x86_64-linux-gnu.so | grep NEEDED
  NEEDED               libpython3.7m.so.1.0
  NEEDED               libpthread.so.0
  NEEDED               libc.so.6
```

While Pillow on Python 3.8 doesn't
```console
# objdump -p /home/linuxbrew/.linuxbrew/Cellar/pillow/8.3.1/lib/python3.8/site-packages/PIL/_imagingtk.cpython-38-x86_64-linux-gnu.so | grep NEEDED
  NEEDED               libpthread.so.0
  NEEDED               libc.so.6
```