### PR TITLE
sqlite formulae: update livecheck

### DIFF
--- a/Formula/dbhash.rb
+++ b/Formula/dbhash.rb
@@ -7,11 +7,7 @@ class Dbhash < Formula
   license "blessing"
 
   livecheck do
-    url "https://sqlite.org/index.html"
-    regex(%r{href=.*?releaselog/v?(\d+(?:[._]\d+)+)\.html}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match&.first&.gsub("_", ".") }
-    end
+    formula "sqlite"
   end
 
   bottle do

--- a/Formula/lemon.rb
+++ b/Formula/lemon.rb
@@ -7,11 +7,7 @@ class Lemon < Formula
   license "blessing"
 
   livecheck do
-    url "https://sqlite.org/index.html"
-    regex(%r{href=.*?releaselog/v?(\d+(?:[._]\d+)+)\.html}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match&.first&.gsub("_", ".") }
-    end
+    formula "sqlite"
   end
 
   bottle do

--- a/Formula/sqldiff.rb
+++ b/Formula/sqldiff.rb
@@ -7,11 +7,7 @@ class Sqldiff < Formula
   license "blessing"
 
   livecheck do
-    url "https://sqlite.org/index.html"
-    regex(%r{href=.*?releaselog/v?(\d+(?:[._]\d+)+)\.html}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match&.first&.gsub("_", ".") }
-    end
+    formula "sqlite"
   end
 
   bottle do

--- a/Formula/sqlite-analyzer.rb
+++ b/Formula/sqlite-analyzer.rb
@@ -7,11 +7,7 @@ class SqliteAnalyzer < Formula
   license "blessing"
 
   livecheck do
-    url "https://sqlite.org/index.html"
-    regex(%r{href=.*?releaselog/v?(\d+(?:[._]\d+)+)\.html}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match&.first&.gsub("_", ".") }
-    end
+    formula "sqlite"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In the past, we had to duplicate the `livecheck` block from `sqlite` in formulae that use a `sqlite` source tarball as the `stable` URL. With this in mind, I recently expanded the `livecheck` block DSL to add `formula`/`cask` methods, which allow us to use the check from a parent formula in the same tap.

Now that this feature is in a tagged `brew` release, this PR replaces the contents of these duplicated `sqlite` `livecheck` blocks with `formula "sqlite"`. This ensures that these checks will be kept in sync and we only have to worry about making changes to the `sqlite` formula's `livecheck` block.