### PR TITLE
spack: depend on python@3.9

### DIFF
--- a/Formula/spack.rb
+++ b/Formula/spack.rb
@@ -1,7 +1,6 @@
 class Spack < Formula
   desc "Package manager that builds multiple versions and configurations of software"
   homepage "https://spack.io"
-  # TODO: depend on python@3.9 once v0.16.3 is released
   url "https://github.com/spack/spack/archive/v0.16.2.tar.gz"
   sha256 "ed3e5d479732b0ba82489435b4e0f9088571604e789f7ab9bc5ce89030793350"
   license any_of: ["Apache-2.0", "MIT"]
@@ -20,10 +19,17 @@ class Spack < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "ab713b17720b8b02b22c0d2070e6b27d498d552c420e73bd7cf246e565bf7eae"
   end
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
+
+  # Fix incompatibility with Python 3.9.6+, remove with next release
+  # https://github.com/spack/spack/issues/24644
+  patch do
+    url "https://github.com/spack/spack/commit/3b94e22ad44a5921b639dfc5a59a7626562457c7.patch?full_index=1"
+    sha256 "77d9e48ecde83595a249b1859d62a2e94fda5c4aa9ed7cd1bc441f6083388132"
+  end
 
   def install
-    cp_r Dir["bin", "etc", "lib", "share", "var"], prefix.to_s
+    prefix.install Dir["*"]
   end
 
   def post_install
@@ -54,7 +60,7 @@ class Spack < Formula
 
     # Get the path to one of the compiled library files
     zlib_prefix = shell_output("#{bin}/spack -ddd -C #{testpath}/cfg-store find --format={prefix} zlib").strip
-    zlib_dylib_file = Pathname.new "#{zlib_prefix}/lib/libz.dylib"
+    zlib_dylib_file = Pathname.new "#{zlib_prefix}/lib/libz.a"
     assert_predicate zlib_dylib_file, :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
From #84284, appears the latest `python@3.8` has the same issue experienced on `python@3.9`