### PR TITLE
radare2 5.4.0

### DIFF
--- a/Formula/radare2.rb
+++ b/Formula/radare2.rb
@@ -1,10 +1,15 @@
 class Radare2 < Formula
   desc "Reverse engineering framework"
   homepage "https://radare.org"
-  url "https://github.com/radareorg/radare2/archive/5.3.1.tar.gz"
-  sha256 "f95cbbba27f427bc3da41e9296e632c4bba1c47d107a9c911e82a524c136c406"
+  url "https://github.com/radareorg/radare2/archive/5.4.0.tar.gz"
+  sha256 "21ddae80a18d5ceef4bcd3a7cae1ba09d14b510d68ac9134681e1e9967123b23"
   license "LGPL-3.0-only"
   head "https://github.com/radareorg/radare2.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 arm64_big_sur: "fb6a2b27a04b3c58eb9cc9f3c11966c6497190f8500a574610d48b1df8884416"
@@ -21,6 +26,6 @@ class Radare2 < Formula
   end
 
   test do
-    assert_match "radare2 #{version}", shell_output("#{bin}/r2 -version")
+    assert_match "radare2 #{version}", shell_output("#{bin}/r2 -v")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `radare2` to the latest version, 5.4.0.

This also adds a `livecheck` block with a regex that restricts matching to Git tags like `1.2.3`/`v1.2.3`. By default, livecheck was reporting `5.4.0-git` as the latest version instead of the later `5.4.0` release tag and this addresses it.

Lastly, this updates the test to use the `-v` flag instead of `-version`, which was causing the following output:

```
==> Testing radare2
==> /usr/local/Cellar/radare2/5.4.0/bin/r2 -version
r_config_get: variable 'rsion' not found
Invalid config key rsion
```