### PR TITLE
gegl: remove outdated workaround

### DIFF
--- a/Formula/gegl.rb
+++ b/Formula/gegl.rb
@@ -43,9 +43,8 @@ class Gegl < Formula
       -Ddocs=false
       -Dcairo=disabled
       -Djasper=disabled
-      -Dmfpack=disabled
+      -Dumfpack=disabled
       -Dlibspiro=disabled
-      --wrap-mode=default
       --force-fallback-for=libnsgif,poly2tri-c
     ]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

With #83524 (which includes a fix for https://github.com/mesonbuild/meson/issues/9065), this workaround is unnecessary.

Also, fix my spelling mistake 😅 