### PR TITLE
scummvm: update livecheck

### DIFF
--- a/Formula/scummvm.rb
+++ b/Formula/scummvm.rb
@@ -8,8 +8,8 @@ class Scummvm < Formula
   head "https://github.com/scummvm/scummvm.git", branch: "master"
 
   livecheck do
-    url "https://www.scummvm.org/frs/scummvm/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["']}i)
+    url "https://www.scummvm.org/downloads/"
+    regex(/href=.*?scummvm[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `scummvm` checks the directory listing page for releases, which lists version subdirectories. This works but the existing URL is currently redirecting from `https://www.scummvm.org/frs/scummvm/` to `https://downloads.scummvm.org/frs/scummvm/`. The `stable` URL had been updated to avoid the redirection but the `livecheck` block wasn't updated to follow suit.

This PR sidesteps the issue by updating the `livecheck` block to check the first-party download page instead. This also ensures that livecheck doesn't report a new version before it's announced on the website (e.g., if there's a gap between when the assets are uploaded and the download page is updated).