### PR TITLE
pdns: fix gcc runtime dependency

### DIFF
--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -36,7 +36,7 @@ class Pdns < Formula
   uses_from_macos "curl"
 
   on_linux do
-    depends_on "gcc" => :build # for C++17
+    depends_on "gcc" # for C++17
   end
 
   fails_with gcc: "5"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```console
# objdump -p /home/linuxbrew/.linuxbrew/Cellar/pdns/4.5.1/sbin/pdns_server | grep CXX
    0x0bafd178 0x00 33 CXXABI_1.3.8
    0x0297f876 0x00 32 GLIBCXX_3.4.26
    0x0297f868 0x00 31 GLIBCXX_3.4.18
    0x0297f864 0x00 30 GLIBCXX_3.4.14
    0x0297f869 0x00 29 GLIBCXX_3.4.19
    0x0bafd175 0x00 24 CXXABI_1.3.5
    0x0297f879 0x00 23 GLIBCXX_3.4.29
    0x0afd17f1 0x00 22 CXXABI_1.3.11
    0x0297f872 0x00 21 GLIBCXX_3.4.22
    0x02297f89 0x00 20 GLIBCXX_3.4.9
    0x0bafd177 0x00 19 CXXABI_1.3.7
    0x0bafd173 0x00 17 CXXABI_1.3.3
    0x0afd17f3 0x00 15 CXXABI_1.3.13
    0x0297f865 0x00 14 GLIBCXX_3.4.15
    0x0bafd179 0x00 13 CXXABI_1.3.9
    0x0297f861 0x00 11 GLIBCXX_3.4.11
    0x056bafd3 0x00 09 CXXABI_1.3
    0x0297f870 0x00 08 GLIBCXX_3.4.20
    0x08922974 0x00 07 GLIBCXX_3.4
    0x0bafd172 0x00 05 CXXABI_1.3.2
    0x0297f871 0x00 03 GLIBCXX_3.4.21
```