### PR TITLE
libnetworkit: add livecheck

### DIFF
--- a/Formula/libnetworkit.rb
+++ b/Formula/libnetworkit.rb
@@ -5,6 +5,10 @@ class Libnetworkit < Formula
   sha256 "c574473bc7d86934f0f4b3049c0eeb9c4444cfa873e5fecda194ee5b1930f82c"
   license "MIT"
 
+  livecheck do
+    formula "networkit"
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "64c44c774f168ca26948606efcdb7169fe4635f691b3d90ed12a433cc3fe45eb"
     sha256 cellar: :any, big_sur:       "81ff9507c3ebdf80e372d5526d2bae58ef7aa69f983ad0f695965101301dd1d6"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `libnetworkit` and this successfully identifies the correct latest version. This PR preemptively adds a `formula "networkit"` `livecheck` block to `libnetworkit`, as these formulae share the same `stable` URL and `networkit` is the canonical formula (`libnetworkit` is a dependency).

Though `networkit` is currently using the default check, this ensures that `libnetworkit` will automatically inherit any changes to the check for `networkit` (if a `livecheck` block is added in the future). This allows us to avoid duplicating a `livecheck` block between these formulae and manually keeping them in parity.