### PR TITLE
firefoxpwa: use unversioned paths in config

### DIFF
--- a/Formula/firefoxpwa.rb
+++ b/Formula/firefoxpwa.rb
@@ -4,6 +4,7 @@ class Firefoxpwa < Formula
   url "https://github.com/filips123/FirefoxPWA/archive/refs/tags/v1.1.0.tar.gz"
   sha256 "e3a18c742cc44d0ffde698753182733da75bfe9a2e331efddeb133c479108328"
   license "MPL-2.0"
+  revision 1
   head "https://github.com/filips123/FirefoxPWA.git", branch: "main"
 
   bottle do
@@ -19,9 +20,9 @@ class Firefoxpwa < Formula
     cd "native"
 
     # Prepare the project to work with Homebrew
-    ENV["FFPWA_EXECUTABLES"] = bin
-    ENV["FFPWA_SYSDATA"] = share
-    system "bash", "./packages/brew/configure.sh", version, bin, libexec
+    ENV["FFPWA_EXECUTABLES"] = opt_bin
+    ENV["FFPWA_SYSDATA"] = opt_share
+    system "bash", "./packages/brew/configure.sh", version, opt_bin, opt_libexec
 
     # Build and install the project
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Previously, paths contained hardcoded version, which caused some features to break when updating. This PR changes config to use unversioned paths which should not cause problems. See filips123/FirefoxPWA#55.