### PR TITLE
b*: add `head` branch

### DIFF
--- a/Formula/babeld.rb
+++ b/Formula/babeld.rb
@@ -4,7 +4,7 @@ class Babeld < Formula
   url "https://www.irif.fr/~jch/software/files/babeld-1.10.tar.gz"
   sha256 "a5f54a08322640e97399bf4d1411a34319e6e277fbb6fc4966f38a17d72a8dea"
   license "MIT"
-  head "https://github.com/jech/babeld.git"
+  head "https://github.com/jech/babeld.git", branch: "master"
 
   livecheck do
     url "https://www.irif.fr/~jch/software/files/"

--- a/Formula/babl.rb
+++ b/Formula/babl.rb
@@ -5,7 +5,7 @@ class Babl < Formula
   sha256 "4f0d7f4aaa0bb2e725f349adf7b351a957d9fb26d555d9895a7af816b4167039"
   license "LGPL-3.0-or-later"
   # Use GitHub instead of GNOME's git. The latter is unreliable.
-  head "https://github.com/GNOME/babl.git"
+  head "https://github.com/GNOME/babl.git", branch: "master"
 
   livecheck do
     url "https://download.gimp.org/pub/babl/0.1/"

--- a/Formula/bagit.rb
+++ b/Formula/bagit.rb
@@ -7,7 +7,7 @@ class Bagit < Formula
   sha256 "37df1330d2e8640c8dee8ab6d0073ac701f0614d25f5252f9e05263409cee60c"
   license "CC0-1.0"
   version_scheme 1
-  head "https://github.com/LibraryOfCongress/bagit-python.git"
+  head "https://github.com/LibraryOfCongress/bagit-python.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/ballerburg.rb
+++ b/Formula/ballerburg.rb
@@ -4,7 +4,7 @@ class Ballerburg < Formula
   url "https://download.tuxfamily.org/baller/ballerburg-1.2.0.tar.gz"
   sha256 "0625f4b213c1180f2cb2179ef2bc6ce35c7e99db2b27306a8690c389ceac6300"
   license "GPL-3.0"
-  head "https://git.tuxfamily.org/baller/baller.git"
+  head "https://git.tuxfamily.org/baller/baller.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "a82163254a4f1ff916e0d7ba0387914f529ffa67955495e146be69b5c2b2f31e"

--- a/Formula/bam.rb
+++ b/Formula/bam.rb
@@ -4,7 +4,7 @@ class Bam < Formula
   url "https://github.com/matricks/bam/archive/v0.5.1.tar.gz"
   sha256 "cc8596af3325ecb18ebd6ec2baee550e82cb7b2da19588f3f843b02e943a15a9"
   license "Zlib"
-  head "https://github.com/matricks/bam.git"
+  head "https://github.com/matricks/bam.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "6c0a42f9cf83eabac04cd67c5441590f3fea48f7dd9aacd1a7fef524b4a40cf9"

--- a/Formula/bamtools.rb
+++ b/Formula/bamtools.rb
@@ -4,7 +4,7 @@ class Bamtools < Formula
   url "https://github.com/pezmaster31/bamtools/archive/v2.5.2.tar.gz"
   sha256 "4d8b84bd07b673d0ed41031348f10ca98dd6fa6a4460f9b9668d6f1d4084dfc8"
   license "MIT"
-  head "https://github.com/pezmaster31/bamtools.git"
+  head "https://github.com/pezmaster31/bamtools.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "cad31e2a176762fdaa4aa0b311509b30a339395b6da469f005c667b75ce99296"

--- a/Formula/bandcamp-dl.rb
+++ b/Formula/bandcamp-dl.rb
@@ -5,7 +5,7 @@ class BandcampDl < Formula
   homepage "https://github.com/iheanyi/bandcamp-dl"
   license "Unlicense"
   revision 6
-  head "https://github.com/iheanyi/bandcamp-dl.git"
+  head "https://github.com/iheanyi/bandcamp-dl.git", branch: "master"
 
   stable do
     url "https://github.com/iheanyi/bandcamp-dl/archive/v0.0.8-12.tar.gz"

--- a/Formula/bandit.rb
+++ b/Formula/bandit.rb
@@ -6,7 +6,7 @@ class Bandit < Formula
   url "https://files.pythonhosted.org/packages/6c/a1/14b70b67ea9c69e863dd65386bbc948ae34a502512d6f36e2a5a9fd5513b/bandit-1.7.0.tar.gz"
   sha256 "8a4c7415254d75df8ff3c3b15cfe9042ecee628a1e40b44c15a98890fbfc2608"
   license "Apache-2.0"
-  head "https://github.com/PyCQA/bandit.git"
+  head "https://github.com/PyCQA/bandit.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d2349695a19c779eaa47e3d79d80f2a762701722df47f268fe9bdd424ac64535"

--- a/Formula/bartycrouch.rb
+++ b/Formula/bartycrouch.rb
@@ -5,7 +5,7 @@ class Bartycrouch < Formula
       tag:      "4.7.0",
       revision: "c16b219d28ce27e57744dcf67adfde7a2912d78a"
   license "MIT"
-  head "https://github.com/Flinesoft/BartyCrouch.git"
+  head "https://github.com/Flinesoft/BartyCrouch.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "26a99ff30f33322c929a0acab804cd9ddb14e2f588143c40e29b298e01681e29"

--- a/Formula/bash-git-prompt.rb
+++ b/Formula/bash-git-prompt.rb
@@ -4,7 +4,7 @@ class BashGitPrompt < Formula
   url "https://github.com/magicmonty/bash-git-prompt/archive/2.7.1.tar.gz"
   sha256 "5e5fc6f5133b65760fede8050d4c3bc8edb8e78bc7ce26c16db442aa94b8a709"
   license "BSD-2-Clause"
-  head "https://github.com/magicmonty/bash-git-prompt.git"
+  head "https://github.com/magicmonty/bash-git-prompt.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "aba8fdb7276afbd19020d92a907102912674172b4ff9d4883e349fd73fd69995"

--- a/Formula/bash-preexec.rb
+++ b/Formula/bash-preexec.rb
@@ -4,7 +4,7 @@ class BashPreexec < Formula
   url "https://github.com/rcaloras/bash-preexec/archive/0.4.1.tar.gz"
   sha256 "5e6515d247e6156c99a31de6db58e9cbef53071806292a1ca10b7af74633a8c9"
   license "MIT"
-  head "https://github.com/rcaloras/bash-preexec.git"
+  head "https://github.com/rcaloras/bash-preexec.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "72f047a0bb9e083b3c2a2bf491f8b3db94caa40f01710c03083ee005e2aa4454"

--- a/Formula/bash.rb
+++ b/Formula/bash.rb
@@ -2,7 +2,7 @@ class Bash < Formula
   desc "Bourne-Again SHell, a UNIX command interpreter"
   homepage "https://www.gnu.org/software/bash/"
   license "GPL-3.0-or-later"
-  head "https://git.savannah.gnu.org/git/bash.git"
+  head "https://git.savannah.gnu.org/git/bash.git", branch: "master"
 
   stable do
     url "https://ftp.gnu.org/gnu/bash/bash-5.1.tar.gz"

--- a/Formula/bats.rb
+++ b/Formula/bats.rb
@@ -4,7 +4,7 @@ class Bats < Formula
   url "https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz"
   sha256 "480d8d64f1681eee78d1002527f3f06e1ac01e173b761bc73d0cf33f4dc1d8d7"
   license "MIT"
-  head "https://github.com/sstephenson/bats.git"
+  head "https://github.com/sstephenson/bats.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "ab1210bf9790f9002e57584fb139802c79e7d0c7f6124a7024711a2998895a75"

--- a/Formula/bazelisk.rb
+++ b/Formula/bazelisk.rb
@@ -5,7 +5,7 @@ class Bazelisk < Formula
       tag:      "v1.10.1",
       revision: "cf1205edacc5bc8a781786b36324922640ea6ac9"
   license "Apache-2.0"
-  head "https://github.com/bazelbuild/bazelisk.git"
+  head "https://github.com/bazelbuild/bazelisk.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "3aa568fb42d31462693efea8051e7ef2489e1f1f22a07500cfd513b0c7f97cf0"

--- a/Formula/bchunk.rb
+++ b/Formula/bchunk.rb
@@ -4,7 +4,7 @@ class Bchunk < Formula
   url "http://he.fi/bchunk/bchunk-1.2.2.tar.gz"
   sha256 "e7d99b5b60ff0b94c540379f6396a670210400124544fb1af985dd3551eabd89"
   license "GPL-2.0"
-  head "https://github.com/hessu/bchunk.git"
+  head "https://github.com/hessu/bchunk.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "94279b4e400c05770ec6c5cce6fe7ef50a062835508add3e981942944bb3eecc"

--- a/Formula/bcoin.rb
+++ b/Formula/bcoin.rb
@@ -7,7 +7,7 @@ class Bcoin < Formula
   sha256 "b4c63598ee1efc17e4622ef88c1dff972692da1157e8daf7da5ea8abc3d234df"
   license "MIT"
   revision 4
-  head "https://github.com/bcoin-org/bcoin.git"
+  head "https://github.com/bcoin-org/bcoin.git", branch: "master"
 
   bottle do
     sha256                               arm64_big_sur: "03cd2231a1a9761a6e55696ac3285930b18193a390a4e327227e0ed71c4ad350"

--- a/Formula/beancount.rb
+++ b/Formula/beancount.rb
@@ -6,7 +6,7 @@ class Beancount < Formula
   url "https://files.pythonhosted.org/packages/41/ce/33834c4554087bc6f239ae24073f8b472860d42c50b3cbb8ca486dd1853b/beancount-2.3.4.tar.gz"
   sha256 "2bf08ce6a95d98000f4d73395985cd1deb81c0d52ed5a76e610bac77d82f86c0"
   license "GPL-2.0-only"
-  head "https://github.com/beancount/beancount.git"
+  head "https://github.com/beancount/beancount.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b595ea37250c19e9e90091f20e939d8f6c829e516eba6c300f119c9f1231ba6f"

--- a/Formula/beansdb.rb
+++ b/Formula/beansdb.rb
@@ -4,7 +4,7 @@ class Beansdb < Formula
   url "https://github.com/douban/beansdb/archive/v0.7.1.4.tar.gz"
   sha256 "c89f267484dd47bab272b985ba0a9b9196ca63a9201fdf86963b8ed04f52ccdb"
   license "BSD-3-Clause"
-  head "https://github.com/douban/beansdb.git"
+  head "https://github.com/douban/beansdb.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "98bdf58195eda75aba9fc8d1b32cd25252e3ff5eb3957ae626e40b740c8a4d58"

--- a/Formula/bear.rb
+++ b/Formula/bear.rb
@@ -7,7 +7,7 @@ class Bear < Formula
   sha256 "b57d9b139acbbad6439f5b1133266fa5afc5eb095a61cfa07cd9e8941943ae22"
   license "GPL-3.0-or-later"
   revision 2
-  head "https://github.com/rizsotto/Bear.git"
+  head "https://github.com/rizsotto/Bear.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "7278648a98c987fb2ce8ee02b462249f85ece5c9ef3ef7384734e48b393d7e0e"

--- a/Formula/beast.rb
+++ b/Formula/beast.rb
@@ -5,7 +5,7 @@ class Beast < Formula
   sha256 "6e28e2df680364867e088acd181877a5d6a1d664f70abc6eccc2ce3a34f3c54a"
   license "LGPL-2.1"
   revision 1
-  head "https://github.com/beast-dev/beast-mcmc.git"
+  head "https://github.com/beast-dev/beast-mcmc.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/befunge93.rb
+++ b/Formula/befunge93.rb
@@ -5,7 +5,7 @@ class Befunge93 < Formula
   version "2.25"
   sha256 "93a11fbc98d559f2bf9d862b9ffd2932cbe7193236036169812eb8e72fd69b19"
   license "BSD-3-Clause"
-  head "https://github.com/catseye/Befunge-93.git"
+  head "https://github.com/catseye/Befunge-93.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/bench.rb
+++ b/Formula/bench.rb
@@ -3,7 +3,7 @@ class Bench < Formula
   homepage "https://github.com/Gabriel439/bench"
   license "BSD-3-Clause"
   revision 1
-  head "https://github.com/Gabriel439/bench.git"
+  head "https://github.com/Gabriel439/bench.git", branch: "master"
 
   stable do
     url "https://hackage.haskell.org/package/bench-1.0.12/bench-1.0.12.tar.gz"

--- a/Formula/bettercap.rb
+++ b/Formula/bettercap.rb
@@ -4,7 +4,7 @@ class Bettercap < Formula
   url "https://github.com/bettercap/bettercap/archive/v2.31.1.tar.gz"
   sha256 "f37ffb8c13b9f0abccb7766c4ecbf295d6219aaf4dbf141e2b71c2a1c9cdc9aa"
   license "GPL-3.0-only"
-  head "https://github.com/bettercap/bettercap.git"
+  head "https://github.com/bettercap/bettercap.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "63f4451b9ab250464d26d27d4358c4c0d4f5aaadecb2bbfaac1e8f4b1c411d2b"

--- a/Formula/bgpq3.rb
+++ b/Formula/bgpq3.rb
@@ -4,7 +4,7 @@ class Bgpq3 < Formula
   url "https://github.com/snar/bgpq3/archive/v0.1.35.tar.gz"
   sha256 "571b99dc4186618ad3c77317eef2c20a8e601ce665a6b0f1ffca6e3d8d804cde"
   license "BSD-2-Clause"
-  head "https://github.com/snar/bgpq3.git"
+  head "https://github.com/snar/bgpq3.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/bgrep.rb
+++ b/Formula/bgrep.rb
@@ -4,7 +4,7 @@ class Bgrep < Formula
   url "https://github.com/tmbinc/bgrep/archive/bgrep-0.2.tar.gz"
   sha256 "24c02393fb436d7a2eb02c6042ec140f9502667500b13a59795388c1af91f9ba"
   license "BSD-2-Clause"
-  head "https://github.com/tmbinc/bgrep.git"
+  head "https://github.com/tmbinc/bgrep.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "2d5628a1b93a4ad2e770502b011140bc301051e1679ac5d59eadbd9b94944b1b"

--- a/Formula/bibtexconv.rb
+++ b/Formula/bibtexconv.rb
@@ -4,7 +4,7 @@ class Bibtexconv < Formula
   url "https://github.com/dreibh/bibtexconv/archive/bibtexconv-1.2.0.tar.gz"
   sha256 "0ace3aa17eedbc4c4950e5ef8763b1dd58bfa2d33cd00fa2b35f07febb6df940"
   license "GPL-3.0-or-later"
-  head "https://github.com/dreibh/bibtexconv.git"
+  head "https://github.com/dreibh/bibtexconv.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "e1695a1a03185cbf7f50c031cfab3d77777a6c8bd47c88ea1799fd097d4b8dfa"

--- a/Formula/bind.rb
+++ b/Formula/bind.rb
@@ -12,7 +12,7 @@ class Bind < Formula
   sha256 "4d0d93c0d0b63080609e84625f24ff8777f8d164e78a75b1c19c334ce42d5b58"
   license "MPL-2.0"
   version_scheme 1
-  head "https://gitlab.isc.org/isc-projects/bind9.git"
+  head "https://gitlab.isc.org/isc-projects/bind9.git", branch: "main"
 
   # BIND indicates stable releases with an even-numbered minor (e.g., x.2.x)
   # and the regex below only matches these versions.

--- a/Formula/binwalk.rb
+++ b/Formula/binwalk.rb
@@ -6,7 +6,7 @@ class Binwalk < Formula
   url "https://github.com/ReFirmLabs/binwalk/archive/v2.3.1.tar.gz"
   sha256 "7ec9d8fcb8686f4060d37e1096669e3ed8ce1194c91ad80199622448bcc01b19"
   license "MIT"
-  head "https://github.com/ReFirmLabs/binwalk.git"
+  head "https://github.com/ReFirmLabs/binwalk.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/bit.rb
+++ b/Formula/bit.rb
@@ -6,7 +6,7 @@ class Bit < Formula
   url "https://registry.npmjs.org/bit-bin/-/bit-bin-14.8.8.tgz"
   sha256 "25d899bacd06d77fad41026a9b19cbe94c8fb986f5fe59ead7ccec9f60fd0ef9"
   license "Apache-2.0"
-  head "https://github.com/teambit/bit.git"
+  head "https://github.com/teambit/bit.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "616bf52a2d9e825320d9aab1af3603ee79e43f6d1455abd09576691049b70f0e"

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -4,7 +4,7 @@ class Bitcoin < Formula
   url "https://bitcoincore.org/bin/bitcoin-core-0.21.1/bitcoin-0.21.1.tar.gz"
   sha256 "caff23449220cf45753f312cefede53a9eac64000bb300797916526236b6a1e0"
   license "MIT"
-  head "https://github.com/bitcoin/bitcoin.git"
+  head "https://github.com/bitcoin/bitcoin.git", branch: "master"
 
   livecheck do
     url "https://bitcoincore.org/en/download/"

--- a/Formula/bitlbee.rb
+++ b/Formula/bitlbee.rb
@@ -2,7 +2,7 @@ class Bitlbee < Formula
   desc "IRC to other chat networks gateway"
   homepage "https://www.bitlbee.org/"
   license "GPL-2.0"
-  head "https://github.com/bitlbee/bitlbee.git"
+  head "https://github.com/bitlbee/bitlbee.git", branch: "master"
 
   stable do
     url "https://get.bitlbee.org/src/bitlbee-3.6.tar.gz"

--- a/Formula/blaze.rb
+++ b/Formula/blaze.rb
@@ -5,7 +5,7 @@ class Blaze < Formula
   sha256 "dfaae1a3a9fea0b3cc92e78c9858dcc6c93301d59f67de5d388a3a41c8a629ae"
   license "BSD-3-Clause"
   revision 1
-  head "https://bitbucket.org/blaze-lib/blaze.git"
+  head "https://bitbucket.org/blaze-lib/blaze.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:      "c05e15582afef1b0d7961736731a844b1939a8c99c1d60aa412aee5c5c5507f0"

--- a/Formula/blink1.rb
+++ b/Formula/blink1.rb
@@ -5,7 +5,7 @@ class Blink1 < Formula
       tag:      "v2.2.0",
       revision: "99d272ab1e398b744e2a17b4f4a20bfb1c1d606c"
   license "CC-BY-SA-3.0"
-  head "https://github.com/todbot/blink1-tool.git"
+  head "https://github.com/todbot/blink1-tool.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "889f3e102d43f059049cec76aa5b80bb099add9927f1bd7d29f7decaa4009741"

--- a/Formula/blis.rb
+++ b/Formula/blis.rb
@@ -2,7 +2,7 @@ class Blis < Formula
   desc "BLAS-like Library Instantiation Software Framework"
   homepage "https://github.com/flame/blis"
   license "BSD-3-Clause"
-  head "https://github.com/flame/blis.git"
+  head "https://github.com/flame/blis.git", branch: "master"
 
   stable do
     url "https://github.com/flame/blis/archive/0.8.1.tar.gz"

--- a/Formula/blitz.rb
+++ b/Formula/blitz.rb
@@ -4,7 +4,7 @@ class Blitz < Formula
   url "https://github.com/blitzpp/blitz/archive/1.0.2.tar.gz"
   sha256 "500db9c3b2617e1f03d0e548977aec10d36811ba1c43bb5ef250c0e3853ae1c2"
   license "Artistic-2.0"
-  head "https://github.com/blitzpp/blitz.git"
+  head "https://github.com/blitzpp/blitz.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "0b04264665a05ca8b018a1f9b8e7452297d675b5bb5b50f49af2dd5176de462e"

--- a/Formula/blockhash.rb
+++ b/Formula/blockhash.rb
@@ -5,7 +5,7 @@ class Blockhash < Formula
   sha256 "56e8d2fecf2c7658c9f8b32bfb2d29fdd0d0535ddb3082e44b45a5da705aca86"
   license "MIT"
   revision 4
-  head "https://github.com/commonsmachinery/blockhash.git"
+  head "https://github.com/commonsmachinery/blockhash.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "1263f1d1a652f85a0cd026b5f9d1e1df6f1f467aee9a4336dfcacd02d590253b"

--- a/Formula/blogc.rb
+++ b/Formula/blogc.rb
@@ -4,7 +4,7 @@ class Blogc < Formula
   url "https://github.com/blogc/blogc/releases/download/v0.20.1/blogc-0.20.1.tar.xz"
   sha256 "d1289367362b7b11b438670fe703ff2c751e795393c06e1999d6b9a6e438fdd8"
   license "BSD-3-Clause"
-  head "https://github.com/blogc/blogc.git"
+  head "https://github.com/blogc/blogc.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f51d0d693775155a5eb1199a7ee90abb00e35a00a7469e02f3a31c074aff57cf"

--- a/Formula/bluepill.rb
+++ b/Formula/bluepill.rb
@@ -5,7 +5,7 @@ class Bluepill < Formula
       tag:      "v5.8.1",
       revision: "2dfc0a965ab564d015a2a0f00be89edf53c0f256"
   license "BSD-2-Clause"
-  head "https://github.com/linkedin/bluepill.git"
+  head "https://github.com/linkedin/bluepill.git", branch: "master"
 
   # Typically the preceding `v` is optional in livecheck regexes but we need it
   # to be required here to omit older versions that break version comparison

--- a/Formula/bluetoothconnector.rb
+++ b/Formula/bluetoothconnector.rb
@@ -4,7 +4,7 @@ class Bluetoothconnector < Formula
   url "https://github.com/lapfelix/BluetoothConnector/archive/2.0.0.tar.gz"
   sha256 "41474f185fd40602fb197e79df5cd4783ff57b92c1dfe2b8e2c4661af038ed9b"
   license "MIT"
-  head "https://github.com/lapfelix/BluetoothConnector.git"
+  head "https://github.com/lapfelix/BluetoothConnector.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b37f1ec5f2a36af25b4156b5d5abe9a43e7e541a6353075798e8daf523312deb"

--- a/Formula/blueutil.rb
+++ b/Formula/blueutil.rb
@@ -4,7 +4,7 @@ class Blueutil < Formula
   url "https://github.com/toy/blueutil/archive/v2.9.0.tar.gz"
   sha256 "cbd66abe0c4044b0d62095e340abf3e63925d4380e0dce710a550764a1f62352"
   license "MIT"
-  head "https://github.com/toy/blueutil.git"
+  head "https://github.com/toy/blueutil.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e29ddccdf7253406a3685f4099f3424ffb6d399ff2643f2d79f281ad97b93a67"

--- a/Formula/bnfc.rb
+++ b/Formula/bnfc.rb
@@ -4,7 +4,7 @@ class Bnfc < Formula
   url "https://github.com/BNFC/bnfc/archive/v2.9.1.tar.gz"
   sha256 "d79125168636fdcf0acd64a9b83ea620c311b16dcada0848d8a577aa8aeddec4"
   license "BSD-3-Clause"
-  head "https://github.com/BNFC/bnfc.git"
+  head "https://github.com/BNFC/bnfc.git", branch: "master"
 
   bottle do
     rebuild 2

--- a/Formula/boom-completion.rb
+++ b/Formula/boom-completion.rb
@@ -4,7 +4,7 @@ class BoomCompletion < Formula
   url "https://github.com/holman/boom/archive/v0.5.0.tar.gz"
   sha256 "d107accf1fb84d9c245bb25383486179605d3b397c439c2f4690341283b0b2dd"
   license "MIT"
-  head "https://github.com/holman/boom.git"
+  head "https://github.com/holman/boom.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "041329aa65f67c47539617cd6b7a585d0abd3158b0f1d1c8314807b2b1cdecae"

--- a/Formula/boost-bcp.rb
+++ b/Formula/boost-bcp.rb
@@ -4,7 +4,7 @@ class BoostBcp < Formula
   url "https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.bz2"
   sha256 "fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854"
   license "BSL-1.0"
-  head "https://github.com/boostorg/boost.git"
+  head "https://github.com/boostorg/boost.git", branch: "master"
 
   livecheck do
     formula "boost"

--- a/Formula/boost-build.rb
+++ b/Formula/boost-build.rb
@@ -5,7 +5,7 @@ class BoostBuild < Formula
   sha256 "17ad1addbc08d1cc6ef52f7140097915bc4904c28c7d6d733c4a1a20d40bbc1c"
   license "BSL-1.0"
   version_scheme 1
-  head "https://github.com/boostorg/build.git"
+  head "https://github.com/boostorg/build.git", branch: "develop"
 
   livecheck do
     url :stable

--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -4,7 +4,7 @@ class BoostMpi < Formula
   url "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2"
   sha256 "f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41"
   license "BSL-1.0"
-  head "https://github.com/boostorg/boost.git"
+  head "https://github.com/boostorg/boost.git", branch: "master"
 
   livecheck do
     formula "boost"

--- a/Formula/boost-python.rb
+++ b/Formula/boost-python.rb
@@ -4,7 +4,7 @@ class BoostPython < Formula
   url "https://downloads.sourceforge.net/project/boost/boost/1.74.0/boost_1_74_0.tar.bz2"
   sha256 "83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1"
   license "BSL-1.0"
-  head "https://github.com/boostorg/boost.git"
+  head "https://github.com/boostorg/boost.git", branch: "master"
 
   disable! date: "2021-04-08", because: :does_not_build
 

--- a/Formula/boost-python3.rb
+++ b/Formula/boost-python3.rb
@@ -4,7 +4,7 @@ class BoostPython3 < Formula
   url "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2"
   sha256 "f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41"
   license "BSL-1.0"
-  head "https://github.com/boostorg/boost.git"
+  head "https://github.com/boostorg/boost.git", branch: "master"
 
   livecheck do
     formula "boost"

--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -4,7 +4,7 @@ class Boost < Formula
   url "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2"
   sha256 "f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41"
   license "BSL-1.0"
-  head "https://github.com/boostorg/boost.git"
+  head "https://github.com/boostorg/boost.git", branch: "master"
 
   livecheck do
     url "https://www.boost.org/users/download/"

--- a/Formula/boringtun.rb
+++ b/Formula/boringtun.rb
@@ -4,7 +4,7 @@ class Boringtun < Formula
   url "https://github.com/cloudflare/boringtun/archive/v0.3.0.tar.gz"
   sha256 "1107b0170a33769db36876334261924edc71dfc1eb00f9b464c7d2ad6d5743d3"
   license "BSD-3-Clause"
-  head "https://github.com/cloudflare/boringtun.git"
+  head "https://github.com/cloudflare/boringtun.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:      "0de06cdb03839450dbe101b3f1042820f82aee7eda323039be0f48a0b2baf3e9"

--- a/Formula/botan.rb
+++ b/Formula/botan.rb
@@ -4,7 +4,7 @@ class Botan < Formula
   url "https://botan.randombit.net/releases/Botan-2.18.1.tar.xz"
   sha256 "f8c7b46222a857168a754a5cc329bb780504122b270018dda5304c98db28ae29"
   license "BSD-2-Clause"
-  head "https://github.com/randombit/botan.git"
+  head "https://github.com/randombit/botan.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "49d7c6c498d9eeb8d5d8be5b1dfe36107c499bb651df544028e9fec7cdac814d"

--- a/Formula/box2d.rb
+++ b/Formula/box2d.rb
@@ -4,7 +4,7 @@ class Box2d < Formula
   url "https://github.com/erincatto/box2d/archive/v2.4.1.tar.gz"
   sha256 "d6b4650ff897ee1ead27cf77a5933ea197cbeef6705638dd181adc2e816b23c2"
   license "MIT"
-  head "https://github.com/erincatto/Box2D.git"
+  head "https://github.com/erincatto/Box2D.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:     "bec33552a3bf184fd75f6adbb193b15595c7729dd7f457c833b7826c6253c28d"

--- a/Formula/boxes.rb
+++ b/Formula/boxes.rb
@@ -4,7 +4,7 @@ class Boxes < Formula
   url "https://github.com/ascii-boxes/boxes/archive/v2.1.1.tar.gz"
   sha256 "95ae6b46e057a79c6414b8c0b5b561c3e9d886ab8123a4085d256edccce625f9"
   license "GPL-2.0-only"
-  head "https://github.com/ascii-boxes/boxes.git"
+  head "https://github.com/ascii-boxes/boxes.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "8a84a206ca3a46d2364dd51f3e025762545645ff161e593a60149fc55e7a1f97"

--- a/Formula/bpm-tools.rb
+++ b/Formula/bpm-tools.rb
@@ -4,7 +4,7 @@ class BpmTools < Formula
   url "https://www.pogo.org.uk/~mark/bpm-tools/releases/bpm-tools-0.3.tar.gz"
   sha256 "37efe81ef594e9df17763e0a6fc29617769df12dfab6358f5e910d88f4723b94"
   license "GPL-2.0"
-  head "https://www.pogo.org.uk/~mark/bpm-tools.git"
+  head "https://www.pogo.org.uk/~mark/bpm-tools.git", branch: "master"
 
   bottle do
     rebuild 2

--- a/Formula/bpython.rb
+++ b/Formula/bpython.rb
@@ -6,7 +6,7 @@ class Bpython < Formula
   url "https://files.pythonhosted.org/packages/8f/34/7bdeba9999d2dfe5c0682291966bfa7edcedf2859885fa0037b8a38d0878/bpython-0.21.tar.gz"
   sha256 "88aa9b89974f6a7726499a2608fa7ded216d84c69e78114ab2ef996a45709487"
   license "MIT"
-  head "https://github.com/bpython/bpython.git"
+  head "https://github.com/bpython/bpython.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f576b76fa2209abfa8b0923f378318199af89ddfb4915150243d1d7e73543ac0"

--- a/Formula/brainfuck.rb
+++ b/Formula/brainfuck.rb
@@ -2,7 +2,7 @@ class Brainfuck < Formula
   desc "Interpreter for the brainfuck language"
   homepage "https://github.com/fabianishere/brainfuck"
   license "Apache-2.0"
-  head "https://github.com/fabianishere/brainfuck.git"
+  head "https://github.com/fabianishere/brainfuck.git", branch: "master"
 
   # Remove stable block in next release with merged patch
   stable do

--- a/Formula/brew-cask-completion.rb
+++ b/Formula/brew-cask-completion.rb
@@ -5,7 +5,7 @@ class BrewCaskCompletion < Formula
   sha256 "27c7ea3b7f7c060f5b5676a419220c4ce6ebf384237e859a61c346f61c8f7a1b"
   license "BSD-2-Clause"
   revision 1
-  head "https://github.com/xyb/homebrew-cask-completion.git"
+  head "https://github.com/xyb/homebrew-cask-completion.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "a058f8dd7fb25aa2ca8452d32f7d419b3b461b0f3b1dfe4f2f2e6d0e79b014ab"

--- a/Formula/brew-gem.rb
+++ b/Formula/brew-gem.rb
@@ -4,7 +4,7 @@ class BrewGem < Formula
   url "https://github.com/sportngin/brew-gem/archive/v1.1.1.tar.gz"
   sha256 "affa68105dcabc5c8b4832cf70ee2b35c1fbf19496173753645bda496d9b0a34"
   license "MIT"
-  head "https://github.com/sportngin/brew-gem.git"
+  head "https://github.com/sportngin/brew-gem.git", branch: "master"
 
   # Until versions exceed 2.2, the leading `v` in this regex isn't optional, as
   # we need to avoid an older `2.2` tag (a typo) while continuing to match

--- a/Formula/brew-php-switcher.rb
+++ b/Formula/brew-php-switcher.rb
@@ -4,7 +4,7 @@ class BrewPhpSwitcher < Formula
   url "https://github.com/philcook/brew-php-switcher/archive/v2.3.tar.gz"
   sha256 "5e6a622354422c66737ac6b76c6ea2db6d1591558a0238d680ba530f2c8b5773"
   license "MIT"
-  head "https://github.com/philcook/brew-php-switcher.git"
+  head "https://github.com/philcook/brew-php-switcher.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "ff0c773aa993b39343b501b7d5fca1355249bfce4e4d6a068ea30c6490ddbb7b"

--- a/Formula/broot.rb
+++ b/Formula/broot.rb
@@ -4,7 +4,7 @@ class Broot < Formula
   url "https://github.com/Canop/broot/archive/v1.6.3.tar.gz"
   sha256 "c7ef696a9da162a4338790a9e021eddedcc9a5be321bfea5cc2c33b2b2a53472"
   license "MIT"
-  head "https://github.com/Canop/broot.git"
+  head "https://github.com/Canop/broot.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "3cff2cf84e7a32b908b85701ea06c6f92e19e25db0e9344b694065816d53cc22"

--- a/Formula/brotli.rb
+++ b/Formula/brotli.rb
@@ -4,7 +4,7 @@ class Brotli < Formula
   url "https://github.com/google/brotli/archive/v1.0.9.tar.gz"
   sha256 "f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46"
   license "MIT"
-  head "https://github.com/google/brotli.git"
+  head "https://github.com/google/brotli.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "bcd00b6f423ec35f98aec55bc2c1cf433b6e70e915cdf04dd2c3a3707f1ce341"

--- a/Formula/bsdconv.rb
+++ b/Formula/bsdconv.rb
@@ -4,7 +4,7 @@ class Bsdconv < Formula
   url "https://github.com/buganini/bsdconv/archive/11.6.tar.gz"
   sha256 "e856e24474deb3731ac059a96af0078ba951895f2cb3b31f125148a29cc32b70"
   license "BSD-2-Clause"
-  head "https://github.com/buganini/bsdconv.git"
+  head "https://github.com/buganini/bsdconv.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "92a2e9b7e7389c00556c577f05e2e7d6ff39919d62153fb07dd98df8ba6347ab"

--- a/Formula/btfs.rb
+++ b/Formula/btfs.rb
@@ -4,7 +4,7 @@ class Btfs < Formula
   url "https://github.com/johang/btfs/archive/v2.22.tar.gz"
   sha256 "03ebfffd7cbd91e2113d0c43d8d129ad7851753c287c326416ecf622789c4a8d"
   license "GPL-3.0-only"
-  head "https://github.com/johang/btfs.git"
+  head "https://github.com/johang/btfs.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, catalina:    "d5b103b5b9004549a555352be373c2160bcd5b9f6a8e7e8b030cbf113ae76fcd"

--- a/Formula/buildapp.rb
+++ b/Formula/buildapp.rb
@@ -5,7 +5,7 @@ class Buildapp < Formula
   sha256 "d77fb6c151605da660b909af058206f7fe7d9faf972e2c30876d42cb03d6a3ed"
   license "BSD-2-Clause"
   revision 3
-  head "https://github.com/xach/buildapp.git"
+  head "https://github.com/xach/buildapp.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "3a4d0ac54096f853b8b271e02369dd2666e5b69c975d3b3f18ae6e54b4adf966"

--- a/Formula/buildkit.rb
+++ b/Formula/buildkit.rb
@@ -5,7 +5,7 @@ class Buildkit < Formula
       tag:      "v0.9.0",
       revision: "c8bb937807d405d92be91f06ce2629e6202ac7a9"
   license "Apache-2.0"
-  head "https://github.com/moby/buildkit.git"
+  head "https://github.com/moby/buildkit.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/buku.rb
+++ b/Formula/buku.rb
@@ -6,7 +6,7 @@ class Buku < Formula
   url "https://files.pythonhosted.org/packages/94/96/1d62b1346c07f8abc661fa499fef0acc7a110735e5b768b8899e58be8dc5/buku-4.6.tar.gz"
   sha256 "e598045dc6b41121f2b706355d41e771aca9d30df71880fdeaed6f2f670d8dd8"
   license "GPL-3.0-or-later"
-  head "https://github.com/jarun/buku.git"
+  head "https://github.com/jarun/buku.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "df8722e84c15d946c4119c1adab73729e6e3f86d3e73daf56bdaf33a27739709"

--- a/Formula/bullet.rb
+++ b/Formula/bullet.rb
@@ -4,7 +4,7 @@ class Bullet < Formula
   url "https://github.com/bulletphysics/bullet3/archive/3.17.tar.gz"
   sha256 "baa642c906576d4d98d041d0acb80d85dd6eff6e3c16a009b1abf1ccd2bc0a61"
   license "Zlib"
-  head "https://github.com/bulletphysics/bullet3.git"
+  head "https://github.com/bulletphysics/bullet3.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/bundler-completion.rb
+++ b/Formula/bundler-completion.rb
@@ -5,7 +5,7 @@ class BundlerCompletion < Formula
       revision: "f3e4345042b0cc48317e45b673dfd3d23904b9a7"
   version "2"
   license "MIT"
-  head "https://github.com/mernen/completion-ruby.git"
+  head "https://github.com/mernen/completion-ruby.git", branch: "main"
 
   livecheck do
     formula "ruby-completion"

--- a/Formula/bup.rb
+++ b/Formula/bup.rb
@@ -4,7 +4,7 @@ class Bup < Formula
   url "https://github.com/bup/bup/archive/0.32.tar.gz"
   sha256 "a894cfa96c44b9ef48003b2c2104dc5fa6361dd2f4d519261a93178984a51259"
   license all_of: ["BSD-2-Clause", "LGPL-2.0-only"]
-  head "https://github.com/bup/bup.git"
+  head "https://github.com/bup/bup.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "301e0ea9de87b821c591dcdc780c5e0ce5bc2964a78fd695f5fd0ad673de5600"

--- a/Formula/butane.rb
+++ b/Formula/butane.rb
@@ -4,7 +4,7 @@ class Butane < Formula
   url "https://github.com/coreos/butane/archive/v0.13.1.tar.gz"
   sha256 "b71a6cdb54fcacbf78adc06cc291958c228e5a9c8de3cacf04cebc0925ae37ab"
   license "Apache-2.0"
-  head "https://github.com/coreos/butane.git"
+  head "https://github.com/coreos/butane.git", branch: "main"
 
   livecheck do
     url :stable

--- a/Formula/bwm-ng.rb
+++ b/Formula/bwm-ng.rb
@@ -4,7 +4,7 @@ class BwmNg < Formula
   url "https://github.com/vgropp/bwm-ng/archive/v0.6.3.tar.gz"
   sha256 "c1a552b6ff48ea3e4e10110a7c188861abc4750befc67c6caaba8eb3ecf67f46"
   license "GPL-2.0-or-later"
-  head "https://github.com/vgropp/bwm-ng.git"
+  head "https://github.com/vgropp/bwm-ng.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "5f572a2c3cba92b810273eec515a00b0dc406319efd33934a571e97a2f48fb9c"

--- a/Formula/byteman.rb
+++ b/Formula/byteman.rb
@@ -4,7 +4,7 @@ class Byteman < Formula
   url "https://downloads.jboss.org/byteman/4.0.16/byteman-download-4.0.16-bin.zip"
   sha256 "4d3a25d7cbe1432be3689854775e692e18f539d8d75328c4e1ad8cf33989c80b"
   license "LGPL-2.1-or-later"
-  head "https://github.com/bytemanproject/byteman"
+  head "https://github.com/bytemanproject/byteman", branch: "main"
 
   livecheck do
     url "https://byteman.jboss.org/downloads.html"

--- a/Formula/bzt.rb
+++ b/Formula/bzt.rb
@@ -6,7 +6,7 @@ class Bzt < Formula
   url "https://files.pythonhosted.org/packages/bc/44/802b7f740ef7ce53aed555223279760e1a253cebb9f3dd665e7f01f8db40/bzt-1.15.2.tar.gz"
   sha256 "c06b3eb7e965583394832550581a52bb2c53d076beebe74d23d795802ed2b522"
   license "Apache-2.0"
-  head "https://github.com/Blazemeter/taurus.git"
+  head "https://github.com/Blazemeter/taurus.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "74f43e75579eaac72b2e1edb4ed9916a4b44c382ac0ff7e39a4e9d1c84a85259"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds `head` branch information to `b*` formulae with `head` URLs of the form `head "<URL>"` (and where a branch wasn't already specified). Changes were made using a script that is similar to the audit added in Homebrew/brew#11720.