### PR TITLE
pstoedit: fix gcc runtime dependency

### DIFF
--- a/Formula/pstoedit.rb
+++ b/Formula/pstoedit.rb
@@ -20,12 +20,11 @@ class Pstoedit < Formula
   depends_on "plotutils"
 
   on_linux do
-    depends_on "gcc" => :build
+    depends_on "gcc"
   end
 
   # "You need a C++ compiler, e.g., g++ (newer than 6.0) to compile pstoedit."
   fails_with gcc: "5"
-  fails_with gcc: "6"
 
   def install
     on_macos { ENV.cxx11 }


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```console
# objdump -p /home/linuxbrew/.linuxbrew/opt/pstoedit/lib/pstoedit/libp2edrvstd.so | grep CXX
    0x0bafd178 0x00 13 CXXABI_1.3.8
    0x0297f861 0x00 12 GLIBCXX_3.4.11
    0x0bafd179 0x00 11 CXXABI_1.3.9
    0x0297f879 0x00 09 GLIBCXX_3.4.29
    0x02297f89 0x00 08 GLIBCXX_3.4.9
    0x056bafd3 0x00 06 CXXABI_1.3
    0x0297f871 0x00 05 GLIBCXX_3.4.21
    0x0297f865 0x00 04 GLIBCXX_3.4.15
    0x08922974 0x00 02 GLIBCXX_3.4
```