### PR TITLE
Update broken GithubLatest regexes

### DIFF
--- a/Formula/cataclysm.rb
+++ b/Formula/cataclysm.rb
@@ -9,8 +9,8 @@ class Cataclysm < Formula
 
   livecheck do
     url :stable
+    regex(%r{href=["']?[^"' >]*?/tag/([^"' >]+)["' >]}i)
     strategy :github_latest
-    regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
   end
 
   bottle do

--- a/Formula/vgmstream.rb
+++ b/Formula/vgmstream.rb
@@ -12,8 +12,8 @@ class Vgmstream < Formula
 
   livecheck do
     url :stable
+    regex(%r{href=["']?[^"' >]*?/tag/([^"' >]+)["' >]}i)
     strategy :github_latest
-    regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
   end
 
   bottle do

--- a/Formula/vlmcsd.rb
+++ b/Formula/vlmcsd.rb
@@ -8,8 +8,8 @@ class Vlmcsd < Formula
 
   livecheck do
     url :stable
+    regex(%r{href=["']?[^"' >]*?/tag/([^"' >]+)["' >]}i)
     strategy :github_latest
-    regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Under normal circumstances, `href=.*?` is fine in a `livecheck` block regex but this has become a problem for a few formulae that are using the `GithubLatest` strategy, as it's matching more than it should. It appears that GitHub release pages now contain text that is also matched by a generic regex like `%r{href=.*?/tag/([^"' >]+)["' >]}i` and this results in an additional unwanted match (e.g., `svn1113&quot;,&quot;user_id&quot;:null}}` alongside the desired match (e.g., `svn1113`).

The formulae in this PR all use this generic regex because they have unusual version formats that aren't matched by the default `GithubLatest` regex (e.g., `0.F`, `r1050-3448-g77cc431b`, `svn1113`). This PR updates the regexes for the formulae that are currently broken by the upstream GitHub change to use the more specific leading `href=["']?[^"' >]*?` anchor, which prevents the regex from escaping the bounds of the `href` attribute.

I've thought about modifying how `GithubLatest` works but, in the interim time, I'm tweaking regexes in related `livecheck` blocks and I'll update the default strategy regex. Though this modified leading anchor is more correct than `href=.*?`, I'm holding off on rolling out this change to all existing regexes simply because it's more verbose and we haven't encountered similar issues in other contexts. In the future, when I create a PR to establish regex constants, it will hopefully be easier to address this without making regexes harder to visually parse.