### PR TITLE
libcello: fix test for Linux

### DIFF
--- a/Formula/libcello.rb
+++ b/Formula/libcello.rb
@@ -40,7 +40,7 @@ class Libcello < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-L#{lib}", "-lCello", "-o", "test"
+    system ENV.cc, "test.c", "-L#{lib}", "-lCello", "-lpthread", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3208218725?check_suite_focus=true
```
==> brew test --verbose libcello
==> FAILED
==> Testing libcello
==> /usr/bin/gcc-5 test.c -L/home/linuxbrew/.linuxbrew/Cellar/libcello/2.1.0/lib -lCello -o test
/home/linuxbrew/.linuxbrew/Cellar/libcello/2.1.0/lib/libCello.a(Thread.o): In function `Thread_Call':
Thread.c:(.text+0x42b): undefined reference to `pthread_create'
Thread.c:(.text+0x47a): undefined reference to `pthread_key_create'
/home/linuxbrew/.linuxbrew/Cellar/libcello/2.1.0/lib/libCello.a(Thread.o): In function `Thread_Init_Run':

```