### PR TITLE
libgraphqlparser: deprecate as it requires Python 2

### DIFF
--- a/Formula/libgraphqlparser.rb
+++ b/Formula/libgraphqlparser.rb
@@ -14,6 +14,8 @@ class Libgraphqlparser < Formula
     sha256 cellar: :any, high_sierra:   "64779ec3108d9eef789d279abfafa90437c6a76b2ed3973d45979cd1051dc170"
   end
 
+  deprecate! date: "2020-04-20", because: "requires Python 2 to build"
+
   depends_on "cmake" => :build
   depends_on :macos # Due to Python 2
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Experimenting with `pypy` for some Python 2-dependent formulae.

Seemed to build locally.