### PR TITLE
djbdns: add livecheck

### DIFF
--- a/Formula/djbdns.rb
+++ b/Formula/djbdns.rb
@@ -4,6 +4,11 @@ class Djbdns < Formula
   url "https://cr.yp.to/djbdns/djbdns-1.05.tar.gz"
   sha256 "3ccd826a02f3cde39be088e1fc6aed9fd57756b8f970de5dc99fcd2d92536b48"
 
+  livecheck do
+    url "https://cr.yp.to/djbdns/install.html"
+    regex(/href=.*?djbdns[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 3
     sha256 arm64_big_sur: "62ab5e22e0c15787a98c84f23905dd569067cd4376dc8c472509ac5ee5d24955"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a recreation of #82729, which CI wouldn't run the `tap_syntax` job on, for whatever reason. I [made various attempts to fix the issue](https://github.com/Homebrew/homebrew-core/pull/82729#issuecomment-893831335) to no avail but a subsequent `livecheck` PR worked fine, so this seemed like the next thing to try. The original PR message can be found below:

By default, livecheck gives an `Unable to get versions` error for `djbdns`. This PR adds a `livecheck` block that checks the installation instructions page, which links to the `stable` archive.