### PR TITLE
exact-image: add Linux dependencies

### DIFF
--- a/Formula/exact-image.rb
+++ b/Formula/exact-image.rb
@@ -3,7 +3,7 @@ class ExactImage < Formula
   homepage "https://exactcode.com/opensource/exactimage/"
   url "https://dl.exactcode.de/oss/exact-image/exact-image-1.0.2.tar.bz2"
   sha256 "0694c66be5dec41377acead475de69b3d7ffb42c702402f8b713f8b44cdc2791"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url "https://dl.exactcode.de/oss/exact-image/"
@@ -21,6 +21,9 @@ class ExactImage < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libagg"
+
+  uses_from_macos "expat"
+  uses_from_macos "zlib"
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3257374979?check_suite_focus=true
```
==> brew linkage --test exact-image
==> FAILED
Unwanted system libraries:
  /lib/x86_64-linux-gnu/libz.so.1
```


On macOS:
```
/usr/local/Cellar/exact-image/1.0.2/bin/bardecode:
	/usr/local/opt/libagg/lib/libagg.2.dylib (compatibility version 3.0.0, current version 3.4.0)
	/usr/lib/libexpat.1.dylib (compatibility version 7.0.0, current version 8.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 904.4.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.0.0)
```