### PR TITLE
qtfaststart: update license and fix test for Linux

### DIFF
--- a/Formula/qtfaststart.rb
+++ b/Formula/qtfaststart.rb
@@ -3,7 +3,7 @@ class Qtfaststart < Formula
   homepage "https://libav.org/"
   url "https://libav.org/releases/libav-12.3.tar.gz"
   sha256 "115b659022dd387f662e26fbc5bc0cc14ec18daa100003ffd34f4da0479b272e"
-  license "LGPL-2.1"
+  license :public_domain
 
   bottle do
     rebuild 1
@@ -30,8 +30,8 @@ class Qtfaststart < Formula
   test do
     input = "H264_test4_Talkingheadclipped_mov_480x320.mov"
     output = "out.mov"
-    resource("mov").stage testpath
-    system "#{bin}/qt-faststart", input, output
+    resource("mov").stage { testpath.install Dir["*"].first => input }
+    system bin/"qt-faststart", input, output
 
     assert_predicate testpath/output, :exist?
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3092097057?check_suite_focus=true
```
==> brew test --verbose qtfaststart
==> FAILED
==> Testing qtfaststart
cp -p /home/linuxbrew/.cache/Homebrew/downloads/2dfe8e01f2419ad1b1467e1bbd746bf62d13fe9f1e93e5e0581dea650be6a611--examples /tmp/qtfaststart--mov-20210717-4401-1i5myjf/examples
==> /home/linuxbrew/.linuxbrew/Cellar/qtfaststart/12.3/bin/qt-faststart H264_test4_Talkingheadclipped_mov_480x320.mov out.mov
H264_test4_Talkingheadclipped_mov_480x320.mov: No such file or directory
Error: test failed
Error: qtfaststart: failed
An exception occurred within a child process:
  BuildError: Failed executing: /home/linuxbrew/.linuxbrew/Cellar/qtfaststart/12.3/bin/qt-faststart H264_test4_Talkingheadclipped_mov_480x320.mov out.mov
```