### PR TITLE
osxutils: add `depends_on :macos`

### DIFF
--- a/Formula/osxutils.rb
+++ b/Formula/osxutils.rb
@@ -16,6 +16,8 @@ class Osxutils < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:    "3bd65cf2550b709c111e31db7cb7d829a9260ed5dd35a682c370ed01593c1989"
   end
 
+  depends_on :macos
+
   def install
     system "make"
     system "make", "PREFIX=#{prefix}", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
