### PR TITLE
tagref 1.5.0 (new formula)

### DIFF
--- a/Formula/tagref.rb
+++ b/Formula/tagref.rb
@@ -1,0 +1,45 @@
+class Tagref < Formula
+  desc "Refer to other locations in your codebase"
+  homepage "https://github.com/stepchowfun/tagref"
+  url "https://github.com/stepchowfun/tagref/archive/v1.5.0.tar.gz"
+  sha256 "dd6321133c2bef64f9230d6aaddfba8a4327749236638c23c65d0832ca2fef48"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    (testpath/"file-1.txt").write <<~EOS
+      Here's a reference to the tag below: [ref:foo]
+      Here's a reference to a tag in another file: [ref:bar]
+      Here's a tag: [tag:foo]
+    EOS
+
+    (testpath/"file-2.txt").write <<~EOS
+      Here's a tag: [tag:bar]
+    EOS
+
+    output, status = Open3.capture2e({ "NO_COLOR" => "true" }, "#{bin}/tagref")
+    assert(status.success?, "Tagref did not exit successfully.")
+    assert_match(
+      /2 tags and 2 references validated in \d+ files\./,
+      output,
+      "Tagref did not find all the tags.",
+    )
+
+    (testpath/"file-3.txt").write <<~EOS
+      Here's a reference to a non-existent tag: [ref:baz]
+    EOS
+
+    output, status = Open3.capture2e({ "NO_COLOR" => "true" }, "#{bin}/tagref")
+    assert(!status.success?, "Tagref did not exit successfully.")
+    assert_match(
+      %r{No tag found for \[ref:baz\] @ \./file-3\.txt:1\.},
+      output,
+      "Tagref did not complain about a missing tag.",
+    )
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
