### PR TITLE
libcec: fix build for ARM and Linux

### DIFF
--- a/Formula/libcec.rb
+++ b/Formula/libcec.rb
@@ -24,16 +24,25 @@ class Libcec < Formula
   def install
     ENV.cxx11
 
+    # The CMake scripts don't work well with some common LIBDIR values:
+    # - `CMAKE_INSTALL_LIBDIR=lib` is interpreted as path relative to build dir
+    # - `CMAKE_INSTALL_LIBDIR=#{lib}` breaks pkg-config and cmake config files
+    # - Setting no value uses UseMultiArch.cmake to set platform-specific paths
+    # To avoid theses issues, we can specify the type of input as STRING
+    cmake_args = std_cmake_args.map do |s|
+      s.gsub "-DCMAKE_INSTALL_LIBDIR=", "-DCMAKE_INSTALL_LIBDIR:STRING="
+    end
+
     resource("p8-platform").stage do
       mkdir "build" do
-        system "cmake", "..", *std_cmake_args
+        system "cmake", "..", *cmake_args
         system "make"
         system "make", "install"
       end
     end
 
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", *cmake_args
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3073979305?check_suite_focus=true
```
-- Installing: /home/linuxbrew/.linuxbrew/Cellar/libcec/6.0.2/include/p8-platform/util/StdString.h
-- Installing: /home/linuxbrew/.linuxbrew/Cellar/libcec/6.0.2/include/p8-platform/util/timeutils.h
-- Installing: /home/linuxbrew/.linuxbrew/Cellar/libcec/6.0.2/include/p8-platform/util/util.h
-- Installing: /tmp/libcec--p8-platform-20210715-3411-khlh2e/platform-p8-platform-2.1.0.1/build/lib/pkgconfig/p8-platform.pc
-- Installing: /tmp/libcec--p8-platform-20210715-3411-khlh2e/platform-p8-platform-2.1.0.1/build/lib/p8-platform/p8-platform-config.cmake
```