### PR TITLE
envoy: removes go dependency

### DIFF
--- a/Formula/envoy.rb
+++ b/Formula/envoy.rb
@@ -8,6 +8,7 @@ class Envoy < Formula
       revision: "a2a1e3eed4214a38608ec223859fcfa8fb679b14"
   license "Apache-2.0"
 
+  # Apple M1/arm64 is pending envoyproxy/envoy#16482
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:      "5d242c76931465e1bebc4ac62742bcdd68a42334679cc69f8c058e1f7b4147a1"
     sha256 cellar: :any_skip_relocation, catalina:     "48e53aac4dc4b8c7603141b711730427a5ca94ce4d3e3ce572c1c01cd96ad9f2"
@@ -18,7 +19,6 @@ class Envoy < Formula
   depends_on "bazelisk" => :build
   depends_on "cmake" => :build
   depends_on "coreutils" => :build
-  depends_on "go" => :build
   depends_on "libtool" => :build
   depends_on "ninja" => :build
   depends_on macos: :catalina


### PR DESCRIPTION
According to @lizan https://github.com/Homebrew/homebrew-core/pull/83413#issuecomment-906884606

> Envoy build process pulls Go 1.15.5 by Bazel (https://github.com/envoyproxy/envoy/blob/main/bazel/dependency_imports.bzl#L14), so it isn't relevant to system Go. M1 support should be ignored until Envoy supports that.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
