### PR TITLE
mailcatcher: add `service do` block

### DIFF
--- a/Formula/mailcatcher.rb
+++ b/Formula/mailcatcher.rb
@@ -126,6 +126,13 @@ class Mailcatcher < Formula
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
   end
 
+  service do
+    run [opt_bin/"mailcatcher", "-f"]
+    log_path var/"log/mailcatcher.log"
+    error_log_path var/"log/mailcatcher.log"
+    keep_alive true
+  end
+
   test do
     system "mailcatcher"
     (testpath/"mailcatcher.exp").write <<~EOS


### PR DESCRIPTION
Adds a simple service to run `mailcatcher` in the background with default ports and on localhost.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----