### PR TITLE
mkhexgrid: add livecheck

### DIFF
--- a/Formula/mkhexgrid.rb
+++ b/Formula/mkhexgrid.rb
@@ -1,9 +1,14 @@
 class Mkhexgrid < Formula
   desc "Fully-configurable hex grid generator"
-  homepage "http://www.nomic.net/~uckelman/mkhexgrid/"
-  url "http://www.nomic.net/~uckelman/mkhexgrid/releases/mkhexgrid-0.1.1.src.tar.bz2"
+  homepage "https://www.nomic.net/~uckelman/mkhexgrid/"
+  url "https://www.nomic.net/~uckelman/mkhexgrid/releases/mkhexgrid-0.1.1.src.tar.bz2"
   sha256 "122609261cc91c2063ab5315d4316a27c9a0ab164f663a6cb781dd87310be3dc"
   license "GPL-2.0"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?mkhexgrid[._-]v?(\d+(?:\.\d+)+)[._-]src\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "488eb3b7fa3023c4326755bd7bd3546b926d3e03e353063d700c3f15c41e59f1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `mkhexgrid`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This PR also updates the `homepage` and `stable` URLs to use HTTPS, as the existing HTTP URLs were redirecting to HTTPS. I'm not running this as `CI-syntax-only`, as the `stable` URL has technically been modified.