### PR TITLE
rzip: add livecheck

### DIFF
--- a/Formula/rzip.rb
+++ b/Formula/rzip.rb
@@ -5,6 +5,11 @@ class Rzip < Formula
   sha256 "4bb96f4d58ccf16749ed3f836957ce97dbcff3e3ee5fd50266229a48f89815b7"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://rzip.samba.org/ftp/rzip/"
+    regex(/href=.*?rzip[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "16c1e072a6f596e4bda1fb3bd99a743cdb1ef6c0ec552f1ea33224f24fb28047"
     sha256 cellar: :any_skip_relocation, big_sur:       "544443eda6593899f3358c6e7f5bce878ff590f357151b587b3c83785745492e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `rzip`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The homepage doesn't link to the `stable` archive and instead refers users to the directory listing page.