### PR TITLE
liquidctl: update upstream URL and head branch

### DIFF
--- a/Formula/liquidctl.rb
+++ b/Formula/liquidctl.rb
@@ -2,11 +2,11 @@ class Liquidctl < Formula
   include Language::Python::Virtualenv
 
   desc "Cross-platform tool and drivers for liquid coolers and other devices"
-  homepage "https://github.com/jonasmalacofilho/liquidctl"
+  homepage "https://github.com/liquidctl/liquidctl"
   url "https://files.pythonhosted.org/packages/cb/53/6edf9da254d2e80580b116c45a7c50edaf055917bf6d771185a5adf52d2a/liquidctl-1.7.1.tar.gz"
   sha256 "10f650b9486ddac184330940550433685ae0abc70b66fe92d994042491aab356"
   license "GPL-3.0-or-later"
-  head "https://github.com/jonasmalacofilho/liquidctl.git"
+  head "https://github.com/liquidctl/liquidctl.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "bdb9efa7b382210874c57fe35f67213f3f6ec1355aae12d5190c1b39dd412814"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

No local tests were performed (I don't have access to a system with homebrew or linuxbrew right now).

-----

Update the upstream URL and head branch, which have changed over the last months:

 - the project was moved to an organization last Decemeber 2020;
 - the head branch was changed in the beginning of the last release cycle.
 
 Related: liquidctl/liquidctl#366 ("Homebrew --HEAD installation is not working")