### PR TITLE
pipebench: update homepage

### DIFF
--- a/Formula/pipebench.rb
+++ b/Formula/pipebench.rb
@@ -1,6 +1,6 @@
 class Pipebench < Formula
   desc "Measure the speed of STDIN/STDOUT communication"
-  homepage "https://www.habets.pp.se/synscan/programs.php?prog=pipebench"
+  homepage "https://www.habets.pp.se/synscan/programs_pipebench.html"
   # Upstream server behaves oddly: https://github.com/Homebrew/homebrew/issues/40897
   # url "http://www.habets.pp.se/synscan/files/pipebench-0.40.tar.gz"
   url "https://deb.debian.org/debian/pool/main/p/pipebench/pipebench_0.40.orig.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` for `pipebench` redirects from `https://www.habets.pp.se/synscan/programs.php?prog=pipebench` to `https://www.habets.pp.se/synscan/programs_pipebench.html`. This PR updates the URL to avoid the redirection.