### PR TITLE
gtksourceviewmm3: use repo as homepage as original url is 404

### DIFF
--- a/Formula/gtksourceviewmm3.rb
+++ b/Formula/gtksourceviewmm3.rb
@@ -1,6 +1,6 @@
 class Gtksourceviewmm3 < Formula
   desc "C++ bindings for gtksourceview3"
-  homepage "https://developer.gnome.org/gtksourceviewmm/"
+  homepage "https://gitlab.gnome.org/GNOME/gtksourceviewmm"
   url "https://download.gnome.org/sources/gtksourceviewmm/3.18/gtksourceviewmm-3.18.0.tar.xz"
   sha256 "51081ae3d37975dae33d3f6a40621d85cb68f4b36ae3835eec1513482aacfb39"
   license "LGPL-2.1-or-later"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

404 - https://developer.gnome.org/gtksourceviewmm/

Also try Linux build.