### PR TITLE
vapoursynth-*: add livecheck

### DIFF
--- a/Formula/vapoursynth-imwri.rb
+++ b/Formula/vapoursynth-imwri.rb
@@ -6,6 +6,10 @@ class VapoursynthImwri < Formula
   license "LGPL-2.1-or-later"
   head "https://github.com/vapoursynth/vapoursynth.git"
 
+  livecheck do
+    formula "vapoursynth"
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "5836132cd53eaa1767021d26597b1cfd3108f342abe0cad7f1ce40dd3fb6511d"
     sha256 cellar: :any, big_sur:       "01ffc95970768ce9c4b3197a0f60c51083299c44e8a46e596e85c31dc98c07a9"

--- a/Formula/vapoursynth-ocr.rb
+++ b/Formula/vapoursynth-ocr.rb
@@ -6,6 +6,10 @@ class VapoursynthOcr < Formula
   license "ISC"
   head "https://github.com/vapoursynth/vapoursynth.git"
 
+  livecheck do
+    formula "vapoursynth"
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "0ee61239f71e594c05f6a93b675b9863ab53227715c355ef9b75ca1f92e577d5"
     sha256 cellar: :any, big_sur:       "c73eea38acf6dde0e271aa71393020d8f76c9c1c48607048c14b2ca53616d629"

--- a/Formula/vapoursynth-sub.rb
+++ b/Formula/vapoursynth-sub.rb
@@ -6,6 +6,10 @@ class VapoursynthSub < Formula
   license "ISC"
   head "https://github.com/vapoursynth/vapoursynth.git"
 
+  livecheck do
+    formula "vapoursynth"
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "e00dd437364121c4633ac304e1494bffa20a9fad1e4f4fee4de3cd16015a17f2"
     sha256 cellar: :any, big_sur:       "40eda0329ae57f8deaac051521a8ee8f1fe6f5106db3ef024f2fce9ce3432f09"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `vapoursynth` formula contains a `livecheck` block with a `regex` that restricts matching to stable versions like `54` (from `R54`). Related formulae like `vapoursynth-imwri` use the same `stable` URL as `vapoursynth` but livecheck reports an unstable version (`54-RC1`) as the newest version because these formulae don't have a `livecheck` block with a regex like `vapoursynth`.

This PR addresses this issue by using the new `livecheck` block `formula` method to allow the `vapoursynth-` formulae to use the same check as `vapoursynth`. This ensures that these checks are kept in sync and any changes to `vapoursynth`'s check will automatically apply to these other formulae. With these changes, livecheck correctly reports `54` as newest for all of these formulae.