### PR TITLE
inspectrum: fix build for Linux and add head branch

### DIFF
--- a/Formula/inspectrum.rb
+++ b/Formula/inspectrum.rb
@@ -5,7 +5,7 @@ class Inspectrum < Formula
   sha256 "7be5be96f50b0cea5b3dd647f06cc00adfa805a395484aa2ab84cf3e49b7227b"
   license "GPL-3.0-or-later"
   revision 1
-  head "https://github.com/miek/inspectrum.git"
+  head "https://github.com/miek/inspectrum.git", branch: "main"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "a0fb5fe1d6d28598185e4b550c3eb023edd06caa538965143ad9368fb12fde29"
@@ -20,9 +20,17 @@ class Inspectrum < Formula
   depends_on "liquid-dsp"
   depends_on "qt@5"
 
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5"
+
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3447558515?check_suite_focus=true
```
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/g++-5 -O2 -std=gnu++11 -O3 -DNDEBUG -rdynamic CMakeFiles/inspectrum.dir/inspectrum_autogen/mocs_compilation.cpp.o CMakeFiles/inspectrum.dir/abstractsamplesource.cpp.o CMakeFiles/inspectrum.dir/amplitudedemod.cpp.o CMakeFiles/inspectrum.dir/cursor.cpp.o CMakeFiles/inspectrum.dir/cursors.cpp.o CMakeFiles/inspectrum.dir/main.cpp.o CMakeFiles/inspectrum.dir/fft.cpp.o CMakeFiles/inspectrum.dir/frequencydemod.cpp.o CMakeFiles/inspectrum.dir/mainwindow.cpp.o CMakeFiles/inspectrum.dir/inputsource.cpp.o CMakeFiles/inspectrum.dir/phasedemod.cpp.o CMakeFiles/inspectrum.dir/plot.cpp.o CMakeFiles/inspectrum.dir/plots.cpp.o CMakeFiles/inspectrum.dir/plotview.cpp.o CMakeFiles/inspectrum.dir/samplebuffer.cpp.o CMakeFiles/inspectrum.dir/samplesource.cpp.o CMakeFiles/inspectrum.dir/spectrogramcontrols.cpp.o CMakeFiles/inspectrum.dir/spectrogramplot.cpp.o CMakeFiles/inspectrum.dir/threshold.cpp.o CMakeFiles/inspectrum.dir/traceplot.cpp.o CMakeFiles/inspectrum.dir/tuner.cpp.o CMakeFiles/inspectrum.dir/tunertransform.cpp.o CMakeFiles/inspectrum.dir/util.cpp.o -o inspectrum  /home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5Widgets.so.5.15.2 /home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5Concurrent.so.5.15.2 -lfftw3f -lliquid /home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5Gui.so.5.15.2 /home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5Core.so.5.15.2 
/home/linuxbrew/.linuxbrew/bin/ld: /home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5Widgets.so.5.15.2: undefined reference to `std::pmr::monotonic_buffer_resource::~monotonic_buffer_resource()@GLIBCXX_3.4.28'
/home/linuxbrew/.linuxbrew/bin/ld: /home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5Core.so.5.15.2: undefined reference to `std::__exception_ptr::exception_ptr::_M_release()@CXXABI_1.3.13'
/home/linuxbrew/.linuxbrew/bin/ld: /home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5Widgets.so.5.15.2: undefined reference to `vtable for std::pmr::monotonic_buffer_resource@GLIBCXX_3.4.28'
/home/linuxbrew/.linuxbrew/bin/ld: /home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5Widgets.so.5.15.2: undefined reference to `std::pmr::get_default_resource()@GLIBCXX_3.4.26'
```

Also build in separate directory based on upstream instructions in https://github.com/miek/inspectrum/wiki/Build