### PR TITLE
daemon: update urls to use https

### DIFF
--- a/Formula/daemon.rb
+++ b/Formula/daemon.rb
@@ -1,7 +1,7 @@
 class Daemon < Formula
   desc "Turn other processes into daemons"
-  homepage "http://libslack.org/daemon/"
-  url "http://libslack.org/daemon/download/daemon-0.8.tar.gz"
+  homepage "https://libslack.org/daemon/"
+  url "https://libslack.org/daemon/download/daemon-0.8.tar.gz"
   sha256 "74f12e6d4b3c85632489bd08431d3d997bc17264bf57b7202384f2e809cff596"
   license "GPL-2.0-or-later"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs are redirecting from HTTP to HTTPS, so this PR updates them to use HTTPS to avoid the redirection. The `stable` archive is the same as before (the `sha256` is unchanged) and this built/tested fine locally.

Since the `stable` URL has been modified, I'm not labeling this as `CI-syntax-only`, to allow tests to run on CI. I've labeled this as `CI-no-bottles`, as we don't need new bottles.