### PR TITLE
libbladerf: fix build for Linux

### DIFF
--- a/Formula/libbladerf.rb
+++ b/Formula/libbladerf.rb
@@ -4,7 +4,7 @@ class Libbladerf < Formula
   url "https://github.com/Nuand/bladeRF.git",
       tag:      "2021.02",
       revision: "3b4f42dee4300669d58718df4b85616a85b64904"
-  license "GPL-2.0"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later", "MIT"]
   head "https://github.com/Nuand/bladeRF.git"
 
   livecheck do
@@ -24,9 +24,9 @@ class Libbladerf < Formula
   depends_on "libusb"
 
   def install
-    ENV.prepend "CFLAGS", "-I#{MacOS.sdk_path}/usr/include/malloc"
+    on_macos { ENV.prepend "CFLAGS", "-I#{MacOS.sdk_path}/usr/include/malloc" }
     mkdir "host/build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", *std_cmake_args, "-DUDEV_RULES_PATH=#{lib}/udev/rules.d"
       system "make", "install"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3073972833?check_suite_focus=true
```
-- Installing: /home/linuxbrew/.linuxbrew/Cellar/libbladerf/2021.02/include/bladeRF2.h
CMake Error at misc/udev/cmake_install.cmake:54 (file):
  file cannot create directory: /etc/udev/rules.d.  Maybe need administrative
  privileges.
Call Stack (most recent call first):
  misc/cmake_install.cmake:47 (include)
  cmake_install.cmake:49 (include)
```
