### PR TITLE
gdb: update 'Caveats' 

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -63,10 +63,6 @@ class Gdb < Formula
       You will need to codesign the binary. For instructions, see:
 
         https://sourceware.org/gdb/wiki/PermissionsDarwin
-
-      On 10.12 (Sierra) or later with SIP, you need to run this:
-
-        echo "set startup-with-shell off" >> ~/.gdbinit
     EOS
   end
 

--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -62,7 +62,7 @@ class Gdb < Formula
       gdb requires special privileges to access Mach ports.
       You will need to codesign the binary. For instructions, see:
 
-        https://sourceware.org/gdb/wiki/BuildingOnDarwin
+        https://sourceware.org/gdb/wiki/PermissionsDarwin
 
       On 10.12 (Sierra) or later with SIP, you need to run this:
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The instructions to codesign the GDB executable have moved from
https://sourceware.org/gdb/wiki/BuildingOnDarwin to
https://sourceware.org/gdb/wiki/PermissionsDarwin. The former still
exists but links to the later.

Refer users to the new page in the Caveats. 

Also, the Caveats section mentions that 'set startup-with-shell off' is needed
on macOS 10.12 and later with SIP. This was added in 3b74e45 (gdb:
fix for Sierra SIP, 2016-11-10) when GDB 7.12 was released.

GDB later learned to cache a copy of the user's shell to work around SIP in
b50a8b9a916 (Cache a copy of the user's shell on macOS, 2018-09-17) [1],
which was released in GDB 8.3.1. As such, it's not necessary to set
'startup-with-shell' in one's ~/.gdbinit. GDB will itself tell the user
to set that config if caching the user's shell fail.

1. https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=b50a8b9a916ea2fe1379bcd8f122feef8129a0e9