### PR TITLE
libmtp: fix build for Linux

### DIFF
--- a/Formula/libmtp.rb
+++ b/Formula/libmtp.rb
@@ -3,7 +3,7 @@ class Libmtp < Formula
   homepage "https://libmtp.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/libmtp/libmtp/1.1.18/libmtp-1.1.18.tar.gz"
   sha256 "7280fe50c044c818a06667f45eabca884deab3193caa8682e0b581e847a281f0"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "4af12c090f3214200d4a37b9511c1fc1ba0269b40f26c0e9c45c4dbfe2c64474"
@@ -19,7 +19,8 @@ class Libmtp < Formula
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--disable-mtpz"
+                          "--disable-mtpz",
+                          "--with-udev=#{lib}/udev"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3082040294?check_suite_focus=true
```
make[2]: Entering directory '/tmp/libmtp-20210716-6506-1iy35b3/libmtp-1.1.18/util'
 /bin/mkdir -p '/home/linuxbrew/.linuxbrew/Cellar/libmtp/1.1.18/bin'
 /bin/mkdir -p '/usr/lib/udev'
/bin/mkdir: cannot create directory ‘/usr/lib/udev’: Permission denied
Makefile:408: recipe for target 'install-mtp_probePROGRAMS' failed
make[2]: *** [install-mtp_probePROGRAMS] Error 1
make[2]: *** Waiting for unfinished jobs....
```