### PR TITLE
cilium-cli 0.8.6 (new formula)

### DIFF
--- a/Formula/cilium-cli.rb
+++ b/Formula/cilium-cli.rb
@@ -1,0 +1,26 @@
+class CiliumCli < Formula
+  desc "CLI to install, manage & troubleshoot Kubernetes clusters running Cilium"
+  homepage "https://cilium.io"
+  url "https://github.com/cilium/cilium-cli/archive/refs/tags/v0.8.6.tar.gz"
+  sha256 "7d4adfc511206af56570ba90dd523bd31f1703c8f9b36bca90e4d0863dd06ab7"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X github.com/cilium/cilium-cli/internal/cli/cmd.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags: ldflags), "-o", "#{bin}/cilium", "./cmd/cilium"
+
+    bash_output = Utils.safe_popen_read(bin/"cilium", "completion", "bash")
+    (bash_completion/"cilium").write bash_output
+    zsh_output = Utils.safe_popen_read(bin/"cilium", "completion", "zsh")
+    (zsh_completion/"_cilium").write zsh_output
+    fish_output = Utils.safe_popen_read(bin/"cilium", "completion", "fish")
+    (fish_completion/"cilium.fish").write fish_output
+  end
+
+  test do
+    assert_match('Cluster name "" is not valid', shell_output("#{bin}/cilium install 2>&1", 1))
+    assert_match("Error: Unable to enable Hubble", shell_output("#{bin}/cilium hubble enable 2>&1", 1))
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds the Cilium CLI to install, manage & troubleshoot Kubernetes
clusters running Cilium. See https://cilium.io for more information.