### PR TITLE
age 1.0.0 (new formula)

### DIFF
--- a/Formula/age.rb
+++ b/Formula/age.rb
@@ -1,0 +1,23 @@
+class Age < Formula
+  desc "Simple, modern, secure file encryption"
+  homepage "https://filippo.io/age"
+  url "https://github.com/FiloSottile/age/archive/v1.0.0.tar.gz"
+  sha256 "8d27684f62f9dc74014035e31619e2e07f8b56257b1075560456cbf05ddbcfce"
+  license "BSD-3-Clause"
+  head "https://github.com/FiloSottile/age.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    bin.mkpath
+    system "go", "build", *std_go_args(ldflags: "-X main.Version=v#{version}"), "-o", bin, "filippo.io/age/cmd/..."
+    man1.install "doc/age.1"
+    man1.install "doc/age-keygen.1"
+  end
+
+  test do
+    system bin/"age-keygen", "-o", "key.txt"
+    pipe_output("#{bin}/age -e -i key.txt -o test.age", "test")
+    assert_equal "test", shell_output("#{bin}/age -d -i key.txt test.age")
+  end
+end


### PR DESCRIPTION
The [age](https://github.com/FiloSottile/age) has finally released v1.0.0

Up until now because it has been in beta for almost 2 years they have kept a formula [in their own source tree](https://github.com/FiloSottile/age/tree/master/HomebrewFormula). With the 1.0.0 release I think it's time to get it into Homebrew official!

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
