### PR TITLE
gegl: fix build

### DIFF
--- a/Formula/gegl.rb
+++ b/Formula/gegl.rb
@@ -38,11 +38,12 @@ class Gegl < Formula
 
   def install
     args = std_meson_args + %w[
-      -Dwith-docs=false
-      -Dwith-cairo=false
-      -Dwith-jasper=false
-      -Dwith-umfpack=false
-      -Dwith-libspiro=false
+      -Ddocs=false
+      -Dcairo=disabled
+      -Djasper=disabled
+      -Dmfpack=disabled
+      -Dlibspiro=disabled
+      --wrap-mode=default
       --force-fallback-for=libnsgif,poly2tri-c
     ]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fix build failure seen in #82155, caused by a regression in meson 0.59 (see https://github.com/mesonbuild/meson/issues/9065)

Also, correct the existing meson options: `WARNING: Unknown options: "with-cairo, with-docs, with-jasper, with-libspiro, with-umfpack"` 
