### PR TITLE
libtorch: update livecheck

### DIFF
--- a/Formula/libtorch.rb
+++ b/Formula/libtorch.rb
@@ -10,7 +10,7 @@ class Libtorch < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `libtorch` uses the `GithubLatest` strategy to check the latest release in the GitHub project. This is currently giving `1.8.2` as the latest version instead of `1.9.0`, since the "latest" release is an LTS version that was published after `1.9.0`.

This `livecheck` block was originally added some time ago when we were checking the "latest" release on GitHub more frequently. Nowadays we only use the `GithubLatest` strategy when it's both necessary and correct. Neither of these criteria apply here, so this PR replaces `strategy :github_latest` with the standard regex for Git tags like `1.2.3`/`v1.2.3`. This approach correctly gives `1.9.0` as the latest version.