### PR TITLE
libcello: update urls

### DIFF
--- a/Formula/libcello.rb
+++ b/Formula/libcello.rb
@@ -1,10 +1,10 @@
 class Libcello < Formula
   desc "Higher-level programming in C"
-  homepage "http://libcello.org/"
-  url "http://libcello.org/static/libCello-2.1.0.tar.gz"
+  homepage "https://libcello.org/"
+  url "https://libcello.org/static/libCello-2.1.0.tar.gz"
   sha256 "49acf6525ac6808c49f2125ecdc101626801cffe87da16736afb80684b172b28"
   license "BSD-2-Clause"
-  head "https://github.com/orangeduck/libCello.git"
+  head "https://github.com/orangeduck/libCello.git", branch: "master"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs for `libcello` are redirecting from from HTTP to HTTPS, so this PR updates these URLs to avoid the redirection. I'm not running this as `CI-syntax-only`, as this technically modifies the `stable` URL.

This also adds `branch: "master"` to `head`, to address the related audit.