### PR TITLE
go: replace `rm_rf` calls with `rmtree`

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -59,9 +59,9 @@ class Go < Formula
 
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files
-    rm_rf Dir[libexec/"src/debug/elf/testdata"]
+    (libexec/"src/debug/elf/testdata").rmtree
     # Binaries built for an incompatible architecture
-    rm_rf Dir[libexec/"src/runtime/pprof/testdata"]
+    (libexec/"src/runtime/pprof/testdata").rmtree
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`rm_rf` will silently succeed even when passed an empty argument. Let's
do `rmtree` instead so that we error out when the directories we're
trying to delete no longer exist.