### PR TITLE
wordplay: add livecheck

### DIFF
--- a/Formula/wordplay.rb
+++ b/Formula/wordplay.rb
@@ -1,9 +1,18 @@
 class Wordplay < Formula
   desc "Anagram generator"
-  homepage "http://hsvmovies.com/static_subpages/personal_orig/wordplay/index.html"
+  homepage "http://hsvmovies.com/static_subpages/personal_orig/wordplay/"
   url "http://hsvmovies.com/static_subpages/personal_orig/wordplay/wordplay722.tar.Z"
   version "7.22"
   sha256 "9436a8c801144ab32e38b1e168130ef43e7494f4b4939fcd510c7c5bf7f4eb6d"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?wordplay[._-]?v?(\d+(?:\.\d+)*)\.t/i)
+    strategy :page_match do |page, regex|
+      # Naively convert a version string like `722` to `7.22`
+      page.scan(regex).map { |match| match.first.sub(/^(\d)(\d+)$/, '\1.\2') }
+    end
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `wordplay`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

Besides that, this simply updates the `homepage` to omit the unnecessary trailing `/index.html`, as it works fine without it.