### PR TITLE
openj9: update license to GPL-2.0-only

### DIFF
--- a/Formula/openj9.rb
+++ b/Formula/openj9.rb
@@ -7,8 +7,8 @@ class Openj9 < Formula
   license any_of: [
     "EPL-2.0",
     "Apache-2.0",
-    { "GPL-2.0-or-later" => { with: "Classpath-exception-2.0" } },
-    { "GPL-2.0-or-later" => { with: "OpenJDK-assembly-exception-1.0" } },
+    { "GPL-2.0-only" => { with: "Classpath-exception-2.0" } },
+    { "GPL-2.0-only" => { with: "OpenJDK-assembly-exception-1.0" } },
   ]
 
   livecheck do


### PR DESCRIPTION
According to https://github.com/eclipse-openj9/openj9/blob/master/LICENSE, openj9 only uses GPL 2.0, not any later versions.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
