### PR TITLE
globe: add livecheck

### DIFF
--- a/Formula/globe.rb
+++ b/Formula/globe.rb
@@ -5,6 +5,14 @@ class Globe < Formula
   version "0.0.20140814"
   sha256 "5507a4caaf3e3318fd895ab1f8edfa5887c9f64547cad70cff3249350caa6c86"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?globe[._-](\d{1,2}\w+\d{2,4})\.t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("0.0.%Y%m%d") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d614010f862d04bbc2fc08ba4f220fde562ee07f08fe7f2fe15470afa2ad09c1"
     sha256 cellar: :any_skip_relocation, big_sur:       "d0c0291f6767d96e3e5e21dfbdd71f793e83208841de96b1d2907c509b5dc62d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `globe`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive. The `strategy` block simply converts the date in the filename (e.g., `14Aug2014`) to the `version` format used in the formula (`0.0.20140814`).