### PR TITLE
odt2txt: fix build on Linux

### DIFF
--- a/Formula/odt2txt.rb
+++ b/Formula/odt2txt.rb
@@ -3,7 +3,7 @@ class Odt2txt < Formula
   homepage "https://github.com/dstosberg/odt2txt/"
   url "https://github.com/dstosberg/odt2txt/archive/v0.5.tar.gz"
   sha256 "23a889109ca9087a719c638758f14cc3b867a5dcf30a6c90bf6a0985073556dd"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     rebuild 2
@@ -16,6 +16,8 @@ class Odt2txt < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:    "4b86c07be0d96899d76adee3bf65390beb4288eeddbfb531dfcdbc3f17ff5bc8"
     sha256 cellar: :any_skip_relocation, yosemite:      "2005cd3ccfc24aa3c188339a63d48454636ace229cffc6b2add8ecf05eea40a1"
   end
+
+  uses_from_macos "zlib"
 
   resource "sample" do
     url "https://github.com/Turbo87/odt2txt/raw/samples/samples/sample-1.odt"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
```
/*
 * odt2txt.c: A simple (and stupid) converter from OpenDocument Text
 *            to plain text.
 *
 * Copyright (c) 2006-2009 Dennis Stosberg <dennis@stosberg.net>
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License,
 * version 2 as published by the Free Software Foundation
 */
```