### PR TITLE
scrollkeeper: fix test

### DIFF
--- a/Formula/scrollkeeper.rb
+++ b/Formula/scrollkeeper.rb
@@ -53,6 +53,10 @@ class Scrollkeeper < Formula
   end
 
   test do
-    assert_match "11eb", shell_output("scrollkeeper-gen-seriesid")
+    seriesid1 = shell_output("scrollkeeper-gen-seriesid").strip
+    seriesid2 = shell_output("scrollkeeper-gen-seriesid").strip
+    assert_match(/^\h+(?:-\h+)+$/, seriesid1)
+    assert_match(/^\h+(?:-\h+)+$/, seriesid2)
+    refute_equal seriesid1, seriesid2
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since `scrollkeeper-gen-seriesid` generates unique IDs, it probably doesn't make sense to compare to hardcoded hex.

Just check that the id is a hexadecimal delimited by dashes, and that repeated calls do produce unique values.

https://linux.die.net/man/1/scrollkeeper-gen-seriesid