### PR TITLE
liblwgeom: fix build for Linux

### DIFF
--- a/Formula/liblwgeom.rb
+++ b/Formula/liblwgeom.rb
@@ -3,6 +3,7 @@ class Liblwgeom < Formula
   homepage "https://postgis.net/"
   url "https://download.osgeo.org/postgis/source/postgis-2.5.4.tar.gz"
   sha256 "146d59351cf830e2a2a72fa14e700cd5eab6c18ad3e7c644f57c4cee7ed98bbe"
+  license "GPL-2.0-or-later"
   revision 1
   head "https://git.osgeo.org/gitea/postgis/postgis.git"
 
@@ -19,7 +20,7 @@ class Liblwgeom < Formula
   # See details in https://github.com/postgis/postgis/pull/348
   deprecate! date: "2020-11-23", because: "liblwgeom headers are not installed anymore, use librttopo instead"
 
-  depends_on "autoconf" => :build
+  depends_on "autoconf@2.69" => :build
   depends_on "automake" => :build
   depends_on "gpp" => :build
   depends_on "libtool" => :build
@@ -27,7 +28,7 @@ class Liblwgeom < Formula
 
   depends_on "geos"
   depends_on "json-c"
-  depends_on "proj"
+  depends_on "proj@7"
 
   uses_from_macos "libxml2"
 
@@ -39,7 +40,7 @@ class Liblwgeom < Formula
       "--disable-dependency-tracking",
       "--disable-nls",
 
-      "--with-projdir=#{Formula["proj"].opt_prefix}",
+      "--with-projdir=#{Formula["proj@7"].opt_prefix}",
       "--with-jsondir=#{Formula["json-c"].opt_prefix}",
 
       # Disable extraneous support
@@ -72,7 +73,7 @@ class Liblwgeom < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-I#{include}", "-I#{Formula["proj"].opt_include}",
+    system ENV.cc, "test.c", "-I#{include}", "-I#{Formula["proj@7"].opt_include}",
                    "-L#{lib}", "-llwgeom", "-o", "test"
     system "./test"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3127558347?check_suite_focus=true

Need `autoconf@2.69`:
```
======================================
Now you are ready to run './configure'
======================================
==> ./configure --disable-dependency-tracking --disable-nls --with-projdir=/home/linuxbrew/.linuxbrew/opt/proj --with-jsondir=/home/linuxbrew/.linuxbrew/opt/json-c --without-pgconfig --without-libiconv-prefix --without-libintl-prefix --without-raster --without-topology
configure: WARNING: unrecognized options: --disable-dependency-tracking
configure: error: cannot find required auxiliary files: config.rpath
```

Need `proj@7`:
```
Using user-specified proj directory: /opt/homebrew/opt/proj
checking for proj_api.h... no
configure: error: could not find proj_api.h - you may need to specify the directory of a PROJ.4 installation using --with-projdir
```