### PR TITLE
hfsutils: use different mirror as main url

### DIFF
--- a/Formula/hfsutils.rb
+++ b/Formula/hfsutils.rb
@@ -1,9 +1,8 @@
 class Hfsutils < Formula
   desc "Tools for reading and writing Macintosh volumes"
   homepage "https://www.mars.org/home/rob/proj/hfs/"
-  url "https://sources.voidlinux.org/hfsutils-3.2.6/hfsutils-3.2.6.tar.gz"
+  url "https://ftp.osuosl.org/pub/clfs/conglomeration/hfsutils/hfsutils-3.2.6.tar.gz"
   mirror "https://fossies.org/linux/misc/old/hfsutils-3.2.6.tar.gz"
-  mirror "https://ftp.osuosl.org/pub/clfs/conglomeration/hfsutils/hfsutils-3.2.6.tar.gz"
   sha256 "bc9d22d6d252b920ec9cdf18e00b7655a6189b3f34f42e58d5bb152957289840"
   license "GPL-2.0-or-later"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Current main URL has been dead for 18+ days
From old run: https://github.com/Homebrew/homebrew-core/runs/3073779047?check_suite_focus=true
```
==> brew audit hfsutils --online --git --skip-style
==> FAILED
Error: 1 problem in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
hfsutils:
  * Stable: The source URL https://sources.voidlinux.org/hfsutils-3.2.6/hfsutils-3.2.6.tar.gz is not reachable (HTTP status code 404)
```

voidlinux.org either deleted some old projects or relocated them.