### PR TITLE
tunnel: fix test

### DIFF
--- a/Formula/tunnel.rb
+++ b/Formula/tunnel.rb
@@ -22,6 +22,6 @@ class Tunnel < Formula
   end
 
   test do
-    system bin/"tunnel", "ping"
+    assert_match "you need an api key", shell_output(bin/"tunnel 8080", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fix test failure from #82758. 

It seems `tunnel`'s server is no longer accessible, so maybe this should be deprecated/removed instead?