### PR TITLE
cargo-instruments: fix for rust 1.54

### DIFF
--- a/Formula/cargo-instruments.rb
+++ b/Formula/cargo-instruments.rb
@@ -16,6 +16,12 @@ class CargoInstruments < Formula
   depends_on :macos
   depends_on "openssl@1.1"
 
+  # Support rust 1.54, remove with next release after 0.4.1
+  patch do
+    url "https://github.com/cmyr/cargo-instruments/commit/5371c086007e15da55360fdea2e3b8e79cff002b.patch?full_index=1"
+    sha256 "73e4e95de7052d2c9393037a7b6f32dd16933c67615693b3e70722f4cf97c334"
+  end
+
   def install
     system "cargo", "install", *std_cargo_args
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fixes build failure with rust 1.54, noticed in #82155