### PR TITLE
workflows: add autobumping

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -1,0 +1,84 @@
+name: Bump formulae on schedule
+
+on:
+  schedule:
+    # Every day at 5am
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+env:
+  HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
+
+jobs:
+  autobump:
+    if: github.repository == 'Homebrew/homebrew-core'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Configure Git user
+        uses: Homebrew/actions/git-user-config@master
+
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
+      - name: Bump formulae
+        uses: Homebrew/actions/bump-formula@master
+        continue-on-error: true
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          formulae: |
+            ack
+            apidoc
+            argo
+            b3sum
+            buildkit
+            chezmoi
+            consul
+            consul-template
+            devspace
+            docker
+            docker-compose
+            docker-slim
+            doctl
+            envconsul
+            etcd
+            gitleaks
+            gofish
+            golang-migrate
+            goreleaser
+            gostatic
+            hcloud
+            helm
+            helmfile
+            jfrog-cli
+            just
+            k3d
+            k9s
+            kubeaudit
+            kumactl
+            kustomize
+            lazydocker
+            mdbook
+            mdcat
+            micro
+            minikube
+            mmctl
+            neofetch
+            nomad
+            nushell
+            okteto
+            skopeo
+            starship
+            stress-ng
+            syncthing
+            teleport
+            termshark
+            terraform-ls
+            traefik
+            vale
+            virgil


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I think it would be nice to have an internal automated formulae bumping process. Starting with initial list of tested formulae, can expand later and when the list grows - split to two jobs running on different schedules so we won't hit any timeouts or limits.

Needs: https://github.com/Homebrew/actions/pull/212