### PR TITLE
mysql-client: update livecheck

### DIFF
--- a/Formula/mysql-client.rb
+++ b/Formula/mysql-client.rb
@@ -6,8 +6,7 @@ class MysqlClient < Formula
   license "GPL-2.0-only" => { with: "Universal-FOSS-exception-1.0" }
 
   livecheck do
-    url "https://github.com/mysql/mysql-server.git"
-    regex(/^mysql[._-]v?(\d+(?:\.\d+)+)$/i)
+    formula "mysql"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`mysql-client` uses the same `stable` URL as `mysql` but its `livecheck` block is different. The check for `mysql` is the more appropriate of the two.

Since `mysql` is the canonical formula, this updates the `livecheck` block for `mysql-client` to simply use `formula "mysql"`. This ensures that `mysql-client` uses the check for `mysql` without needing to duplicate the `livecheck` block and manually keep them in parity.