### PR TITLE
solarus: depend on luajit-openresty

### DIFF
--- a/Formula/solarus.rb
+++ b/Formula/solarus.rb
@@ -5,6 +5,7 @@ class Solarus < Formula
       tag:      "v1.6.5",
       revision: "3aec70b0556a8d7aed7903d1a3e4d9a18c5d1649"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any, big_sur:  "8432227fe84cb749c77d45a9349c6d65793f0bff13fd77640266bcd51d564b95"
@@ -17,7 +18,7 @@ class Solarus < Formula
   depends_on "libmodplug"
   depends_on "libogg"
   depends_on "libvorbis"
-  depends_on "luajit"
+  depends_on "luajit-openresty"
   depends_on "physfs"
   depends_on "sdl2"
   depends_on "sdl2_image"
@@ -28,6 +29,8 @@ class Solarus < Formula
       ENV.append_to_cflags "-I#{Formula["glm"].opt_include}"
       ENV.append_to_cflags "-I#{Formula["physfs"].opt_include}"
       system "cmake", "..",
+                      "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                      "-DSOLARUS_ARCH=#{Hardware::CPU.arch}",
                       "-DSOLARUS_GUI=OFF",
                       "-DVORBISFILE_INCLUDE_DIR=#{Formula["libvorbis"].opt_include}",
                       "-DOGG_INCLUDE_DIR=#{Formula["libogg"].opt_include}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Previous attempt #69171

At least tried build on ARM and confirmed one of games available was able to run:
```console
❯ solarus-run zsdx-v1.12.3.solarus
[Solarus] [0] Info: Solarus 1.6.5 (3aec70b05)
[Solarus] [0] Info: Opening quest 'zsdx-v1.12.3.solarus'
[Solarus] [0] Info: Connected to audio device 'MacBook Pro Speakers'
[Solarus] [0] Info: Joypad support enabled: true
[Solarus] [0] Info: SDL: 2.0.16
[Solarus] [0] Info: Using modern GL Shaders
[Solarus] [0] Info: Renderer: GlRenderer
[Solarus] [0] Info: OpenGL: 4.1 Metal - 71.7.1
[Solarus] [0] Info: OpenGL vendor: Apple
[Solarus] [0] Info: OpenGL renderer: Apple M1
[Solarus] [0] Info: OpenGL shading language: 4.10
[Solarus] [0] Info: Quest format: 1.6
[Solarus] [0] Info: Fullscreen: no
[Solarus] [0] Info: LuaJIT: yes (LuaJIT 2.1.0-beta3)
[Solarus] [0] Info: Fullscreen: no
[Solarus] [0] Info: Language: en
[Solarus] [0] Info: Lua console: yes
[Solarus] [0] Info: Turbo mode: no
[Solarus] [0] Info: Simulation started
```