### PR TITLE
i386-elf-gdb: fix build for Linux

### DIFF
--- a/Formula/i386-elf-gdb.rb
+++ b/Formula/i386-elf-gdb.rb
@@ -19,6 +19,7 @@ class I386ElfGdb < Formula
   depends_on "python@3.9"
   depends_on "xz" # required for lzma support
 
+  uses_from_macos "texinfo" => :build
   uses_from_macos "zlib"
 
   # Fix for https://sourceware.org/bugzilla/show_bug.cgi?id=26949#c8
@@ -57,8 +58,8 @@ class I386ElfGdb < Formula
 
   test do
     (testpath/"test.c").write "void _start(void) {}"
-    system "#{Formula["i686-elf-gcc"].bin}/i686-elf-gcc", "-g", "-nostdlib", "test.c"
+    system Formula["i686-elf-gcc"].bin/"i686-elf-gcc", "-g", "-nostdlib", "test.c"
     assert_match "Symbol \"_start\" is a function at address 0x",
-          shell_output("#{bin}/i386-elf-gdb -batch -ex 'info address _start' a.out")
+                 shell_output("#{bin}/i386-elf-gdb -batch -ex 'info address _start' a.out")
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3257372304?check_suite_focus=true
```
/tmp/i386-elf-gdb-20210805-4776-uh25rf/gdb-10.2/missing: 81: /tmp/i386-elf-gdb-20210805-4776-uh25rf/gdb-10.2/missing: makeinfo: not found
WARNING: 'makeinfo' is missing on your system.
         You should only need it if you modified a '.texi' file, or
         any other file indirectly affecting the aspect of the manual.
         You might want to install the Texinfo package:
         <http://www.gnu.org/software/texinfo/>
         The spurious makeinfo call might also be the consequence of
         using a buggy 'make' (AIX, DU, IRIX), in which case you might
         want to install GNU make:
         <http://www.gnu.org/software/make/>
Makefile:490: recipe for target 'gdb.info' failed
make[4]: *** [gdb.info] Error 127
```