### PR TITLE
onedpl: add livecheck

### DIFF
--- a/Formula/onedpl.rb
+++ b/Formula/onedpl.rb
@@ -6,6 +6,11 @@ class Onedpl < Formula
   # Apache License Version 2.0 with LLVM exceptions
   license "Apache-2.0" => { with: "LLVM-exception" }
 
+  livecheck do
+    url :stable
+    regex(/^oneDPL[._-](\d+(?:\.\d+)+)(?:[._-]release)?$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "5c09dcadf4308512478900387b6cb785cf95af41aaa280487341120d765a1842"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `onedpl` but it reports an older version (`20201111`) as newer than the latest version, `2021.4.0`. This is because `20201111` is treated as the major version and it's greater than `2021`, so it's treated as newer from the standpoint of `Version` comparison.

This PR addresses this issue for the time being by adding a `livecheck` block that restricts matching to the current tag format like `oneDPL-2021.4.0-release`. This omits the older `YYYYMMDD` tag format and other tags like `oneDPL-release-beta07`, `oneDPL-beta08-release`, `oneDPL-golden-release`, etc. and returns the correct latest version.

The tag format doesn't seem super consistent, so this `livecheck` block may need to be updated if the situation changes again in the future.