### PR TITLE
Ruby completion formulae add livecheck

### DIFF
--- a/Formula/bundler-completion.rb
+++ b/Formula/bundler-completion.rb
@@ -8,7 +8,7 @@ class BundlerCompletion < Formula
   head "https://github.com/mernen/completion-ruby.git"
 
   livecheck do
-    skip "No version information available"
+    formula "ruby-completion"
   end
 
   bottle do

--- a/Formula/gem-completion.rb
+++ b/Formula/gem-completion.rb
@@ -8,7 +8,7 @@ class GemCompletion < Formula
   head "https://github.com/mernen/completion-ruby.git"
 
   livecheck do
-    skip "No version information available"
+    formula "ruby-completion"
   end
 
   bottle do

--- a/Formula/rails-completion.rb
+++ b/Formula/rails-completion.rb
@@ -8,7 +8,7 @@ class RailsCompletion < Formula
   head "https://github.com/mernen/completion-ruby.git"
 
   livecheck do
-    skip "No version information available to check"
+    formula "ruby-completion"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the formulae related to the `ruby-completion` formula to use `formula "ruby-completion"` instead of duplicating the same `skip` message. These formulae all use the same mernen/completion-ruby repository as the `stable` source and the `ruby-completion` formula feels like the most canonical of these formulae, so it makes sense to sync the checks for the other related formulae with it.

At the moment, these will continue to use the same `skip` message as `ruby-completion`, as there's no version information to check. If this situation changes in the future, we would only need to update the `livecheck` block for `ruby-completion` and the others would automatically receive the changes as well. [To be clear, the `livecheck` block `formula`/`cask` feature also inherits default checks, so removing the `skip` `livecheck` block in `ruby-completion` is also technically an option, if that makes sense.]