### PR TITLE
envoy@1.18: removes go dependency

### DIFF
--- a/Formula/envoy@1.18.rb
+++ b/Formula/envoy@1.18.rb
@@ -6,6 +6,7 @@ class EnvoyAT118 < Formula
       revision: "bef18019d8fc33a4ed6aca3679aff2100241ac5e"
   license "Apache-2.0"
 
+  # Apple M1/arm64 is pending envoyproxy/envoy#16482
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:  "3536e288183abeb9f36505065c889bc376ca3b3b3e526f8850a33d5b9a0399d5"
     sha256 cellar: :any_skip_relocation, catalina: "2af03e6c0a7f978f1f87ffdb84861c9e75995ff783356f14e088c07bb8bbb03f"
@@ -19,7 +20,6 @@ class EnvoyAT118 < Formula
   depends_on "bazelisk" => :build
   depends_on "cmake" => :build
   depends_on "coreutils" => :build
-  depends_on "go" => :build
   depends_on "libtool" => :build
   depends_on "ninja" => :build
   depends_on macos: :catalina


### PR DESCRIPTION
According to @lizan https://github.com/Homebrew/homebrew-core/pull/83413#issuecomment-906884606

> Envoy build process pulls Go 1.15.5 by Bazel (https://github.com/envoyproxy/envoy/blob/main/bazel/dependency_imports.bzl#L14), so it isn't relevant to system Go. M1 support should be ignored until Envoy supports that.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
