### PR TITLE
highlight: add minimum gcc version requirement on Linux

### DIFF
--- a/Formula/highlight.rb
+++ b/Formula/highlight.rb
@@ -22,6 +22,12 @@ class Highlight < Formula
   depends_on "pkg-config" => :build
   depends_on "lua"
 
+  on_linux do
+    depends_on "gcc" => :build
+  end
+
+  fails_with gcc: "5" # needs C++17
+
   def install
     conf_dir = etc/"highlight/" # highlight needs a final / for conf_dir
     system "make", "PREFIX=#{prefix}", "conf_dir=#{conf_dir}"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add add minimum gcc version requirement while building formula `highlight` on Linux. Fix Homebrew/linuxbrew-core#24273.