### PR TITLE
functionalplus: add livecheck

### DIFF
--- a/Formula/functionalplus.rb
+++ b/Formula/functionalplus.rb
@@ -7,6 +7,15 @@ class Functionalplus < Formula
   license "BSL-1.0"
   head "https://github.com/Dobiasd/FunctionalPlus.git"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+(?:[._-]p\d+)?)$/i)
+    strategy :git do |tags, regex|
+      # Omit `-p0` suffix but allow `-p1`, etc.
+      tags.map { |tag| tag[regex, 1]&.sub(/[._-]p0/i, "") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "ab75da7d297b2258e1e906027bd3d5abe6b7464339288730eae5fec22b931715"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `functionalplus` GitHub repository uses version tags like `v0.2.9-p0` but the formula omits `-p0` suffixes. There is one early tag that uses a `-p1` suffix, so we assumedly wouldn't omit something like that.

This PR adds a `livecheck` block that checks the Git tags using a regex that matches tags like `0.2`, `v0.2-p1`, `v0.2.9-p0`, etc. along with a `strategy` block that removes `-p0` suffixes (but not `-p1`, `-p2`, etc.). This ensures that livecheck doesn't treat `0.2.15-p0` as newer than the manual `0.2.15` version used in the formula.