### PR TITLE
mytop: fix build for Linux

### DIFF
--- a/Formula/mytop.rb
+++ b/Formula/mytop.rb
@@ -23,6 +23,13 @@ class Mytop < Formula
 
   uses_from_macos "perl"
 
+  on_linux do
+    resource "Term::ReadKey" do
+      url "https://cpan.metacpan.org/authors/id/J/JS/JSTOWE/TermReadKey-2.38.tar.gz"
+      sha256 "5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290"
+    end
+  end
+
   conflicts_with "mariadb", because: "both install `mytop` binaries"
 
   resource "List::Util" do
@@ -35,12 +42,9 @@ class Mytop < Formula
     sha256 "d6d38a416da79de874c5f1825221f22e972ad500b6527d190cc6e9ebc45194b4"
   end
 
-  # In Mojave, this is not part of the system Perl anymore
-  if MacOS.version >= :mojave
-    resource "DBI" do
-      url "https://cpan.metacpan.org/authors/id/T/TI/TIMB/DBI-1.641.tar.gz"
-      sha256 "5509e532cdd0e3d91eda550578deaac29e2f008a12b64576e8c261bb92e8c2c1"
-    end
+  resource "DBI" do
+    url "https://cpan.metacpan.org/authors/id/T/TI/TIMB/DBI-1.641.tar.gz"
+    sha256 "5509e532cdd0e3d91eda550578deaac29e2f008a12b64576e8c261bb92e8c2c1"
   end
 
   resource "DBD::mysql" do
@@ -67,8 +71,14 @@ class Mytop < Formula
   end
 
   def install
+    res = resources
+    on_macos do
+      # Before Mojave, DBI was part of the system Perl
+      res -= [resource("DBI")] if MacOS.version < :mojave
+    end
+
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
-    resources.each do |r|
+    res.each do |r|
       r.stage do
         system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
         system "make", "install"
@@ -78,7 +88,7 @@ class Mytop < Formula
     system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}"
     system "make", "install"
     share.install prefix/"man"
-    bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
+    bin.env_script_all_files libexec/"bin", PERL5LIB: ENV["PERL5LIB"]
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3259354037?check_suite_focus=true
```
==> perl Makefile.PL INSTALL_BASE=/home/linuxbrew/.linuxbrew/Cellar/mytop/1.9.1_9/libexec
Can't locate DBI/DBD.pm in @INC (you may need to install the DBI::DBD module) (@INC contains: /home/linuxbrew/.linuxbrew/Cellar/mytop/1.9.1_9/libexec/lib/perl5/x86_64-linux-thread-multi /home/linuxbrew/.linuxbrew/Cellar/mytop/1.9.1_9/libexec/lib/perl5 /home/linuxbrew/.linuxbrew/Cellar/perl/5.34.0/lib/perl5/site_perl/5.34.0/x86_64-linux-thread-multi /home/linuxbrew/.linuxbrew/Cellar/perl/5.34.0/lib/perl5/site_perl/5.34.0 /home/linuxbrew/.linuxbrew/Cellar/perl/5.34.0/lib/perl5/5.34.0/x86_64-linux-thread-multi /home/linuxbrew/.linuxbrew/Cellar/perl/5.34.0/lib/perl5/5.34.0 /home/linuxbrew/.linuxbrew/lib/perl5/site_perl/5.34.0/x86_64-linux-thread-multi /home/linuxbrew/.linuxbrew/lib/perl5/site_perl/5.34.0) at Makefile.PL line 16.
```