### PR TITLE
gtk+ 2.24.33 updated URL of patch

### DIFF
--- a/Formula/gtk+.rb
+++ b/Formula/gtk+.rb
@@ -49,12 +49,14 @@ class Gtkx < Formula
 
   # Patch to allow Eiffel Studio to run in Cocoa / non-X11 mode, as well as Freeciv's freeciv-gtk2 client
   # See:
+  # - https://gitlab.gnome.org/GNOME/gtk/-/issues/580
+  # referenced from
   # - https://bugzilla.gnome.org/show_bug.cgi?id=757187
   # referenced from
   # - https://bugzilla.gnome.org/show_bug.cgi?id=557780
   # - Homebrew/homebrew-games#278
   patch do
-    url "https://bug757187.bugzilla-attachments.gnome.org/attachment.cgi?id=331173"
+    url "https://gitlab.gnome.org/GNOME/gtk/uploads/2a194d81de8e8346a81816870264b3bf/gdkimage.patch"
     sha256 "ce5adf1a019ac7ed2a999efb65cfadeae50f5de8663638c7f765f8764aa7d931"
   end
 


### PR DESCRIPTION
The old URL pointed to an xz compressed file after pango moved from
github to gitlab. The new, correct, URL points to the uncompressed
patch file.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
