### PR TITLE
google-java-format: add google-java-format-diff

### DIFF
--- a/Formula/google-java-format.rb
+++ b/Formula/google-java-format.rb
@@ -11,6 +11,11 @@ class GoogleJavaFormat < Formula
 
   depends_on "openjdk"
 
+  resource "google-java-format-diff" do
+    url "https://raw.githubusercontent.com/google/google-java-format/v1.11.0/scripts/google-java-format-diff.py"
+    sha256 "5ba9907e08db60ae041fd5746ef57cb528815847ea84f5d0743a61d1379ccf17"
+  end
+
   def install
     libexec.install "google-java-format-#{version}-all-deps.jar" => "google-java-format.jar"
     bin.write_jar_script libexec / "google-java-format.jar", "google-java-format",
@@ -19,6 +24,7 @@ class GoogleJavaFormat < Formula
       --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
       --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
       --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+    resource("google-java-format-diff").stage { bin.install "google-java-format-diff.py" }
   end
 
   test do


### PR DESCRIPTION
This script formats changed lines in a given patch.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
