### PR TITLE
rollup 2.56.3 (new formula)

### DIFF
--- a/Formula/rollup.rb
+++ b/Formula/rollup.rb
@@ -1,0 +1,44 @@
+require "language/node"
+
+class Rollup < Formula
+  desc "Next-generation ES module bundler"
+  homepage "https://rollupjs.org/"
+  url "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz"
+  sha256 "ff1b1ea315ec186efb3f70a643ef17e552e076c518bb54d4e84a22b3e9f48cda"
+  license all_of: ["ISC", "MIT"]
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+    deuniversalize_machos
+  end
+
+  test do
+    (testpath/"test/main.js").write <<~EOS
+      import foo from './foo.js';
+      export default function () {
+        console.log(foo);
+      }
+    EOS
+
+    (testpath/"test/foo.js").write <<~EOS
+      export default 'hello world!';
+    EOS
+
+    expected = <<~EOS
+      'use strict';
+
+      var foo = 'hello world!';
+
+      function main () {
+        console.log(foo);
+      }
+
+      module.exports = main;
+    EOS
+
+    assert_equal expected, shell_output("#{bin}/rollup #{testpath}/test/main.js -f cjs")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
rollup:
  * Unexpected universal binaries were found.
    The offending files are:
      /usr/local/Cellar/rollup/2.56.3/libexec/lib/node_modules/rollup/node_modules/fsevents/fsevents.node
```