### PR TITLE
dpkg: make keg-only on Linux

### DIFF
--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -32,6 +32,10 @@ class Dpkg < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
+  on_linux do
+    keg_only "not linked to prevent conflicts with system dpkg"
+  end
+
   patch :DATA
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Brewed dpkg isn't fully functional and having Homebrew prefix at the front of PATH can cause much pain for users on Debian based distros. Same goes for apt formula which I'm going to take care next if this one goes well.

> This installation of dpkg is not configured to install software, so
      commands such as `dpkg -i`, `dpkg --configure` will fail.