### PR TITLE
omega, xapian: add/update livecheck

### DIFF
--- a/Formula/omega.rb
+++ b/Formula/omega.rb
@@ -5,6 +5,11 @@ class Omega < Formula
   sha256 "14bec53234bea5eb36aa4b91940842e62c7968f4fd68c959db396c15069acbaf"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://xapian.org/download"
+    regex(/href=.*?xapian-omega[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "e93f8e12861eae4aef56482f4daad7d017060bb420cbb9b6973dc1e4756286e1"
     sha256 big_sur:       "a9adc43192d3cfefc48b5102405b8542549336ae7c7a73c4f964c64f2f3c9306"

--- a/Formula/xapian.rb
+++ b/Formula/xapian.rb
@@ -7,8 +7,8 @@ class Xapian < Formula
   version_scheme 1
 
   livecheck do
-    url :homepage
-    regex(/latest stable version.*?is v?(\d+(?:\.\d+)+)</im)
+    url "https://xapian.org/download"
+    regex(/href=.*?xapian-core[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `omega`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.

This PR also updates the existing `livecheck` block for `xapian` to bring it up to current standards, using the same approach as `omega`.