### PR TITLE
thrift@0.9: fix build for Linux

### DIFF
--- a/Formula/thrift@0.9.rb
+++ b/Formula/thrift@0.9.rb
@@ -23,6 +23,8 @@ class ThriftAT09 < Formula
   depends_on "boost"
   depends_on "openssl@1.1"
 
+  uses_from_macos "flex" => :build
+
   # Fix CRYPTO_num_locks compile error
   patch do
     url "https://github.com/apache/thrift/commit/4bbfe6120e71b81df7f23dcc246990c29eb27859.patch?full_index=1"
@@ -45,7 +47,8 @@ class ThriftAT09 < Formula
       --without-php_extension
       --without-python
       --without-ruby
-      --without-tests
+      --disable-tests
+      --disable-tutorial
     ]
 
     ENV.cxx11 if ENV.compiler == :clang
@@ -60,10 +63,7 @@ class ThriftAT09 < Formula
     # We need to regenerate the configure script since it doesn't have all the changes.
     system "./bootstrap.sh"
 
-    system "./configure", "--disable-debug",
-                          "--prefix=#{prefix}",
-                          "--libdir=#{lib}",
-                          *args
+    system "./configure", *std_configure_args, *args
     ENV.deparallelize
     system "make", "install"
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3094523729?check_suite_focus=true
```
x/bin/bash ../../ylwrap src/thriftl.ll .c src/thriftl.cc -- /bin/bash '/tmp/thriftA0.9-20210717-5245-11ds030/thrift-0.9.3.1/missing' flex  
/tmp/thriftA0.9-20210717-5245-11ds030/thrift-0.9.3.1/missing: line 81: flex: command not found
WARNING: 'flex' is missing on your system.
         You should only need it if you modified a '.l' file.
         You may want to install the Fast Lexical Analyzer package:
         <https://github.com/westes/flex>
Makefile:1434: recipe for target 'src/thriftl.cc' failed
make[2]: *** [src/thriftl.cc] Error 127
make[2]: Leaving directory '/tmp/thriftA0.9-20210717-5245-11ds030/thrift-0.9.3.1/compiler/cpp'
Makefile:1540: recipe for target 'install' failed
make[1]: *** [install] Error 2
make[1]: Leaving directory '/tmp/thriftA0.9-20210717-5245-11ds030/thrift-0.9.3.1/compiler/cpp'
```
