### PR TITLE
autojump: fix test to use Bash

### DIFF
--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -43,12 +43,12 @@ class Autojump < Formula
   test do
     path = testpath/"foo/bar"
     path.mkpath
-    output = `
-      . #{etc}/profile.d/autojump.sh
-      j -a "#{path.relative_path_from(testpath)}"
-      j foo >/dev/null
-      pwd
-    `.strip
-    assert_equal path.realpath.to_s, output
+    cmds = [
+      ". #{etc}/profile.d/autojump.sh",
+      "j -a \"#{path.relative_path_from(testpath)}\"",
+      "j foo >/dev/null",
+      "pwd",
+    ]
+    assert_equal path.realpath.to_s, shell_output("bash -c '#{cmds.join("; ")}'").strip
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
