### PR TITLE
angband: add livecheck

### DIFF
--- a/Formula/angband.rb
+++ b/Formula/angband.rb
@@ -6,6 +6,11 @@ class Angband < Formula
   license "GPL-2.0-only"
   head "https://github.com/angband/angband.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "ab6002b750047f4c544b8427a2f021395b75ab7f9f93c26fc0f3625b758f5842"
     sha256 big_sur:       "3f6aee791649219ab05f70d1c9170e09137d23ee31fcfdd3862c242dd2165771"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `angband` but it's reporting a pre-release version, `4.2.3-68-g188d30373`, as newest instead of `4.2.3`.

This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`. This omits pre-release versions as well as a bunch of other tags in the repository that we don't want to match. This correctly gives `4.2.3` as newest, so it's not necessary to use the `GithubLatest` strategy at this time.