### PR TITLE
docuum: add `service` block

### DIFF
--- a/Formula/docuum.rb
+++ b/Formula/docuum.rb
@@ -18,6 +18,15 @@ class Docuum < Formula
     system "cargo", "install", *std_cargo_args
   end
 
+  # https://github.com/stepchowfun/docuum#configuring-your-operating-system-to-run-the-binary-as-a-daemon
+  service do
+    run opt_bin/"docuum"
+    keep_alive true
+    log_path var/"log/docuum.log"
+    error_log_path var/"log/docuum.log"
+    environment_variables PATH: std_service_path_env
+  end
+
   test do
     started_successfully = false
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See https://github.com/stepchowfun/docuum#configuring-your-operating-system-to-run-the-binary-as-a-daemon. Also, let's try to build this on Linux.

CC @stepchowfun