### PR TITLE
logcli, promtail: add livecheck

### DIFF
--- a/Formula/logcli.rb
+++ b/Formula/logcli.rb
@@ -5,6 +5,10 @@ class Logcli < Formula
   sha256 "c71174a2fbb7b6183cb84fc3a5e328cb4276a495c7c0be8ec53c377ec0363489"
   license "AGPL-3.0-only"
 
+  livecheck do
+    formula "loki"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "7f8431ea1c5b8556ae75c572eae2d20c044da0a1c3bb44395ba4b13f5916e667"
     sha256 cellar: :any_skip_relocation, big_sur:       "7c266f64a13b0e2c96d8fc394a4cc59b4f406e3071a41aaf5d19cdf085ed560a"

--- a/Formula/promtail.rb
+++ b/Formula/promtail.rb
@@ -5,6 +5,10 @@ class Promtail < Formula
   sha256 "c71174a2fbb7b6183cb84fc3a5e328cb4276a495c7c0be8ec53c377ec0363489"
   license "AGPL-3.0-only"
 
+  livecheck do
+    formula "loki"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "61a6d1f9f6f4ffc0cde6bf6fe908ef94fbe2d0a583eb4ff7f99255e02ac3fdc3"
     sha256 cellar: :any_skip_relocation, big_sur:       "2ac1bf4de911eaf2e6a0711dd22d87153e2503f50306bf768f12eb89b65a6be3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`logcli` and `promtail` use the same `stable` URL as `loki` (albeit `loki` is currently behind by a version but there's an open PR for `2.3.0`). By default, `livecheck` checks the Git tags for these formulae and successfully identifies the latest version.

This PR adds `formula "loki"` `livecheck` blocks to ~~the Loki variants~~ `logcli` and `promtail`, as `loki` is the canonical formula. This ensures that if a `livecheck` block is added to the `loki` formula in the future, these others will automatically inherit the changes without needing to duplicate a `livecheck` block and manually keep them in parity.