### PR TITLE
apache-pulsar 2.8.0 (new formula)

### DIFF
--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -38,7 +38,6 @@ class ApachePulsar < Formula
     libexec.install "#{binpfx}/bin", "#{binpfx}/lib", "#{binpfx}/instances", "#{binpfx}/conf"
     (libexec/"lib/presto/bin/procname/Linux-ppc64le").rmtree
     pkgshare.install "#{binpfx}/examples", "#{binpfx}/licenses"
-    (var/"log/pulsar").mkpath
     (etc/"pulsar").install_symlink libexec/"conf"
 
     libexec.glob("bin/*") do |path|

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -49,6 +49,10 @@ class ApachePulsar < Formula
     end
   end
 
+  def post_install
+    (var/"log/pulsar").mkpath
+  end
+
   service do
     run [bin/"pulsar", "standalone"]
     log_path var/"log/pulsar/output.log"

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -22,7 +22,7 @@ class ApachePulsar < Formula
     chmod "+x", "src/rename-netty-native-libs.sh"
     with_env(
       "TMPDIR"    => buildpath,
-      "JAVA_HOME" => Formula["openjdk@11"].opt_prefix,
+      "JAVA_HOME" => Language::Java.java_home_env("11"),
     ) do
       system(
         "mvn",

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -18,11 +18,9 @@ class ApachePulsar < Formula
   depends_on "openjdk@11"
 
   def install
+    # Missing executable permission reported upstream: https://github.com/apache/pulsar/issues/11833
     chmod "+x", "src/rename-netty-native-libs.sh"
-    with_env(
-      "JAVA_HOME" => Formula["openjdk@11"].opt_prefix,
-      "TMPDIR"    => buildpath,
-    ) do
+    with_env("TMPDIR" => buildpath) do
       system(
         "mvn",
         "-X",
@@ -50,7 +48,7 @@ class ApachePulsar < Formula
     Pathname.glob("#{libexec}/bin/*") do |path|
       if !path.fnmatch?("*common.sh") && !path.directory?
         bin_name = path.basename
-        (bin/bin_name).write_env_script libexec/"bin/#{bin_name}", Language::Java.overridable_java_home_env
+        (bin/bin_name).write_env_script libexec/"bin/#{bin_name}", Language::Java.java_home_env("11")
       end
     end
   end

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -20,10 +20,7 @@ class ApachePulsar < Formula
   def install
     # Missing executable permission reported upstream: https://github.com/apache/pulsar/issues/11833
     chmod "+x", "src/rename-netty-native-libs.sh"
-    with_env(
-      "TMPDIR"    => buildpath,
-      "JAVA_HOME" => Language::Java.java_home_env("11"),
-    ) do
+    with_env("TMPDIR" => buildpath, **Language::Java.java_home_env("11")) do
       system(
         "mvn",
         "-X",

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -7,6 +7,7 @@ class ApachePulsar < Formula
   license "Apache-2.0"
   head "https://github.com/apache/pulsar.git", branch: "master"
 
+  depends_on arch: :x86_64
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "cppunit" => :build

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -20,7 +20,10 @@ class ApachePulsar < Formula
   def install
     # Missing executable permission reported upstream: https://github.com/apache/pulsar/issues/11833
     chmod "+x", "src/rename-netty-native-libs.sh"
-    with_env("TMPDIR" => buildpath) do
+    with_env(
+      "TMPDIR"    => buildpath,
+      "JAVA_HOME" => Formula["openjdk@11"].opt_prefix,
+    ) do
       system(
         "mvn",
         "-X",

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -33,8 +33,13 @@ class ApachePulsar < Formula
         "-Pcore-modules",
       )
     end
-    system "tar", "-xf", "distribution/server/target/apache-pulsar-#{version}-bin.tar.gz"
-    binpfx = "apache-pulsar-#{version}"
+    built_version = if build.head?
+      `python src/get-project-version.py`.strip
+    else
+      version
+    end
+    binpfx = "apache-pulsar-#{built_version}"
+    system "tar", "-xf", "distribution/server/target/#{binpfx}-bin.tar.gz"
     libexec.install binpfx+"/bin", binpfx+"/lib", binpfx+"/instances", binpfx+"/conf"
     (libexec/"lib/presto/bin/procname/Linux-ppc64le").rmtree
     share.install binpfx+"/examples"

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -20,7 +20,6 @@ class ApachePulsar < Formula
   def install
     chmod "+x", "src/rename-netty-native-libs.sh"
     with_env(
-      "PATH"      => "#{Formula["openjdk@11"].bin}:#{ENV["PATH"]}",
       "JAVA_HOME" => Formula["openjdk@11"].opt_prefix,
       "TMPDIR"    => buildpath,
     ) do
@@ -51,12 +50,7 @@ class ApachePulsar < Formula
     Pathname.glob("#{libexec}/bin/*") do |path|
       if !path.fnmatch?("*common.sh") && !path.directory?
         bin_name = path.basename
-        (bin+bin_name).write <<~EOS
-          #!/bin/bash
-          export PATH="#{Formula["openjdk@11"].bin}:$PATH"
-          export JAVA_HOME="#{Formula["openjdk@11"].opt_prefix}"
-          exec "#{libexec}/bin/#{bin_name}" "$@"
-        EOS
+        (bin/bin_name).write_env_script libexec/"bin/#{bin_name}", Language::Java.overridable_java_home_env
       end
     end
   end

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -21,26 +21,21 @@ class ApachePulsar < Formula
     # Missing executable permission reported upstream: https://github.com/apache/pulsar/issues/11833
     chmod "+x", "src/rename-netty-native-libs.sh"
     with_env("TMPDIR" => buildpath, **Language::Java.java_home_env("11")) do
-      system(
-        "mvn",
-        "-X",
-        "clean",
-        "package",
-        "-DskipTests",
-        "-Pcore-modules",
-      )
+      system("mvn", "-X", "clean", "package", "-DskipTests", "-Pcore-modules")
     end
     built_version = if build.head?
-      `python src/get-project-version.py`.strip
+      # This script does not need any particular version of py3 nor any libs, so both
+      # brew-installed python and system python will work.
+      Utils.safe_popen_read("python3", "src/get-project-version.py").strip
     else
       version
     end
     binpfx = "apache-pulsar-#{built_version}"
     system "tar", "-xf", "distribution/server/target/#{binpfx}-bin.tar.gz"
-    libexec.install binpfx+"/bin", binpfx+"/lib", binpfx+"/instances", binpfx+"/conf"
+    libexec.install "#{binpfx}/bin", "#{binpfx}/lib", "#{binpfx}/instances", "#{binpfx}/conf"
     (libexec/"lib/presto/bin/procname/Linux-ppc64le").rmtree
-    share.install binpfx+"/examples"
-    share.install binpfx+"/licenses"
+    share.install "#{binpfx}/examples"
+    share.install "#{binpfx}/licenses"
     (var/"log/pulsar").mkpath
     (etc/"pulsar").mkpath
     (etc/"pulsar").install_symlink libexec/"conf"

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -7,7 +7,6 @@ class ApachePulsar < Formula
   license "Apache-2.0"
   head "https://github.com/apache/pulsar.git", branch: "master"
 
-  depends_on arch: :x86_64
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "cppunit" => :build
@@ -15,6 +14,7 @@ class ApachePulsar < Formula
   depends_on "maven" => :build
   depends_on "pkg-config" => :build
   depends_on "protobuf" => :build
+  depends_on arch: :x86_64
   depends_on "openjdk@11"
 
   def install

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -1,0 +1,82 @@
+class ApachePulsar < Formula
+  desc "Cloud-native distributed messaging and streaming platform"
+  homepage "https://pulsar.apache.org/"
+  url "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-2.8.0/apache-pulsar-2.8.0-src.tar.gz"
+  mirror "https://archive.apache.org/dist/pulsar/pulsar-2.8.0/apache-pulsar-2.8.0-src.tar.gz"
+  sha256 "0e161a81c62c7234c1e0c243bb6fe30046ec1cd01472618573ecdc2a73b1163b"
+  license "Apache-2.0"
+  head "https://github.com/apache/pulsar.git", branch: "master"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "cppunit" => :build
+  depends_on "libtool" => :build
+  depends_on "maven" => :build
+  depends_on "pkg-config" => :build
+  depends_on "openjdk@11"
+
+  def install
+    chmod "+x", "src/rename-netty-native-libs.sh"
+    with_env(
+      "PATH"      => "#{Formula["openjdk@11"].bin}:#{ENV["PATH"]}",
+      "JAVA_HOME" => Formula["openjdk@11"].opt_prefix,
+      "TMPDIR"    => buildpath,
+    ) do
+      system "mvn", "-X", "clean", "package", "-DskipTests", "-Pcore-modules"
+    end
+    system "tar", "-xf", "distribution/server/target/apache-pulsar-#{version}-bin.tar.gz"
+    binpfx = "apache-pulsar-#{version}"
+    libexec.install binpfx+"/bin", binpfx+"/lib", binpfx+"/instances", binpfx+"/conf"
+    share.install binpfx+"/examples"
+    share.install binpfx+"/licenses"
+    (var/"log/pulsar").mkpath
+    (etc/"pulsar").install_symlink libexec/"conf/*"
+
+    Pathname.glob("#{libexec}/bin/*") do |path|
+      if path.fnmatch?("*common.sh") || path.directory?
+        bin.install path
+      else
+        bin_name = path.basename
+        (bin+bin_name).write <<~EOS
+          #!/bin/bash
+          export PATH="#{Formula["openjdk@11"].bin}:$PATH"
+          export JAVA_HOME="#{Formula["openjdk@11"].opt_prefix}"
+          exec "#{libexec}/bin/#{bin_name}" "$@"
+        EOS
+      end
+    end
+  end
+
+  plist_options manual: "pulsar standalone"
+
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{bin}/pulsar</string>
+            <string>standalone</string>
+          </array>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>WorkingDirectory</key>
+          <string>#{prefix}</string>
+          <key>StandardOutPath</key>
+          <string>#{var}/log/pulsar/output.log</string>
+          <key>StandardErrorPath</key>
+          <string>#{var}/log/pulsar/error.log</string>
+        </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    output = shell_output("#{bin}/pulsar version")
+    assert_match "Current version of pulsar is: #{version}", output
+  end
+end

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -29,8 +29,6 @@ class ApachePulsar < Formula
         "clean",
         "package",
         "-DskipTests",
-        "-Dprotobuf3.version=3.17.3",
-        "-Dgrpc.version=1.40.0",
         "-Pcore-modules",
       )
     end

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -23,9 +23,7 @@ class ApachePulsar < Formula
       "JAVA_HOME" => Formula["openjdk@11"].opt_prefix,
       "TMPDIR"    => buildpath,
     ) do
-      # Force x86_64 (using rosetta on M1 at a speed penalty) until Maven upstream protoc/grpc release changes
-      # supporting aarch64 build: https://github.com/grpc/grpc-java/issues/7690
-      system "mvn", "-X", "clean", "package", "-DskipTests", "-Dos.detected.classifier=osx-x86_64", "-Pcore-modules"
+      system "mvn", "-X", "clean", "package", "-DskipTests", "-DprotocCommand=protoc", "-Pcore-modules"
     end
     system "tar", "-xf", "distribution/server/target/apache-pulsar-#{version}-bin.tar.gz"
     binpfx = "apache-pulsar-#{version}"
@@ -70,3 +68,4 @@ class ApachePulsar < Formula
     assert_match "Cluster metadata for 'a' setup correctly", output
   end
 end
+

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -13,6 +13,7 @@ class ApachePulsar < Formula
   depends_on "libtool" => :build
   depends_on "maven" => :build
   depends_on "pkg-config" => :build
+  depends_on "protobuf" => :build
   depends_on "openjdk@11"
 
   def install

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -68,4 +68,3 @@ class ApachePulsar < Formula
     assert_match "Cluster metadata for 'a' setup correctly", output
   end
 end
-

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -16,6 +16,8 @@ class ApachePulsar < Formula
   depends_on "openjdk@11"
 
   def install
+    (var/"log/pulsar").mkpath
+    (etc/"pulsar").mkpath
     chmod "+x", "src/rename-netty-native-libs.sh"
     with_env(
       "PATH"      => "#{Formula["openjdk@11"].bin}:#{ENV["PATH"]}",
@@ -29,8 +31,6 @@ class ApachePulsar < Formula
     libexec.install binpfx+"/bin", binpfx+"/lib", binpfx+"/instances", binpfx+"/conf"
     share.install binpfx+"/examples"
     share.install binpfx+"/licenses"
-    (var/"log/pulsar").mkpath
-    (etc/"pulsar").mkpath
     (etc/"pulsar").install_symlink libexec/"conf/*"
 
     Pathname.glob("#{libexec}/bin/*") do |path|

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -23,7 +23,16 @@ class ApachePulsar < Formula
       "JAVA_HOME" => Formula["openjdk@11"].opt_prefix,
       "TMPDIR"    => buildpath,
     ) do
-      system "mvn", "-X", "clean", "package", "-DskipTests", "-Dprotobuf3.version=3.17.3", "-Pcore-modules"
+      system(
+        "mvn",
+        "-X",
+        "clean",
+        "package",
+        "-DskipTests",
+        "-Dprotobuf3.version=3.17.3",
+        "-Dgrpc.version=1.40.0",
+        "-Pcore-modules",
+      )
     end
     system "tar", "-xf", "distribution/server/target/apache-pulsar-#{version}-bin.tar.gz"
     binpfx = "apache-pulsar-#{version}"

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -23,8 +23,8 @@ class ApachePulsar < Formula
       "JAVA_HOME" => Formula["openjdk@11"].opt_prefix,
       "TMPDIR"    => buildpath,
     ) do
-    	# Force x86_64 (using rosetta on M1 at a speed penalty) until Maven upstream protoc/grpc release changes
-    	# supporting aarch64 build: https://github.com/grpc/grpc-java/issues/7690
+      # Force x86_64 (using rosetta on M1 at a speed penalty) until Maven upstream protoc/grpc release changes
+      # supporting aarch64 build: https://github.com/grpc/grpc-java/issues/7690
       system "mvn", "-X", "clean", "package", "-DskipTests", "-Dos.detected.classifier=osx-x86_64", "-Pcore-modules"
     end
     system "tar", "-xf", "distribution/server/target/apache-pulsar-#{version}-bin.tar.gz"
@@ -70,4 +70,3 @@ class ApachePulsar < Formula
     assert_match "Cluster metadata for 'a' setup correctly", output
   end
 end
-

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -33,8 +33,8 @@ class ApachePulsar < Formula
     (etc/"pulsar").install_symlink libexec/"conf/*"
 
     Pathname.glob("#{libexec}/bin/*") do |path|
-      if path.fnmatch?("*common.sh") || path.directory?
-        bin.install path
+      if path.fnmatch?("*common.sh")
+        bin.install path unless path.directory?
       else
         bin_name = path.basename
         (bin+bin_name).write <<~EOS

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -23,7 +23,9 @@ class ApachePulsar < Formula
       "JAVA_HOME" => Formula["openjdk@11"].opt_prefix,
       "TMPDIR"    => buildpath,
     ) do
-      system "mvn", "-X", "clean", "package", "-DskipTests", "-Pcore-modules"
+    	# Force x86_64 (using rosetta on M1 at a speed penalty) until Maven upstream protoc/grpc release changes
+    	# supporting aarch64 build: https://github.com/grpc/grpc-java/issues/7690
+      system "mvn", "-X", "clean", "package", "-DskipTests", "-Dos.detected.classifier=osx-x86_64", "-Pcore-modules"
     end
     system "tar", "-xf", "distribution/server/target/apache-pulsar-#{version}-bin.tar.gz"
     binpfx = "apache-pulsar-#{version}"
@@ -68,3 +70,4 @@ class ApachePulsar < Formula
     assert_match "Cluster metadata for 'a' setup correctly", output
   end
 end
+

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -27,6 +27,7 @@ class ApachePulsar < Formula
     system "tar", "-xf", "distribution/server/target/apache-pulsar-#{version}-bin.tar.gz"
     binpfx = "apache-pulsar-#{version}"
     libexec.install binpfx+"/bin", binpfx+"/lib", binpfx+"/instances", binpfx+"/conf"
+    (libexec/"lib/presto/bin/procname/Linux-ppc64le").rmtree
     share.install binpfx+"/examples"
     share.install binpfx+"/licenses"
     (var/"log/pulsar").mkpath

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -16,8 +16,6 @@ class ApachePulsar < Formula
   depends_on "openjdk@11"
 
   def install
-    (var/"log/pulsar").mkpath
-    (etc/"pulsar").mkpath
     chmod "+x", "src/rename-netty-native-libs.sh"
     with_env(
       "PATH"      => "#{Formula["openjdk@11"].bin}:#{ENV["PATH"]}",
@@ -31,7 +29,9 @@ class ApachePulsar < Formula
     libexec.install binpfx+"/bin", binpfx+"/lib", binpfx+"/instances", binpfx+"/conf"
     share.install binpfx+"/examples"
     share.install binpfx+"/licenses"
-    (etc/"pulsar").install_symlink libexec/"conf/*"
+    (var/"log/pulsar").mkpath
+    (etc/"pulsar").mkpath
+    (etc/"pulsar").install_symlink libexec/"conf"
 
     Pathname.glob("#{libexec}/bin/*") do |path|
       if !path.fnmatch?("*common.sh") && !path.directory?

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -23,7 +23,7 @@ class ApachePulsar < Formula
       "JAVA_HOME" => Formula["openjdk@11"].opt_prefix,
       "TMPDIR"    => buildpath,
     ) do
-      system "mvn", "-X", "clean", "package", "-DskipTests", "-DprotocCommand=protoc", "-Pcore-modules"
+      system "mvn", "-X", "clean", "package", "-DskipTests", "-Dprotobuf3.version=3.17.3", "-Pcore-modules"
     end
     system "tar", "-xf", "distribution/server/target/apache-pulsar-#{version}-bin.tar.gz"
     binpfx = "apache-pulsar-#{version}"

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -33,9 +33,7 @@ class ApachePulsar < Formula
     (etc/"pulsar").install_symlink libexec/"conf/*"
 
     Pathname.glob("#{libexec}/bin/*") do |path|
-      if path.fnmatch?("*common.sh")
-        bin.install path unless path.directory?
-      else
+      if !path.fnmatch?("*common.sh") && !path.directory?
         bin_name = path.basename
         (bin+bin_name).write <<~EOS
           #!/bin/bash
@@ -47,36 +45,23 @@ class ApachePulsar < Formula
     end
   end
 
-  plist_options manual: "pulsar standalone"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{bin}/pulsar</string>
-            <string>standalone</string>
-          </array>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{prefix}</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/pulsar/output.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/pulsar/error.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run [bin/"pulsar", "standalone"]
+    log_path var/"log/pulsar/output.log"
+    error_log_path var/"log/pulsar/error.log"
   end
 
   test do
-    output = shell_output("#{bin}/pulsar version")
-    assert_match "Current version of pulsar is: #{version}", output
+    fork do
+      exec bin/"pulsar", "standalone", "--zookeeper-dir", "#{testpath}/zk", " --bookkeeper-dir", "#{testpath}/bk"
+    end
+    # The daemon takes some time to start; pulsar-client will retry until it gets a connection, but emit confusing
+    # errors until that happens, so sleep to reduce log spam.
+    sleep 15
+
+    output = shell_output("#{bin}/pulsar-client produce my-topic --messages 'hello-pulsar'")
+    assert_match "1 messages successfully produced", output
+    output = shell_output("#{bin}/pulsar initialize-cluster-metadata -c a -cs localhost -uw localhost -zk localhost")
+    assert_match "Cluster metadata for 'a' setup correctly", output
   end
 end

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -30,6 +30,7 @@ class ApachePulsar < Formula
     share.install binpfx+"/examples"
     share.install binpfx+"/licenses"
     (var/"log/pulsar").mkpath
+    (etc/"pulsar").mkpath
     (etc/"pulsar").install_symlink libexec/"conf/*"
 
     Pathname.glob("#{libexec}/bin/*") do |path|


### PR DESCRIPTION
This commit adds a formula for the Apache Pulsar message broker
(https://pulsar.apache.org/). The broker will operate in its minimal/
default "standalone" mode when started by this formula, which is
roughly equivalent to the behavior of ZooKeeper and other similar
formulae.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
