### PR TITLE
baidupcs-go: fix release sha

### DIFF
--- a/Formula/baidupcs-go.rb
+++ b/Formula/baidupcs-go.rb
@@ -2,7 +2,7 @@ class BaidupcsGo < Formula
   desc "Terminal utility for Baidu Network Disk"
   homepage "https://github.com/qjfoidnh/BaiduPCS-Go"
   url "https://github.com/qjfoidnh/BaiduPCS-Go/archive/v3.8.2.tar.gz"
-  sha256 "3f6c95b82a769fb7c947a181d8f57ae60344acabba0a27a33249b9abbf365601"
+  sha256 "65d5482bc2a82cb244b978b8e1369bd5b1c429afce74651e5aea28e057a78ae3"
   license "Apache-2.0"
   head "https://github.com/qjfoidnh/BaiduPCS-Go.git", branch: "main"
 

--- a/Formula/baidupcs-go.rb
+++ b/Formula/baidupcs-go.rb
@@ -4,6 +4,7 @@ class BaidupcsGo < Formula
   url "https://github.com/qjfoidnh/BaiduPCS-Go/archive/v3.8.2.tar.gz"
   sha256 "65d5482bc2a82cb244b978b8e1369bd5b1c429afce74651e5aea28e057a78ae3"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/qjfoidnh/BaiduPCS-Go.git", branch: "main"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`v3.8.2` was retagged according to https://github.com/qjfoidnh/BaiduPCS-Go/issues/102#issuecomment-889608085

Required to unblock https://github.com/Homebrew/homebrew-core/pull/83413

