### PR TITLE
awsume: fix test for Linux

### DIFF
--- a/Formula/awsume.rb
+++ b/Formula/awsume.rb
@@ -17,6 +17,7 @@ class Awsume < Formula
 
   depends_on "openssl@1.1"
   depends_on "python@3.9"
+
   uses_from_macos "sqlite"
 
   resource "boto3" do
@@ -79,11 +80,12 @@ class Awsume < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output(". #{bin}/awsume -v 2>&1")
+    assert_match version.to_s, shell_output("bash -c '. #{bin}/awsume -v 2>&1'")
 
     file_path = File.expand_path("~/.awsume/config.yaml")
     shell_output(File.exist?(file_path))
 
-    assert_match "PROFILE  TYPE  SOURCE  MFA?  REGION  ACCOUNT", shell_output(". #{bin}/awsume --list-profiles 2>&1")
+    assert_match "PROFILE  TYPE  SOURCE  MFA?  REGION  ACCOUNT",
+                 shell_output("bash -c '. #{bin}/awsume --list-profiles 2>&1'")
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3094526318?check_suite_focus=true
```
==> brew test --verbose awsume
==> FAILED
==> Testing awsume
==> . /home/linuxbrew/.linuxbrew/Cellar/awsume/4.5.3/bin/awsume -v 2>&1
sh: 6: /home/linuxbrew/.linuxbrew/Cellar/awsume/4.5.3/bin/awsume: Bad substitution
Error: awsume: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected: 0
  Actual: 2

```