### PR TITLE
grin: add ncurses dependency for Linux

### DIFF
--- a/Formula/grin.rb
+++ b/Formula/grin.rb
@@ -15,6 +15,8 @@ class Grin < Formula
   depends_on "llvm" => :build # for libclang
   depends_on "rust" => :build
 
+  uses_from_macos "ncurses"
+
   def install
     ENV["CLANG_PATH"] = Formula["llvm"].opt_bin/"clang"
 
@@ -22,7 +24,7 @@ class Grin < Formula
   end
 
   test do
-    system "#{bin}/grin", "server", "config"
+    system bin/"grin", "server", "config"
     assert_predicate testpath/"grin-server.toml", :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3216644185?check_suite_focus=true
```
==> brew test --verbose grin
==> FAILED
==> Testing grin
==> /home/linuxbrew/.linuxbrew/Cellar/grin/5.1.0/bin/grin server config
/home/linuxbrew/.linuxbrew/Cellar/grin/5.1.0/bin/grin: error while loading shared libraries: libncursesw.so.6: cannot open shared object file: No such file or directory
Error: grin: failed
An exception occurred within a child process:
  BuildError: Failed executing: /home/linuxbrew/.linuxbrew/Cellar/grin/5.1.0/bin/grin server config
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2249:in `block in system'
```