### PR TITLE
bat: fix for rust 1.54

### DIFF
--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -17,6 +17,12 @@ class Bat < Formula
 
   uses_from_macos "zlib"
 
+  # Support rust 1.54, remove with next release after 0.18.2
+  patch do
+    url "https://github.com/sharkdp/bat/commit/f3d53b79a2d7a51f470ac8a06b6bdd9a4f225e8f.patch?full_index=1"
+    sha256 "2770049cc989c4e1f417ace483aa55ac0a1843476c97c7af947589cb804898d7"
+  end
+
   def install
     ENV["SHELL_COMPLETIONS_DIR"] = buildpath
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fixes build failure with rust 1.54, noticed in #82155