### PR TITLE
ghz: add livecheck

### DIFF
--- a/Formula/ghz.rb
+++ b/Formula/ghz.rb
@@ -5,6 +5,11 @@ class Ghz < Formula
   sha256 "474c84f9d8cf7da5db177f12b0f0f242b500ff42363323bed39f73b4a318bcc3"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "df7ff8d875e96c7aedd85c3edd4dc0d28041d3c37d984d65e358811da5ed5f2b"
     sha256 cellar: :any_skip_relocation, big_sur:       "a8812340400cbcdffdfcfa52c4ef1df6e31d649adae06b9efc0d788442868146"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ghz` and it currently works properly but there's at least one non-version tag (`help`) and a couple unstable version tags that use a format that isn't automatically filtered out by livecheck (e.g., `v0.37.0-pre.0`). These types of tags may cause issues in the future, so this PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, to ensure we're only matching stable versions.

I'll add a `formula "ghz"` `livecheck` block to `ghz-web` in a separate PR, as that formula also needs a version bump.