### PR TITLE
psftools: add livecheck

### DIFF
--- a/Formula/psftools.rb
+++ b/Formula/psftools.rb
@@ -8,6 +8,15 @@ class Psftools < Formula
   license "GPL-2.0"
   version_scheme 1
 
+  # The development release on the homepage uses the same filename format as
+  # the stable release (e.g., psftools-1.1.1.tar.gz). However, the "Development
+  # Release" section comes before the "Stable Release" section, so we can use
+  # this heading to anchor stable releases for now.
+  livecheck do
+    url :homepage
+    regex(/Stable Release.+?href=.*?psftools[._-]v?(\d+(?:\.\d+)+)\.t/im)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "474daee5c218ce90013ce498fa84dc5486bfdd1ff736535a87bd618fa72f3da9"
     sha256 cellar: :any,                 big_sur:       "42056401c680e3a2372f2b16c78936b6e06c1cb3f8125f1a7c0fff8d23372de9"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `psftools`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

Unfortunately, the development release tarball uses the same filename format as the stable release (e.g., `psftools-1.1.1.tar.gz`), so we can't use a typical regex like `/href=.*?psftools[._-]v?(\d+(?:\.\d+)+)\.t/i`. However, the "Development Release" section comes before the "Stable Release" section, so we can use this heading (for now) to anchor the regex to identify only stable releases. To do this, the regex in the `livecheck` block starts with `Stable Release.+?` and uses the `m` (multiline) option.