### PR TITLE
samba: fix compilation error on Linux

### DIFF
--- a/Formula/samba.rb
+++ b/Formula/samba.rb
@@ -7,6 +7,7 @@ class Samba < Formula
   url "https://download.samba.org/pub/samba/stable/samba-4.14.7.tar.gz"
   sha256 "6f50353f9602aa20245eb18ceb00e7e5ec793df0974aebd5254c38f16d8f1906"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.samba.org/samba/download/"
@@ -50,6 +51,7 @@ class Samba < Formula
         system "make", "install"
       end
     end
+    ENV.append "LDFLAGS", "-Wl,-rpath,#{lib}/private" if OS.linux?
     system "./configure",
            "--disable-cephfs",
            "--disable-cups",
@@ -69,6 +71,7 @@ class Samba < Formula
            "--without-syslog",
            "--without-utmp",
            "--without-winbind",
+           "--with-shared-modules=!vfs_snapper",
            "--prefix=#{prefix}"
     system "make"
     system "make", "install"


### PR DESCRIPTION
Compilation was failing for Linux

https://github.com/Homebrew/homebrew-core/runs/3455435102

> Checking for dbus                                                                 : not found
> vfs_snapper is enabled but prerequisite dbus-1 package not found. Use --with-shared-modules='!vfs_snapper' to disable vfs_snapper support.



- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
