### PR TITLE
apache-arrow-glib: add livecheck

### DIFF
--- a/Formula/apache-arrow-glib.rb
+++ b/Formula/apache-arrow-glib.rb
@@ -7,6 +7,10 @@ class ApacheArrowGlib < Formula
   license "Apache-2.0"
   head "https://github.com/apache/arrow.git"
 
+  livecheck do
+    formula "apache-arrow"
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "37c2b194b6c0648b40a2627dabdf9073ef280bcb85c3633a1b528636b00ef9e7"
     sha256 cellar: :any, big_sur:       "feb4e5e5d8257e0ab042fe905f999ff425cf219641d64bb98e5b6f4226104436"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`apache-arrow-glib` uses the same `stable` archive as `apache-arrow`. By default, livecheck successfully uses the `Apache` strategy for both of these formulae.

Since `apache-arrow` is the canonical formula, this PR adds a `formula "apache-arrow"` `livecheck` block to `apache-arrow-glib`, to ensure its check remains in sync. With this change, if we need to add a `livecheck` block to `apache-arrow` in the future to address any issues, we wouldn't have to duplicate it in `apache-arrow-glib` and manually keep it up to date.