### PR TITLE
cfengine: update livecheck

### DIFF
--- a/Formula/cfengine.rb
+++ b/Formula/cfengine.rb
@@ -6,8 +6,8 @@ class Cfengine < Formula
   license all_of: ["BSD-3-Clause", "GPL-2.0-or-later", "GPL-3.0-only", "LGPL-2.0-or-later"]
 
   livecheck do
-    url "https://cfengine.com/release-data/community/releases.json"
-    regex(/"version": ?"(\d+(?:\.\d+)+)"/i)
+    url "https://cfengine-package-repos.s3.amazonaws.com/release-data/community/releases.json"
+    regex(/["']version["']:\s*["'](\d+(?:\.\d+)+)["']/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `url` in the `livecheck` block is redirecting from `https://cfengine.com/release-data/community/releases.json` to `https://cfengine-package-repos.s3.amazonaws.com/release-data/community/releases.json`. This JSON file is used to populate the [`cfengine` source code download page](https://cfengine.com/downloads/cfengine-community-source/) (using JavaScript) and the URL has been updated to the aforementioned S3 URL there as well.

This PR updates the `livecheck` block URL and also updates the `regex` to use the slightly-more-flexible approach that we've been using to parse a JSON field. [Eventually this will be replaced with a `Json` strategy but I won't be creating a brew PR for this work until after I've worked through some others.]