### PR TITLE
algol68g: update license and use mirror as download url is down

### DIFF
--- a/Formula/algol68g.rb
+++ b/Formula/algol68g.rb
@@ -1,9 +1,12 @@
 class Algol68g < Formula
   desc "Algol 68 compiler-interpreter"
   homepage "https://jmvdveer.home.xs4all.nl/algol.html"
-  url "https://jmvdveer.home.xs4all.nl/algol68g-2.8.5.tar.gz"
+  # The upstream download url currently returns a 404 error.
+  # Until fixed, we can use a copy from OpenBSD.
+  url "https://ftp.openbsd.org/pub/OpenBSD/distfiles/algol68g-2.8.5.tar.gz"
+  mirror "https://jmvdveer.home.xs4all.nl/algol68g-2.8.5.tar.gz"
   sha256 "0f757c64a8342fe38ec501bde68b61d26d051dffd45742ca58b7288a99c7e2d8"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   # The homepage hasn't been updated for the latest release (2.8.5), even though
   # the related archive is available on the site. Until the website is updated


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Download URL has been 404 for almost a month now:
https://github.com/Homebrew/homebrew-core/runs/3049696968?check_suite_focus=true

URL: https://jmvdveer.home.xs4all.nl/algol68g-2.8.5.tar.gz
