### PR TITLE
firefoxpwa 1.0.0 (new formula)

### DIFF
--- a/Formula/firefoxpwa.rb
+++ b/Formula/firefoxpwa.rb
@@ -1,0 +1,61 @@
+class Firefoxpwa < Formula
+  desc "Tool to install, manage and use Progressive Web Apps in Mozilla Firefox"
+  homepage "https://github.com/filips123/FirefoxPWA"
+  url "https://github.com/filips123/FirefoxPWA/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "47cb03a8f5773da235e360655a4ef93203d7d3ed760ebf6013692ec20239c2c1"
+  license "MPL-2.0"
+  head "https://github.com/filips123/FirefoxPWA.git"
+
+  depends_on "rust" => :build
+
+  def install
+    cd "native"
+
+    # Prepare the project to work with Homebrew
+    ENV["FFPWA_EXECUTABLES"] = bin
+    ENV["FFPWA_SYSDATA"] = share
+    system "bash", "./packages/brew/configure.sh", version, bin, libexec
+
+    # Build and install the project
+    system "cargo", "install", *std_cargo_args
+
+    # Install all files
+    libexec.install bin/"firefoxpwa-connector"
+    share.install "manifests/brew.json" => "firefoxpwa.json"
+    share.install "userchrome/"
+    bash_completion.install "target/release/completions/firefoxpwa.bash" => "firefoxpwa"
+    fish_completion.install "target/release/completions/firefoxpwa.fish"
+    zsh_completion.install "target/release/completions/_firefoxpwa"
+  end
+
+  def caveats
+    filename = "firefoxpwa.json"
+
+    source = share
+    destination = "/Library/Application Support/Mozilla/NativeMessagingHosts"
+
+    on_linux do
+      destination = "/usr/lib/mozilla/native-messaging-hosts"
+    end
+
+    <<~EOS
+      Before you can use the browser extension, you will need to manually link the app manifest
+      This is needed because Homebrew formulae cannot access directories outside Homebrew directory
+
+      To link the manifest, run the following commands after the formula is installed:
+      $ sudo mkdir -p #{destination}
+      $ sudo ln -sf "#{source}/#{filename}" "#{destination}/#{filename}"
+
+      #{Tty.red}You will not be able to use the extension until you link the manifest!#{Tty.reset}
+    EOS
+  end
+
+  test do
+    # Test version so we know if Homebrew configure script correctly sets it
+    assert_match "firefoxpwa #{version}", shell_output("#{bin}/firefoxpwa --version")
+
+    # Test launching non-existing site which should fail
+    output = shell_output("#{bin}/firefoxpwa site launch 00000000000000000000000000 2>&1", 1)
+    assert_includes output, "Site does not exist"
+  end
+end

--- a/Formula/firefoxpwa.rb
+++ b/Formula/firefoxpwa.rb
@@ -31,7 +31,7 @@ class Firefoxpwa < Formula
   def caveats
     filename = "firefoxpwa.json"
 
-    source = share
+    source = opt_share
     destination = "/Library/Application Support/Mozilla/NativeMessagingHosts"
 
     on_linux do

--- a/Formula/firefoxpwa.rb
+++ b/Formula/firefoxpwa.rb
@@ -39,14 +39,9 @@ class Firefoxpwa < Formula
     end
 
     <<~EOS
-      Before you can use the browser extension, you will need to manually link the app manifest
-      This is needed because Homebrew formulae cannot access directories outside Homebrew directory
-
-      To link the manifest, run the following commands after the formula is installed:
-      $ sudo mkdir -p #{destination}
-      $ sudo ln -sf "#{source}/#{filename}" "#{destination}/#{filename}"
-
-      #{Tty.red}You will not be able to use the extension until you link the manifest!#{Tty.reset}
+      To use the browser extension, manually link the app manifest with:
+        sudo mkdir -p #{destination}
+        sudo ln -sf "#{source}/#{filename}" "#{destination}/#{filename}"
     EOS
   end
 


### PR DESCRIPTION
This is a program and Firefox addon/extension that allows users to use progressive web apps in Firefox. You can find its repository [here](https://github.com/filips123/FirefoxPWA).

To be clear, this does **not** install Firefox extension. However, it provides both a command-line program that users can use to manage PWAs and other things, and additional program/connector which communicates with the extension using [native messaging](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging). Extension will not function without that program.

I think adding this to Homebrew would benefit macOS users that would like to use FirefoxPWA without manually compiling and installing it from source, and want to have automated/managed updates. Because it also provides a "normal" command-line program (and doesn't provide any GUI other than extension which is completely separate), I think this should be a normal formula instead of cask.

The only caveat for users is that Homebrew formulae cannot access directories outside Homebrew directory, but my formula needs to install native app manifest to a location where Firefox expects it to be. I solved this by simply instructing users to just create a symlink in the correct directory.

~~Also, `brew audit` will fail because of "* 36: col 5: use "cargo", "install", *std_cargo_args". However, I cannot use `cargo install` because I also need to install the other binary, native app manifest, shell completions and additional required files. Is there any way to fix or suppress this error?~~ Fixed.

~~I would also like to add this to `linuxbrew-core`. Should I make another PR or will this formula be automatically transferred there when/if it is merged?~~ Ok, I saw contribution guidelines for Linuxbrew.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? *Only on Linux, but it should also work on macOS*
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? *Only on Linux, but it should also work on macOS*
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
