### PR TITLE
pari-* data packages (new formulae)

### DIFF
--- a/Formula/pari-galdata.rb
+++ b/Formula/pari-galdata.rb
@@ -1,0 +1,21 @@
+class PariGaldata < Formula
+  desc "Galois resolvents data for PARI/GP"
+  homepage "https://pari.math.u-bordeaux.fr/packages.html"
+  url "https://pari.math.u-bordeaux.fr/pub/pari/packages/galdata.tgz"
+  # Refer to http://pari.math.u-bordeaux.fr/packages.html#packages for most recent package date
+  version "20080411"
+  sha256 "b7c1650099b24a20bdade47a85a928351c586287f0d4c73933313873e63290dd"
+  license "GPL-2.0-or-later"
+
+  depends_on "pari"
+
+  def install
+    (share/"pari/galdata").install gzip(*Dir["#{buildpath}/galdata/*"])
+  end
+
+  test do
+    expected_output = "[16, -1, 8, \"2D_8(8)=[D(4)]2\"]"
+    output = pipe_output(Formula["pari"].opt_bin/"gp -q", "polgalois(x^8-2)").chomp
+    assert_equal expected_output, output
+  end
+end

--- a/Formula/pari-galpol.rb
+++ b/Formula/pari-galpol.rb
@@ -1,0 +1,25 @@
+class PariGalpol < Formula
+  desc "Galois polynomial database for PARI/GP"
+  homepage "https://pari.math.u-bordeaux.fr/packages.html"
+  url "https://pari.math.u-bordeaux.fr/pub/pari/packages/galpol.tgz"
+  # Refer to http://pari.math.u-bordeaux.fr/packages.html#packages for most recent package date
+  version "20180625"
+  sha256 "562af28316ee335ee38c1172c2d5ecccb79f55c368fb9f2c6f40fc0f416bb01b"
+  license "GPL-2.0-or-later"
+
+  depends_on "pari"
+
+  def install
+    Dir.glob("galpol/*/**/*").each do |path|
+      gzip(path) unless File.directory?(path)
+    end
+
+    (share/"pari/galpol").install Dir["galpol/*/"]
+    doc.install "galpol/README"
+  end
+
+  test do
+    assert_equal "5", pipe_output(Formula["pari"].opt_bin/"gp -q", "galoisgetpol(8)").chomp
+    assert_equal "\"C3 : C4\"", pipe_output(Formula["pari"].opt_bin/"gp -q", "galoisgetname(12,1)").chomp
+  end
+end

--- a/Formula/pari-seadata-big.rb
+++ b/Formula/pari-seadata-big.rb
@@ -1,0 +1,23 @@
+class PariSeadataBig < Formula
+  desc "Additional modular polynomial data for PARI/GP"
+  homepage "https://pari.math.u-bordeaux.fr/packages.html"
+  url "https://pari.math.u-bordeaux.fr/pub/pari/packages/seadata-big.tar"
+  # Refer to http://pari.math.u-bordeaux.fr/packages.html#packages for most recent package date
+  version "20170418"
+  sha256 "7c4db2624808a5bbd2ba00f8b644a439f0508532efd680a247610fdd5822a5f2"
+  license "GPL-2.0-or-later"
+
+  depends_on "pari"
+  depends_on "pari-seadata"
+
+  def install
+    (share/"pari/seadata").install Dir["#{buildpath}/seadata/sea*"]
+    doc.install "seadata/README.big" => "README"
+  end
+
+  test do
+    term = "-812742150726123010437180630597083*y^19"
+    output = pipe_output(Formula["pari"].opt_bin/"gp -q", "ellmodulareqn(503)").chomp
+    assert_match term, output
+  end
+end

--- a/Formula/pari-seadata.rb
+++ b/Formula/pari-seadata.rb
@@ -1,0 +1,22 @@
+class PariSeadata < Formula
+  desc "Modular polynomial data for PARI/GP"
+  homepage "https://pari.math.u-bordeaux.fr/packages.html"
+  url "https://pari.math.u-bordeaux.fr/pub/pari/packages/seadata.tgz"
+  # Refer to http://pari.math.u-bordeaux.fr/packages.html#packages for most recent package date
+  version "20090618"
+  sha256 "c9282a525ea3f92c1f9c6c69e37ac5a87b48fb9ccd943cfd7c881a3851195833"
+  license "GPL-2.0-or-later"
+
+  depends_on "pari"
+
+  def install
+    (share/"pari/seadata").install gzip(*Dir["#{buildpath}/seadata/sea*"])
+    doc.install "seadata/README"
+  end
+
+  test do
+    expected_output = "[x^4 + 36*x^3 + 270*x^2 + (-y + 756)*x + 729, 0]"
+    output = pipe_output(Formula["pari"].opt_bin/"gp -q", "ellmodulareqn(3)").chomp
+    assert_equal expected_output, output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Follow-up from #83039. These are optional data packages for `pari`. Due to their size (except for `galdata`, which is reasonably small), they're not distributed with `pari` itself. They also seem to have differing release schedules from `pari` itself as well as each other.

Part of #83030.