### PR TITLE
gost: fix test for Linux

### DIFF
--- a/Formula/gost.rb
+++ b/Formula/gost.rb
@@ -26,7 +26,10 @@ class Gost < Formula
     fork do
       exec "#{bin}/gost -L #{bind_address}"
     end
-    sleep 1
-    assert_match "HTTP/2 200", shell_output("curl -I -x #{bind_address} https://github.com")
+    sleep 2
+    output = shell_output("curl -I -x #{bind_address} https://github.com")
+    assert_match %r{HTTP/\d+(?:\.\d+)? 200}, output
+    assert_match %r{Proxy-Agent: gost/#{version}}i, output
+    assert_match(/Server: GitHub.com/i, output)
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3063536352?check_suite_focus=true
```
Killing child processes...
Error: gost: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /HTTP\/2\ 200/ to match "HTTP/1.1 200 Connection established\r\nProxy-Agent: gost/2.11.1\r\n\r\nHTTP/1.1 200 OK\r\nServer: GitHub.com\r\nDate: Wed, 14 Jul 2021 05:04:13 GMT\r\nContent-Type: text/html; charset=utf-8\r\nVary: X-PJAX, Accept-Language, Accept-Encoding,
...
```

```
Killing child processes...
Error: gost: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /Server:\ GitHub\.com/ to match "HTTP/1.1 200 Connection established\r\nProxy-Agent: gost/2.11.1\r\n\r\nHTTP/2 200 \r\nserver: GitHub.com\r\ndate: Sat, 07 Aug 2021 07:25:30 GMT\r\ncontent-type: text/html; charset=utf-8\r\nvary: X-PJAX, Accept-Language, Accept-Encoding, Accept,
```
