### PR TITLE
qwt-qt5: new alias

### DIFF
--- a/Aliases/qwt-qt5
+++ b/Aliases/qwt-qt5
@@ -1,0 +1,1 @@
+../Formula/qwt.rb


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A `qwt-qt5 formula` is proposed to be added in https://github.com/Homebrew/homebrew-core/pull/84246, which updates the `qwt` formula to depend on `qt@6` instead of `qt@5`. This adds `qwt-qt5` now as an alias of `qwt` to allow 3rd-party taps a smoother migration to the new formula name.
