### PR TITLE
vtclock 0.0.20161228

### DIFF
--- a/Formula/vtclock.rb
+++ b/Formula/vtclock.rb
@@ -1,9 +1,16 @@
 class Vtclock < Formula
   desc "Text-mode fullscreen digital clock"
-  homepage "https://webonastick.com/vtclock/"
-  url "https://webonastick.com/vtclock/vtclock-2005-02-20.tar.gz"
-  sha256 "5fcbceff1cba40c57213fa5853c4574895755608eaf7248b6cc2f061133dab68"
-  license "GPL-2.0"
+  homepage "https://github.com/dse/vtclock"
+  url "https://github.com/dse/vtclock/archive/0.0.20161228.tar.gz"
+  sha256 "0148411febd672c34e436361f5969371ae5291bdc497c771af403a5ee85a78b4"
+  license "GPL-2.0-or-later"
+  version_scheme 1
+  head "https://github.com/dse/vtclock.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "34bc3937dbc073c9f9a210beda09527ae97f49826a3ef32f8f997317481cdf72"
@@ -15,6 +22,9 @@ class Vtclock < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:    "f87c685e59533a0085b439c4153c2734d4091447f5a81c627ccc0d2e589ac65d"
     sha256 cellar: :any_skip_relocation, yosemite:      "a72a8c176276c40a3e9b0c6083a61013efb55b5ea43cd786000dad3c4243dd96"
   end
+
+  depends_on "pkg-config" => :build
+  uses_from_macos "ncurses"
 
   def install
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URL for `vtclock` currently gives a 403 Forbidden response. `vtclock` isn't referenced on the [main webonastick.com page](https://webonastick.com/) but it links to the author's GitHub account, which contains a `vtclock` repository.

This PR modifies the `homepage` and `stable` URL to use the GitHub project, updating to the latest available version (`0.0.20161228`) in the process. The version scheme has changed from the previous `2005-02-20` format and the old format will be treated as newer (as `2005` > `0`), so this bumps the `version_scheme`. [I've also added the GitHub repository as the `head` URL and this built/tested fine locally using `brew install --HEAD vtclock`.]

This also updates the `license` from `GPL-2.0` to `GPL-2.0-or-later`, as the [`Makefile`](https://github.com/dse/vtclock/blob/master/Makefile) includes a license comment using the "or...later" language. Outside of the [`COPYING` file](https://github.com/dse/vtclock/blob/master/COPYING), this appears to be the only reference to the license in the source code.

Lastly, this adds a `livecheck` block that checks the GitHub repository tags using the standard regex for versions like `1.2.3`/`v1.2.3`, as this will match the `0.0.20161228` format. The tags look a bit unpredictable at this point and if this regex ends up matching more/less than it should in the future, we can always update it as needed.