### PR TITLE
liboping: fix Linux build and update license

### DIFF
--- a/Formula/liboping.rb
+++ b/Formula/liboping.rb
@@ -3,7 +3,7 @@ class Liboping < Formula
   homepage "https://noping.cc/"
   url "https://noping.cc/files/liboping-1.10.0.tar.bz2"
   sha256 "eb38aa93f93e8ab282d97e2582fbaea88b3f889a08cbc9dbf20059c3779d5cd8"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :homepage
@@ -22,6 +22,7 @@ class Liboping < Formula
   end
 
   uses_from_macos "ncurses"
+  uses_from_macos "perl"
 
   def install
     system "./configure", "--disable-debug",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3082055522?check_suite_focus=true
```
chmod 644 "Oping.bs"
"/usr/bin/perl" "/usr/share/perl/5.22/ExtUtils/xsubpp"  -typemap "/usr/share/perl/5.22/ExtUtils/typemap" -typemap "typemap"  Oping.xs > Oping.xsc && mv Oping.xsc Oping.c
cp lib/Net/Oping.pm blib/lib/Net/Oping.pm
x86_64-linux-gnu-gcc -c  -I../../src -D_REENTRANT -D_GNU_SOURCE -DDEBIAN -fwrapv -fno-strict-aliasing -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2 -g   -DVERSION=\"1.21\" -DXS_VERSION=\"1.21\" -fPIC "-I/usr/lib/x86_64-linux-gnu/perl/5.22/CORE"   Oping.c
Oping.xs:24:20: fatal error: EXTERN.h: No such file or directory
compilation terminated.
Makefile:345: recipe for target 'Oping.o' failed
make[2]: *** [Oping.o] Error 1
make[2]: Leaving directory '/tmp/liboping-20210716-2912-adc8kh/liboping-1.10.0/bindings/perl'
Makefile:455: recipe for target 'perl-bindings' failed
make[1]: *** [perl-bindings] Error 2
make[1]: Leaving directory '/tmp/liboping-20210716-2912-adc8kh/liboping-1.10.0/bindings'
Makefile:382: recipe for target 'install-recursive' failed
make: *** [install-recursive] Error 1
```