### PR TITLE
gdb formulae: add livecheck

### DIFF
--- a/Formula/i386-elf-gdb.rb
+++ b/Formula/i386-elf-gdb.rb
@@ -8,6 +8,10 @@ class I386ElfGdb < Formula
   revision 1
   head "https://sourceware.org/git/binutils-gdb.git"
 
+  livecheck do
+    formula "gdb"
+  end
+
   bottle do
     sha256 arm64_big_sur: "b4c91d248b5ba7d765c277903ac03f1f3d35a77079ae3acbdba8768a9dcb4c55"
     sha256 big_sur:       "dbf60ac8e71d01328d134cb1eaa47cd734dd612cd67cc7b730d56afc138ea969"

--- a/Formula/x86_64-elf-gdb.rb
+++ b/Formula/x86_64-elf-gdb.rb
@@ -8,6 +8,10 @@ class X8664ElfGdb < Formula
   revision 1
   head "https://sourceware.org/git/binutils-gdb.git"
 
+  livecheck do
+    formula "gdb"
+  end
+
   bottle do
     sha256 arm64_big_sur: "c2ad5a848a586c732f9ef0d51c432a2606343336bafd226c909d832a66e63411"
     sha256 big_sur:       "5c67cee5589f207de3b521fea5b1805e717b5101bb95d335752e74250e520abf"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`i386-elf-gdb` and `x86_64-elf-gdb` use the same `stable` URL as `gdb` and livecheck successfully uses the `Gnu` strategy on the URL by default. `gdb` is the canonical formula here, so this PR adds a `formula "gdb"` `livecheck` block to the other formulae to ensure that their checks are automatically synced with `gdb`.

This doesn't produce a functional change at the moment (they all continue to use the default check) but if we need to modify `gdb`'s check in the future, this would ensure that these related formulae will automatically get the changes as well without us needing to duplicate `livecheck` blocks and keep them in parity.