### PR TITLE
docker*: add livecheck

### DIFF
--- a/Formula/docker-completion.rb
+++ b/Formula/docker-completion.rb
@@ -6,6 +6,10 @@ class DockerCompletion < Formula
       revision: "3967b7d28e15a020e4ee344283128ead633b3e0c"
   license "Apache-2.0"
 
+  livecheck do
+    formula "docker"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "90ed4550064c756f9cc165649143b5daf88a32af7c254ee20410cb1b26e7c064"
   end

--- a/Formula/docker.rb
+++ b/Formula/docker.rb
@@ -7,6 +7,11 @@ class Docker < Formula
   license "Apache-2.0"
   head "https://github.com/docker/cli.git"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)(?:[._-]ce)?$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "2f006963b0e5393fa808670e88c3b6c6bab963aca3a7968f5bfeb41c331217c1"
     sha256 cellar: :any_skip_relocation, big_sur:       "1e6f9213259e150fcc57d05c55336018031f484277577a07b5740c3bbbc1cebb"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds a `livecheck` block for `docker` that uses a version of the standard regex for Git tags like `1.2.3`, `v1.2.3` that's modified to optionally match tags like `v17.06.0-ce`. This ensures that the trailing `-ce` is omitted from the version (i.e., giving `17.06.0` instead of `17.06.0-ce`).

This also adds a `livecheck` block to `docker-completion` that uses `formula "docker"`, as it uses the same `stable` URL and `docker` is the more canonical formula. This allows us to use the same check for `docker-completion` without having to duplicate the `livecheck` block and manually keep them in parity.