### PR TITLE
node: build with LTO

### DIFF
--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -52,6 +52,7 @@ class Node < Formula
     args = %W[
       --prefix=#{prefix}
       --without-npm
+      --enable-lto
       --with-intl=system-icu
       --shared-libuv
       --shared-nghttp2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Building with LTO should result in faster and smaller binaries. This
previously was possible only when building with GCC until [v16.3.0](https://github.com/nodejs/node/releases/tag/v16.3.0).