### PR TITLE
runcocoa: add livecheck

### DIFF
--- a/Formula/runcocoa.rb
+++ b/Formula/runcocoa.rb
@@ -5,6 +5,10 @@ class Runcocoa < Formula
   version "20120108"
   sha256 "d90079efb92c8eef3c8e2c142683eb0c632ca61120c9e4a617bf9dac5362bf86"
 
+  livecheck do
+    skip "No version information available to check"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "878f152f9c0e3915335074975020b52290f867142bcced9b44f8d8b3b6f0aaea"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck tries to identify version information for `runcocoa` from the [GitHub repository](https://github.com/michaeltyson/Commandline-Cocoa/)'s tags. Unfortunately, there are no tags in the repository and version information isn't otherwise available. The latest commit is from 2012-01-08, so this PR simply adds a `livecheck` block to `skip` the formula.