### PR TITLE
portaudio: add alsa and jack for Linux

### DIFF
--- a/Formula/portaudio.rb
+++ b/Formula/portaudio.rb
@@ -27,16 +27,19 @@ class Portaudio < Formula
 
   depends_on "pkg-config" => :build
 
+  on_linux do
+    depends_on "alsa-lib"
+    depends_on "jack"
+  end
+
   def install
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-debug",
-                          "--disable-dependency-tracking",
+    system "./configure", *std_configure_args,
                           "--enable-mac-universal=no",
                           "--enable-cxx"
     system "make", "install"
 
     # Need 'pa_mac_core.h' to compile PyAudio
-    include.install "include/pa_mac_core.h"
+    include.install "include/pa_mac_core.h" if OS.mac?
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Actually blocked by #84000, so will rebase once other PR is done.

Current Linux bottle/build isn't that good based on upstream docs http://portaudio.com/docs/v19-doxydocs/compile_linux.html
> The OSS sound API is very old and not well supported. It is recommended that you use the ALSA sound API. The PortAudio configure script will look for the ALSA SDK.

Jack and ALSA/asound are used by other Linux distros like:
- Arch https://github.com/archlinux/svntogit-packages/blob/packages/portaudio/trunk/PKGBUILD
- Debian https://packages.debian.org/sid/libportaudio2
- Fedora https://src.fedoraproject.org/rpms/portaudio/blob/rawhide/f/portaudio.spec

Though, Jack does have a larger dependency tree, so, just using `alsa-lib` could be an alternative option that improves current bottle with smaller number of dependencies