### PR TITLE
xboard: uses texinfo from macOS

### DIFF
--- a/Formula/xboard.rb
+++ b/Formula/xboard.rb
@@ -4,6 +4,7 @@ class Xboard < Formula
   url "https://ftp.gnu.org/gnu/xboard/xboard-4.9.1.tar.gz"
   mirror "https://ftpmirror.gnu.org/xboard/xboard-4.9.1.tar.gz"
   sha256 "2b2e53e8428ad9b6e8dc8a55b3a5183381911a4dae2c0072fa96296bbb1970d6"
+  license "GPL-3.0-or-later"
   revision 3
 
   bottle do
@@ -16,7 +17,7 @@ class Xboard < Formula
   end
 
   head do
-    url "https://git.savannah.gnu.org/git/xboard.git"
+    url "https://git.savannah.gnu.org/git/xboard.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
   end
@@ -28,6 +29,8 @@ class Xboard < Formula
   depends_on "gtk+"
   depends_on "librsvg"
   depends_on "polyglot"
+
+  uses_from_macos "texinfo" => :build
 
   def install
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
(It's only a `--help` check, but yes)
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

xboard needs makeinfo during the build; see https://gist.github.com/rwhogg/9fb10caab7d5b9b0ac3ac0b4211fa1cf#file-01-configure-L49

Originally submitted to linuxbrew-core, but migrated to this repo by request: https://github.com/Homebrew/linuxbrew-core/pull/24264