### PR TITLE
dprint: use std_cargo_args

### DIFF
--- a/Formula/dprint.rb
+++ b/Formula/dprint.rb
@@ -17,9 +17,7 @@ class Dprint < Formula
   depends_on "rust" => :build
 
   def install
-    # replace `--path` arg with `./crates/dprint`
-    args = std_cargo_args.map { |s| s == "." ? "./crates/dprint" : s }
-    system "cargo", "install", *args
+    system "cargo", "install", *std_cargo_args(path: "crates/dprint")
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a belated follow-up to Homebrew/brew#11749, which modified `#std_cargo_args` to accept optional `root` and `path` arguments (to override the default values). This change was intended to replace verbose or error-prone code in formulae that modifies the default `path` argument.

With this in mind, this PR replaces related code in `dprint` that sets the path to `./crates/dprint` with `*std_cargo_args(path: "crates/dprint")`, which accomplishes the same thing in a way that can't fail if `std_cargo_args` ever contains more than one `.` argument.