### PR TITLE
nanoflann, fastq-tools: remove `livecheck` blocks

### DIFF
--- a/Formula/fastq-tools.rb
+++ b/Formula/fastq-tools.rb
@@ -5,10 +5,6 @@ class FastqTools < Formula
   sha256 "0cd7436e81129090e707f69695682df80623b06448d95df483e572c61ddf538e"
   license "MIT"
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "ac48791014e14979ad786e59178d0b468510d02f5d51a86608b388adad4405f1"
     sha256 cellar: :any,                 big_sur:       "18f3e795ec5c2c182bfc995ce662816cf17ccbd719fef30937f5456d28bbccc5"

--- a/Formula/nanoflann.rb
+++ b/Formula/nanoflann.rb
@@ -6,10 +6,6 @@ class Nanoflann < Formula
   license "BSD-3-Clause"
   head "https://github.com/jlblancoc/nanoflann.git", branch: "master"
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "dd4506127f2bd65002f11b2deb0b2f6b636fd864bee4a4294fd6123b9c94b6b6"
     sha256 cellar: :any_skip_relocation, big_sur:       "9ce420030884830f6b94c1fa7304d647ad4ceb44622a56781e94d2c3e8c5ca6c"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

If I remember correctly, the stable URL is the "default" or first-checked page for formulae, so these `livecheck` blocks shouldn't be necessary. This is a follow-up to #84729.