### PR TITLE
libtins: fix build for Linux

### DIFF
--- a/Formula/libtins.rb
+++ b/Formula/libtins.rb
@@ -17,13 +17,17 @@ class Libtins < Formula
   depends_on "cmake" => :build
   depends_on "openssl@1.1"
 
+  uses_from_macos "libpcap"
+
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
-    doc.install "examples"
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args, "-DLIBTINS_ENABLE_CXX11=1"
+      system "make", "install"
+      doc.install "examples"
+    end
 
     # Clean up the build file garbage that has been installed.
-    rm_r Dir["#{share}/doc/libtins/**/CMakeFiles/"]
+    rm_r Dir[share/"doc/libtins/**/CMakeFiles/"]
   end
 
   test do
@@ -33,6 +37,6 @@ class Libtins < Formula
         Tins::Sniffer sniffer("en0");
       }
     EOS
-    system ENV.cxx, "test.cpp", "-L#{lib}", "-ltins", "-o", "test"
+    system ENV.cxx, "-std=c++11", "test.cpp", "-L#{lib}", "-ltins", "-o", "test"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3216645837?check_suite_focus=true
```
-- Build will generate a shared library. Use LIBTINS_BUILD_SHARED=0 to perform a static build
CMake Error at /home/linuxbrew/.linuxbrew/Cellar/cmake/3.21.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PCAP (missing: PCAP_LIBRARY PCAP_INCLUDE_DIR)
Call Stack (most recent call first):
  /home/linuxbrew/.linuxbrew/Cellar/cmake/3.21.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  cmake/Modules/FindPCAP.cmake:46 (find_package_handle_standard_args)
  CMakeLists.txt:61 (FIND_PACKAGE)
```

```
==> FAILED
==> Testing libtins
==> /usr/bin/g++-5 test.cpp -L/home/linuxbrew/.linuxbrew/Cellar/libtins/4.3/lib -ltins -o test
In file included from /home/linuxbrew/.linuxbrew/opt/libtins/include/tins/tins.h:65:0,
                 from test.cpp:1:
/home/linuxbrew/.linuxbrew/opt/libtins/include/tins/crypto.h:271:18: error: ‘function’ in namespace ‘std’ does not name a template type
     typedef std::function<void(const std::string&,
                  ^
/home/linuxbrew/.linuxbrew/opt/libtins/include/tins/crypto.h:282:18: error: ‘function’ in namespace ‘std’ does not name a template type
     typedef std::function<void(const std::string&,
                  ^
```