### PR TITLE
ringojs: add livecheck

### DIFF
--- a/Formula/ringojs.rb
+++ b/Formula/ringojs.rb
@@ -6,6 +6,11 @@ class Ringojs < Formula
   license "Apache-2.0"
   revision 2
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "86b956cc3c7d0279529323450abaf3bca2a61ae520cdc262c44a2ff5035b810c"
     sha256 cellar: :any_skip_relocation, big_sur:       "445095a17c58cb61c8275e174c2630cd4ac2acba61198fdf7fe978544815ad9d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ringojs` but it's reporting an unstable version (`3.0.0-RC2`) as newest instead of the latest stable version, `2.0.0`. This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`), which only matches stable versions.