### PR TITLE
pari-*: add livecheck

### DIFF
--- a/Formula/pari-elldata.rb
+++ b/Formula/pari-elldata.rb
@@ -7,6 +7,16 @@ class PariElldata < Formula
   sha256 "dd551e64932d4ab27b3f2b2d1da871c2353672fc1a74705c52e3c0de84bd0cf6"
   license "GPL-2.0-or-later"
 
+  # The only difference in the `livecheck` blocks for pari-* formulae is the
+  # package name in the regex and they should otherwise be kept in parity.
+  livecheck do
+    url :homepage
+    regex(%r{>\s*elldata\.t[^<]+?</a>(?:[&(.;\s\w]+?(?:\),?|,))?\s*([a-z]+\s+\d{1,2},?\s+\d{4})\D}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "14d4b536fee818631a347a24bc5fa176f2a82bae24a9aa5fbe2db690315b1c74"
     sha256 cellar: :any_skip_relocation, big_sur:       "14d4b536fee818631a347a24bc5fa176f2a82bae24a9aa5fbe2db690315b1c74"

--- a/Formula/pari-galdata.rb
+++ b/Formula/pari-galdata.rb
@@ -7,6 +7,16 @@ class PariGaldata < Formula
   sha256 "b7c1650099b24a20bdade47a85a928351c586287f0d4c73933313873e63290dd"
   license "GPL-2.0-or-later"
 
+  # The only difference in the `livecheck` blocks for pari-* formulae is the
+  # package name in the regex and they should otherwise be kept in parity.
+  livecheck do
+    url :homepage
+    regex(%r{>\s*galdata\.t[^<]+?</a>(?:[&(.;\s\w]+?(?:\),?|,))?\s*([a-z]+\s+\d{1,2},?\s+\d{4})\D}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "0955aa684155ddba3d65a6ba99b05a7e0e02fdc3b6f5cf3b9da11e0a102ca37e"
   end

--- a/Formula/pari-galpol.rb
+++ b/Formula/pari-galpol.rb
@@ -7,6 +7,16 @@ class PariGalpol < Formula
   sha256 "562af28316ee335ee38c1172c2d5ecccb79f55c368fb9f2c6f40fc0f416bb01b"
   license "GPL-2.0-or-later"
 
+  # The only difference in the `livecheck` blocks for pari-* formulae is the
+  # package name in the regex and they should otherwise be kept in parity.
+  livecheck do
+    url :homepage
+    regex(%r{>\s*galpol\.t[^<]+?</a>(?:[&(.;\s\w]+?(?:\),?|,))?\s*([a-z]+\s+\d{1,2},?\s+\d{4})\D}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "5574927ca436092cb927939102bb2fc3402f2c3d9aa137295959061002c362ad"
   end

--- a/Formula/pari-seadata-big.rb
+++ b/Formula/pari-seadata-big.rb
@@ -7,6 +7,16 @@ class PariSeadataBig < Formula
   sha256 "7c4db2624808a5bbd2ba00f8b644a439f0508532efd680a247610fdd5822a5f2"
   license "GPL-2.0-or-later"
 
+  # The only difference in the `livecheck` blocks for pari-* formulae is the
+  # package name in the regex and they should otherwise be kept in parity.
+  livecheck do
+    url :homepage
+    regex(%r{>\s*seadata-big\.t[^<]+?</a>(?:[&(.;\s\w]+?(?:\),?|,))?\s*([a-z]+\s+\d{1,2},?\s+\d{4})\D}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "ad28655dc8e08ca7dd3aa0f0fd327da56e8801e76fb4a76373d0714dcd30e85f"
   end

--- a/Formula/pari-seadata.rb
+++ b/Formula/pari-seadata.rb
@@ -7,6 +7,16 @@ class PariSeadata < Formula
   sha256 "c9282a525ea3f92c1f9c6c69e37ac5a87b48fb9ccd943cfd7c881a3851195833"
   license "GPL-2.0-or-later"
 
+  # The only difference in the `livecheck` blocks for pari-* formulae is the
+  # package name in the regex and they should otherwise be kept in parity.
+  livecheck do
+    url :homepage
+    regex(%r{>\s*seadata\.t[^<]+?</a>(?:[&(.;\s\w]+?(?:\),?|,))?\s*([a-z]+\s+\d{1,2},?\s+\d{4})\D}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e1310a89e74bc49b8fb00213aa9210b7e2fa89c6529a23771b185a63c3b1a668"
     sha256 cellar: :any_skip_relocation, big_sur:       "e1310a89e74bc49b8fb00213aa9210b7e2fa89c6529a23771b185a63c3b1a668"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #83158, where additional `pari-` data packages were added. I mentioned a potential `livecheck` block format for these formulae but we decided to handle this separately.

This PR adds `livecheck` blocks for the newly-added `pari-` formulae in addition to `pari-elldata`, which already existed. These `livecheck` blocks check the first-party [packages page](https://pari.math.u-bordeaux.fr/packages.html), identify the release date for the related package, and parse/format it to match the formula version (e.g., `20210301`). The only difference between these `livecheck` blocks is the package name near the start of the regex.

To be clear, since there isn't a canonical formulae between these (they're all siblings), it's not appropriate to use the `formula` DSL in this context to minimize duplication. In this context, it's appropriate to manually keep these in parity and I've added a comment before the `livecheck` blocks saying as much.