### PR TITLE
kyoto-tycoon: update urls, add livecheck

### DIFF
--- a/Formula/kyoto-tycoon.rb
+++ b/Formula/kyoto-tycoon.rb
@@ -1,10 +1,15 @@
 class KyotoTycoon < Formula
   desc "Database server with interface to Kyoto Cabinet"
-  homepage "https://fallabs.com/kyototycoon/"
-  url "https://fallabs.com/kyototycoon/pkg/kyototycoon-0.9.56.tar.gz"
+  homepage "https://dbmx.net/kyototycoon/"
+  url "https://dbmx.net/kyototycoon/pkg/kyototycoon-0.9.56.tar.gz"
   sha256 "553e4ea83237d9153cc5e17881092cefe0b224687f7ebcc406b061b2f31c75c6"
   license "GPL-3.0-or-later"
   revision 5
+
+  livecheck do
+    url "https://dbmx.net/kyototycoon/pkg/"
+    regex(/href=.*?kyototycoon[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 arm64_big_sur: "244a150072e722f1ee861425fdfd1cb12a6a09ee27899b998b0794bd01cd1f12"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs for `kyoto-tycoon` are redirecting from fallabs.com to dbmx.net. This PR updates these URLs to avoid the redirections. I built/tested this locally and the `stable` archive is unchanged (the `sha256` remains the same).

This also adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. [The homepage links to the directory listing page as the source to find packages, rather than linking to the latest archive file.]