### PR TITLE
gnirehtet: use std_cargo_args

### DIFF
--- a/Formula/gnirehtet.rb
+++ b/Formula/gnirehtet.rb
@@ -27,7 +27,7 @@ class Gnirehtet < Formula
   def install
     resource("java_bundle").stage { libexec.install "gnirehtet.apk" }
 
-    system "cargo", "install", "--locked", "--root", libexec, "--path", "relay-rust"
+    system "cargo", "install", *std_cargo_args(root: libexec, path: "relay-rust")
     mv "#{libexec}/bin/gnirehtet", "#{libexec}/gnirehtet"
 
     (bin/"gnirehtet").write_env_script("#{libexec}/gnirehtet", GNIREHTET_APK: "#{libexec}/gnirehtet.apk")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a belated follow-up to Homebrew/brew#11749, which modified `#std_cargo_args` to accept optional `root` and `path` arguments (to override the default values). This change was partly intended to allow formulae that provide manual arguments to `cargo install` to use `#std_cargo_args`.

With this in mind, this PR replaces related code in `gnirehtet` that manually provides `--root` and `--path` arguments to `cargo install` with `*std_cargo_args(root: libexec, path: "relay-rust")`. This accomplishes the same thing but using `#std_cargo_args` means that this formula will automatically benefit from any changes to the standard args without needing to be manually updated.