### PR TITLE
poppler-qt5: update livecheck

### DIFF
--- a/Formula/poppler-qt5.rb
+++ b/Formula/poppler-qt5.rb
@@ -7,8 +7,7 @@ class PopplerQt5 < Formula
   head "https://gitlab.freedesktop.org/poppler/poppler.git"
 
   livecheck do
-    url :homepage
-    regex(/href=.*?poppler[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    formula "poppler"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`poppler-qt5` uses the same `stable` URL and `livecheck` block as `poppler`. Since `poppler` is the canonical formula, this updates the `livecheck` block for `poppler-qt5` to simply use `formula "poppler"`. This ensures that `poppler-qt5` uses the same check as `poppler` without needing to duplicate the `livecheck` block and manually keep them in parity.