### PR TITLE
libvncserver, libvnc: update livecheck

### DIFF
--- a/Formula/libvnc.rb
+++ b/Formula/libvnc.rb
@@ -7,9 +7,7 @@ class Libvnc < Formula
   head "https://github.com/LibVNC/libvncserver.git"
 
   livecheck do
-    url :stable
-    strategy :github_latest
-    regex(%r{href=.*?/tag/LibVNCServer[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    formula "libvncserver"
   end
 
   bottle do

--- a/Formula/libvncserver.rb
+++ b/Formula/libvncserver.rb
@@ -7,8 +7,7 @@ class Libvncserver < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
-    regex(%r{href=.*?/tag/(?:LibVNCServer[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+    regex(/^LibVNCServer[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `livecheck` blocks for `libvncserver` uses the `GithubLatest` strategy to identify the "latest" version from the GitHub repository. I originally added this `livecheck` block at a time when we were using the `GithubLatest` strategy more freely but these days we only use it when it's both correct and necessary. In this case, it's correct but it's not necessary, as the newest version can be successfully obtained from the Git tags by using a regex that restricts matching to tags like `LibVNCServer-1.2.3`.

`libvnc` shares a `stable` URL with `libvncserver` and contains a duplicate of its `livecheck` block. This PR also updates the `livecheck` block for `libvnc` to simply use `formula "libvncserver"`, as `libvncserver` is the canonical formula. This ensures that the check for `libvnc` is the same as `libvncserver` without needing to duplicate the `livecheck` block and manually keep it in parity.