### PR TITLE
fping: fix test for Linux

### DIFF
--- a/Formula/fping.rb
+++ b/Formula/fping.rb
@@ -14,20 +14,26 @@ class Fping < Formula
   end
 
   head do
-    url "https://github.com/schweikert/fping.git"
+    url "https://github.com/schweikert/fping.git", branch: "develop"
+
     depends_on "autoconf" => :build
     depends_on "automake" => :build
   end
 
   def install
     system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--sbindir=#{bin}"
+    system "./configure", *std_configure_args, "--sbindir=#{bin}"
     system "make", "install"
   end
 
   test do
-    assert_equal "::1 is alive", shell_output("#{bin}/fping -A localhost").chomp
+    assert_match "Version #{version}", shell_output("#{bin}/fping --version")
+    assert_match "Probing options:", shell_output("#{bin}/fping --help")
+    on_macos do
+      assert_equal "::1 is alive", shell_output("#{bin}/fping -A localhost").chomp
+    end
+    on_linux do
+      assert_match "can't create socket", shell_output("#{bin}/fping -A localhost 2>&1", 4)
+    end
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3127593854?check_suite_focus=true
```
==> brew test --verbose fping
==> FAILED
==> Testing fping
==> /home/linuxbrew/.linuxbrew/Cellar/fping/5.0/bin/fping -A localhost
/home/linuxbrew/.linuxbrew/Cellar/fping/5.0/bin/fping: can't create socket (must run as root?)

Error: fping: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected: 0
  Actual: 4
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/minitest-5.14.4/lib/minitest/assertions.rb:183:in `assert'
```