### PR TITLE
a*: add `head` branch

### DIFF
--- a/Formula/abcde.rb
+++ b/Formula/abcde.rb
@@ -5,7 +5,7 @@ class Abcde < Formula
   sha256 "046cd0bba78dd4bbdcbcf82fe625865c60df35a005482de13a6699c5a3b83124"
   license "GPL-2.0-or-later"
   revision 1
-  head "https://git.einval.com/git/abcde.git"
+  head "https://git.einval.com/git/abcde.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "4240ff000419b4ca9c0d275d70fccb10255ea17718906768892ba3a2d7ecb444"

--- a/Formula/abduco.rb
+++ b/Formula/abduco.rb
@@ -4,7 +4,7 @@ class Abduco < Formula
   url "https://github.com/martanne/abduco/releases/download/v0.6/abduco-0.6.tar.gz"
   sha256 "c90909e13fa95770b5afc3b59f311b3d3d2fdfae23f9569fa4f96a3e192a35f4"
   license "ISC"
-  head "https://github.com/martanne/abduco.git"
+  head "https://github.com/martanne/abduco.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e261303a69440aa46e09bfc3be3b7fb0c5cb6b2a3f6fbeb94338491a8538a90a"

--- a/Formula/abook.rb
+++ b/Formula/abook.rb
@@ -4,7 +4,7 @@ class Abook < Formula
   url "https://abook.sourceforge.io/devel/abook-0.6.1.tar.gz"
   sha256 "f0a90df8694fb34685ecdd45d97db28b88046c15c95e7b0700596028bd8bc0f9"
   license "GPL-2.0"
-  head "https://git.code.sf.net/p/abook/git.git"
+  head "https://git.code.sf.net/p/abook/git.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/abseil.rb
+++ b/Formula/abseil.rb
@@ -4,7 +4,7 @@ class Abseil < Formula
   url "https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz"
   sha256 "59b862f50e710277f8ede96f083a5bb8d7c9595376146838b9580be90374ee1f"
   license "Apache-2.0"
-  head "https://github.com/abseil/abseil-cpp.git"
+  head "https://github.com/abseil/abseil-cpp.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "e6f4665315350736b5cd574f4316ebba4d10cfeda0531602f358c1c013ae9256"

--- a/Formula/acpica.rb
+++ b/Formula/acpica.rb
@@ -4,7 +4,7 @@ class Acpica < Formula
   url "https://acpica.org/sites/acpica/files/acpica-unix-20210730.tar.gz"
   sha256 "4a0c14d5148666612aa0555c5179eaa86230602394fd1bc3d16b506fcf49b5de"
   license any_of: ["Intel-ACPI", "GPL-2.0-only", "BSD-3-Clause"]
-  head "https://github.com/acpica/acpica.git"
+  head "https://github.com/acpica/acpica.git", branch: "master"
 
   livecheck do
     url "https://acpica.org/downloads"

--- a/Formula/act.rb
+++ b/Formula/act.rb
@@ -4,7 +4,7 @@ class Act < Formula
   url "https://github.com/nektos/act/archive/v0.2.24.tar.gz"
   sha256 "c6bc09cac52483e175f25d50a262e6b0815789a243a657b6b0c597f048487e0f"
   license "MIT"
-  head "https://github.com/nektos/act.git"
+  head "https://github.com/nektos/act.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "a20e74be00a60813dda3b8cf2ff6b15ee16127989b9b5e316796b311391997c9"

--- a/Formula/adns.rb
+++ b/Formula/adns.rb
@@ -4,7 +4,7 @@ class Adns < Formula
   url "https://www.chiark.greenend.org.uk/~ian/adns/ftp/adns-1.6.0.tar.gz"
   sha256 "fb427265a981e033d1548f2b117cc021073dc8be2eaf2c45fd64ab7b00ed20de"
   license all_of: ["GPL-3.0-or-later", "LGPL-2.0-or-later"]
-  head "https://www.chiark.greenend.org.uk/ucgi/~ianmdlvl/githttp/adns.git"
+  head "https://www.chiark.greenend.org.uk/ucgi/~ianmdlvl/githttp/adns.git", branch: "master"
 
   livecheck do
     url "https://www.chiark.greenend.org.uk/~ian/adns/ftp/"

--- a/Formula/afio.rb
+++ b/Formula/afio.rb
@@ -3,7 +3,7 @@ class Afio < Formula
   homepage "https://github.com/kholtman/afio"
   url "https://github.com/kholtman/afio/archive/v2.5.2.tar.gz"
   sha256 "c64ca14109df547e25702c9f3a9ca877881cd4bf38dcbe90fbd09c8d294f42b9"
-  head "https://github.com/kholtman/afio.git"
+  head "https://github.com/kholtman/afio.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/agedu.rb
+++ b/Formula/agedu.rb
@@ -4,7 +4,7 @@ class Agedu < Formula
   url "https://www.chiark.greenend.org.uk/~sgtatham/agedu/agedu-20200705.2a7d4a2.tar.gz"
   version "20200705"
   sha256 "432dd9602df326088956b3e4f5efe656ad09777873d38695e0d68810899941c2"
-  head "https://git.tartarus.org/simon/agedu.git"
+  head "https://git.tartarus.org/simon/agedu.git", branch: "main"
 
   livecheck do
     url :homepage

--- a/Formula/aha.rb
+++ b/Formula/aha.rb
@@ -4,7 +4,7 @@ class Aha < Formula
   url "https://github.com/theZiz/aha/archive/0.5.1.tar.gz"
   sha256 "6aea13487f6b5c3e453a447a67345f8095282f5acd97344466816b05ebd0b3b1"
   license "LGPL-2.1"
-  head "https://github.com/theZiz/aha.git"
+  head "https://github.com/theZiz/aha.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "fed59f6650f5b40100644b0baf1bee57b0b3ca6a05d413af70350d9d0eaa8441"

--- a/Formula/airspy.rb
+++ b/Formula/airspy.rb
@@ -3,7 +3,7 @@ class Airspy < Formula
   homepage "https://airspy.com/"
   url "https://github.com/airspy/airspyone_host/archive/v1.0.10.tar.gz"
   sha256 "fcca23911c9a9da71cebeffeba708c59d1d6401eec6eb2dd73cae35b8ea3c613"
-  head "https://github.com/airspy/airspyone_host.git"
+  head "https://github.com/airspy/airspyone_host.git", branch: "master"
 
   bottle do
     sha256                               arm64_big_sur: "3cebc54737172b116e3cdabc7770777954b6c1840940588cd29f431c4db526c7"

--- a/Formula/algernon.rb
+++ b/Formula/algernon.rb
@@ -5,7 +5,7 @@ class Algernon < Formula
   sha256 "6127eb975da960fd8aa7732c82f3b5e62d14ea763801778552bdbeec28846bf7"
   license "MIT"
   version_scheme 1
-  head "https://github.com/xyproto/algernon.git"
+  head "https://github.com/xyproto/algernon.git", branch: "main"
 
   livecheck do
     url :stable

--- a/Formula/aliddns.rb
+++ b/Formula/aliddns.rb
@@ -5,7 +5,7 @@ class Aliddns < Formula
       tag:      "v0.0.12",
       revision: "adcb7cc3b57c254a43f696bd83122cc693cc7ad0"
   license "MIT"
-  head "https://github.com/OpenIoTHub/aliddns.git"
+  head "https://github.com/OpenIoTHub/aliddns.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "0dc04fa8aaf8dd3d48798a71300ddf0f4bb905fe2b97875e9734b7ac15c40218"

--- a/Formula/allegro.rb
+++ b/Formula/allegro.rb
@@ -4,7 +4,7 @@ class Allegro < Formula
   url "https://github.com/liballeg/allegro5/releases/download/5.2.7.0/allegro-5.2.7.0.tar.gz"
   sha256 "c1e3b319d99cb453b39d393572ba2b9f3de42a96de424aee7d4a1abceaaa970c"
   license "Zlib"
-  head "https://github.com/liballeg/allegro5.git"
+  head "https://github.com/liballeg/allegro5.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/allureofthestars.rb
+++ b/Formula/allureofthestars.rb
@@ -5,7 +5,7 @@ class Allureofthestars < Formula
   sha256 "fcb9f38ea543d3277fa90eee004f7624d1168bf7f2c17902cda1870293b7c2f4"
   license all_of: ["AGPL-3.0-or-later", "GPL-2.0-or-later", "OFL-1.1", "MIT", :cannot_represent]
   revision 2
-  head "https://github.com/AllureOfTheStars/Allure.git"
+  head "https://github.com/AllureOfTheStars/Allure.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "5d4b52ab398c06ea763ada17bbcc5ce1809e7fa41ca86d51e84a1b735e2bf1fc"

--- a/Formula/alot.rb
+++ b/Formula/alot.rb
@@ -7,7 +7,7 @@ class Alot < Formula
   sha256 "ee2c1ab1b43d022a8fe2078820ed57d8d72aec260a7d750776dac4ee841d1de4"
   license "GPL-3.0-only"
   revision 2
-  head "https://github.com/pazz/alot.git"
+  head "https://github.com/pazz/alot.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "5f9ba3f7cc0858982386261853661c35eeaf4f0ecf928033345f5cf84005dcc7"

--- a/Formula/alp.rb
+++ b/Formula/alp.rb
@@ -4,7 +4,7 @@ class Alp < Formula
   url "https://github.com/tkuchiki/alp/archive/v1.0.7.tar.gz"
   sha256 "8a7e89547ac26f7c7446ef641ab29d08bc495fc8ae707eeab57e87b4983c3262"
   license "MIT"
-  head "https://github.com/tkuchiki/alp.git"
+  head "https://github.com/tkuchiki/alp.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "7809110b0e065a91816cdd2331a639a6c7c6f900c9721fa82323490b0ab34fab"

--- a/Formula/alpine.rb
+++ b/Formula/alpine.rb
@@ -4,7 +4,7 @@ class Alpine < Formula
   url "https://alpine.x10host.com/alpine/release/src/alpine-2.24.tar.xz"
   sha256 "651a9ffa0a29e2b646a0a6e0d5a2c8c50f27a07a26a61640b7c783d06d0abcef"
   license "Apache-2.0"
-  head "https://repo.or.cz/alpine.git"
+  head "https://repo.or.cz/alpine.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/amazon-ecs-cli.rb
+++ b/Formula/amazon-ecs-cli.rb
@@ -4,7 +4,7 @@ class AmazonEcsCli < Formula
   url "https://github.com/aws/amazon-ecs-cli/archive/v1.21.0.tar.gz"
   sha256 "27e93a5439090486a2f2f5a9b02cbbd1493e3c14affbbe2375ed57f8f903e677"
   license "Apache-2.0"
-  head "https://github.com/aws/amazon-ecs-cli.git"
+  head "https://github.com/aws/amazon-ecs-cli.git", branch: "mainline"
 
   bottle do
     rebuild 1

--- a/Formula/amfora.rb
+++ b/Formula/amfora.rb
@@ -8,7 +8,7 @@ class Amfora < Formula
     "GPL-3.0-only",
     any_of: ["GPL-3.0-only", "MIT"], # rr
   ]
-  head "https://github.com/makeworld-the-better-one/amfora.git"
+  head "https://github.com/makeworld-the-better-one/amfora.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "4d37d2bfd27691d2b2a69f5ec5ef94b3af3afbca7fe399dc0af3bb3eec4cab3e"

--- a/Formula/amp.rb
+++ b/Formula/amp.rb
@@ -5,7 +5,7 @@ class Amp < Formula
   sha256 "9279efcecdb743b8987fbedf281f569d84eaf42a0eee556c3447f3dc9c9dfe3b"
   license "GPL-3.0-or-later"
   revision 1
-  head "https://github.com/jmacdonald/amp.git"
+  head "https://github.com/jmacdonald/amp.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f001a886b5ea456bc925ae37ef45c6f5ae70ef8506ae576fe3f831e78f2ecbcb"

--- a/Formula/amqp-cpp.rb
+++ b/Formula/amqp-cpp.rb
@@ -4,7 +4,7 @@ class AmqpCpp < Formula
   url "https://github.com/CopernicaMarketingSoftware/AMQP-CPP/archive/v4.3.14.tar.gz"
   sha256 "6ac69a407c0edf9f8f56fdbb56acb4e5e9b331e3243cb95f26b861ae794549f4"
   license "Apache-2.0"
-  head "https://github.com/CopernicaMarketingSoftware/AMQP-CPP.git"
+  head "https://github.com/CopernicaMarketingSoftware/AMQP-CPP.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/amtterm.rb
+++ b/Formula/amtterm.rb
@@ -4,7 +4,7 @@ class Amtterm < Formula
   url "https://www.kraxel.org/releases/amtterm/amtterm-1.6.tar.gz"
   sha256 "1242cea467827aa1e2e91b41846229ca0a5b3f3e09260b0df9d78dc875075590"
   license "GPL-2.0"
-  head "https://git.kraxel.org/git/amtterm/", using: :git
+  head "https://git.kraxel.org/git/amtterm/", branch: "master", using: :git
 
   livecheck do
     url "https://www.kraxel.org/releases/amtterm/"

--- a/Formula/angband.rb
+++ b/Formula/angband.rb
@@ -4,7 +4,7 @@ class Angband < Formula
   url "https://github.com/angband/angband/releases/download/4.2.3/Angband-4.2.3.tar.gz"
   sha256 "833c4f8cff2aee61ad015f9346fceaa4a8c739fe2dbe5bd1acd580c91818e6bb"
   license "GPL-2.0-only"
-  head "https://github.com/angband/angband.git"
+  head "https://github.com/angband/angband.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "ab6002b750047f4c544b8427a2f021395b75ab7f9f93c26fc0f3625b758f5842"

--- a/Formula/anime-downloader.rb
+++ b/Formula/anime-downloader.rb
@@ -6,7 +6,7 @@ class AnimeDownloader < Formula
   url "https://files.pythonhosted.org/packages/00/8b/2f354c0c2e56f1fe45e805698bd6a81c472473a48b814c44aaed2d41016d/anime-downloader-5.0.9.tar.gz"
   sha256 "40eaded9508a30f35993b2fc0f436c357d9939d58625a10bd595bfc11816ead4"
   license "Unlicense"
-  head "https://github.com/anime-dl/anime-downloader.git"
+  head "https://github.com/anime-dl/anime-downloader.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "51528ac11b71b803cec6866244164cc4b5e837fbc189c38cdb054bf189ef59f7"

--- a/Formula/ansiweather.rb
+++ b/Formula/ansiweather.rb
@@ -4,7 +4,7 @@ class Ansiweather < Formula
   url "https://github.com/fcambus/ansiweather/archive/1.17.0.tar.gz"
   sha256 "eabc5ad709e2a459d59402b190511b44542eafce293205a29fb2b73c3e075ee7"
   license "BSD-2-Clause"
-  head "https://github.com/fcambus/ansiweather.git"
+  head "https://github.com/fcambus/ansiweather.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "ef34ba57b350fcf65cfd5fbcab88c5209c75d225e2af9a8b9c48bffc99d01b37"

--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -5,7 +5,7 @@ class Ant < Formula
   mirror "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.11-bin.tar.xz"
   sha256 "baa049855cdecbefa62539555824058e52412e5ebe8f102e1db944cb762e06d9"
   license "Apache-2.0"
-  head "https://git-wip-us.apache.org/repos/asf/ant.git"
+  head "https://git-wip-us.apache.org/repos/asf/ant.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "46a14d89d209b9f1442199a73c18f88c3f2d6a1ed9c68fb170cf3b4beb161b89"

--- a/Formula/anycable-go.rb
+++ b/Formula/anycable-go.rb
@@ -4,7 +4,7 @@ class AnycableGo < Formula
   url "https://github.com/anycable/anycable-go/archive/v1.1.2.tar.gz"
   sha256 "4df04424a8e9ed54e7a8f6794d0de7ff6e66a4b008d7e477c5434bd70dcee5da"
   license "MIT"
-  head "https://github.com/anycable/anycable-go.git"
+  head "https://github.com/anycable/anycable-go.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/apache-arrow-glib.rb
+++ b/Formula/apache-arrow-glib.rb
@@ -5,7 +5,7 @@ class ApacheArrowGlib < Formula
   mirror "https://archive.apache.org/dist/arrow/arrow-5.0.0/apache-arrow-5.0.0.tar.gz"
   sha256 "c3b4313eca594c20f761a836719721aaf0760001af896baec3ab64420ff9910a"
   license "Apache-2.0"
-  head "https://github.com/apache/arrow.git"
+  head "https://github.com/apache/arrow.git", branch: "master"
 
   livecheck do
     formula "apache-arrow"

--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -6,7 +6,7 @@ class ApacheArrow < Formula
   sha256 "c3b4313eca594c20f761a836719721aaf0760001af896baec3ab64420ff9910a"
   license "Apache-2.0"
   revision 1
-  head "https://github.com/apache/arrow.git"
+  head "https://github.com/apache/arrow.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "2fde45fd60e6e8ded9d49800c6c610504e8e79489ba1b458457593754e2cf951"

--- a/Formula/apache-flink.rb
+++ b/Formula/apache-flink.rb
@@ -6,7 +6,7 @@ class ApacheFlink < Formula
   version "1.13.2"
   sha256 "b1da0ca78ca669c206b7e5755fbab1eb9d997694cfc34acd549215d60c978e18"
   license "Apache-2.0"
-  head "https://github.com/apache/flink.git"
+  head "https://github.com/apache/flink.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "41eb13d3f41fe1f3aa1d13e0bfc96263c8843bbfaee7419b2de01942e0603a1b"

--- a/Formula/apache-spark.rb
+++ b/Formula/apache-spark.rb
@@ -6,7 +6,7 @@ class ApacheSpark < Formula
   version "3.1.2"
   sha256 "0d9cf9dbbb3b4215afebe7fa4748b012e406dd1f1ad2a61b993ac04adcb94eaa"
   license "Apache-2.0"
-  head "https://github.com/apache/spark.git"
+  head "https://github.com/apache/spark.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "5c1a0656373e8ece0a03ea78d4e90895b307ed48b7e8f4eeb2dca88d0bf6c32b"

--- a/Formula/apib.rb
+++ b/Formula/apib.rb
@@ -4,7 +4,7 @@ class Apib < Formula
   url "https://github.com/apigee/apib/archive/APIB_1_2_1.tar.gz"
   sha256 "e47f639aa6ffc14a2e5b03bf95e8b0edc390fa0bb2594a521f779d6e17afc14c"
   license "Apache-2.0"
-  head "https://github.com/apigee/apib.git"
+  head "https://github.com/apigee/apib.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "6c066e87db949d59e554c6c9b9e7657d249171dee7a2d3b7bc53b54f36daa762"

--- a/Formula/apngasm.rb
+++ b/Formula/apngasm.rb
@@ -5,7 +5,7 @@ class Apngasm < Formula
   sha256 "0068e31cd878e07f3dffa4c6afba6242a753dac83b3799470149d2e816c1a2a7"
   license "Zlib"
   revision 2
-  head "https://github.com/apngasm/apngasm.git"
+  head "https://github.com/apngasm/apngasm.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "9f447e672e2a167926aba3a733123ad244be88f5814dbf86dff970394537abf4"

--- a/Formula/appium.rb
+++ b/Formula/appium.rb
@@ -6,7 +6,7 @@ class Appium < Formula
   url "https://registry.npmjs.org/appium/-/appium-1.21.0.tgz"
   sha256 "8d61454f8f969260aecc1f46f4ca0123c55c2fbe4ecd3303d095ec90ecd3dc4f"
   license "Apache-2.0"
-  head "https://github.com/appium/appium.git"
+  head "https://github.com/appium/appium.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "4dd71c228058ccb1d8d5228bfe2e185f56b6bf3319bc0eb7a869063061a5d865"

--- a/Formula/appledoc.rb
+++ b/Formula/appledoc.rb
@@ -4,7 +4,7 @@ class Appledoc < Formula
   url "https://github.com/tomaz/appledoc/archive/2.2.1.tar.gz"
   sha256 "0ec881f667dfe70d565b7f1328e9ad4eebc8699ee6dcd381f3bd0ccbf35c0337"
   license "Apache-2.0"
-  head "https://github.com/tomaz/appledoc.git"
+  head "https://github.com/tomaz/appledoc.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/appscale-tools.rb
+++ b/Formula/appscale-tools.rb
@@ -5,7 +5,7 @@ class AppscaleTools < Formula
   sha256 "ae3f373626d5d88d38cf17fef8bd5faaf92234bc6421d5f5c49cf5788acbe93a"
   license "Apache-2.0"
   revision 3
-  head "https://github.com/AppScale/appscale-tools.git"
+  head "https://github.com/AppScale/appscale-tools.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, big_sur:     "69c1aff6adfd929cdce565af76c67dd20e95bf6be18a2aae4f3c69cb1c498bec"

--- a/Formula/aptly.rb
+++ b/Formula/aptly.rb
@@ -5,7 +5,7 @@ class Aptly < Formula
   sha256 "4172d54613139f6c34d5a17396adc9675d7ed002e517db8381731d105351fbe5"
   license "MIT"
   revision 1
-  head "https://github.com/aptly-dev/aptly.git"
+  head "https://github.com/aptly-dev/aptly.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "7e20f2357e98719f0364e6e66322d0ea2d59b8be278cc656ace3f6386212fa11"

--- a/Formula/arabica.rb
+++ b/Formula/arabica.rb
@@ -5,7 +5,7 @@ class Arabica < Formula
   version "20200425"
   sha256 "b00c7b8afd2c3f17b5a22171248136ecadf0223b598fd9631c23f875a5ce87fe"
   license "BSD-3-Clause"
-  head "https://github.com/jezhiggins/arabica.git"
+  head "https://github.com/jezhiggins/arabica.git", branch: "main"
 
   # The `strategy` block below is used to generate a version from the datetime
   # of the "latest" release on GitHub, so it will match the formula `version`.

--- a/Formula/arb.rb
+++ b/Formula/arb.rb
@@ -4,7 +4,7 @@ class Arb < Formula
   url "https://github.com/fredrik-johansson/arb/archive/2.20.0.tar.gz"
   sha256 "d2f186b10590c622c11d1ca190c01c3da08bac9bc04e84cb591534b917faffe7"
   license "LGPL-2.1-or-later"
-  head "https://github.com/fredrik-johansson/arb.git"
+  head "https://github.com/fredrik-johansson/arb.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "3791204d0c0dbb5bd44f063344bc8a1615c63a3935f95e74eddbe8ce26a89049"

--- a/Formula/arcade-learning-environment.rb
+++ b/Formula/arcade-learning-environment.rb
@@ -5,7 +5,7 @@ class ArcadeLearningEnvironment < Formula
   sha256 "8059a4087680da03878c1648a8ceb0413a341032ecaa44bef4ef1f9f829b6dde"
   license "GPL-2.0"
   revision 2
-  head "https://github.com/mgbellemare/Arcade-Learning-Environment.git"
+  head "https://github.com/mgbellemare/Arcade-Learning-Environment.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "ac79a55da2582b1750e695bbe66943cd3e79111708b0692edad3fdefb870d291"

--- a/Formula/archey.rb
+++ b/Formula/archey.rb
@@ -3,7 +3,7 @@ class Archey < Formula
   homepage "https://obihann.github.io/archey-osx/"
   license "GPL-2.0-or-later"
   revision 1
-  head "https://github.com/obihann/archey-osx.git"
+  head "https://github.com/obihann/archey-osx.git", branch: "master"
 
   stable do
     url "https://github.com/obihann/archey-osx/archive/1.6.0.tar.gz"

--- a/Formula/archi-steam-farm.rb
+++ b/Formula/archi-steam-farm.rb
@@ -5,7 +5,7 @@ class ArchiSteamFarm < Formula
     tag:      "5.1.2.4",
     revision: "7ff747fb6ed26229101909f2b0abb0ca03b98988"
   license "Apache-2.0"
-  head "https://github.com/JustArchiNET/ArchiSteamFarm.git"
+  head "https://github.com/JustArchiNET/ArchiSteamFarm.git", branch: "main"
 
   livecheck do
     url :stable

--- a/Formula/archiver.rb
+++ b/Formula/archiver.rb
@@ -4,7 +4,7 @@ class Archiver < Formula
   url "https://github.com/mholt/archiver/archive/v3.5.0.tar.gz"
   sha256 "8f2e3ad68553f6b58bf99e8635ff0953f62ff0a7804da7658954ffaa7d0aaa0a"
   license "MIT"
-  head "https://github.com/mholt/archiver.git"
+  head "https://github.com/mholt/archiver.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d717896d49eb78330bc10d6cb050cc0c3bf7f89d84f1dd5f4fce3529ced17776"

--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -6,7 +6,7 @@ class ArduinoCli < Formula
      revision: "d710b642ef7992a678053e9d68996c02f5863721"
   license "GPL-3.0-only"
   revision 1
-  head "https://github.com/arduino/arduino-cli.git"
+  head "https://github.com/arduino/arduino-cli.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/argon2.rb
+++ b/Formula/argon2.rb
@@ -5,7 +5,7 @@ class Argon2 < Formula
   sha256 "daf972a89577f8772602bf2eb38b6a3dd3d922bf5724d45e7f9589b5e830442c"
   license "Apache-2.0"
   revision 1
-  head "https://github.com/P-H-C/phc-winner-argon2.git"
+  head "https://github.com/P-H-C/phc-winner-argon2.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "192f3381abe337df8af214cf4dccef2cbfaa9c88df489b5cf9276cea9f8c6080"

--- a/Formula/armor.rb
+++ b/Formula/armor.rb
@@ -4,7 +4,7 @@ class Armor < Formula
   url "https://github.com/labstack/armor/archive/v0.4.14.tar.gz"
   sha256 "bcaee0eaa1ef29ef439d5235b955516871c88d67c3ec5191e3421f65e364e4b8"
   license "MIT"
-  head "https://github.com/labstack/armor.git"
+  head "https://github.com/labstack/armor.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/arp-scan.rb
+++ b/Formula/arp-scan.rb
@@ -4,7 +4,7 @@ class ArpScan < Formula
   url "https://github.com/royhills/arp-scan/archive/1.9.7.tar.gz"
   sha256 "e03c36e4933c655bd0e4a841272554a347cd0136faf42c4a6564059e0761c039"
   license "GPL-3.0"
-  head "https://github.com/royhills/arp-scan.git"
+  head "https://github.com/royhills/arp-scan.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "bab165d30f8039bba63d086234d0c57c64152fe73d586081dfaa7eec177fcefd"

--- a/Formula/arpack.rb
+++ b/Formula/arpack.rb
@@ -5,7 +5,7 @@ class Arpack < Formula
   sha256 "ada5aeb3878874383307239c9235b716a8a170c6d096a6625bfd529844df003d"
   license "BSD-3-Clause"
   revision 1
-  head "https://github.com/opencollab/arpack-ng.git"
+  head "https://github.com/opencollab/arpack-ng.git", branch: "master"
 
   bottle do
     sha256                               arm64_big_sur: "ce6c690e2da971fd3c2b1b481e2a1a63c74e45ab308abc8212d4e8622ab57fb3"

--- a/Formula/asciidoc.rb
+++ b/Formula/asciidoc.rb
@@ -6,7 +6,7 @@ class Asciidoc < Formula
   url "https://github.com/asciidoc-py/asciidoc-py/archive/9.1.0.tar.gz"
   sha256 "5056c20157349f8dc74f005b6e88ccbf1078c4e26068876f13ca3d1d7d045fe7"
   license "GPL-2.0-only"
-  head "https://github.com/asciidoc-py/asciidoc-py.git"
+  head "https://github.com/asciidoc-py/asciidoc-py.git", branch: "main"
 
   livecheck do
     url :stable

--- a/Formula/asciinema.rb
+++ b/Formula/asciinema.rb
@@ -7,7 +7,7 @@ class Asciinema < Formula
   sha256 "32f2c1a046564e030708e596f67e0405425d1eca9d5ec83cd917ef8da06bc423"
   license "GPL-3.0"
   revision 3
-  head "https://github.com/asciinema/asciinema.git"
+  head "https://github.com/asciinema/asciinema.git", branch: "develop"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b681c70de003112e00b3c31555e06453e0d22483095713fd27cfe9113e5363c6"

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -5,7 +5,7 @@ class Asdf < Formula
   sha256 "6ca280287dcb687ec12f0c37e4e193de390cdab68f2b2a0e271e3a4f1e20bd2e"
   license "MIT"
   revision 1
-  head "https://github.com/asdf-vm/asdf.git"
+  head "https://github.com/asdf-vm/asdf.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "075bbc7db5d24b81f3f171b2dcd5afaf47842f46371ff48aae58740c3358a20e"

--- a/Formula/asio.rb
+++ b/Formula/asio.rb
@@ -4,7 +4,7 @@ class Asio < Formula
   url "https://downloads.sourceforge.net/project/asio/asio/1.18.2%20%28Stable%29/asio-1.18.2.tar.bz2"
   sha256 "3ac05d4586d4b10afc28ff09017639652fb04feb9e575f9d48410db3ab27f9f2"
   license "BSL-1.0"
-  head "https://github.com/chriskohlhoff/asio.git"
+  head "https://github.com/chriskohlhoff/asio.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/asroute.rb
+++ b/Formula/asroute.rb
@@ -4,7 +4,7 @@ class Asroute < Formula
   url "https://github.com/stevenpack/asroute/archive/v0.1.0.tar.gz"
   sha256 "dfbf910966cdfacf18ba200b83791628ebd1b5fa89fdfa69b989e0cb05b3ca37"
   license "MIT"
-  head "https://github.com/stevenpack/asroute.git"
+  head "https://github.com/stevenpack/asroute.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "816be1190f677bb1ba13d1b1fd92a0ca7550341810310b59be200227936afc9c"

--- a/Formula/assh.rb
+++ b/Formula/assh.rb
@@ -4,7 +4,7 @@ class Assh < Formula
   url "https://github.com/moul/assh/archive/v2.11.3.tar.gz"
   sha256 "da95db33f72ad2531124b0de42074ba61ac1eebdad90bac90c68d1b02aa51354"
   license "MIT"
-  head "https://github.com/moul/assh.git"
+  head "https://github.com/moul/assh.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "0860549309f01ea758615ab322bffc4599bc18e57122f7cbaf307bd3ea97a5ef"

--- a/Formula/assimp.rb
+++ b/Formula/assimp.rb
@@ -4,7 +4,7 @@ class Assimp < Formula
   url "https://github.com/assimp/assimp/archive/v5.0.1.tar.gz"
   sha256 "11310ec1f2ad2cd46b95ba88faca8f7aaa1efe9aa12605c55e3de2b977b3dbfc"
   license :cannot_represent
-  head "https://github.com/assimp/assimp.git"
+  head "https://github.com/assimp/assimp.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "0571a9c07e7166cbfbd2c12b17f121c718204491501f268cdd904791df3c3697"

--- a/Formula/atlantis.rb
+++ b/Formula/atlantis.rb
@@ -4,7 +4,7 @@ class Atlantis < Formula
   url "https://github.com/runatlantis/atlantis/archive/v0.17.2.tar.gz"
   sha256 "7dcba88cbcad2f7830bbc4e42839593a912c5419f0e1d49796f2a7b27203cf3f"
   license "Apache-2.0"
-  head "https://github.com/runatlantis/atlantis.git"
+  head "https://github.com/runatlantis/atlantis.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "0e1f196a5494132156d664e66871244352d59a1d9606fb72bf148190add97a7d"

--- a/Formula/atomicparsley.rb
+++ b/Formula/atomicparsley.rb
@@ -6,7 +6,7 @@ class Atomicparsley < Formula
   sha256 "546dcb5f3b625aff4f6bf22d27a0a636d15854fd729402a6933d31f3d0417e0d"
   license "GPL-2.0-or-later"
   version_scheme 1
-  head "https://github.com/wez/atomicparsley.git"
+  head "https://github.com/wez/atomicparsley.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f1997965e9c425cd6b4d524f79ccae01c052554f1cf3926dd24ea86c50c8f494"

--- a/Formula/auditbeat.rb
+++ b/Formula/auditbeat.rb
@@ -5,7 +5,7 @@ class Auditbeat < Formula
       tag:      "v7.14.0",
       revision: "e127fc31fc6c00fdf8649808f9421d8f8c28b5db"
   license "Apache-2.0"
-  head "https://github.com/elastic/beats.git"
+  head "https://github.com/elastic/beats.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "489c0f9baa754fabf10b89985c14cdf1dd9d9fcce77034cd7687bac07f09a7ea"

--- a/Formula/augustus.rb
+++ b/Formula/augustus.rb
@@ -5,7 +5,7 @@ class Augustus < Formula
   sha256 "4cc4d32074b18a8b7f853ebaa7c9bef80083b38277f8afb4d33c755be66b7140"
   license "Artistic-1.0"
   revision 2
-  head "https://github.com/Gaius-Augustus/Augustus.git"
+  head "https://github.com/Gaius-Augustus/Augustus.git", branch: "master"
 
   livecheck do
     url "https://bioinf.uni-greifswald.de/augustus/binaries/"

--- a/Formula/austin.rb
+++ b/Formula/austin.rb
@@ -4,7 +4,7 @@ class Austin < Formula
   url "https://github.com/P403n1x87/austin/archive/v3.0.0.tar.gz"
   sha256 "df57cd33e74fe9b7b0c87ea82827b0d7863cc5761bd3e75b3367d7d3384c3836"
   license "GPL-3.0-or-later"
-  head "https://github.com/P403n1x87/austin.git"
+  head "https://github.com/P403n1x87/austin.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "7f3464bfa7fd1f576832f25a56e19f551bf5c6778d77a158ca1b25b48f7c671d"

--- a/Formula/autodiff.rb
+++ b/Formula/autodiff.rb
@@ -4,7 +4,7 @@ class Autodiff < Formula
   url "https://github.com/autodiff/autodiff/archive/v0.6.3.tar.gz"
   sha256 "afcc21c74c9c20ecf08c53ab82965652438d5bb65d146a2db43795b051c12135"
   license "MIT"
-  head "https://github.com/autodiff/autodiff.git"
+  head "https://github.com/autodiff/autodiff.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "5d115a24200aeaf67131453c70b6082be66d99d2920d43d3857a90f68b54945d"

--- a/Formula/autoenv.rb
+++ b/Formula/autoenv.rb
@@ -4,7 +4,7 @@ class Autoenv < Formula
   url "https://github.com/kennethreitz/autoenv/archive/v0.2.1.tar.gz"
   sha256 "d10ee4d916a11a664453e60864294fec221c353f8ad798aa0aa6a2d2c5d5b318"
   license "MIT"
-  head "https://github.com/kennethreitz/autoenv.git"
+  head "https://github.com/kennethreitz/autoenv.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "657fdd3a35ac9967764be96cd948ad27ac9eb3160120ff16d77c24b7ab15cd09"

--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -5,7 +5,7 @@ class Autojump < Formula
   sha256 "00daf3698e17ac3ac788d529877c03ee80c3790472a85d0ed063ac3a354c37b1"
   license "GPL-3.0-or-later"
   revision 2
-  head "https://github.com/wting/autojump.git"
+  head "https://github.com/wting/autojump.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/autorestic.rb
+++ b/Formula/autorestic.rb
@@ -4,7 +4,7 @@ class Autorestic < Formula
   url "https://github.com/cupcakearmy/autorestic/archive/v1.2.0.tar.gz"
   sha256 "394f708ee77b71ea9d337dc265fd3436ad0adcb85e6c6da9ab70d6c49e32734b"
   license "Apache-2.0"
-  head "https://github.com/cupcakearmy/autorestic.git"
+  head "https://github.com/cupcakearmy/autorestic.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "6c76d60fdbe620a6520dc9877c500592439d8990abbabfb371ada96db062e656"

--- a/Formula/awf.rb
+++ b/Formula/awf.rb
@@ -5,7 +5,7 @@ class Awf < Formula
   sha256 "bb14517ea3eed050b3fec37783b79c515a0f03268a55dfd0b96a594b5b655c78"
   license "GPL-3.0"
   revision 2
-  head "https://github.com/valr/awf.git"
+  head "https://github.com/valr/awf.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "60373a676e554ca3b82465ff01d7bfbde233fad9e7d1ec115656903c90336a29"

--- a/Formula/awk.rb
+++ b/Formula/awk.rb
@@ -5,7 +5,7 @@ class Awk < Formula
   sha256 "c9232d23410c715234d0c26131a43ae6087462e999a61f038f1790598ce4807f"
   # https://fedoraproject.org/wiki/Licensing:MIT?rd=Licensing/MIT#Standard_ML_of_New_Jersey_Variant
   license "MIT"
-  head "https://github.com/onetrueawk/awk.git"
+  head "https://github.com/onetrueawk/awk.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/aws-google-auth.rb
+++ b/Formula/aws-google-auth.rb
@@ -7,7 +7,7 @@ class AwsGoogleAuth < Formula
   sha256 "0cc76e88ac188a26a484faffb21f1c7f31c0c56932aa30e6772e17245d0eb7cc"
   license "MIT"
   revision 3
-  head "https://github.com/cevoaustralia/aws-google-auth.git"
+  head "https://github.com/cevoaustralia/aws-google-auth.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "92c6a08357e8f2b971d3a3c086fd481ebbcabda69c65b9abff041dfcaa4ef298"

--- a/Formula/aws-iam-authenticator.rb
+++ b/Formula/aws-iam-authenticator.rb
@@ -5,7 +5,7 @@ class AwsIamAuthenticator < Formula
       tag:      "v0.5.3",
       revision: "a0516fb9ace571024263424f1770e6d861e65d09"
   license "Apache-2.0"
-  head "https://github.com/kubernetes-sigs/aws-iam-authenticator.git"
+  head "https://github.com/kubernetes-sigs/aws-iam-authenticator.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "30639bda3ecb72388aeabc0f3e6587f58bc9867dc6b3a9f3046e9d0ef659f122"

--- a/Formula/aws-rotate-key.rb
+++ b/Formula/aws-rotate-key.rb
@@ -4,7 +4,7 @@ class AwsRotateKey < Formula
   url "https://github.com/stefansundin/aws-rotate-key/archive/v1.0.7.tar.gz"
   sha256 "9dadb689583dc4d8869a346c2e7f12201e1fe65d5bf1d64eb09b69f65518bc44"
   license "MIT"
-  head "https://github.com/stefansundin/aws-rotate-key.git"
+  head "https://github.com/stefansundin/aws-rotate-key.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f386fd25ede2321a6f64f20ccbaa0d3de3079e96b24689f07accc710bd7cfc6e"

--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -6,7 +6,7 @@ class AwsSdkCpp < Formula
     tag:      "1.9.80",
     revision: "3ab68c3179dbe9e1e9e52da0c95c7e8b778c7cf2"
   license "Apache-2.0"
-  head "https://github.com/aws/aws-sdk-cpp.git"
+  head "https://github.com/aws/aws-sdk-cpp.git", branch: "main"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "7936363c4aca487382596547109cdb1e3c32e7e6c66f0c9a626a57594f05759c"

--- a/Formula/awscurl.rb
+++ b/Formula/awscurl.rb
@@ -6,7 +6,7 @@ class Awscurl < Formula
   url "https://files.pythonhosted.org/packages/9c/82/33679049696e05fc85596ff93f19fa0b9f73200de62d5ab0bfd4eed9aa9f/awscurl-0.24.tar.gz"
   sha256 "6a8eab18238f41297b9f568fead3161e898fb0f68f2b1bb3ed5ece358a929206"
   license "MIT"
-  head "https://github.com/okigan/awscurl.git"
+  head "https://github.com/okigan/awscurl.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "99eeee8b8c25ac9eca8935f086d7049009a23dd6cdff955932b69684eb5fc092"

--- a/Formula/awslogs.rb
+++ b/Formula/awslogs.rb
@@ -7,7 +7,7 @@ class Awslogs < Formula
   sha256 "1b249f87fa2adfae39b9867f3066ac00b9baf401f4783583ab28fcdea338f77e"
   license "BSD-3-Clause"
   revision 1
-  head "https://github.com/jorgebastida/awslogs.git"
+  head "https://github.com/jorgebastida/awslogs.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "38caa20a341705f9ef458157f2efcd340ebac1ed4a28a9f087fd362aeb10651b"

--- a/Formula/awsume.rb
+++ b/Formula/awsume.rb
@@ -6,7 +6,7 @@ class Awsume < Formula
   url "https://files.pythonhosted.org/packages/2f/d4/2f9621851aa22e06b0242d1c5dc2fbeb6267d5beca92c0adf875438793c2/awsume-4.5.3.tar.gz"
   sha256 "e94cc4c1d0f3cc0db8270572e2880c0641ce14cf226355bf42440b726bf453ef"
   license "MIT"
-  head "https://github.com/trek10inc/awsume.git"
+  head "https://github.com/trek10inc/awsume.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "4aabc67dc8a89b21b22e87f5daaed8098c0d8d088593588cf2877348e78e02c6"

--- a/Formula/awsweeper.rb
+++ b/Formula/awsweeper.rb
@@ -4,7 +4,7 @@ class Awsweeper < Formula
   url "https://github.com/jckuester/awsweeper/archive/v0.11.1.tar.gz"
   sha256 "6bd1db96a1fad22df4c22a0ce95f49f91de14c962b5599b3b9d8a730e287767d"
   license "MPL-2.0"
-  head "https://github.com/jckuester/awsweeper.git"
+  head "https://github.com/jckuester/awsweeper.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:      "0d73492221e06ae265d9e81fc3583dbf286f386beb7a711f0283822e9ba8759f"

--- a/Formula/axel.rb
+++ b/Formula/axel.rb
@@ -4,7 +4,7 @@ class Axel < Formula
   url "https://github.com/axel-download-accelerator/axel/releases/download/v2.17.10/axel-2.17.10.tar.xz"
   sha256 "46eb4f10a11c4e50320ae6a034ef03ffe59dc11c3c6542a9867a3e4dc0c4b44e"
   license "GPL-2.0-or-later"
-  head "https://github.com/eribertomota/axel.git"
+  head "https://github.com/eribertomota/axel.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "43a36bca363fd2a2700dbaca686de5d92793ae79b1813e26e6ba1965e9d0acc7"

--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -6,7 +6,7 @@ class AzureCli < Formula
   url "https://github.com/Azure/azure-cli/archive/azure-cli-2.27.1.tar.gz"
   sha256 "302379dcee1a3bf0ccbbdf6a2e599c4f3b4a2efafd1ab8152894f5febec6a7ef"
   license "MIT"
-  head "https://github.com/Azure/azure-cli.git"
+  head "https://github.com/Azure/azure-cli.git", branch: "dev"
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds `head` branch information to `a*` formulae with `head` URLs of the form `head "<URL>"` (and where a branch wasn't already specified). Changes were made using a script that is similar to the audit added in Homebrew/brew#11720.