### PR TITLE
tcl-tk, sqlite-analyzer: fix build for Linux

### DIFF
--- a/Formula/sqlite-analyzer.rb
+++ b/Formula/sqlite-analyzer.rb
@@ -18,10 +18,18 @@ class SqliteAnalyzer < Formula
     sha256 cellar: :any_skip_relocation, catalina:       "a6052e4c2c43c900d8cd541ccf21495c4e82ab1f3b952c16aca584d82570c69a"
   end
 
+  uses_from_macos "sqlite" => :test
+  uses_from_macos "tcl-tk"
+
   def install
-    sdkprefix = MacOS.sdk_path_if_needed
+    tcl = if OS.mac?
+      MacOS.sdk_path/"System/Library/Frameworks/Tcl.framework"
+    else
+      Formula["tcl-tk"].opt_lib
+    end
+
     system "./configure", "--disable-debug",
-                          "--with-tcl=#{sdkprefix}/System/Library/Frameworks/Tcl.framework/",
+                          "--with-tcl=#{tcl}",
                           "--prefix=#{prefix}"
     system "make", "sqlite3_analyzer"
     bin.install "sqlite3_analyzer"
@@ -36,7 +44,7 @@ class SqliteAnalyzer < Formula
       insert into students (name, age) values ('Sue', 12);
       insert into students (name, age) values ('Tim', 13);
     EOS
-    system "/usr/bin/sqlite3 #{dbpath} < #{sqlpath}"
+    system "sqlite3 #{dbpath} < #{sqlpath}"
     system bin/"sqlite3_analyzer", dbpath
   end
 end

--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -5,6 +5,7 @@ class TclTk < Formula
   mirror "https://fossies.org/linux/misc/tcl8.6.12-src.tar.gz"
   sha256 "26c995dd0f167e48b11961d891ee555f680c175f7173ff8cb829f4ebcde4c1a6"
   license "TCL"
+  revision 1
 
   livecheck do
     url :stable
@@ -125,6 +126,16 @@ class TclTk < Formula
 
     # Conflicts with perl
     mv man/"man3/Thread.3", man/"man3/ThreadTclTk.3"
+
+    # Use the sqlite-analyzer formula instead
+    # https://github.com/Homebrew/homebrew-core/pull/82698
+    rm bin/"sqlite3_analyzer"
+  end
+
+  def caveats
+    <<~EOS
+      The sqlite3_analyzer binary is in the `sqlite-analyzer` formula.
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Conflict in #81888 where both `tcl-tk` and `sqlite-analyzer` create a `sqlite3_analyzer` executable.

Need to check on bottled files before merging, so added `do not merge` label.

Also disabled in:
- Arch Linux https://github.com/archlinux/svntogit-packages/blob/packages/tcl/trunk/PKGBUILD#L15-L19
    ```
    prepare() {
      cd tcl${pkgver}
      # we build the tcl sqlite interface in sqlite-tcl package
      rm -rf pkgs/sqlite3*
    }
    ```
- MacPorts https://github.com/macports/macports-ports/blob/master/lang/tcl/Portfile#L39-L42
    ```
    pre-configure {
        # sqlite3 package is provided by sqlite3-tcl
        delete [glob ${worksrcpath}/../pkgs/sqlite*]
    }
    ```

Can probably leave in macOS as keg_only there. 

Alternatively, can follow Arch and MacPorts and provide `sqlite-tcl` formula built from latest SQLite source code.