### PR TITLE
openvdb: fix gcc runtime dependency and add head branch

### DIFF
--- a/Formula/openvdb.rb
+++ b/Formula/openvdb.rb
@@ -7,7 +7,7 @@ class Openvdb < Formula
   url "https://github.com/AcademySoftwareFoundation/openvdb/archive/v8.1.0.tar.gz"
   sha256 "3e09d47331429be7409a3a3c27fdd3c297f96d31d2153febe194e664a99d6183"
   license "MPL-2.0"
-  head "https://github.com/AcademySoftwareFoundation/openvdb.git"
+  head "https://github.com/AcademySoftwareFoundation/openvdb.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "3b009e6f335c6dd6264c391ede13d7dcda7731851f8e6bb8d7f1395d1baa1338"
@@ -28,7 +28,7 @@ class Openvdb < Formula
   depends_on "tbb@2020"
 
   on_linux do
-    depends_on "gcc" => :build
+    depends_on "gcc"
   end
 
   fails_with gcc: "5"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`gcc` is pulled in via other dependencies, but better to make explicit in formula.

```console
# brew linkage --reverse openvdb
/home/linuxbrew/.linuxbrew/lib/gcc/11/libgcc_s.so.1
  lib/libopenvdb.so.8.1.0

/home/linuxbrew/.linuxbrew/lib/gcc/11/libstdc++.so.6
  lib/libopenvdb.so.8.1.0

...

# objdump -p .linuxbrew/opt/openvdb/bin/vdb_print | grep GLIBCXX
    0x0297f870 0x00 11 GLIBCXX_3.4.20
    0x0297f876 0x00 10 GLIBCXX_3.4.26
    0x02297f89 0x00 08 GLIBCXX_3.4.9
    0x0297f861 0x00 07 GLIBCXX_3.4.11
    0x0297f871 0x00 03 GLIBCXX_3.4.21
    0x08922974 0x00 02 GLIBCXX_3.4
```