### PR TITLE
samba: apply "Fixes the Grouplimit of 16 users os OS X." patch

### DIFF
--- a/Formula/samba.rb
+++ b/Formula/samba.rb
@@ -7,7 +7,7 @@ class Samba < Formula
   url "https://download.samba.org/pub/samba/stable/samba-4.14.7.tar.gz"
   sha256 "6f50353f9602aa20245eb18ceb00e7e5ec793df0974aebd5254c38f16d8f1906"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://www.samba.org/samba/download/"
@@ -40,6 +40,10 @@ class Samba < Formula
     url "https://attachments.samba.org/attachment.cgi?id=16579"
     sha256 "86fce5306349d1c8f3732ca978a31065df643c8770114dc9d068b7b4dfa7d282"
   end
+
+  # Workaround for a user with more than 16 groups
+  # From https://github.com/Homebrew/legacy-homebrew/pull/10311/files
+  patch :DATA
 
   def install
     # avoid `perl module "Parse::Yapp::Driver" not found` error on macOS 10.xx (not required on 11)
@@ -93,8 +97,6 @@ class Samba < Formula
         - smbd:     #{HOMEBREW_PREFIX}/sbin/samba-dot-org-smbd
         - mdfind:   #{HOMEBREW_PREFIX}/bin/samba-dot-org-mdfind
         - profiles: #{HOMEBREW_PREFIX}/bin/samba-dot-org-profiles
-
-        On macOS, Samba should be executed as a non-root user: https://bugzilla.samba.org/show_bug.cgi?id=8773
       EOS
     end
   end
@@ -148,3 +150,27 @@ class Samba < Formula
     assert_equal "hello", (testpath/"got/hello").read
   end
 end
+__END__
+# From https://github.com/Homebrew/legacy-homebrew/pull/10311/files
+#
+# Fixes the Grouplimit of 16 users os OS X. 
+# Bug has been raised upstream: https://bugzilla.samba.org/show_bug.cgi?id=8773
+
+--- a/source3/lib/system.c	2012-02-22 22:46:14.000000000 -0200
++++ b/source3/lib/system.c	2012-02-22 22:47:51.000000000 -0200
+@@ -1161,7 +1161,14 @@
+
+ int groups_max(void)
+ {
+-#if defined(SYSCONF_SC_NGROUPS_MAX)
++#if defined(DARWINOS)
++	/* On OS X, sysconf(_SC_NGROUPS_MAX) returns 16
++	 * due to OS X's group nesting and getgrouplist
++	 * will return a flat list; users can exceed the
++	 * maximum of 16 groups. And easily will.
++	 */
++	return 32; // NGROUPS_MAX is defined, hence the define above is void.
++#elif defined(SYSCONF_SC_NGROUPS_MAX)
+ 	int ret = sysconf(_SC_NGROUPS_MAX);
+ 	return (ret == -1) ? NGROUPS_MAX : ret;
+ #else


### PR DESCRIPTION
This patch fixes `get_user_groups: failed to get the unix group list` error that occurs when the user belongs to more than 16 groups.

The patch is from https://github.com/Homebrew/legacy-homebrew/pull/10311/files .
Discussed in https://bugzilla.samba.org/show_bug.cgi?id=8773 .

This patch is required for running Samba on GitHub Actions with the default macOS 10.15 runner, which assigns 18 groups for the "runner" user.

```console
$ groups
staff wheel everyone localaccounts _appserverusr admin _appserveradm _lpadmin _webdeveloper com.apple.access_ssh com.apple.sharepoint.group.1 _appstore _lpoperator _developer _analyticsusers com.apple.access_ftp com.apple.access_screensharing com.apple.access_remote_ae
```

The custom GHA runners used in the Homebrew project are not affected.

Other than applying this patch, there is no known workaround to avoid the error.

Note that just dropping the supplemental groups of the `samba-dot-org-smbd` process (with a helper tool that calls `setgroup(2)` syscall) does not seem to work as a workaround, because `samba-dot-org-smbd` calls `getgrouplist(3)`which talks to `opendirectoryd(8)` to obtain the group list, regardless to the current groups of the `samba-dot-org-smbd` process.
https://github.com/samba-team/samba/blob/samba-4.14.7/source3/lib/system_smbd.c#L185



- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
