### PR TITLE
cargo-outdated 0.9.17 (new formula)

### DIFF
--- a/Formula/cargo-outdated.rb
+++ b/Formula/cargo-outdated.rb
@@ -1,0 +1,39 @@
+class CargoOutdated < Formula
+  desc "Cargo subcommand for displaying when Rust dependencies are out of date"
+  homepage "https://github.com/kbknapp/cargo-outdated"
+  url "https://github.com/kbknapp/cargo-outdated/archive/v0.9.17.tar.gz"
+  sha256 "9311409ce07bad0883439fdba4bfb160e8d0c7a63d84e45dc0c71fbeb5ac673a"
+  license "MIT"
+  head "https://github.com/kbknapp/cargo-outdated.git", branch: "master"
+
+  depends_on "libgit2"
+  depends_on "openssl@1.1"
+  depends_on "rust"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    crate = testpath/"demo-crate"
+    mkdir crate do
+      (crate/"Cargo.toml").write <<~EOS
+        [package]
+        name = "demo-crate"
+        version = "0.1.0"
+
+        [lib]
+        path = "lib.rs"
+
+        [dependencies]
+        libc = "0.1"
+      EOS
+
+      (crate/"lib.rs").write "use libc;"
+
+      output = shell_output("cargo outdated 2>&1")
+      # libc 0.1 is outdated
+      assert_match "libc", output
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
https://github.com/kbknapp/cargo-outdated
