### PR TITLE
dnstracer: fix test for Linux

### DIFF
--- a/Formula/dnstracer.rb
+++ b/Formula/dnstracer.rb
@@ -36,6 +36,6 @@ class Dnstracer < Formula
   end
 
   test do
-    system "#{bin}/dnstracer", "brew.sh"
+    system bin/"dnstracer", "-4", "brew.sh"
   end
 end

--- a/Formula/dnstracer.rb
+++ b/Formula/dnstracer.rb
@@ -4,6 +4,7 @@ class Dnstracer < Formula
   url "https://www.mavetju.org/download/dnstracer-1.9.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/d/dnstracer/dnstracer_1.9.orig.tar.gz"
   sha256 "2ebc08af9693ba2d9fa0628416f2d8319ca1627e41d64553875d605b352afe9c"
+  license "BSD-2-Clause"
 
   # It's necessary to check the `/unix/general.php` page, instead of
   # `/download/`, until a real 1.10 version exists. The file name for version


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3269541448?check_suite_focus=true
```
==> brew test --verbose dnstracer
==> FAILED
==> Testing dnstracer
==> /home/linuxbrew/.linuxbrew/Cellar/dnstracer/1.9/bin/dnstracer brew.sh
Tracing to brew.sh[a] via 168.63.129.16, maximum of 3 retries
168.63.129.16 (168.63.129.16) 
 |\___ a2.nic.sh [sh] (2a01:8840:00a1:0000:0000:0000:0000:0009) send_data/sendto: Cannot assign requested address
* send_data/sendto: Cannot assign requested address
* send_data/sendto: Cannot assign requested address
* 
 |\___ a2.nic.sh [sh] (65.22.163.9) 
 |     |\___ ns4.dnsimple.com [brew.sh] (162.159.27.4) Got authoritative answer 
 |     |\___ ns4.dnsimple.com [brew.sh] (2400:cb00:2049:0001:0000:0000:a29f:1b04) 
```
