### PR TITLE
sshguard: upstream test fix on Linux

### DIFF
--- a/Formula/sshguard.rb
+++ b/Formula/sshguard.rb
@@ -3,6 +3,7 @@ class Sshguard < Formula
   homepage "https://www.sshguard.net/"
   url "https://downloads.sourceforge.net/project/sshguard/sshguard/2.4.2/sshguard-2.4.2.tar.gz"
   sha256 "2770b776e5ea70a9bedfec4fd84d57400afa927f0f7522870d2dcbbe1ace37e8"
+  license "ISC"
   version_scheme 1
 
   bottle do
@@ -79,6 +80,8 @@ class Sshguard < Formula
     require "pty"
     PTY.spawn(sbin/"sshguard", "-v") do |r, _w, pid|
       assert_equal "SSHGuard #{version}", r.read.strip
+    rescue Errno::EIO
+      nil
     ensure
       Process.wait pid
     end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
