### PR TITLE
helmfile 0.140.0 republish

### DIFF
--- a/Formula/helmfile.rb
+++ b/Formula/helmfile.rb
@@ -2,7 +2,7 @@ class Helmfile < Formula
   desc "Deploy Kubernetes Helm Charts"
   homepage "https://github.com/roboll/helmfile"
   url "https://github.com/roboll/helmfile/archive/v0.140.0.tar.gz"
-  sha256 "0e613f76b1190053a39209f52d3d7f4797807218521c78e6bf013b9b0dcf9429"
+  sha256 "ceebc1ac44fb828ec098f79a34434dc748d46e49c9aba5ff0fd4f45ab36a65db"
   license "MIT"
 
   bottle do

--- a/Formula/helmfile.rb
+++ b/Formula/helmfile.rb
@@ -4,6 +4,7 @@ class Helmfile < Formula
   url "https://github.com/roboll/helmfile/archive/v0.140.0.tar.gz"
   sha256 "ceebc1ac44fb828ec098f79a34434dc748d46e49c9aba5ff0fd4f45ab36a65db"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "869aff6c9f3bfcf5f0b4967b493bbb46313421ec075979607686e985c3acc456"


### PR DESCRIPTION
`helmfile` release was republished (see https://github.com/roboll/helmfile/issues/1928) so now installation is failing:
```
$ brew install --build-from-source helmfile
==> Downloading https://github.com/roboll/helmfile/archive/v0.140.0.tar.gz
Already downloaded: /Users/name/Library/Caches/Homebrew/downloads/871ac95f23c0e6424e8d2a43cb79b44eb5faed9cce8d6bfa666057677123d31b--helmfile-0.140.0.tar.gz
Error: SHA256 mismatch
Expected: 0e613f76b1190053a39209f52d3d7f4797807218521c78e6bf013b9b0dcf9429
  Actual: ceebc1ac44fb828ec098f79a34434dc748d46e49c9aba5ff0fd4f45ab36a65db
```

This is also affecting go1.17 formula build https://github.com/Homebrew/homebrew-core/pull/83413
