### PR TITLE
pipebench: use https url and update license

### DIFF
--- a/Formula/pipebench.rb
+++ b/Formula/pipebench.rb
@@ -1,11 +1,11 @@
 class Pipebench < Formula
   desc "Measure the speed of STDIN/STDOUT communication"
-  homepage "http://www.habets.pp.se/synscan/programs.php?prog=pipebench"
+  homepage "https://www.habets.pp.se/synscan/programs.php?prog=pipebench"
   # Upstream server behaves oddly: https://github.com/Homebrew/homebrew/issues/40897
   # url "http://www.habets.pp.se/synscan/files/pipebench-0.40.tar.gz"
   url "https://deb.debian.org/debian/pool/main/p/pipebench/pipebench_0.40.orig.tar.gz"
   sha256 "ca764003446222ad9dbd33bbc7d94cdb96fa72608705299b6cc8734cd3562211"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "5bb970ea3b27cad7960f3f60a86b3a55ad36d29cf11169019c5057e803d8ea75"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3082040294?check_suite_focus=true
```
==> brew audit pipebench --online --git --skip-style
==> FAILED
Error: 1 problem in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
pipebench:
  * The homepage URL http://www.habets.pp.se/synscan/programs.php?prog=pipebench should use HTTPS rather than HTTP
```

pipebench.c:
```
 *  Copyright (C) 2002 Thomas Habets <thomas@habets.pp.se>
 *
 *  This library is free software; you can redistribute it and/or
 *  modify it under the terms of the GNU General Public
 *  License as published by the Free Software Foundation; either
 *  version 2 of the License, or (at your option) any later version.
```