### PR TITLE
openvdb: fix build for Linux

### DIFF
--- a/Formula/openvdb.rb
+++ b/Formula/openvdb.rb
@@ -26,6 +26,12 @@ class Openvdb < Formula
   depends_on "openexr@2"
   depends_on "tbb@2020"
 
+  on_linux do
+    depends_on "gcc" => :build
+  end
+
+  fails_with gcc: "5"
+
   resource "test_file" do
     url "https://artifacts.aswf.io/io/aswf/openvdb/models/cube.vdb/1.0.0/cube.vdb-1.0.0.zip"
     sha256 "05476e84e91c0214ad7593850e6e7c28f777aa4ff0a1d88d91168a7dd050f922"
@@ -46,6 +52,6 @@ class Openvdb < Formula
 
   test do
     resource("test_file").stage testpath
-    system "#{bin}/vdb_print", "-m", "cube.vdb"
+    system bin/"vdb_print", "-m", "cube.vdb"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3257330149?check_suite_focus=true
```
/tmp/openvdb-20210805-12249-1qpv4ra/openvdb-8.1.0/openvdb/openvdb/../openvdb/tree/RootNode.h:2916:5: error: ‘template<class T> constexpr const bool openvdb::v8_1::TypeList<openvdb::v8_1::tree::LeafNode<int, 3u>, openvdb::v8_1::tree::InternalNode<openvdb::v8_1::tree::LeafNode<int, 3u>, 4u>, openvdb::v8_1::tree::InternalNode<openvdb::v8_1::tree::InternalNode<openvdb::v8_1::tree::LeafNode<int, 3u>, 4u>, 5u>, openvdb::v8_1::tree::RootNode<openvdb::v8_1::tree::InternalNode<openvdb::v8_1::tree::InternalNode<openvdb::v8_1::tree::LeafNode<int, 3u>, 4u>, 5u> > >::Contains<T>’ is not a function template
     }
     ^
```