### PR TITLE
hdf5-mpi: update livecheck

### DIFF
--- a/Formula/hdf5-mpi.rb
+++ b/Formula/hdf5-mpi.rb
@@ -5,12 +5,8 @@ class Hdf5Mpi < Formula
   sha256 "aaf9f532b3eda83d3d3adc9f8b40a9b763152218fa45349c3bc77502ca1f8f1c"
   license "BSD-3-Clause"
 
-  # This regex isn't matching filenames within href attributes (as we normally
-  # do on HTML pages) because this page uses JavaScript to handle the download
-  # buttons and the HTML doesn't contain the related URLs.
   livecheck do
-    url "https://www.hdfgroup.org/downloads/hdf5/source-code/"
-    regex(/>\s*hdf5[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    formula "hdf5"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `hdf5-mpi` is a duplicate of the one in `hdf5`. Both these formulae share the same `stable` URL, so this makes sense.

This PR updates the `hdf5-mpi` `livecheck` block to simply use `formula "hdf5"`, as `hdf5` is the canonical formula. This ensures that `hdf5-mpi` uses the same check without needing to duplicate it and manually keep these `livecheck` blocks in parity.