### PR TITLE
librtlsdr: fix test for Linux

### DIFF
--- a/Formula/librtlsdr.rb
+++ b/Formula/librtlsdr.rb
@@ -37,7 +37,7 @@ class Librtlsdr < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "-L#{lib}", "-lrtlsdr", "test.c", "-o", "test"
+    system ENV.cc, "test.c", "-L#{lib}", "-lrtlsdr", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3127437073?check_suite_focus=true
```
==> brew test --verbose librtlsdr
==> FAILED
==> Testing librtlsdr
==> /usr/bin/gcc-5 -L/home/linuxbrew/.linuxbrew/Cellar/librtlsdr/0.6.0/lib -lrtlsdr test.c -o test
/tmp/ccK0dWVc.o: In function `main':
test.c:(.text+0x5): undefined reference to `rtlsdr_get_device_count'
collect2: error: ld returned 1 exit status
```