### PR TITLE
tcpkali: fix build for Linux

### DIFF
--- a/Formula/tcpkali.rb
+++ b/Formula/tcpkali.rb
@@ -16,9 +16,11 @@ class Tcpkali < Formula
     sha256 cellar: :any_skip_relocation, yosemite:      "71573c4926d086721c028e73d9812475fe3a58bd8313a43ef9c6a54918334760"
   end
 
+  uses_from_macos "bison" => :build
+  uses_from_macos "ncurses"
+
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/runs/3468496334?check_suite_focus=true
```
configure: error: 
    tcpkali requires bison or byacc, plain yacc doesn't count.
    Install 'bison' package first.
```