### PR TITLE
Replace bazaar with breezy

### DIFF
--- a/Formula/bazaar.rb
+++ b/Formula/bazaar.rb
@@ -14,7 +14,11 @@ class Bazaar < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "cb1c0c8b5f19abef4043195d8cbd19f363a78581596de1ddcc763621964335b3"
   end
 
+  deprecate! date: "2021-08-19", because: "is not supported. Check out `breezy` instead"
+
   depends_on :macos # Due to Python 2
+
+  conflicts_with "breezy", because: "both install `bzr` binaries"
 
   # CVE-2017-14176
   # https://bugs.launchpad.net/brz/+bug/1710979

--- a/Formula/breezy.rb
+++ b/Formula/breezy.rb
@@ -5,7 +5,8 @@ class Breezy < Formula
   homepage "https://www.breezy-vcs.org"
   url "https://files.pythonhosted.org/packages/e4/93/101bb70d7e6c171c7a3a99d50d9f9b64a17a5845cfd6c8ecb95d844bac68/breezy-3.2.1.tar.gz"
   sha256 "e0b268eb1a28a2af045280c37d021ae32d7ff175f4c9b99f33aad7db0b29d85c"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "91ac24be8f4fc563cff558d5d4d08e176235a9ad5510c0ecf2af6790e4ecf27c"
@@ -21,6 +22,8 @@ class Breezy < Formula
   depends_on "python@3.9"
   depends_on "six"
 
+  conflicts_with "bazaar", because: "both install `bzr` binaries"
+
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/6d/78/f8db8d57f520a54f0b8a438319c342c61c22759d8f9a1cd2e2180b5e5ea9/certifi-2021.5.30.tar.gz"
     sha256 "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"
@@ -32,8 +35,8 @@ class Breezy < Formula
   end
 
   resource "dulwich" do
-    url "https://files.pythonhosted.org/packages/85/f1/eab86c0058d2195ec084dd200c3e4179871e13e4f38f17ff3f6c7dee3c56/dulwich-0.20.23.tar.gz"
-    sha256 "402e56b5c07f040479d1188e5c2f406e2c006aa3943080155d4c6d05e5fca865"
+    url "https://files.pythonhosted.org/packages/7c/d2/a361b4831494531d5112e000d92762fc2926ed45ca7f9e9013f2e90c011c/dulwich-0.20.24.tar.gz"
+    sha256 "6b61ac0a2a8b1b1e18914310f3f7a422396334208b426b9de570f1de31644cf1"
   end
 
   resource "patiencediff" do
@@ -48,6 +51,10 @@ class Breezy < Formula
 
   def install
     virtualenv_install_with_resources
+    man1.install_symlink Dir[libexec/"man/man1/*.1"]
+
+    # Replace bazaar with breezy
+    bin.install_symlink "brz" => "bzr"
   end
 
   test do

--- a/Formula/bzr-builder.rb
+++ b/Formula/bzr-builder.rb
@@ -8,6 +8,8 @@ class BzrBuilder < Formula
     sha256 cellar: :any_skip_relocation, all: "54b83a353f26372404bf40fc06f56b2105527e58e9f7aa88c22cc89b8ee3254d"
   end
 
+  deprecate! date: "2021-08-19", because: :unsupported
+
   depends_on "bazaar"
 
   def install

--- a/Formula/bzr-colo.rb
+++ b/Formula/bzr-colo.rb
@@ -8,6 +8,8 @@ class BzrColo < Formula
     sha256 cellar: :any_skip_relocation, all: "3174aca6218d012389e14dba29a075e90201bb6436a42350164626b223f5818d"
   end
 
+  deprecate! date: "2021-08-19", because: :unsupported
+
   depends_on "bazaar"
 
   def install

--- a/Formula/bzr-externals.rb
+++ b/Formula/bzr-externals.rb
@@ -8,6 +8,8 @@ class BzrExternals < Formula
     sha256 cellar: :any_skip_relocation, all: "f99c72d0a05f987beb57d609527ab543e93fb1db7245c454193a932f6e5c01df"
   end
 
+  deprecate! date: "2021-08-19", because: :unsupported
+
   depends_on "bazaar"
 
   def install

--- a/Formula/bzr-extmerge.rb
+++ b/Formula/bzr-extmerge.rb
@@ -8,6 +8,8 @@ class BzrExtmerge < Formula
     sha256 cellar: :any_skip_relocation, all: "8aa67f424683414f0e2553170e9835caf54aad70e99517ad79da66a46c3ff6bd"
   end
 
+  deprecate! date: "2021-08-19", because: :unsupported
+
   depends_on "bazaar"
 
   def install

--- a/Formula/bzr-rewrite.rb
+++ b/Formula/bzr-rewrite.rb
@@ -8,6 +8,8 @@ class BzrRewrite < Formula
     sha256 cellar: :any_skip_relocation, all: "766e43ea10eb6eae8ed9f177faa70b7e8f26be6d79367a060775da9e247b6d4c"
   end
 
+  deprecate! date: "2021-08-19", because: :unsupported
+
   depends_on "bazaar"
 
   def install

--- a/Formula/bzr-upload.rb
+++ b/Formula/bzr-upload.rb
@@ -8,6 +8,8 @@ class BzrUpload < Formula
     sha256 cellar: :any_skip_relocation, all: "1ed703bbd059cad6589230219b1425f5bfc4d67c15819da557e6b72813b0b476"
   end
 
+  deprecate! date: "2021-08-19", because: :unsupported
+
   depends_on "bazaar"
 
   def install

--- a/Formula/bzr-xmloutput.rb
+++ b/Formula/bzr-xmloutput.rb
@@ -8,6 +8,8 @@ class BzrXmloutput < Formula
     sha256 cellar: :any_skip_relocation, all: "cb0f2bde2a3d23624cf9d0215149d0f72c1c52f9be66fcfea51e833255a42245"
   end
 
+  deprecate! date: "2021-08-19", because: :unsupported
+
   depends_on "bazaar"
 
   def install

--- a/Formula/bzrtools.rb
+++ b/Formula/bzrtools.rb
@@ -19,6 +19,8 @@ class Bzrtools < Formula
     sha256 cellar: :any_skip_relocation, all: "27337af0179d9a1a9897def816bfc6c9e85df08186bdb72918bc6327c2b7c2db"
   end
 
+  deprecate! date: "2021-08-19", because: :unsupported
+
   depends_on "bazaar"
 
   def install

--- a/Formula/cayley.rb
+++ b/Formula/cayley.rb
@@ -15,7 +15,7 @@ class Cayley < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "0dc598decbc9c70660d22fc670f71581e7fec09e5c9d9bc13ccee4c88c758338"
   end
 
-  depends_on "bazaar" => :build
+  depends_on "breezy" => :build
   depends_on "go" => :build
   depends_on "mercurial" => :build
 

--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -20,7 +20,7 @@ class Influxdb < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "79a485ca7cdf37b3c11ae7405501857fcfda1df0c2c9945350384dc766344ea2"
   end
 
-  depends_on "bazaar" => :build
+  depends_on "breezy" => :build
   depends_on "go" => :build
   depends_on "pkg-config" => :build
   depends_on "protobuf" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`bazaar` required Python 2 and was unsupported for a long time, so let's deprecate it and replace it with `breezy`.

This PR deprecated `bazaar` and adds a required symlink to `breezy` formula to make it a drop-in replacement.
We have only 2 dependants on `bazaar` formula (except `bazaar` plugins) `cayley` and `influxdb` — let's try to rebuild it with `breezy` instead.

And it looks like other package managers did the same:
- https://fedoraproject.org/wiki/Changes/ReplaceBazaarWithBreezy
- https://bugs.archlinux.org/task/62658
- https://github.com/NixOS/nixpkgs/issues/80740

The thing I'd like to point out (just in case) is that currently, `bazaar` has significantly more installs than `breezy`:
- `bazaar`: `install: 202 (30 days), 774 (90 days), 3,981 (365 days);
- `breezy`: `install: 10 (30 days), 43 (90 days), 123 (365 days)`

PS I hate their naming, that's too easy to make a typo and confuse one with the other.
