### PR TITLE
modd: deprecate

### DIFF
--- a/Formula/modd.rb
+++ b/Formula/modd.rb
@@ -15,7 +15,10 @@ class Modd < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "4ecbbb67e695368d3830b5c273f6abf7f659b73bcfe47c3f18332cf76fedf997"
   end
 
-  depends_on "go" => :build
+  # https://github.com/cortesi/modd/issues/96
+  deprecate! date: "2021-08-27", because: :unmaintained
+
+  depends_on "go@1.16" => :build
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

To use go 1.17 for #83413, `x/sys` needs to be upgraded (see https://github.com/cortesi/modd/pull/103). However, the patch isn't directly usable as the latest release isn't using modules and we've had no response from https://github.com/cortesi/modd/issues/96. 

I first tried applying https://github.com/cortesi/devd/commit/4ab3fc9061542fd35b5544627354e5755fa74c1c, but that fails due to a symlink:
```
patch: **** File vendor/github.com/bmatcuk/doublestar/test/b/symlink-dir is not a regular file -- can't patch
```

any other alternatives here?