### PR TITLE
neovim: fix linkage with luv on `HEAD`

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -73,7 +73,7 @@ class Neovim < Formula
     end
 
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", *std_cmake_args, "-DLIBLUV_LIBRARY=#{Formula["luv"].opt_lib/shared_library("libluv")}"
       # Patch out references to Homebrew shims
       inreplace "config/auto/versiondef.h", /#{HOMEBREW_LIBRARY}[^ ]+/o, ENV.cc
       system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

neovim/neovim@f8eae29d396b7476baf8e1da9466d9768a7edbfa makes CMake
prioritise luv's static library when linking. This means that Homebrew
Neovim will keep using an outdated version of luv even when the luv
formula is updated.

This is currently only on issue with `HEAD` installs, but I imagine
we'll need this too for stable builds eventually. Giving CMake hints
about the right library to use doesn't hurt even when it's not needed.

Related: neovim/neovim#15370