### PR TITLE
newrelic-infra-agent: build with go@1.16

### DIFF
--- a/Formula/newrelic-infra-agent.rb
+++ b/Formula/newrelic-infra-agent.rb
@@ -1,9 +1,11 @@
 class NewrelicInfraAgent < Formula
   desc "New Relic infrastructure agent"
   homepage "https://github.com/newrelic/infrastructure-agent"
-  url "https://github.com/newrelic/infrastructure-agent/archive/refs/tags/1.20.2.tar.gz"
-  sha256 "83f521ed6ed903d9fdbeed8eb59b6b488ce5492fe305d38a7096d4c2f017138d"
+  url "https://github.com/newrelic/infrastructure-agent.git",
+      tag:      "1.20.2",
+      revision: "d30d434995dc539e38ab84f8324f1a07d0f552ff"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/newrelic/infrastructure-agent.git", branch: "master"
 
   bottle do
@@ -13,20 +15,22 @@ class NewrelicInfraAgent < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "80a1f2d22913a89ec427d20a8e03579b6de3f74e23ecf7db99546d513eec35f6"
   end
 
-  depends_on "go" => :build
+  # https://github.com/newrelic/infrastructure-agent/issues/723
+  depends_on "go@1.16" => :build
   # https://github.com/newrelic/infrastructure-agent/issues/695
   depends_on arch: :x86_64
 
   def install
     goarch = Hardware::CPU.arm? ? "arm64" : "amd64"
     ENV["VERSION"] = version.to_s
-    ENV["GOOS"] = if OS.mac?
+    os = if OS.mac?
       ENV["CGO_ENABLED"] = "1"
       "darwin"
     else
       ENV["CGO_ENABLED"] = "0"
       "linux"
     end
+    ENV["GOOS"] = os
     system "make", "dist-for-os"
     bin.install "dist/#{os}-newrelic-infra_#{os}_#{goarch}/newrelic-infra"
     bin.install "dist/#{os}-newrelic-infra-ctl_#{os}_#{goarch}/newrelic-infra-ctl"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
We notices that there is an issue with one libraries that happens during the runtime. Latest tested version of go is 1.16.7 so we would like to fix it in order to avoid this issues. Once we test go@1.17 we will update it in the formula as well.

I am not sure, should we remove bottles. If we should not, let me know and I will update PR.
