### PR TITLE
highlight: fix gcc runtime dependency

### DIFF
--- a/Formula/highlight.rb
+++ b/Formula/highlight.rb
@@ -24,7 +24,7 @@ class Highlight < Formula
   depends_on "lua"
 
   on_linux do
-    depends_on "gcc" => :build
+    depends_on "gcc"
   end
 
   fails_with gcc: "5" # needs C++17


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```console
# brew test highlight
==> Testing highlight
==> /home/linuxbrew/.linuxbrew/Cellar/highlight/4.1/bin/highlight /home/linuxbrew/.linuxbrew/Cellar/highlight/4.1/
Last 15 lines from /root/.cache/Homebrew/Logs/highlight/test.01.highlight:
2021-08-27 19:43:24 +0000

/home/linuxbrew/.linuxbrew/Cellar/highlight/4.1/bin/highlight
/home/linuxbrew/.linuxbrew/Cellar/highlight/4.1/share/doc/highlight/extras/highlight_pipe.php

/home/linuxbrew/.linuxbrew/Cellar/highlight/4.1/bin/highlight: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by /home/linuxbrew/.linuxbrew/Cellar/highlight/4.1/bin/highlight)
/home/linuxbrew/.linuxbrew/Cellar/highlight/4.1/bin/highlight: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /home/linuxbrew/.linuxbrew/Cellar/highlight/4.1/bin/highlight)

```