### PR TITLE
umple: add livecheck

### DIFF
--- a/Formula/umple.rb
+++ b/Formula/umple.rb
@@ -6,6 +6,12 @@ class Umple < Formula
   sha256 "686beb3c8aa3c0546f4a218dad353f4efce05aed056c59ccf3d5394747c0e13d"
   license "MIT"
 
+  livecheck do
+    url :stable
+    regex(/href=.*?umple[._-]v?(\d+(?:\.\d+)+(?:\.[\da-f]+)?)\.jar/i)
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b588ed54d528a7301c1450bd03a8651abcb88119e18dd9166631adf3143a2180"
     sha256 cellar: :any_skip_relocation, big_sur:       "b588ed54d528a7301c1450bd03a8651abcb88119e18dd9166631adf3143a2180"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `umple` and returns `1.31.1` as the latest version (from the `v1.31.1` tag). The formula uses the version from the `jar` file, `1.31.1.5860.78bb27cc6`, which is notably longer.

To obtain the full version (with respect to the formula), it's necessary to check the page for the "latest" release on GitHub and match the version from the attached `jar` file. This PR adds a `livecheck` block that uses the `GithubLatest` strategy with an appropriate regex.