### PR TITLE
crystal-icr: fix build with newer crystal

### DIFF
--- a/Formula/crystal-icr.rb
+++ b/Formula/crystal-icr.rb
@@ -17,6 +17,18 @@ class CrystalIcr < Formula
   depends_on "libyaml"
   depends_on "openssl@1.1"
 
+  # Fix build: src/icr/cli.cr:69:14: Error: undefined method 'parse!' for OptionParser.class
+  # Remove in the next release.
+  patch do
+    url "https://github.com/crystal-community/icr/commit/39d0f075aa5afd895473a223d854089de86f9230.patch?full_index=1"
+    sha256 "51867797493ebd2ec681c57132ca5576cef16b0e188ce2f6cacb41b523ae04ed"
+  end
+
+  # Fix build: src/icr/executer.cr:66:13: Error: undefined method 'rmdir' for Dir.class
+  # https://github.com/crystal-community/icr/commit/2a8b05b5b98a804fb0daa5be4834db4f56db0496
+  # Remove in the next release.
+  patch :DATA
+
   def install
     system "make", "install", "PREFIX=#{prefix}"
   end
@@ -25,3 +37,18 @@ class CrystalIcr < Formula
     assert_match "icr version #{version}", shell_output("#{bin}/icr -v")
   end
 end
+
+__END__
+diff --git a/src/icr/executer.cr b/src/icr/executer.cr
+index 0c1ce0b..102f28e 100644
+--- a/src/icr/executer.cr
++++ b/src/icr/executer.cr
+@@ -63,7 +65,7 @@ module Icr
+
+       # Remove empty directories, including ".crystal"
+       while empty_dir?(path)
+-        Dir.rmdir(path)
++        Dir.delete(path)
+         break if path == dot_crystal_dir
+         path = File.expand_path("..", path)
+       end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3207367944?check_suite_focus=true
```
Error target icr failed to compile:
Showing last frame. Use --error-trace for full trace.

In src/icr/cli.cr:69:14

 69 | OptionParser.parse! do |parser|
                   ^-----
Error: undefined method 'parse!' for OptionParser.class

Makefile:7: recipe for target 'build' failed
make: *** [build] Error 1
```