### PR TITLE
hyperscan: fix build for Linux

### DIFF
--- a/Formula/hyperscan.rb
+++ b/Formula/hyperscan.rb
@@ -15,11 +15,20 @@ class Hyperscan < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "ragel" => :build
+  # Only supports x86 instructions and will fail to build on ARM.
+  # See https://github.com/intel/hyperscan/issues/197
+  depends_on arch: :x86_64
   depends_on "pcre"
 
   def install
+    cmake_args = std_cmake_args + ["-DBUILD_STATIC_AND_SHARED=ON"]
+    on_linux do
+      # Linux CI cannot guarantee AVX2 support needed to build fat runtime.
+      cmake_args << "-DFAT_RUNTIME=OFF"
+    end
+
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args, "-DBUILD_STATIC_AND_SHARED=on"
+      system "cmake", "..", *cmake_args
       system "make", "install"
     end
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Previous bottle attempt: https://github.com/Homebrew/homebrew-core/runs/3034740332?check_suite_focus=true
```
CMake Error at cmake/arch.cmake:89 (message):
  AVX2 support required to build fat runtime
Call Stack (most recent call first):
  CMakeLists.txt:340 (include)
```

Some Ubuntu runners in pool may have AVX2 support, but probably not reliable enough as we would have to re-run CI until one of those get picked.

---

Didn't check what self-hosted runner is using.