### PR TITLE
kestrel: add license and deprecate

### DIFF
--- a/Formula/kestrel.rb
+++ b/Formula/kestrel.rb
@@ -3,6 +3,7 @@ class Kestrel < Formula
   homepage "https://twitter-archive.github.io/kestrel/"
   url "https://twitter-archive.github.io/kestrel/download/kestrel-2.4.1.zip"
   sha256 "5d72a301737cc6cc3908483ce73d4bdb6e96521f3f8c96f93b732d740aaea80c"
+  license "Apache-2.0"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "57b8c7f3a898f32a556efc9f79f1944f8739a458f07b671664357239d6a5b7e8"
@@ -11,6 +12,9 @@ class Kestrel < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "8106b504796e7c73733c4206d00e2d7f7213e998729a9fe6c56a6016b14b822d"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "57b8c7f3a898f32a556efc9f79f1944f8739a458f07b671664357239d6a5b7e8"
   end
+
+  # See: https://github.com/twitter-archive/kestrel#status
+  deprecate! date: "2016-01-22", because: :deprecated_upstream
 
   def install
     inreplace "scripts/kestrel.sh" do |s|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The ["Status" section of the `kestrel` GitHub repository `README`](https://github.com/twitter-archive/kestrel#status) states:

> We've deprecated Kestrel because internally we've shifted our attention to an alternative project based on DistributedLog, and we no longer have the resources to contribute fixes or accept pull requests. While Kestrel is a great solution up to a certain point (simple, fast, durable, and easy to deploy), it hasn't been able to cope with Twitter's massive scale (in terms of number of tenants, QPS, operability, diversity of workloads etc.) or operating environment (an Aurora cluster without persistent storage).

As such, this PR deprecates `kestrel` as `:deprecated_upstream`, using the date [the deprecation text was added to the README](https://github.com/twitter-archive/kestrel/commit/2cce69e2a3aab6d0fdbf4626d9713b34a52d4506) (2016-01-22).