### PR TITLE
CODEOWNERS: add @carlocab for `universal_binary_allowlist`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,3 +18,4 @@ LICENSE.txt           @Homebrew/plc @MikeMcQuaid
 
 audit_exceptions/permitted_formula_license_mismatches.json   @Homebrew/plc
 audit_exceptions/provided_by_macos_depends_on_allowlist.json @Homebrew/tsc
+audit_exceptions/universal_binary_allowlist.json             @carlocab


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Now that we have a `deuniversalize_machos` method available for use in
formulae, we shouldn't be adding new formulae to this allowlist.

I'm adding myself here to make sure I can chime in when someone tries
to, but also so that I can more quickly spot problems with the
`deuniversalize_machos` method, if any.