### PR TITLE
amtterm: add livecheck

### DIFF
--- a/Formula/amtterm.rb
+++ b/Formula/amtterm.rb
@@ -6,6 +6,11 @@ class Amtterm < Formula
   license "GPL-2.0"
   head "https://git.kraxel.org/git/amtterm/", using: :git
 
+  livecheck do
+    url "https://www.kraxel.org/releases/amtterm/"
+    regex(/href=.*?amtterm[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "7130d5cc879edc7425791e096234f76891e742ebcfcc5c9a7043ebad0fbf8afd"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `amtterm`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The `homepage` doesn't link to the `stable` archive and instead points to the directory listing page as the place to find downloads.