### PR TITLE
sipp: enable pcap/ssl features and add ncurses for Linux

### DIFF
--- a/Formula/sipp.rb
+++ b/Formula/sipp.rb
@@ -3,7 +3,8 @@ class Sipp < Formula
   homepage "https://sipp.sourceforge.io/"
   url "https://github.com/SIPp/sipp/releases/download/v3.6.1/sipp-3.6.1.tar.gz"
   sha256 "6a560e83aff982f331ddbcadfb3bd530c5896cd5b757dd6eb682133cc860ecb1"
-  license "BSD-3-Clause"
+  license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "449c55fa3ed88cbbd0ec9f1034d93df5b9affe4e168c7d332fc4a41b4b9f6d0a"
@@ -14,9 +15,13 @@ class Sipp < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "openssl@1.1"
+
+  uses_from_macos "libpcap"
+  uses_from_macos "ncurses"
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", ".", *std_cmake_args, "-DUSE_PCAP=1", "-DUSE_SSL=1"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`ncurses` is needed for Linux
https://github.com/Homebrew/homebrew-core/runs/3258903931?check_suite_focus=true
```
==> brew linkage --test sipp
==> FAILED
Missing libraries:
  unexpected (libncursesw.so.6)
```

---

Also enabled SSL and PCAP features since they seem pretty common among Linux distros:
- [Gentoo](https://gitweb.gentoo.org/repo/gentoo.git/tree/net-misc/sipp/sipp-3.6.1.ebuild) defaults are SSL and PCAP, while GSL and SCTP are optional
- [Fedora](https://src.fedoraproject.org/rpms/sipp/blob/rawhide/f/sipp.spec) enables SSL, PCAP, and SCTP
- [Arch AUR](https://aur.archlinux.org/packages/sipp) enables SSL, PCAP, and SCTP.
- [Alpine](https://git.alpinelinux.org/aports/tree/main/sipp/APKBUILD) enables SSL, PCAP, and SCTP.
