### PR TITLE
pygitup: fix build for Linux

### DIFF
--- a/Formula/pygitup.rb
+++ b/Formula/pygitup.rb
@@ -14,6 +14,7 @@ class Pygitup < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "99ea13e47193752b83c7ac7751d1ab44cc1c2b549c2b4662ce54cf9ac6fe4255"
   end
 
+  depends_on "poetry" => :build
   depends_on "python@3.9"
 
   resource "click" do
@@ -47,7 +48,10 @@ class Pygitup < Formula
   end
 
   def install
-    virtualenv_install_with_resources
+    venv = virtualenv_create(libexec, "python3")
+    venv.pip_install resources
+    system Formula["poetry"].opt_bin/"poetry", "build", "--format", "wheel", "--verbose", "--no-interaction"
+    venv.pip_install_and_link Dir["dist/git_up-*.whl"].first
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Another problematic `poetry` dependency for Linux: https://github.com/Homebrew/homebrew-core/runs/3092093101?check_suite_focus=true

Main issue is https://github.com/msiemens/PyGitUp/blob/master/pyproject.toml#L43-L45
```
[build-system]
requires = ["poetry>=0.12"]
build-backend = "poetry.masonry.api"
```

As `poetry` pulls in extra dependencies (i.e. Cryptography + Rust) while `poetry-core` avoids these. Though, `poetry-core` will still cause an extra `poetry-core` package to be installed during build-time.