### PR TITLE
minizip: update livecheck

### DIFF
--- a/Formula/minizip.rb
+++ b/Formula/minizip.rb
@@ -6,8 +6,7 @@ class Minizip < Formula
   license "Zlib"
 
   livecheck do
-    url "https://zlib.net/"
-    regex(/href=.*?zlib[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    formula "zlib"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`minizip` uses the same `stable` archive and `livecheck` block as `zlib`. Since `zlib` is the canonical formula, this PR updates the `livecheck` block for `minizip` to simply use `formula "zlib"`. This ensures that `minizip` uses the same check as `zlib` without needing to duplicate the `livecheck` block and manually keep them in parity.