### PR TITLE
advancemame, advancemenu: add/update livecheck

### DIFF
--- a/Formula/advancemame.rb
+++ b/Formula/advancemame.rb
@@ -7,7 +7,7 @@ class Advancemame < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/advancemenu.rb
+++ b/Formula/advancemenu.rb
@@ -5,6 +5,10 @@ class Advancemenu < Formula
   sha256 "3e4628e1577e70a1dbe104f17b1b746745b8eda80837f53fbf7b091c88be8c2b"
   license "GPL-2.0"
 
+  livecheck do
+    formula "advancemame"
+  end
+
   bottle do
     sha256 arm64_big_sur: "28169ad5c0b9efda64ff4b27e5306df4ba1239937d30403dc569076e8f692010"
     sha256 big_sur:       "81fba884c95faf6fbe13f1dfa128e6875bb3ec7e9743ae70830b2b086863df10"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing check for `advancemame` uses the `GithubLatest` strategy but this is a legacy `livecheck` block that was originally added on 2018-05-03 and (checking the `releases` page, which we avoid doing), later adapted to check the "latest" release on GitHub, and then updated to use the `GithubLatest` strategy after it was created. In the interim time, we've adapted our approach to only use the `GithubLatest` strategy when it's both correct and necessary. In this instance, it's not necessary, as checking the Git tags with the standard regex for tags like `1.2.3`/`v1.2.3` gives the correct latest version. As such, this PR removes `strategy :github_latest` and adds the aforementioned regex.

Past that, this adds a `livecheck` block to `advancemenu` that uses `formula "advancemame"`, so that it's check will be synced with that formula. `advancemame` and `advancemenu` both use the same `stable` tarball but `advancemame` is the canonical formula, so `advancemenu` references it.