### PR TITLE
packetbeat: fix build for Linux

### DIFF
--- a/Formula/packetbeat.rb
+++ b/Formula/packetbeat.rb
@@ -18,6 +18,8 @@ class Packetbeat < Formula
   depends_on "mage" => :build
   depends_on "python@3.9" => :build
 
+  uses_from_macos "libpcap"
+
   def install
     # remove non open source files
     rm_rf "x-pack"
@@ -68,7 +70,9 @@ class Packetbeat < Formula
   end
 
   test do
-    assert_match "0: en0", shell_output("#{bin}/packetbeat devices")
+    eth = "en"
+    on_linux { eth = "eth" }
+    assert_match "0: #{eth}0", shell_output("#{bin}/packetbeat devices")
     assert_match version.to_s, shell_output("#{bin}/packetbeat version")
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3216647068?check_suite_focus=true
```
# github.com/tsg/gopacket/pcap
/home/linuxbrew/.cache/Homebrew/go_mod_cache/pkg/mod/github.com/tsg/gopacket@v0.0.0-20200626092518-2ab8e397a786/pcap/pcap.go:20:18: fatal error: pcap.h: No such file or directory
compilation terminated.
Error: running "go build -o packetbeat -buildmode pie -ldflags -s -X github.com/elastic/beats/v7/libbeat/version.buildTime=2021-08-02T02:23:35Z -X github.com/elastic/beats/v7/libbeat/version.commit=1907c246c8b0d23ae4027699c44bf3fbef57f4a4" failed with exit code 2
```