### PR TITLE
udptunnel: switch to FreeBSD URL as VoidLinux URL is 404

### DIFF
--- a/Formula/udptunnel.rb
+++ b/Formula/udptunnel.rb
@@ -4,7 +4,8 @@ class Udptunnel < Formula
   # site, but currently www.cs.columbia.edu returns a 404 error if you
   # try to fetch them over https instead of http
   homepage "https://web.archive.org/web/20161224191851/www.cs.columbia.edu/~lennox/udptunnel/"
-  url "https://sources.voidlinux.org/udptunnel-1.1/udptunnel-1.1.tar.gz"
+  url "https://pkg.freebsd.org/ports-distfiles/udptunnel-1.1.tar.gz"
+  mirror "https://sources.voidlinux.org/udptunnel-1.1/udptunnel-1.1.tar.gz"
   sha256 "45c0e12045735bc55734076ebbdc7622c746d1fe4e6f7267fa122e2421754670"
   license "BSD-3-Clause"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3093698680?check_suite_focus=true
```
==> Starting build of udptunnel
==> brew fetch --retry udptunnel --build-bottle --force
==> FAILED
==> Downloading https://sources.voidlinux.org/udptunnel-1.1/udptunnel-1.1.tar.gz
curl: (22) The requested URL returned error: 404 Not Found
==> Retrying download
==> Downloading https://sources.voidlinux.org/udptunnel-1.1/udptunnel-1.1.tar.gz
curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "udptunnel"
Download failed: https://sources.voidlinux.org/udptunnel-1.1/udptunnel-1.1.tar.gz
```