### PR TITLE
ttf2eot: fix test for Linux

### DIFF
--- a/Formula/ttf2eot.rb
+++ b/Formula/ttf2eot.rb
@@ -21,9 +21,14 @@ class Ttf2eot < Formula
   end
 
   test do
-    font_name = (MacOS.version >= :catalina) ? "Arial Unicode.ttf" : "Arial.ttf"
-    cp "/Library/Fonts/#{font_name}", testpath
-    system("#{bin}/ttf2eot < '#{font_name}' > Arial.eot")
-    assert_predicate testpath/"Arial.eot", :exist?
+    font_name = (MacOS.version >= :catalina) ? "Arial Unicode" : "Arial"
+    font_dir = "/Library/Fonts"
+    on_linux do
+      font_name = "DejaVuSans"
+      font_dir = "/usr/share/fonts/truetype/dejavu"
+    end
+    cp "#{font_dir}/#{font_name}.ttf", testpath
+    system("#{bin}/ttf2eot < '#{font_name}.ttf' > '#{font_name}.eot'")
+    assert_predicate testpath/"#{font_name}.eot", :exist?
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3093687656?check_suite_focus=true
```
==> brew test --verbose ttf2eot
==> FAILED
==> Testing ttf2eot
Error: ttf2eot: failed
An exception occurred within a child process:
  Errno::ENOENT: No such file or directory @ rb_sysopen - /Library/Fonts/Arial.ttf
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/fileutils.rb:1385:in `initialize'
```