### PR TITLE
skymaker: use temp mirror url as original url returns 404 error

### DIFF
--- a/Formula/skymaker.rb
+++ b/Formula/skymaker.rb
@@ -1,7 +1,10 @@
 class Skymaker < Formula
   desc "Generates fake astronomical images"
   homepage "https://www.astromatic.net/software/skymaker"
-  url "https://www.astromatic.net/download/skymaker/skymaker-3.10.5.tar.gz"
+  # Upstream URL is currently 404 Not Found. Can re-enable if upstream restores URL.
+  # url "https://www.astromatic.net/download/skymaker/skymaker-3.10.5.tar.gz"
+  url "https://web.archive.org/web/20161206053718/www.astromatic.net/download/skymaker/skymaker-3.10.5.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/distfiles.macports.org/skymaker/skymaker-3.10.5.tar.gz"
   sha256 "a16f9c2bd653763b5e1629e538d49f63882c46291b479b4a4997de84d8e9fb0f"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Not sure if this is syntax only? Probably just need to check SHA matches.

Original URL goes to 404 Not Found: https://www.astromatic.net/download/skymaker/skymaker-3.10.5.tar.gz

No new URL listed on website.

Doing a Google/Archive search, the options I found were old version from archive.org, a MacPorts URL, and Gentoo URL. Using other formulae as examples, I switched to archive.org variant and also added mirror on MacPorts via MirrorService.
- https://web.archive.org/web/20161206053718/www.astromatic.net/download/skymaker/skymaker-3.10.5.tar.gz
- https://www.mirrorservice.org/sites/distfiles.macports.org/skymaker/skymaker-3.10.5.tar.gz
- http://mirrors.sohu.com/gentoo/distfiles/cc/skymaker-3.10.5.tar.gz