### PR TITLE
ttfautohint: fix test for Linux

### DIFF
--- a/Formula/ttfautohint.rb
+++ b/Formula/ttfautohint.rb
@@ -3,6 +3,7 @@ class Ttfautohint < Formula
   homepage "https://www.freetype.org/ttfautohint/"
   url "https://downloads.sourceforge.net/project/freetype/ttfautohint/1.8.3/ttfautohint-1.8.3.tar.gz"
   sha256 "87bb4932571ad57536a7cc20b31fd15bc68cb5429977eb43d903fa61617cf87e"
+  license any_of: ["FTL", "GPL-2.0-or-later"]
 
   livecheck do
     url "https://sourceforge.net/projects/freetype/rss?path=/ttfautohint"
@@ -44,8 +45,13 @@ class Ttfautohint < Formula
 
   test do
     font_name = (MacOS.version >= :catalina) ? "Arial Unicode.ttf" : "Arial.ttf"
-    cp "/Library/Fonts/#{font_name}", testpath
-    system "#{bin}/ttfautohint", font_name, "output.ttf"
+    font_dir = "/Library/Fonts"
+    on_linux do
+      font_name = "DejaVuSans.ttf"
+      font_dir = "/usr/share/fonts/truetype/dejavu"
+    end
+    cp "#{font_dir}/#{font_name}", testpath
+    system bin/"ttfautohint", font_name, "output.ttf"
     assert_predicate testpath/"output.ttf", :exist?
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3093689021?check_suite_focus=true
```
==> brew test --verbose ttfautohint
==> FAILED
==> Testing ttfautohint
Error: ttfautohint: failed
An exception occurred within a child process:
  Errno::ENOENT: No such file or directory @ rb_sysopen - /Library/Fonts/Arial.ttf
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/fileutils.rb:1385:in `initialize'
```