### PR TITLE
libressl: make keg_only on Linux

### DIFF
--- a/Formula/libressl.rb
+++ b/Formula/libressl.rb
@@ -30,6 +30,10 @@ class Libressl < Formula
 
   keg_only :provided_by_macos
 
+  on_linux do
+    keg_only "it conflicts with OpenSSL formula"
+  end
+
   def install
     args = %W[
       --disable-dependency-tracking


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
==> Pouring libressl--3.3.3.x86_64_linux.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /home/linuxbrew/.linuxbrew
Could not symlink bin/openssl
Target /home/linuxbrew/.linuxbrew/bin/openssl
is a symlink belonging to openssl@1.1. You can unlink it:
  brew unlink openssl@1.1

To force the link and overwrite all conflicting files:
  brew link --overwrite libressl

To list all files that would be deleted:
  brew link --overwrite --dry-run libressl

Possible conflicting files are:
/home/linuxbrew/.linuxbrew/bin/openssl -> /home/linuxbrew/.linuxbrew/Cellar/openssl@1.1/1.1.1k/bin/openssl
Error: Could not symlink include/openssl/aes.h
Target /home/linuxbrew/.linuxbrew/include/openssl/aes.h
is a symlink belonging to openssl@1.1. You can unlink it:
  brew unlink openssl@1.1

To force the link and overwrite all conflicting files:
  brew link --overwrite openssl@1.1

To list all files that would be deleted:
  brew link --overwrite --dry-run openssl@1.1
```