### PR TITLE
rmlint: use elfutils on Linux

### DIFF
--- a/Formula/rmlint.rb
+++ b/Formula/rmlint.rb
@@ -20,15 +20,17 @@ class Rmlint < Formula
   depends_on "sphinx-doc" => :build
   depends_on "glib"
   depends_on "json-glib"
-  depends_on "libelf"
 
   on_linux do
+    depends_on "elfutils"
     depends_on "util-linux"
   end
 
   def install
     on_linux do
       ENV.append_to_cflags "-I#{Formula["util-linux"].opt_include}"
+      ENV.append_to_cflags "-I#{Formula["elfutils"].opt_include}"
+      ENV.append "LDFLAGS", "-Wl,-rpath=#{Formula["elfutils"].opt_lib}"
       ENV.append "LDFLAGS", "-Wl,-rpath=#{Formula["glib"].opt_lib}"
       ENV.append "LDFLAGS", "-Wl,-rpath=#{Formula["json-glib"].opt_lib}"
       ENV.append "LDFLAGS", "-Wl,-rpath=#{Formula["util-linux"].opt_lib}"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

**EDIT:** `rmlint` has a High Sierra bottle, so if we want to keep that one, then the Linux bottle will require some manual update.

---

On macOS, `libelf` isn't detected/used in current bottle (at least Big Sur and also from source build), so just dropping dependency.

Trying to add CFLAGS doesn't help.

It seems to be an issue where `-isysroot/...` prevents build system from searching `-I.../libelf`.

```console
❯ CFLAGS="-I/usr/local/opt/libelf/include/libelf -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk" scons config 2>/dev/null | rg "needs libelf"
    Find non-stripped binaries (needs libelf)             : no

❯ CFLAGS="-I/usr/local/opt/libelf/include/libelf" scons config 2>/dev/null | rg "needs libelf"
    Find non-stripped binaries (needs libelf)             : yes
```