### PR TITLE
muffet: fix test for Linux

### DIFF
--- a/Formula/muffet.rb
+++ b/Formula/muffet.rb
@@ -20,10 +20,10 @@ class Muffet < Formula
   end
 
   test do
-    assert_match "failed to fetch root page: lookup does.not.exist: no such host",
-        shell_output("#{bin}/muffet https://does.not.exist 2>&1", 1)
+    assert_match(/failed to fetch root page: lookup does\.not\.exist.*: no such host/,
+                 shell_output("#{bin}/muffet https://does.not.exist 2>&1", 1))
 
     assert_match "https://httpbin.org/",
-        shell_output("#{bin}/muffet https://httpbin.org 2>&1", 1)
+                 shell_output("#{bin}/muffet https://httpbin.org 2>&1", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3091418363?check_suite_focus=true
```
==> brew test --verbose muffet
Error: test failed
==> FAILED
==> Testing muffet
==> /home/linuxbrew/.linuxbrew/Cellar/muffet/2.4.2/bin/muffet https://does.not.exist 2>&1
Error: muffet: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /failed\ to\ fetch\ root\ page:\ lookup\ does\.not\.exist:\ no\ such\ host/ to match "failed to fetch root page: lookup does.not.exist on 168.63.129.16:53: no such host\n".
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/minitest-5.14.4/lib/minitest/assertions.rb:183:in `assert'
```