### PR TITLE
spice-protocol: fix test for Linux

### DIFF
--- a/Formula/spice-protocol.rb
+++ b/Formula/spice-protocol.rb
@@ -21,6 +21,11 @@ class SpiceProtocol < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
 
+  on_linux do
+    # Test fails on gcc-5: spice/macros.h:68:32: error: expected '}' before '__attribute__'
+    depends_on "gcc" => :test
+  end
+
   def install
     mkdir "build" do
       system "meson", *std_meson_args, "-Dwith-docs=false", ".."
@@ -36,9 +41,13 @@ class SpiceProtocol < Formula
         return (SPICE_LINK_ERR_OK == 0) ? 0 : 1;
       }
     EOS
-    system ENV.cc, "test.cpp",
-                   "-I#{include}/spice-1",
-                   "-o", "test"
+
+    cc = ENV.cc
+    on_linux do
+      cc = Formula["gcc"].opt_bin/"gcc-#{Formula["gcc"].any_installed_version.major}"
+    end
+
+    system cc, "test.cpp", "-I#{include}/spice-1", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3378459430?check_suite_focus=true#step:8:55
```
==> brew test --verbose spice-protocol
==> FAILED
==> Testing spice-protocol
==> /usr/bin/gcc-5 test.cpp -I/home/linuxbrew/.linuxbrew/Cellar/spice-protocol/0.14.3/include/spice-1 -o test
In file included from /home/linuxbrew/.linuxbrew/Cellar/spice-protocol/0.14.3/include/spice-1/spice/enums.h:35:0,
                 from /home/linuxbrew/.linuxbrew/Cellar/spice-protocol/0.14.3/include/spice-1/spice/protocol.h:35,
                 from test.cpp:1:
/home/linuxbrew/.linuxbrew/Cellar/spice-protocol/0.14.3/include/spice-1/spice/macros.h:68:32: error: expected ‘}’ before ‘__attribute__’
 #define SPICE_GNUC_DEPRECATED  __attribute__((__deprecated__))
                                ^
/home/linuxbrew/.linuxbrew/Cellar/spice-protocol/0.14.3/include/spice-1/spice/enums.h:380:38: note: in expansion of macro ‘SPICE_GNUC_DEPRECATED’
     SPICE_AUDIO_DATA_MODE_CELT_0_5_1 SPICE_GNUC_DEPRECATED,
                                      ^

```