### PR TITLE
ebook-tools: fix build for Linux

### DIFF
--- a/Formula/ebook-tools.rb
+++ b/Formula/ebook-tools.rb
@@ -3,6 +3,7 @@ class EbookTools < Formula
   homepage "https://sourceforge.net/projects/ebook-tools/"
   url "https://downloads.sourceforge.net/project/ebook-tools/ebook-tools/0.2.2/ebook-tools-0.2.2.tar.gz"
   sha256 "cbc35996e911144fa62925366ad6a6212d6af2588f1e39075954973bbee627ae"
+  license "MIT"
   revision 3
 
   bottle do
@@ -17,6 +18,8 @@ class EbookTools < Formula
 
   depends_on "cmake" => :build
   depends_on "libzip"
+
+  uses_from_macos "libxml2"
 
   def install
     system "cmake", ".",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3216608928?check_suite_focus=true
```
-- Detecting C compile features - done
CMake Error at /home/linuxbrew/.linuxbrew/Cellar/cmake/3.21.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find LibXml2 (missing: LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR)
Call Stack (most recent call first):
  /home/linuxbrew/.linuxbrew/Cellar/cmake/3.21.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /home/linuxbrew/.linuxbrew/Cellar/cmake/3.21.1/share/cmake/Modules/FindLibXml2.cmake:108 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:13 (find_package)
```