### PR TITLE
msgpuck: fix test for Linux

### DIFF
--- a/Formula/msgpuck.rb
+++ b/Formula/msgpuck.rb
@@ -56,7 +56,7 @@ class Msgpuck < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "-I#{include}", "-L#{lib}", "-lmsgpuck", "-o", "test", "test.c"
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmsgpuck", "-o", "test"
     system "#{testpath}/test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3210532527?check_suite_focus=true
```
==> brew test --verbose msgpuck
==> FAILED
==> Testing msgpuck
==> /usr/bin/gcc-5 -I/home/linuxbrew/.linuxbrew/Cellar/msgpuck/2.0/include -L/home/linuxbrew/.linuxbrew/Cellar/msgpuck/2.0/lib -lmsgpuck -o test test.c
Error: test failed
/tmp/ccxNzT9J.o: In function `main':
test.c:(.text+0x51): undefined reference to `mp_encode_array'
test.c:(.text+0x6c): undefined reference to `mp_encode_uint'
```