### PR TITLE
pari-elldata 20210301 (new formula)

### DIFF
--- a/Formula/pari-elldata.rb
+++ b/Formula/pari-elldata.rb
@@ -1,0 +1,23 @@
+class PariElldata < Formula
+  desc "J.E. Cremona elliptic curve data for PARI/GP"
+  homepage "https://pari.math.u-bordeaux.fr/packages.html"
+  url "https://pari.math.u-bordeaux.fr/pub/pari/packages/elldata.tgz"
+  # Refer to http://pari.math.u-bordeaux.fr/packages.html#packages for most recent package date
+  version "20210301"
+  sha256 "dd551e64932d4ab27b3f2b2d1da871c2353672fc1a74705c52e3c0de84bd0cf6"
+  license "GPL-2.0-or-later"
+
+  depends_on "pari"
+
+  def install
+    (share/"pari/elldata").install gzip(*Dir["#{buildpath}/elldata/ell*"])
+    doc.install "elldata/README"
+  end
+
+  test do
+    expected_output = "[0, -1, 1, -10, -20, -4, -20, -79, -21, 496, 20008, -161051, -122023936/161051, " \
+                      "Vecsmall([1]), [Vecsmall([128, -1])], [0, 0, 0, 0, 0, 0, 0, 0]]"
+    output = pipe_output(Formula["pari"].opt_bin/"gp -q", "ellinit(\"11a1\")").chomp
+    assert_equal expected_output, output
+  end
+end

--- a/Formula/pari.rb
+++ b/Formula/pari.rb
@@ -4,6 +4,7 @@ class Pari < Formula
   url "https://pari.math.u-bordeaux.fr/pub/pari/unix/pari-2.13.2.tar.gz"
   sha256 "1679985094a0b723d14f49aa891dbe5ec967aa4040050a2c50bd764ddb3eba24"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://pari.math.u-bordeaux.fr/pub/pari/unix/"
@@ -28,6 +29,12 @@ class Pari < Formula
                           "--with-gmp=#{gmp}",
                           "--with-readline=#{readline}",
                           "--graphic=ps"
+
+    # Explicitly set datadir to HOMEBREW_PREFIX/share/pari to allow for external packages to be found
+    # We do this here rather than in configure because we still want the actual files to be installed to the Cellar
+    objdir = Utils.safe_popen_read("./config/objdir").chomp
+    inreplace %W[#{objdir}/pari.cfg #{objdir}/paricfg.h], pkgshare, "#{HOMEBREW_PREFIX}/share/pari"
+
     # make needs to be done in two steps
     system "make", "all"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The first of a handful of extra data packages for PARI/GP. Update the `pari` formula so that we can install data packages to `#{HOMEBREW_PREFIX}/share/pari`.

The `pari` bottle itself is about 4-5 MB. The `elldata` is about 153 MB uncompressed. Considering the differences in size, it makes sense to ship this (and probably other extra packages) as a separate formula.

Pari is capable of reading compressed data files, so we compress them to reduce the installed size on disk.

The versioning scheme is a bit odd - there's no well-preserved archive of older versions, but the homepage does list the update date for the package. Most distributions just seem to use the unversioned tarball like seen here and explicitly attach a version to it. If we can find a versioned source to pull from, I'd be open to that too. The usual places to find versioned archives (Debian) isn't carrying any of the more recent versions.

Part of #83030.