### PR TITLE
nut: fix build for Linux

### DIFF
--- a/Formula/nut.rb
+++ b/Formula/nut.rb
@@ -1,7 +1,7 @@
 class Nut < Formula
   desc "Network UPS Tools: Support for various power devices"
   homepage "https://networkupstools.org/"
-  license "GPL-3.0"
+  license "GPL-2.0-or-later"
   revision 2
 
   stable do
@@ -40,35 +40,43 @@ class Nut < Formula
 
   def install
     if build.head?
-      ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+      ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
       system "./autogen.sh"
     else
       # Regenerate configure, due to patch applied
       system "autoreconf", "-i"
     end
 
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--localstatedir=#{var}",
-                          "--sysconfdir=#{etc}/nut",
-                          "--with-statepath=#{var}/state/ups",
-                          "--with-pidpath=#{var}/run",
-                          "--with-macosx_ups",
-                          "--with-openssl",
-                          "--with-serial",
-                          "--with-usb",
-                          "--without-avahi",
-                          "--without-cgi",
-                          "--without-dev",
-                          "--without-doc",
-                          "--without-ipmi",
-                          "--without-libltdl",
-                          "--without-neon",
-                          "--without-nss",
-                          "--without-powerman",
-                          "--without-snmp",
-                          "--without-wrap"
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --localstatedir=#{var}
+      --sysconfdir=#{etc}/nut
+      --with-statepath=#{var}/state/ups
+      --with-pidpath=#{var}/run
+      --with-openssl
+      --with-serial
+      --with-usb
+      --without-avahi
+      --without-cgi
+      --without-dev
+      --without-doc
+      --without-ipmi
+      --without-libltdl
+      --without-neon
+      --without-nss
+      --without-powerman
+      --without-snmp
+      --without-wrap
+    ]
+    on_macos do
+      args << "--with-macosx_ups"
+    end
+    on_linux do
+      args << "--with-udev-dir=#{lib}/udev"
+    end
 
+    system "./configure", *args
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3091996898?check_suite_focus=true
```
make[3]: Nothing to be done for 'install-exec-am'.
 /bin/mkdir -p '/lib/udev/rules.d'
 /usr/bin/install -c -m 644 62-nut-usbups.rules '/lib/udev/rules.d'
/usr/bin/install: cannot create regular file '/lib/udev/rules.d/62-nut-usbups.rules': Permission denied
Makefile:412: recipe for target 'install-udevrulesDATA' failed
make[3]: *** [install-udevrulesDATA] Error 1
make[3]: Leaving directory '/tmp/nut-20210717-7503-10gphkv/nut-2.7.4/scripts/udev'
Makefile:485: recipe for target 'install-am' failed
make[2]: *** [install-am] Error 2
```
