### PR TITLE
vala: fix gstreamer vapi, which in turn fixes build for pdfpc

### DIFF
--- a/Formula/vala.rb
+++ b/Formula/vala.rb
@@ -4,6 +4,7 @@ class Vala < Formula
   url "https://download.gnome.org/sources/vala/0.52/vala-0.52.4.tar.xz"
   sha256 "ecde520e5160e659ee699f8b1cdc96065edbd44bbd08eb48ef5f2506751fdf31"
   license "LGPL-2.1-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "980295e63a373da1594e5148ee9e5c24b58e43438ca56d3adf6fdf17706d79bc"
@@ -20,6 +21,15 @@ class Vala < Formula
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
+
+  # Fix regressions in GStreamer VAPI, which cause issues for dependents like `pdfpc`
+  # Upstream pdfpc ref: https://github.com/pdfpc/pdfpc/issues/594
+  # Upstream vala ref: https://gitlab.gnome.org/GNOME/vala/-/issues/1210
+  # Remove in the next release.
+  patch do
+    url "https://gitlab.gnome.org/GNOME/vala/-/commit/873c879367d1a4d7265e32dda55d4c01d5dd957b.diff"
+    sha256 "144b964cee117b6def5c673e7447003bd4a94b7d681c3d7a8ceaf43f709c0992"
+  end
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/valabind.rb
+++ b/Formula/valabind.rb
@@ -23,7 +23,7 @@ class Valabind < Formula
   uses_from_macos "flex" => :build
 
   def install
-    system "make"
+    system "make", "VALA_PKGLIBDIR=#{Formula["vala"].opt_lib}/vala-#{Formula["vala"].version.major_minor}"
     system "make", "install", "PREFIX=#{prefix}"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`pdfpc` has failed to build as a dependent test for other PRs due to change in `vala` version.

Originally opened `pdfpc` issue https://github.com/pdfpc/pdfpc/issues/594

The problem was identified to be in `vala`: https://gitlab.gnome.org/GNOME/vala/-/issues/1210