### PR TITLE
imap-uw: fix build for Linux

### DIFF
--- a/Formula/imap-uw.rb
+++ b/Formula/imap-uw.rb
@@ -23,6 +23,12 @@ class ImapUw < Formula
 
   depends_on "openssl@1.1"
 
+  uses_from_macos "krb5"
+
+  on_linux do
+    depends_on "linux-pam"
+  end
+
   # Two patches below are from Debian, to fix OpenSSL 1.1 compatibility
   # https://salsa.debian.org/holmgren/uw-imap/tree/master/debian/patches
   patch do
@@ -46,7 +52,13 @@ class ImapUw < Formula
     end
     inreplace "src/osdep/unix/ssl_unix.c", "#include <x509v3.h>\n#include <ssl.h>",
                                            "#include <ssl.h>\n#include <x509v3.h>"
-    system "make", "oxp"
+
+    # Skip IPv6 warning on Linux as libc should be IPv6 safe.
+    touch "ip6"
+
+    target = "oxp"
+    on_linux { target = "ldb" }
+    system "make", target
 
     # email servers:
     sbin.install "imapd/imapd", "ipopd/ipop2d", "ipopd/ipop3d"

--- a/Formula/imap-uw.rb
+++ b/Formula/imap-uw.rb
@@ -6,6 +6,7 @@ class ImapUw < Formula
   url "https://mirrorservice.org/sites/ftp.cac.washington.edu/imap/imap-2007f.tar.gz"
   mirror "https://fossies.org/linux/misc/old/imap-2007f.tar.gz"
   sha256 "53e15a2b5c1bc80161d42e9f69792a3fa18332b7b771910131004eb520004a28"
+  license "Apache-2.0"
   revision 1
 
   livecheck do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR:
- Adds `krb5` and `linux-pam` to `imap-uw` as dependencies on Linux and sets the make target for Linux.
- Adds license to the `imap-uw` formula.