### PR TITLE
qmmp 2.0.0

### DIFF
--- a/Formula/qmmp.rb
+++ b/Formula/qmmp.rb
@@ -1,14 +1,13 @@
 class Qmmp < Formula
   desc "Qt-based Multimedia Player"
   homepage "https://qmmp.ylsoftware.com/"
-  url "https://downloads.sourceforge.net/project/qmmp-dev/qmmp/1.5/qmmp-1.5.1.tar.bz2"
-  sha256 "f3dc676039b5f190e6a87377a6b2bd2bcca122d1659b5f22668c7a284bb91f43"
+  url "https://qmmp.ylsoftware.com/files/qmmp/2.0/qmmp-2.0.0.tar.bz2"
+  sha256 "c631d69c8bfcd77746bb94e2fc4cb7186d16cd29598de08d9771a45c212c6519"
   license "GPL-2.0-or-later"
-  head "https://svn.code.sf.net/p/qmmp-dev/code/branches/qmmp-1.5/"
 
   livecheck do
-    url :stable
-    regex(%r{url=.*?/qmmp[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url "https://qmmp.ylsoftware.com/downloads.php"
+    regex(/href=.*?qmmp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do
@@ -17,38 +16,70 @@ class Qmmp < Formula
     sha256 mojave:   "7001d36b42beb62f494c03d0e15bf5a153712ad9784af50df1e8042b52d682f6"
   end
 
-  depends_on "cmake" => :build
+  depends_on "cmake"      => :build
+  depends_on "pkg-config" => :build
+
+  # TODO: on linux: pipewire
   depends_on "faad2"
   depends_on "ffmpeg"
   depends_on "flac"
+  depends_on "game-music-emu"
+  depends_on "jack"
+  depends_on "libarchive"
   depends_on "libbs2b"
+  depends_on "libcddb"
+  depends_on "libcdio"
   depends_on "libmms"
+  depends_on "libmodplug"
   depends_on "libogg"
   depends_on "libsamplerate"
+  depends_on "libshout"
   depends_on "libsndfile"
   depends_on "libsoxr"
   depends_on "libvorbis"
+  depends_on "libxcb"
+  depends_on "libxmp"
   depends_on "mad"
   depends_on "mplayer"
   depends_on "musepack"
   depends_on "opus"
   depends_on "opusfile"
-  depends_on "qt@5"
+  depends_on "projectm"
+  depends_on "pulseaudio"
+  depends_on "qt"
   depends_on "taglib"
+  depends_on "wavpack"
+  depends_on "wildmidi"
+
+  uses_from_macos "curl"
+
+  resource "qmmp-plugin-pack" do
+    url "https://qmmp.ylsoftware.com/files/qmmp-plugin-pack/2.0/qmmp-plugin-pack-2.0.0.tar.bz2"
+    sha256 "dd10362e42804e604d216a79e9a8b1d4851be0da72d7c6ee0ad9ddb1166f69dc"
+  end
 
   def install
-    system "cmake", "./", "-USE_SKINNED", "-USE_ENCA", "-USE_QMMP_DIALOG", *std_cmake_args
-    system "make", "install"
+    cmake_args = std_cmake_args + %W[
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+      -DUSE_SKINNED=ON
+      -DUSE_ENCA=ON
+      -DUSE_QMMP_DIALOG=ON
+      -DCMAKE_EXE_LINKER_FLAGS=-Wl,-undefined,dynamic_lookup
+      -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-undefined,dynamic_lookup
+      -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-undefined,dynamic_lookup
 
-    # fix linkage
-    cd (lib.to_s) do
-      Dir["*.dylib", "qmmp/*/*.so"].select { |f| File.ftype(f) == "file" }.each do |f|
-        MachO::Tools.dylibs(f).select { |d| d.start_with?("/tmp") }.each do |d|
-          bname = File.dirname(d)
-          d_new = d.sub(bname, opt_lib.to_s)
-          MachO::Tools.change_install_name(f, d, d_new)
-        end
-      end
+      -S .
+    ]
+
+    system "cmake", *cmake_args
+    system "cmake", "--build", "."
+    system "cmake", "--install", "."
+
+    ENV.append_path "PKG_CONFIG_PATH", lib/"pkgconfig"
+    resource("qmmp-plugin-pack").stage do
+      system "cmake", ".", *std_cmake_args
+      system "cmake", "--build", "."
+      system "cmake", "--install", "."
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Some interesting dependencies i.e. [`libcdio-paranoia`](https://github.com/rocky/libcdio-paranoia), [`libsidplayfp`](https://sourceforge.net/projects/sidplay-residfp/), [`pipewire`](https://pipewire.org/)(linux) and [`librcd`](http://rusxmms.sourceforge.net/) are still missing.
On linux, it can depend on `alsa-lib`.