### PR TITLE
bashdb: fix build with bash 5.1 and update license

### DIFF
--- a/Formula/bashdb.rb
+++ b/Formula/bashdb.rb
@@ -4,7 +4,7 @@ class Bashdb < Formula
   url "https://downloads.sourceforge.net/project/bashdb/bashdb/5.0-1.1.2/bashdb-5.0-1.1.2.tar.bz2"
   version "5.0-1.1.2"
   sha256 "30176d2ad28c5b00b2e2d21c5ea1aef8fbaf40a8f9d9f723c67c60531f3b7330"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   # We check the "bashdb" directory page because the bashdb project contains
   # various software and bashdb releases may be pushed out of the SourceForge
@@ -22,9 +22,16 @@ class Bashdb < Formula
     sha256 cellar: :any_skip_relocation, high_sierra: "0ab6de48ce871bc7b6abc582154b425350a70b7f2ecadd3b303c7a91dafc3c41"
   end
 
+  depends_on "autoconf" => :build # due to patch
+  depends_on "automake" => :build # due to patch
   depends_on "bash"
 
+  # Bypass error with Bash 5.1: "error: This package is only known to work with Bash 5.0"
+  # Upstream ref: https://sourceforge.net/p/bashdb/code/ci/6daffb5c7337620b429f5e94c282b75a0777fc82/
+  patch :DATA
+
   def install
+    system "autoreconf", "--verbose", "--install", "--force"
     system "./configure", "--with-bash=#{HOMEBREW_PREFIX}/bin/bash",
                           "--disable-debug",
                           "--disable-dependency-tracking",
@@ -37,3 +44,26 @@ class Bashdb < Formula
     assert_match version.to_s, pipe_output("#{bin}/bashdb --version 2>&1")
   end
 end
+
+__END__
+--- a/configure.ac
++++ b/configure.ac
+@@ -107,7 +107,7 @@
+ [bash_minor=`$SH_PROG -c 'echo ${BASH_VERSINFO[1]}'`]
+ bash_5_or_greater=no
+ case "${bash_major}.${bash_minor}" in
+-  'OK_BASH_VERS' | '5.0')
++  'OK_BASH_VERS' | '5.0' | '5.1')
+     bash_5_or_greater=yes
+     ;;
+   *)
+@@ -118,7 +118,8 @@
+
+ AC_ARG_WITH(dbg-main, AC_HELP_STRING([--with-dbg-main],
+                   [location of dbg-main.sh]),
+-		  DBGR_MAIN=$withval)
++		  [DBGR_MAIN=$withval]
++		  [DBGR_MAIN=${ac_default_prefix/prefix}/bashdb/bashdb-main.inc])
+ AC_SUBST(DBGR_MAIN)
+
+ mydir=$(dirname $0)


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/1041953608
```
checking whether make sets $(MAKE)... (cached) yes
configure: WARNING: You have Bash GNU bash, version 5.1.8(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law. installed.
configure: error: This package is only known to work with Bash 5.0
```