### PR TITLE
mrboom: upstream Linux fixes

### DIFF
--- a/Formula/mrboom.rb
+++ b/Formula/mrboom.rb
@@ -21,7 +21,7 @@ class Mrboom < Formula
 
   def install
     system "make", "mrboom", "LIBSDL2=1"
-    system "make", "install", "PREFIX=#{prefix}"
+    system "make", "install", "PREFIX=#{prefix}", "MANDIR=share/man/man6"
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3408740896?check_suite_focus=true
```
==> brew audit mrboom --online --git --skip-style
==> FAILED
Error: 1 problem in 1 formula detected
Error: No such file or directory @ realpath_rec - /home/runner
mrboom:
  * A top-level "man" directory was found.
    Homebrew requires that man pages live under "share".
    This can often be fixed by passing `--mandir=#{man}` to `configure`.
```

---

Makefile:
```make
...
MANDIR := man/man6
...

# OS X
else ifneq (,$(findstring osx,$(platform)))
   ...
   MANDIR := share/man/man6
```