### PR TITLE
git-interactive-rebase-tool: fix for rust 1.54

### DIFF
--- a/Formula/git-interactive-rebase-tool.rb
+++ b/Formula/git-interactive-rebase-tool.rb
@@ -22,6 +22,12 @@ class GitInteractiveRebaseTool < Formula
 
   uses_from_macos "zlib"
 
+  # Support rust 1.54, remove with next release after 2.1.0
+  patch do
+    url "https://github.com/MitMaro/git-interactive-rebase-tool/commit/f4d3026f23118d29a263bbca6c83f963e76c34c4.patch?full_index=1"
+    sha256 "74a9ff98f668707f41df910b41eab6006970f2cf703f2a02a65e8c9901ddbd12"
+  end
+
   def install
     system "cargo", "install", *std_cargo_args
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes build failure with rust 1.54, noticed in #82155
