### PR TITLE
cbmc: fix gcc runtime dependency

### DIFF
--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -22,7 +22,7 @@ class Cbmc < Formula
   uses_from_macos "flex" => :build
 
   on_linux do
-    depends_on "gcc" => :build
+    depends_on "gcc"
   end
 
   fails_with gcc: "5"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```console
# brew test cbmc
==> Testing cbmc
==> /home/linuxbrew/.linuxbrew/Cellar/cbmc/5.37.0/bin/cbmc --pointer-check main.c
/home/linuxbrew/.linuxbrew/Cellar/cbmc/5.37.0/bin/cbmc: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /home/linuxbrew/.linuxbrew/Cellar/cbmc/5.37.0/bin/cbmc)
/home/linuxbrew/.linuxbrew/Cellar/cbmc/5.37.0/bin/cbmc: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by /home/linuxbrew/.linuxbrew/Cellar/cbmc/5.37.0/bin/cbmc)
Error: cbmc: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected: 10
  Actual: 1
```