### PR TITLE
falcon: add livecheck

### DIFF
--- a/Formula/falcon.rb
+++ b/Formula/falcon.rb
@@ -6,6 +6,11 @@ class Falcon < Formula
   sha256 "f4b00983e7f91a806675d906afd2d51dcee048f12ad3af4b1dadd92059fa44b9"
   revision 1
 
+  livecheck do
+    url "http://www.falconpl.org/index.ftd?page_id=official_download"
+    regex(/href=.*?Falcon[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "8727eb2b82dfbe15b089ffe42ff0e5f205399badde1c7dcfaf470a13141e4334"
     sha256 cellar: :any, big_sur:       "fab1a5546fe1e1abff7525ef791126c341fc305ef1bee37ad3b1c2788342c451"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `falcon`. This PR adds a `livecheck` block that checks the first-party download page. The `stable` URL is from a mirror (not the first-party site) but it's better to check a first-party source rather than a mirror in this context.