### PR TITLE
i2pd 2.39.0

### DIFF
--- a/Formula/i2pd.rb
+++ b/Formula/i2pd.rb
@@ -24,7 +24,7 @@ class I2pd < Formula
       PREFIX=#{prefix}
     ]
 
-    args << "USE_AVX=no" if Hardware::CPU.arm?
+    args << "USE_AESNI=no" if Hardware::CPU.arm?
 
     system "make", "install", *args
 

--- a/Formula/i2pd.rb
+++ b/Formula/i2pd.rb
@@ -1,8 +1,8 @@
 class I2pd < Formula
   desc "Full-featured C++ implementation of I2P client"
   homepage "https://i2pd.website/"
-  url "https://github.com/PurpleI2P/i2pd/archive/2.38.0.tar.gz"
-  sha256 "8452f5323795a1846d554096c08fffe5ac35897867b93a5079605df8f80a3089"
+  url "https://github.com/PurpleI2P/i2pd/archive/2.39.0.tar.gz"
+  sha256 "3ffeb614cec826e13b50e8306177018ecb8d873668dfe66aadc733ca9fcaa568"
   license "BSD-3-Clause"
 
   bottle do
@@ -17,8 +17,7 @@ class I2pd < Formula
   depends_on "openssl@1.1"
 
   def install
-    system "make", "install", "DEBUG=no", "HOMEBREW=1", "USE_UPNP=yes",
-                              "USE_AENSI=no", "USE_AVX=no", "PREFIX=#{prefix}"
+    system "make", "install", "DEBUG=no", "HOMEBREW=1", "USE_UPNP=yes", "PREFIX=#{prefix}"
 
     # preinstall to prevent overwriting changed by user configs
     confdir = etc/"i2pd"

--- a/Formula/i2pd.rb
+++ b/Formula/i2pd.rb
@@ -17,7 +17,16 @@ class I2pd < Formula
   depends_on "openssl@1.1"
 
   def install
-    system "make", "install", "DEBUG=no", "HOMEBREW=1", "USE_UPNP=yes", "PREFIX=#{prefix}"
+    args = %W[
+      DEBUG=no
+      HOMEBREW=1
+      USE_UPNP=yes
+      PREFIX=#{prefix}
+    ]
+
+    args << "USE_AVX=no" if Hardware::CPU.arm?
+
+    system "make", "install", *args
 
     # preinstall to prevent overwriting changed by user configs
     confdir = etc/"i2pd"


### PR DESCRIPTION
* Update i2pd to 2.39.0
* Remove `USE_AVX` and `USE_AESNI` in `make` command due to:
  * AVX flag is deprecated
  * AESNI checked at runtime, so disabling is not required since 2.35.0.
