### PR TITLE
ndiff: add livecheck

### DIFF
--- a/Formula/ndiff.rb
+++ b/Formula/ndiff.rb
@@ -5,6 +5,11 @@ class Ndiff < Formula
   sha256 "f2bbd9a2c8ada7f4161b5e76ac5ebf9a2862cab099933167fe604b88f000ec2c"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?ndiff[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c7c14877b300c9a36d4047b883e773397f819f60718b9e13d17ca4359b317541"
     sha256 cellar: :any_skip_relocation, big_sur:       "409ac74964648efd98d55c7b07ffcb90066e23b08a50b495b4e43183fd3a9aef"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `ndiff`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.