### PR TITLE
redland: update resource url to https

### DIFF
--- a/Formula/redland.rb
+++ b/Formula/redland.rb
@@ -3,6 +3,7 @@ class Redland < Formula
   homepage "https://librdf.org/"
   url "https://download.librdf.org/source/redland-1.0.17.tar.gz"
   sha256 "de1847f7b59021c16bdc72abb4d8e2d9187cd6124d69156f3326dd34ee043681"
+  license any_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later", "Apache-2.0"]
   revision 1
 
   livecheck do
@@ -28,7 +29,7 @@ class Redland < Formula
   depends_on "unixodbc"
 
   resource "bindings" do
-    url "http://download.librdf.org/source/redland-bindings-1.0.17.1.tar.gz"
+    url "https://download.librdf.org/source/redland-bindings-1.0.17.1.tar.gz"
     sha256 "ff72b587ab55f09daf81799cb3f9d263708fad5df7a5458f0c28566a2563b7f5"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3267297543?check_suite_focus=true
```
==> brew audit redland --online --git --skip-style
==> FAILED
Error: 1 problem in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
redland:
  * Stable resource "bindings": The source URL http://download.librdf.org/source/redland-bindings-1.0.17.1.tar.gz should use HTTPS rather than HTTP

```