### PR TITLE
kim-api, openkim-models: fix compiler selection on Linux

### DIFF
--- a/Formula/openkim-models.rb
+++ b/Formula/openkim-models.rb
@@ -21,12 +21,15 @@ class OpenkimModels < Formula
   depends_on "kim-api"
 
   def install
-    args = std_cmake_args
-    args << "-DKIM_API_MODEL_DRIVER_INSTALL_PREFIX=#{lib}/openkim-models/model-drivers"
-    args << "-DKIM_API_PORTABLE_MODEL_INSTALL_PREFIX=#{lib}/openkim-models/portable-models"
-    args << "-DKIM_API_SIMULATOR_MODEL_INSTALL_PREFIX=#{lib}/openkim-models/simulator-models"
-    system "cmake", ".", *args
-    system "make", "install"
+    args = std_cmake_args + %W[
+      -DKIM_API_MODEL_DRIVER_INSTALL_PREFIX=#{lib}/openkim-models/model-drivers
+      -DKIM_API_PORTABLE_MODEL_INSTALL_PREFIX=#{lib}/openkim-models/portable-models
+      -DKIM_API_SIMULATOR_MODEL_INSTALL_PREFIX=#{lib}/openkim-models/simulator-models
+    ]
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3225139247?check_suite_focus=true
```
-- The CXX compiler identification is unknown
-- The C compiler identification is unknown
-- The Fortran compiler identification is GNU 11.2.0
CMake Error at model-drivers/DUNN__MD_292677547454_000/CMakeLists.txt:40 (project):
  The CMAKE_CXX_COMPILER:

    /usr/bin/clang++

  is not a full path to an existing compiler tool.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.


CMake Error at model-drivers/DUNN__MD_292677547454_000/CMakeLists.txt:40 (project):
  The CMAKE_C_COMPILER:

    /usr/bin/clang
```