### PR TITLE
python-tk@3.9: update livecheck

### DIFF
--- a/Formula/python-tk@3.9.rb
+++ b/Formula/python-tk@3.9.rb
@@ -7,8 +7,7 @@ class PythonTkAT39 < Formula
   license "Python-2.0"
 
   livecheck do
-    url "https://www.python.org/ftp/python/"
-    regex(%r{href=.*?v?(3\.9(?:\.\d+)*)/?["' >]}i)
+    formula "python@3.9"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`python-tk@3.9` uses the same `stable` URL and `livecheck` block as `python@3.9`. Since `python@3.9` is the canonical formula, this updates the `livecheck` block for `python-tk@3.9` to simply use `formula "python@3.9"`. This ensures that `python-tk@3.9` uses the same check as `python@3.9` without duplicating the `livecheck` block and manually keeping these in parity.

The `python-tk@3.9` formula also has a comment above the `stable` URL that says, "Keep in sync with python@3.9", so this PR is in keeping with this idea.