### PR TITLE
fluent-bit: update livecheck

### DIFF
--- a/Formula/fluent-bit.rb
+++ b/Formula/fluent-bit.rb
@@ -8,7 +8,7 @@ class FluentBit < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
It would be good to add `github_latest` to avoid eager release bumps (like it happened with #82294 #83669)