### PR TITLE
c*: add `head` branch

### DIFF
--- a/Formula/c-ares.rb
+++ b/Formula/c-ares.rb
@@ -5,7 +5,7 @@ class CAres < Formula
   url "https://c-ares.haxx.se/download/c-ares-1.17.2.tar.gz"
   sha256 "4803c844ce20ce510ef0eb83f8ea41fa24ecaae9d280c468c582d2bb25b3913d"
   license "MIT"
-  head "https://github.com/c-ares/c-ares.git"
+  head "https://github.com/c-ares/c-ares.git", branch: "main"
 
   livecheck do
     url :homepage

--- a/Formula/c14-cli.rb
+++ b/Formula/c14-cli.rb
@@ -4,7 +4,7 @@ class C14Cli < Formula
   url "https://github.com/scaleway/c14-cli/archive/v0.5.0.tar.gz"
   sha256 "b93960ee3ba516a91df9f81cf9b258858f8b5da6238d44a339966a5636643cb2"
   license "MIT"
-  head "https://github.com/scaleway/c14-cli.git"
+  head "https://github.com/scaleway/c14-cli.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "46d65ade1ad6406be53f136729cbeca6892dd53f6958dfd7417e3773ac9d2041"

--- a/Formula/c2048.rb
+++ b/Formula/c2048.rb
@@ -5,7 +5,7 @@ class C2048 < Formula
       revision: "578a5f314e1ce31b57e645a8c0a2c9d9d5539cde"
   version "0+20150805"
   license "MIT"
-  head "https://github.com/mevdschee/2048.c.git"
+  head "https://github.com/mevdschee/2048.c.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "89bc7f84063b8621271115ee8f9c84c836ae1e57a72db5533b11d8247d57e043"

--- a/Formula/cadaver.rb
+++ b/Formula/cadaver.rb
@@ -7,7 +7,7 @@ class Cadaver < Formula
   sha256 "fd4ce68a3230ba459a92bcb747fc6afa91e46d803c1d5ffe964b661793c13fca"
   license "GPL-2.0-or-later"
   revision 5
-  head "https://github.com/notroj/cadaver.git"
+  head "https://github.com/notroj/cadaver.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/caddy.rb
+++ b/Formula/caddy.rb
@@ -4,7 +4,7 @@ class Caddy < Formula
   url "https://github.com/caddyserver/caddy/archive/v2.4.3.tar.gz"
   sha256 "10317b5ab7bee861631a8d94d13aeafb62e9665759271a6c65422a70d6584d6b"
   license "Apache-2.0"
-  head "https://github.com/caddyserver/caddy.git"
+  head "https://github.com/caddyserver/caddy.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b3c3e8b95721eb7562d11326d8cfbff6cada1a318f71ca7e181ec55e6f356a05"

--- a/Formula/cadence-workflow.rb
+++ b/Formula/cadence-workflow.rb
@@ -5,7 +5,7 @@ class CadenceWorkflow < Formula
     tag:      "v0.21.3",
     revision: "36cfde8b88b17e2ff0f810e72c808ccfdc2e97f5"
   license "MIT"
-  head "https://github.com/uber/cadence.git"
+  head "https://github.com/uber/cadence.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "029e2c39a8c5999af05be8351e943f1c31e4f091d0705ea73fa23053c57fc782"

--- a/Formula/cadence.rb
+++ b/Formula/cadence.rb
@@ -4,7 +4,7 @@ class Cadence < Formula
   url "https://github.com/onflow/cadence/archive/v0.18.0.tar.gz"
   sha256 "6739b8b79367847885a0ab0e51f3ee5b2018cbd270fe494fe9b2368acfbbf223"
   license "Apache-2.0"
-  head "https://github.com/onflow/cadence.git"
+  head "https://github.com/onflow/cadence.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/caf.rb
+++ b/Formula/caf.rb
@@ -5,7 +5,7 @@ class Caf < Formula
   url "https://github.com/actor-framework/actor-framework/archive/0.18.5.tar.gz"
   sha256 "4c96f896f000218bb65890b4d7175451834add73750d5f33b0c7fe82b7d5a679"
   license "BSD-3-Clause"
-  head "https://github.com/actor-framework/actor-framework.git"
+  head "https://github.com/actor-framework/actor-framework.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "ab16a7c7af1cb9ebcf94b0f51185d2318de6c658e2c58fea826011eecd3e09f9"

--- a/Formula/caire.rb
+++ b/Formula/caire.rb
@@ -4,7 +4,7 @@ class Caire < Formula
   url "https://github.com/esimov/caire/archive/v1.3.2.tar.gz"
   sha256 "fe759bbbf4ddb2a89d43ac99812f8a3027e2f84fc8f9771db88ac043cc41cbf7"
   license "MIT"
-  head "https://github.com/esimov/caire.git"
+  head "https://github.com/esimov/caire.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "99e369779abadd222e6d46031536c33f0097054633eae3e077f61eb5951a85cc"

--- a/Formula/calicoctl.rb
+++ b/Formula/calicoctl.rb
@@ -5,7 +5,7 @@ class Calicoctl < Formula
       tag:      "v3.20.0",
       revision: "38b00edd005363b369dd7c585933b08376f76d6c"
   license "Apache-2.0"
-  head "https://github.com/projectcalico/calicoctl.git"
+  head "https://github.com/projectcalico/calicoctl.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/camlp5.rb
+++ b/Formula/camlp5.rb
@@ -5,7 +5,7 @@ class Camlp5 < Formula
   sha256 "906d5325798cd0985a634e9b6b5c76c6810f3f3b8e98b80a7c30b899082c2332"
   license "BSD-3-Clause"
   revision 1
-  head "https://github.com/camlp5/camlp5.git"
+  head "https://github.com/camlp5/camlp5.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/capnp.rb
+++ b/Formula/capnp.rb
@@ -4,7 +4,7 @@ class Capnp < Formula
   url "https://capnproto.org/capnproto-c++-0.8.0.tar.gz"
   sha256 "d1f40e47574c65700f0ec98bf66729378efabe3c72bc0cda795037498541c10d"
   license "MIT"
-  head "https://github.com/capnproto/capnproto.git"
+  head "https://github.com/capnproto/capnproto.git", branch: "master"
 
   livecheck do
     url "https://capnproto.org/install.html"

--- a/Formula/cargo-watch.rb
+++ b/Formula/cargo-watch.rb
@@ -4,7 +4,7 @@ class CargoWatch < Formula
   url "https://github.com/passcod/cargo-watch/archive/v8.0.0.tar.gz"
   sha256 "42d0acfc579e7deeda57e6c1252165a17b19e2fe7486d2fd17f24adfc2876e03"
   license "CC0-1.0"
-  head "https://github.com/passcod/cargo-watch.git"
+  head "https://github.com/passcod/cargo-watch.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "22dd85a3bbe42bf3fd00a18d14d105e9631e3ab559cd5cdbf28c5f10cc924047"

--- a/Formula/carina.rb
+++ b/Formula/carina.rb
@@ -5,7 +5,7 @@ class Carina < Formula
         tag:      "v2.1.3",
         revision: "2b3ec267e298e095d7c2f81a2d82dc50a720e81c"
   license "Apache-2.0"
-  head "https://github.com/getcarina/carina.git"
+  head "https://github.com/getcarina/carina.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:     "90280ee4749e9e92f90a215418485a9dc1ded4d2ced295f333979f914459dfbf"

--- a/Formula/carthage.rb
+++ b/Formula/carthage.rb
@@ -6,7 +6,7 @@ class Carthage < Formula
       revision: "9a3d1799ba8f8b9e2d4514cfa53a2cca6064136e",
       shallow:  false
   license "MIT"
-  head "https://github.com/Carthage/Carthage.git"
+  head "https://github.com/Carthage/Carthage.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e9be26e66087b149d4d6ff813323fb5fa1ac0ec1a55d3d1a26fc3aafc8f8e8ec"

--- a/Formula/carton.rb
+++ b/Formula/carton.rb
@@ -5,7 +5,7 @@ class Carton < Formula
   sha256 "77d42b92732bcfc18a59d341e56ce476205b1c4d380eab3a07224f5745c23e45"
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   revision 2
-  head "https://github.com/perl-carton/carton.git"
+  head "https://github.com/perl-carton/carton.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "4ce1ddd8777839a7c6335edb8aeccb0603e7199f77e8535039888e4f17c1c16b"

--- a/Formula/cask.rb
+++ b/Formula/cask.rb
@@ -4,7 +4,7 @@ class Cask < Formula
   url "https://github.com/cask/cask/archive/v0.8.7.tar.gz"
   sha256 "6b664da044e8faef77717f79bb90069ec9e7868e9c47da498057236b409a501b"
   license "GPL-3.0-or-later"
-  head "https://github.com/cask/cask.git"
+  head "https://github.com/cask/cask.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "bd85befe31659e948617b988ed604d70199af9e7dd22dcfc8be6d76ecd92ee0b"

--- a/Formula/cassandra-cpp-driver.rb
+++ b/Formula/cassandra-cpp-driver.rb
@@ -4,7 +4,7 @@ class CassandraCppDriver < Formula
   url "https://github.com/datastax/cpp-driver/archive/2.16.1.tar.gz"
   sha256 "168d6fe9f3cf61be82cf5817024b92a186d7f944f0d390ed546f521bdabfc32e"
   license "Apache-2.0"
-  head "https://github.com/datastax/cpp-driver.git"
+  head "https://github.com/datastax/cpp-driver.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "c3127af73fe5c279aa1fce70d690770b00bc6754a74b9163fde9c897122517da"

--- a/Formula/cassowary.rb
+++ b/Formula/cassowary.rb
@@ -4,7 +4,7 @@ class Cassowary < Formula
   url "https://github.com/rogerwelin/cassowary/archive/v0.14.0.tar.gz"
   sha256 "385232478b8552d56429fbe2584950bfbe42e3b611919a31075366a143aae9a9"
   license "MIT"
-  head "https://github.com/rogerwelin/cassowary.git"
+  head "https://github.com/rogerwelin/cassowary.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "648d2b294a0a5523a9941c54d4399ba7af9574d00535c27560642e4df77cd883"

--- a/Formula/castxml.rb
+++ b/Formula/castxml.rb
@@ -5,7 +5,7 @@ class Castxml < Formula
   sha256 "3dd94096e07ffe103b2a951e4ff0f9486cc615b3ef08e95e5778eaaec667fb65"
   license "Apache-2.0"
   revision 1
-  head "https://github.com/CastXML/castxml.git"
+  head "https://github.com/CastXML/castxml.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/cataclysm.rb
+++ b/Formula/cataclysm.rb
@@ -5,7 +5,7 @@ class Cataclysm < Formula
   version "0.F"
   sha256 "f7c373cd2450353f99a5c3937a72ae745f5440531266d2d596e5bf798001ac57"
   license "CC-BY-SA-3.0"
-  head "https://github.com/CleverRaven/Cataclysm-DDA.git"
+  head "https://github.com/CleverRaven/Cataclysm-DDA.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/catimg.rb
+++ b/Formula/catimg.rb
@@ -4,7 +4,7 @@ class Catimg < Formula
   url "https://github.com/posva/catimg/archive/2.7.0.tar.gz"
   sha256 "3a6450316ff62fb07c3facb47ea208bf98f62abd02783e88c56f2a6508035139"
   license "MIT"
-  head "https://github.com/posva/catimg.git"
+  head "https://github.com/posva/catimg.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f5537238f20cc678e14f52ecdc1bdbf2b9d20d58d51a322ae044bad5c0df2418"

--- a/Formula/cbmbasic.rb
+++ b/Formula/cbmbasic.rb
@@ -4,7 +4,7 @@ class Cbmbasic < Formula
   url "https://downloads.sourceforge.net/project/cbmbasic/cbmbasic/1.0/cbmbasic-1.0.tgz"
   sha256 "2735dedf3f9ad93fa947ad0fb7f54acd8e84ea61794d786776029c66faf64b04"
   license "BSD-2-Clause"
-  head "https://github.com/mist64/cbmbasic.git"
+  head "https://github.com/mist64/cbmbasic.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b693c2b8fbfe49736bdc0ae4bce13d96295da75a6683e593c021c9335f6c57fd"

--- a/Formula/cc65.rb
+++ b/Formula/cc65.rb
@@ -4,7 +4,7 @@ class Cc65 < Formula
   url "https://github.com/cc65/cc65/archive/V2.19.tar.gz"
   sha256 "157b8051aed7f534e5093471e734e7a95e509c577324099c3c81324ed9d0de77"
   license "Zlib"
-  head "https://github.com/cc65/cc65.git"
+  head "https://github.com/cc65/cc65.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "47405e34cd591b17d9ed65842f25ac7c6d9f61e98f21b9c403596257d7e23dae"

--- a/Formula/ccache.rb
+++ b/Formula/ccache.rb
@@ -5,7 +5,7 @@ class Ccache < Formula
   sha256 "504a0f2184465c306826f035b4bc00bae7500308d6af4abbfb50e33a694989b4"
   license "GPL-3.0-or-later"
   revision 1
-  head "https://github.com/ccache/ccache.git"
+  head "https://github.com/ccache/ccache.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "038f86ecd8902ca8714e8d86c1232543d44abf75ee7bb8b3647f8cf2011a7ba3"

--- a/Formula/ccextractor.rb
+++ b/Formula/ccextractor.rb
@@ -4,7 +4,7 @@ class Ccextractor < Formula
   url "https://github.com/CCExtractor/ccextractor/archive/v0.93.tar.gz"
   sha256 "0e66d3e360db1b02a88271af11313ca4c9bbda1b03728e264a44c4c9f77192e3"
   license "GPL-2.0-only"
-  head "https://github.com/ccextractor/ccextractor.git"
+  head "https://github.com/ccextractor/ccextractor.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "6efaaf1c5561ca5b8111ec6d5c4a218478b1ab516879eeed63c253413c29a0fd"

--- a/Formula/ccls.rb
+++ b/Formula/ccls.rb
@@ -5,7 +5,7 @@ class Ccls < Formula
   sha256 "28c228f49dfc0f23cb5d581b7de35792648f32c39f4ca35f68ff8c9cb5ce56c2"
   license "Apache-2.0"
   revision 1
-  head "https://github.com/MaskRay/ccls.git"
+  head "https://github.com/MaskRay/ccls.git", branch: "master"
 
   bottle do
     sha256                               arm64_big_sur: "4b2edaf5fa08c9846ca7bc5cc20d36cbf6c6299af4df34527fbd511bbdebb5d7"

--- a/Formula/ccm.rb
+++ b/Formula/ccm.rb
@@ -5,7 +5,7 @@ class Ccm < Formula
   sha256 "f07cc0a37116d2ce1b96c0d467f792668aa25835c73beb61639fa50a1954326c"
   license "Apache-2.0"
   revision 1
-  head "https://github.com/pcmanus/ccm.git"
+  head "https://github.com/pcmanus/ccm.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "955fd74e54ceaed0772238587c7fe45600813c685cdd4c1af19a5c0c99462a1f"

--- a/Formula/cd-discid.rb
+++ b/Formula/cd-discid.rb
@@ -3,7 +3,7 @@ class CdDiscid < Formula
   homepage "https://linukz.org/cd-discid.shtml"
   license "GPL-2.0"
   revision 2
-  head "https://github.com/taem/cd-discid.git"
+  head "https://github.com/taem/cd-discid.git", branch: "master"
 
   stable do
     url "https://linukz.org/download/cd-discid-1.4.tar.gz"

--- a/Formula/cdargs.rb
+++ b/Formula/cdargs.rb
@@ -4,7 +4,7 @@ class Cdargs < Formula
   url "https://github.com/cbxbiker61/cdargs/archive/2.1.tar.gz"
   sha256 "062515c3fbd28c68f9fa54ff6a44b81cf647469592444af0872b5ecd7444df7d"
   license "GPL-2.0"
-  head "https://github.com/cbxbiker61/cdargs.git"
+  head "https://github.com/cbxbiker61/cdargs.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "fb52b8d939ea7fde7c8579710b1bad8617e987214f2bfb730300b2e761ebf4dd"

--- a/Formula/cdogs-sdl.rb
+++ b/Formula/cdogs-sdl.rb
@@ -4,7 +4,7 @@ class CdogsSdl < Formula
   url "https://github.com/cxong/cdogs-sdl/archive/0.13.0.tar.gz"
   sha256 "1d51c1d918493761a1d702e6f9bf46409b9ecd0ea98ca4081fc41d355957222a"
   license "GPL-2.0-or-later"
-  head "https://github.com/cxong/cdogs-sdl.git"
+  head "https://github.com/cxong/cdogs-sdl.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/cedille.rb
+++ b/Formula/cedille.rb
@@ -6,7 +6,7 @@ class Cedille < Formula
     revision: "4d8a343a8d3f0b318e3c1b3209d216912dbc06ee"
   license "MIT"
   revision 3
-  head "https://github.com/cedille/cedille.git"
+  head "https://github.com/cedille/cedille.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/ceres-solver.rb
+++ b/Formula/ceres-solver.rb
@@ -5,7 +5,7 @@ class CeresSolver < Formula
   sha256 "10298a1d75ca884aa0507d1abb0e0f04800a92871cd400d4c361b56a777a7603"
   license "BSD-3-Clause"
   revision 4
-  head "https://ceres-solver.googlesource.com/ceres-solver.git"
+  head "https://ceres-solver.googlesource.com/ceres-solver.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "1b729631e1d4e35fa8cdb4e38daeab4db1900273bb3b3a97800d6609c9048011"

--- a/Formula/cern-ndiff.rb
+++ b/Formula/cern-ndiff.rb
@@ -4,7 +4,7 @@ class CernNdiff < Formula
   homepage "https://mad.web.cern.ch/mad/"
   url "https://github.com/MethodicalAcceleratorDesign/MAD-X/archive/5.07.00.tar.gz"
   sha256 "77c0ec591dc3ea76cf57c60a5d7c73b6c0d66cca1fa7c4eb25a9071e8fc67e60"
-  head "https://github.com/MethodicalAcceleratorDesign/MAD-X.git"
+  head "https://github.com/MethodicalAcceleratorDesign/MAD-X.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/certbot.rb
+++ b/Formula/certbot.rb
@@ -6,7 +6,7 @@ class Certbot < Formula
   url "https://files.pythonhosted.org/packages/a9/21/7c867d866c85140e60605b77ed6b1e691337ce7a30196a96f413241d8e91/certbot-1.18.0.tar.gz"
   sha256 "f3e56e18246ba5dc4951132e206844f7191d7b6a97264a005557fff25cd7287b"
   license "Apache-2.0"
-  head "https://github.com/certbot/certbot.git"
+  head "https://github.com/certbot/certbot.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "1fd1ea900f5d564ac45a3527f3bbbfa0b169f3b4ad5f979b29c23b06ccff081d"

--- a/Formula/certigo.rb
+++ b/Formula/certigo.rb
@@ -4,7 +4,7 @@ class Certigo < Formula
   url "https://github.com/square/certigo/archive/v1.12.1.tar.gz"
   sha256 "800bdfa10ffc7f6313397220d02769e88ed5dae001224c9f0199383dcb63eaec"
   license "Apache-2.0"
-  head "https://github.com/square/certigo.git"
+  head "https://github.com/square/certigo.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/cfr-decompiler.rb
+++ b/Formula/cfr-decompiler.rb
@@ -5,7 +5,7 @@ class CfrDecompiler < Formula
       tag:      "0.151",
       revision: "fecd6421a8b9de98ade2b9f9b89caecf4a8c93d8"
   license "MIT"
-  head "https://github.com/leibnitz27/cfr.git"
+  head "https://github.com/leibnitz27/cfr.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/cfssl.rb
+++ b/Formula/cfssl.rb
@@ -4,7 +4,7 @@ class Cfssl < Formula
   url "https://github.com/cloudflare/cfssl/archive/v1.6.0.tar.gz"
   sha256 "9694e84b42bf3fc547fa5ac5b15099da28129b9b274b3aad3534d7145ca1cc04"
   license "BSD-2-Clause"
-  head "https://github.com/cloudflare/cfssl.git"
+  head "https://github.com/cloudflare/cfssl.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "637f4d77e1d9504dd8c8bc9e9e3635191de063898630b2b17fa84dfb27c6294f"

--- a/Formula/cgns.rb
+++ b/Formula/cgns.rb
@@ -5,7 +5,7 @@ class Cgns < Formula
   sha256 "090ec6cb0916d90c16790183fc7c2bd2bd7e9a5e3764b36c8196ba37bf1dc817"
   license "BSD-3-Clause"
   revision 1
-  head "https://github.com/CGNS/CGNS.git"
+  head "https://github.com/CGNS/CGNS.git", branch: "develop"
 
   livecheck do
     url :stable

--- a/Formula/cgrep.rb
+++ b/Formula/cgrep.rb
@@ -4,7 +4,7 @@ class Cgrep < Formula
   url "https://github.com/awgn/cgrep/archive/v6.6.33.tar.gz"
   sha256 "f0d7114e9c26dc3ff3515711cce63864f3995ac06ed3743acf2560fc5a1eb78e"
   license "GPL-2.0-or-later"
-  head "https://github.com/awgn/cgrep.git"
+  head "https://github.com/awgn/cgrep.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/chamber.rb
+++ b/Formula/chamber.rb
@@ -4,7 +4,7 @@ class Chamber < Formula
   url "https://github.com/segmentio/chamber/archive/v2.10.2.tar.gz"
   sha256 "50e8bf541aac590a7eefbee7fe4d064a4bf23ddc8d83bbb81921f8b38c497299"
   license "MIT"
-  head "https://github.com/segmentio/chamber.git"
+  head "https://github.com/segmentio/chamber.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/charge.rb
+++ b/Formula/charge.rb
@@ -6,7 +6,7 @@ class Charge < Formula
   url "https://registry.npmjs.org/@static/charge/-/charge-1.7.0.tgz"
   sha256 "477e6eb2a5d99854b4640017d85ee5f4ea09431a2ff046113047764f64d21ab5"
   license "MIT"
-  head "https://github.com/brandonweiss/charge.git"
+  head "https://github.com/brandonweiss/charge.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "cfacd98af0f9c2293eef24cb7610a5d2cf60ff237cf790b1ad5ff6cad018a855"

--- a/Formula/chars.rb
+++ b/Formula/chars.rb
@@ -4,7 +4,7 @@ class Chars < Formula
   url "https://github.com/antifuchs/chars/archive/v0.5.0.tar.gz"
   sha256 "5e2807b32bd75862d8b155fa774db26b649529b62da26a74e817bec5a26e1d7c"
   license "MIT"
-  head "https://github.com/antifuchs/chars.git"
+  head "https://github.com/antifuchs/chars.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/chart-testing.rb
+++ b/Formula/chart-testing.rb
@@ -6,7 +6,7 @@ class ChartTesting < Formula
       revision: "68a43ac09699ef9473266457e893a7ddd7ef6b5b"
   license "Apache-2.0"
   revision 1
-  head "https://github.com/helm/chart-testing.git"
+  head "https://github.com/helm/chart-testing.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "66bd1f0419bfcf97ce06a3a91f107735563ee94e1e5953bcad7e48d5f1a31e9f"

--- a/Formula/check_postgres.rb
+++ b/Formula/check_postgres.rb
@@ -5,7 +5,7 @@ class CheckPostgres < Formula
   sha256 "11b52f86c44d6cc26e9a4129e67c2589071dbe1b8ac1f8895761517491c6e44b"
   license "BSD-2-Clause"
   revision 1
-  head "https://github.com/bucardo/check_postgres.git"
+  head "https://github.com/bucardo/check_postgres.git", branch: "master"
 
   livecheck do
     url "https://bucardo.org/check_postgres/"

--- a/Formula/chezmoi.rb
+++ b/Formula/chezmoi.rb
@@ -5,7 +5,7 @@ class Chezmoi < Formula
       tag:      "v2.1.5",
       revision: "1a59ced6df2009460cc063e06310197c4eddf2fe"
   license "MIT"
-  head "https://github.com/twpayne/chezmoi.git"
+  head "https://github.com/twpayne/chezmoi.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b2beb0d90626a08df5558a8d375064f56abbf9eaaba2981870c38ccc2373bcfd"

--- a/Formula/chgems.rb
+++ b/Formula/chgems.rb
@@ -4,7 +4,7 @@ class Chgems < Formula
   url "https://github.com/postmodern/chgems/archive/v0.3.2.tar.gz"
   sha256 "515d1bfebb5d5183a41a502884e329fd4c8ddccb14ba8a6548a1f8912013f3dd"
   license "MIT"
-  head "https://github.com/postmodern/chgems.git"
+  head "https://github.com/postmodern/chgems.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "0f8b93d560718a526d4ee4c307168a2d15cbb824cdabd626974466acf4f6e80e"

--- a/Formula/chibi-scheme.rb
+++ b/Formula/chibi-scheme.rb
@@ -4,7 +4,7 @@ class ChibiScheme < Formula
   url "https://github.com/ashinn/chibi-scheme/archive/0.10.tar.gz"
   sha256 "ae1d2057138b7f438f01bfb1e072799105faeea1de0ab3cc10860adf373993b3"
   license "BSD-3-Clause"
-  head "https://github.com/ashinn/chibi-scheme.git"
+  head "https://github.com/ashinn/chibi-scheme.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/chicken.rb
+++ b/Formula/chicken.rb
@@ -4,7 +4,7 @@ class Chicken < Formula
   url "https://code.call-cc.org/releases/5.2.0/chicken-5.2.0.tar.gz"
   sha256 "819149c8ce7303a9b381d3fdc1d5765c5f9ac4dee6f627d1652f47966a8780fa"
   license "BSD-3-Clause"
-  head "https://code.call-cc.org/git/chicken-core.git"
+  head "https://code.call-cc.org/git/chicken-core.git", branch: "master"
 
   livecheck do
     url "https://code.call-cc.org/releases/current/"

--- a/Formula/chipmunk.rb
+++ b/Formula/chipmunk.rb
@@ -5,7 +5,7 @@ class Chipmunk < Formula
   mirror "https://www.mirrorservice.org/sites/distfiles.macports.org/chipmunk/Chipmunk-7.0.3.tgz"
   sha256 "048b0c9eff91c27bab8a54c65ad348cebd5a982ac56978e8f63667afbb63491a"
   license "MIT"
-  head "https://github.com/slembcke/Chipmunk2D.git"
+  head "https://github.com/slembcke/Chipmunk2D.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "53a1d8968efd45940eda303182f7a68be0e31221295a85e803f92f3c968c45ad"

--- a/Formula/chisel.rb
+++ b/Formula/chisel.rb
@@ -4,7 +4,7 @@ class Chisel < Formula
   url "https://github.com/facebook/chisel/archive/2.0.1.tar.gz"
   sha256 "6f019d5e7ab5eb06542a9eccbbe29e7d26165d3676828a32e143575ff102d5f9"
   license "MIT"
-  head "https://github.com/facebook/chisel.git"
+  head "https://github.com/facebook/chisel.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "bd381685bf1bf3682e51c355acbca980b35659b8161f226329b3a0196aab55df"

--- a/Formula/choose.rb
+++ b/Formula/choose.rb
@@ -5,7 +5,7 @@ class Choose < Formula
   sha256 "d09a679920480e66bff36c76dd4d33e8ad739a53eace505d01051c114a829633"
   license "MIT"
   revision 3
-  head "https://github.com/geier/choose.git"
+  head "https://github.com/geier/choose.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c8408b41107e7824596b3c28b2f63f98c910a7452ff676805a7ec5e77ba505bc"

--- a/Formula/chrome-cli.rb
+++ b/Formula/chrome-cli.rb
@@ -4,7 +4,7 @@ class ChromeCli < Formula
   url "https://github.com/prasmussen/chrome-cli/archive/1.7.1.tar.gz"
   sha256 "27ee5ab9a9d60fbd829f069074fe592f2aafd129df0df4aedbbc12b8df11ac32"
   license "MIT"
-  head "https://github.com/prasmussen/chrome-cli.git"
+  head "https://github.com/prasmussen/chrome-cli.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "835b7a9995ff61f7623ded6ce772d5ae712651aa690102c79afa0f989a6f5285"

--- a/Formula/chronograf.rb
+++ b/Formula/chronograf.rb
@@ -6,7 +6,7 @@ class Chronograf < Formula
   url "https://github.com/influxdata/chronograf/archive/1.9.0.tar.gz"
   sha256 "d372ed570ffca770395ec2f8b3cf3da5c493462b3f9a9a23431bce48fa58db12"
   license "AGPL-3.0-or-later"
-  head "https://github.com/influxdata/chronograf.git"
+  head "https://github.com/influxdata/chronograf.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "a3ca0abd746047054e2fa1e16af01c66959d5016a0e53378f06d5e3abeefe6df"

--- a/Formula/chruby-fish.rb
+++ b/Formula/chruby-fish.rb
@@ -4,7 +4,7 @@ class ChrubyFish < Formula
   url "https://github.com/JeanMertz/chruby-fish/archive/v0.8.2.tar.gz"
   sha256 "e3726d39da219f5339f86302f7b5d7b62ca96570ddfcc3976595f1d62e3b34e1"
   license "MIT"
-  head "https://github.com/JeanMertz/chruby-fish.git"
+  head "https://github.com/JeanMertz/chruby-fish.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "9aa6835f1c13b8d9ab4bfcd0468825d0ae6edba016bdabc88b3ab0f2b521ec74"

--- a/Formula/chruby.rb
+++ b/Formula/chruby.rb
@@ -4,7 +4,7 @@ class Chruby < Formula
   url "https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz"
   sha256 "7220a96e355b8a613929881c091ca85ec809153988d7d691299e0a16806b42fd"
   license "MIT"
-  head "https://github.com/postmodern/chruby.git"
+  head "https://github.com/postmodern/chruby.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "97ca44a014def181a1bd3cacb5ff86783c6fddb1d1262336e9765d14a7d5959a"

--- a/Formula/chuck.rb
+++ b/Formula/chuck.rb
@@ -5,7 +5,7 @@ class Chuck < Formula
   mirror "http://chuck.stanford.edu/release/files/chuck-1.4.1.0.tgz"
   sha256 "74bf99ad515e3113c55b833152936fad02a3cf006a54105ff11777c473194928"
   license "GPL-2.0-or-later"
-  head "https://github.com/ccrma/chuck.git"
+  head "https://github.com/ccrma/chuck.git", branch: "main"
 
   livecheck do
     url "https://chuck.cs.princeton.edu/release/files/"

--- a/Formula/cig.rb
+++ b/Formula/cig.rb
@@ -4,7 +4,7 @@ class Cig < Formula
   url "https://github.com/stevenjack/cig/archive/v0.1.5.tar.gz"
   sha256 "545a4a8894e73c4152e0dcf5515239709537e0192629dc56257fe7cfc995da24"
   license "MIT"
-  head "https://github.com/stevenjack/cig.git"
+  head "https://github.com/stevenjack/cig.git", branch: "master"
 
   bottle do
     rebuild 3

--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -6,7 +6,7 @@ class Circleci < Formula
       tag:      "v0.1.15848",
       revision: "da3388b703500bb515aa29e67cce853ba5a5a111"
   license "MIT"
-  head "https://github.com/CircleCI-Public/circleci-cli.git"
+  head "https://github.com/CircleCI-Public/circleci-cli.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "923ce12d1bcf89d01620c440036ca17578ace6c286654b465eeef8a7c733eb62"

--- a/Formula/citus.rb
+++ b/Formula/citus.rb
@@ -4,7 +4,7 @@ class Citus < Formula
   url "https://github.com/citusdata/citus/archive/v10.1.2.tar.gz"
   sha256 "cade8cfb842bac1b7522ed92f668293a316d0d3a383cca27ed7e9ef16be641d6"
   license "AGPL-3.0-only"
-  head "https://github.com/citusdata/citus.git"
+  head "https://github.com/citusdata/citus.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "5366b3445216b125427ad8a3272510173467d39799ea6ee01db93fe9d52cd343"

--- a/Formula/cjdns.rb
+++ b/Formula/cjdns.rb
@@ -4,7 +4,7 @@ class Cjdns < Formula
   url "https://github.com/cjdelisle/cjdns/archive/cjdns-v21.1.tar.gz"
   sha256 "a6158ce7847159aa44e86f74ccc7b6ded6910a230ed8f3830db53cda5838f0b0"
   license all_of: ["GPL-3.0-or-later", "GPL-2.0-or-later", "BSD-3-Clause", "MIT"]
-  head "https://github.com/cjdelisle/cjdns.git"
+  head "https://github.com/cjdelisle/cjdns.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:  "b57d1c38866eab0c671732fdf70890fde76e7b03a2fc6a3dc59d5dea29e9fbaa"

--- a/Formula/clazy.rb
+++ b/Formula/clazy.rb
@@ -4,7 +4,7 @@ class Clazy < Formula
   url "https://download.kde.org/stable/clazy/1.10/src/clazy-1.10.tar.xz"
   sha256 "4ce6d55ffcddacdb005d847e0c329ade88a01e8e4f7590ffd2a9da367c1ba39d"
   license "LGPL-2.0-or-later"
-  head "https://invent.kde.org/sdk/clazy.git"
+  head "https://invent.kde.org/sdk/clazy.git", branch: "master"
 
   livecheck do
     url :head

--- a/Formula/clearlooks-phenix.rb
+++ b/Formula/clearlooks-phenix.rb
@@ -5,7 +5,7 @@ class ClearlooksPhenix < Formula
   sha256 "2a9b21400f9960422e31dc4dabb4f320a16b76776a9574f0986bb00e97d357f4"
   license "GPL-3.0"
   revision 1
-  head "https://github.com/jpfleury/clearlooks-phenix.git"
+  head "https://github.com/jpfleury/clearlooks-phenix.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "0b785c8577696a7fdaa9d1c8f1130e7653972d7b1a497d0ae37ebbf1cb79cf30"

--- a/Formula/cli11.rb
+++ b/Formula/cli11.rb
@@ -4,7 +4,7 @@ class Cli11 < Formula
   url "https://github.com/CLIUtils/CLI11/archive/v2.0.0.tar.gz"
   sha256 "2c672f17bf56e8e6223a3bfb74055a946fa7b1ff376510371902adb9cb0ab6a3"
   license "BSD-3-Clause"
-  head "https://github.com/CLIUtils/CLI11.git"
+  head "https://github.com/CLIUtils/CLI11.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "4dcc37a06d7c5bbb42aedacda62065c2006de9bbf471fab39a96526aef318da9"

--- a/Formula/clib.rb
+++ b/Formula/clib.rb
@@ -4,7 +4,7 @@ class Clib < Formula
   url "https://github.com/clibs/clib/archive/2.7.0.tar.gz"
   sha256 "99640506e1cf69d69451dc5d0db2d8fd169ff8247bda8c6d01dd66e9471ac6a0"
   license "MIT"
-  head "https://github.com/clibs/clib.git"
+  head "https://github.com/clibs/clib.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/click.rb
+++ b/Formula/click.rb
@@ -4,7 +4,7 @@ class Click < Formula
   url "https://github.com/databricks/click/archive/v0.5.4.tar.gz"
   sha256 "fa9b2cb3911ae8331217cafb941cdee52b09a27a58a5dccbdb52f408dc22f4f4"
   license "Apache-2.0"
-  head "https://github.com/databricks/click.git"
+  head "https://github.com/databricks/click.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:      "aa74cec2f0d6854791b46d54adbdb96bff085b67278629695f0ac266eef54717"

--- a/Formula/cliclick.rb
+++ b/Formula/cliclick.rb
@@ -4,7 +4,7 @@ class Cliclick < Formula
   url "https://github.com/BlueM/cliclick/archive/5.0.1.tar.gz"
   sha256 "798fb8b26f6a42b5002ca58e018b91f7677162c4f035b38aee8d905829db64a7"
   license "BSD-3-Clause"
-  head "https://github.com/BlueM/cliclick.git"
+  head "https://github.com/BlueM/cliclick.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "38bed03738e5b08fd7956b06168522bf50649b89d77f9db7f11ede0556c769f7"

--- a/Formula/clinfo.rb
+++ b/Formula/clinfo.rb
@@ -4,7 +4,7 @@ class Clinfo < Formula
   url "https://github.com/Oblomov/clinfo/archive/3.0.21.02.21.tar.gz"
   sha256 "e52f5c374a10364999d57a1be30219b47fb0b4f090e418f2ca19a0c037c1e694"
   license "CC0-1.0"
-  head "https://github.com/Oblomov/clinfo.git"
+  head "https://github.com/Oblomov/clinfo.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/cloc.rb
+++ b/Formula/cloc.rb
@@ -4,7 +4,7 @@ class Cloc < Formula
   url "https://github.com/AlDanial/cloc/archive/v1.90.tar.gz"
   sha256 "60b429dd2aa5cd65707b359dcbcbeb710c8e4db880886528ced0962c67e52548"
   license "GPL-2.0-or-later"
-  head "https://github.com/AlDanial/cloc.git"
+  head "https://github.com/AlDanial/cloc.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "83f761b258052b7cc8ef375d5b7affa4d17afc372833b09b20695a9168ac6b9f"

--- a/Formula/clojure-lsp.rb
+++ b/Formula/clojure-lsp.rb
@@ -6,7 +6,7 @@ class ClojureLsp < Formula
       revision: "226fa911d10d332a2b1df9201cc8565a3002f642"
   version "20210816T190230"
   license "MIT"
-  head "https://github.com/clojure-lsp/clojure-lsp.git"
+  head "https://github.com/clojure-lsp/clojure-lsp.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/clojurescript.rb
+++ b/Formula/clojurescript.rb
@@ -4,7 +4,7 @@ class Clojurescript < Formula
   url "https://github.com/clojure/clojurescript/releases/download/r1.10.866/cljs.jar"
   sha256 "a1b0e00934d6fe059d5a84f8f19879c702cdebb8a507799b921932354dcc020e"
   license "EPL-1.0"
-  head "https://github.com/clojure/clojurescript.git"
+  head "https://github.com/clojure/clojurescript.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/cloud-nuke.rb
+++ b/Formula/cloud-nuke.rb
@@ -4,7 +4,7 @@ class CloudNuke < Formula
   url "https://github.com/gruntwork-io/cloud-nuke/archive/v0.4.0.tar.gz"
   sha256 "18cc93a7245420ed86dedf5a604afea238e6bde953ea4e938b0c43939c59c5ab"
   license "MIT"
-  head "https://github.com/gruntwork-io/cloud-nuke.git"
+  head "https://github.com/gruntwork-io/cloud-nuke.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "8217bdcf73183837cbb9b9fb36ca20ea5f19954705d5d4dce76dd2b6b3579d3d"

--- a/Formula/clozure-cl.rb
+++ b/Formula/clozure-cl.rb
@@ -4,7 +4,7 @@ class ClozureCl < Formula
   url "https://github.com/Clozure/ccl/archive/v1.12.1.tar.gz"
   sha256 "bd005fdb24cee2f7b20077cbca5e9174c10a82d98013df5cc3eabc7f31ccd933"
   license "Apache-2.0"
-  head "https://github.com/Clozure/ccl.git"
+  head "https://github.com/Clozure/ccl.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/clucene.rb
+++ b/Formula/clucene.rb
@@ -3,7 +3,7 @@ class Clucene < Formula
   homepage "https://clucene.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/clucene/clucene-core-unstable/2.3/clucene-core-2.3.3.4.tar.gz"
   sha256 "ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab"
-  head "https://git.code.sf.net/p/clucene/code.git"
+  head "https://git.code.sf.net/p/clucene/code.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/clusterctl.rb
+++ b/Formula/clusterctl.rb
@@ -5,7 +5,7 @@ class Clusterctl < Formula
       tag:      "v0.4.1",
       revision: "f6fd5ed7dc0fa75788f76f17c64ae82976fcc70b"
   license "Apache-2.0"
-  head "https://github.com/kubernetes-sigs/cluster-api.git"
+  head "https://github.com/kubernetes-sigs/cluster-api.git", branch: "master"
 
   # Upstream creates releases on GitHub for the two most recent major/minor
   # versions (e.g., 0.3.x, 0.4.x), so the "latest" release can be incorrect. We

--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -4,7 +4,7 @@ class Cmake < Formula
   url "https://github.com/Kitware/CMake/releases/download/v3.21.1/cmake-3.21.1.tar.gz"
   sha256 "fac3915171d4dff25913975d712f76e69aef44bf738ba7b976793a458b4cfed4"
   license "BSD-3-Clause"
-  head "https://gitlab.kitware.com/cmake/cmake.git"
+  head "https://gitlab.kitware.com/cmake/cmake.git", branch: "master"
 
   # The "latest" release on GitHub has been an unstable version before, so we
   # check the Git tags instead.

--- a/Formula/cmigemo.rb
+++ b/Formula/cmigemo.rb
@@ -2,7 +2,7 @@ class Cmigemo < Formula
   desc "Migemo is a tool that supports Japanese incremental search with Romaji"
   homepage "https://www.kaoriya.net/software/cmigemo"
   license "MIT"
-  head "https://github.com/koron/cmigemo.git"
+  head "https://github.com/koron/cmigemo.git", branch: "master"
 
   stable do
     url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/cmigemo/cmigemo-default-src-20110227.zip"

--- a/Formula/cminpack.rb
+++ b/Formula/cminpack.rb
@@ -4,7 +4,7 @@ class Cminpack < Formula
   url "https://github.com/devernay/cminpack/archive/v1.3.8.tar.gz"
   sha256 "3ea7257914ad55eabc43a997b323ba0dfee0a9b010d648b6d5b0c96425102d0e"
   license "BSD-3-Clause"
-  head "https://github.com/devernay/cminpack.git"
+  head "https://github.com/devernay/cminpack.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "d508c68c13b468c31d533289722929544c43a01e3c24082d6a58b02fb8dd875d"

--- a/Formula/cmocka.rb
+++ b/Formula/cmocka.rb
@@ -4,7 +4,7 @@ class Cmocka < Formula
   url "https://cmocka.org/files/1.1/cmocka-1.1.5.tar.xz"
   sha256 "f0ccd8242d55e2fd74b16ba518359151f6f8383ff8aef4976e48393f77bba8b6"
   license "Apache-2.0"
-  head "https://git.cryptomilk.org/projects/cmocka.git"
+  head "https://git.cryptomilk.org/projects/cmocka.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "e2ed51c48c56006bb4b8591259eb206968e46457e78b15570c567d990b5f97d3"

--- a/Formula/cmockery2.rb
+++ b/Formula/cmockery2.rb
@@ -4,7 +4,7 @@ class Cmockery2 < Formula
   url "https://github.com/lpabon/cmockery2/archive/v1.3.9.tar.gz"
   sha256 "c38054768712351102024afdff037143b4392e1e313bdabb9380cab554f9dbf2"
   license "Apache-2.0"
-  head "https://github.com/lpabon/cmockery2.git"
+  head "https://github.com/lpabon/cmockery2.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/cmt.rb
+++ b/Formula/cmt.rb
@@ -5,7 +5,7 @@ class Cmt < Formula
   sha256 "364faaf5f44544f952b511be184a724e2011fba8f0f88fdfc05fef6985dd32f6"
   license "BSD-3-Clause"
   revision 1
-  head "https://github.com/smallhadroncollider/cmt.git"
+  head "https://github.com/smallhadroncollider/cmt.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -4,7 +4,7 @@ class Cmus < Formula
   url "https://github.com/cmus/cmus/archive/v2.9.1.tar.gz"
   sha256 "6fb799cae60db9324f03922bbb2e322107fd386ab429c0271996985294e2ef44"
   license "GPL-2.0-or-later"
-  head "https://github.com/cmus/cmus.git"
+  head "https://github.com/cmus/cmus.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "ecccaccd592e7f937d93e0baf6c839d022bfd0142fb4c1ba1fb737bc5320cb8d"

--- a/Formula/coccinelle.rb
+++ b/Formula/coccinelle.rb
@@ -6,7 +6,7 @@ class Coccinelle < Formula
       revision: "25e7cee77b4b6efbabf60ffaa8bccd72500ba8bd"
   license "GPL-2.0-only"
   revision 1
-  head "https://github.com/coccinelle/coccinelle.git"
+  head "https://github.com/coccinelle/coccinelle.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/cocot.rb
+++ b/Formula/cocot.rb
@@ -4,7 +4,7 @@ class Cocot < Formula
   url "https://github.com/vmi/cocot/archive/cocot-1.2-20171118.tar.gz"
   sha256 "b718630ce3ddf79624d7dcb625fc5a17944cbff0b76574d321fb80c61bb91e4c"
   license "BSD-3-Clause"
-  head "https://github.com/vmi/cocot.git"
+  head "https://github.com/vmi/cocot.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "835a54f7142add9b9a3ab35097a6821fc9c100568b54c2d7fa52c283fd5ca6af"

--- a/Formula/codemod.rb
+++ b/Formula/codemod.rb
@@ -8,7 +8,7 @@ class Codemod < Formula
   license "Apache-2.0"
   revision 4
   version_scheme 1
-  head "https://github.com/facebook/codemod.git"
+  head "https://github.com/facebook/codemod.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "cd163a10ae30dfc11ed64e45e746472360361c084339fb3c426fd97734cbf1c3"

--- a/Formula/coffeescript.rb
+++ b/Formula/coffeescript.rb
@@ -6,7 +6,7 @@ class Coffeescript < Formula
   url "https://registry.npmjs.org/coffeescript/-/coffeescript-2.5.1.tgz"
   sha256 "0ab43e873a859d323f2f5a0069a8bef3acfa72b09769be3350c9d43c5bb489a0"
   license "MIT"
-  head "https://github.com/jashkenas/coffeescript.git"
+  head "https://github.com/jashkenas/coffeescript.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "cfe10ba50bec4e20897d1d2ead0a21e8bfcd25841dae5e875e8c04a8cbfdd44f"

--- a/Formula/coinutils.rb
+++ b/Formula/coinutils.rb
@@ -5,7 +5,7 @@ class Coinutils < Formula
   sha256 "d4effff4452e73356eed9f889efd9c44fe9cd68bd37b608a5ebb2c58bd45ef81"
   license "EPL-1.0"
   revision 1
-  head "https://github.com/coin-or/CoinUtils.git"
+  head "https://github.com/coin-or/CoinUtils.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/collada-dom.rb
+++ b/Formula/collada-dom.rb
@@ -3,7 +3,7 @@ class ColladaDom < Formula
   homepage "https://www.khronos.org/collada/wiki/Portal:COLLADA_DOM"
   url "https://github.com/rdiankov/collada-dom/archive/v2.5.0.tar.gz"
   sha256 "3be672407a7aef60b64ce4b39704b32816b0b28f61ebffd4fbd02c8012901e0d"
-  head "https://github.com/rdiankov/collada-dom.git"
+  head "https://github.com/rdiankov/collada-dom.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "74fdb739480d5afe0a658201d2ac35bbcc3612ba67760072fd6f9984bac0de89"

--- a/Formula/colormake.rb
+++ b/Formula/colormake.rb
@@ -4,7 +4,7 @@ class Colormake < Formula
   url "https://github.com/pagekite/Colormake/archive/0.9.20140503.tar.gz"
   sha256 "a3f9fae9a455ac96be1cce0371b28bda33a9af73b06fa8e4329aa2f693d68d22"
   license "GPL-2.0"
-  head "https://github.com/pagekite/Colormake.git"
+  head "https://github.com/pagekite/Colormake.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "0022e24dd1386f086be55a80bdcd0b7de7c2871995a4980f18db436c69dc4c63"

--- a/Formula/commitizen.rb
+++ b/Formula/commitizen.rb
@@ -6,7 +6,7 @@ class Commitizen < Formula
   url "https://files.pythonhosted.org/packages/66/1f/2a25267d9b3c5052b3c52f256a40a318bf33069677e2268e364b8639560b/commitizen-2.18.0.tar.gz"
   sha256 "f24a22eb6734e1791046e817dff72505b515e9a1f282577a82423cf7563201d7"
   license "MIT"
-  head "https://github.com/commitizen-tools/commitizen.git"
+  head "https://github.com/commitizen-tools/commitizen.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "391c069b524a408ae1815f4f7b9dfc16e24e29d9854bdf8432364bc7ffdfaf98"

--- a/Formula/conan.rb
+++ b/Formula/conan.rb
@@ -6,7 +6,7 @@ class Conan < Formula
   url "https://files.pythonhosted.org/packages/9e/60/e602099325468128a8826cc881aefeee9866f70df3a0e9c88488e80547f5/conan-1.39.0.tar.gz"
   sha256 "7f1fa90578f84d5801e53cce6aa7c98ed97a99fb2b38b3f12a5d9784722340e0"
   license "MIT"
-  head "https://github.com/conan-io/conan.git"
+  head "https://github.com/conan-io/conan.git", branch: "develop"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b956a0bbec27743cbfd39bf9c2eb8f20f945d978a1d35a5bb1de0441e51839ff"

--- a/Formula/concurrencykit.rb
+++ b/Formula/concurrencykit.rb
@@ -4,7 +4,7 @@ class Concurrencykit < Formula
   url "https://github.com/concurrencykit/ck/archive/0.7.0.tar.gz"
   sha256 "e730cb448fb0ecf9d19bf4c7efe9efc3c04dd9127311d87d8f91484742b0da24"
   license "BSD-2-Clause"
-  head "https://github.com/concurrencykit/ck.git"
+  head "https://github.com/concurrencykit/ck.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "fad8ab6678349a6ae3a81ba7a8264591868f8c180c867f06ad98cb422d9627bf"

--- a/Formula/confd.rb
+++ b/Formula/confd.rb
@@ -4,7 +4,7 @@ class Confd < Formula
   url "https://github.com/kelseyhightower/confd/archive/v0.16.0.tar.gz"
   sha256 "4a6c4d87fab77aa9827370541024a365aa6b4c8c25a3a9cab52f95ba6b9a97ea"
   license "MIT"
-  head "https://github.com/kelseyhightower/confd.git"
+  head "https://github.com/kelseyhightower/confd.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f2eb5cdb05b9f92b2472331857765f5b4922183d4cde23e61c44d7bb3d080dfe"

--- a/Formula/configen.rb
+++ b/Formula/configen.rb
@@ -4,7 +4,7 @@ class Configen < Formula
   url "https://github.com/theappbusiness/ConfigGenerator/archive/1.1.2.tar.gz"
   sha256 "24a0d51f90b36d56c2f75ced9653cf34fe396fd687305903b31eeb822d520608"
   license "MIT"
-  head "https://github.com/theappbusiness/ConfigGenerator.git"
+  head "https://github.com/theappbusiness/ConfigGenerator.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d7aa87ea082759093c1192bf7e0ee69c1146ef4626534731ff506a83ec682641"

--- a/Formula/conftest.rb
+++ b/Formula/conftest.rb
@@ -4,7 +4,7 @@ class Conftest < Formula
   url "https://github.com/open-policy-agent/conftest/archive/v0.27.0.tar.gz"
   sha256 "b1a38065a1de5208ed72250b257149e21e3381423e6e3028adb214fd4380f3ef"
   license "Apache-2.0"
-  head "https://github.com/open-policy-agent/conftest.git"
+  head "https://github.com/open-policy-agent/conftest.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "854edb50cb872782f0aba919f067158ae5a36c068c2ae55b70afd65cf7376988"

--- a/Formula/connect.rb
+++ b/Formula/connect.rb
@@ -4,7 +4,7 @@ class Connect < Formula
   url "https://github.com/gotoh/ssh-connect/archive/1.105.tar.gz"
   sha256 "96c50fefe7ecf015cf64ba6cec9e421ffd3b18fef809f59961ef9229df528f3e"
   license "GPL-2.0-or-later"
-  head "https://github.com/gotoh/ssh-connect.git"
+  head "https://github.com/gotoh/ssh-connect.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/consul-backinator.rb
+++ b/Formula/consul-backinator.rb
@@ -4,7 +4,7 @@ class ConsulBackinator < Formula
   url "https://github.com/myENA/consul-backinator/archive/v1.6.6.tar.gz"
   sha256 "b668801ca648ecf888687d7aa69d84c3f2c862f31b92076c443fdea77c984c58"
   license "MPL-2.0"
-  head "https://github.com/myENA/consul-backinator.git"
+  head "https://github.com/myENA/consul-backinator.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "579fbf5bed18b1db8efc3d97621580316dc3d2d903fe085be3cd3dbd3ef72930"

--- a/Formula/consul-template.rb
+++ b/Formula/consul-template.rb
@@ -5,7 +5,7 @@ class ConsulTemplate < Formula
       tag:      "v0.27.0",
       revision: "d4af0222e8853b1ae1435cadf0b819651a6f149b"
   license "MPL-2.0"
-  head "https://github.com/hashicorp/consul-template.git"
+  head "https://github.com/hashicorp/consul-template.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "954a0becbeafa3a6e0811ee83b749e9711f41302125713484edc3692e5b32449"

--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -4,7 +4,7 @@ class Consul < Formula
   url "https://github.com/hashicorp/consul/archive/refs/tags/v1.10.1.tar.gz"
   sha256 "c840ba7b52df3ec6105a7febe900e52dde504a33bd1fa4e2e1985a88b6072d41"
   license "MPL-2.0"
-  head "https://github.com/hashicorp/consul.git"
+  head "https://github.com/hashicorp/consul.git", branch: "main"
 
   livecheck do
     url :stable

--- a/Formula/container-structure-test.rb
+++ b/Formula/container-structure-test.rb
@@ -4,7 +4,7 @@ class ContainerStructureTest < Formula
   url "https://github.com/GoogleContainerTools/container-structure-test/archive/v1.10.0.tar.gz"
   sha256 "52ba2ff4e948c6740da6da8804aeb674cf631e4d470ae5d78af07f17ba0ecbec"
   license "Apache-2.0"
-  head "https://github.com/GoogleContainerTools/container-structure-test.git"
+  head "https://github.com/GoogleContainerTools/container-structure-test.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "91fcb7cb88abaa849aa25cbf4a6f1d4d7115fd214f80f16e4a0cdb8e38c04e23"

--- a/Formula/contentful-cli.rb
+++ b/Formula/contentful-cli.rb
@@ -6,7 +6,7 @@ class ContentfulCli < Formula
   url "https://registry.npmjs.org/contentful-cli/-/contentful-cli-1.8.20.tgz"
   sha256 "857f353743e58db8d2e8168ee3b75ad005f737102cdbca41214d5efd95409290"
   license "MIT"
-  head "https://github.com/contentful/contentful-cli.git"
+  head "https://github.com/contentful/contentful-cli.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "4765a6bf58c944bbfccbd35f355654ec1b182fbb7963be60de145e4590f4881e"

--- a/Formula/cookiecutter.rb
+++ b/Formula/cookiecutter.rb
@@ -6,7 +6,7 @@ class Cookiecutter < Formula
   url "https://files.pythonhosted.org/packages/58/f5/6f41fa38e6efe4a0e85771f99a4ad8c33b4c14f03b4cc53b459aac4a629a/cookiecutter-1.7.3.tar.gz"
   sha256 "6b9a4d72882e243be077a7397d0f1f76fe66cf3df91f3115dbb5330e214fa457"
   license "BSD-3-Clause"
-  head "https://github.com/cookiecutter/cookiecutter.git"
+  head "https://github.com/cookiecutter/cookiecutter.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "48c4107866f0afcb5084b0da38170546238c59776cb9d313b7a88de73852a0f0"

--- a/Formula/copilot.rb
+++ b/Formula/copilot.rb
@@ -7,7 +7,7 @@ class Copilot < Formula
       tag:      "v1.9.0",
       revision: "8fb57aca1cd7a355bbdf1b8a5c5fc590b40649f5"
   license "Apache-2.0"
-  head "https://github.com/aws/copilot-cli.git"
+  head "https://github.com/aws/copilot-cli.git", branch: "mainline"
 
   livecheck do
     url :stable

--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -4,7 +4,7 @@ class Coq < Formula
   url "https://github.com/coq/coq/archive/V8.13.2.tar.gz"
   sha256 "1e7793d8483f1e939f62df6749f843df967a15d843a4a5acb024904b76e25a14"
   license "LGPL-2.1-only"
-  head "https://github.com/coq/coq.git"
+  head "https://github.com/coq/coq.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/coredns.rb
+++ b/Formula/coredns.rb
@@ -4,7 +4,7 @@ class Coredns < Formula
   url "https://github.com/coredns/coredns/archive/v1.8.4.tar.gz"
   sha256 "d85c8c52f4d38ab1915eb60523b4e5241ffa19d20e4f7bbce8b0f4fb59171f2a"
   license "Apache-2.0"
-  head "https://github.com/coredns/coredns.git"
+  head "https://github.com/coredns/coredns.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/corral.rb
+++ b/Formula/corral.rb
@@ -4,7 +4,7 @@ class Corral < Formula
   url "https://github.com/ponylang/corral/archive/0.5.3.tar.gz"
   sha256 "caee35ca820201c13b87e11224ede472d1ed9798985d17eee8c46b14711f7d07"
   license "BSD-2-Clause"
-  head "https://github.com/ponylang/corral.git"
+  head "https://github.com/ponylang/corral.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:      "8bf55316637ccd844945fb01255fd17adc6c32450468ce0f4fa6419c3fb721d7"

--- a/Formula/corsixth.rb
+++ b/Formula/corsixth.rb
@@ -4,7 +4,7 @@ class Corsixth < Formula
   url "https://github.com/CorsixTH/CorsixTH/archive/v0.65.1.tar.gz"
   sha256 "b8a1503371fa0c0f3d07d3b39a3de2769b8ed25923d0d931b7075bc88e3f508f"
   license "MIT"
-  head "https://github.com/CorsixTH/CorsixTH.git"
+  head "https://github.com/CorsixTH/CorsixTH.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "85159ab0c32c43fbe98e88181abd47c941acec95b5760646237d350f18ac403a"

--- a/Formula/couchpotatoserver.rb
+++ b/Formula/couchpotatoserver.rb
@@ -4,7 +4,7 @@ class Couchpotatoserver < Formula
   url "https://github.com/CouchPotato/CouchPotatoServer/archive/build/3.0.1.tar.gz"
   sha256 "f08f9c6ac02f66c6667f17ded1eea4c051a62bbcbadd2a8673394019878e92f7"
   license "GPL-3.0"
-  head "https://github.com/CouchPotato/CouchPotatoServer.git"
+  head "https://github.com/CouchPotato/CouchPotatoServer.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/counterfeiter.rb
+++ b/Formula/counterfeiter.rb
@@ -4,7 +4,7 @@ class Counterfeiter < Formula
   url "https://github.com/maxbrunsfeld/counterfeiter/archive/v6.4.1.tar.gz"
   sha256 "bd51c80ad44881ae2008e50540fcb95a3f8e84104ee230aee86acf78c2c24bf6"
   license "MIT"
-  head "https://github.com/maxbrunsfeld/counterfeiter.git"
+  head "https://github.com/maxbrunsfeld/counterfeiter.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "9cdad6769afe63f7dfdaaac7758e0bf6cc5d8265a4ab274d2f008b36ee201eb0"

--- a/Formula/cpanminus.rb
+++ b/Formula/cpanminus.rb
@@ -5,7 +5,7 @@ class Cpanminus < Formula
   sha256 "d0a37547a3c4b6dbd3806e194cd6cf4632158ebed44d740ac023e0739538fb46"
   # dual licensed same as perl (GPL-1.0 or Artistic-1.0)
   license "GPL-1.0"
-  head "https://github.com/miyagawa/cpanminus.git"
+  head "https://github.com/miyagawa/cpanminus.git", branch: "devel"
 
   livecheck do
     url :stable

--- a/Formula/cpansearch.rb
+++ b/Formula/cpansearch.rb
@@ -4,7 +4,7 @@ class Cpansearch < Formula
   url "https://github.com/c9s/cpansearch/archive/0.2.tar.gz"
   sha256 "09e631f361766fcacd608a0f5b3effe7b66b3a9e0970a458d418d58b8f3f2a74"
   revision 1
-  head "https://github.com/c9s/cpansearch.git"
+  head "https://github.com/c9s/cpansearch.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "37c73b9a5acde5677d8cb3d423c671eba4f0fae0e01fd057789c20184b033a54"

--- a/Formula/cpm.rb
+++ b/Formula/cpm.rb
@@ -4,7 +4,7 @@ class Cpm < Formula
   url "https://cpan.metacpan.org/authors/id/S/SK/SKAJI/App-cpm-0.997006.tar.gz"
   sha256 "3a5198daddf0f3c87834a3630bd11cf5ff314aa222c7dd36806ce140c25b04d6"
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
-  head "https://github.com/skaji/cpm.git"
+  head "https://github.com/skaji/cpm.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "8ae7304a9f908a3a623b0d5ae9abd756eb6c04874be680059f693d051411642d"

--- a/Formula/cpp-gsl.rb
+++ b/Formula/cpp-gsl.rb
@@ -4,7 +4,7 @@ class CppGsl < Formula
   url "https://github.com/Microsoft/GSL/archive/v3.1.0.tar.gz"
   sha256 "d3234d7f94cea4389e3ca70619b82e8fb4c2f33bb3a070799f1e18eef500a083"
   license "MIT"
-  head "https://github.com/Microsoft/GSL.git"
+  head "https://github.com/Microsoft/GSL.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "1fe9e903b18a03aa61226caafb7109b2c7f638b0e4d510c64c4911b2566b855a"

--- a/Formula/cppad.rb
+++ b/Formula/cppad.rb
@@ -6,7 +6,7 @@ class Cppad < Formula
   sha256 "271e13fd94dd618b8a55113a1c0c441ea7f3fcf06499841773c0c81a6bee960b"
   license "EPL-2.0"
   version_scheme 1
-  head "https://github.com/coin-or/CppAD.git"
+  head "https://github.com/coin-or/CppAD.git", branch: "master"
 
   livecheck do
     url :stable

--- a/Formula/cppcheck.rb
+++ b/Formula/cppcheck.rb
@@ -5,7 +5,7 @@ class Cppcheck < Formula
   sha256 "dc27154d799935c96903dcc46653c526c6f4148a6912b77d3a50cb35dabd82e1"
   license "GPL-3.0-or-later"
   revision 1
-  head "https://github.com/danmar/cppcheck.git"
+  head "https://github.com/danmar/cppcheck.git", branch: "main"
 
   bottle do
     sha256 arm64_big_sur: "7a9b2837b94a6ac5517dd8b4b204b940fff42e5b7d98fcfa3fe2f7ea5d3a7d45"

--- a/Formula/cpputest.rb
+++ b/Formula/cpputest.rb
@@ -4,7 +4,7 @@ class Cpputest < Formula
   url "https://github.com/cpputest/cpputest/releases/download/v4.0/cpputest-4.0.tar.gz"
   sha256 "21c692105db15299b5529af81a11a7ad80397f92c122bd7bf1e4a4b0e85654f7"
   license "BSD-3-Clause"
-  head "https://github.com/cpputest/cpputest.git"
+  head "https://github.com/cpputest/cpputest.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/cpr.rb
+++ b/Formula/cpr.rb
@@ -5,7 +5,7 @@ class Cpr < Formula
       tag:      "1.6.2",
       revision: "f4622efcb59d84071ae11404ae61bd821c1c344b"
   license "MIT"
-  head "https://github.com/whoshuu/cpr.git"
+  head "https://github.com/whoshuu/cpr.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "6b725644e68fd8fd18ee1624248de28bff8e0c206d566852a4821714fed3099e"

--- a/Formula/cpulimit.rb
+++ b/Formula/cpulimit.rb
@@ -4,7 +4,7 @@ class Cpulimit < Formula
   url "https://github.com/opsengine/cpulimit/archive/v0.2.tar.gz"
   sha256 "64312f9ac569ddcadb615593cd002c94b76e93a0d4625d3ce1abb49e08e2c2da"
   license "GPL-2.0"
-  head "https://github.com/opsengine/cpulimit.git"
+  head "https://github.com/opsengine/cpulimit.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f09919436a14d7b1598720ca832435b2500aebe0839f5055a253f52c59642a5d"

--- a/Formula/cql.rb
+++ b/Formula/cql.rb
@@ -4,7 +4,7 @@ class Cql < Formula
   url "https://github.com/CovenantSQL/CovenantSQL/archive/v0.8.1.tar.gz"
   sha256 "73abb65106e5045208aa4a7cda56bc7c17ba377557ae47d60dad39a63f9c88a6"
   license "Apache-2.0"
-  head "https://github.com/CovenantSQL/CovenantSQL.git"
+  head "https://github.com/CovenantSQL/CovenantSQL.git", branch: "develop"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "74a8c72f8d73c53ca3dbfcc443cf4319a9c5b590de766acb53f618063454bafa"

--- a/Formula/cquery.rb
+++ b/Formula/cquery.rb
@@ -6,7 +6,7 @@ class Cquery < Formula
       tag:      "v20180718",
       revision: "b523aa928acf8ffb3de6b22c79db7366a9672489"
   license "MIT"
-  head "https://github.com/cquery-project/cquery.git"
+  head "https://github.com/cquery-project/cquery.git", branch: "master"
 
   bottle do
     rebuild 1

--- a/Formula/crc32c.rb
+++ b/Formula/crc32c.rb
@@ -4,7 +4,7 @@ class Crc32c < Formula
   url "https://github.com/google/crc32c/archive/1.1.1.tar.gz"
   sha256 "a6533f45b1670b5d59b38a514d82b09c6fb70cc1050467220216335e873074e8"
   license "BSD-3-Clause"
-  head "https://github.com/google/crc32c.git"
+  head "https://github.com/google/crc32c.git", branch: "main"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "82e70741895a3e29dc0f8e48b0dd10e13e8cd380012457c1bf984ace3fd6dd03"

--- a/Formula/crcany.rb
+++ b/Formula/crcany.rb
@@ -4,7 +4,7 @@ class Crcany < Formula
   url "https://github.com/madler/crcany/archive/v2.0.tar.gz"
   sha256 "33dbe92f05a0cd9b9e133d0a6f864793d96c5c6055845e0f7220bdf3372aa5bf"
   license "Zlib"
-  head "https://github.com/madler/crcany.git"
+  head "https://github.com/madler/crcany.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "6fae645339969bae0ce4cc2af169508a6ace50ccea0c5062ad67706ae573f0ae"

--- a/Formula/credstash.rb
+++ b/Formula/credstash.rb
@@ -7,7 +7,7 @@ class Credstash < Formula
   sha256 "6c04e8734ef556ab459018da142dd0b244093ef176b3be5583e582e9a797a120"
   license "Apache-2.0"
   revision 3
-  head "https://github.com/fugue/credstash.git"
+  head "https://github.com/fugue/credstash.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "7e4514215fac5cf99ec2ba21cc03b842b8bd3d2e8a8524652ef81a5e166bef72"

--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -5,7 +5,7 @@ class Creduce < Formula
   sha256 "db1c0f123967f24d620b040cebd53001bf3dcf03e400f78556a2ff2e11fea063"
   license "BSD-3-Clause"
   revision 2
-  head "https://github.com/csmith-project/creduce.git"
+  head "https://github.com/csmith-project/creduce.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/crf++.rb
+++ b/Formula/crf++.rb
@@ -5,7 +5,7 @@ class Crfxx < Formula
   mirror "https://drive.google.com/uc?id=0B4y35FiV1wh7QVR6VXJ5dWExSTQ&export=download"
   sha256 "9d1c0a994f25a5025cede5e1d3a687ec98cd4949bfb2aae13f2a873a13259cb2"
   license any_of: ["LGPL-2.1-only", "BSD-3-Clause"]
-  head "https://github.com/taku910/crfpp.git"
+  head "https://github.com/taku910/crfpp.git", branch: "master"
 
   # Archive files from upstream are hosted on Google Drive, so we can't identify
   # versions from the tarballs, as the links on the homepage don't include this

--- a/Formula/crispy-doom.rb
+++ b/Formula/crispy-doom.rb
@@ -5,7 +5,7 @@ class CrispyDoom < Formula
   sha256 "eef8dc26e8952b23717be3b20239fda4ee59842511328387766d1c8fe8252f6b"
   license "GPL-2.0-only"
 
-  head "https://github.com/fabiangreffrath/crispy-doom"
+  head "https://github.com/fabiangreffrath/crispy-doom", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "6d9000bd5ee7e800eecf8748c419ea4f8d42dc1e5c78ec5e49e91ab095e34895"

--- a/Formula/croaring.rb
+++ b/Formula/croaring.rb
@@ -4,7 +4,7 @@ class Croaring < Formula
   url "https://github.com/RoaringBitmap/CRoaring/archive/v0.3.4.tar.gz"
   sha256 "ddc5899823c46707d7dbf4e4c117a811b0428bdcb84978d9e65ceaefe6f59595"
   license "Apache-2.0"
-  head "https://github.com/RoaringBitmap/CRoaring.git"
+  head "https://github.com/RoaringBitmap/CRoaring.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "48c13771996920e1fe157a567214cad04e6c2203924abbe3edad98ff508f59c0"

--- a/Formula/croc.rb
+++ b/Formula/croc.rb
@@ -4,7 +4,7 @@ class Croc < Formula
   url "https://github.com/schollz/croc/archive/v9.3.0.tar.gz"
   sha256 "a55153b4b13aae2986e4fe3e5f652228a83835bf27651e83a71750f4942c612d"
   license "MIT"
-  head "https://github.com/schollz/croc.git"
+  head "https://github.com/schollz/croc.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "8256fb33e8e47a4fbe901afc8b9282af3aa1620f810ce29b2687f233917f2608"

--- a/Formula/crosstool-ng.rb
+++ b/Formula/crosstool-ng.rb
@@ -5,7 +5,7 @@ class CrosstoolNg < Formula
   sha256 "804ced838ea7fe3fac1e82f0061269de940c82b05d0de672e7d424af98f22d2d"
   license "GPL-2.0-only"
   revision 2
-  head "https://github.com/crosstool-ng/crosstool-ng.git"
+  head "https://github.com/crosstool-ng/crosstool-ng.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "6b511659323ff03bd405c20e8591cacb55dbb081fe8f2416666228d9ed4cf1a8"

--- a/Formula/cryptol.rb
+++ b/Formula/cryptol.rb
@@ -4,7 +4,7 @@ class Cryptol < Formula
   url "https://hackage.haskell.org/package/cryptol-2.11.0/cryptol-2.11.0.tar.gz"
   sha256 "43b7535f5cb792efccddbb3f4c09bd2e922777d19a6537cb3aa27adf69280716"
   license "BSD-3-Clause"
-  head "https://github.com/GaloisInc/cryptol.git"
+  head "https://github.com/GaloisInc/cryptol.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:      "7864c5659f35ee68c4c84683362063dfb2efd8c143b0bb507fbfc3f67661af87"

--- a/Formula/csfml.rb
+++ b/Formula/csfml.rb
@@ -5,7 +5,7 @@ class Csfml < Formula
   url "https://github.com/SFML/CSFML/archive/2.5.1.tar.gz"
   sha256 "0c6693805b700c53552565149405a041a00dbe898c2efb828e91999ab8b6b1d4"
   license "Zlib"
-  head "https://github.com/SFML/CSFML.git"
+  head "https://github.com/SFML/CSFML.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "d2021fddf559448c443461ccfab70aaeb69c6067599404bb181dc1b979c0c0ea"

--- a/Formula/csmith.rb
+++ b/Formula/csmith.rb
@@ -4,7 +4,7 @@ class Csmith < Formula
   url "https://embed.cs.utah.edu/csmith/csmith-2.3.0.tar.gz"
   sha256 "f247cc0aede5f8a0746271b40a5092b5b5a2d034e5e8f7a836c879dde3fb65d5"
   license "BSD-2-Clause"
-  head "https://github.com/csmith-project/csmith.git"
+  head "https://github.com/csmith-project/csmith.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "79b39e5332514e816d46c871b31a283e9d16adc4d39f2b5177c3569ce2508c4a"

--- a/Formula/css-crush.rb
+++ b/Formula/css-crush.rb
@@ -4,7 +4,7 @@ class CssCrush < Formula
   url "https://github.com/peteboere/css-crush/archive/v3.0.1.tar.gz"
   sha256 "6f24a857b496edccc2eaf261a6f34d64ae1dc2c288304df8dd4fcddb905d89d8"
   license "MIT"
-  head "https://github.com/peteboere/css-crush.git"
+  head "https://github.com/peteboere/css-crush.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "06eec82e0757d06c7780b1695c31946d52e02e17af3566434023ac8262ddc28b"

--- a/Formula/csshx.rb
+++ b/Formula/csshx.rb
@@ -6,7 +6,7 @@ class Csshx < Formula
   sha256 "eaa9e52727c8b28dedc87398ed33ffa2340d6d0f3ea9d261749c715cb7a0e9c8"
   # same terms as Perl
   license "GPL-1.0"
-  head "https://github.com/brockgr/csshx.git"
+  head "https://github.com/brockgr/csshx.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "d073f3e8d11762fe8b72a3110d88a031b8f19c671f400827b68bba2adfb8b4ae"

--- a/Formula/ctemplate.rb
+++ b/Formula/ctemplate.rb
@@ -5,7 +5,7 @@ class Ctemplate < Formula
   sha256 "ccc4105b3dc51c82b0f194499979be22d5a14504f741115be155bd991ee93cfa"
   license "BSD-3-Clause"
   revision 1
-  head "https://github.com/olafvdspek/ctemplate.git"
+  head "https://github.com/olafvdspek/ctemplate.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "3ef5f869569f3f4034fb55f1d15ceca68da21a01ff5c9e30d5b941addecf91db"

--- a/Formula/cubeb.rb
+++ b/Formula/cubeb.rb
@@ -4,7 +4,7 @@ class Cubeb < Formula
   url "https://github.com/kinetiknz/cubeb/archive/cubeb-0.2.tar.gz"
   sha256 "cac10876da4fa3b3d2879e0c658d09e8a258734562198301d99c1e8228e66907"
   license "ISC"
-  head "https://github.com/kinetiknz/cubeb.git"
+  head "https://github.com/kinetiknz/cubeb.git", branch: "master"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "e56366a9d51f95c573e9bcc0a7f8985e4607cf88a9e6a87c0f2193a363c18a93"

--- a/Formula/cuetools.rb
+++ b/Formula/cuetools.rb
@@ -4,7 +4,7 @@ class Cuetools < Formula
   url "https://github.com/svend/cuetools/archive/1.4.1.tar.gz"
   sha256 "24a2420f100c69a6539a9feeb4130d19532f9f8a0428a8b9b289c6da761eb107"
   license "GPL-2.0"
-  head "https://github.com/svend/cuetools.git"
+  head "https://github.com/svend/cuetools.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d6065775e7e6286464caa093613104c747720e1b9ea98f29f71abea5a365ac05"

--- a/Formula/cups.rb
+++ b/Formula/cups.rb
@@ -6,7 +6,7 @@ class Cups < Formula
   # https://lists.debian.org/debian-printing/2020/12/msg00006.html
   sha256 "deb3575bbe79c0ae963402787f265bfcf8d804a71fc2c94318a74efec86f96df"
   license "Apache-2.0"
-  head "https://github.com/OpenPrinting/cups.git"
+  head "https://github.com/OpenPrinting/cups.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "ac83d0ea52bebcdb2eff93c6ccbaf29c14369a7d2643bf3a85780ed34c13e0a4"

--- a/Formula/curaengine.rb
+++ b/Formula/curaengine.rb
@@ -5,7 +5,7 @@ class Curaengine < Formula
   sha256 "bbc931251c89f68b8670cd0e5a06b81fde99a5e440bdbfe0e7efc3a749642157"
   license "AGPL-3.0-or-later"
   version_scheme 1
-  head "https://github.com/Ultimaker/CuraEngine.git"
+  head "https://github.com/Ultimaker/CuraEngine.git", branch: "master"
 
   # Releases like xx.xx or xx.xx.x are older than releases like x.x.x, so we
   # work around this less-than-ideal situation by restricting the major version

--- a/Formula/curseofwar.rb
+++ b/Formula/curseofwar.rb
@@ -4,7 +4,7 @@ class Curseofwar < Formula
   url "https://github.com/a-nikolaev/curseofwar/archive/v1.3.0.tar.gz"
   sha256 "2a90204d95a9f29a0e5923f43e65188209dc8be9d9eb93576404e3f79b8a652b"
   license "GPL-3.0"
-  head "https://github.com/a-nikolaev/curseofwar.git"
+  head "https://github.com/a-nikolaev/curseofwar.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "ebc08cc6d912fdb3df613a397b1ac467e910a280fc2a4955971d53bb7555045b"

--- a/Formula/cutter.rb
+++ b/Formula/cutter.rb
@@ -4,7 +4,7 @@ class Cutter < Formula
   url "https://osdn.mirror.constant.com/cutter/73761/cutter-1.2.8.tar.gz"
   sha256 "bd5fcd6486855e48d51f893a1526e3363f9b2a03bac9fc23c157001447bc2a23"
   license "LGPL-3.0"
-  head "https://github.com/clear-code/cutter.git"
+  head "https://github.com/clear-code/cutter.git", branch: "master"
 
   bottle do
     sha256 arm64_big_sur: "ac45c9987b4d770856db1f5e2c8fc20fb1ed882297c22691fe29fb153f7b9828"

--- a/Formula/cxxopts.rb
+++ b/Formula/cxxopts.rb
@@ -4,7 +4,7 @@ class Cxxopts < Formula
   url "https://github.com/jarro2783/cxxopts/archive/v2.2.1.tar.gz"
   sha256 "984aa3c8917d649b14d7f6277104ce38dd142ce378a9198ec926f03302399681"
   license "MIT"
-  head "https://github.com/jarro2783/cxxopts.git"
+  head "https://github.com/jarro2783/cxxopts.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "dffc57a1cc6de42f042163c6d44e42e24a778bd1cdf7f7e45e96f9b07b64880c"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds `head` branch information to `c*` formulae with `head` URLs of the form `head "<URL>"` (and where a branch wasn't already specified). Changes were made using a script that is similar to the audit added in Homebrew/brew#11720.