### PR TITLE
clip: fix gcc runtime dependency

### DIFF
--- a/Formula/clip.rb
+++ b/Formula/clip.rb
@@ -23,7 +23,7 @@ class Clip < Formula
   depends_on "harfbuzz"
 
   on_linux do
-    depends_on "gcc" => :build # for C++17
+    depends_on "gcc" # for C++17
   end
 
   fails_with gcc: "5"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```console
# brew test clip
==> Testing clip
==> /home/linuxbrew/.linuxbrew/Cellar/clip/0.7_1/bin/clip --export chart.svg test/examples/charts_basic_areachart.
Last 15 lines from /root/.cache/Homebrew/Logs/clip/test.01.clip:
2021-08-27 19:49:18 +0000

/home/linuxbrew/.linuxbrew/Cellar/clip/0.7_1/bin/clip
--export
chart.svg
test/examples/charts_basic_areachart.clp

/home/linuxbrew/.linuxbrew/Cellar/clip/0.7_1/bin/clip: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /home/linuxbrew/.linuxbrew/Cellar/clip/0.7_1/bin/clip)
```