### PR TITLE
irrtoolset: fix build for Linux

### DIFF
--- a/Formula/irrtoolset.rb
+++ b/Formula/irrtoolset.rb
@@ -26,6 +26,12 @@ class Irrtoolset < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
 
+  uses_from_macos "flex" => :build
+
+  on_linux do
+    depends_on "readline"
+  end
+
   def install
     system "autoreconf", "-iv"
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3216123377?check_suite_focus=true
```
/bin/bash '/tmp/irrtoolset-20210802-4298-1xk9f4z/irrtoolset-release-5.1.3/missing' flex object_log.l
/tmp/irrtoolset-20210802-4298-1xk9f4z/irrtoolset-release-5.1.3/missing: line 81: flex: command not found
WARNING: 'flex' is missing on your system.
         You should only need it if you modified a '.l' file.
         You may want to install the Fast Lexical Analyzer package:
         <https://github.com/westes/flex>
Makefile:801: recipe for target 'object_log.l.cc' failed
make[2]: *** [object_log.l.cc] Error 127
make[2]: *** Waiting for unfinished jobs....
```

```
==> brew install ./irrtoolset--5.1.3.x86_64_linux.bottle.1.tar.gz
==> brew linkage --test irrtoolset
==> FAILED
Missing libraries:
  unexpected (libhistory.so.8)
  unexpected (libreadline.so.8)

==> brew install --only-dependencies --include-test irrtoolset
==> brew test --verbose irrtoolset
```