### PR TITLE
s-nail: generate test date string in Ruby

### DIFF
--- a/Formula/s-nail.rb
+++ b/Formula/s-nail.rb
@@ -32,10 +32,11 @@ class SNail < Formula
   end
 
   test do
-    ENV["SOURCE_DATE_EPOCH"] = "844221007"
+    timestamp = 844_221_007
+    ENV["SOURCE_DATE_EPOCH"] = timestamp.to_s
 
-    date1 = shell_output("date -r 844221007 '+%a %b %e %T %Y'")
-    date2 = shell_output("date -r 844221007 '+%a, %d %b %Y %T %z'")
+    date1 = Time.at(timestamp).strftime("%a %b %e %T %Y")
+    date2 = Time.at(timestamp).strftime("%a, %d %b %Y %T %z")
 
     expected = <<~EOS
       From reproducible_build #{date1.chomp}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Depending on Linux/macOS, the syntax of `date` can vary:
```
==> date -r 844221007 '+%a %b %e %T %Y'
date: 844221007: No such file or directory
```

Instead of trying to account for variations in the flags/syntax available to `date`, just build the date string in Ruby instead, where the syntax is consistent and predictable.

The license situation is complex - some individual source files are `BSD-3-Clause` but looks like the project is trying to move to `ISC`, in the process of re-implementing/re-licensing the `BSD-3-Clause` parts.