### PR TITLE
notmuch-mutt: update livecheck

### DIFF
--- a/Formula/notmuch-mutt.rb
+++ b/Formula/notmuch-mutt.rb
@@ -7,8 +7,7 @@ class NotmuchMutt < Formula
   head "https://git.notmuchmail.org/git/notmuch", using: :git
 
   livecheck do
-    url "https://notmuchmail.org/releases/"
-    regex(/href=.*?notmuch[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    formula "notmuch"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`notmuch-mutt` uses the same `stable` URL and `livecheck` block as `notmuch`. Since `notmuch` is the canonical formula, this PR updates the `notmuch-mutt` `livecheck` block to simply use `formula "notmuch"`. This ensures that `notmuch-mutt` uses the same check as `notmuch` without needing to duplicate the `livecheck` block and manually keep them in parity.