### PR TITLE
msgpack-cxx: add `msgpack-cpp` alias

### DIFF
--- a/Aliases/msgpack-cpp
+++ b/Aliases/msgpack-cpp
@@ -1,0 +1,1 @@
+../Formula/msgpack-cxx.rb


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Most other related formulae in Homebrew/core are suffixed with `-cpp`
rather than `-cxx`. Also, the upstream branch this formula is built on
is called `cpp_master`, despite the actual artefact being called
`msgpack-cxx`.

This makes it likely that some users are going to try to do `brew
install msgpack-cpp` and end up confused by the resulting error. Let's
try to avoid that by adding this alias.