### PR TITLE
gitbucket: Fix HEAD build (sbt instead of ant)

### DIFF
--- a/Formula/gitbucket.rb
+++ b/Formula/gitbucket.rb
@@ -11,15 +11,15 @@ class Gitbucket < Formula
 
   head do
     url "https://github.com/gitbucket/gitbucket.git"
-    depends_on "ant" => :build
+    depends_on "sbt" => :build
   end
 
   depends_on "openjdk"
 
   def install
     if build.head?
-      system "ant"
-      libexec.install "war/target/gitbucket.war", "."
+      system "sbt", "executable"
+      libexec.install "target/executable/gitbucket.war"
     else
       libexec.install "gitbucket.war"
     end

--- a/Formula/gitbucket.rb
+++ b/Formula/gitbucket.rb
@@ -10,7 +10,7 @@ class Gitbucket < Formula
   end
 
   head do
-    url "https://github.com/gitbucket/gitbucket.git"
+    url "https://github.com/gitbucket/gitbucket.git", branch: "master"
     depends_on "sbt" => :build
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Per https://github.com/gitbucket/gitbucket/blob/master/doc/build.md `sbt` is used to build and the build.xml file for `ant` is gone. Furthermore, the resulting output location has changed.

Specifying the default branch satisfies a `--online` audit.