### PR TITLE
iperf: fix shasum

### DIFF
--- a/Formula/iperf.rb
+++ b/Formula/iperf.rb
@@ -2,7 +2,7 @@ class Iperf < Formula
   desc "Tool to measure maximum TCP and UDP bandwidth"
   homepage "https://sourceforge.net/projects/iperf2/"
   url "https://downloads.sourceforge.net/project/iperf2/iperf-2.1.4.tar.gz"
-  sha256 "f07a0f343c60f6d07f18fa22d3501f8ca8fcb64d20b96e6a74739af444f66d5c"
+  sha256 "062b392e87b8e227aca74fef0a99b04fe0382d4518957041b508a56885b4d4f9"
   license "BSD-3-Clause"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fixes https://github.com/Homebrew/brew/issues/11970.

This PR adjusts the shasum of `iperf`.
It seems like `iperf-2.1.4.tar.gz` has been [updated](https://sourceforge.net/p/iperf2/activity/?page=0&limit=100#611eda7a20b7921c1cd3b5bd) since its original [release](https://sourceforge.net/p/iperf2/activity/?page=0&limit=100#611ddbb73fd011954c8ec68e), which causes the shasum in the formulae to mismatch.