### PR TITLE
notcurses 2.3.13

### DIFF
--- a/Formula/notcurses.rb
+++ b/Formula/notcurses.rb
@@ -1,8 +1,9 @@
 class Notcurses < Formula
   desc "Blingful character graphics/TUI library"
   homepage "https://nick-black.com/dankwiki/index.php/Notcurses"
-  url "https://github.com/dankamongmen/notcurses/archive/refs/tags/v2.3.12.tar.gz"
-  sha256 "ce042908fac11f7df1f9eaa610e46e9c615f53ab036b7c27ae2396292512407b"
+  url "https://github.com/dankamongmen/notcurses/archive/refs/tags/v2.3.13.tar.gz"
+  sha256 "c5eb822ea5b98028acd4a8dd21b155f893d928e4a30a8309eea0c406403af4e8"
+
   license "Apache-2.0"
 
   bottle do
@@ -17,7 +18,6 @@ class Notcurses < Formula
   depends_on "pkg-config" => :build
   depends_on "ffmpeg"
   depends_on "libunistring"
-  depends_on macos: :catalina # requires std::filesystem
   depends_on "ncurses"
   depends_on "readline"
   uses_from_macos "zlib"


### PR DESCRIPTION
New upstream release 2.3.13: https://github.com/dankamongmen/notcurses/releases/tag/v2.3.13. In particular, this fixes issues preventing the `intro` and `uniblcok` demos from running in a default-sized `Terminal.app` or `iTerm2`.

Enables building on Mojave, having removed the std::filesystem code that prevented it before. I don't have a Mojave machine to test this on, but hopefully it'll work.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
