### PR TITLE
movgrab: fix build for Linux

### DIFF
--- a/Formula/movgrab.rb
+++ b/Formula/movgrab.rb
@@ -3,7 +3,7 @@ class Movgrab < Formula
   homepage "https://sites.google.com/site/columscode/home/movgrab"
   url "https://github.com/ColumPaget/Movgrab/archive/3.1.2.tar.gz"
   sha256 "30be6057ddbd9ac32f6e3d5456145b09526cc6bd5e3f3fb3999cc05283457529"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 2
 
   bottle do
@@ -16,6 +16,8 @@ class Movgrab < Formula
 
   depends_on "libressl"
 
+  uses_from_macos "zlib"
+
   # Fixes an incompatibility between Linux's getxattr and macOS's.
   # Reported upstream; half of this is already committed, and there's
   # a PR for the other half.
@@ -25,6 +27,10 @@ class Movgrab < Formula
     url "https://github.com/Homebrew/formula-patches/raw/936597e74d22ab8cf421bcc9c3a936cdae0f0d96/movgrab/libUseful_xattr_backport.diff"
     sha256 "d77c6661386f1a6d361c32f375b05bfdb4ac42804076922a4c0748da891367c2"
   end
+
+  # Backport fix for GCC linker library search order
+  # Upstream ref: https://github.com/ColumPaget/Movgrab/commit/fab3c87bc44d6ce47f91ded430c3512ebcf7501b
+  patch :DATA
 
   def install
     # Can you believe this? A forgotten semicolon! Probably got missed because it's
@@ -51,3 +57,18 @@ class Movgrab < Formula
     system "#{bin}/movgrab", "--version"
   end
 end
+
+__END__
+diff --git a/Makefile.in b/Makefile.in
+index 04ea67d..5516051 100755
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -11,7 +11,7 @@ OBJ=common.o settings.o containerfiles.o outputfiles.o servicetypes.o extract_te
+ 
+ all: $(OBJ)
+ 	@cd libUseful-2.8; $(MAKE)
+-	$(CC) $(FLAGS) -o movgrab main.c $(LIBS) $(OBJ) libUseful-2.8/libUseful-2.8.a
++	$(CC) $(FLAGS) -o movgrab main.c $(OBJ) libUseful-2.8/libUseful-2.8.a $(LIBS)
+ 
+ clean:
+ 	@rm -f movgrab *.o libUseful-2.8/*.o libUseful-2.8/*.a libUseful-2.8/*.so config.log config.status


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream change doesn't apply due to other commits
https://github.com/ColumPaget/Movgrab/commit/fab3c87bc44d6ce47f91ded430c3512ebcf7501b

`openssl` support may require applying a larger diff, which could be less stable: https://github.com/ColumPaget/Movgrab/commit/6ea84080e4f70ca7dd709b9347022773b37f8267

---

https://github.com/Homebrew/homebrew-core/actions/runs/1039483987
```
#ld -i -o libUseful-2.8.a String.o List.o socket.o unix_socket.o file.o Errors.o Terminal.o FileSystem.o GeneralFunctions.o DataProcessing.o pty.o Log.o http.o inet.o Expect.o base64.o  crc32.o md5c.o sha1.o sha2.o whirlpool.o jh_ref.o Hash.o ssh.o Compression.o oauth.o libsettings.o Vars.o Time.o Markup.o SpawnPrograms.o Tokenizer.o PatternMatch.o URL.o DataParser.o ConnectionChain.o openssl.o Process.o Encodings.o RawData.o SecureMem.o
ar rcs libUseful-2.8.a String.o List.o socket.o unix_socket.o file.o Errors.o Terminal.o FileSystem.o GeneralFunctions.o DataProcessing.o pty.o Log.o http.o inet.o Expect.o base64.o  crc32.o md5c.o sha1.o sha2.o whirlpool.o jh_ref.o Hash.o ssh.o Compression.o oauth.o libsettings.o Vars.o Time.o Markup.o SpawnPrograms.o Tokenizer.o PatternMatch.o URL.o DataParser.o ConnectionChain.o openssl.o Process.o Encodings.o RawData.o SecureMem.o
make[1]: Leaving directory '/tmp/movgrab-20210717-2971-1y5m0on/Movgrab-3.1.2/libUseful-2.8'
gcc-5 -g -O2 -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DSTDC_HEADERS=1 -DHAVE_LIBZ=1 -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64 -DHAVE_LIBSSL=1 -DHAVE_LIBCRYPTO=1  -o movgrab main.c -lcrypto -lssl -lz  common.o settings.o containerfiles.o outputfiles.o servicetypes.o extract_text.o download.o display.o players.o selectformat.o ehow.o ign.o youtube.o  libUseful-2.8/libUseful-2.8.a
libUseful-2.8/libUseful-2.8.a(file.o): In function `STREAMInternalFinalWriteBytes':
file.c:(.text+0x1067): undefined reference to `SSL_write'
libUseful-2.8/libUseful-2.8.a(file.o): In function `STREAMReadCharsToBuffer':
file.c:(.text+0x22e5): undefined reference to `SSL_read'
file.c:(.text+0x22fc): undefined reference to `SSL_pending'
libUseful-2.8/libUseful-2.8.a(DataProcessing.o): In function `libCryptoProcessorClose':
DataProcessing.c:(.text+0x2d7): undefined reference to `EVP_CIPHER_CTX_cleanup'
DataProcessing.c:(.text+0x2e0): undefined reference to `EVP_CIPHER_CTX_cleanup'
libUseful-2.8/libUseful-2.8.a(DataProcessing.o): In function `libCryptoProcessorInit':
DataProcessing.c:(.text+0x9f1): undefined reference to `EVP_idea_cbc'
DataProcessing.c:(.text+0xa38): undefined reference to `EVP_CIPHER_CTX_init'
```