### PR TITLE
gcc formulae: add/update livecheck

### DIFF
--- a/Formula/i686-elf-gcc.rb
+++ b/Formula/i686-elf-gcc.rb
@@ -6,6 +6,10 @@ class I686ElfGcc < Formula
   sha256 "d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 
+  livecheck do
+    formula "gcc"
+  end
+
   bottle do
     sha256 arm64_big_sur: "03ea1c0b8db4064c4acd673fb1138d410699bd37c74db3e255479f93fe0f991b"
     sha256 big_sur:       "cbf70ba4c4dcd222b84b9bde4e3f69a8c621959e20facaa8677ebd0b0f14d4da"

--- a/Formula/libgccjit.rb
+++ b/Formula/libgccjit.rb
@@ -13,17 +13,11 @@ class Libgccjit < Formula
     sha256 "d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
   end
   homepage "https://gcc.gnu.org/"
-  license "GPL-3.0-or-later" => {
-    with: "GCC-exception-3.1",
-  }
+  license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
   head "https://gcc.gnu.org/git/gcc.git"
 
   livecheck do
-    # Should be
-    # url :stable
-    # but that does not work with the ARM-specific branch above
-    url "https://ftp.gnu.org/gnu/gcc/gcc-11.1.0"
-    regex(%r{href=.*?gcc[._-]v?(\d+(?:\.\d+)+)(?:/?["' >]|\.t)}i)
+    formula "gcc"
   end
 
   bottle do

--- a/Formula/x86_64-elf-gcc.rb
+++ b/Formula/x86_64-elf-gcc.rb
@@ -6,6 +6,10 @@ class X8664ElfGcc < Formula
   sha256 "d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 
+  livecheck do
+    formula "gcc"
+  end
+
   bottle do
     sha256 arm64_big_sur: "8e89022ae000f049ac34f4e2f886faf94204e37b70da7e1b15f38c7b3d4a8f24"
     sha256 big_sur:       "549b28626170548e9def8448a09f4bb1854900652ef802672a30f691a9b44a3e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`libgccjit` uses the same `stable` archive as `gcc` and the existing `livecheck` block is also the same as the one in `gcc`. This updates `libgccjit` to simply use `formula "gcc"`, as `gcc` is the canonical formula and this will allow us to use the same check without having to manually keep them in parity.

Similarly, this adds `formula "gcc"` `livecheck` blocks to `i686-elf-gcc` and `x86_64-elf-gcc`, which also use the same `stable` archive as `gcc`.

The only other change is that I converted the multi-line `license` hash in `libgccjit` to one line, as is used in the other related formulae. This is simply a stylistic change to better align these formulae.