### PR TITLE
shogun: use GitHub as homepage due to expired cert

### DIFF
--- a/Formula/shogun.rb
+++ b/Formula/shogun.rb
@@ -1,6 +1,6 @@
 class Shogun < Formula
   desc "Large scale machine learning toolbox"
-  homepage "https://www.shogun-toolbox.org/"
+  homepage "https://github.com/shogun-toolbox/shogun"
   url "https://github.com/shogun-toolbox/shogun.git",
       tag:      "shogun_6.1.4",
       revision: "ab274e7ab6bf24dd598c1daf1e626cb686d6e1cc"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Expired certificate at https://www.shogun-toolbox.org/

Using HTTP tries to redirect to HTTPS so same issue: http://www.shogun-toolbox.org/

Using GitHub instead.