### PR TITLE
petsc-complex: update livecheck

### DIFF
--- a/Formula/petsc-complex.rb
+++ b/Formula/petsc-complex.rb
@@ -6,8 +6,7 @@ class PetscComplex < Formula
   license "BSD-2-Clause"
 
   livecheck do
-    url "https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/"
-    regex(/href=.*?petsc-lite[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    formula "petsc"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`petsc-complex` uses the same `stable` URL and `livecheck` block as `petsc`. Since `petsc` is the canonical formula, this updates the `livecheck` block for `petsc-complex` to simply use `formula "petsc"`. This ensures that `petsc-complex` uses the same check as `petsc` without needing to duplicate the `livecheck` block and manually keep them in parity.