### PR TITLE
shtools 4.9.1

### DIFF
--- a/Formula/shtools.rb
+++ b/Formula/shtools.rb
@@ -1,8 +1,8 @@
 class Shtools < Formula
   desc "Spherical Harmonic Tools"
   homepage "https://shtools.github.io/SHTOOLS/"
-  url "https://github.com/SHTOOLS/SHTOOLS/releases/download/v4.8/SHTOOLS-4.8.tar.gz"
-  sha256 "c36fc86810017e544abbfb12f8ddf6f101a1ac8b89856a76d7d9801ffc8dac44"
+  url "https://github.com/SHTOOLS/SHTOOLS/releases/download/v4.9.1/SHTOOLS-4.9.1.tar.gz"
+  sha256 "5c22064f9daf6e9aa08cace182146993aa6b25a6ea593d92572c59f4013d53c2"
   license "BSD-3-Clause"
   head "https://github.com/SHTOOLS/SHTOOLS.git", branch: "master"
 
@@ -20,20 +20,11 @@ class Shtools < Formula
   def install
     system "make", "fortran"
     system "make", "fortran-mp"
-
-    pkgshare.install "examples/fortran/", "examples/ExampleDataFiles/"
-
-    lib.install "lib/libSHTOOLS.a", "lib/libSHTOOLS-mp.a"
-    include.install "include/fftw3.mod",
-                    "include/planetsconstants.mod",
-                    "include/shtools.mod",
-                    "include/ftypes.mod",
-                    "include/shtools.h"
-    share.install "man"
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do
-    cp_r pkgshare, testpath
+    cp_r "#{prefix}/share/examples/shtools", testpath
     system "make", "-C", "shtools/fortran",
                    "run-fortran-tests-no-timing",
                    "F95=gfortran",

--- a/Formula/shtools.rb
+++ b/Formula/shtools.rb
@@ -24,7 +24,7 @@ class Shtools < Formula
   end
 
   test do
-    cp_r "#{prefix}/share/examples/shtools", testpath
+    cp_r "#{share}/examples/shtools", testpath
     system "make", "-C", "shtools/fortran",
                    "run-fortran-tests-no-timing",
                    "F95=gfortran",


### PR DESCRIPTION
* Update shtools from v4.8 to 4.9.1
* Use `system "make", "install", "PREFIX=#{prefix}"` instead of the longer previous ruby commands that did the same thing.
* Change location of test directory

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
