### PR TITLE
uftrace: enable luajit, show python support, improved test

### DIFF
--- a/Formula/uftrace.rb
+++ b/Formula/uftrace.rb
@@ -4,6 +4,7 @@ class Uftrace < Formula
   url "https://github.com/namhyung/uftrace/archive/v0.10.tar.gz"
   sha256 "b8b56d540ea95c3eafe56440d6a998e0a140d53ca2584916b6ca82702795bbd9"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/namhyung/uftrace.git", branch: "master"
 
   bottle do
@@ -16,19 +17,29 @@ class Uftrace < Formula
   depends_on "elfutils"
   depends_on "libunwind"
   depends_on :linux
+  depends_on "luajit-openresty"
   depends_on "ncurses"
   depends_on "python@3.9"
 
   def install
+    # Obsolete with git master, to be removed when updating to next release
+    inreplace "misc/version.sh", "deps/have_libpython2.7", "deps/have_libpython*"
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install", "V=1"
   end
 
   test do
     out = shell_output("#{bin}/uftrace -A . -R . -P main #{bin}/uftrace -V")
+    assert_match "dwarf", out
+    assert_match "python", out
+    assert_match "luajit", out
+    assert_match "tui", out
+    assert_match "sched", out
     assert_match "dynamic", out
+
     assert_match "| main() {", out
+    assert_match "|   getopt_long(2, ", out
     assert_match "printf", out
-    assert_match "} /* main */", out
+    assert_match "| } /* main */", out
   end
 end


### PR DESCRIPTION
update the uftrace dynamic function graph tracer formula:
- enable luajit
- show support or python on the command line
- improved test case

PS: bump-formula-pr was not used,
it fails with "Formula/howdoi.rb: needs merge" (was comitted here today)