### PR TITLE
llvm: various improvements

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -53,6 +53,14 @@ class Llvm < Formula
     end
   end
 
+  # Fix parallel builds. Remove for LLVM 13.
+  # https://reviews.llvm.org/D106305
+  # https://lists.llvm.org/pipermail/llvm-dev/2021-July/151665.html
+  patch do
+    url "https://github.com/llvm/llvm-project/commit/b31080c596246bc26d2493cfd5e07f053cf9541c.patch?full_index=1"
+    sha256 "b4576303404e68100dc396d2414d6740c5bfd0162979d22152a688d1e7307379"
+  end
+
   def install
     projects = %w[
       clang
@@ -109,26 +117,32 @@ class Llvm < Formula
       -DLLDB_PYTHON_RELATIVE_PATH=libexec/#{site_packages}
       -DLIBOMP_INSTALL_ALIASES=OFF
       -DCLANG_PYTHON_BINDINGS_VERSIONS=#{py_ver}
+      -DLLVM_CREATE_XCODE_TOOLCHAIN=#{MacOS::Xcode.installed? ? "ON" : "OFF"}
       -DPACKAGE_VENDOR=#{tap.user}
       -DBUG_REPORT_URL=#{tap.issues_url}
       -DCLANG_VENDOR_UTI=org.#{tap.user.downcase}.clang
     ]
 
+    macos_sdk = MacOS.sdk_path_if_needed
     if MacOS.version >= :catalina
-      args << "-DFFI_INCLUDE_DIR=#{MacOS.sdk_path}/usr/include/ffi"
-      args << "-DFFI_LIBRARY_DIR=#{MacOS.sdk_path}/usr/lib"
+      args << "-DFFI_INCLUDE_DIR=#{macos_sdk}/usr/include/ffi"
+      args << "-DFFI_LIBRARY_DIR=#{macos_sdk}/usr/lib"
     else
       args << "-DFFI_INCLUDE_DIR=#{Formula["libffi"].opt_include}"
       args << "-DFFI_LIBRARY_DIR=#{Formula["libffi"].opt_lib}"
     end
 
-    sdk = MacOS.sdk_path_if_needed
+    # gcc-5 fails at building compiler-rt. Enable PGO
+    # build on Linux when we switch to Ubuntu 18.04.
+    pgo_build = false
     on_macos do
       args << "-DLLVM_BUILD_LLVM_C_DYLIB=ON"
       args << "-DLLVM_ENABLE_LIBCXX=ON"
-      args << "-DLLVM_CREATE_XCODE_TOOLCHAIN=#{MacOS::Xcode.installed? ? "ON" : "OFF"}"
       args << "-DRUNTIMES_CMAKE_ARGS=-DCMAKE_INSTALL_RPATH=#{rpath}"
-      args << "-DDEFAULT_SYSROOT=#{sdk}" if sdk
+      args << "-DDEFAULT_SYSROOT=#{macos_sdk}" if macos_sdk
+
+      # Skip the PGO build on HEAD installs or non-bottle source builds
+      pgo_build = build.stable? && build.bottle?
     end
 
     on_linux do
@@ -136,7 +150,6 @@ class Llvm < Formula
       ENV.append "CFLAGS", "-fpermissive"
 
       args << "-DLLVM_ENABLE_LIBCXX=OFF"
-      args << "-DLLVM_CREATE_XCODE_TOOLCHAIN=OFF"
       args << "-DCLANG_DEFAULT_CXX_STDLIB=libstdc++"
       # Enable llvm gold plugin for LTO
       args << "-DLLVM_BINUTILS_INCDIR=#{Formula["binutils"].opt_include}"
@@ -162,8 +175,6 @@ class Llvm < Formula
     end
 
     llvmpath = buildpath/"llvm"
-    pgo_build = false
-    on_macos { pgo_build = build.stable? && build.bottle? }
     if pgo_build
       # We build LLVM a few times first for optimisations. See
       # https://github.com/Homebrew/homebrew-core/issues/77975
@@ -188,7 +199,7 @@ class Llvm < Formula
 
       on_macos do
         extra_args << "-DLLVM_ENABLE_LIBCXX=ON"
-        extra_args << "-DDEFAULT_SYSROOT=#{sdk}" if sdk
+        extra_args << "-DDEFAULT_SYSROOT=#{macos_sdk}" if macos_sdk
       end
 
       extra_args << "-DCMAKE_C_FLAGS=#{cflags.join(" ")}" unless cflags.empty?
@@ -205,10 +216,10 @@ class Llvm < Formula
       end
 
       # Our just-built Clang needs a little help finding C++ headers,
-      # since the atomic and type_traits headers are not in the SDK
-      # on macOS versions before Big Sur.
+      # since we did not build libc++, and the atomic and type_traits
+      # headers are not in the SDK on macOS versions before Big Sur.
       on_macos do
-        if MacOS.version <= :catalina && sdk
+        if MacOS.version <= :catalina && macos_sdk
           toolchain_path = if MacOS::CLT.installed?
             MacOS::CLT::PKG_PATH
           else
@@ -217,7 +228,7 @@ class Llvm < Formula
 
           cxxflags << "-isystem#{toolchain_path}/usr/include/c++/v1"
           cxxflags << "-isystem#{toolchain_path}/usr/include"
-          cxxflags << "-isystem#{MacOS.sdk_path_if_needed}/usr/include"
+          cxxflags << "-isystem#{macos_sdk}/usr/include"
 
           extra_args.reject! { |s| s["CMAKE_CXX_FLAGS"] }
           extra_args << "-DCMAKE_CXX_FLAGS=#{cxxflags.join(" ")}"
@@ -261,8 +272,6 @@ class Llvm < Formula
                         *extra_args, *std_cmake_args
 
         # This build is for profiling, so it is safe to ignore errors.
-        # We pass `--keep-going` to `make` to ignore the error that requires
-        # deparallelisation on ARM. (See below.)
         begin
           system "cmake", "--build", ".", "--", "--keep-going"
         rescue RuntimeError
@@ -292,8 +301,6 @@ class Llvm < Formula
     # Now, we can build.
     mkdir llvmpath/"build" do
       system "cmake", "-G", "Unix Makefiles", "..", *(std_cmake_args + args)
-      # Workaround for CMake Error: failed to create symbolic link
-      ENV.deparallelize if Hardware::CPU.arm?
       system "cmake", "--build", "."
       system "cmake", "--build", ".", "--target", "install"
       system "cmake", "--build", ".", "--target", "install-xcode-toolchain" if MacOS::Xcode.installed?
@@ -304,9 +311,19 @@ class Llvm < Formula
       lib.install_symlink "libLLVM.dylib" => "libLLVM-#{version.major}.dylib" unless build.head?
     end
 
+    # Install the `llvm-lit` testing tool
+    cd llvmpath/"utils/lit" do
+      system "python3", *Language::Python.setup_install_args(prefix)
+    end
+
     # Install LLVM Python bindings
     # Clang Python bindings are installed by CMake
     (lib/site_packages).install llvmpath/"bindings/python/llvm"
+
+    # Install Vim plugins
+    %w[ftdetect ftplugin indent syntax].each do |dir|
+      (share/"vim/vimfiles"/dir).install Dir["*/utils/vim/#{dir}/*.vim"]
+    end
 
     # Install Emacs modes
     elisp.install Dir[llvmpath/"utils/emacs/*.el"] + Dir[share/"clang/*.el"]
@@ -506,6 +523,11 @@ class Llvm < Formula
     EOS
     assert_equal "int main() { printf(\"Hello world!\"); }\n",
       shell_output("#{bin}/clang-format -style=google clangformattest.c")
+
+    # Test llvm-lit
+    with_env(PYTHONPATH: prefix/Language::Python.site_packages("python3")) do
+      system "python3", "-c", "import lit"
+    end
 
     # Ensure LLVM did not regress output of `llvm-config --system-libs` which for a time
     # was known to output incorrect linker flags; e.g., `-llibxml2.tbd` instead of `-lxml2`.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

1. ~~Enable bootstrap build on Linux~~. This fails with `gcc-5`. Let's try again when we switch to Ubuntu 18.04.
2. Clean up some duplication
3. Install the `lit` command line tool
4. Install Vim editor integration
5. Add patch to fix parallel builds on ARM

The `lit` tool adds very little to the bottle size, and it seems some
users might find it useful. Let's install it directly using Python to
avoid having to set `LLVM_INCLUDE_TESTS` to `ON`, as that has many other
side-effects that we don't need or want. This is also how Arch installs
`lit`. [1]

Closes #82479.

[1] https://github.com/archlinux/svntogit-packages/blob/5e7a8f09f53d0fb19c0680bb5b4691b1c6a78ad1/trunk/PKGBUILD#L79-L82