### PR TITLE
wownero: re-add removal of libminiupnpc.a and fix finding readline

### DIFF
--- a/Formula/wownero.rb
+++ b/Formula/wownero.rb
@@ -5,6 +5,7 @@ class Wownero < Formula
       tag:      "v0.10.1.0",
       revision: "8ab87421d9321d0b61992c924cfa6e3918118ad0"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "081e5d143f966063342d63774d83c9e27d9030d692d6e392f58b4d090fc0c8ad"
@@ -32,8 +33,13 @@ class Wownero < Formula
   patch :DATA
 
   def install
-    system "cmake", ".", *std_cmake_args
+    # Need to help CMake find `readline` when not using /usr/local prefix
+    system "cmake", ".", *std_cmake_args, "-DReadline_ROOT_DIR=#{Formula["readline"].opt_prefix}"
     system "make", "install"
+
+    # Fix conflict with miniupnpc.
+    # This has been reported at https://github.com/monero-project/monero/issues/3862
+    rm lib/"libminiupnpc.a"
   end
 
   service do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`libminiupnpc.a` issue seems to be back based on perl PR #84510. Copied previous workaround from #80359
```
==> Pouring wownero--0.10.1.0.x86_64_linux.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /home/linuxbrew/.linuxbrew
Could not symlink lib/libminiupnpc.a
Target /home/linuxbrew/.linuxbrew/lib/libminiupnpc.a
is a symlink belonging to miniupnpc. You can unlink it:
  brew unlink miniupnpc
```

Also `wownero` has trouble finding Readline when not using `/usr/local` prefix: https://git.wownero.com/wownero/wownero/src/branch/master/cmake/FindReadline.cmake#L24

Readline is not detected/linked on Linux (and maybe ARM). Probably should check bottles to make sure.