### PR TITLE
grap: add livecheck

### DIFF
--- a/Formula/grap.rb
+++ b/Formula/grap.rb
@@ -4,6 +4,11 @@ class Grap < Formula
   url "https://www.lunabase.org/~faber/Vault/software/grap/grap-1.46.tar.gz"
   sha256 "7a8ecefdecfee96699913f2a412da68703911fa640bac3b964a413131f848bb4"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?grap[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "b881e8e5a9e9b93597d99ad6fc3ffa06e277855fa2b49ccb697c53d463ae597b"
     sha256 big_sur:       "a36a748595465d9a1a85db3613a4cbd6c1511e802e56b77408581f9af567326f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `grap`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.