### PR TITLE
ronn: add util-linux as Linux test dependency

### DIFF
--- a/Formula/ronn.rb
+++ b/Formula/ronn.rb
@@ -22,6 +22,10 @@ class Ronn < Formula
 
   uses_from_macos "ruby"
 
+  on_linux do
+    depends_on "util-linux" => :test # for `col`
+  end
+
   def install
     ENV["GEM_HOME"] = libexec
     system "gem", "build", "ronn.gemspec"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`util-linux` is indirectly added via test dependency `groff`. Usually no issues, but in situation where `util-linux` fails to link in CI (e.g. #84510), the `col` command is not found:
```
==> Testing ronn
==> /home/linuxbrew/.linuxbrew/Cellar/ronn/0.7.3/bin/ronn --date 1970-01-01 test.ronn
     roff: ./test.7                                   
     html: ./test.7.html                                         +man
==> groff -t -man -Tascii test.7 | col -bx
sh: 1: col: not found
```