### PR TITLE
taktuk: fix build on Linux

### DIFF
--- a/Formula/taktuk.rb
+++ b/Formula/taktuk.rb
@@ -3,7 +3,7 @@ class Taktuk < Formula
   homepage "https://taktuk.gforge.inria.fr/"
   url "https://gforge.inria.fr/frs/download.php/file/37055/taktuk-3.7.7.tar.gz"
   sha256 "56a62cca92670674c194e4b59903e379ad0b1367cec78244641aa194e9fe893e"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://gforge.inria.fr/frs/?group_id=274"
@@ -20,6 +20,8 @@ class Taktuk < Formula
     sha256 cellar: :any, el_capitan:    "4a731d243e6915729240deb75dc99cfee513bb7d0f69169981623b14ce6601c1"
   end
 
+  uses_from_macos "perl"
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make"
@@ -28,6 +30,6 @@ class Taktuk < Formula
   end
 
   test do
-    system "#{bin}/taktuk", "quit"
+    system bin/"taktuk", "quit"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3206392220?check_suite_focus=true
```
==> brew audit taktuk --online --git --skip-style
==> FAILED
Error: 1 problem in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
taktuk:
  * A top-level "man" directory was found.
    Homebrew requires that man pages live under "share".
    This can often be fixed by passing `--mandir=#{man}` to `configure`.
```