### PR TITLE
sbuild: add livecheck

### DIFF
--- a/Formula/sbuild.rb
+++ b/Formula/sbuild.rb
@@ -7,6 +7,11 @@ class Sbuild < Formula
   license "Apache-2.0"
   revision 2
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?sbuild[._-]v?(\d+(?:\.\d+)+)(?:[._-]dist)?\.zip/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "7c54295e4c98758e18d7d5a5ffd76185e429561e59b4a716d25d3482e2546eeb"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `sbuild`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

The first-party website has a [download page](http://sbuild.org/download) but it also links to development releases, which have a similar filename format to stable releases (e.g., `sbuild-0.7.7-dist.zip` for stable and `sbuild-0.7.9013-dist.zip` for development). The homepage only links to the latest stable release, so that's the path of least resistance for now. If they remove that link in the future, we can check the download page and add a `strategy` block that filters out versions with a very high patch version.