### PR TITLE
gcc: don't encode full version in paths

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -14,7 +14,8 @@ class Gcc < Formula
     sha256 "d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
   end
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
-  head "https://gcc.gnu.org/git/gcc.git"
+  revision 1
+  head "https://gcc.gnu.org/git/gcc.git", branch: "master"
 
   # We can't use `url :stable` here due to the ARM-specific branch above.
   livecheck do
@@ -73,9 +74,9 @@ class Gcc < Formula
 
     args = %W[
       --prefix=#{prefix}
-      --libdir=#{lib}/gcc/#{version_suffix}
       --disable-nls
       --enable-checking=release
+      --with-gcc-major-version-only
       --enable-languages=#{languages.join(",")}
       --program-suffix=-#{version_suffix}
       --with-gmp=#{Formula["gmp"].opt_prefix}
@@ -106,10 +107,6 @@ class Gcc < Formula
         args << "--with-native-system-header-dir=/usr/include"
         args << "--with-sysroot=#{sdk}"
       end
-
-      # Ensure correct install names when linking against libgcc_s;
-      # see discussion in https://github.com/Homebrew/legacy-homebrew/pull/34303
-      inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
     end
 
     on_linux do

--- a/Formula/libgccjit.rb
+++ b/Formula/libgccjit.rb
@@ -14,7 +14,8 @@ class Libgccjit < Formula
   end
   homepage "https://gcc.gnu.org/"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
-  head "https://gcc.gnu.org/git/gcc.git"
+  revision 1
+  head "https://gcc.gnu.org/git/gcc.git", branch: "master"
 
   livecheck do
     formula "gcc"
@@ -52,9 +53,9 @@ class Libgccjit < Formula
     args = %W[
       --build=#{cpu}-apple-darwin#{OS.kernel_version.major}
       --prefix=#{prefix}
-      --libdir=#{lib}/gcc/#{version.major}
       --disable-nls
       --enable-checking=release
+      --with-gcc-major-version-only
       --with-gmp=#{Formula["gmp"].opt_prefix}
       --with-mpfr=#{Formula["mpfr"].opt_prefix}
       --with-mpc=#{Formula["libmpc"].opt_prefix}

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -5,6 +5,7 @@ class Octave < Formula
   mirror "https://ftpmirror.gnu.org/octave/octave-6.3.0.tar.xz"
   sha256 "fb472cb957c748670391cbc3385ff230cf44832bc314fee359e43c69cf9da5ef"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "6bf235731cccb20bba3e58414147bcb63f3b2d3c8f33a2f05d4ca139f9b8f55a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

From `./configure --help`:

      --with-gcc-major-version-only
                              use only GCC major number in filesystem paths

Some formulae rely on paths that encode GCC's full version [1] (e.g.
`octave`, see #84245), so we should stop trying to create these paths so
that these formulae don't get broken on GCC version bumps.

[1] e.g. `include/c++/11.2.0`, `lib/gcc/11/gcc/x86_64-apple-darwin20/11.2.0`

Closes #84245.