### PR TITLE
quill: fix test for Linux

### DIFF
--- a/Formula/quill.rb
+++ b/Formula/quill.rb
@@ -38,7 +38,7 @@ class Quill < Formula
       }
     EOS
 
-    system ENV.cxx, "-std=c++14", "test.cpp", "-I#{include}", "-L#{lib}", "-lquill", "-o", "test"
+    system ENV.cxx, "-std=c++14", "test.cpp", "-I#{include}", "-L#{lib}", "-lquill", "-o", "test", "-pthread"
     system "./test"
     assert_predicate testpath/"basic-log.txt", :exist?
     assert_match "Test", (testpath/"basic-log.txt").read


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3216125668?check_suite_focus=true
```
==> brew test --verbose quill
Error: test failed
==> FAILED
==> Testing quill
==> /usr/bin/g++-5 -std=c++14 test.cpp -I/home/linuxbrew/.linuxbrew/Cellar/quill/1.6.2/include -L/home/linuxbrew/.linuxbrew/Cellar/quill/1.6.2/lib -lquill -o test
/tmp/ccnhJzTe.o: In function `std::thread::thread<quill::detail::BackendWorker::run()::{lambda()#1}::operator()() const::{lambda()#1}>(quill::detail::BackendWorker::run()::{lambda()#1}::operator()() const::{lambda()#1}&&)':
test.cpp:(.text._ZNSt6threadC2IZZN5quill6detail13BackendWorker3runEvENKUlvE_clEvEUlvE_JEEEOT_DpOT0_[_ZNSt6threadC5IZZN5quill6detail13BackendWorker3runEvENKUlvE_clEvEUlvE_JEEEOT_DpOT0_]+0x7d): undefined reference to `pthread_create'
collect2: error: ld returned 1 exit status
Error: quill: failed
```
