### PR TITLE
msgpack: add `msgpack-c` alias

### DIFF
--- a/Aliases/msgpack-c
+++ b/Aliases/msgpack-c
@@ -1,0 +1,1 @@
+../Formula/msgpack.rb


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The C++ library is now in a separate `msgpack-cxx` formula, so it seems
natural to try to `brew install msgpack-c` to install the C library,
which we've kept in the original `msgpack` formula.

Let's add an alias to make sure this and related commands succeed.