### PR TITLE
leaf-proxy: fix for rust 1.54

### DIFF
--- a/Formula/leaf-proxy.rb
+++ b/Formula/leaf-proxy.rb
@@ -23,6 +23,11 @@ class LeafProxy < Formula
         revision: "86632e2747c926a75d32be8bd9af059aa38ae75e"
   end
 
+  patch do
+    url "https://github.com/eycorsican/leaf/commit/cfaf9736f42cd7c4e6eb6f3b696d0343834aec7c.patch?full_index=1"
+    sha256 "4403b66732e84d9faedd5a7dae7b32caa32a46099a63af22139640f30a66b3ed"
+  end
+
   def install
     (buildpath/"leaf/src/proxy/tun/netstack/lwip").install resource("lwip")
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fixes build failure with rust 1.54, noticed in #82155