### PR TITLE
snort: use Homebrew libpcap as macOS version segfaults

### DIFF
--- a/Formula/snort.rb
+++ b/Formula/snort.rb
@@ -5,6 +5,7 @@ class Snort < Formula
   mirror "https://fossies.org/linux/misc/snort3-3.1.10.0.tar.gz"
   sha256 "6bd1c2c243ff69f9222aee6fb5d48998c7e24acaa4d2349115af324f9810bb01"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/snort3/snort3.git"
 
   bottle do
@@ -25,12 +26,12 @@ class Snort < Formula
   # Hyperscan improves IPS performance, but is only available for x86_64 arch.
   depends_on "hyperscan" if Hardware::CPU.intel?
   depends_on "libdnet"
+  depends_on "libpcap" # macOS version segfaults
   depends_on "luajit-openresty"
   depends_on "openssl@1.1"
   depends_on "pcre"
   depends_on "xz" # for lzma.h
 
-  uses_from_macos "libpcap"
   uses_from_macos "zlib"
 
   on_linux do
@@ -43,7 +44,7 @@ class Snort < Formula
     inreplace "cmake/FindLuaJIT.cmake", " -pagezero_size 10000 -image_base 100000000\"", "\""
 
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args, "-DENABLE_STATIC_DAQ=OFF", "-DENABLE_TCMALLOC=ON"
+      system "cmake", "..", *std_cmake_args, "-DENABLE_TCMALLOC=ON"
       system "make", "install"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Follow up to #82937 for some changes after testing.

macOS `libpcap` (v1.9.1) causes segmentation faults. After installing bottle, I tried
```console
❯ sudo snort -i en0 -L pcap -n 10 --daq-dir /opt/homebrew/lib/daq
--------------------------------------------------
o")~   Snort++ 3.1.10.0
--------------------------------------------------
--------------------------------------------------
pcap DAQ configured to passive.
Commencing packet processing
++ [0] en0

Snort (PID 52494) caught fatal signal: SIGSEGV (11)
Version: 3.1.10.0

...

zsh: segmentation fault  sudo snort -i en0 -L pcap -n 10 --daq-dir /opt/homebrew/lib/daq
```

Reinstalling with Homebrew `libpcap` (v1.10.1) fixed this:
```console
❯ sudo snort -i en0 -L pcap -n 10
--------------------------------------------------
o")~   Snort++ 3.1.10.0
--------------------------------------------------
--------------------------------------------------
pcap DAQ configured to passive.
Commencing packet processing
++ [0] en0
-- [0] en0
--------------------------------------------------
Packet Statistics
--------------------------------------------------
daq
                 received: 11
                 analyzed: 10
              outstanding: 1
                    allow: 10
                     idle: 1
                 rx_bytes: 2578
...
```