### PR TITLE
envoy: clean up url comment

### DIFF
--- a/Formula/envoy.rb
+++ b/Formula/envoy.rb
@@ -1,8 +1,8 @@
 class Envoy < Formula
   desc "Cloud-native high-performance edge/middle/service proxy"
   homepage "https://www.envoyproxy.io/index.html"
-  # TODO: We can't use the tar.gz archive URL, which means bump-homebrew-formula-action doesn't work.
-  # See https://github.com/envoyproxy/envoy/issues/17859
+  # Switch to a tarball when the following issue is resolved:
+  # https://github.com/envoyproxy/envoy/issues/17859
   url "https://github.com/envoyproxy/envoy.git",
       tag:      "v1.19.1",
       revision: "a2a1e3eed4214a38608ec223859fcfa8fb679b14"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We probably want to switch this to a tarball when we can, as those are
typically faster and easier to cache, so I've adjusted the comment
accordingly.