### PR TITLE
lnav: fix gcc runtime dependency and add head branch

### DIFF
--- a/Formula/lnav.rb
+++ b/Formula/lnav.rb
@@ -20,7 +20,7 @@ class Lnav < Formula
   end
 
   head do
-    url "https://github.com/tstack/lnav.git"
+    url "https://github.com/tstack/lnav.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -33,7 +33,7 @@ class Lnav < Formula
   depends_on "sqlite"
 
   on_linux do
-    depends_on "gcc" => :build
+    depends_on "gcc"
   end
 
   fails_with gcc: "5"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```console
# brew test lnav
==> Testing lnav
==> /home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav -V
Last 15 lines from /root/.cache/Homebrew/Logs/lnav/test.01.lnav:
2021-08-27 23:17:28 +0000

/home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav
-V

/home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.11' not found (required by /home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav)
/home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by /home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav)
/home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav)
/home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.22' not found (required by /home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav)
/home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.13' not found (required by /home/linuxbrew/.linuxbrew/Cellar/lnav/0.10.0_1/bin/lnav)
```