### PR TITLE
tmuxinator-completion: add livecheck

### DIFF
--- a/Formula/tmuxinator-completion.rb
+++ b/Formula/tmuxinator-completion.rb
@@ -6,6 +6,10 @@ class TmuxinatorCompletion < Formula
   license "MIT"
   head "https://github.com/tmuxinator/tmuxinator.git"
 
+  livecheck do
+    formula "tmuxinator"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "fa94e8d05c5886957c4bd033771f196db3bc3665b4354ab8c2485a6e833db134"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`tmuxinator-completion` uses the same `stable` URL as `tmuxinator`. By default, livecheck checks the Git tags for these formulae and successfully identifies the newest version.

Since `tmuxinator` is the canonical formula, this adds a `formula "tmuxinator"` `livecheck` block to `tmuxinator-completion`. This ensures that `tmuxinator-completion` uses the same check as `tmuxinator` and will automatically inherit any changes if a `livecheck` block is added in the future. This saves us from having to duplicate the `livecheck` block and manually keep them in parity.