### PR TITLE
dwm: update livecheck

### DIFF
--- a/Formula/dwm.rb
+++ b/Formula/dwm.rb
@@ -8,7 +8,7 @@ class Dwm < Formula
   head "https://git.suckless.org/dwm", using: :git
 
   livecheck do
-    url :homepage
+    url "https://dl.suckless.org/dwm/"
     regex(/href=.*?dwm[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `livecheck` block's URL to check the `dwm` directory listing page where the `stable` archive is found. This is simply to align the check with the approach used in the other suckless.org formulae (i.e., `dmenu`, `ii`, `sic`) for the sake of consistency.