### PR TITLE
gnuplot: fix build for Linux

### DIFF
--- a/Formula/gnuplot.rb
+++ b/Formula/gnuplot.rb
@@ -28,6 +28,12 @@ class Gnuplot < Formula
   depends_on "qt@5"
   depends_on "readline"
 
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5"
+
   def install
     # Qt5 requires c++11 (and the other backends do not care)
     ENV.cxx11


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3447564426?check_suite_focus=true
```
g++-5  -g -O2 -fPIC   -L/home/linuxbrew/.linuxbrew/Cellar/libcerf/1.17/lib -lcerf -L/home/linuxbrew/.linuxbrew/opt/readline/lib  -o gnuplot alloc.o axis.o breaders.o boundary.o color.o command.o contour.o datablock.o datafile.o dynarray.o encoding.o eval.o external.o fit.o gadgets.o getcolor.o graph3d.o graphics.o help.o hidden3d.o history.o internal.o interpol.o jitter.o libcerf.o matrix.o misc.o mouse.o multiplot.o parse.o plot.o plot2d.o plot3d.o pm3d.o readline.o save.o scanner.o set.o show.o specfun.o standard.o stats.o stdfn.o tables.o tabulate.o term.o time.o unset.o util.o util3d.o variable.o version.o voxelgrid.o vplot.o  wxterminal/gp_cairo.o wxterminal/gp_cairo_helpers.o  qtterminal/qt_term.o -lreadline  -lncurses  -lz -lgd -L/home/linuxbrew/.linuxbrew/Cellar/gd/2.3.2/lib -lgd -L/home/linuxbrew/.linuxbrew/lib -llua -lm -ldl   -L/home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.2/lib -lQt5Network -lQt5Svg -lQt5PrintSupport -lQt5Widgets -lQt5Gui -lQt5Core -ldl -lm -lcerf  -L/home/linuxbrew/.linuxbrew/Cellar/glib/2.68.4/lib -L/home/linuxbrew/.linuxbrew/Cellar/cairo/1.16.0_5/lib -L/home/linuxbrew/.linuxbrew/Cellar/harfbuzz/2.9.0/lib -L/home/linuxbrew/.linuxbrew/Cellar/pango/1.48.9/lib -lz -lpangocairo-1.0 -lpango-1.0 -lgobject-2.0 -lharfbuzz -lcairo -lglib-2.0
/home/linuxbrew/.linuxbrew/bin/ld: /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.2/lib/libQt5Core.so: undefined reference to `std::pmr::monotonic_buffer_resource::~monotonic_buffer_resource()@GLIBCXX_3.4.28'
/home/linuxbrew/.linuxbrew/bin/ld: /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.2/lib/libQt5Core.so: undefined reference to `std::__exception_ptr::exception_ptr::_M_release()@CXXABI_1.3.13'
/home/linuxbrew/.linuxbrew/bin/ld: /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.2/lib/libQt5Core.so: undefined reference to `vtable for std::pmr::monotonic_buffer_resource@GLIBCXX_3.4.28'
/home/linuxbrew/.linuxbrew/bin/ld: /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.2/lib/libQt5Core.so: undefined reference to `std::pmr::get_default_resource()@GLIBCXX_3.4.26'

```