### PR TITLE
gif2png: add livecheck

### DIFF
--- a/Formula/gif2png.rb
+++ b/Formula/gif2png.rb
@@ -4,6 +4,11 @@ class Gif2png < Formula
   url "http://www.catb.org/~esr/gif2png/gif2png-2.5.13.tar.gz"
   sha256 "997275b20338e6cfe3bd4adb084f82627c34c856bc1d67c915c397cf55146924"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?gif2png[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "a8b1dd6b1f3b029b7ca53f99f18caea098810634aea1a745630028e66ecc4203"
     sha256 cellar: :any,                 big_sur:       "2c3b07aba9f301e689fbc6268894e3ab3a56044741b8b4adabd6afb1d4962af1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `gif2png`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.