### PR TITLE
aws-vault: only build on linux, remove macOS build

### DIFF
--- a/Formula/aws-vault.rb
+++ b/Formula/aws-vault.rb
@@ -15,15 +15,9 @@ class AwsVault < Formula
 
   depends_on "go" => :build
 
-  def install
-    # Remove this line because we don't have a certificate to code sign with
-    inreplace "Makefile",
-      "codesign --options runtime --timestamp --sign \"$(CERT_ID)\" $(INSTALL_DIR)/aws-vault || true", ""
-    os = "darwin"
-    on_linux { os = "linux" }
-    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+  depends_on :linux # at upstreams request because without signed binaries it's less convenient to use
 
-    system "make", "aws-vault-#{os}-#{arch}", "VERSION=#{version}-#{tap.user}"
+  def install
     system "make", "install", "INSTALL_DIR=#{bin}", "VERSION=#{version}-#{tap.user}"
 
     zsh_completion.install "contrib/completions/zsh/aws-vault.zsh"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I'm the maintainer of [aws-vault](https://github.com/99designs/aws-vault). This PR ~removes aws-vault~ removes the macOS build in order to avoid confusion and a poor user experience when using aws-vault

A formula for aws-vault was recently added in https://github.com/Homebrew/homebrew-core/pull/83093. I'm sure this was well-intentioned, however the `aws-vault` binary must be signed and notorized to avoid constant keychain prompts. Failing to sign the binary leads to a very poor experience when using aws-vault with macOS Keychain.

Signed and notarized binaries are present in the forumula in homebrew-cask 
