### PR TITLE
snapcraft: update livecheck

### DIFF
--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -10,7 +10,7 @@ class Snapcraft < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
Updating snapcraft livecheck to check against the `latest release` tag, it also matches with the snapcraft store:
![image](https://user-images.githubusercontent.com/1580956/131930814-2636dd5c-94e3-4d88-bafe-06f162504950.png)
