### PR TITLE
audacious: fix build

### DIFF
--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -71,6 +71,7 @@ class Audacious < Formula
         -Dcoreaudio=false
         -Dmpris2=false
         -Dmac-media-keys=true
+        -Dcpp_std=c++14
       ]
 
       ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Attempt to fix build failure seen in #82155:

```
../meson.build:22:2: ERROR: Value "gnu++11" (of type "string") for combo option "C++ language standard to use" is not one of the choices. Possible choices are (as string): "none", "c++98", "c++11", "c++14", "c++17".
```

I'm really not sure what's happening here, so maybe there's a more appropriate fix