### PR TITLE
web100clt: add livecheck

### DIFF
--- a/Formula/web100clt.rb
+++ b/Formula/web100clt.rb
@@ -5,6 +5,12 @@ class Web100clt < Formula
   sha256 "bd298eb333d4c13f191ce3e9386162dd0de07cddde8fe39e9a74fde4e072cdd9"
   revision 1
 
+  # This page gives a 403 Forbidden response over HTTPS, so we use HTTP.
+  livecheck do
+    url "http://software.internet2.edu/sources/ndt/"
+    regex(/href=.*?ndt[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any, arm64_big_sur: "e6fb064b785043092357a6ca59164fad4ddb9be375f84b466a307b6af724d994"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `web100clt`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The [first-party download page](https://software.internet2.edu/ndt/download.html) links to the directory listing page as the place to download source tarballs.