### PR TITLE
git-gui: add livecheck

### DIFF
--- a/Formula/git-gui.rb
+++ b/Formula/git-gui.rb
@@ -7,6 +7,10 @@ class GitGui < Formula
   license "GPL-2.0-only"
   head "https://github.com/git/git.git"
 
+  livecheck do
+    formula "git"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "4c74f3625ae0a40d8fe38346045b635aa0489e7a92239c7fed3b33c16867c613"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the `head` repository for `git-gui` and successfully finds the latest version but this doesn't align with the `stable` source.

The `git` formula has a `livecheck` block that finds versions from the `stable` source, so this PR adds a `formula "git"` `livecheck` block to `git-gui` as these formulae use the same `stable` URL and `git` is the canonical formula. This ensures that the check for `git-gui` is kept in sync with `git` without having to duplicate the `livecheck` block and manually keep them in parity. This is also in keeping with the "Please keep these values in sync with git.rb when updating" comment above the `stable` URL.