### PR TITLE
ghz-web 0.99.0

### DIFF
--- a/Formula/ghz-web.rb
+++ b/Formula/ghz-web.rb
@@ -1,9 +1,13 @@
 class GhzWeb < Formula
   desc "Web interface for ghz"
   homepage "https://ghz.sh"
-  url "https://github.com/bojand/ghz/archive/v0.98.0.tar.gz"
-  sha256 "0f0a8651f88d067c8d7b8bce318060ea61ffe5f021bd82cd2d0d98e4699b15b9"
+  url "https://github.com/bojand/ghz/archive/v0.99.0.tar.gz"
+  sha256 "474c84f9d8cf7da5db177f12b0f0f242b500ff42363323bed39f73b4a318bcc3"
   license "Apache-2.0"
+
+  livecheck do
+    formula "ghz"
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "95344a07ed48448946db436f7b3c231edc6724ba9a26431a3cc5f03e1ac30be2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates `ghz-web` to the latest version, 0.99.0.

Besides that, this adds a `formula "ghz"` `livecheck` block, as `ghz-web` uses the same `stable` archive and `ghz` is the canonical formula. This ensures that `ghz-web` uses the same check as `ghz` without having to duplicate the `livecheck` block and manually keep them in parity.