### PR TITLE
yt-dlp 2021.08.10 (new formula)

### DIFF
--- a/Formula/yt-dlp.rb
+++ b/Formula/yt-dlp.rb
@@ -1,22 +1,34 @@
 class YtDlp < Formula
-  include Language::Python::Virtualenv
-
   desc "Fork of youtube-dl with additional features and fixes"
-  homepage "https://discord.gg/H5MNcFW63r"
-  url "https://github.com/yt-dlp/yt-dlp/releases/download/2021.08.10/yt-dlp.tar.gz"
-  sha256 "15bd1028840e9230f7b89ee928914b119858b9011c7083c6cb0c5a60d525f1e6"
+  homepage "https://github.com/yt-dlp/yt-dlp"
+  url "https://github.com/yt-dlp/yt-dlp/archive/2021.08.10.tar.gz"
+  sha256 "d847e32bc18767be2f27183f5da2ba05d0142e194e95ac6b3e69494353ee366b"
   license "Unlicense"
+  head "https://github.com/yt-dlp/yt-dlp.git", branch: "master"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+    regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
+  end
+
+  depends_on "pandoc" => :build
   depends_on "python@3.9"
+  uses_from_macos "zip" => :build
 
   def install
-    virtualenv_install_with_resources
+    system "make </dev/null"
+    bin.install "yt-dlp"
+    bash_completion.install "completions/bash/yt-dlp"
+    zsh_completion.install "completions/zsh/_yt-dlp"
+    fish_completion.install "completions/fish/yt-dlp.fish"
+    man1.install "yt-dlp.1"
   end
 
   test do
-    # commit history of homebrew-core repo
-    system "#{bin}/youtube-dl", "--simulate", "https://www.youtube.com/watch?v=pOtd1cbOP7k"
-    # homebrew playlist
-    system "#{bin}/youtube-dl", "--simulate", "--yes-playlist", "https://www.youtube.com/watch?v=pOtd1cbOP7k&list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj"
+    # "History of homebrew-core", uploaded 3 Feb 2020
+    system "#{bin}/yt-dlp", "--simulate", "https://www.youtube.com/watch?v=pOtd1cbOP7k"
+    # "homebrew", playlist last updated 3 Mar 2020
+    system "#{bin}/yt-dlp", "--simulate", "--yes-playlist", "https://www.youtube.com/watch?v=pOtd1cbOP7k&list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj"
   end
 end

--- a/Formula/yt-dlp.rb
+++ b/Formula/yt-dlp.rb
@@ -1,0 +1,22 @@
+class YtDlp < Formula
+  include Language::Python::Virtualenv
+
+  desc "Fork of youtube-dl with additional features and fixes"
+  homepage "https://discord.gg/H5MNcFW63r"
+  url "https://github.com/yt-dlp/yt-dlp/releases/download/2021.08.10/yt-dlp.tar.gz"
+  sha256 "15bd1028840e9230f7b89ee928914b119858b9011c7083c6cb0c5a60d525f1e6"
+  license "Unlicense"
+
+  depends_on "python@3.9"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    # commit history of homebrew-core repo
+    system "#{bin}/youtube-dl", "--simulate", "https://www.youtube.com/watch?v=pOtd1cbOP7k"
+    # homebrew playlist
+    system "#{bin}/youtube-dl", "--simulate", "--yes-playlist", "https://www.youtube.com/watch?v=pOtd1cbOP7k&list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj"
+  end
+end


### PR DESCRIPTION
yt-dlp is a fork of youtube-dl. As such, this formula is heavily based on youtube-dl's formula.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Unfortunately, I cannot quite get `brew install --build-from-source yt-dlp` to not fail. But I don’t know why. Can anybody help me?