### PR TITLE
udunits 2.2.27.13

### DIFF
--- a/Formula/udunits.rb
+++ b/Formula/udunits.rb
@@ -1,9 +1,9 @@
 class Udunits < Formula
   desc "Unidata unit conversion library"
   homepage "https://www.unidata.ucar.edu/software/udunits/"
-  url "https://github.com/Unidata/UDUNITS-2/archive/v2.2.27.6.tar.gz"
-  sha256 "74fd7fb3764ce2821870fa93e66671b7069a0c971513bf1904c6b053a4a55ed1"
-  revision 1
+  url "https://github.com/Unidata/UDUNITS-2/archive/v2.2.27.13.tar.gz"
+  sha256 "23c8a2182c41c3c5c44a3113c05cf7342f35823cb5c831c1ff3e8878bf6ee89e"
+  license :cannot_represent
 
   bottle do
     sha256 arm64_big_sur: "11fbb852b729b417f5c3cca75fcf53b30e5e662638ddac30c59c699e04ae7c75"
@@ -16,9 +16,9 @@ class Udunits < Formula
   depends_on "cmake" => :build
 
   uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
   uses_from_macos "texinfo" => :build
   uses_from_macos "expat"
-  uses_from_macos "flex"
 
   on_linux do
     patch :p1 do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

license is `UCAR` (listed in [federoa repo](https://fedoraproject.org/wiki/Licensing/UCAR), but not listed in SPDX license yet)

this is bumping the udunits to the last buildable/testable release (gonna create a upstream issue for upgrading to the latest)