### PR TITLE
orgalorg: fix test dependency on ssh

### DIFF
--- a/Formula/orgalorg.rb
+++ b/Formula/orgalorg.rb
@@ -5,7 +5,7 @@ class Orgalorg < Formula
       tag:      "1.1.1",
       revision: "c51061ef46e1ba8e4eafdb07094287721c6a18cd"
   license "MIT"
-  head "https://github.com/reconquest/orgalorg.git"
+  head "https://github.com/reconquest/orgalorg.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "14f5394a84d3ae2ef72ff633b5afb8e011f43fd216ce5f01ccb23bce6d3ca226"
@@ -24,8 +24,10 @@ class Orgalorg < Formula
     assert_match version.to_s, shell_output("#{bin}/orgalorg --version")
     assert_match "orgalorg - files synchronization on many hosts.", shell_output("#{bin}/orgalorg --help")
 
+    ENV.delete "SSH_AUTH_SOCK"
+
     port = free_port
-    output = shell_output("#{bin}/orgalorg -u tester --host=127.0.0.1:#{port} -C uptime 2>&1", 1)
+    output = shell_output("#{bin}/orgalorg -u tester --key '' --host=127.0.0.1:#{port} -C uptime 2>&1", 1)
     assert_match("connecting to cluster failed", output)
     assert_match("dial tcp 127.0.0.1:#{port}: connect: connection refused", output)
     assert_match("can't connect to address: [tester@127.0.0.1:#{port}]", output)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Without this change testing of the formula depends on whether `SSH_AUTH_SOCK` actually points to active ssh-agent, or if you have private ssh key in default path, both can vary depending on OS version or your setup.

Currently, it sometimes fails like this:
```
==> /usr/local/Cellar/orgalorg/1.1.1/bin/orgalorg -u tester --host=127.0.0.1:56240 -C uptime 2>&1
Error: orgalorg: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /connecting\ to\ cluster\ failed/ to match "2021-08-17 19:30:43 [FATAL] can't create runner factory\n                            └─ unable to dial to ssh agent socket: /private/tmp/com.apple.launchd.eR353DMPva/Listeners\n                               └─ dial unix /private/tmp/com.apple.launchd.eR353DMPva/Listeners: connect: no such file or directory\n".
```


Required to unblock https://github.com/Homebrew/homebrew-core/pull/83413