### PR TITLE
vim: throttle to 50 again

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -1,7 +1,7 @@
 class Vim < Formula
   desc "Vi 'workalike' with many additional features"
   homepage "https://www.vim.org/"
-  # vim should only be updated every 25 releases on multiples of 25
+  # vim should only be updated every 50 releases on multiples of 50
   url "https://github.com/vim/vim/archive/v8.2.3350.tar.gz"
   sha256 "f705470b5c95a2c02f96344d6b3c570f8f0eee23893b9118370cb7812815f9ce"
   license "Vim"

--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -7,5 +7,5 @@
   "gatsby-cli": 10,
   "netlify-cli": 5,
   "quicktype": 10,
-  "vim": 25
+  "vim": 50
 }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This was de-throttled to 25 in #69328, but recent bumps were happened 3-4 days apart. This is quite frequent, I have a tmux session with several vim opened, and everytime I run `brew upgrade`, it updates Vim, then I have to quit and re-open them one by one. If it's possible, throttling by release date would be more appropriate for Vim.