### PR TITLE
shakespeare: add livecheck

### DIFF
--- a/Formula/shakespeare.rb
+++ b/Formula/shakespeare.rb
@@ -4,6 +4,11 @@ class Shakespeare < Formula
   url "https://shakespearelang.sourceforge.io/download/spl-1.2.1.tar.gz"
   sha256 "1206ef0a2c853b8b40ca0c682bc9d9e0a157cc91a7bf4e28f19ccd003674b7d3"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?spl[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any, arm64_big_sur: "60ae733b2e127fb14ce46ba46451ee2879f36e01154ab1d01ebd3347c7c18932"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `shakespeare`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.