### PR TITLE
devd: support go 1.17

### DIFF
--- a/Formula/devd.rb
+++ b/Formula/devd.rb
@@ -15,14 +15,20 @@ class Devd < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "9718a2a8ec148738db0127f1dc4a0e7a1ca6c4e69d2505f02a9580230ea30b91"
   end
 
+  depends_on "dep" => :build
   depends_on "go" => :build
+
+  # Support go 1.17, remove when upstream patch is merged/released
+  # Patch is the `dep` equivalent of https://github.com/cortesi/devd/pull/117
+  patch :DATA
 
   def install
     ENV["GOPATH"] = buildpath
     ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/cortesi/devd").install buildpath.children
     cd "src/github.com/cortesi/devd" do
-      system "go", "build", *std_go_args, "./cmd/devd"
+      system "dep", "ensure", "-vendor-only"
+      system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/devd"
     end
   end
 
@@ -39,3 +45,27 @@ class Devd < Formula
     assert_equal "Hello World!\n", output
   end
 end
+
+__END__
+diff --git a/Gopkg.lock b/Gopkg.lock
+index 437a8b5..257a307 100644
+--- a/Gopkg.lock
++++ b/Gopkg.lock
+@@ -172,14 +172,15 @@
+
+ [[projects]]
+   branch = "master"
+-  digest = "1:e6d1805ead5b8f2439808f76187f54042ed35ee26eb9ca63127259a0e612b119"
++  digest = "1:d5b479606f9456b8e3200dbe988b32e211f824d6a612c4cfac46c1a31458d568"
+   name = "golang.org/x/sys"
+   packages = [
++    "internal/unsafeheader",
+     "unix",
+     "windows",
+   ]
+   pruneopts = ""
+-  revision = "b4a75ba826a64a70990f11a225237acd6ef35c9f"
++  revision = "63515b42dcdf9544f4e6a02fd7632793fde2f72d"
+
+ [[projects]]
+   digest = "1:15d017551627c8bb091bde628215b2861bed128855343fdd570c62d08871f6e1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
See #83413 and a similar patch for `modd` in #84056

These are both from the same developer and have not seen a tagged release since Jan 2019