### PR TITLE
ninja: uses curl for test

### DIFF
--- a/Formula/ninja.rb
+++ b/Formula/ninja.rb
@@ -22,6 +22,8 @@ class Ninja < Formula
 
   depends_on "python@3.9"
 
+  uses_from_macos "curl" => :test
+
   def install
     py = Formula["python@3.9"].opt_bin/"python3"
     system py, "./configure.py", "--bootstrap", "--verbose", "--with-python=python3"


### PR DESCRIPTION
Should Fix:
2021-09-04T00:59:12.8307590Z [34m==>[0m [1mbrew test --retry --verbose ninja[0m
2021-09-04T00:59:23.2769350Z [31m==>[0m [1m[31mFAILED[0m[0m
2021-09-04T00:59:23.2770054Z [32m==>[0m [1mTesting ninja[0m
2021-09-04T00:59:23.2770892Z [34m==>[0m [1m/home/linuxbrew/.linuxbrew/Cellar/ninja/1.10.2/bin/ninja -t targets[0m
2021-09-04T00:59:23.2771460Z foo.o: cc
2021-09-04T00:59:23.2771863Z Web server pid 1996626
2021-09-04T00:59:23.2772601Z [34m==>[0m [1mcurl -s http://localhost:41069?foo.o[0m
2021-09-04T00:59:23.2774022Z curl: error while loading shared libraries: libnghttp2.so.14: cannot open shared object file: No such file or directory
2021-09-04T00:59:23.2774706Z
2021-09-04T00:59:23.2775118Z Killing child processes...

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
