### PR TITLE
osslsigncode 2.2

### DIFF
--- a/Formula/osslsigncode.rb
+++ b/Formula/osslsigncode.rb
@@ -1,9 +1,9 @@
 class Osslsigncode < Formula
   desc "OpenSSL based Authenticode signing for PE/MSI/Java CAB files"
   homepage "https://github.com/mtrojnar/osslsigncode"
-  url "https://github.com/mtrojnar/osslsigncode/archive/2.1.tar.gz"
-  sha256 "1d142f4e0b9d490d6d7bc495dc57b8c322895b0e6ec474d04d5f6910d61e5476"
-  license "GPL-3.0"
+  url "https://github.com/mtrojnar/osslsigncode/archive/2.2.tar.gz"
+  sha256 "dd7d6867264d8967f354dd3933429afb806fb56b9a1e88c3a6f100ecee06d83e"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "8625c68db1963c4e359fd16862ccde8ae433889c441adb8892fc4cb0a63dc377"
@@ -18,19 +18,18 @@ class Osslsigncode < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "libgsf"
   depends_on "openssl@1.1"
 
   uses_from_macos "curl"
 
   def install
-    system "./autogen.sh"
-    system "./configure", "--with-gsf", "--prefix=#{prefix}"
+    system "./bootstrap"
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 
   test do
     # Requires Windows PE executable as input, so we're just showing the version
-    assert_match "osslsigncode", shell_output("#{bin}/osslsigncode --version", 255)
+    assert_match "osslsigncode", shell_output("#{bin}/osslsigncode --version")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
[Upstream release notes](https://github.com/mtrojnar/osslsigncode/releases/tag/2.2) note that there is no longer a dependency on `libgsf`. Confirmed that the `--with-gsf` argument is not recognized by `configure`.