### PR TITLE
mp3info: fix build for Linux

### DIFF
--- a/Formula/mp3info.rb
+++ b/Formula/mp3info.rb
@@ -3,7 +3,7 @@ class Mp3info < Formula
   homepage "https://www.ibiblio.org/mp3info/"
   url "https://www.ibiblio.org/pub/linux/apps/sound/mp3-utils/mp3info/mp3info-0.8.5a.tgz"
   sha256 "0438ac68e9f04947fb14ca5573d27c62454cb9db3a93b7f1d2c226cd3e0b4e10"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://www.ibiblio.org/pub/linux/apps/sound/mp3-utils/mp3info/"
@@ -20,6 +20,8 @@ class Mp3info < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "dd9e2ab142307a9587ca28f8ca574cf3115f380f2692f1eb1e38e24d4e5a1008"
     sha256 cellar: :any_skip_relocation, el_capitan:    "30c85d8b2afd6e6ad03e473de3bd83ef9c6c607b979570798cfc778ad887b902"
   end
+
+  uses_from_macos "ncurses"
 
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/bedf6f8/mp3info/patch-mp3tech.c.diff"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3257368718?check_suite_focus=true
```
In file included from textfunc.c:26:0:
mp3info.h:40:20: fatal error: curses.h: No such file or directory
compilation terminated.
<builtin>: recipe for target 'textfunc.o' failed
make: *** [textfunc.o] Error 1
make: *** Waiting for unfinished jobs....
In file included from mp3info.c:31:0:
mp3info.h:40:20: fatal error: curses.h: No such file or directory
compilation terminated.
<builtin>: recipe for target 'mp3info.o' failed
make: *** [mp3info.o] Error 1
```