### PR TITLE
tiny-fugue: update livecheck

### DIFF
--- a/Formula/tiny-fugue.rb
+++ b/Formula/tiny-fugue.rb
@@ -10,6 +10,9 @@ class TinyFugue < Formula
   livecheck do
     url :stable
     regex(%r{url=.*?/tf[._-]v?(\d+(?:\.\d+)*(?:[a-z]\d+?)?)\.t}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map { |match| match.first.sub(/^(\d)(\d)([a-z])/i, '\1.\2\3') }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `tiny-fugue` uses the `Sourceforge` strategy to identify versions from tarballs but the filenames use a version format like `50b8`, whereas the formula uses a `version` format like `5.0b8`. I previously added the initial `livecheck` block so we could at least match the versions (before `strategy` blocks were available) and this PR gets us the rest of the way by adding a `strategy` block that converts the filename version format to the formula `version` format.