### PR TITLE
rom-tools: update livecheck

### DIFF
--- a/Formula/rom-tools.rb
+++ b/Formula/rom-tools.rb
@@ -8,14 +8,8 @@ class RomTools < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/mamedev/mame.git"
 
-  # MAME tags (and filenames) are formatted like `mame0226`, so livecheck will
-  # report the version like `0226`. We work around this by matching the link
-  # text for the release title, since it contains the properly formatted version
-  # (e.g., 0.226).
   livecheck do
-    url :stable
-    strategy :github_latest
-    regex(%r{release-header.*?/releases/tag/mame[._-]?\d+(?:\.\d+)*["' >]>MAME v?(\d+(?:\.\d+)+)}im)
+    formula "mame"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`rom-tools` uses the same `stable` URL and `livecheck` block as `mame` and contains a comment above the `stable` URL saying, "Please keep these values in sync with mame.rb when updating".

Since `mame` is the canonical formula, this updates the `livecheck` block for `rom-tools` to use `formula "mame"`. This ensures that it uses the same check as `mame` without needing to duplicate the `livecheck` block and manually keep them in parity.