### PR TITLE
singularity: fixes for build, run and test

### DIFF
--- a/Formula/singularity.rb
+++ b/Formula/singularity.rb
@@ -1,24 +1,40 @@
 class Singularity < Formula
-  desc "Application containers for Linux"
+  desc "Application container and unprivileged sandbox platform for Linux"
   homepage "https://singularity.hpcng.org"
   url "https://github.com/hpcng/singularity/releases/download/v3.8.2/singularity-3.8.2.tar.gz"
   sha256 "996611dec402b4d372b8b9456dd9ec1cb43712d08502e455f38521bd199856d3"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "565338bfa4b430b4e3de41de908e91b225e98fdcba64db857f2aedfc1c782be2"
   end
 
+  # No relocation, the localstatedir to find configs etc is compiled into the program
+  pour_bottle? only_if: :default_prefix
+
   depends_on "go" => :build
   depends_on "openssl@1.1" => :build
-  depends_on "libarchive"
+  depends_on "pkg-config" => :build
+  depends_on "libseccomp"
   depends_on :linux
-  depends_on "pkg-config"
   depends_on "squashfs"
-  depends_on "util-linux" # for libuuid
 
   def install
-    system "./mconfig", "--prefix=#{prefix}"
+    inreplace "pkg/util/singularityconf/config.go" do |s|
+      unsquashfs_dir = Formula["squashfs"].bin.to_s
+      s.sub!(/(directive:"mksquashfs path)/, "default:\"#{unsquashfs_dir}\" \\1")
+    end
+    args = %W[
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}
+      --localstatedir=#{var}
+      --without-suid
+      -P release-stripped
+      -v
+    ]
+    ENV.O0
+    system "./mconfig", *args
     cd "./builddir" do
       system "make"
       system "make", "install"
@@ -26,6 +42,8 @@ class Singularity < Formula
   end
 
   test do
-    assert_match "There are 0 container file(s)", shell_output("#{bin}/singularity cache list")
+    assert_match(/There are [0-9]+ container file/, shell_output("#{bin}/singularity cache list"))
+    # This does not work inside older github runners, but for a simple quick check, run:
+    # singularity exec library://alpine cat /etc/alpine-release
   end
 end


### PR DESCRIPTION
- The configdir is compiled-in hard => singularity isn't relocatable:
  Installs which write to the bottle's default dir, have to compile it
  and default, don't require singuarity to have suid privileges.
  -> This makes the package work also when the user has no sudo access.

- To install&extract eg a downloaded container image, it uses unsquashfs:
  Add the path to our squashfs to the default path used to look for it,
  so the package can work without investiation into doing configuration.

- Fix build failures caused by brew or the system having libseccomp,
  by specifically depending on brew's libseccomp and compiling with it.

- Singularity now uses internal uuid.go, no longer util-linux libuuid,
  and it no longer uses libarchive at all, so remove both from depends,
  and pkg-config is only a build dependency, not a runtime dependency.

- Fix test to work even when the user installed containers in the past.
  and make the compilation stage verbose for analyzing build logs