### PR TITLE
aalib: fix test for Linux

### DIFF
--- a/Formula/aalib.rb
+++ b/Formula/aalib.rb
@@ -40,6 +40,23 @@ class Aalib < Formula
   end
 
   test do
-    system "script", "-q", "/dev/null", bin/"aainfo"
+    output = shell_output("#{bin}/aainfo -width 100 -height 50")
+    assert_match "AAlib version:#{version.major_minor}", output
+    assert_match(/Width +:100$/, output)
+    assert_match(/Height +:50$/, output)
+
+    output = shell_output("yes '' | #{bin}/aatest -width 20 -height 10")
+    assert_match <<~EOS, output
+      floyd-steelberg dith
+      ering. . ....----:.:
+          . .......-.:.:::
+         . . . ....---:-::
+          . .......-.:.:-:
+         . . . ....--.:-::
+          . .......-.:-:-:
+         . . . ....:.:.:-:
+          . ........:.:-::
+         . . . ....:.--:-:
+    EOS
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3049638848?check_suite_focus=true
```
==> brew test --verbose aalib
==> FAILED
==> Testing aalib
==> script -q /dev/null /home/linuxbrew/.linuxbrew/Cellar/aalib/1.4rc5_2/bin/aainfo
Killing child processes...
Error: aalib: failed
An exception occurred within a child process:
  Timeout::Error: execution expired
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2193:in `gets'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2193:in `block in system'
```