### PR TITLE
spotifyd: update args format

### DIFF
--- a/Formula/spotifyd.rb
+++ b/Formula/spotifyd.rb
@@ -28,7 +28,7 @@ class Spotifyd < Formula
   def install
     ENV["COREAUDIO_SDK_PATH"] = MacOS.sdk_path_if_needed
     system "cargo", "install", "--no-default-features",
-                               "--features=dbus_keyring,portaudio_backend",
+                               "--features", "dbus_keyring,portaudio_backend",
                                *std_cargo_args
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR simply updates the `--features` argument to `cargo install` to split it into two strings (instead of `--features=...`), as this is the prevailing format in `rust`-related formulae. This is part of some ongoing work to better standardize the code for `cargo install` statements.