### PR TITLE
wildmidi 0.4.4: new formula

### DIFF
--- a/Formula/wildmidi.rb
+++ b/Formula/wildmidi.rb
@@ -1,0 +1,36 @@
+class Wildmidi < Formula
+  desc "Simple software midi player"
+  homepage "https://www.mindwerks.net/projects/wildmidi/"
+  url "https://github.com/Mindwerks/wildmidi/archive/refs/tags/wildmidi-0.4.4.tar.gz"
+  sha256 "6f267c8d331e9859906837e2c197093fddec31829d2ebf7b958cf6b7ae935430"
+  license all_of: ["GPL-3.0-only", "LGPL-3.0-only"]
+
+  depends_on "cmake" => :build
+
+  def install
+    cmake_args = std_cmake_args + %w[
+      -S .
+      -B build
+    ]
+
+    system "cmake", *cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <wildmidi_lib.h>
+      #include <stdio.h>
+      #include <assert.h>
+      int main() {
+        long version = WildMidi_GetVersion();
+        assert(version != 0);
+        return 0;
+      }
+    EOS
+
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lWildMidi"
+    system "./a.out"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This formula is as dependency for some multimedia related formulae, e.g. `qmmp` and `mpd`.