### PR TITLE
memcached: fix test for Linux

### DIFF
--- a/Formula/memcached.rb
+++ b/Formula/memcached.rb
@@ -37,15 +37,13 @@ class Memcached < Formula
     pidfile = testpath/"memcached.pid"
     port = free_port
     args = %W[
-      --listen=localhost:#{port}
+      --listen=127.0.0.1
+      --port=#{port}
       --daemon
       --pidfile=#{pidfile}
     ]
     on_linux do
-      if ENV["HOMEBREW_GITHUB_ACTIONS"]
-        args << "-u"
-        args << ENV["USER"]
-      end
+      args << "--user=#{ENV["USER"]}" if ENV["HOMEBREW_GITHUB_ACTIONS"]
     end
     system bin/"memcached", *args
     sleep 1


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3376891979?check_suite_focus=true
```
==> brew test --verbose memcached
==> FAILED
==> Testing memcached
==> /home/linuxbrew/.linuxbrew/Cellar/memcached/1.6.10/bin/memcached --listen=localhost:46645 --daemon --pidfile=/tmp/memcached-test-20210819-7018-136tak4/memcached.pid -u linuxbrew
Error: memcached: failed
An exception occurred within a child process:
  Minitest::Assertion: Failed to start memcached daemon.
Expected #<Pathname:/tmp/memcached-test-20210819-7018-136tak4/memcached.pid> to be exist?.
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/minitest-5.14.4/lib/minitest/assertions.rb:183:in `assert'

```
