### PR TITLE
bsponmpi: deprecate as needs `scons` installed in Python 2

### DIFF
--- a/Formula/bsponmpi.rb
+++ b/Formula/bsponmpi.rb
@@ -13,6 +13,9 @@ class Bsponmpi < Formula
     sha256 el_capitan:  "10a864ad11ea1145898ae9bcd8897f107c034818e66faf3632d916d51a13a191"
   end
 
+  # SConstruct is written in Python 2 but Homebrew `scons` is built for Python 3
+  deprecate! date: "2021-08-08", because: :does_not_build
+
   depends_on "scons" => :build
   depends_on "open-mpi"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Python version used at build is determined by `scons` formula, i.e. Homebrew's Python 3.

I did try some workarounds but it didn't seem worth the amount of work to successfully build.

---

1. Original formula fails to build on Python 2 syntax
    ```
    ==> scons -Q mode=release
      File "/tmp/bsponmpi-20210712-7553-asoczx/bsponmpi/SConstruct", line 27
    
        print 'To use specific options for this system, use options file "'+optfilename_local+'"'
    
              ^
    ```

2. Running `2to3 -w SConstruct` gets past that but results in `TabError: inconsistent use of tabs and spaces in indentation`

3. Inreplacing all tab characters gets past that but results in
    ```
    Using options from opts.py
    Compiling on platform darwin using mode release and compiler g++.
    AttributeError: module 'string' has no attribute 'find':
      File "/private/tmp/bsponmpi-20210808-17704-136nrwz/bsponmpi/SConstruct", line 140:
        if string.find(cxx, 'g++') >= 0 or string.find(cxx, 'c++') >= 0 or root['toolset'] == 'gcc':
    ```

Looks like some Python 2-isms that were not automatically converted by `2to3`, so would require a bit more effort to rewrite SConstruct file.

Also, v0.3 release was from 2010: https://sourceforge.net/projects/bsponmpi/files/bsponmpi/0.3/ and low installs:
```
==> Analytics
install: 2 (30 days), 5 (90 days), 40 (365 days)
install-on-request: 2 (30 days), 5 (90 days), 40 (365 days)
build-error: 0 (30 days)
```