### PR TITLE
libcds: fix test for Linux

### DIFF
--- a/Formula/libcds.rb
+++ b/Formula/libcds.rb
@@ -4,6 +4,7 @@ class Libcds < Formula
   url "https://github.com/khizmax/libcds/archive/v2.3.3.tar.gz"
   sha256 "f090380ecd6b63a3c2b2f0bdb27260de2ccb22486ef7f47cc1175b70c6e4e388"
   license "BSL-1.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any, big_sur:     "8933bb8f315e15e385985ba2ddd4b1ebecbcce970fa434afb8648d1d95b34e5d"
@@ -17,8 +18,13 @@ class Libcds < Formula
   depends_on "boost"
 
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    # Change the install library directory for x86_64 arch to `lib`
+    inreplace "CMakeLists.txt", "set(LIB_SUFFIX \"64\")", ""
+
+    mkdir "_build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
   end
 
   test do
@@ -31,7 +37,7 @@ class Libcds < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "-o", "test", "test.cpp", "-L#{lib}64", "-lcds", "-std=c++11"
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", "-L#{lib}", "-lcds", "-lpthread"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3073978220?check_suite_focus=true
```
==> FAILED
Error: test failed
==> Testing libcds
==> /usr/bin/g++-5 -o test test.cpp -L/home/linuxbrew/.linuxbrew/Cellar/libcds/2.3.3/lib64 -lcds -std=c++11
/usr/bin/ld: /tmp/ccqXAdTg.o: undefined reference to symbol 'pthread_key_delete@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```