### PR TITLE
apidoc: remove from universal binary allowlist

### DIFF
--- a/Formula/apidoc.rb
+++ b/Formula/apidoc.rb
@@ -25,7 +25,7 @@ class Apidoc < Formula
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
 
-    term_size_vendor_dir = libexec/"lib/node_modules/#{name}/node_modules/term-size/vendor"
+    term_size_vendor_dir = libexec/"lib/node_modules"/name/"node_modules/term-size/vendor"
     term_size_vendor_dir.rmtree # remove pre-built binaries
 
     on_macos do
@@ -34,6 +34,9 @@ class Apidoc < Formula
       # Replace the vendored pre-built term-size with one we build ourselves
       ln_sf (Formula["macos-term-size"].opt_bin/"term-size").relative_path_from(macos_dir), macos_dir
     end
+
+    # Extract native slices from universal binaries
+    deuniversalize_machos
   end
 
   test do

--- a/audit_exceptions/universal_binary_allowlist.json
+++ b/audit_exceptions/universal_binary_allowlist.json
@@ -1,5 +1,4 @@
 [
-  "apidoc",
   "ask-cli",
   "babel",
   "cdktf",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`deuniversalize_machos` has now landed in a `brew` release tag, so it
can be used in formulae.