### PR TITLE
perl: exclude version patch number in lib directory

### DIFF
--- a/Formula/collectd.rb
+++ b/Formula/collectd.rb
@@ -4,7 +4,7 @@ class Collectd < Formula
   url "https://collectd.org/files/collectd-5.12.0.tar.bz2"
   sha256 "5bae043042c19c31f77eb8464e56a01a5454e0b39fa07cf7ad0f1bfc9c3a09d6"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     sha256 arm64_big_sur: "c0a9e32a3407d094ae4fe5f8bf0fc19d0b4f5f0bb40f8ce6335fe4d2241a72b3"
@@ -15,7 +15,7 @@ class Collectd < Formula
   end
 
   head do
-    url "https://github.com/collectd/collectd.git"
+    url "https://github.com/collectd/collectd.git", branch: "main"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -27,19 +27,17 @@ class Collectd < Formula
   depends_on "net-snmp"
   depends_on "riemann-client"
 
-  uses_from_macos "bison"
-  uses_from_macos "flex"
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
   uses_from_macos "perl"
 
   def install
-    args = %W[
-      --disable-debug
-      --disable-dependency-tracking
-      --prefix=#{prefix}
+    args = std_configure_args + %W[
       --localstatedir=#{var}
       --disable-java
       --enable-write_riemann
     ]
+    args << "--with-perl-bindings=PREFIX=#{prefix} INSTALLSITEMAN3DIR=#{man3}" if OS.linux?
 
     system "./build.sh" if build.head?
     system "./configure", *args

--- a/Formula/freeradius-server.rb
+++ b/Formula/freeradius-server.rb
@@ -1,10 +1,24 @@
 class FreeradiusServer < Formula
   desc "High-performance and highly configurable RADIUS server"
   homepage "https://freeradius.org/"
-  url "https://github.com/FreeRADIUS/freeradius-server/archive/release_3_0_23.tar.gz"
-  sha256 "6192b6a8d141545dc54c00c1a7af7f502f990418d780dcae76074163070dbb86"
-  license "GPL-2.0"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
+  revision 1
   head "https://github.com/FreeRADIUS/freeradius-server.git"
+
+  stable do
+    url "https://github.com/FreeRADIUS/freeradius-server/archive/release_3_0_23.tar.gz"
+    sha256 "6192b6a8d141545dc54c00c1a7af7f502f990418d780dcae76074163070dbb86"
+
+    depends_on "autoconf" => :build # for patch
+    depends_on "automake" => :build # for patch
+
+    # Add a configure option to disable opportunistic linking to collectd when CI
+    # needs to build both formulae, e.g. perl PRs. In master/4.x, the configure.ac
+    # was rewritten to support this by using a local m4 macro AX_WITH_LIB_ARGS_OPT.
+    # TODO: Remove when upstream has option in stable release, or when Homebrew CI
+    # is able to uninstall previously-built formulae to avoid unwanted linkage.
+    patch :DATA
+  end
 
   livecheck do
     url :stable
@@ -22,6 +36,8 @@ class FreeradiusServer < Formula
   depends_on "openssl@1.1"
   depends_on "talloc"
 
+  uses_from_macos "krb5"
+  uses_from_macos "libpcap"
   uses_from_macos "perl"
   uses_from_macos "sqlite"
 
@@ -30,6 +46,9 @@ class FreeradiusServer < Formula
   end
 
   def install
+    # TODO: remove autoreconf when patch is no longer needed
+    system "autoreconf", "--verbose", "--install", "--force" if build.stable?
+
     ENV.deparallelize
 
     args = %W[
@@ -40,6 +59,7 @@ class FreeradiusServer < Formula
       --with-openssl-libraries=#{Formula["openssl@1.1"].opt_lib}
       --with-talloc-lib-dir=#{Formula["talloc"].opt_lib}
       --with-talloc-include-dir=#{Formula["talloc"].opt_include}
+      --without-collectdclient
     ]
 
     system "./configure", *args
@@ -57,3 +77,60 @@ class FreeradiusServer < Formula
     assert_match "77C8009C912CFFCF3832C92FC614B7D1", output
   end
 end
+
+__END__
+diff --git a/configure.ac b/configure.ac
+index 3fc6e9df03..e80f96c518 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -968,6 +968,22 @@ fi
+ dnl Set by FR_SMART_CHECK_LIB
+ LIBS="${old_LIBS}"
+ 
++dnl #
++dnl #  extra argument: --with-collectdclient
++dnl #
++WITH_COLLECTDCLIENT=yes
++AC_ARG_WITH(collectdclient,
++[  --with-collectdclient   use collectd client. (default=yes)],
++[ case "$withval" in
++  no)
++    WITH_COLLECTDCLIENT=no
++    ;;
++  *)
++    WITH_COLLECTDCLIENT=yes
++    ;;
++  esac ]
++)
++
+ dnl Check for collectdclient
+ dnl extra argument: --with-collectdclient-lib-dir=DIR
+ collectdclient_lib_dir=
+@@ -1001,16 +1017,18 @@ AC_ARG_WITH(collectdclient-include-dir,
+       ;;
+   esac])
+ 
+-smart_try_dir="$collectdclient_lib_dir"
+-FR_SMART_CHECK_LIB(collectdclient, lcc_connect)
+-if test "x$ac_cv_lib_collectdclient_lcc_connect" != "xyes"; then
+-  AC_MSG_WARN([collectdclient library not found. Use --with-collectdclient-lib-dir=<path>.])
+-else
+-  COLLECTDC_LIBS="${smart_lib}"
+-  COLLECTDC_LDFLAGS="${smart_ldflags}"
++if test "x$WITH_COLLECTDCLIENT" = xyes; then
++  smart_try_dir="$collectdclient_lib_dir"
++  FR_SMART_CHECK_LIB(collectdclient, lcc_connect)
++  if test "x$ac_cv_lib_collectdclient_lcc_connect" != "xyes"; then
++    AC_MSG_WARN([collectdclient library not found. Use --with-collectdclient-lib-dir=<path>.])
++  else
++    COLLECTDC_LIBS="${smart_lib}"
++    COLLECTDC_LDFLAGS="${smart_ldflags}"
++  fi
++  dnl Set by FR_SMART_CHECKLIB
++  LIBS="${old_LIBS}"
+ fi
+-dnl Set by FR_SMART_CHECKLIB
+-LIBS="${old_LIBS}"
+ 
+ dnl Check for cap
+ dnl extra argument: --with-cap-lib-dir=DIR

--- a/Formula/gnumeric.rb
+++ b/Formula/gnumeric.rb
@@ -4,6 +4,7 @@ class Gnumeric < Formula
   url "https://download.gnome.org/sources/gnumeric/1.12/gnumeric-1.12.50.tar.xz"
   sha256 "758819ba1bd6983829f9e7c6d71a7fa20cd75a3652a271e5bb003d5d8bcc14b8"
   license any_of: ["GPL-3.0-only", "GPL-2.0-only"]
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "e35e87954fd36d10ba7d5eb67eb55cda22480501b0244d11d73227efac32eb84"

--- a/Formula/irssi.rb
+++ b/Formula/irssi.rb
@@ -4,7 +4,7 @@ class Irssi < Formula
   url "https://github.com/irssi/irssi/releases/download/1.2.3/irssi-1.2.3.tar.xz"
   sha256 "a647bfefed14d2221fa77b6edac594934dc672c4a560417b1abcbbc6b88d769f"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://irssi.org/download/"

--- a/Formula/mhonarc.rb
+++ b/Formula/mhonarc.rb
@@ -4,7 +4,7 @@ class Mhonarc < Formula
   url "https://www.mhonarc.org/release/MHonArc/tar/MHonArc-2.6.19.tar.bz2"
   sha256 "08912eae8323997b940b94817c83149d2ee3ed11d44f29b3ef4ed2a39de7f480"
   license "GPL-2.0-or-later"
-  revision 2
+  revision 3
 
   livecheck do
     url :homepage
@@ -24,8 +24,9 @@ class Mhonarc < Formula
   end
 
   def install
-    # Handle the hardcoded binary script
-    inreplace "mhonarc", "#!/usr/bin/perl", "#!/usr/bin/env perl"
+    # Using Perl's `installprefix` rather than `prefix` allows install.me to use
+    # Homebrew Perl directory structure even if the prefixes are different paths.
+    inreplace "install.me", "$Config{'prefix'}", "$Config{'installprefix'}"
 
     system "perl", "install.me",
            "-batch",

--- a/Formula/perl-build.rb
+++ b/Formula/perl-build.rb
@@ -4,6 +4,7 @@ class PerlBuild < Formula
   url "https://github.com/tokuhirom/Perl-Build/archive/1.32.tar.gz"
   sha256 "ba86d74ff9718977637806ef650c85615534f0b17023a72f447587676d7f66fd"
   license any_of: ["Artistic-1.0", "GPL-1.0-or-later"]
+  revision 1
   head "https://github.com/tokuhirom/perl-build.git", branch: "master"
 
   bottle do
@@ -124,6 +125,15 @@ class PerlBuild < Formula
 
     %w[perl-build plenv-install plenv-uninstall].each do |cmd|
       (bin/cmd).write_env_script(libexec/"bin/#{cmd}", PERL5LIB: ENV["PERL5LIB"])
+    end
+
+    # Some scripts' shebang is set to the realpath of Homebrew perl, which is not
+    # found using `detected_perl_shebang`. Also, since Formula["perl"].bin returns
+    # the opt_bin directory, we need to manually construct the Cellar path.
+    if OS.linux?
+      inreplace Dir[libexec/"bin/{perl-build,config_data}"] do |s|
+        s.sub! %r{^#!#{HOMEBREW_PREFIX}/Cellar/perl/[^/]+/bin/perl}o, "#!#{Formula["perl"].opt_bin}/perl"
+      end
     end
   end
 

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -4,6 +4,7 @@ class Perl < Formula
   url "https://www.cpan.org/src/5.0/perl-5.34.0.tar.xz"
   sha256 "82c2e5e5c71b0e10487a80d79140469ab1f8056349ca8545140a224dbbed7ded"
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
+  revision 1
   head "https://github.com/perl/perl5.git", branch: "blead"
 
   livecheck do
@@ -30,26 +31,24 @@ class Perl < Formula
   def install
     args = %W[
       -des
-      -Dprefix=#{prefix}
-      -Dprivlib=#{lib}/perl5/#{version}
-      -Dsitelib=#{lib}/perl5/site_perl/#{version}
-      -Dotherlibdirs=#{HOMEBREW_PREFIX}/lib/perl5/site_perl/#{version}
+      -Dinstallprefix=#{prefix}
+      -Dprefix=#{opt_prefix}
+      -Dprivlib=#{opt_lib}/perl5/#{version.major_minor}
+      -Dsitelib=#{opt_lib}/perl5/site_perl/#{version.major_minor}
+      -Dotherlibdirs=#{HOMEBREW_PREFIX}/lib/perl5/site_perl/#{version.major_minor}
       -Dperlpath=#{opt_bin}/perl
       -Dstartperl=#!#{opt_bin}/perl
-      -Dman1dir=#{man1}
-      -Dman3dir=#{man3}
+      -Dman1dir=#{opt_share}/man/man1
+      -Dman3dir=#{opt_share}/man/man3
       -Duseshrplib
       -Duselargefiles
       -Dusethreads
     ]
     args << "-Dsed=/usr/bin/sed" if OS.mac?
-
     args << "-Dusedevel" if build.head?
 
     system "./Configure", *args
-
     system "make"
-
     system "make", "install"
   end
 

--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -4,6 +4,7 @@ class Postgresql < Formula
   url "https://ftp.postgresql.org/pub/source/v13.4/postgresql-13.4.tar.bz2"
   sha256 "ea93e10390245f1ce461a54eb5f99a48d8cabd3a08ce4d652ec2169a357bc0cd"
   license "PostgreSQL"
+  revision 1
   head "https://github.com/postgres/postgres.git", branch: "master"
 
   livecheck do

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -4,6 +4,7 @@ class PostgresqlAT10 < Formula
   url "https://ftp.postgresql.org/pub/source/v10.18/postgresql-10.18.tar.bz2"
   sha256 "57477c2edc82c3f86a74747707b3babc1f301f389315ae14e819e025c0ba3801"
   license "PostgreSQL"
+  revision 1
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"

--- a/Formula/postgresql@11.rb
+++ b/Formula/postgresql@11.rb
@@ -4,6 +4,7 @@ class PostgresqlAT11 < Formula
   url "https://ftp.postgresql.org/pub/source/v11.13/postgresql-11.13.tar.bz2"
   sha256 "a0c3689ff7f565288002cbc138779d5121d74831a5e8341aea7aa86e99b6bc48"
   license "PostgreSQL"
+  revision 1
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -4,6 +4,7 @@ class PostgresqlAT12 < Formula
   url "https://ftp.postgresql.org/pub/source/v12.8/postgresql-12.8.tar.bz2"
   sha256 "e26401e090c34ccb15ffb33a111f340833833535a7b7c5cd11cd88ab57d9c62a"
   license "PostgreSQL"
+  revision 1
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"

--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -4,6 +4,7 @@ class PostgresqlAT96 < Formula
   url "https://ftp.postgresql.org/pub/source/v9.6.23/postgresql-9.6.23.tar.bz2"
   sha256 "a849f798401ab8c6dfa653ebbcd853b43f2200b4e3bc1ea3cb5bec9a691947b9"
   license "PostgreSQL"
+  revision 1
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"

--- a/Formula/rxvt-unicode.rb
+++ b/Formula/rxvt-unicode.rb
@@ -4,6 +4,7 @@ class RxvtUnicode < Formula
   url "http://dist.schmorp.de/rxvt-unicode/rxvt-unicode-9.26.tar.bz2"
   sha256 "643116b9a25d29ad29f4890131796d42e6d2d21312282a613ef66c80c5b8c98b"
   license "GPL-3.0-only"
+  revision 1
 
   livecheck do
     url "http://dist.schmorp.de/rxvt-unicode/"

--- a/Formula/uwsgi.rb
+++ b/Formula/uwsgi.rb
@@ -2,7 +2,7 @@ class Uwsgi < Formula
   desc "Full stack for building hosting services"
   homepage "https://uwsgi-docs.readthedocs.io/en/latest/"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/unbit/uwsgi.git", branch: "master"
 
   stable do

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -5,6 +5,7 @@ class Vim < Formula
   url "https://github.com/vim/vim/archive/v8.2.3400.tar.gz"
   sha256 "a5517f5b5176559732bd082700eddae13e12cd8f0f57c3e35b7538ec0ad00c3b"
   license "Vim"
+  revision 1
   head "https://github.com/vim/vim.git", branch: "master"
 
   bottle do

--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -4,6 +4,7 @@ class Weechat < Formula
   url "https://weechat.org/files/src/weechat-3.2.1.tar.xz"
   sha256 "2bb3a708e006f2d22df9e813f3567569178f30ba4082fd8fb06ca0f6f4d1613f"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/weechat/weechat.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Splitting off the change from #84191.

Directory structure using only major/minor version to avoid breakage on Perl patch releases. This is closer to how Arch Linux and macOS package it:
- **Arch** https://archlinux.org/packages/core/x86_64/perl/
   - usr/lib/perl5/5.34/core_perl/CORE/libperl.so
- **macOS**
   - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/System/Library/Perl/5.30/darwin-thread-multi-2level/CORE/libperl.tbd 

---

One thing that may be worth considering is setting up an installation structure for Perl formulae similar to other Linux distros and Homebrew's Python formulae so that we can easily pick up very common packages like XML::Parser rather than jumping through hoops with the `PERL5LIB`.