### PR TITLE
balena-cli: add livecheck

### DIFF
--- a/Formula/balena-cli.rb
+++ b/Formula/balena-cli.rb
@@ -8,6 +8,11 @@ class BalenaCli < Formula
   sha256 "af78b891de5492e567d731dee62369b3d1247c262acf94d2bf4e2379790a947e"
   license "Apache-2.0"
 
+  livecheck do
+    url "https://registry.npmjs.org/balena-cli/latest"
+    regex(/["']version["']:\s*?["']([^"']+)["']/i)
+  end
+
   bottle do
     sha256 catalina:    "1d68785ff12ddc57c8a6e93a0b83d3613e29ccf0ae8331dc8197a06bd1f47336"
     sha256 mojave:      "c2e8432c28bb7875f42d7815befa98001dbc72a65cffc121fb8dd6bf2d75290e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck uses the `Npm` strategy on the `stable` URL. However, `balena-cli` has published thousands of versions, so the website is several MB in size and this can cause the check to timeout.

This PR adds a `livecheck` block that checks the npm API to identify the latest version from the JSON response. This response is only a few KB in size, so it's unlikely to fail like the default check.

I'll be updating the `Npm` strategy in the future to avoid this type of situation automatically but this addresses this situation for `balena-cli` in the interim time.