### PR TITLE
stubby: service block + clean up test

### DIFF
--- a/Formula/stubby.rb
+++ b/Formula/stubby.rb
@@ -29,29 +29,10 @@ class Stubby < Formula
     system "make", "install"
   end
 
-  plist_options startup: true, manual: "sudo stubby -C #{HOMEBREW_PREFIX}/etc/stubby/stubby.yml"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>KeepAlive</key>
-          <true/>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_bin}/stubby</string>
-            <string>-C</string>
-            <string>#{etc}/stubby/stubby.yml</string>
-          </array>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"stubby", "-C", etc/"stubby/stubby.yml"]
+    keep_alive true
+    run_type :immediate
   end
 
   test do
@@ -78,7 +59,6 @@ class Stubby < Formula
     end
     sleep 2
 
-    output = shell_output("dig @127.0.0.1 -p 5553 getdnsapi.net")
-    assert_match "status: NOERROR", output
+    assert_match "status: NOERROR", shell_output("dig @127.0.0.1 -p 5553 getdnsapi.net")
   end
 end


### PR DESCRIPTION
Supports https://github.com/Homebrew/linuxbrew-core/issues/23986

NOTE: Linuxbrew disabled the `dig` portion of the test block, for reasons I couldn't determine. Since `bind` itself includes `dig` (the official container doesn't), I've reenabled this test, and it seems to work in the official Homebrew container.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
