### PR TITLE
ssdb: update sha256 for retagged release with patch

### DIFF
--- a/Formula/ssdb.rb
+++ b/Formula/ssdb.rb
@@ -1,8 +1,8 @@
 class Ssdb < Formula
   desc "NoSQL database supporting many data structures: Redis alternative"
-  homepage "http://ssdb.io/"
+  homepage "https://ssdb.io/"
   url "https://github.com/ideawu/ssdb/archive/1.9.9.tar.gz"
-  sha256 "28b5b6505a6a660b587b7d07ef77a3983a0696f7d481aa70696e53048fa92e45"
+  sha256 "a32009950114984d6e468e10d964b0ef1e846077b69d7c7615715fdfa01aaf6e"
   license "BSD-3-Clause"
   head "https://github.com/ideawu/ssdb.git"
 
@@ -13,12 +13,6 @@ class Ssdb < Formula
   end
 
   depends_on "autoconf" => :build
-
-  # Fix ssdb 1.9.9 build
-  patch do
-    url "https://github.com/chenrui333/ssdb/commit/9556a38fb1e3cb4920e2b6ab242183a747d55a51.patch?full_index=1"
-    sha256 "ee765e6c98c991c0cf069a5bf4b0d571987b0fa35be756b5a8960190f1d14be9"
-  end
 
   def install
     inreplace "tools/ssdb-cli", /^DIR=.*$/, "DIR=#{prefix}"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3093606263?check_suite_focus=true
```
==> Downloading https://github.com/ideawu/ssdb/archive/1.9.9.tar.gz
Error: SHA256 mismatch
Expected: 28b5b6505a6a660b587b7d07ef77a3983a0696f7d481aa70696e53048fa92e45
  Actual: a32009950114984d6e468e10d964b0ef1e846077b69d7c7615715fdfa01aaf6e
    File: 

==> brew audit ssdb --online --git --skip-style
==> FAILED
Error: 1 problem in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
ssdb:
  * The homepage URL http://ssdb.io/ should use HTTPS rather than HTTP
```

---

Taking a look upstream, the release https://github.com/ideawu/ssdb/releases/tag/1.9.9 appears to be retagged with the patch.

The patch we apply: https://github.com/chenrui333/ssdb/commit/9556a38fb1e3cb4920e2b6ab242183a747d55a51

It has been added to 1.9.9 release: https://github.com/ideawu/ssdb/commit/3e556e4bf4cee96d2577e3c3002f00c540e4ba10
