### PR TITLE
u-boot-tools: enable build on macOS arm

### DIFF
--- a/Formula/u-boot-tools.rb
+++ b/Formula/u-boot-tools.rb
@@ -1,8 +1,8 @@
 class UBootTools < Formula
   desc "Universal boot loader"
   homepage "https://www.denx.de/wiki/U-Boot/"
-  url "https://ftp.denx.de/pub/u-boot/u-boot-2021.01.tar.bz2"
-  sha256 "b407e1510a74e863b8b5cb42a24625344f0e0c2fc7582d8c866bd899367d0454"
+  url "https://ftp.denx.de/pub/u-boot/u-boot-2021.07.tar.bz2"
+  sha256 "312b7eeae44581d1362c3a3f02c28d806647756c82ba8c72241c7cdbe68ba77e"
   license all_of: ["GPL-2.0-only", "GPL-2.0-or-later", "BSD-3-Clause"]
 
   livecheck do
@@ -17,6 +17,7 @@ class UBootTools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "736e048541bf3be0bc7b299672078862e501e01dec9b9d4ffee15a42a7385961"
   end
 
+  depends_on "coreutils" => :build # Makefile needs $(gdate)
   depends_on "openssl@1.1"
 
   uses_from_macos "bison" => :build
@@ -26,8 +27,8 @@ class UBootTools < Formula
     # Replace keyword not present in make 3.81
     inreplace "Makefile", "undefine MK_ARCH", "unexport MK_ARCH"
 
-    system "make", "sandbox_defconfig"
-    system "make", "tools", "NO_SDL=1"
+    system "make", "tools-only_defconfig"
+    system "make", "tools-only", "NO_SDL=1"
     bin.install "tools/mkimage"
     bin.install "tools/dumpimage"
     man1.install "doc/mkimage.1"

--- a/Formula/u-boot-tools.rb
+++ b/Formula/u-boot-tools.rb
@@ -17,6 +17,7 @@ class UBootTools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "736e048541bf3be0bc7b299672078862e501e01dec9b9d4ffee15a42a7385961"
   end
 
+  depends_on "coreutils" => :build # Makefile needs $(gdate)
   depends_on "openssl@1.1"
 
   uses_from_macos "bison" => :build
@@ -26,7 +27,6 @@ class UBootTools < Formula
     # Replace keyword not present in make 3.81
     inreplace "Makefile", "undefine MK_ARCH", "unexport MK_ARCH"
 
-    ENV["SOURCE_DATE_EPOCH"] = ""
     system "make", "tools-only_defconfig"
     system "make", "tools-only", "NO_SDL=1"
     bin.install "tools/mkimage"

--- a/Formula/u-boot-tools.rb
+++ b/Formula/u-boot-tools.rb
@@ -11,11 +11,10 @@ class UBootTools < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_big_sur: "155827f724507948f502d86566c7da271c30cc1106aebb56a89f85c59b8be306"
-    sha256 cellar: :any,                 big_sur:       "6b4871d6839ee624ddd039dc7e5e59ca7c00d134cf5eb259e1016fba367573eb"
-    sha256 cellar: :any,                 catalina:      "16a44059e70ea3e5b304002930aa64676c0523b4d81cd1dca21de82ceb342f76"
-    sha256 cellar: :any,                 mojave:        "be9e797cbde27d348dfe240985021a162cc390fe9ecff11e8f56666050830dcf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "736e048541bf3be0bc7b299672078862e501e01dec9b9d4ffee15a42a7385961"
+    sha256 cellar: :any,                 big_sur:      "6b4871d6839ee624ddd039dc7e5e59ca7c00d134cf5eb259e1016fba367573eb"
+    sha256 cellar: :any,                 catalina:     "16a44059e70ea3e5b304002930aa64676c0523b4d81cd1dca21de82ceb342f76"
+    sha256 cellar: :any,                 mojave:       "be9e797cbde27d348dfe240985021a162cc390fe9ecff11e8f56666050830dcf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "736e048541bf3be0bc7b299672078862e501e01dec9b9d4ffee15a42a7385961"
   end
 
   depends_on "openssl@1.1"

--- a/Formula/u-boot-tools.rb
+++ b/Formula/u-boot-tools.rb
@@ -11,6 +11,7 @@ class UBootTools < Formula
   end
 
   bottle do
+    sha256 cellar: :any,                 arm64_big_sur: "155827f724507948f502d86566c7da271c30cc1106aebb56a89f85c59b8be306"
     sha256 cellar: :any,                 big_sur:       "6b4871d6839ee624ddd039dc7e5e59ca7c00d134cf5eb259e1016fba367573eb"
     sha256 cellar: :any,                 catalina:      "16a44059e70ea3e5b304002930aa64676c0523b4d81cd1dca21de82ceb342f76"
     sha256 cellar: :any,                 mojave:        "be9e797cbde27d348dfe240985021a162cc390fe9ecff11e8f56666050830dcf"

--- a/Formula/u-boot-tools.rb
+++ b/Formula/u-boot-tools.rb
@@ -1,8 +1,8 @@
 class UBootTools < Formula
   desc "Universal boot loader"
   homepage "https://www.denx.de/wiki/U-Boot/"
-  url "https://ftp.denx.de/pub/u-boot/u-boot-2021.01.tar.bz2"
-  sha256 "b407e1510a74e863b8b5cb42a24625344f0e0c2fc7582d8c866bd899367d0454"
+  url "https://ftp.denx.de/pub/u-boot/u-boot-2021.07.tar.bz2"
+  sha256 "312b7eeae44581d1362c3a3f02c28d806647756c82ba8c72241c7cdbe68ba77e"
   license all_of: ["GPL-2.0-only", "GPL-2.0-or-later", "BSD-3-Clause"]
 
   livecheck do
@@ -26,8 +26,9 @@ class UBootTools < Formula
     # Replace keyword not present in make 3.81
     inreplace "Makefile", "undefine MK_ARCH", "unexport MK_ARCH"
 
-    system "make", "sandbox_defconfig"
-    system "make", "tools", "NO_SDL=1"
+    ENV["SOURCE_DATE_EPOCH"] = ""
+    system "make", "tools-only_defconfig"
+    system "make", "tools-only", "NO_SDL=1"
     bin.install "tools/mkimage"
     bin.install "tools/dumpimage"
     man1.install "doc/mkimage.1"

--- a/Formula/u-boot-tools.rb
+++ b/Formula/u-boot-tools.rb
@@ -11,10 +11,11 @@ class UBootTools < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 big_sur:      "6b4871d6839ee624ddd039dc7e5e59ca7c00d134cf5eb259e1016fba367573eb"
-    sha256 cellar: :any,                 catalina:     "16a44059e70ea3e5b304002930aa64676c0523b4d81cd1dca21de82ceb342f76"
-    sha256 cellar: :any,                 mojave:       "be9e797cbde27d348dfe240985021a162cc390fe9ecff11e8f56666050830dcf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "736e048541bf3be0bc7b299672078862e501e01dec9b9d4ffee15a42a7385961"
+    sha256 cellar: :any,                 arm64_big_sur: "155827f724507948f502d86566c7da271c30cc1106aebb56a89f85c59b8be306"
+    sha256 cellar: :any,                 big_sur:       "6b4871d6839ee624ddd039dc7e5e59ca7c00d134cf5eb259e1016fba367573eb"
+    sha256 cellar: :any,                 catalina:      "16a44059e70ea3e5b304002930aa64676c0523b4d81cd1dca21de82ceb342f76"
+    sha256 cellar: :any,                 mojave:        "be9e797cbde27d348dfe240985021a162cc390fe9ecff11e8f56666050830dcf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "736e048541bf3be0bc7b299672078862e501e01dec9b9d4ffee15a42a7385961"
   end
 
   depends_on "openssl@1.1"

--- a/Formula/u-boot-tools.rb
+++ b/Formula/u-boot-tools.rb
@@ -11,7 +11,6 @@ class UBootTools < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_big_sur: "155827f724507948f502d86566c7da271c30cc1106aebb56a89f85c59b8be306"
     sha256 cellar: :any,                 big_sur:       "6b4871d6839ee624ddd039dc7e5e59ca7c00d134cf5eb259e1016fba367573eb"
     sha256 cellar: :any,                 catalina:      "16a44059e70ea3e5b304002930aa64676c0523b4d81cd1dca21de82ceb342f76"
     sha256 cellar: :any,                 mojave:        "be9e797cbde27d348dfe240985021a162cc390fe9ecff11e8f56666050830dcf"


### PR DESCRIPTION
enable build on macOS 11.5.2-arm64

brew install --build-from-source u-boot-tools
```
==> Downloading https://ftp.denx.de/pub/u-boot/u-boot-2021.07.tar.bz2
Already downloaded: xxxxxx/Library/Caches/Homebrew/downloads/276f2c3434fc032b03047d75164fd0e7d9c69f82f669568bbb1b408072ea52f6--u-boot-2021.07.tar.bz2
==> make tools-only_defconfig
==> make tools-only NO_SDL=1
🍺  /opt/homebrew/Cellar/u-boot-tools/2021.07: 6 files, 737.2KB, built in 17 seconds
```
brew test u-boot-tools
```
==> Testing u-boot-tools
==> /opt/homebrew/Cellar/u-boot-tools/2021.07/bin/mkimage -V
==> /opt/homebrew/Cellar/u-boot-tools/2021.07/bin/dumpimage -V
```
brew audit --strict u-boot-tools
```
no output
```
