### PR TITLE
libaec szip: add conflicts

### DIFF
--- a/Formula/libaec.rb
+++ b/Formula/libaec.rb
@@ -15,6 +15,8 @@ class Libaec < Formula
 
   depends_on "cmake" => :build
 
+  conflicts_with "szip", because: "libaec provides a replacement for szip"
+
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args

--- a/Formula/szip.rb
+++ b/Formula/szip.rb
@@ -21,6 +21,8 @@ class Szip < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "6c3487d85f941aa0fcdd567ae2801c7c147f2bb1d9cc55b1cb82bcce1eec3d9c"
   end
 
+  conflicts_with "libaec", because: "libaec provides a replacement for szip"
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`libaec` claims to be a drop-in replacement for `szip`: https://gitlab.dkrz.de/k202009/libaec/-/blob/v1.0.5/README.SZIP

Found in https://github.com/Homebrew/homebrew-core/pull/83906:
```
==> Pouring libaec--1.0.5.big_sur.bottle.tar.gz
The formula built, but is not symlinked into /usr/local
Error: The `brew link` step did not complete successfully
Could not symlink include/szlib.h
Target /usr/local/include/szlib.h
is a symlink belonging to szip. You can unlink it:
  brew unlink szip

To force the link and overwrite all conflicting files:
  brew link --overwrite libaec

To list all files that would be deleted:
  brew link --overwrite --dry-run libaec

Possible conflicting files are:
/usr/local/include/szlib.h -> /usr/local/Cellar/szip/2.1.1_1/include/szlib.h
/usr/local/lib/libsz.2.dylib -> /usr/local/Cellar/szip/2.1.1_1/lib/libsz.2.dylib
/usr/local/lib/libsz.a -> /usr/local/Cellar/szip/2.1.1_1/lib/libsz.a
/usr/local/lib/libsz.dylib -> /usr/local/Cellar/szip/2.1.1_1/lib/libsz.dylib
```
