### PR TITLE
lit 12.0.1 (new formula)

### DIFF
--- a/Formula/lit.rb
+++ b/Formula/lit.rb
@@ -1,0 +1,44 @@
+class Lit < Formula
+  include Language::Python::Virtualenv
+
+  desc "Portable tool for LLVM- and Clang-style test suites"
+  homepage "https://llvm.org"
+  url "https://files.pythonhosted.org/packages/7c/0c/2d58790cb0fa24812382289a584e05dd1df4b30ccf5e2218ee5a556a0529/lit-12.0.1.tar.gz"
+  sha256 "d2957aac5d560e98662a9fe7a2f5a485d2320ded2ef26e065e4fe871967ecf07"
+  license "Apache-2.0" => { with: "LLVM-exception" }
+
+  depends_on "llvm" => :test
+  depends_on "python@3.9"
+
+  def install
+    system "python3", *Language::Python.setup_install_args(prefix)
+  end
+
+  test do
+    ENV.prepend_path "PATH", Formula["llvm"].opt_bin
+
+    (testpath/"example.c").write <<~EOS
+      // RUN: cc %s -o %t
+      // RUN: %t | FileCheck %s
+      // CHECK: hello world
+      #include <stdio.h>
+
+      int main() {
+        printf("hello world");
+        return 0;
+      }
+    EOS
+
+    (testpath/"lit.site.cfg.py").write <<~EOS
+      import lit.formats
+
+      config.name = "Example"
+      config.test_format = lit.formats.ShTest(True)
+
+      config.suffixes = ['.c']
+    EOS
+
+    system bin/"lit", "-v", "."
+    system "python3", "-c", "import lit"
+  end
+end

--- a/audit_exceptions/provided_by_macos_depends_on_allowlist.json
+++ b/audit_exceptions/provided_by_macos_depends_on_allowlist.json
@@ -2,6 +2,7 @@
   "apr",
   "apr-util",
   "libressl",
+  "llvm",
   "openblas",
   "openssl@1.1"
 ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Closes #82479.


~~This fails the audit because of the `llvm` dependency, but the test uses it for `FileCheck`, which is not provided by macOS (but comes with the `llvm` formula).~~

~~Using `FileCheck` is the standard way of using `lit`, so we probably do want to use it to better simulate how a user might try to make use of this.~~