### PR TITLE
rom-tools: fix build for Linux

### DIFF
--- a/Formula/rom-tools.rb
+++ b/Formula/rom-tools.rb
@@ -31,16 +31,11 @@ class RomTools < Formula
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "glm" => :build
-    depends_on "jpeg" => :build
     depends_on "portaudio" => :build
     depends_on "portmidi" => :build
-    depends_on "pugixml" => :build
     depends_on "pulseaudio" => :build
     depends_on "qt@5" => :build
-    depends_on "rapidjson" => :build
     depends_on "sdl2_ttf" => :build
-    depends_on "sqlite" => :build
     depends_on "gcc" # for C++17
   end
 
@@ -64,16 +59,8 @@ class RomTools < Formula
       USE_SYSTEM_LIB_UTF8PROC=1
     ]
     on_linux do
-      args += %w[
-        USE_SYSTEM_LIB_GLM=1
-        USE_SYSTEM_LIB_JPEG=1
-        USE_SYSTEM_LIB_LUA=
-        USE_SYSTEM_LIB_PORTAUDIO=1
-        USE_SYSTEM_LIB_PORTMIDI=1
-        USE_SYSTEM_LIB_PUGIXML=1
-        USE_SYSTEM_LIB_RAPIDJSON=1
-        USE_SYSTEM_LIB_SQLITE3=1
-      ]
+      args << "USE_SYSTEM_LIB_PORTAUDIO=1"
+      args << "USE_SYSTEM_LIB_PORTMIDI=1"
     end
     system "make", *args
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`mame` binary built in `rom-tools` is not distributed in bottle, so it doesn't really make a difference if we use bundled libraries or system libraries. Dropping some system libraries to avoid unwanted dynamic linkage, like `pugixml`.

Build time from previous PR #83859 attempt wasn't that different, so system libraries didn't help there.

The only build issue is for `portaudio`, i.e.:
- either needs `alsa-lib` to build local `portaudio`
- or needs `portaudio` set as system library.