### PR TITLE
joplin-cli 2.2.2 (new formula)

### DIFF
--- a/Formula/joplin-cli.rb
+++ b/Formula/joplin-cli.rb
@@ -1,0 +1,43 @@
+require "language/node"
+
+class JoplinCli < Formula
+  desc "Note taking and to-do application with synchronization capabilities"
+  homepage "https://joplinapp.org/"
+  url "https://registry.npmjs.org/joplin/-/joplin-2.2.2.tgz"
+  sha256 "15b932b51632dbcf8dfa0c39541af49b7e072b1a7c204e304d0fbdea6f1d787a"
+  license "MIT"
+
+  depends_on "pkg-config" => :build
+  depends_on "node"
+  depends_on "sqlite"
+  depends_on "vips"
+
+  on_macos do
+    depends_on "terminal-notifier"
+  end
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+
+    node_notifier_vendor_dir = libexec/"lib/node_modules/joplin/node_modules/node-notifier/vendor"
+    node_notifier_vendor_dir.rmtree # remove vendored pre-built binaries
+
+    on_macos do
+      terminal_notifier_dir = node_notifier_vendor_dir/"mac.noindex"
+      terminal_notifier_dir.mkpath
+
+      # replace vendored terminal-notifier with our own
+      terminal_notifier_app = Formula["terminal-notifier"].opt_prefix/"terminal-notifier.app"
+      ln_sf terminal_notifier_app.relative_path_from(terminal_notifier_dir), terminal_notifier_dir
+    end
+  end
+
+  # All joplin commands rely on the system keychain and so they cannot run
+  # unattended. The version command was specially modified in order to allow it
+  # to be run in homebrew tests. Hence we test with `joplin version` here. This
+  # does assert that joplin runs successfully on the environment.
+  test do
+    assert_match "joplin #{version}", shell_output("#{bin}/joplin version")
+  end
+end

--- a/audit_exceptions/universal_binary_allowlist.json
+++ b/audit_exceptions/universal_binary_allowlist.json
@@ -9,6 +9,7 @@
   "gatsby-cli",
   "gitversion",
   "infer",
+  "joplin-cli",
   "llvm",
   "llvm@11",
   "llvm@7",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?

~~I tried to create a test, however, joplin relies on the keychain service. So any command (`joplin help`, `joplin version`) will always throw a popup telling me that my credentials don't exist. I'm not sure how to workaround this problem as I understood the [tests must be non interactive](https://docs.brew.sh/Formula-Cookbook#add-a-test-to-the-formula). Any suggestions here would be appreciated. Instead I added a stupid `assert_match "joplin", "joplin"` test for now. My previous tries were:~~

    assert_match "joplin ", shell_output("#{bin}/joplin version")

- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

I get the following error, to do with npm installing a universal binary for fsevents:

```
joplin-terminal:
  * Unexpected universal binaries were found.
    The offending files are:
      /usr/local/Cellar/joplin-terminal/2.2.1/libexec/lib/node_modules/joplin/node_modules/fsevents/fsevents.node
Error: 1 problem in 1 formula detected
```

~~I'm not sure how to fix this. Any input / feedback would be appreciated. I've created this PR as a draft as I don't expect it to be merged with these two issues, but I'm unsure how to resolve them.~~

I've added this package to the `audit_exceptions/universal_binary_allowlist.json` file. I'm assuming that this is an acceptable strategy, but I'll defer judgement on that to somebody who knows brew's policies.
