### PR TITLE
cppp: add livecheck

### DIFF
--- a/Formula/cppp.rb
+++ b/Formula/cppp.rb
@@ -4,6 +4,11 @@ class Cppp < Formula
   url "https://www.muppetlabs.com/~breadbox/pub/software/cppp-2.6.tar.gz"
   sha256 "d42cd410882c3b660c77122b232f96c209026fe0a38d819c391307761e651935"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?cppp[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "24b206e97713f4f12168a2c1a29fe546b931e2da5b72b8ed050170522b1fabf5"
     sha256 cellar: :any_skip_relocation, big_sur:       "e4e6c9586586b0c2d014cf83cd3cf0e1434f2643667900b0dfd4cb194f4f5b1c"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `cppp`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.