### PR TITLE
gradle-profiler: add livecheck

### DIFF
--- a/Formula/gradle-profiler.rb
+++ b/Formula/gradle-profiler.rb
@@ -6,6 +6,11 @@ class GradleProfiler < Formula
   license "Apache-2.0"
   revision 1
 
+  livecheck do
+    url "https://repo.gradle.org/ui/api/v1/download?repoKey=ext-releases-local&path=org%252Fgradle%252Fprofiler%252Fgradle-profiler%252Fmaven-metadata.xml"
+    regex(%r{<version>\s*v?(\d+(?:\.\d+)+)\s*</version>}i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "92d79f184d9dff7724d483c56d3ab6822fde8e7b30008fa90b9a3f8b57bc304f"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `gradle-profiler`, since the `homepage` is the only automatically checkable URL. However, this currently gives an unstable version (`0.17.0-SNAPSHOT`) as newest instead of the newest stable version, `0.16.0`.

This PR adds a `livecheck` block that checks the `maven-metadata.xml` file from the source where the `stable` archive comes from and adds a regex that restricts matching to stable versions. This fixes the aforementioned issue while also aligning the check with the `stable` source, which we generally prefer to do whenever possible.