### PR TITLE
shapelib: fix build for ARM and Linux

### DIFF
--- a/Formula/shapelib.rb
+++ b/Formula/shapelib.rb
@@ -3,6 +3,7 @@ class Shapelib < Formula
   homepage "http://shapelib.maptools.org/"
   url "https://download.osgeo.org/shapelib/shapelib-1.5.0.tar.gz"
   sha256 "1fc0a480982caef9e7b9423070b47750ba34cd0ba82668f2e638fab1d07adae1"
+  license any_of: ["LGPL-2.0-or-later", "MIT"]
 
   livecheck do
     url "https://download.osgeo.org/shapelib/"
@@ -20,8 +21,11 @@ class Shapelib < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    # shapelib's CMake scripts interpret `CMAKE_INSTALL_LIBDIR=lib` as relative
+    # to the current directory, i.e. `CMAKE_INSTALL_LIBDIR:PATH=$(pwd)/lib`
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args(install_libdir: lib)
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3092148940?check_suite_focus=true
```
==> brew linkage --test shapelib
==> FAILED
Missing libraries:
  unexpected (libshp.so.1)

==> brew install --only-dependencies --include-test shapelib
==> brew test --verbose shapelib
==> FAILED
==> Testing shapelib
==> /home/linuxbrew/.linuxbrew/Cellar/shapelib/1.5.0/bin/shptreedump
/home/linuxbrew/.linuxbrew/Cellar/shapelib/1.5.0/bin/shptreedump: error while loading shared libraries: libshp.so.1: cannot open shared object file: No such file or directory

Error: shapelib: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected: 1
  Actual: 127
```