### PR TITLE
tomcat: Make Tomcat use etc/"tomcat" for its configuration

### DIFF
--- a/Formula/tomcat.rb
+++ b/Formula/tomcat.rb
@@ -22,6 +22,17 @@ class Tomcat < Formula
     (bin/"catalina").write_env_script "#{libexec}/bin/catalina.sh", JAVA_HOME: Formula["openjdk"].opt_prefix
   end
 
+  def post_install
+    pkgetc.mkpath
+    ln_s pkgetc, libexec/"config" unless (libexec/"config").exist?
+  end
+
+  def caveats
+    <<~EOS
+      Configuration files: #{pkgetc}
+    EOS
+  end
+
   service do
     run [opt_bin/"catalina", "run"]
     keep_alive true

--- a/Formula/tomcat@7.rb
+++ b/Formula/tomcat@7.rb
@@ -32,6 +32,17 @@ class TomcatAT7 < Formula
     (bin/"catalina").write_env_script "#{libexec}/bin/catalina.sh", JAVA_HOME: Formula["openjdk"].opt_prefix
   end
 
+  def post_install
+    pkgetc.mkpath
+    ln_s pkgetc, libexec/"config" unless (libexec/"config").exist?
+  end
+
+  def caveats
+    <<~EOS
+      Configuration files: #{pkgetc}
+    EOS
+  end
+
   service do
     run [opt_bin/"catalina", "run"]
     keep_alive true

--- a/Formula/tomcat@8.rb
+++ b/Formula/tomcat@8.rb
@@ -28,6 +28,17 @@ class TomcatAT8 < Formula
     (bin/"catalina").write_env_script "#{libexec}/bin/catalina.sh", JAVA_HOME: Formula["openjdk"].opt_prefix
   end
 
+  def post_install
+    pkgetc.mkpath
+    ln_s pkgetc, libexec/"config" unless (libexec/"config").exist?
+  end
+
+  def caveats
+    <<~EOS
+      Configuration files: #{pkgetc}
+    EOS
+  end
+
   service do
     run [opt_bin/"catalina", "run"]
     keep_alive true

--- a/Formula/tomcat@9.rb
+++ b/Formula/tomcat@9.rb
@@ -28,6 +28,17 @@ class TomcatAT9 < Formula
     (bin/"catalina").write_env_script "#{libexec}/bin/catalina.sh", JAVA_HOME: Formula["openjdk"].opt_prefix
   end
 
+  def post_install
+    pkgetc.mkpath
+    ln_s pkgetc, libexec/"config" unless (libexec/"config").exist?
+  end
+
+  def caveats
+    <<~EOS
+      Configuration files: #{pkgetc}
+    EOS
+  end
+
   service do
     run [opt_bin/"catalina", "run"]
     keep_alive true


### PR DESCRIPTION
Refers to #84392.

Currently every update overwrites tomcat's configuration so any user
settings are lost. This commit tries to use /etc/tomcat symlinks so that
the configuration is kept during upgrades.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
