### PR TITLE
lunchy: add `depends_on :macos`

### DIFF
--- a/Formula/lunchy.rb
+++ b/Formula/lunchy.rb
@@ -14,6 +14,8 @@ class Lunchy < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "71f804d56f0ff8a37209dfc427400885833fffc2d6139cf40a99e91151099900"
   end
 
+  depends_on :macos
+
   uses_from_macos "ruby"
 
   conflicts_with "lunchy-go", because: "both install a `lunchy` binary"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`lunchy` is wrapper for `launchctl` and I think `launchctl` is macOS-only (and maybe ported to BSD).
