### PR TITLE
protobuf: add zlib dependency for Linux

### DIFF
--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -29,6 +29,8 @@ class Protobuf < Formula
   depends_on "python@3.9" => [:build, :test]
   depends_on "six"
 
+  uses_from_macos "zlib"
+
   def install
     # Don't build in debug mode. See:
     # https://github.com/Homebrew/homebrew/issues/9279


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen while testing dependents in #82698
```
==> brew install --only-dependencies protobuf
==> brew linkage --test protobuf
==> FAILED
Unwanted system libraries:
  /lib/x86_64-linux-gnu/libz.so.1
```

`protobuf` seemed to avoid this during bottle dispatch on Linux.

Linux `libprotobuf.so` linkage:
```console
# objdump -p .linuxbrew/opt/protobuf/lib/libprotobuf.so | grep -E 'NEEDED|RPATH'
  NEEDED               libpthread.so.0
  NEEDED               libz.so.1
  NEEDED               libstdc++.so.6
  NEEDED               libc.so.6
  NEEDED               ld-linux-x86-64.so.2
  NEEDED               libgcc_s.so.1
  RPATH                /home/linuxbrew/.linuxbrew/Cellar/protobuf/3.17.3/lib:/home/linuxbrew/.linuxbrew/lib:/home/linuxbrew/.linuxbrew/opt/six/lib
```

macOS installation shows `protoc` links to `/usr/lib/libz.1.dylib`