### PR TITLE
mupdf, mupdf-tools: update livecheck

### DIFF
--- a/Formula/mupdf-tools.rb
+++ b/Formula/mupdf-tools.rb
@@ -7,8 +7,7 @@ class MupdfTools < Formula
   head "https://git.ghostscript.com/mupdf.git"
 
   livecheck do
-    url "https://mupdf.com/downloads/archive/?C=M&O=D"
-    regex(/href=.*?mupdf[._-]v?(\d+(?:\.\d+)+)-source\.(?:t|zip)/i)
+    formula "mupdf"
   end
 
   bottle do

--- a/Formula/mupdf.rb
+++ b/Formula/mupdf.rb
@@ -9,7 +9,7 @@ class Mupdf < Formula
 
   livecheck do
     url "https://mupdf.com/downloads/archive/"
-    regex(/href=.*?mupdf[._-]v?(\d+(?:\.\d+)+)-source\.t/i)
+    regex(/href=.*?mupdf[._-]v?(\d+(?:\.\d+)+)-source\.(?:t|zip)/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `mupdf` and `mupdf-tools` formulae share a `stable` URL and basically have the same `livecheck` block. The `mupdf-tools` regex is more correct, as there's at least one version where the source archive was a zip instead of a tarball. As such, this updates the `livecheck` block for `mupdf`.

Since `mupdf` is the canonical formula, this updates the `livecheck` block `mupdf-tools` to simply use `formula "mupdf"`. This ensures that `mupdf-tools` uses the check for `mupdf` without needing to duplicate the `livecheck` block and manually keep them in parity.