### PR TITLE
ssh-copy-id: update livecheck

### DIFF
--- a/Formula/ssh-copy-id.rb
+++ b/Formula/ssh-copy-id.rb
@@ -8,6 +8,10 @@ class SshCopyId < Formula
   license "SSH-OpenSSH"
   head "https://github.com/openssh/openssh-portable.git"
 
+  livecheck do
+    formula "openssh"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "0a70abbf0873a98e1f1653781006036f67a2cdf6a2d372e7de2865a50d2ba2cd"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`ssh-copy-id` uses the same `stable` URL as `openssh`. By default, livecheck checks the Git tags for `ssh-copy-id` (from the `openssh/openssh-portable` GitHub repository) but this doesn't align with the `stable` source. The `openssh` formula contains a `livecheck` block that checks the `stable` source, so that's the preferable approach.

Since `openssh` is the canonical formula, this adds a `formula "openssh"` `livecheck` block to `ssh-copy-id`. This ensures that `ssh-copy-id` uses the same check as `openssh` without needing to duplicate the `livecheck` block and manually keep them in parity.