### PR TITLE
cloudformation-cli: fix test for Linux

### DIFF
--- a/Formula/cloudformation-cli.rb
+++ b/Formula/cloudformation-cli.rb
@@ -272,8 +272,7 @@ class CloudformationCli < Formula
   end
 
   test do
-    script = (testpath/"test.sh")
-    script.write <<~EOS
+    (testpath/"test.exp").write <<~EOS
       #!/usr/bin/env expect -f
       set timeout -1
 
@@ -295,8 +294,7 @@ class CloudformationCli < Formula
       expect eof
     EOS
 
-    script.chmod 0700
-    system "./test.sh"
+    system "expect", "-f", "test.exp"
 
     rpdk_config = JSON.parse(File.read(testpath/".rpdk-config"))
     assert_equal "brew::formula::test", rpdk_config["typeName"]


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3216633309?check_suite_focus=true
```
==> brew test --verbose cloudformation-cli
==> FAILED
==> Testing cloudformation-cli
==> ./test.sh
/usr/bin/env: ‘expect -f’: No such file or directory
Error: cloudformation-cli: failed
An exception occurred within a child process:
  BuildError: Failed executing: ./test.sh
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2249:in `block in system'
```