### PR TITLE
msgpack*: add livechecks

### DIFF
--- a/Formula/msgpack-cxx.rb
+++ b/Formula/msgpack-cxx.rb
@@ -6,6 +6,11 @@ class MsgpackCxx < Formula
   license "BSL-1.0"
   head "https://github.com/msgpack/msgpack-c.git", branch: "cpp_master"
 
+  livecheck do
+    url :stable
+    regex(/^cpp[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "5fac8a087e33ac7fa6624da35020a6d15487d75d47d4565639e3c78d72d41b2b"
   end

--- a/Formula/msgpack.rb
+++ b/Formula/msgpack.rb
@@ -6,6 +6,11 @@ class Msgpack < Formula
   license "BSL-1.0"
   head "https://github.com/msgpack/msgpack-c.git", branch: "c_master"
 
+  livecheck do
+    url :stable
+    regex(/^c[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "94519c5e879506abb6e665f65982df1b461e53e83904a4ff88bd9ef34a05db83"
     sha256 cellar: :any,                 big_sur:       "a6922853180da9206a75c706502c24971bfa73abf6aeed7b8341a6824e179580"


### PR DESCRIPTION
With msgpack 4.x release (c-4.0.0 and cpp-4.0.0), msgpack repo contains two separate releases for [msgpack](https://github.com/Homebrew/homebrew-core/pull/84363) and [msgpack-cxx](https://github.com/Homebrew/homebrew-core/pull/84240), respectively. Thus, adding the livechecks to differentiate that.