### PR TITLE
podman-gvproxy 0.1.0 (new formula)

### DIFF
--- a/Formula/podman-gvproxy.rb
+++ b/Formula/podman-gvproxy.rb
@@ -1,0 +1,18 @@
+class PodmanGvproxy < Formula
+  desc "Network stack for Podman based on gVisor"
+  homepage "https://github.com/containers/gvisor-tap-vsock"
+  url "https://github.com/containers/gvisor-tap-vsock/archive/v0.1.0.tar.gz"
+  sha256 "e1e1bec2fc42039da1ae68d382d4560a27c04bbe2aae535837294dd6773e88e0"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    system "make"
+    bin.install "bin/gvproxy"
+  end
+
+  test do
+    assert_match(/cannot listen: listen unix/i, shell_output("#{bin}/gvproxy 2>&1"))
+  end
+end


### PR DESCRIPTION
Podman-gvproxy is a gVisor based network stack that allows Podman to forward connections to and from its VM.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----
