### PR TITLE
boost*: add/update livecheck

### DIFF
--- a/Formula/boost-bcp.rb
+++ b/Formula/boost-bcp.rb
@@ -6,6 +6,10 @@ class BoostBcp < Formula
   license "BSL-1.0"
   head "https://github.com/boostorg/boost.git"
 
+  livecheck do
+    formula "boost"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "bf348b4c85bb27b40dc95fb19f63aa8963ef93734b722fb6712bd413ca590af9"
     sha256 cellar: :any_skip_relocation, big_sur:       "16fbea4de8f872bac006d526c2bac139b04d0f1bf72741902c7f78825f8945a6"

--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -6,6 +6,10 @@ class BoostMpi < Formula
   license "BSL-1.0"
   head "https://github.com/boostorg/boost.git"
 
+  livecheck do
+    formula "boost"
+  end
+
   bottle do
     sha256                               arm64_big_sur: "8289fe7bb5a684360ab11462bf4312024a620854714ce02d6553e32274e5bfeb"
     sha256                               big_sur:       "76544350ace536b0af831854f3ce18a5c101155a132001685bcfa3ea411bbb94"

--- a/Formula/boost-python3.rb
+++ b/Formula/boost-python3.rb
@@ -6,6 +6,10 @@ class BoostPython3 < Formula
   license "BSL-1.0"
   head "https://github.com/boostorg/boost.git"
 
+  livecheck do
+    formula "boost"
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "5c5d10ed0373c7e068e2ca80fa98ff39ac444392bbcf0d6932fe92259f0f9f4a"
     sha256 cellar: :any,                 big_sur:       "031cfc31e2d655019467833a4c6ba4fcb7ed69f2e28798fead339cf5a1a84681"

--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -7,8 +7,11 @@ class Boost < Formula
   head "https://github.com/boostorg/boost.git"
 
   livecheck do
-    url "https://www.boost.org/feed/downloads.rss"
-    regex(/>Version v?(\d+(?:\.\d+)+)</i)
+    url "https://www.boost.org/users/download/"
+    regex(/href=.*?boost[._-]v?(\d+(?:[._]\d+)+)\.t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match.first.tr("_", ".") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `boost` formula to check the first-party download page (which links to the `stable` archive) and match versions from tarball file names. The existing check was originally added on 2018-03-21 and uses an older approach, so this brings the check up to current guidelines.

Additionally, this adds `livecheck` blocks using `formula "boost"` to `boost-*` formulae that use the same `stable` archive as `boost`. `boost` is the canonical formula and these others are variations, so this ensures these formulae use the same check as `boost` without having to manually duplicate the `livecheck` block and keep them in parity.