### PR TITLE
ifstat: fix patch due to missing spaces and update license

### DIFF
--- a/Formula/ifstat.rb
+++ b/Formula/ifstat.rb
@@ -3,7 +3,7 @@ class Ifstat < Formula
   homepage "http://gael.roualland.free.fr/ifstat/"
   url "http://gael.roualland.free.fr/ifstat/ifstat-1.1.tar.gz"
   sha256 "8599063b7c398f9cfef7a9ec699659b25b1c14d2bc0f535aed05ce32b7d9f507"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage
@@ -48,7 +48,7 @@ index d5ac501..47fb320 100644
 -  int count, size;
 +  int count;
 +  size_t size;
-
+   
    size = sizeof(count);
    if (sysctl(ifcount, sizeof(ifcount) / sizeof(int), &count, &size, NULL, 0) < 0) {
 @@ -607,7 +608,7 @@ static int get_ifdata(int index, struct ifmibdata * ifmd) {
@@ -57,6 +57,6 @@ index d5ac501..47fb320 100644
    };
 -  int size = sizeof(*ifmd);
 +  size_t size = sizeof(*ifmd);
-
+ 
    if (sysctl(ifinfo, sizeof(ifinfo) / sizeof(int), ifmd, &size, NULL, 0) < 0)
      return 0;


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3073821927?check_suite_focus=true
```
==> Patching
Error: Failure while executing; `patch -g 0 -f -p1` exited with 1. Here's the output:
patching file drivers.c
Hunk #1 FAILED at 593.
1 out of 2 hunks FAILED -- saving rejects to file drivers.c.rej
```
