### PR TITLE
vcsh: remove bottle diff

### DIFF
--- a/Formula/vcsh.rb
+++ b/Formula/vcsh.rb
@@ -14,13 +14,16 @@ class Vcsh < Formula
   end
 
   def install
+    # Set GIT, SED, and GREP to prevent
+    # hardcoding shim references and absolute paths
     system "./configure", "--with-zsh-completion-dir=#{zsh_completion}",
                           "--with-bash-completion-dir=#{bash_completion}",
+                          "GIT=git", "SED=sed", "GREP=grep",
                           *std_configure_args
     system "make", "install"
 
-    # Remove references to git shim
-    inreplace bin/"vcsh", %r{#{HOMEBREW_SHIMS_PATH}/[^/]+/super/git}o, "git"
+    # Make the shebang uniform across macOS and Linux
+    inreplace bin/"vcsh", %r{^#!/bin/(ba)?sh$}, "#!/usr/bin/env bash"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The current bottles assume that `grep` and `sed` are found in `/bin` on
Linux, and I'm not sure that's portable. Also, let's remove the full
pathnames so that the macOS and Linux bottles are identical.