### PR TITLE
zabbix-cli: fix build for Linux

### DIFF
--- a/Formula/zabbix-cli.rb
+++ b/Formula/zabbix-cli.rb
@@ -5,7 +5,7 @@ class ZabbixCli < Formula
   homepage "https://github.com/unioslo/zabbix-cli/"
   url "https://github.com/unioslo/zabbix-cli/archive/2.2.1.tar.gz"
   sha256 "884ecd2a4a4c7f68a080bb7e0936dd208c813284ec3ed60b948ce90a1be7c828"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 1
   head "https://github.com/unioslo/zabbix-cli.git"
 
@@ -59,7 +59,8 @@ class ZabbixCli < Formula
   end
 
   def install
-    # script tries to install config directly to /usr/local/bin
+    # script tries to install config into /usr/local/bin (macOS) or /usr/share (Linux)
+    inreplace %w[setup.py etc/zabbix-cli.conf zabbix_cli/config.py], %r{(["' ])/usr/share/}, "\\1#{share}/"
     inreplace "setup.py", "/usr/local/bin", share
 
     virtualenv_install_with_resources


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3206066605?check_suite_focus=true
```
    running install_data
    creating /usr/share/zabbix-cli
    error: could not create '/usr/share/zabbix-cli': Permission denied
    Running setup.py install for zabbix-cli: finished with status 'error'
ERROR: Command errored out with exit status 1: /home/linuxbrew/.linuxbrew/Cellar/zabbix-cli/2.2.1_1/libexec/bin/python3.9 -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-4k0wn7l_/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-4k0wn7l_/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-h4g95ejo/install-record.txt --single-version-externally-managed --compile --install-headers /home/linuxbrew/.linuxbrew/Cellar/zabbix-cli/2.2.1_1/libexec/include/site/python3.9/zabbix-cli Check the logs for full command output.
```