### PR TITLE
pakchois: use http url as https has ssl error

### DIFF
--- a/Formula/pakchois.rb
+++ b/Formula/pakchois.rb
@@ -1,7 +1,7 @@
 class Pakchois < Formula
   desc "PKCS #11 wrapper library"
-  homepage "https://www.manyfish.co.uk/pakchois/"
-  url "https://www.manyfish.co.uk/pakchois/pakchois-0.4.tar.gz"
+  homepage "http://www.manyfish.co.uk/pakchois/"
+  url "http://www.manyfish.co.uk/pakchois/pakchois-0.4.tar.gz"
   sha256 "d73dc5f235fe98e4d1e8c904f40df1cf8af93204769b97dbb7ef7a4b5b958b9a"
   license "GPL-2.0-or-later"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

At least down for a week: https://github.com/Homebrew/homebrew-core/runs/3208249709?check_suite_focus=true
```
==> brew fetch --retry pakchois --build-bottle --force
==> FAILED
==> Downloading https://www.manyfish.co.uk/pakchois/pakchois-0.4.tar.gz
curl: (35) gnutls_handshake() failed: An unexpected TLS packet was received.
==> Retrying download
==> Downloading https://www.manyfish.co.uk/pakchois/pakchois-0.4.tar.gz
curl: (35) gnutls_handshake() failed: An unexpected TLS packet was received.
Error: Failed to download resource "pakchois"
Download failed: https://www.manyfish.co.uk/pakchois/pakchois-0.4.tar.gz
```

Last archive.org capture was still recent July 01, 2021, so may be restored in future.