### PR TITLE
qdbm: update urls/license, add livecheck

### DIFF
--- a/Formula/qdbm.rb
+++ b/Formula/qdbm.rb
@@ -1,9 +1,14 @@
 class Qdbm < Formula
   desc "Library of routines for managing a database"
-  homepage "https://fallabs.com/qdbm/"
-  url "https://fallabs.com/qdbm/qdbm-1.8.78.tar.gz"
+  homepage "https://dbmx.net/qdbm/"
+  url "https://dbmx.net/qdbm/qdbm-1.8.78.tar.gz"
   sha256 "b466fe730d751e4bfc5900d1f37b0fb955f2826ac456e70012785e012cdcb73e"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?qdbm[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 1
@@ -36,12 +41,10 @@ class Qdbm < Formula
     system "./configure", *args
     on_macos do
       system "make", "mac"
-      system "make", "check-mac"
       system "make", "install-mac"
     end
     on_linux do
       system "make"
-      system "make", "check"
       system "make", "install"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `qdbm`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

The existing `homepage` and `stable` URL redirect from `fallabs.com` to `dbmx.net` (and this isn't a new development), so this PR also updates these URLs to avoid the redirection. Since this technically modifies the `stable` URL (the `sha256` is unchanged), I didn't label this as `CI-syntax-only`.

This also updates the `license` from `LGPL-2.1` to `LGPL-2.1-or-later`, as the source files contain license comments that use the "or...later" language.

Lastly, this removes the `make check` steps in the `install` block, to resolve the "Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks" audit.

Edit: Ignore the subsequent pushes to this; I modified the wrong PR by accident.