### PR TITLE
go@1.16 1.16.7 (new formula)

### DIFF
--- a/Formula/go@1.16.rb
+++ b/Formula/go@1.16.rb
@@ -1,0 +1,58 @@
+class GoAT116 < Formula
+  desc "Go programming environment (1.16)"
+  homepage "https://golang.org"
+  url "https://golang.org/dl/go1.16.7.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.16.7.src.tar.gz"
+  sha256 "1a9f2894d3d878729f7045072f30becebe243524cf2fce4e0a7b248b1e0654ac"
+  license "BSD-3-Clause"
+
+  livecheck do
+    url "https://golang.org/dl/"
+    regex(/href=.*?go[._-]?v?(1\.16(?:\.\d+)*)[._-]src\.t/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOROOT_BOOTSTRAP"] = Formula["go"].opt_libexec
+
+    cd "src" do
+      ENV["GOROOT_FINAL"] = libexec
+      system "./make.bash", "--no-clean"
+    end
+
+    (buildpath/"pkg/obj").rmtree
+    libexec.install Dir["*"]
+    bin.install_symlink Dir[libexec/"bin/go*"]
+
+    system bin/"go", "install", "-race", "std"
+
+    # Remove useless files.
+    # Breaks patchelf because folder contains weird debug/test files
+    (libexec/"src/debug/elf/testdata").rmtree
+    # Binaries built for an incompatible architecture
+    (libexec/"src/runtime/pprof/testdata").rmtree
+  end
+
+  test do
+    (testpath/"hello.go").write <<~EOS
+      package main
+
+      import "fmt"
+
+      func main() {
+        fmt.Println("Hello World")
+      }
+    EOS
+    # Run go fmt check for no errors then run the program.
+    # This is a a bare minimum of go working as it uses fmt, build, and run.
+    system bin/"go", "fmt", "hello.go"
+    assert_equal "Hello World\n", shell_output("#{bin}/go run hello.go")
+
+    ENV["GOOS"] = "freebsd"
+    ENV["GOARCH"] = Hardware::CPU.intel? ? "amd64" : Hardware::CPU.arch.to_s
+    system bin/"go", "build", "hello.go"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

One noteworthy departure from the other versioned go formulae is that
I've used the main Go formula to bootstrap, instead of specifying a
bootstrap resource. This should make the formula simpler (and hopefully
doesn't break anything...).

We do do this with `go-boring`, and haven't gotten any complaints about
it so far.