### PR TITLE
dsda-doom 0.20.1 (new formula)

### DIFF
--- a/Formula/dsda-doom.rb
+++ b/Formula/dsda-doom.rb
@@ -1,0 +1,37 @@
+class DsdaDoom < Formula
+  desc "This is a fork of prboom+ with a focus on speedrunning"
+  homepage "https://github.com/kraflab/dsda-doom"
+  url "https://github.com/kraflab/dsda-doom/archive/refs/tags/v0.20.1.tar.gz"
+  sha256 "fe5715f2ded951bf61f67f7e148c5ef86049a0ba08ed4833e45b21b39fc169fe"
+  license "GPL-2.0-only"
+
+  head "https://github.com/kraflab/dsda-doom"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "dumb"
+  depends_on "fluid-synth"
+  depends_on "libpng"
+  depends_on "mad"
+  depends_on "pcre"
+  depends_on "portmidi"
+  depends_on "sdl2"
+  depends_on "sdl2_mixer"
+  depends_on "sdl2_net"
+
+  def install
+    system "cmake", "./prboom2"
+    system "make"
+    bin.install "dsda-doom", "dsda-doom.wad"
+  end
+
+  test do
+    testdata = <<~EOS
+    EOS
+    (testpath/"test_invalid.wad").write testdata
+    cp "#{bin}/dsda-doom.wad", "."
+    shell_output("#{bin}/dsda-doom -iwad test_invalid.wad", 255)
+  end
+end


### PR DESCRIPTION
- [y ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [y ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [y ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [y ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [y ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [y ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hmm, idk if I can leave a comment here, but here are some observations:
- brew audit shows there is a non executable installed on bin, but this package requires that file to be in that place
- brew audit also shows that the repo is not notable enough. Is this necessary? It is notable enough to the community it is made for (classic Doom fans)
- brew test fail proves that it is working fine, since it noticed that a fake .wad file cannot be loaded