### PR TITLE
resty: fix test for Linux

### DIFF
--- a/Formula/resty.rb
+++ b/Formula/resty.rb
@@ -1,4 +1,6 @@
 class Resty < Formula
+  include Language::Python::Shebang
+
   desc "Command-line REST client that can be used in pipelines"
   homepage "https://github.com/micha/resty"
   url "https://github.com/micha/resty/archive/v3.0.tar.gz"
@@ -17,6 +19,10 @@ class Resty < Formula
   end
 
   uses_from_macos "perl"
+
+  on_linux do
+    depends_on "python@3.9"
+  end
 
   conflicts_with "nss", because: "both install `pp` binaries"
 
@@ -40,6 +46,9 @@ class Resty < Formula
     bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
 
     bin.install "pypp"
+    on_linux do
+      rewrite_shebang detected_python_shebang, bin/"pypp"
+    end
   end
 
   def caveats
@@ -50,7 +59,7 @@ class Resty < Formula
   end
 
   test do
-    cmd = "zsh -c '. #{pkgshare}/resty && resty https://api.github.com' 2>&1"
+    cmd = "bash -c '. #{pkgshare}/resty && resty https://api.github.com' 2>&1"
     assert_equal "https://api.github.com*", shell_output(cmd).chomp
     json_pretty_pypp=<<~EOS
       {


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3266731370?check_suite_focus=true
```
==> brew test --verbose resty
==> FAILED
==> Testing resty
==> zsh -c '. /home/linuxbrew/.linuxbrew/Cellar/resty/3.0/share/resty/resty && resty https://api.github.com' 2>&1
sh: 1: zsh: not found
Error: resty: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected: 0
  Actual: 127
```
