### PR TITLE
mpi4py: fix test on self-hosted Linux CI

### DIFF
--- a/Formula/mpi4py.rb
+++ b/Formula/mpi4py.rb
@@ -33,9 +33,9 @@ class Mpi4py < Formula
     system python, "-c", "import mpi4py.MPI"
     system python, "-c", "import mpi4py.futures"
 
-    system "mpiexec", "-n", ENV.make_jobs,
+    system "mpiexec", "-n", ENV.make_jobs, "--use-hwthread-cpus",
            python, "-m", "mpi4py.run", "-m", "mpi4py.bench", "helloworld"
-    system "mpiexec", "-n", ENV.make_jobs,
+    system "mpiexec", "-n", ENV.make_jobs, "--use-hwthread-cpus",
            python, "-m", "mpi4py.run", "-m", "mpi4py.bench", "ringtest", "-l", "10", "-n", "1024"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Using `ENV.make_jobs (= 4)` on self-hosted Linux fails test due to insufficient slots. Simple fix is to allow oversubscribing, though this means we are not testing that formula can detect/run on exact number of cores.

Error from Perl PR #84510:
```
==> mpiexec -n 4 /home/linuxbrew/.linuxbrew/opt/python@3.9/bin/python3 -m mpi4py.run -m mpi4py.bench helloworld
--------------------------------------------------------------------------
There are not enough slots available in the system to satisfy the 4
slots that were requested by the application:

  /home/linuxbrew/.linuxbrew/opt/python@3.9/bin/python3

Either request fewer slots for your application, or make more slots
available for use.

A "slot" is the Open MPI term for an allocatable unit where we can
launch a process.  The number of slots available are defined by the
environment in which Open MPI processes are run:

  1. Hostfile, via "slots=N" clauses (N defaults to number of
     processor cores if not provided)
  2. The --host command line parameter, via a ":N" suffix on the
     hostname (N defaults to 1 if not provided)
  3. Resource manager (e.g., SLURM, PBS/Torque, LSF, etc.)
  4. If none of a hostfile, the --host command line parameter, or an
     RM is present, Open MPI defaults to the number of processor cores

In all the above cases, if you want Open MPI to default to the number
of hardware threads instead of the number of processor cores, use the
--use-hwthread-cpus option.
```
