### PR TITLE
open-adventure: fix build for Linux

### DIFF
--- a/Formula/open-adventure.rb
+++ b/Formula/open-adventure.rb
@@ -22,8 +22,12 @@ class OpenAdventure < Formula
   depends_on "asciidoc" => :build
   depends_on "python@3.9" => :build
 
-  uses_from_macos "libedit" => :build
   uses_from_macos "libxml2" => :build
+  uses_from_macos "libedit"
+
+  on_linux do
+    depends_on "pkg-config" => :build
+  end
 
   resource "PyYAML" do
     url "https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3260394880?check_suite_focus=true
```
make: pkg-config: Command not found
gcc-5 -std=c99 -D_DEFAULT_SOURCE -DVERSION=\"1.9\" -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-all   -c misc.c
make: pkg-config: Command not found
gcc-5 -std=c99 -D_DEFAULT_SOURCE -DVERSION=\"1.9\" -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-all   -c saveresume.c
gcc-5 -std=c99 -D_DEFAULT_SOURCE -DVERSION=\"1.9\" -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-all  -c dungeon.c
make: pkg-config: Command not found
gcc-5 -std=c99 -D_DEFAULT_SOURCE -DVERSION=\"1.9\" -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-all  -o advent main.o init.o actions.o score.o misc.o saveresume.o dungeon.o  
misc.o: In function `get_input':
misc.c:(.text+0xad5): undefined reference to `readline'
misc.c:(.text+0xb2a): undefined reference to `add_history'
saveresume.o: In function `suspend':
saveresume.c:(.text+0xdb): undefined reference to `readline'
saveresume.o: In function `resume':
saveresume.c:(.text+0x552): undefined reference to `readline'
collect2: error: ld returned 1 exit status
Makefile:29: recipe for target 'advent' failed
make: *** [advent] Error 1
```