### PR TITLE
duktape: fix test for Linux

### DIFF
--- a/Formula/duktape.rb
+++ b/Formula/duktape.rb
@@ -41,7 +41,7 @@ class Duktape < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.cc", "-o", "test", "-I#{include}", "-L#{lib}", "-lduktape"
+    system ENV.cc, "test.cc", "-o", "test", "-I#{include}", "-L#{lib}", "-lduktape", "-lm"
     assert_equal "1 + 2 = 3", shell_output("./test").strip, "Duktape can add number"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3257347488?check_suite_focus=true
```
==> Testing duktape
==> /home/linuxbrew/.linuxbrew/Cellar/duktape/2.6.0/bin/duk test.js
==> /usr/bin/gcc-5 test.cc -o test -I/home/linuxbrew/.linuxbrew/Cellar/duktape/2.6.0/include -L/home/linuxbrew/.linuxbrew/Cellar/duktape/2.6.0/lib -lduktape
/home/linuxbrew/.linuxbrew/Cellar/duktape/2.6.0/lib/libduktape.so: undefined reference to `log2'
/home/linuxbrew/.linuxbrew/Cellar/duktape/2.6.0/lib/libduktape.so: undefined reference to `ceil'
```
