### PR TITLE
file-formula: add livecheck

### DIFF
--- a/Formula/file-formula.rb
+++ b/Formula/file-formula.rb
@@ -8,6 +8,11 @@ class FileFormula < Formula
   license :cannot_represent
   head "https://github.com/file/file.git"
 
+  livecheck do
+    url "https://astron.com/pub/file/"
+    regex(/href=.*?file[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "707df034d66e4a7e448fd1849f266634d5095f0605a8c7354bf5f0cf4fc5a45f"
     sha256 cellar: :any,                 big_sur:       "90936b82c5dae98ee47784aea42bb8c085febf2bdc860c5c5d8d553d6b958201"

--- a/Formula/libmagic.rb
+++ b/Formula/libmagic.rb
@@ -7,8 +7,7 @@ class Libmagic < Formula
   license :cannot_represent
 
   livecheck do
-    url "https://astron.com/pub/file/"
-    regex(/href=.*?file[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    formula "file-formula"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds the `livecheck` block from `libmagic` to `file-formula`. By default, livecheck was checking the `head` repository for `file-formula` which works but doesn't align with the `stable` source. The `livecheck` block from `libmagic` aligns with the `stable` source, so it's a more appropriate check.

Since `libmagic` and `file-formula` use the same `stable` URL and `file-formula` is the canonical formula, this updates the existing `livecheck` block for `libmagic` to simply use `formula "file-formula"`. This ensures that both of these formulae use the same check without needing to duplicate the `livecheck` block and manually keep them in parity.