### PR TITLE
spot 2.9.8 (new formula)

### DIFF
--- a/Formula/spot.rb
+++ b/Formula/spot.rb
@@ -10,6 +10,8 @@ class Spot < Formula
     regex(/href=.*?spot[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
+  depends_on "python@3.9" => :build
+
   def install
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install"

--- a/Formula/spot.rb
+++ b/Formula/spot.rb
@@ -1,5 +1,5 @@
 class Spot < Formula
-  desc ": a platform for LTL and ω-automata manipulation"
+  desc "A platform for LTL and ω-automata manipulation"
   homepage "https://spot.lrde.epita.fr/"
   url "https://www.lrde.epita.fr/dload/spot/spot-2.9.8.tar.gz"
   sha256 "b7f404bb90a335a5914384ecc3fc3a2021ff22c57ee97a40c07bb2ab40e20cf9"
@@ -7,9 +7,15 @@ class Spot < Formula
 
   def install
     system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make", "install"
   end
 
   test do
     system bin/"randltl -n20 a b c d | ltlcross 'ltl2tgba -H -D %f >%O' 'ltl2tgba -s %f >%O' 'ltl2tgba -DP %f >%O'"
+  end
+
+  livecheck do
+    url "https://spot.lrde.epita.fr/install.html"
+    regex(/href=.*?spot[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Formula/spot.rb
+++ b/Formula/spot.rb
@@ -1,0 +1,15 @@
+class Spot < Formula
+  desc ": a platform for LTL and ω-automata manipulation"
+  homepage "https://spot.lrde.epita.fr/"
+  url "https://www.lrde.epita.fr/dload/spot/spot-2.9.8.tar.gz"
+  sha256 "b7f404bb90a335a5914384ecc3fc3a2021ff22c57ee97a40c07bb2ab40e20cf9"
+  license "GPL-3.0-or-later"
+
+  def install
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+  end
+
+  test do
+    system bin/"randltl -n20 a b c d | ltlcross 'ltl2tgba -H -D %f >%O' 'ltl2tgba -s %f >%O' 'ltl2tgba -DP %f >%O'"
+  end
+end

--- a/Formula/spot.rb
+++ b/Formula/spot.rb
@@ -1,9 +1,14 @@
 class Spot < Formula
-  desc "A platform for LTL and ω-automata manipulation"
+  desc "Platform for LTL and ω-automata manipulation"
   homepage "https://spot.lrde.epita.fr/"
   url "https://www.lrde.epita.fr/dload/spot/spot-2.9.8.tar.gz"
   sha256 "b7f404bb90a335a5914384ecc3fc3a2021ff22c57ee97a40c07bb2ab40e20cf9"
   license "GPL-3.0-or-later"
+
+  livecheck do
+    url "https://spot.lrde.epita.fr/install.html"
+    regex(/href=.*?spot[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   def install
     system "./configure", *std_configure_args, "--disable-silent-rules"
@@ -12,10 +17,5 @@ class Spot < Formula
 
   test do
     system bin/"randltl -n20 a b c d | ltlcross 'ltl2tgba -H -D %f >%O' 'ltl2tgba -s %f >%O' 'ltl2tgba -DP %f >%O'"
-  end
-
-  livecheck do
-    url "https://spot.lrde.epita.fr/install.html"
-    regex(/href=.*?spot[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
Spot is a C++14 library for LTL, ω-automata manipulation and model checking. It is the de facto standard library for working with ω-automata and is quite actively used in certain branches of theoretical computer science research.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
