### PR TITLE
adios2: add livecheck

### DIFF
--- a/Formula/adios2.rb
+++ b/Formula/adios2.rb
@@ -7,6 +7,11 @@ class Adios2 < Formula
   revision 1
   head "https://github.com/ornladios/ADIOS2.git", branch: "master"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 arm64_big_sur: "b6b6dbcbe7d3d1ad478d47b4004d9ac932707a2503f810439680672a87b89e2b"
     sha256 big_sur:       "7d1abe16be0173d2c1e645c51641b59fea8983c140c5caef132016d4e1416568"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `adios2` but it's currently giving a version that's marked as "pre-release" on GitHub as newest (` 2.7.1.436`) instead of the latest stable version, ` 2.7.1`.

This PR adds a `livecheck` block that uses the `GithubLatest` strategy to identify the "latest" version on GitHub. It's technically possible to use a `regex` instead that restricts matching to versions with only three parts (so `2.7.1` would be matched and ` 2.7.1.436` would be omitted) but there's no guarantee that we won't see a stable version with more than three parts in the future (e.g., ` 2.7.1.1`), so I've opted to use the `GithubLatest` strategy for now.

` 2.7.1.436` is a one-off version and if upstream doesn't make a habit of producing unstable versions like this, we can potentially remove this `livecheck` block sometime after the next stable version above ` 2.7.1` is released.