### PR TITLE
spdylay: fix test to just check failure

### DIFF
--- a/Formula/spdylay.rb
+++ b/Formula/spdylay.rb
@@ -39,6 +39,8 @@ class Spdylay < Formula
   test do
     # Check here for popular websites using SPDY:
     # https://w3techs.com/technologies/details/ce-spdy/all/all
-    system "#{bin}/spdycat", "-ns", "https://www.academia.edu/"
+    # With deprecation and lack of sites using SPDY, just test for failure
+    output = shell_output("#{bin}/spdycat -ns https://www.academia.edu/ 2>&1", 1).chomp
+    assert_equal "No supported SPDY version was negotiated.", output
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Due to lack of sites using SPDY, just test failure condition. 