### PR TITLE
ndiff: update license and use https for url

### DIFF
--- a/Formula/ndiff.rb
+++ b/Formula/ndiff.rb
@@ -1,9 +1,9 @@
 class Ndiff < Formula
   desc "Virtual package provided by nmap"
   homepage "https://www.math.utah.edu/~beebe/software/ndiff/"
-  url "http://ftp.math.utah.edu/pub/misc/ndiff-2.00.tar.gz"
+  url "https://ftp.math.utah.edu/pub/misc/ndiff-2.00.tar.gz"
   sha256 "f2bbd9a2c8ada7f4161b5e76ac5ebf9a2862cab099933167fe604b88f000ec2c"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c7c14877b300c9a36d4047b883e773397f819f60718b9e13d17ca4359b317541"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3091985728?check_suite_focus=true
```
==> brew audit ndiff --online --git --skip-style
==> FAILED
Error: 1 problem in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
ndiff:
  * Stable: The source URL http://ftp.math.utah.edu/pub/misc/ndiff-2.00.tar.gz should use HTTPS rather than HTTP
```