### PR TITLE
git-series: add TODO comment

### DIFF
--- a/Formula/git-series.rb
+++ b/Formula/git-series.rb
@@ -28,6 +28,8 @@ class GitSeries < Formula
     ENV["LIBGIT2_SYS_USE_PKG_CONFIG"] = "1"
     ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"
 
+    # TODO: In the next version after 0.9.1, update this command as follows:
+    # system "cargo", "install", *std_cargo_args
     system "cargo", "install", "--root", prefix, "--path", "."
     man1.install "git-series.1"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR simply adds a comment before the `cargo install` line to note that it should be updated to use `std_cargo_args` if/when the next `git-series` version is released.

This is the one `rust`-related formula that can't use `std_cargo_args` at the moment. In this case, it's because the version of `openssl-sys` in the `Cargo.lock` file (0.9.1) isn't compatible with the current version of OpenSSL. This formula currently runs `cargo install` without the `--locked` option, which works because a newer version of `openssl-sys` (0.9.65) is used and that's compatible with newer versions of OpenSSL.

Assuming the dependencies are updated in the next version, we should be able to migrate this formula to `std_cargo_args` at that point.