### PR TITLE
libdill: fix test for Linux

### DIFF
--- a/Formula/libdill.rb
+++ b/Formula/libdill.rb
@@ -46,7 +46,7 @@ class Libdill < Formula
           return 0;
       }
     EOS
-    system ENV.cc, "-I#{include}", "-L#{lib}", "-ldill", "-o", "test", "test.c"
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ldill", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3082006886?check_suite_focus=true
```
==> brew test --verbose libdill
==> FAILED
==> Testing libdill
==> /usr/bin/gcc-5 -I/home/linuxbrew/.linuxbrew/Cellar/libdill/2.14/include -L/home/linuxbrew/.linuxbrew/Cellar/libdill/2.14/lib -ldill -o test test.c
/tmp/cc1DJCbW.o: In function `worker':
test.c:(.text+0x1a): undefined reference to `dill_now'
test.c:(.text+0x5e): undefined reference to `dill_msleep'
/tmp/cc1DJCbW.o: In function `main':
test.c:(.text+0xa5): undefined reference to `dill_prologue'
test.c:(.text+0x132): undefined reference to `dill_epilogue'
```