### PR TITLE
libpq: update homepage, livecheck

### DIFF
--- a/Formula/libpq.rb
+++ b/Formula/libpq.rb
@@ -1,13 +1,12 @@
 class Libpq < Formula
   desc "Postgres C API library"
-  homepage "https://www.postgresql.org/docs/12/libpq.html"
+  homepage "https://www.postgresql.org/docs/13/libpq.html"
   url "https://ftp.postgresql.org/pub/source/v13.3/postgresql-13.3.tar.bz2"
   sha256 "3cd9454fa8c7a6255b6743b767700925ead1b9ab0d7a0f9dcb1151010f8eb4a1"
   license "PostgreSQL"
 
   livecheck do
-    url "https://ftp.postgresql.org/pub/source/?C=M&O=A"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    formula "postgresql"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `libpq` is basically a duplicate of the `livecheck` block in `postgresql` but the latter is more correct. These two formulae share a `stable` URL and `postgresql` is the canonical formula, so this PR updates the `livecheck` block for `libpq` to simply use `formula "postgresql"`. This ensures that `libpq` uses the same check as `postgresql` without needing to duplicate the `livecheck` block and manually keep it in parity.

Besides that, this updates the `homepage` to use the `libpq` documentation for the major version currently used in the formula (13).