### PR TITLE
serverless: fix Linux build by deleting unused CPython library

### DIFF
--- a/Formula/serverless.rb
+++ b/Formula/serverless.rb
@@ -6,6 +6,7 @@ class Serverless < Formula
   url "https://github.com/serverless/serverless/archive/v2.57.0.tar.gz"
   sha256 "80a4ce6a737a58fb23cc5095f14e2a147f72b7607b48c28709f085467f9377d1"
   license "MIT"
+  head "https://github.com/serverless/serverless.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "be114aa3dc7ed36e15b8ca08e7762ab44509b6ce23535e85d5cfa5e5f97fbd7f"
@@ -18,7 +19,14 @@ class Serverless < Formula
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink Dir[libexec/"bin/*"]
+
+    # Delete incompatible Linux CPython shared library included in dependency package.
+    # Raise an error if no longer found so that the unused logic can be removed.
+    (libexec/"lib/node_modules/serverless/node_modules/@serverless/dashboard-plugin")
+      .glob("sdk-py/serverless_sdk/vendor/wrapt/_wrappers.cpython-*-linux-gnu.so")
+      .map(&:unlink)
+      .empty? && raise("Unable to find wrapt shared library to delete.")
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/serverless/dashboard-plugin/tree/master/sdk-py/serverless_sdk/vendor/wrapt

`_wrappers.cpython-37m-x86_64-linux-gnu.so` can be deleted and code in `wrappers.py` will fallback to pure Python:
https://github.com/serverless/dashboard-plugin/blob/master/sdk-py/serverless_sdk/vendor/wrapt/wrappers.py#L719-L725
```py
try:
    if not os.environ.get('WRAPT_DISABLE_EXTENSIONS'):
        from ._wrappers import (ObjectProxy, CallableObjectProxy,
            PartialCallableObjectProxy, FunctionWrapper,
            BoundFunctionWrapper, _FunctionWrapperBase)
except ImportError:
    pass
```