### PR TITLE
ranger: fix shebang to use Homebrew Python

### DIFF
--- a/Formula/ranger.rb
+++ b/Formula/ranger.rb
@@ -1,4 +1,6 @@
 class Ranger < Formula
+  include Language::Python::Shebang
+
   desc "File browser"
   homepage "https://ranger.github.io"
   url "https://ranger.github.io/ranger-1.9.3.tar.gz"
@@ -19,7 +21,8 @@ class Ranger < Formula
   def install
     man1.install "doc/ranger.1"
     libexec.install "ranger.py", "ranger"
-    bin.install_symlink libexec+"ranger.py" => "ranger"
+    rewrite_shebang detected_python_shebang, libexec/"ranger.py"
+    bin.install_symlink libexec/"ranger.py" => "ranger"
     doc.install "examples"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Existing formula/bottle uses `/usr/bin/python`.

https://github.com/Homebrew/homebrew-core/runs/3370259409?check_suite_focus=true
```
==> brew test --verbose ranger
==> FAILED
==> Testing ranger
==> /home/linuxbrew/.linuxbrew/Cellar/ranger/1.9.3/bin/ranger --version
Error: ranger: failed
An exception occurred within a child process:
```