### PR TITLE
elfutils, libelf: switch conflicts_with to keg_only

### DIFF
--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -15,8 +15,6 @@ class Elfutils < Formula
   depends_on "xz"
   depends_on "zlib"
 
-  conflicts_with "libelf", because: "both install `libelf.a` library"
-
   def install
     system "./configure",
            "--disable-debug",

--- a/Formula/libelf.rb
+++ b/Formula/libelf.rb
@@ -29,11 +29,15 @@ class Libelf < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "c72de6e960f70dd98ea52b419d6e254362813c899d4859c4778d385a7c80e0dd"
   end
 
+  deprecate! date: "2019-05-17", because: :unmaintained # and upstream site is gone
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
-  conflicts_with "elfutils", because: "both install `libelf.a` library"
+  on_linux do
+    keg_only "it conflicts with elfutils, which installs a maintained libelf.a"
+  end
 
   def install
     # Workaround for ancient config files not recognising aarch64 macos.


### PR DESCRIPTION
`libelf` has been using archive.org/mirror URLs since #39936.

Also, the current `conflicts_with` makes it difficult to migrate Linux dependents to `elfutils` instead.

Follow-up would be seeing if Linux formulae that depend on `libelf` can be switched to `elfutils`.
