### PR TITLE
libngspice: update livecheck

### DIFF
--- a/Formula/libngspice.rb
+++ b/Formula/libngspice.rb
@@ -5,8 +5,7 @@ class Libngspice < Formula
   sha256 "2263fffc6694754972af7072ef01cfe62ac790800dad651bc290bfcae79bd7b5"
 
   livecheck do
-    url :stable
-    regex(%r{url=.*?/ngspice[._-]v?(\d+(?:\.\d+)*)\.t}i)
+    formula "ngspice"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `libngspice` is a duplicate of the one in `ngspice`. Both these formulae share the same `stable` URL , so this makes sense.

This PR updates the `libngspice` `livecheck` block to simply use `formula "ngspice"`, as `ngspice` is the canonical formula. This ensures that `libngspice` uses the same check without needing to duplicate it and manually keep these `livecheck` blocks in parity.