### PR TITLE
ldpl: fix build for Linux

### DIFF
--- a/Formula/ldpl.rb
+++ b/Formula/ldpl.rb
@@ -14,7 +14,11 @@ class Ldpl < Formula
   end
 
   on_linux do
-    depends_on "man-db"
+    # Disable running mandb as it needs to modify /var/cache/man
+    # Copied from AUR: https://aur.archlinux.org/cgit/aur.git/tree/dont-do-mandb.patch?h=ldpl
+    # Upstream ref: https://github.com/Lartu/ldpl/commit/66c1513a38fba8048c209c525335ce0e3a32dbe5
+    # Remove in the next release.
+    patch :DATA
   end
 
   def install
@@ -33,3 +37,18 @@ class Ldpl < Formula
     assert_match "Hello World!", shell_output("./hello")
   end
 end
+
+__END__
+diff --unified --recursive --text ldpl-4.4.orig/src/makefile ldpl-4.4/src/makefile
+--- ldpl-4.4.orig/src/makefile	2019-12-16 13:09:46.441774536 -0300
++++ ldpl-4.4/src/makefile	2019-12-16 13:10:01.648441421 -0300
+@@ -51,9 +51,6 @@
+ 	install -m 775 lpm $(DESTDIR)$(PREFIX)/bin/
+ 	install -d $(DESTDIR)$(PREFIX)/share/man/man1/
+ 	install ../man/ldpl.1 $(DESTDIR)$(PREFIX)/share/man/man1/
+-ifneq ($(shell uname -s),Darwin)
+-	mandb
+-endif
+
+ uninstall:
+ 	rm $(DESTDIR)$(PREFIX)/bin/ldpl


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3208215895?check_suite_focus=true
```
==> make install PREFIX=/home/linuxbrew/.linuxbrew/Cellar/ldpl/4.4
install -d /home/linuxbrew/.linuxbrew/Cellar/ldpl/4.4/bin/
install -m 775 ldpl /home/linuxbrew/.linuxbrew/Cellar/ldpl/4.4/bin/
install -d /home/linuxbrew/.linuxbrew/Cellar/ldpl/4.4/bin/
install -m 775 lpm /home/linuxbrew/.linuxbrew/Cellar/ldpl/4.4/bin/
install -d /home/linuxbrew/.linuxbrew/Cellar/ldpl/4.4/share/man/man1/
install ../man/ldpl.1 /home/linuxbrew/.linuxbrew/Cellar/ldpl/4.4/share/man/man1/
mandb
Processing manual pages under /usr/share/man...
mandb: warning: cannot create catdir /var/cache/man
mandb: can't create index cache /var/cache/man/17164: No such file or directory
mandb: can't update index cache /var/cache/man/17164: No such file or directory
done.
makefile:48: recipe for target 'install' failed
make: *** [install] Error 2
```
