### PR TITLE
platypus: add `depends_on :macos`

### DIFF
--- a/Formula/platypus.rb
+++ b/Formula/platypus.rb
@@ -16,6 +16,7 @@ class Platypus < Formula
   end
 
   depends_on xcode: ["8.0", :build]
+  depends_on :macos
 
   def install
     xcodebuild "SYMROOT=build", "DSTROOT=#{buildpath}/dst",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
