### PR TITLE
*-binutils: add livecheck

### DIFF
--- a/Formula/arm-linux-gnueabihf-binutils.rb
+++ b/Formula/arm-linux-gnueabihf-binutils.rb
@@ -6,6 +6,10 @@ class ArmLinuxGnueabihfBinutils < Formula
   sha256 "820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c"
   license "GPL-3.0-or-later"
 
+  livecheck do
+    formula "binutils"
+  end
+
   bottle do
     sha256 arm64_big_sur: "f090259411ea17662b23b08700cc6bb63116624932ef17388e80cb88ec431fa5"
     sha256 big_sur:       "6fae8a0bdc7ef15c1f6dcfac0ae2a8bd533f0e5cbbdb44e857f48c5412b90a0c"

--- a/Formula/i686-elf-binutils.rb
+++ b/Formula/i686-elf-binutils.rb
@@ -6,6 +6,10 @@ class I686ElfBinutils < Formula
   sha256 "820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c"
   license "GPL-3.0-or-later"
 
+  livecheck do
+    formula "binutils"
+  end
+
   bottle do
     sha256 arm64_big_sur: "04659e65f3d10dc3881947446255bc02f946783669a26daaf79386e99e00039c"
     sha256 big_sur:       "5fff1dc8e6b6b0859f21ade50d38937bc04c03b7a36e0c48f3e6848efacf8b46"

--- a/Formula/x86_64-elf-binutils.rb
+++ b/Formula/x86_64-elf-binutils.rb
@@ -6,6 +6,10 @@ class X8664ElfBinutils < Formula
   sha256 "820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c"
   license "GPL-3.0-or-later"
 
+  livecheck do
+    formula "binutils"
+  end
+
   bottle do
     sha256 arm64_big_sur: "c1cc0eeef6981f55e0df57f0e8115956ab5b4d94d043daf805c8833ed843dc1d"
     sha256 big_sur:       "085e8d5b89905e85c00951d3f12a6b36ea2e085b07e6af28b4138956b9c53384"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Today's 3.2.6 release of `brew` includes the new `formula`/`cask` `livecheck` block DSL methods (see Homebrew/brew#11743), so now we can start using them in `livecheck` blocks.

The main purpose of this feature is to allow formulae/casks to use the same check as another, so we can easily sync checks for formulae/casks that use the same `stable`/`url` file. Up until now, we've had to duplicate `livecheck` blocks and manually update them when the canonical `livecheck` block changes (e.g., `sqlite` and related formulae). With this, we can simply update the canonical `livecheck` block and others that reference are automatically updated.

As mentioned in the [related documentation](https://docs.brew.sh/Brew-Livecheck#referenced-formulacask), these methods should only reference a formula/cask in the same tap, as they will error when a tap isn't already tapped.

One thing that I'll need to update the documentation to mention is that this DSL should only be used when one formula/cask is canonical among those with a duplicate `stable`/`url`. If the formulae/casks are all of equal stature (e.g., the `beats` formulae), this feature shouldn't be used.

---

With this in mind, this PR updates formulae that have the same `stable` URL as `binutils` to use `formula "binutils"`, so these checks are synced.

I've identified the other sets of formulae that can use `formula` and I'll be creating follow-up PRs for those.