### PR TITLE
openssl@3 migration: leaf formulae

### DIFF
--- a/Formula/activemq-cpp.rb
+++ b/Formula/activemq-cpp.rb
@@ -5,7 +5,7 @@ class ActivemqCpp < Formula
   mirror "https://archive.apache.org/dist/activemq/activemq-cpp/3.9.5/activemq-cpp-library-3.9.5-src.tar.bz2"
   sha256 "6bd794818ae5b5567dbdaeb30f0508cc7d03808a4b04e0d24695b2501ba70c15"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "972d1a36b67866aa3181868044bce04ec8b70cc65e5ebf3e638d5b666c6585f5"
@@ -19,7 +19,7 @@ class ActivemqCpp < Formula
 
   depends_on "pkg-config" => :build
   depends_on "apr"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/aircrack-ng.rb
+++ b/Formula/aircrack-ng.rb
@@ -4,6 +4,7 @@ class AircrackNg < Formula
   url "https://download.aircrack-ng.org/aircrack-ng-1.6.tar.gz"
   sha256 "4f0bfd486efc6ea7229f7fbc54340ff8b2094a0d73e9f617e0a39f878999a247"
   license all_of: ["GPL-2.0-or-later", "BSD-3-Clause", "OpenSSL"]
+  revision 1
 
   livecheck do
     url :homepage
@@ -22,7 +23,7 @@ class AircrackNg < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
   depends_on "sqlite"
 

--- a/Formula/amap.rb
+++ b/Formula/amap.rb
@@ -4,7 +4,7 @@ class Amap < Formula
   url "https://github.com/hackerschoice/THC-Archive/raw/master/Tools/amap-5.4.tar.gz"
   mirror "https://downloads.sourceforge.net/project/slackbuildsdirectlinks/amap/amap-5.4.tar.gz"
   sha256 "a75ea58de75034de6b10b0de0065ec88e32f9e9af11c7d69edbffc4da9a5b059"
-  revision 3
+  revision 4
 
   livecheck do
     url "https://github.com/hackerschoice/THC-Archive/tree/master/Tools/"
@@ -21,11 +21,11 @@ class Amap < Formula
 
   disable! date: "2020-11-12", because: :unmaintained
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     # Last release was 2011 & there's nowhere supported to report this.
-    openssl = Formula["openssl@1.1"]
+    openssl = Formula["openssl@3"]
     inreplace "configure" do |s|
       s.gsub! 'SSL_IPATH=""', "SSL_IPATH=\"#{openssl.opt_include}/openssl\""
       s.gsub! 'SSL_PATH=""', "SSL_PATH=\"#{openssl.opt_lib}\""
@@ -42,7 +42,7 @@ class Amap < Formula
   end
 
   test do
-    openssl_linked = MachO::Tools.dylibs("#{bin}/amap").any? { |d| d.include? Formula["openssl@1.1"].opt_lib.to_s }
+    openssl_linked = MachO::Tools.dylibs("#{bin}/amap").any? { |d| d.include? Formula["openssl@3"].opt_lib.to_s }
     assert openssl_linked
     # We can do more than this, but unsure how polite it is to port-scan
     # someone's domain every time this goes through CI.

--- a/Formula/amqp-cpp.rb
+++ b/Formula/amqp-cpp.rb
@@ -4,6 +4,7 @@ class AmqpCpp < Formula
   url "https://github.com/CopernicaMarketingSoftware/AMQP-CPP/archive/v4.3.14.tar.gz"
   sha256 "6ac69a407c0edf9f8f56fdbb56acb4e5e9b331e3243cb95f26b861ae794549f4"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/CopernicaMarketingSoftware/AMQP-CPP.git", branch: "master"
 
   livecheck do
@@ -20,7 +21,7 @@ class AmqpCpp < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # Fix missing include. Patch accepted upstream, remove on next release.
   patch do

--- a/Formula/apib.rb
+++ b/Formula/apib.rb
@@ -4,6 +4,7 @@ class Apib < Formula
   url "https://github.com/apigee/apib/archive/APIB_1_2_1.tar.gz"
   sha256 "e47f639aa6ffc14a2e5b03bf95e8b0edc390fa0bb2594a521f779d6e17afc14c"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apigee/apib.git", branch: "master"
 
   bottle do
@@ -17,7 +18,7 @@ class Apib < Formula
 
   depends_on "cmake" => :build
   depends_on "libev"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/appscale-tools.rb
+++ b/Formula/appscale-tools.rb
@@ -4,7 +4,7 @@ class AppscaleTools < Formula
   url "https://github.com/AppScale/appscale-tools/archive/3.5.3.tar.gz"
   sha256 "ae3f373626d5d88d38cf17fef8bd5faaf92234bc6421d5f5c49cf5788acbe93a"
   license "Apache-2.0"
-  revision 3
+  revision 4
   head "https://github.com/AppScale/appscale-tools.git", branch: "master"
 
   bottle do
@@ -16,7 +16,7 @@ class AppscaleTools < Formula
 
   depends_on "libyaml"
   depends_on :macos # Due to Python 2 (Uses SOAPPy, which does not support Python 3)
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "libffi"
   uses_from_macos "ssh-copy-id"

--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -4,6 +4,7 @@ class Arangodb < Formula
   url "https://download.arangodb.com/Source/ArangoDB-3.8.1.tar.gz"
   sha256 "31a17e09cd7fdec94430b8a97864009f24a142e35cdf185068fe148ae781c3a9"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/arangodb/arangodb.git", branch: "devel"
 
   bottle do
@@ -17,7 +18,7 @@ class Arangodb < Formula
   depends_on "go@1.13" => :build
   depends_on "python@3.9" => :build
   depends_on macos: :mojave
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # the ArangoStarter is in a separate github repository;
   # it is used to easily start single server and clusters
@@ -50,7 +51,7 @@ class Arangodb < Formula
     end
 
     mkdir "build" do
-      openssl = Formula["openssl@1.1"]
+      openssl = Formula["openssl@3"]
       args = std_cmake_args + %W[
         -DHOMEBREW=ON
         -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -4,7 +4,7 @@ class Asdf < Formula
   url "https://github.com/asdf-vm/asdf/archive/v0.8.1.tar.gz"
   sha256 "6ca280287dcb687ec12f0c37e4e193de390cdab68f2b2a0e271e3a4f1e20bd2e"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/asdf-vm/asdf.git", branch: "master"
 
   bottle do
@@ -16,7 +16,7 @@ class Asdf < Formula
   depends_on "coreutils"
   depends_on "libtool"
   depends_on "libyaml"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
   depends_on "unixodbc"
 

--- a/Formula/authoscope.rb
+++ b/Formula/authoscope.rb
@@ -4,6 +4,7 @@ class Authoscope < Formula
   url "https://github.com/kpcyrd/authoscope/archive/v0.8.0.tar.gz"
   sha256 "977df6f08a2fece7076f362bc9db6686b829de93ed3c29806d7b841a50bd9d1c"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "1d62f93b6ba4ca88798e510ee70fa66c2c4b280ff20eabc5aaacc59166b3a83d"
@@ -14,14 +15,14 @@ class Authoscope < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
+    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
 
     system "cargo", "install", *std_cargo_args
     man1.install "docs/authoscope.1"

--- a/Formula/avfs.rb
+++ b/Formula/avfs.rb
@@ -3,6 +3,7 @@ class Avfs < Formula
   homepage "https://avf.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/avf/avfs/1.1.3/avfs-1.1.3.tar.bz2"
   sha256 "4f4ec1e8c0d5da94949e3dab7500ee29fa3e0dda723daf8e7d60e5f3ce4450df"
+  revision 1
 
   bottle do
     sha256 catalina:    "6f496a30b6bd1c8eba1005e4bc0da26b53353effab3f447cf8d43a669ad7a6b5"
@@ -12,7 +13,7 @@ class Avfs < Formula
 
   depends_on "pkg-config" => :build
   depends_on macos: :sierra # needs clock_gettime
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "xz"
 
   on_macos do
@@ -31,7 +32,7 @@ class Avfs < Formula
       --disable-silent-rules
       --enable-fuse
       --enable-library
-      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-ssl=#{Formula["openssl@3"].opt_prefix}
     ]
 
     system "./configure", *args

--- a/Formula/axel.rb
+++ b/Formula/axel.rb
@@ -4,6 +4,7 @@ class Axel < Formula
   url "https://github.com/axel-download-accelerator/axel/releases/download/v2.17.10/axel-2.17.10.tar.xz"
   sha256 "46eb4f10a11c4e50320ae6a034ef03ffe59dc11c3c6542a9867a3e4dc0c4b44e"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/eribertomota/axel.git", branch: "master"
 
   bottle do
@@ -19,7 +20,7 @@ class Axel < Formula
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/bacula-fd.rb
+++ b/Formula/bacula-fd.rb
@@ -3,6 +3,7 @@ class BaculaFd < Formula
   homepage "https://www.bacula.org/"
   url "https://downloads.sourceforge.net/project/bacula/bacula/11.0.5/bacula-11.0.5.tar.gz"
   sha256 "ef5b3b67810442201b80dc1d47ccef77b5ed378fe1285406f3a73401b6e8111a"
+  revision 1
 
   bottle do
     sha256                               arm64_big_sur: "90c424f536aadb83c4532a7b32c2e1e63d3fb1bafc561b9746cfbc27cda3a39e"
@@ -12,7 +13,7 @@ class BaculaFd < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "49bdfa04ce4520b84cd06dcc07a45720712866d2a76c0a93bf0905712f45edf4"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   uses_from_macos "zlib"

--- a/Formula/bareos-client.rb
+++ b/Formula/bareos-client.rb
@@ -4,6 +4,7 @@ class BareosClient < Formula
   url "https://github.com/bareos/bareos/archive/Release/19.2.9.tar.gz"
   sha256 "ea203d4bdacc8dcc86164a74f628888ce31cc90858398498137bd25900b8f723"
   license "AGPL-3.0-only"
+  revision 1
 
   livecheck do
     url "https://github.com/bareos/bareos.git"
@@ -18,7 +19,7 @@ class BareosClient < Formula
 
   depends_on "cmake" => :build
   depends_on "gettext"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   conflicts_with "bacula-fd",

--- a/Formula/bigloo.rb
+++ b/Formula/bigloo.rb
@@ -4,6 +4,7 @@ class Bigloo < Formula
   url "ftp://ftp-sop.inria.fr/indes/fp/Bigloo/bigloo-4.4b.tar.gz"
   sha256 "a313922702969b0a3b3d803099ea05aca698758be6bd0aae597caeb6895ce3cf"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www-sop.inria.fr/indes/fp/Bigloo/download.html"
@@ -26,7 +27,7 @@ class Bigloo < Formula
   depends_on "libunistring"
   depends_on "libuv"
   depends_on "openjdk"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   # Fix a configure script bug. Remove when this lands in a release:

--- a/Formula/bitchx.rb
+++ b/Formula/bitchx.rb
@@ -3,7 +3,7 @@ class Bitchx < Formula
   homepage "https://bitchx.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/bitchx/ircii-pana/bitchx-1.2.1/bitchx-1.2.1.tar.gz"
   sha256 "2d270500dd42b5e2b191980d584f6587ca8a0dbda26b35ce7fadb519f53c83e2"
-  revision 1
+  revision 2
 
   bottle do
     sha256 arm64_big_sur: "628166ae821a5f6e24e522aacf347d3789f4c16deeb060e234ba333432ee6dd7"
@@ -14,7 +14,7 @@ class Bitchx < Formula
     sha256 sierra:        "0c9e7fcf39a8fb0c80f867495cf1d6776fbe4aec6010a1986edbca820ed7a6f0"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     # Patch to fix OpenSSL detection with OpenSSL 1.1

--- a/Formula/btpd.rb
+++ b/Formula/btpd.rb
@@ -4,7 +4,7 @@ class Btpd < Formula
   url "https://github.com/downloads/btpd/btpd/btpd-0.16.tar.gz"
   sha256 "296bdb718eaba9ca938bee56f0976622006c956980ab7fc7a339530d88f51eb8"
   license "BSD-2-Clause"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "899a1e60fbe73ab6ed57bfec2e6903b76a52e7831cb0280c6a34d689473def17"
@@ -16,7 +16,7 @@ class Btpd < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "5b2e4da63e65ec96199c8152d3e5e45f5c10c80d2f1e407c9cff9cd26a761ba9"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/bulk_extractor.rb
+++ b/Formula/bulk_extractor.rb
@@ -4,7 +4,7 @@ class BulkExtractor < Formula
   url "https://downloads.digitalcorpora.org/downloads/bulk_extractor/bulk_extractor-1.5.5.tar.gz"
   sha256 "297a57808c12b81b8e0d82222cf57245ad988804ab467eb0a70cf8669594e8ed"
   license "MIT"
-  revision 3
+  revision 4
 
   livecheck do
     url "https://downloads.digitalcorpora.org/downloads/bulk_extractor/"
@@ -23,7 +23,7 @@ class BulkExtractor < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "boost"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # Upstream commits for OpenSSL 1.1 compatibility in dfxm:
   # https://github.com/simsong/dfxml/commits/master/src/hash_t.h

--- a/Formula/burp.rb
+++ b/Formula/burp.rb
@@ -2,7 +2,7 @@ class Burp < Formula
   desc "Network backup and restore"
   homepage "https://burp.grke.org/"
   license "AGPL-3.0"
-  revision 1
+  revision 2
 
   stable do
     url "https://downloads.sourceforge.net/project/burp/burp-2.2.18/burp-2.2.18.tar.bz2"
@@ -43,7 +43,7 @@ class Burp < Formula
 
   depends_on "pkg-config" => :build
   depends_on "librsync"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   uses_from_macos "zlib"
 
   def install

--- a/Formula/cargo-audit.rb
+++ b/Formula/cargo-audit.rb
@@ -4,6 +4,7 @@ class CargoAudit < Formula
   url "https://github.com/RustSec/rustsec/archive/cargo-audit/v0.15.2.tar.gz"
   sha256 "ed330d33f86036acd27ab8f717903aa515c306d02217aa217c95e2a5fdab1f8e"
   license any_of: ["Apache-2.0", "MIT"]
+  revision 1
   head "https://github.com/RustSec/rustsec.git", branch: "main"
 
   livecheck do
@@ -20,7 +21,7 @@ class CargoAudit < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/cargo-instruments.rb
+++ b/Formula/cargo-instruments.rb
@@ -4,6 +4,7 @@ class CargoInstruments < Formula
   url "https://github.com/cmyr/cargo-instruments/archive/v0.4.3.tar.gz"
   sha256 "f78146e82a6a1cf40d2c7d6f84652b2671f7c771ebe4ebdd9a798380c1e9c39c"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "4337fa71363264075999d4089113ff7fa3920d6a46ddede5505ed73cd66ae188"
@@ -14,7 +15,7 @@ class CargoInstruments < Formula
 
   depends_on "rust" => :build
   depends_on :macos
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/cassandra-cpp-driver.rb
+++ b/Formula/cassandra-cpp-driver.rb
@@ -4,6 +4,7 @@ class CassandraCppDriver < Formula
   url "https://github.com/datastax/cpp-driver/archive/2.16.1.tar.gz"
   sha256 "168d6fe9f3cf61be82cf5817024b92a186d7f944f0d390ed546f521bdabfc32e"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/datastax/cpp-driver.git", branch: "master"
 
   bottle do
@@ -16,7 +17,7 @@ class CassandraCppDriver < Formula
 
   depends_on "cmake" => :build
   depends_on "libuv"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/center-im.rb
+++ b/Formula/center-im.rb
@@ -3,7 +3,7 @@ class CenterIm < Formula
   homepage "https://github.com/petrpavlu/centerim5"
   url "https://www.centerim.org/download/releases/centerim-4.22.10.tar.gz"
   sha256 "93ce15eb9c834a4939b5aa0846d5c6023ec2953214daf8dc26c85ceaa4413f6e"
-  revision 2
+  revision 3
 
   # Modify this to use `url :stable` if/when the formula is updated to use an
   # archive from GitHub in the future.
@@ -24,7 +24,7 @@ class CenterIm < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gettext"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # Fix build with clang; 4.22.10 is an outdated release and 5.0 is a rewrite,
   # so this is not reported upstream
@@ -39,7 +39,7 @@ class CenterIm < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-msn",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
 
     # /bin/gawk does not exist on macOS

--- a/Formula/cfengine.rb
+++ b/Formula/cfengine.rb
@@ -4,6 +4,7 @@ class Cfengine < Formula
   url "https://cfengine-package-repos.s3.amazonaws.com/tarballs/cfengine-3.18.0.tar.gz"
   sha256 "d601a3af30f3fba7d51a37476c9e1a00b750682149bf96f4a0002e804bc87783"
   license all_of: ["BSD-3-Clause", "GPL-2.0-or-later", "GPL-3.0-only", "LGPL-2.0-or-later"]
+  revision 1
 
   livecheck do
     url "https://cfengine-package-repos.s3.amazonaws.com/release-data/community/releases.json"
@@ -19,7 +20,7 @@ class Cfengine < Formula
   end
 
   depends_on "lmdb"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   on_linux do

--- a/Formula/cgit.rb
+++ b/Formula/cgit.rb
@@ -4,6 +4,7 @@ class Cgit < Formula
   url "https://git.zx2c4.com/cgit/snapshot/cgit-1.2.3.tar.xz"
   sha256 "5a5f12d2f66bd3629c8bc103ec8ec2301b292e97155d30a9a61884ea414a6da4"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url "https://git.zx2c4.com/cgit/refs/tags"
@@ -19,7 +20,7 @@ class Cgit < Formula
   end
 
   depends_on "gettext"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # git version is mandated by cgit: see GIT_VER variable in Makefile
   # https://git.zx2c4.com/cgit/tree/Makefile?h=v1.2#n17

--- a/Formula/conserver.rb
+++ b/Formula/conserver.rb
@@ -4,7 +4,7 @@ class Conserver < Formula
   url "https://github.com/conserver/conserver/releases/download/v8.2.6/conserver-8.2.6.tar.gz"
   sha256 "33b976a909c6bce8a1290810e26e92bfa16c39bca19e1f8e06d5d768ae940734"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -19,7 +19,7 @@ class Conserver < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1d246f41155c74436f806dc614996631bf92ae385d88476f6b05a60c984574e3"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--with-openssl", "--with-ipv6"

--- a/Formula/cppcms.rb
+++ b/Formula/cppcms.rb
@@ -3,6 +3,7 @@ class Cppcms < Formula
   homepage "http://cppcms.com/wikipp/en/page/main"
   url "https://downloads.sourceforge.net/project/cppcms/cppcms/1.2.1/cppcms-1.2.1.tar.bz2"
   sha256 "10fec7710409c949a229b9019ea065e25ff5687103037551b6f05716bf6cac52"
+  revision 1
 
   livecheck do
     url :stable
@@ -20,7 +21,7 @@ class Cppcms < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   def install

--- a/Formula/crackpkcs.rb
+++ b/Formula/crackpkcs.rb
@@ -4,6 +4,7 @@ class Crackpkcs < Formula
   url "https://download.sourceforge.net/project/crackpkcs12/0.2.11/crackpkcs12-0.2.11.tar.gz"
   sha256 "9cfd0aa1160545810404fff60234c7b6372ce7fcf9df392a7944366cae3fbf25"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "c78cddbd0a61219de5e403a5cf43c710a5a50141ccb3c66767823f0fb8941a70"
@@ -13,7 +14,7 @@ class Crackpkcs < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   resource "cert.p12" do
     url "https://github.com/crackpkcs12/crackpkcs12/raw/9f7375fdc7358451add8b31aaf928ecd025d63d9/misc/utils/certs/usr0052-exportado_desde_firefox.p12"
@@ -24,7 +25,7 @@ class Crackpkcs < Formula
     system "./configure",
             *std_configure_args,
             "--disable-silent-rules",
-            "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
+            "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/cryfs.rb
+++ b/Formula/cryfs.rb
@@ -4,6 +4,7 @@ class Cryfs < Formula
   url "https://github.com/cryfs/cryfs/releases/download/0.10.2/cryfs-0.10.2.tar.xz"
   sha256 "5531351b67ea23f849b71a1bc44474015c5718d1acce039cf101d321b27f03d5"
   license "LGPL-3.0"
+  revision 1
 
   bottle do
     rebuild 1
@@ -20,7 +21,7 @@ class Cryfs < Formula
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "libomp"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_macos do
     disable! date: "2021-04-08", because: "requires closed-source macFUSE"

--- a/Formula/cvsync.rb
+++ b/Formula/cvsync.rb
@@ -3,6 +3,7 @@ class Cvsync < Formula
   homepage "https://www.cvsync.org/"
   url "https://www.cvsync.org/dist/cvsync-0.24.19.tar.gz"
   sha256 "75d99fc387612cb47141de4d59cb3ba1d2965157230f10015fbaa3a1c3b27560"
+  revision 1
 
   livecheck do
     url :homepage
@@ -19,7 +20,7 @@ class Cvsync < Formula
     sha256 cellar: :any, sierra:        "4e92dd3b6a74831724c2da74f761660fa25630d9c44be9d80a0d72dc522e1fae"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     ENV["PREFIX"] = prefix

--- a/Formula/cyrus-sasl.rb
+++ b/Formula/cyrus-sasl.rb
@@ -4,6 +4,7 @@ class CyrusSasl < Formula
   url "https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.27/cyrus-sasl-2.1.27.tar.gz"
   sha256 "26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5"
   license "BSD-3-Clause-Attribution"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "bf65079be801e9e99253d9b2329f42dcf50ce38a76fe0b9cfd0a776651764765"
@@ -15,7 +16,7 @@ class CyrusSasl < Formula
 
   keg_only :provided_by_macos
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure",

--- a/Formula/dmg2img.rb
+++ b/Formula/dmg2img.rb
@@ -4,7 +4,7 @@ class Dmg2img < Formula
   url "http://vu1tur.eu.org/tools/dmg2img-1.6.7.tar.gz"
   sha256 "02aea6d05c5b810074913b954296ddffaa43497ed720ac0a671da4791ec4d018"
   license "GPL-2.0-only"
-  revision 1
+  revision 2
 
   livecheck do
     url :homepage
@@ -21,7 +21,7 @@ class Dmg2img < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "352d7b94084707e2138aa53245f2e3325c36c2faf21c7361fc81b0dbb9d8cabf"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "bzip2"
   uses_from_macos "zlib"

--- a/Formula/dovecot.rb
+++ b/Formula/dovecot.rb
@@ -4,6 +4,7 @@ class Dovecot < Formula
   url "https://dovecot.org/releases/2.3/dovecot-2.3.16.tar.gz"
   sha256 "03a71d53055bd9ec528d55e07afaf15c09dec9856cba734904bfd05acbc6cf12"
   license all_of: ["BSD-3-Clause", "LGPL-2.1-or-later", "MIT", "Unicode-DFS-2016", :public_domain]
+  revision 1
 
   livecheck do
     url "https://www.dovecot.org/download/"
@@ -18,7 +19,7 @@ class Dovecot < Formula
     sha256 x86_64_linux:  "c4c1beb8368da32f6743e58c7a0db23397081c366ceddedf026598a4d215241e"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "bzip2"
   uses_from_macos "sqlite"

--- a/Formula/duo_unix.rb
+++ b/Formula/duo_unix.rb
@@ -4,6 +4,7 @@ class DuoUnix < Formula
   url "https://github.com/duosecurity/duo_unix/archive/duo_unix-1.11.4.tar.gz"
   sha256 "2fcba3e50fd477699d013c789ffc73a0b10c204d25c455abe7c81a2ecd886579"
   license "GPL-2.0"
+  revision 1
 
   livecheck do
     url "https://github.com/duosecurity/duo_unix.git"
@@ -21,7 +22,7 @@ class DuoUnix < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_linux do
     depends_on "linux-pam"
@@ -34,7 +35,7 @@ class DuoUnix < Formula
                           "--prefix=#{prefix}",
                           "--sysconfdir=#{etc}",
                           "--includedir=#{include}/duo",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}",
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}",
                           "--with-pam=#{lib}/pam/"
     system "make", "install"
   end

--- a/Formula/easy-rsa.rb
+++ b/Formula/easy-rsa.rb
@@ -4,6 +4,7 @@ class EasyRsa < Formula
   url "https://github.com/OpenVPN/easy-rsa/archive/v3.0.8.tar.gz"
   sha256 "fd6b67d867c3b8afd53efa2ca015477f6658a02323e1799432083472ac0dd200"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/OpenVPN/easy-rsa.git"
 
   bottle do
@@ -15,13 +16,13 @@ class EasyRsa < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "eb9ed69d68b06a1af68732fcb9722e2016b562b3196d3017416805c81f5f977a"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     libexec.install "easyrsa3/easyrsa"
     (bin/"easyrsa").write_env_script libexec/"easyrsa",
       EASYRSA:         etc/name,
-      EASYRSA_OPENSSL: Formula["openssl@1.1"].bin/"openssl",
+      EASYRSA_OPENSSL: Formula["openssl@3"].bin/"openssl",
       EASYRSA_PKI:     "${EASYRSA_PKI:-#{etc}/pki}"
 
     (etc/name).install %w[

--- a/Formula/ekg2.rb
+++ b/Formula/ekg2.rb
@@ -5,7 +5,7 @@ class Ekg2 < Formula
   mirror "https://web.archive.org/web/20161227025528/pl.ekg2.org/ekg2-0.3.1.tar.gz"
   sha256 "6ad360f8ca788d4f5baff226200f56922031ceda1ce0814e650fa4d877099c63"
   license "GPL-2.0"
-  revision 4
+  revision 5
 
   livecheck do
     url :homepage
@@ -23,7 +23,7 @@ class Ekg2 < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   # Fix the build on OS X 10.9+

--- a/Formula/elinks.rb
+++ b/Formula/elinks.rb
@@ -3,7 +3,7 @@ class Elinks < Formula
   homepage "http://elinks.or.cz/"
   url "http://elinks.or.cz/download/elinks-0.11.7.tar.bz2"
   sha256 "456db6f704c591b1298b0cd80105f459ff8a1fc07a0ec1156a36c4da6f898979"
-  revision 3
+  revision 4
 
   livecheck do
     url "http://elinks.or.cz/download/"
@@ -28,7 +28,7 @@ class Elinks < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -6,7 +6,7 @@ class Encfs < Formula
   # The code comprising the EncFS library (libencfs) is licensed under the LGPL.
   # The main programs (encfs, encfsctl, etc) are licensed under the GPL.
   license "GPL-3.0"
-  revision 3
+  revision 4
   head "https://github.com/vgough/encfs.git"
 
   bottle do
@@ -20,7 +20,7 @@ class Encfs < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_macos do
     disable! date: "2021-04-08", because: "requires closed-source macFUSE"

--- a/Formula/epic5.rb
+++ b/Formula/epic5.rb
@@ -5,6 +5,7 @@ class Epic5 < Formula
   mirror "https://www.mirrorservice.org/sites/distfiles.macports.org/epic5/epic5-2.1.5.tar.xz"
   sha256 "7ca53b9d266fa1b7ba7a1f68a23e65c57b1a89b94bce1a0ea56fafa7d6298cb4"
   license "BSD-3-Clause"
+  revision 1
   head "http://git.epicsol.org/epic5.git"
 
   livecheck do
@@ -19,7 +20,7 @@ class Epic5 < Formula
     sha256 mojave:        "33233d7cd4cbadfb333079083a746791797402df481411568b99c874582fd440"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--disable-debug",
@@ -27,7 +28,7 @@ class Epic5 < Formula
                           "--prefix=#{prefix}",
                           "--mandir=#{man}",
                           "--with-ipv6",
-                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-ssl=#{Formula["openssl@3"].opt_prefix}"
     system "make"
     system "make", "install"
   end

--- a/Formula/erlang@21.rb
+++ b/Formula/erlang@21.rb
@@ -5,7 +5,7 @@ class ErlangAT21 < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-21.3.8.24/otp_src_21.3.8.24.tar.gz"
   sha256 "a82de871d7ba40fd256558b23a3b4c1539e6c7ece7507d6eb2b00330c6135012"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -25,7 +25,7 @@ class ErlangAT21 < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on arch: :x86_64
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "wxwidgets" # for GUI apps like observer
 
   resource "man" do
@@ -62,7 +62,7 @@ class ErlangAT21 < Formula
       --enable-smp-support
       --enable-threads
       --enable-wx
-      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-ssl=#{Formula["openssl@3"].opt_prefix}
       --without-javac
     ]
 

--- a/Formula/erlang@23.rb
+++ b/Formula/erlang@23.rb
@@ -5,6 +5,7 @@ class ErlangAT23 < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-23.3.4.7/otp_src_23.3.4.7.tar.gz"
   sha256 "37e39a43c495861ce69de06e1a013a7eac81d15dc6eebd2d2022fd68791f4b2d"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,7 +22,7 @@ class ErlangAT23 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "wxwidgets" # for GUI apps like observer
 
   resource "html" do
@@ -45,7 +46,7 @@ class ErlangAT23 < Formula
       --enable-smp-support
       --enable-threads
       --enable-wx
-      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-ssl=#{Formula["openssl@3"].opt_prefix}
       --without-javac
     ]
 

--- a/Formula/eureka.rb
+++ b/Formula/eureka.rb
@@ -4,6 +4,7 @@ class Eureka < Formula
   url "https://github.com/simeg/eureka/archive/v1.8.1.tar.gz"
   sha256 "d10d412c71dea51b4973c3ded5de1503a4c5de8751be5050de989ac08eb0455e"
   license "MIT"
+  revision 1
   head "https://github.com/simeg/eureka.git"
 
   bottle do
@@ -16,7 +17,7 @@ class Eureka < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/exim.rb
+++ b/Formula/exim.rb
@@ -4,6 +4,7 @@ class Exim < Formula
   url "https://ftp.exim.org/pub/exim/exim4/exim-4.94.2.tar.xz"
   sha256 "051861fc89f06205162f12129fb7ebfe473383bb6194bf8642952bfd50329274"
   license "GPL-2.0-or-later"
+  revision 1
 
   # Maintenance releases are kept in a `fixes` subdirectory, so it's necessary
   # to check both the main `exim4` directory and the `fixes` subdirectory to
@@ -37,7 +38,7 @@ class Exim < Formula
   end
 
   depends_on "berkeley-db@4"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   def install

--- a/Formula/fastd.rb
+++ b/Formula/fastd.rb
@@ -5,6 +5,7 @@ class Fastd < Formula
       tag:      "v22",
       revision: "0f47d83eac2047d33efdab6eeaa9f81f17e3ebd1"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/NeoRaider/fastd.git"
 
   bottle do
@@ -22,7 +23,7 @@ class Fastd < Formula
   depends_on "json-c"
   depends_on "libsodium"
   depends_on "libuecc"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # remove in next release
   patch do

--- a/Formula/fetchmail.rb
+++ b/Formula/fetchmail.rb
@@ -10,6 +10,7 @@ class Fetchmail < Formula
     :public_domain,
     "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" },
   ]
+  revision 1
 
   livecheck do
     url :stable
@@ -24,12 +25,12 @@ class Fetchmail < Formula
     sha256               x86_64_linux:  "19abe963e79a93c7a422681b01dc49a39bca05676cc97c94be5028562d1708ab"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-ssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/fossil.rb
+++ b/Formula/fossil.rb
@@ -4,6 +4,7 @@ class Fossil < Formula
   url "https://fossil-scm.org/home/tarball/version-2.16/fossil-src-2.16.tar.gz"
   sha256 "fab37e8093932b06b586e99a792bf9b20d00d530764b5bddb1d9a63c8cdafa14"
   license "BSD-2-Clause"
+  revision 1
   head "https://www.fossil-scm.org/", using: :fossil
 
   livecheck do
@@ -19,7 +20,7 @@ class Fossil < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "a3a5e435b6d4fc982e4c700463d9ff8d3009b5f514ff0e776cd8eed0b68922f9"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   uses_from_macos "zlib"
 
   def install

--- a/Formula/fq.rb
+++ b/Formula/fq.rb
@@ -4,6 +4,7 @@ class Fq < Formula
   url "https://github.com/circonus-labs/fq/archive/v0.13.10.tar.gz"
   sha256 "fe304987145ec7ce0103a3d06a75ead38ad68044c0f609ad0bcc20c06cbfd62e"
   license "MIT"
+  revision 1
   head "https://github.com/circonus-labs/fq.git"
 
   bottle do
@@ -14,7 +15,7 @@ class Fq < Formula
 
   depends_on "concurrencykit"
   depends_on "jlog"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     ENV.append_to_cflags "-DNO_BCD=1"

--- a/Formula/getxbook.rb
+++ b/Formula/getxbook.rb
@@ -4,7 +4,7 @@ class Getxbook < Formula
   url "https://njw.name/getxbook/getxbook-1.2.tar.xz"
   sha256 "7a4b1636ecb6dace814b818d9ff6a68167799b81ac6fc4dca1485efd48cf1c46"
   license "ISC"
-  revision 1
+  revision 2
 
   livecheck do
     url :homepage
@@ -21,7 +21,7 @@ class Getxbook < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "14dc92ce6828cfccce34307bfa2f750faf8612ef92f126797cd5b86e6fb5978b"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "make", "CC=#{ENV.cc}", "PREFIX=#{prefix}"

--- a/Formula/git-crypt.rb
+++ b/Formula/git-crypt.rb
@@ -3,7 +3,7 @@ class GitCrypt < Formula
   homepage "https://www.agwa.name/projects/git-crypt/"
   url "https://www.agwa.name/projects/git-crypt/downloads/git-crypt-0.6.0.tar.gz"
   sha256 "6d30fcd99442d50f4b3c8d554067ff1d980cdf9f3120ee774131172dba98fd6f"
-  revision 1
+  revision 2
 
   livecheck do
     url :homepage
@@ -20,7 +20,7 @@ class GitCrypt < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "13febdb36a936377e0ff5f78883dbaba43f70cb9f91ec7fee833d3057f92d85d"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "make"

--- a/Formula/git-trim.rb
+++ b/Formula/git-trim.rb
@@ -4,6 +4,7 @@ class GitTrim < Formula
   url "https://github.com/foriequal0/git-trim/archive/v0.4.2.tar.gz"
   sha256 "0f728c7f49cc8ffb0c485547a114c94bdebd7eead9466b1b43f486ef583a3d73"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 big_sur:      "5c52fe8dd74e83a4a7048ae8a4f42661c2738718ea40ebede07ecf83771ba5ff"
@@ -14,7 +15,7 @@ class GitTrim < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/gloox.rb
+++ b/Formula/gloox.rb
@@ -3,6 +3,7 @@ class Gloox < Formula
   homepage "https://camaya.net/gloox/"
   url "https://camaya.net/download/gloox-1.0.24.tar.bz2"
   sha256 "ae1462be2a2eb8fe5cd054825143617c53c2c9c7195606cb5a5ba68c0f68f9c9"
+  revision 1
 
   livecheck do
     url :homepage
@@ -20,7 +21,7 @@ class Gloox < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libidn"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 
@@ -28,7 +29,7 @@ class Gloox < Formula
     system "./configure", "--prefix=#{prefix}",
                           "--with-zlib",
                           "--disable-debug",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/gocryptfs.rb
+++ b/Formula/gocryptfs.rb
@@ -4,6 +4,7 @@ class Gocryptfs < Formula
   url "https://github.com/rfjakob/gocryptfs/releases/download/v2.0.1/gocryptfs_v2.0.1_src-deps.tar.gz"
   sha256 "31be3f3a9400bd5eb8a4d5f86f7aee52a488207e12d312f2601ae08e7e26dd02"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "43d8cf09fcd4cb76ac51246225cd30c68ea4abe9c944843a9788534e09ea9e18"
@@ -11,7 +12,7 @@ class Gocryptfs < Formula
 
   depends_on "go" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_macos do
     disable! date: "2021-04-08", because: "requires closed-source macFUSE"

--- a/Formula/gsoap.rb
+++ b/Formula/gsoap.rb
@@ -4,6 +4,7 @@ class Gsoap < Formula
   url "https://downloads.sourceforge.net/project/gsoap2/gsoap_2.8.117.zip"
   sha256 "7cadf8808cfd982629948fe09e4fa6cd18e23cafd40df0aaaff1b1f5b695c442"
   license any_of: ["GPL-2.0-or-later", "gSOAP-1.3b"]
+  revision 1
 
   livecheck do
     url :stable
@@ -19,7 +20,7 @@ class Gsoap < Formula
   end
 
   depends_on "autoconf" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "bison"
   uses_from_macos "flex"

--- a/Formula/gtmess.rb
+++ b/Formula/gtmess.rb
@@ -4,7 +4,7 @@ class Gtmess < Formula
   url "https://downloads.sourceforge.net/project/gtmess/gtmess/0.97/gtmess-0.97.tar.gz"
   sha256 "606379bb06fa70196e5336cbd421a69d7ebb4b27f93aa1dfd23a6420b3c6f5c6"
   license "GPL-2.0"
-  revision 2
+  revision 3
 
   bottle do
     sha256 arm64_big_sur: "107b687b5c567bfec9de27d948f1ead0a9c97e7c2a1abfc3d1a819f756bf508d"
@@ -23,13 +23,13 @@ class Gtmess < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "autoreconf", "-fvi" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-ssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/haproxy.rb
+++ b/Formula/haproxy.rb
@@ -4,6 +4,7 @@ class Haproxy < Formula
   url "https://www.haproxy.org/download/2.4/src/haproxy-2.4.4.tar.gz"
   sha256 "116b7329cebee5dab8ba47ad70feeabd0c91680d9ef68c28e41c34869920d1fe"
   license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
+  revision 1
 
   livecheck do
     url :homepage
@@ -18,7 +19,7 @@ class Haproxy < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "d7c8dcf12200833be51a117599d05325d69a384646a31695cff659d43f2450f4"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   uses_from_macos "zlib"

--- a/Formula/http_load.rb
+++ b/Formula/http_load.rb
@@ -4,7 +4,7 @@ class HttpLoad < Formula
   url "https://www.acme.com/software/http_load/http_load-09Mar2016.tar.gz"
   version "20160309"
   sha256 "5a7b00688680e3fca8726dc836fd3f94f403fde831c71d73d9a1537f215b4587"
-  revision 2
+  revision 3
 
   livecheck do
     url :homepage
@@ -28,7 +28,7 @@ class HttpLoad < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "7592ea4f24a3e2288078da70ddde1fbd1cb6133aa7126c43c13cedcbe74439cc"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     bin.mkpath
@@ -39,7 +39,7 @@ class HttpLoad < Formula
       LIBDIR=#{lib}
       MANDIR=#{man1}
       CC=#{ENV.cc}
-      SSL_TREE=#{Formula["openssl@1.1"].opt_prefix}
+      SSL_TREE=#{Formula["openssl@3"].opt_prefix}
     ]
 
     inreplace "Makefile", "#SSL_", "SSL_"

--- a/Formula/httping.rb
+++ b/Formula/httping.rb
@@ -4,7 +4,7 @@ class Httping < Formula
   url "https://www.vanheusden.com/httping/httping-2.5.tgz"
   sha256 "3e895a0a6d7bd79de25a255a1376d4da88eb09c34efdd0476ab5a907e75bfaf8"
   license "GPL-2.0"
-  revision 2
+  revision 3
   head "https://github.com/flok99/httping.git"
 
   bottle do
@@ -19,7 +19,7 @@ class Httping < Formula
   deprecate! date: "2021-05-20", because: "Upstream website has disappeared"
 
   depends_on "gettext"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     # Reported upstream, see: https://github.com/Homebrew/homebrew/pull/28653

--- a/Formula/httrack.rb
+++ b/Formula/httrack.rb
@@ -5,7 +5,7 @@ class Httrack < Formula
   # link to download.httrack.com will break on next HTTrack update.
   url "https://mirror.httrack.com/historical/httrack-3.49.2.tar.gz"
   sha256 "3477a0e5568e241c63c9899accbfcdb6aadef2812fcce0173688567b4c7d4025"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://mirror.httrack.com/historical/"
@@ -22,7 +22,7 @@ class Httrack < Formula
     sha256 x86_64_linux:  "cf514800be63c284276aa19e44b7d6822b182166a64b8ceb45dd96c4818504ee"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/i2pd.rb
+++ b/Formula/i2pd.rb
@@ -4,6 +4,7 @@ class I2pd < Formula
   url "https://github.com/PurpleI2P/i2pd/archive/2.39.0.tar.gz"
   sha256 "3ffeb614cec826e13b50e8306177018ecb8d873668dfe66aadc733ca9fcaa568"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "9e13462dfd0f3cd5e6afc79979ed48c6b09a243c3c5242b399c7dee418a3e1eb"
@@ -14,7 +15,7 @@ class I2pd < Formula
 
   depends_on "boost"
   depends_on "miniupnpc"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     args = %W[

--- a/Formula/ike-scan.rb
+++ b/Formula/ike-scan.rb
@@ -4,7 +4,7 @@ class IkeScan < Formula
   url "https://github.com/royhills/ike-scan/archive/1.9.4.tar.gz"
   sha256 "2865014185c129ac443beb7bf80f3c5eb93adb504cd307c5b6709199abf7c121"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
 
   head "https://github.com/royhills/ike-scan.git"
 
@@ -20,7 +20,7 @@ class IkeScan < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # Fix Xcode 12 build: https://github.com/royhills/ike-scan/pull/32
   patch do
@@ -33,7 +33,7 @@ class IkeScan < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/imapfilter.rb
+++ b/Formula/imapfilter.rb
@@ -4,6 +4,7 @@ class Imapfilter < Formula
   url "https://github.com/lefcha/imapfilter/archive/v2.7.5.tar.gz"
   sha256 "ab19f840712e6951e51c29e44c43b3b2fa42e93693f98f8969cc763a4fad56bf"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "e49fed469e38c13b29df94f07ce45bb40bdcf167961ba08e7199192346ce8cd7"
@@ -13,7 +14,7 @@ class Imapfilter < Formula
   end
 
   depends_on "lua"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre2"
 
   def install

--- a/Formula/iperf3.rb
+++ b/Formula/iperf3.rb
@@ -4,6 +4,7 @@ class Iperf3 < Formula
   url "https://github.com/esnet/iperf/archive/3.10.1.tar.gz"
   sha256 "6a4bb4d5c124b3fa64dfbda469ab16857ad6565310bcaa3dd8cd32f96c2fc473"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "7acd6b3fedf49e5614f825f928d24b035e93db311c25797d94b8ef880b78afe0"
@@ -21,13 +22,13 @@ class Iperf3 < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./bootstrap.sh" if build.head?
     system "./configure", "--prefix=#{prefix}",
                           "--disable-profiling",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "clean" # there are pre-compiled files in the tarball
     system "make", "install"
   end

--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -5,7 +5,7 @@ class Ipmitool < Formula
   mirror "https://deb.debian.org/debian/pool/main/i/ipmitool/ipmitool_1.8.18.orig.tar.bz2"
   sha256 "0c1ba3b1555edefb7c32ae8cd6a3e04322056bc087918f07189eeedfc8b81e01"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "3223279b0188313a5d87ede24617f6bda5921acc1ce135c30c7c43823f14913f"
@@ -17,7 +17,7 @@ class Ipmitool < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "34d7e08574ee45e07c513a90b38c7de24636f7889e940daf8f0d87c3a9739977"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # https://sourceforge.net/p/ipmitool/bugs/433/#89ea and
   # https://sourceforge.net/p/ipmitool/bugs/436/ (prematurely closed):

--- a/Formula/ipmiutil.rb
+++ b/Formula/ipmiutil.rb
@@ -3,6 +3,7 @@ class Ipmiutil < Formula
   homepage "https://ipmiutil.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ipmiutil/ipmiutil-3.1.7.tar.gz"
   sha256 "911fd6f8b33651b98863d57e678d2fc593bc43fcd2a21f5dc7d5db8f92128a9a"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d2870b00ddad6b22295009482c51e7d699dd8d0d0c32fafe3a5699c6b30e3f45"
@@ -16,7 +17,7 @@ class Ipmiutil < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   conflicts_with "renameutils", because: "both install `icmd` binaries"
 

--- a/Formula/ircd-hybrid.rb
+++ b/Formula/ircd-hybrid.rb
@@ -4,6 +4,7 @@ class IrcdHybrid < Formula
   url "https://downloads.sourceforge.net/project/ircd-hybrid/ircd-hybrid/ircd-hybrid-8.2.39/ircd-hybrid-8.2.39.tgz"
   sha256 "035d271f6b0dd451157f80146d189bc1c9b84cc9ba1b7ad06fd72ee5108e6e4d"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -18,7 +19,7 @@ class IrcdHybrid < Formula
     sha256 x86_64_linux:  "fc31f26e809d59c021617055aa26a5f318ba101ce8311c18afbb08233c959627"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   conflicts_with "ircd-irc2", because: "both install an `ircd` binary"
 
@@ -32,7 +33,7 @@ class IrcdHybrid < Formula
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}",
                           "--sysconfdir=#{etc}",
-                          "--enable-openssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--enable-openssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
     etc.install "doc/reference.conf" => "ircd.conf"
   end

--- a/Formula/ircii.rb
+++ b/Formula/ircii.rb
@@ -11,6 +11,7 @@ class Ircii < Formula
     "MIT",
     :public_domain,
   ]
+  revision 1
 
   livecheck do
     url "https://ircii.warped.com/"
@@ -24,7 +25,7 @@ class Ircii < Formula
     sha256 mojave:        "758aa15d57d51e9f2c97115e837cd10c9879bfeb46c84823380291a76573f669"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     ENV.append "LIBS", "-liconv"

--- a/Formula/jimtcl.rb
+++ b/Formula/jimtcl.rb
@@ -4,6 +4,7 @@ class Jimtcl < Formula
   url "https://github.com/msteveb/jimtcl/archive/0.80.tar.gz"
   sha256 "9e79a960de925552eeb4df51121f0ea017e34409568117b1ac461f4c3071289e"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "194b77f5eaea45ef59c1c4f7c458a6cb2840867aab53fda18201a9034beab3d9"
@@ -14,7 +15,7 @@ class Jimtcl < Formula
     sha256 x86_64_linux:  "ae69bc936ae765f61e0c14ccde362c95054c57492fc3650536df4b30b8674f5f"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   uses_from_macos "sqlite"

--- a/Formula/john-jumbo.rb
+++ b/Formula/john-jumbo.rb
@@ -5,6 +5,7 @@ class JohnJumbo < Formula
   version "1.9.0"
   sha256 "f5d123f82983c53d8cc598e174394b074be7a77756f5fb5ed8515918c81e7f3b"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://github.com/magnumripper/JohnTheRipper.git"
@@ -24,7 +25,7 @@ class JohnJumbo < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gmp"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 
@@ -37,7 +38,7 @@ class JohnJumbo < Formula
     sha256 "bb6cfff297f1223dd1177a515657b8f1f780c55f790e5b6e6518bb2cb0986b7b"
   end
 
-  # Fixed setup of openssl@1.1 over series of patches
+  # Fixed setup of openssl@3 over series of patches
   # See details for example from here: https://github.com/magnumripper/JohnTheRipper/pull/4101
   patch do
     url "https://github.com/magnumripper/JohnTheRipper/commit/4844c79bf43dbdbb6ae3717001173355b3de5517.patch?full_index=1"
@@ -72,8 +73,8 @@ class JohnJumbo < Formula
     # Apple's M1 chip has no support for SSE 4.1.
     ENV.append "CFLAGS", "-mno-sse4.1" if Hardware::CPU.intel? && !MacOS.version.requires_sse4?
 
-    ENV["OPENSSL_LIBS"] = "-L#{Formula["openssl@1.1"].opt_lib}"
-    ENV["OPENSSL_CFLAGS"] = "-I#{Formula["openssl@1.1"].opt_include}"
+    ENV["OPENSSL_LIBS"] = "-L#{Formula["openssl@3"].opt_lib}"
+    ENV["OPENSSL_CFLAGS"] = "-I#{Formula["openssl@3"].opt_include}"
 
     cd "src" do
       system "./configure", "--disable-native-tests"

--- a/Formula/jose.rb
+++ b/Formula/jose.rb
@@ -4,6 +4,7 @@ class Jose < Formula
   url "https://github.com/latchset/jose/releases/download/v11/jose-11.tar.xz"
   sha256 "e272afe7717e22790c383f3164480627a567c714ccb80c1ee96f62c9929d8225"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "a3a76d8b25def2f572513ddf580cd35f575a45c1b505c0ac781ea47d0bac4cab"
@@ -17,7 +18,7 @@ class Jose < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "jansson"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/kore.rb
+++ b/Formula/kore.rb
@@ -4,6 +4,7 @@ class Kore < Formula
   url "https://kore.io/releases/kore-4.1.0.tar.gz"
   sha256 "b7d73b005fde0ea01c356a54e4bbd8a209a4dff9cf315802a127ce7267efbe61"
   license "ISC"
+  revision 1
   head "https://github.com/jorisvink/kore.git"
 
   livecheck do
@@ -21,16 +22,16 @@ class Kore < Formula
 
   depends_on macos: :sierra # needs clock_gettime
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     # Ensure make finds our OpenSSL when Homebrew isn't in /usr/local.
     # Current Makefile hardcodes paths for default MacPorts/Homebrew.
-    ENV.prepend "CFLAGS", "-I#{Formula["openssl@1.1"].opt_include}"
-    ENV.prepend "LDFLAGS", "-L#{Formula["openssl@1.1"].opt_lib}"
+    ENV.prepend "CFLAGS", "-I#{Formula["openssl@3"].opt_include}"
+    ENV.prepend "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib}"
     # Also hardcoded paths in src/cli.c at compile.
     inreplace "src/cli.c", "/usr/local/opt/openssl/include",
-                            Formula["openssl@1.1"].opt_include
+                            Formula["openssl@3"].opt_include
 
     ENV.deparallelize { system "make", "PREFIX=#{prefix}", "TASKS=1" }
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/ldid.rb
+++ b/Formula/ldid.rb
@@ -5,6 +5,7 @@ class Ldid < Formula
       tag:      "v2.1.5",
       revision: "a23f0faadd29ec00a6b7fb2498c3d15af15a7100"
   license "AGPL-3.0-or-later"
+  revision 1
   head "https://git.saurik.com/ldid.git"
 
   bottle do
@@ -15,7 +16,7 @@ class Ldid < Formula
   end
 
   depends_on "libplist"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system ENV.cc, "-c",

--- a/Formula/lftp.rb
+++ b/Formula/lftp.rb
@@ -4,7 +4,7 @@ class Lftp < Formula
   url "https://lftp.yar.ru/ftp/lftp-4.9.2.tar.xz"
   sha256 "c517c4f4f9c39bd415d7313088a2b1e313b2d386867fe40b7692b83a20f0670d"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://github.com/lavv17/lftp.git"
@@ -19,7 +19,7 @@ class Lftp < Formula
   end
 
   depends_on "libidn2"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   uses_from_macos "zlib"
@@ -37,7 +37,7 @@ class Lftp < Formula
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}",
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}",
                           "--with-readline=#{Formula["readline"].opt_prefix}",
                           "--with-libidn2=#{Formula["libidn2"].opt_prefix}"
 

--- a/Formula/libcapn.rb
+++ b/Formula/libcapn.rb
@@ -2,7 +2,7 @@ class Libcapn < Formula
   desc "C library to send push notifications to Apple devices"
   homepage "https://web.archive.org/web/20181220090839/libcapn.org/"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/adobkin/libcapn.git"
 
   stable do
@@ -25,7 +25,7 @@ class Libcapn < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # Compatibility with OpenSSL 1.1
   # Original: https://github.com/adobkin/libcapn/pull/46.diff?full_index=1
@@ -41,7 +41,7 @@ class Libcapn < Formula
   def install
     # head gets jansson as a git submodule
     (buildpath/"src/third_party/jansson").install resource("jansson") if build.stable?
-    system "cmake", ".", "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
+    system "cmake", ".", "-DOPENSSL_ROOT_DIR=#{Formula["openssl@3"].opt_prefix}",
                          *std_cmake_args
     system "make", "install"
     pkgshare.install "examples"
@@ -50,7 +50,7 @@ class Libcapn < Formula
   test do
     system ENV.cc, pkgshare/"examples/send_push_message.c",
                    "-o", "send_push_message",
-                   "-I#{Formula["openssl@1.1"].opt_include}",
+                   "-I#{Formula["openssl@3"].opt_include}",
                    "-L#{lib}/capn", "-lcapn"
     output = shell_output("./send_push_message", 255)
     assert_match "unable to use specified PKCS12 file (errno: 9012)", output

--- a/Formula/libcoap.rb
+++ b/Formula/libcoap.rb
@@ -4,6 +4,7 @@ class Libcoap < Formula
   url "https://github.com/obgm/libcoap/archive/v4.3.0.tar.gz"
   sha256 "1a195adacd6188d3b71c476e7b21706fef7f3663ab1fb138652e8da49a9ec556"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "57300cff98f6ad59e6c4cf95de26bf0a4dbcf0fb64d2d911d6bdddadf63da1dc"
@@ -18,7 +19,7 @@ class Libcoap < Formula
   depends_on "doxygen" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./autogen.sh"
@@ -32,8 +33,8 @@ class Libcoap < Formula
   test do
     %w[coap-client coap-server].each do |src|
       system ENV.cc, pkgshare/"examples/#{src}.c",
-        "-I#{Formula["openssl@1.1"].opt_include}", "-I#{include}",
-        "-L#{Formula["openssl@1.1"].opt_lib}", "-L#{lib}",
+        "-I#{Formula["openssl@3"].opt_include}", "-I#{include}",
+        "-L#{Formula["openssl@3"].opt_lib}", "-L#{lib}",
         "-lcrypto", "-lssl", "-lcoap-3-openssl", "-o", src
     end
 

--- a/Formula/libexosip.rb
+++ b/Formula/libexosip.rb
@@ -5,6 +5,7 @@ class Libexosip < Formula
   mirror "https://download-mirror.savannah.gnu.org/releases/exosip/libexosip2-5.2.1.tar.gz"
   sha256 "87256b45a406f3c038e1e75e31372d526820366527c2af3bb89329bafd87ec42"
   license "GPL-2.0"
+  revision 1
 
   livecheck do
     url "https://download.savannah.gnu.org/releases/exosip/"
@@ -21,7 +22,7 @@ class Libexosip < Formula
   depends_on "pkg-config" => :build
   depends_on "c-ares"
   depends_on "libosip"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     # Extra linker flags are needed to build this on macOS. See:

--- a/Formula/libfreefare.rb
+++ b/Formula/libfreefare.rb
@@ -4,7 +4,7 @@ class Libfreefare < Formula
   url "https://github.com/nfc-tools/libfreefare/releases/download/libfreefare-0.4.0/libfreefare-0.4.0.tar.bz2"
   sha256 "bfa31d14a99a1247f5ed49195d6373de512e3eb75bf1627658b40cf7f876bc64"
   license "LGPL-3.0"
-  revision 3
+  revision 4
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "c66fe7ad412745ebd9c10784f9ef7de563a5c1ef7582a72915ad7b50324a65c5"
@@ -17,7 +17,7 @@ class Libfreefare < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libnfc"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # Upstream commit for endianness-related functions, fixes
   # https://github.com/nfc-tools/libfreefare/issues/55

--- a/Formula/libjwt.rb
+++ b/Formula/libjwt.rb
@@ -4,6 +4,7 @@ class Libjwt < Formula
   url "https://github.com/benmcollins/libjwt/archive/v1.13.1.tar.gz"
   sha256 "4df55ac89c6692adaf3badb43daf3241fd876612c9ab627e250dfc4bb59993d9"
   license "MPL-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "4d89729e216bebd3dcd95d7edca9050b125387a122e1525f2b647175074154aa"
@@ -18,7 +19,7 @@ class Libjwt < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "jansson"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "autoreconf", "-fiv"

--- a/Formula/libmowgli.rb
+++ b/Formula/libmowgli.rb
@@ -4,7 +4,7 @@ class Libmowgli < Formula
   url "https://github.com/atheme/libmowgli-2/archive/v2.1.3.tar.gz"
   sha256 "b7faab2fb9f46366a52b51443054a2ed4ecdd04774c65754bf807c5e9bdda477"
   license "ISC"
-  revision 1
+  revision 2
   head "https://github.com/atheme/libmowgli-2.git"
 
   bottle do
@@ -17,11 +17,11 @@ class Libmowgli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "c7646bd88a24aa8d426ec1cbbf4b32504f0f0c062f257c71b445349667f6bf34"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--prefix=#{prefix}",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
     system "make"
     system "make", "install"
   end

--- a/Formula/liboqs.rb
+++ b/Formula/liboqs.rb
@@ -4,6 +4,7 @@ class Liboqs < Formula
   url "https://github.com/open-quantum-safe/liboqs/archive/0.7.0.tar.gz"
   sha256 "7a2b01d33637869b02475c5a7b3b31e8f7cebce491877719f27954a89f6d764e"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable
@@ -19,7 +20,7 @@ class Liboqs < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "ninja" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     mkdir "build" do

--- a/Formula/libp11.rb
+++ b/Formula/libp11.rb
@@ -4,6 +4,7 @@ class Libp11 < Formula
   url "https://github.com/OpenSC/libp11/releases/download/libp11-0.4.11/libp11-0.4.11.tar.gz"
   sha256 "57d47a12a76fd92664ae30032cf969284ebac1dfc25bf824999d74b016d51366"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -26,7 +27,7 @@ class Libp11 < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libtool"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./bootstrap" if build.head?
@@ -38,8 +39,8 @@ class Libp11 < Formula
   end
 
   test do
-    system ENV.cc, "-I#{Formula["openssl@1.1"].include}", "-L#{lib}",
-                   "-L#{Formula["openssl@1.1"].lib}", "-lp11", "-lcrypto",
+    system ENV.cc, "-I#{Formula["openssl@3"].include}", "-L#{lib}",
+                   "-L#{Formula["openssl@3"].lib}", "-lp11", "-lcrypto",
                    pkgshare/"auth.c", "-o", "test"
   end
 end

--- a/Formula/librealsense.rb
+++ b/Formula/librealsense.rb
@@ -4,6 +4,7 @@ class Librealsense < Formula
   url "https://github.com/IntelRealSense/librealsense/archive/v2.49.0.tar.gz"
   sha256 "2578ea0e75546aeebd908da732f52e0122bf37750d5a45f3adf92945a673aefd"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/IntelRealSense/librealsense.git"
 
   livecheck do
@@ -22,10 +23,10 @@ class Librealsense < Formula
   depends_on "pkg-config" => :build
   depends_on "glfw"
   depends_on "libusb"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
-    ENV["OPENSSL_ROOT_DIR"] = Formula["openssl@1.1"].prefix
+    ENV["OPENSSL_ROOT_DIR"] = Formula["openssl@3"].prefix
 
     args = std_cmake_args
     args << "-DENABLE_CCACHE=OFF"

--- a/Formula/libtins.rb
+++ b/Formula/libtins.rb
@@ -4,6 +4,7 @@ class Libtins < Formula
   url "https://github.com/mfontanini/libtins/archive/v4.3.tar.gz"
   sha256 "c70bce5a41a27258bf0e3ad535d8238fb747d909a4b87ea14620f25dd65828fd"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/mfontanini/libtins.git"
 
   bottle do
@@ -16,7 +17,7 @@ class Libtins < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "libpcap"
 

--- a/Formula/libu2f-server.rb
+++ b/Formula/libu2f-server.rb
@@ -4,7 +4,7 @@ class Libu2fServer < Formula
   url "https://developers.yubico.com/libu2f-server/Releases/libu2f-server-1.1.0.tar.xz"
   sha256 "8dcd3caeacebef6e36a42462039fd035e45fa85653dcb2013f45e15aad49a277"
   license "BSD-2-Clause"
-  revision 3
+  revision 4
 
   livecheck do
     url "https://developers.yubico.com/libu2f-server/Releases/"
@@ -25,7 +25,7 @@ class Libu2fServer < Formula
   depends_on "help2man" => :build
   depends_on "pkg-config" => :build
   depends_on "json-c"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # Compatibility with json-c 0.14. Remove with the next release.
   patch do

--- a/Formula/libvnc.rb
+++ b/Formula/libvnc.rb
@@ -4,6 +4,7 @@ class Libvnc < Formula
   url "https://github.com/LibVNC/libvncserver/archive/LibVNCServer-0.9.13.tar.gz"
   sha256 "0ae5bb9175dc0a602fe85c1cf591ac47ee5247b87f2bf164c16b05f87cbfa81a"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/LibVNC/libvncserver.git"
 
   livecheck do
@@ -22,7 +23,7 @@ class Libvnc < Formula
   depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "lzo"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "sdl2"
 
   def install

--- a/Formula/luvit.rb
+++ b/Formula/luvit.rb
@@ -4,6 +4,7 @@ class Luvit < Formula
   url "https://github.com/luvit/luvit/archive/2.18.0.tar.gz"
   sha256 "3c6824878189ca41059d6d4cd8b1646de0ec6b4be1de71b2084f98c36c38e84e"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/luvit/luvit.git"
 
   bottle do
@@ -17,7 +18,7 @@ class Luvit < Formula
   depends_on "luv" => :build
   depends_on "pkg-config" => :build
   depends_on "libuv"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   # To update this resource, check LIT_VERSION in the Makefile:

--- a/Formula/lychee.rb
+++ b/Formula/lychee.rb
@@ -4,6 +4,7 @@ class Lychee < Formula
   url "https://github.com/lycheeverse/lychee/archive/v0.7.1.tar.gz"
   sha256 "f6acf92987aae006273b5fd211cb5c6a2f30036b7fd69ac36ecffb2b28cc3101"
   license any_of: ["Apache-2.0", "MIT"]
+  revision 1
   head "https://github.com/lycheeverse/lychee.git"
 
   bottle do
@@ -15,7 +16,7 @@ class Lychee < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_linux do
     depends_on "pkg-config" => :build

--- a/Formula/lynx.rb
+++ b/Formula/lynx.rb
@@ -5,7 +5,7 @@ class Lynx < Formula
   version "2.8.9rel.1"
   sha256 "387f193d7792f9cfada14c60b0e5c0bff18f227d9257a39483e14fa1aaf79595"
   license "GPL-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://invisible-mirror.net/archives/lynx/tarballs/?C=M&O=D"
@@ -22,7 +22,7 @@ class Lynx < Formula
     sha256 x86_64_linux:  "7067fe13b0e2be8fed0b06b0f83ea0f5b44142db148a6f82866e77e1c90c6b68"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
@@ -38,7 +38,7 @@ class Lynx < Formula
                           "--enable-default-colors",
                           "--with-zlib",
                           "--with-bzlib",
-                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}",
+                          "--with-ssl=#{Formula["openssl@3"].opt_prefix}",
                           "--enable-ipv6",
                           "--with-screen=ncurses",
                           "--disable-config-info"

--- a/Formula/manticoresearch.rb
+++ b/Formula/manticoresearch.rb
@@ -5,6 +5,7 @@ class Manticoresearch < Formula
   version "3.6.0"
   sha256 "320a19c837caf827a75e19e11755a9586487435aeb8b8aa80e8bef552fd5e1f5"
   license "GPL-2.0-only"
+  revision 1
   version_scheme 1
   head "https://github.com/manticoresoftware/manticoresearch.git"
 
@@ -21,7 +22,7 @@ class Manticoresearch < Formula
   depends_on "icu4c" => :build
   depends_on "libpq" => :build
   depends_on "mysql" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   conflicts_with "sphinx", because: "manticoresearch is a fork of sphinx"
 

--- a/Formula/md5sha1sum.rb
+++ b/Formula/md5sha1sum.rb
@@ -4,7 +4,7 @@ class Md5sha1sum < Formula
   url "http://microbrew.org/tools/md5sha1sum/md5sha1sum-0.9.5.tar.gz"
   mirror "https://mirrorservice.org/sites/distfiles.macports.org/md5sha1sum/md5sha1sum-0.9.5.tar.gz"
   sha256 "2fe6b4846cb3e343ed4e361d1fd98fdca6e6bf88e0bba5b767b0fdc5b299f37b"
-  revision 1
+  revision 2
 
   livecheck do
     url :homepage
@@ -21,12 +21,12 @@ class Md5sha1sum < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "c25d9290972bc2bcec287eb11b91349f3dd0e5db8ad3a24b35874f7715682cfa"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   conflicts_with "coreutils", because: "both install `md5sum` and `sha1sum` binaries"
 
   def install
-    openssl = Formula["openssl@1.1"]
+    openssl = Formula["openssl@3"]
     ENV["SSLINCPATH"] = openssl.opt_include
     ENV["SSLLIBPATH"] = openssl.opt_lib
 

--- a/Formula/mfterm.rb
+++ b/Formula/mfterm.rb
@@ -4,7 +4,7 @@ class Mfterm < Formula
   url "https://github.com/4ZM/mfterm/releases/download/v1.0.7/mfterm-1.0.7.tar.gz"
   sha256 "b6bb74a7ec1f12314dee42973eb5f458055b66b1b41316ae0c5380292b86b248"
   license "GPL-3.0"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "e7dffabd037eaff9a07ef2adb7c5731bd6270f04e5f3590280293fc25d478ddb"
@@ -23,11 +23,11 @@ class Mfterm < Formula
 
   depends_on "libnfc"
   depends_on "libusb"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
-    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl@1.1"].opt_include}"
-    ENV.prepend "LDFLAGS", "-L#{Formula["openssl@1.1"].opt_lib}"
+    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl@3"].opt_include}"
+    ENV.prepend "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib}"
 
     if build.head?
       chmod 0755, "./autogen.sh"

--- a/Formula/minimal-racket.rb
+++ b/Formula/minimal-racket.rb
@@ -4,6 +4,7 @@ class MinimalRacket < Formula
   url "https://mirror.racket-lang.org/installers/8.2/racket-minimal-8.2-src.tgz"
   sha256 "6f4dcbb17493898c954973ddde3daee1f18aa3197e6ece0d3e48dc2d4cfa84c7"
   license any_of: ["MIT", "Apache-2.0"]
+  revision 1
 
   # File links on the download page are created using JavaScript, so we parse
   # the filename from a string in an object. We match the version from the
@@ -22,7 +23,7 @@ class MinimalRacket < Formula
     sha256 x86_64_linux:  "5649130e99166343b0147b8fc992d1004f1dfd8529e8de0f284c0912217aa0c8"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "libffi"
 
@@ -46,8 +47,8 @@ class MinimalRacket < Formula
         --enable-useprefix
       ]
 
-      ENV["LDFLAGS"] = "-rpath #{Formula["openssl@1.1"].opt_lib}"
-      ENV["LDFLAGS"] = "-Wl,-rpath=#{Formula["openssl@1.1"].opt_lib}" if OS.linux?
+      ENV["LDFLAGS"] = "-rpath #{Formula["openssl@3"].opt_lib}"
+      ENV["LDFLAGS"] = "-Wl,-rpath=#{Formula["openssl@3"].opt_lib}" if OS.linux?
 
       system "./configure", *args
       system "make"
@@ -91,7 +92,7 @@ class MinimalRacket < Formula
     end
     on_linux do
       output = shell_output("LD_DEBUG=libs #{bin}/racket -e '(require openssl)' 2>&1")
-      assert_match "init: #{Formula["openssl@1.1"].opt_lib}/#{shared_library("libssl")}", output
+      assert_match "init: #{Formula["openssl@3"].opt_lib}/#{shared_library("libssl")}", output
     end
   end
 end

--- a/Formula/monetdb.rb
+++ b/Formula/monetdb.rb
@@ -4,6 +4,7 @@ class Monetdb < Formula
   url "https://www.monetdb.org/downloads/sources/Jul2021/MonetDB-11.41.5.tar.xz"
   sha256 "6f2efd5f6de2273d2f2e3f61ea149236bee3568c227db1cd9769ea5488a9b6e5"
   license "MPL-2.0"
+  revision 1
   head "https://dev.monetdb.org/hg/MonetDB", using: :hg
 
   livecheck do
@@ -24,7 +25,7 @@ class Monetdb < Formula
   depends_on "pkg-config" => :build
   depends_on "python@3.9" => :build
   depends_on "lz4"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
   depends_on "readline" # Compilation fails with libedit
   depends_on "xz"
@@ -53,7 +54,7 @@ class Monetdb < Formula
                       "-DWITH_SNAPPY=OFF",
                       "-DWITH_XML2=ON",
                       "-DWITH_ZLIB=ON",
-                      "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
+                      "-DOPENSSL_ROOT_DIR=#{Formula["openssl@3"].opt_prefix}",
                       "-DREADLINE_ROOT=#{Formula["readline"].opt_prefix}"
       # remove reference to shims directory from compilation/linking info
       inreplace "tools/mserver/monet_version.c", %r{"/[^ ]*/}, "\""

--- a/Formula/mongoose.rb
+++ b/Formula/mongoose.rb
@@ -4,6 +4,7 @@ class Mongoose < Formula
   url "https://github.com/cesanta/mongoose/archive/7.3.tar.gz"
   sha256 "9166cf794e98d352df775f10119fc45b9dcedaf07b0d5f6e1a0791d5cb3c899c"
   license "GPL-2.0-only"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "be10036a119761682e5c9f32c3bd978acf276ecd06563b82d4cde8a8c011fee2"
@@ -13,7 +14,7 @@ class Mongoose < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "17f1e400a66f7be82e5ad2c774674efb308733e5302b91c75aa0924644fb01e2"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   conflicts_with "suite-sparse", because: "suite-sparse vendors libmongoose.dylib"
 

--- a/Formula/monit.rb
+++ b/Formula/monit.rb
@@ -4,6 +4,7 @@ class Monit < Formula
   url "https://mmonit.com/monit/dist/monit-5.29.0.tar.gz"
   sha256 "f665e6dd1f26a74b5682899a877934167de2b2582e048652ecf036318477885f"
   license "AGPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://mmonit.com/monit/dist/"
@@ -18,7 +19,7 @@ class Monit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "99573601eeb2e8d7377fad27e08e1a31a002eec231d84a492ec59532bfdeb49e"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_linux do
     depends_on "linux-pam"
@@ -28,7 +29,7 @@ class Monit < Formula
     system "./configure", "--prefix=#{prefix}",
                           "--localstatedir=#{var}/monit",
                           "--sysconfdir=#{etc}/monit",
-                          "--with-ssl-dir=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-ssl-dir=#{Formula["openssl@3"].opt_prefix}"
     system "make"
     system "make", "install"
     etc.install "monitrc"

--- a/Formula/monitoring-plugins.rb
+++ b/Formula/monitoring-plugins.rb
@@ -3,6 +3,7 @@ class MonitoringPlugins < Formula
   homepage "https://www.monitoring-plugins.org"
   url "https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz"
   sha256 "f56eb84871983fd719247249e3532228b37e2efaae657a3979bd14ac1f84a35b"
+  revision 1
 
   livecheck do
     url "https://www.monitoring-plugins.org/download.html"
@@ -16,7 +17,7 @@ class MonitoringPlugins < Formula
     sha256 cellar: :any, mojave:        "883707c4b2fe29a6d0b8453d4d19005128761d5d6952b9fe21292ec4b4cb2b11"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   conflicts_with "nagios-plugins", because: "both install their plugins to the same folder"
 
@@ -25,7 +26,7 @@ class MonitoringPlugins < Formula
       --disable-dependency-tracking
       --prefix=#{libexec}
       --libexecdir=#{libexec}/sbin
-      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-openssl=#{Formula["openssl@3"].opt_prefix}
     ]
 
     system "./configure", *args

--- a/Formula/monolith.rb
+++ b/Formula/monolith.rb
@@ -4,6 +4,7 @@ class Monolith < Formula
   url "https://github.com/Y2Z/monolith/archive/v2.6.1.tar.gz"
   sha256 "dc08e6fa786c2cdfc7a8f6c307022c368d875c172737b695222c2b2f3bfe2a72"
   license "CC0-1.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f8d25cc101ab57a7b2392d748815de0d2dbf36654a4ef592b5eedf992846f17a"
@@ -15,7 +16,7 @@ class Monolith < Formula
 
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/mysql-client@5.7.rb
+++ b/Formula/mysql-client@5.7.rb
@@ -3,6 +3,7 @@ class MysqlClientAT57 < Formula
   homepage "https://dev.mysql.com/doc/refman/5.7/en/"
   url "https://cdn.mysql.com/archives/mysql-5.7/mysql-boost-5.7.34.tar.gz"
   sha256 "5bc2c7c0bb944b5bb219480dde3c1caeb049e7351b5bba94c3b00ac207929c7b"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "36dad98547a79e55ee6402bcfe841ab90e4f3ed8a0f22004a5d8e7b7e832ad3b"
@@ -16,7 +17,7 @@ class MysqlClientAT57 < Formula
 
   depends_on "cmake" => :build
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "libedit"
 

--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -4,6 +4,7 @@ class MysqlAT56 < Formula
   url "https://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-5.6.51.tar.gz"
   sha256 "262ccaf2930fca1f33787505dd125a7a04844f40d3421289a51974b5935d9abc"
   license "GPL-2.0-only"
+  revision 1
 
   bottle do
     rebuild 1
@@ -18,7 +19,7 @@ class MysqlAT56 < Formula
   deprecate! date: "2021-02-01", because: :unsupported
 
   depends_on "cmake" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "libedit"
 

--- a/Formula/ncrack.rb
+++ b/Formula/ncrack.rb
@@ -4,6 +4,7 @@ class Ncrack < Formula
   url "https://github.com/nmap/ncrack/archive/0.7.tar.gz"
   sha256 "f3f971cd677c4a0c0668cb369002c581d305050b3b0411e18dd3cb9cc270d14a"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/nmap/ncrack.git", branch: "master"
 
   bottle do
@@ -15,7 +16,7 @@ class Ncrack < Formula
     sha256 x86_64_linux:  "7e269a772c515bb8dfdd7f000bc8989f4e4609fa7f1aedbffa6176fcc035f761"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     # Work around configure issues with Xcode 12 (at least in the opensshlib component)
@@ -23,7 +24,7 @@ class Ncrack < Formula
 
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}",
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}",
                           "--prefix=#{prefix}"
     system "make"
     system "make", "install"

--- a/Formula/netdata.rb
+++ b/Formula/netdata.rb
@@ -4,6 +4,7 @@ class Netdata < Formula
   url "https://github.com/netdata/netdata/releases/download/v1.29.3/netdata-v1.29.3.tar.gz"
   sha256 "eeba8b18519a9123a3cc8b450dcd042e23a3b145a78a7017a14c47ed36d923df"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -25,7 +26,7 @@ class Netdata < Formula
   depends_on "json-c"
   depends_on "libuv"
   depends_on "lz4"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -6,6 +6,7 @@ class Nginx < Formula
   url "https://nginx.org/download/nginx-1.21.3.tar.gz"
   sha256 "14774aae0d151da350417efc4afda5cce5035056e71894836797e1f6e2d1175a"
   license "BSD-2-Clause"
+  revision 1
   head "https://hg.nginx.org/nginx/", using: :hg
 
   livecheck do
@@ -21,7 +22,7 @@ class Nginx < Formula
     sha256 x86_64_linux:  "6c0d7245f21d7d421f75e071480ad51bdea69c49b3795cb30269bb7d6daffaaf"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   uses_from_macos "xz" => :build
@@ -37,7 +38,7 @@ class Nginx < Formula
       s.gsub! "    #}\n\n}", "    #}\n    include servers/*;\n}"
     end
 
-    openssl = Formula["openssl@1.1"]
+    openssl = Formula["openssl@3"]
     pcre = Formula["pcre"]
 
     cc_opt = "-I#{pcre.opt_include} -I#{openssl.opt_include}"

--- a/Formula/ngircd.rb
+++ b/Formula/ngircd.rb
@@ -5,6 +5,7 @@ class Ngircd < Formula
   mirror "https://ngircd.sourceforge.io/pub/ngircd/ngircd-26.1.tar.xz"
   sha256 "55c16fd26009f6fc6a007df4efac87a02e122f680612cda1ce26e17a18d86254"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://ngircd.barton.de/download.php"
@@ -19,7 +20,7 @@ class Ngircd < Formula
   end
 
   depends_on "libident"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/nopoll.rb
+++ b/Formula/nopoll.rb
@@ -5,6 +5,7 @@ class Nopoll < Formula
   version "0.4.7.b429"
   sha256 "d5c020fec25e3fa486c308249833d06bed0d76bde9a72fd5d73cfb057c320366"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url "https://www.aspl.es/nopoll/downloads/"
@@ -19,7 +20,7 @@ class Nopoll < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "abbd47332ae6aa89803c11bff2f625ccaac60805dc200af683592d7d0dd3eef9"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -4,6 +4,7 @@ class Ntp < Formula
   url "https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-4.2.8p15.tar.gz"
   version "4.2.8p15"
   sha256 "f65840deab68614d5d7ceb2d0bb9304ff70dcdedd09abb79754a87536b849c19"
+  revision 1
 
   livecheck do
     url "https://www.ntp.org/downloads.html"
@@ -18,7 +19,7 @@ class Ntp < Formula
     sha256 cellar: :any, high_sierra:   "9f7ce9c3ff545ff738fcf4049445923c968ec807cf1ecde451be76412442e6f1"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     args = %W[
@@ -26,8 +27,8 @@ class Ntp < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
-      --with-openssl-libdir=#{Formula["openssl@1.1"].lib}
-      --with-openssl-incdir=#{Formula["openssl@1.1"].include}
+      --with-openssl-libdir=#{Formula["openssl@3"].lib}
+      --with-openssl-incdir=#{Formula["openssl@3"].include}
       --with-net-snmp-config=no
     ]
 

--- a/Formula/nushell.rb
+++ b/Formula/nushell.rb
@@ -4,6 +4,7 @@ class Nushell < Formula
   url "https://github.com/nushell/nushell/archive/0.37.0.tar.gz"
   sha256 "1e8f36a4825e52b28993eec1c63d878f426ee8f091942d6bfc17e60546d5959b"
   license "MIT"
+  revision 1
   head "https://github.com/nushell/nushell.git", branch: "main"
 
   livecheck do
@@ -21,7 +22,7 @@ class Nushell < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/nut.rb
+++ b/Formula/nut.rb
@@ -2,7 +2,7 @@ class Nut < Formula
   desc "Network UPS Tools: Support for various power devices"
   homepage "https://networkupstools.org/"
   license "GPL-2.0-or-later"
-  revision 2
+  revision 3
 
   stable do
     url "https://networkupstools.org/source/2.7/nut-2.7.4.tar.gz"
@@ -35,7 +35,7 @@ class Nut < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "libusb-compat"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   conflicts_with "rhino", because: "both install `rhino` binaries"
 

--- a/Formula/openfortivpn.rb
+++ b/Formula/openfortivpn.rb
@@ -4,6 +4,7 @@ class Openfortivpn < Formula
   url "https://github.com/adrienverge/openfortivpn/archive/v1.17.1.tar.gz"
   sha256 "c674c59cf3201a55d56cb503053982752fb641b13a85ea406b8a7e7df301e30f"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "c4748e81cb20fb01c9d414e0ed293fc368e564301a5bd30a12331c874110386f"
@@ -16,7 +17,7 @@ class Openfortivpn < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./autogen.sh"

--- a/Formula/openrct2.rb
+++ b/Formula/openrct2.rb
@@ -5,6 +5,7 @@ class Openrct2 < Formula
       tag:      "v0.3.4.1",
       revision: "5087e77032e1342006021f680eb9cad2dc6dabef"
   license "GPL-3.0-only"
+  revision 1
   head "https://github.com/OpenRCT2/OpenRCT2.git", branch: "develop"
 
   bottle do
@@ -23,7 +24,7 @@ class Openrct2 < Formula
   depends_on "libzip"
   depends_on macos: :mojave # `error: call to unavailable member function 'value': introduced in macOS 10.14`
   depends_on "nlohmann-json"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "sdl2"
   depends_on "sdl2_ttf"
   depends_on "speexdsp"

--- a/Formula/openrtsp.rb
+++ b/Formula/openrtsp.rb
@@ -6,6 +6,7 @@ class Openrtsp < Formula
   # Keep a mirror as upstream tarballs are removed after each version
   sha256 "ce95a1c79f6d18e959f9dc129b8529b711c60e76754acc285e60946303b923ec"
   license "LGPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "037bd7b7f6b47749662992483a26c35707c8242bddfa35f58f2c7bb8d6d0da2e"
@@ -14,13 +15,13 @@ class Openrtsp < Formula
     sha256 cellar: :any, mojave:        "3cfb1652550415fd0b7fb9e9c5ea6e1841dbc4b3b70910e0bb34866f8c8500fc"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     # Avoid linkage to system OpenSSL
     libs = [
-      Formula["openssl@1.1"].opt_lib/"libcrypto.dylib",
-      Formula["openssl@1.1"].opt_lib/"libssl.dylib",
+      Formula["openssl@3"].opt_lib/"libcrypto.dylib",
+      Formula["openssl@3"].opt_lib/"libssl.dylib",
     ]
 
     system "./genMakefiles", "macosx-no-openssl"

--- a/Formula/opensc.rb
+++ b/Formula/opensc.rb
@@ -4,6 +4,7 @@ class Opensc < Formula
   url "https://github.com/OpenSC/OpenSC/releases/download/0.22.0/opensc-0.22.0.tar.gz"
   sha256 "8d4e5347195ebea332be585df61dcc470331c26969e4b0447c851fb0844c7186"
   license "LGPL-2.1-or-later"
+  revision 1
   head "https://github.com/OpenSC/OpenSC.git", branch: "master"
 
   livecheck do
@@ -24,7 +25,7 @@ class Opensc < Formula
   depends_on "docbook-xsl" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "pcsc-lite"
 

--- a/Formula/pdnsrec.rb
+++ b/Formula/pdnsrec.rb
@@ -4,6 +4,7 @@ class Pdnsrec < Formula
   url "https://downloads.powerdns.com/releases/pdns-recursor-4.5.5.tar.bz2"
   sha256 "a836a39b99fcc21873e4ba3a60aa9915a33fac7b44922696e9a257f551fe05fb"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url "https://downloads.powerdns.com/releases/"
@@ -21,7 +22,7 @@ class Pdnsrec < Formula
   depends_on "pkg-config" => :build
   depends_on "boost"
   depends_on "lua"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_macos do
     depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
@@ -51,7 +52,7 @@ class Pdnsrec < Formula
       --sysconfdir=#{etc}/powerdns
       --disable-silent-rules
       --with-boost=#{Formula["boost"].opt_prefix}
-      --with-libcrypto=#{Formula["openssl@1.1"].opt_prefix}
+      --with-libcrypto=#{Formula["openssl@3"].opt_prefix}
       --with-lua
       --without-net-snmp
     ]

--- a/Formula/pev.rb
+++ b/Formula/pev.rb
@@ -4,6 +4,7 @@ class Pev < Formula
   url "https://downloads.sourceforge.net/project/pev/pev-0.81/pev-0.81.tar.gz"
   sha256 "921b2831ca956aedc272d8580b2ff1a2cb54fb895cabeb81c907fe62b6ac83fb"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/merces/pev.git", branch: "master"
 
   bottle do
@@ -13,7 +14,7 @@ class Pev < Formula
     sha256 mojave:        "0ff3ab7fe514f498dd088d42fd60e63bbd5c7fb3d94222aac68c5a4302404f2f"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   def install

--- a/Formula/pjproject.rb
+++ b/Formula/pjproject.rb
@@ -4,6 +4,7 @@ class Pjproject < Formula
   url "https://github.com/pjsip/pjproject/archive/2.10.tar.gz"
   sha256 "936a4c5b98601b52325463a397ddf11ab4106c6a7b04f8dc7cdd377efbb597de"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/pjsip/pjproject.git", branch: "master"
 
   livecheck do
@@ -21,7 +22,7 @@ class Pjproject < Formula
   end
 
   depends_on macos: :high_sierra # Uses Security framework API enum cases introduced in 10.13.4
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/poco.rb
+++ b/Formula/poco.rb
@@ -4,6 +4,7 @@ class Poco < Formula
   url "https://pocoproject.org/releases/poco-1.11.0/poco-1.11.0-all.tar.gz"
   sha256 "9a29a86bb9b889fc4cc5fb45f4ab065a48700ad71ff842340e13d32759281db9"
   license "BSL-1.0"
+  revision 1
   head "https://github.com/pocoproject/poco.git", branch: "master"
 
   livecheck do
@@ -20,7 +21,7 @@ class Poco < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     mkdir "build" do

--- a/Formula/podofo.rb
+++ b/Formula/podofo.rb
@@ -4,6 +4,7 @@ class Podofo < Formula
   url "https://downloads.sourceforge.net/project/podofo/podofo/0.9.7/podofo-0.9.7.tar.gz"
   sha256 "7cf2e716daaef89647c54ffcd08940492fd40c385ef040ce7529396bfadc1eb8"
   license all_of: ["LGPL-2.0-only", "GPL-2.0-only"]
+  revision 1
   head "svn://svn.code.sf.net/p/podofo/code/podofo/trunk"
 
   bottle do
@@ -21,7 +22,7 @@ class Podofo < Formula
   depends_on "libidn"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     args = std_cmake_args + %W[

--- a/Formula/proxytunnel.rb
+++ b/Formula/proxytunnel.rb
@@ -4,6 +4,7 @@ class Proxytunnel < Formula
   url "https://github.com/proxytunnel/proxytunnel/archive/v1.10.20210604.tar.gz"
   sha256 "47b7ef7acd36881744db233837e7e6be3ad38e45dc49d2488934882fa2c591c3"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "97ccd9b616094e055755979daed8216f418d2aeb4639cf978b5df289d1c7e4ea"
@@ -15,7 +16,7 @@ class Proxytunnel < Formula
 
   depends_on "asciidoc" => :build
   depends_on "xmlto" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"

--- a/Formula/pure-ftpd.rb
+++ b/Formula/pure-ftpd.rb
@@ -3,7 +3,7 @@ class PureFtpd < Formula
   homepage "https://www.pureftpd.org/"
   url "https://download.pureftpd.org/pub/pure-ftpd/releases/pure-ftpd-1.0.49.tar.gz"
   sha256 "767bf458c70b24f80c0bb7a1bbc89823399e75a0a7da141d30051a2b8cc892a5"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://download.pureftpd.org/pub/pure-ftpd/releases/"
@@ -20,7 +20,7 @@ class PureFtpd < Formula
   end
 
   depends_on "libsodium"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     args = %W[

--- a/Formula/pwsafe.rb
+++ b/Formula/pwsafe.rb
@@ -4,7 +4,7 @@ class Pwsafe < Formula
   url "https://src.fedoraproject.org/repo/pkgs/pwsafe/pwsafe-0.2.0.tar.gz/4bb36538a2772ecbf1a542bc7d4746c0/pwsafe-0.2.0.tar.gz"
   sha256 "61e91dc5114fe014a49afabd574eda5ff49b36c81a6d492c03fcb10ba6af47b7"
   license "GPL-2.0"
-  revision 4
+  revision 5
 
   livecheck do
     url "https://src.fedoraproject.org/repo/pkgs/pwsafe/"
@@ -21,7 +21,7 @@ class Pwsafe < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "45c3ced398e2ae04a1449deb1bf23b033a9d82a44d00d1d7da788ce04f81fde1"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   # A password database for testing is provided upstream. How nice!

--- a/Formula/rover.rb
+++ b/Formula/rover.rb
@@ -4,6 +4,7 @@ class Rover < Formula
   url "https://github.com/apollographql/rover/archive/v0.3.0.tar.gz"
   sha256 "1ba8ef546cfef89517a8ee9932aae683cab523d212ea8d3d4fe1359a15aa3be6"
   license "MIT"
+  revision 1
   head "https://github.com/apollographql/rover.git", branch: "main"
 
   bottle do
@@ -14,7 +15,7 @@ class Rover < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/rsync.rb
+++ b/Formula/rsync.rb
@@ -6,6 +6,7 @@ class Rsync < Formula
   mirror "https://www.mirrorservice.org/sites/rsync.samba.org/rsync-3.2.3.tar.gz"
   sha256 "becc3c504ceea499f4167a260040ccf4d9f2ef9499ad5683c179a697146ce50e"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://rsync.samba.org/ftp/rsync/?C=M&O=D"
@@ -22,7 +23,7 @@ class Rsync < Formula
   end
 
   depends_on "lz4"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "popt"
   depends_on "xxhash"
   depends_on "zstd"

--- a/Formula/ruby@2.4.rb
+++ b/Formula/ruby@2.4.rb
@@ -4,6 +4,7 @@ class RubyAT24 < Formula
   url "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.10.tar.xz"
   sha256 "d5668ed11544db034f70aec37d11e157538d639ed0d0a968e2f587191fc530df"
   license "Ruby"
+  revision 1
 
   bottle do
     rebuild 1
@@ -20,7 +21,7 @@ class RubyAT24 < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libyaml"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   uses_from_macos "zlib"
@@ -37,7 +38,7 @@ class RubyAT24 < Formula
     # otherwise `gem` command breaks
     ENV.delete("SDKROOT")
 
-    paths = %w[libyaml openssl@1.1 readline].map { |f| Formula[f].opt_prefix }
+    paths = %w[libyaml openssl@3 readline].map { |f| Formula[f].opt_prefix }
     args = %W[
       --prefix=#{prefix}
       --enable-shared

--- a/Formula/ruby@2.5.rb
+++ b/Formula/ruby@2.5.rb
@@ -4,6 +4,7 @@ class RubyAT25 < Formula
   url "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.9.tar.xz"
   sha256 "a87f2fa901408cc77652c1a55ff976695bbe54830ff240e370039eca14b358f0"
   license "Ruby"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "deb2ee5e006f4fc7b3829dfcdb377300f3dc5f339562a6a1c1b4dec48ed21ae6"
@@ -19,7 +20,7 @@ class RubyAT25 < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libyaml"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   uses_from_macos "zlib"
@@ -36,7 +37,7 @@ class RubyAT25 < Formula
     # otherwise `gem` command breaks
     ENV.delete("SDKROOT")
 
-    paths = %w[libyaml openssl@1.1 readline].map { |f| Formula[f].opt_prefix }
+    paths = %w[libyaml openssl@3 readline].map { |f| Formula[f].opt_prefix }
     args = %W[
       --prefix=#{prefix}
       --enable-shared

--- a/Formula/ruby@2.6.rb
+++ b/Formula/ruby@2.6.rb
@@ -4,6 +4,7 @@ class RubyAT26 < Formula
   url "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.8.tar.xz"
   sha256 "8262e4663169c85787fdc9bfbd04d9eb86eb2a4b56d7f98373a8fcaa18e593eb"
   license "Ruby"
+  revision 1
 
   livecheck do
     url "https://www.ruby-lang.org/en/downloads/"
@@ -24,7 +25,7 @@ class RubyAT26 < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libyaml"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   uses_from_macos "zlib"
@@ -41,7 +42,7 @@ class RubyAT26 < Formula
     # otherwise `gem` command breaks
     ENV.delete("SDKROOT")
 
-    paths = %w[libyaml openssl@1.1 readline].map { |f| Formula[f].opt_prefix }
+    paths = %w[libyaml openssl@3 readline].map { |f| Formula[f].opt_prefix }
     args = %W[
       --prefix=#{prefix}
       --enable-shared

--- a/Formula/s-nail.rb
+++ b/Formula/s-nail.rb
@@ -3,6 +3,7 @@ class SNail < Formula
   homepage "https://www.sdaoden.eu/code.html"
   url "https://www.sdaoden.eu/downloads/s-nail-14.9.22.tar.xz"
   sha256 "e5dfb7d5bcc5d2d1126f2e826569ee0f149aac3f2a8a6b7c23985ffc3a1def0b"
+  revision 1
 
   livecheck do
     url :homepage
@@ -19,12 +20,12 @@ class SNail < Formula
 
   depends_on "awk" => :build
   depends_on "libidn"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "make", "CC=#{ENV.cc}",
-                   "C_INCLUDE_PATH=#{Formula["openssl@1.1"].opt_include}",
-                   "LDFLAGS=-L#{Formula["openssl@1.1"].opt_lib}",
+                   "C_INCLUDE_PATH=#{Formula["openssl@3"].opt_include}",
+                   "LDFLAGS=-L#{Formula["openssl@3"].opt_lib}",
                    "VAL_PREFIX=#{prefix}",
                    "OPT_DOTLOCK=no",
                    "config"

--- a/Formula/s2geometry.rb
+++ b/Formula/s2geometry.rb
@@ -4,7 +4,7 @@ class S2geometry < Formula
   url "https://github.com/google/s2geometry/archive/v0.9.0.tar.gz"
   sha256 "54c09b653f68929e8929bffa60ea568e26f3b4a51e1b1734f5c3c037f1d89062"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   livecheck do
     url :homepage
@@ -20,10 +20,10 @@ class S2geometry < Formula
   depends_on "cmake" => :build
   depends_on "glog" => :build
   depends_on "googletest" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
-    ENV["OPENSSL_ROOT_DIR"] = Formula["openssl@1.1"].opt_prefix
+    ENV["OPENSSL_ROOT_DIR"] = Formula["openssl@3"].opt_prefix
     ENV.append "CXXFLAGS", "-I#{Formula["googletest"].opt_include}"
 
     args = std_cmake_args + %w[

--- a/Formula/s2n.rb
+++ b/Formula/s2n.rb
@@ -4,6 +4,7 @@ class S2n < Formula
   url "https://github.com/aws/s2n-tls/archive/v1.1.0.tar.gz"
   sha256 "e094fd1f2044cfaeedb534ef1d7e4fd8745d8c07a247ce383cd8a6a5288e195c"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/aws/s2n-tls.git", branch: "main"
 
   livecheck do
@@ -19,7 +20,7 @@ class S2n < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DBUILD_SHARED_LIBS=ON"

--- a/Formula/s3-backer.rb
+++ b/Formula/s3-backer.rb
@@ -4,6 +4,7 @@ class S3Backer < Formula
   url "https://archie-public.s3.amazonaws.com/s3backer/s3backer-1.5.6.tar.gz"
   sha256 "deea48205347b24d1298fa16bf3252d9348d0fe81dde9cb20f40071b8de60519"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any, catalina:    "f54a33c549b57b056808803b4cc722596a89bb9413d135161952903de975a3f5"
@@ -12,7 +13,7 @@ class S3Backer < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_macos do
     disable! date: "2021-04-08", because: "requires closed-source macFUSE"

--- a/Formula/sagittarius-scheme.rb
+++ b/Formula/sagittarius-scheme.rb
@@ -4,6 +4,7 @@ class SagittariusScheme < Formula
   url "https://bitbucket.org/ktakashi/sagittarius-scheme/downloads/sagittarius-0.9.8.tar.gz"
   sha256 "09d9c1a53abe734e09762a5f848888f0491516c09cd341a1f9c039cd810d32a2"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 big_sur:      "cf0368881b0be31b65715e3666aa1e98f57967c82cb10a9079bd47683796b4de"
@@ -15,7 +16,7 @@ class SagittariusScheme < Formula
   depends_on "cmake" => :build
   depends_on "bdw-gc"
   depends_on "libffi"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "unixodbc"
 
   uses_from_macos "zlib"

--- a/Formula/sblim-sfcc.rb
+++ b/Formula/sblim-sfcc.rb
@@ -3,7 +3,7 @@ class SblimSfcc < Formula
   homepage "https://sourceforge.net/projects/sblim/"
   url "https://downloads.sourceforge.net/project/sblim/sblim-sfcc/sblim-sfcc-2.2.8.tar.bz2"
   sha256 "1b8f187583bc6c6b0a63aae0165ca37892a2a3bd4bb0682cd76b56268b42c3d6"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -22,7 +22,7 @@ class SblimSfcc < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"

--- a/Formula/scamper.rb
+++ b/Formula/scamper.rb
@@ -4,6 +4,7 @@ class Scamper < Formula
   url "https://www.caida.org/catalog/software/scamper/code/scamper-cvs-20210324.tar.gz"
   sha256 "332dce11a707c03045dd3c3faea4daf8b9d5debb8ac122aea8257f6bd2cf4404"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url "https://www.caida.org/catalog/software/scamper/code/?C=M&O=D"
@@ -19,7 +20,7 @@ class Scamper < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/sccache.rb
+++ b/Formula/sccache.rb
@@ -4,6 +4,7 @@ class Sccache < Formula
   url "https://github.com/mozilla/sccache/archive/v0.2.15.tar.gz"
   sha256 "7dbe71012f9b0b57d8475de6b36a9a3b4802e44a135e886f32c5ad1b0eb506e0"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/mozilla/sccache.git", branch: "master"
 
   bottle do
@@ -15,12 +16,12 @@ class Sccache < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
+    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
 
     system "cargo", "install", "--features", "all", *std_cargo_args
   end

--- a/Formula/sdhash.rb
+++ b/Formula/sdhash.rb
@@ -3,7 +3,7 @@ class Sdhash < Formula
   homepage "http://roussev.net/sdhash/sdhash.html"
   url "http://roussev.net/sdhash/releases/packages/sdhash-3.1.tar.gz"
   sha256 "b991d38533d02ae56e0c7aeb230f844e45a39f2867f70fab30002cfa34ba449c"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any, catalina:    "2b9a824cc177fe984f61eb756447e77f947b993317c6c5909fc5e56f52d7ab5f"
@@ -21,7 +21,7 @@ class Sdhash < Formula
   # but for now it seems dead.
   disable! date: "2020-12-06", because: :does_not_build
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     inreplace "Makefile" do |s|

--- a/Formula/selene.rb
+++ b/Formula/selene.rb
@@ -4,6 +4,7 @@ class Selene < Formula
   url "https://github.com/Kampfkarren/selene/archive/0.14.0.tar.gz"
   sha256 "7accab1f2e2c32af7ca3a28da91f0f3ff89a9437a4d6008a9514f13009912fe3"
   license "MPL-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "db9ad90c61edc0bdd85f36287a857c881ce85488df4a545c7f43623ba3306c06"
@@ -14,7 +15,7 @@ class Selene < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_linux do
     depends_on "pkg-config" => :build

--- a/Formula/shairport.rb
+++ b/Formula/shairport.rb
@@ -4,7 +4,7 @@ class Shairport < Formula
   url "https://github.com/abrasive/shairport/archive/1.1.1.tar.gz"
   sha256 "1b60df6d40bab874c1220d7daecd68fcff3e47bda7c6d7f91db0a5b5c43c0c72"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/abrasive/shairport.git", branch: "master"
 
   bottle do
@@ -18,7 +18,7 @@ class Shairport < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure"

--- a/Formula/shellinabox.rb
+++ b/Formula/shellinabox.rb
@@ -4,7 +4,7 @@ class Shellinabox < Formula
   url "https://github.com/shellinabox/shellinabox/archive/v2.20.tar.gz"
   sha256 "27a5ec6c3439f87aee238c47cc56e7357a6249e5ca9ed0f044f0057ef389d81e"
   license "GPL-2.0"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1
@@ -18,7 +18,7 @@ class Shellinabox < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # Upstream (Debian) patch for OpenSSL 1.1 compatibility
   # Original patch cluster: https://github.com/shellinabox/shellinabox/pull/467

--- a/Formula/siege.rb
+++ b/Formula/siege.rb
@@ -4,6 +4,7 @@ class Siege < Formula
   url "http://download.joedog.org/siege/siege-4.1.1.tar.gz"
   sha256 "143c25727b9bb2c439486c35121602f4d963385305aab4ed1ff9851581bfe4a8"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "http://download.joedog.org/siege/?C=M&O=D"
@@ -18,7 +19,7 @@ class Siege < Formula
     sha256 x86_64_linux:  "14d0a4594a88c19185f06de0bc12a626b2dde2740868250bc58312e57dabbc74"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 
@@ -29,7 +30,7 @@ class Siege < Formula
                           "--prefix=#{prefix}",
                           "--mandir=#{man}",
                           "--localstatedir=#{var}",
-                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}",
+                          "--with-ssl=#{Formula["openssl@3"].opt_prefix}",
                           "--with-zlib=#{MacOS.sdk_path_if_needed}/usr"
     system "make", "install"
   end

--- a/Formula/sipp.rb
+++ b/Formula/sipp.rb
@@ -4,7 +4,7 @@ class Sipp < Formula
   url "https://github.com/SIPp/sipp/releases/download/v3.6.1/sipp-3.6.1.tar.gz"
   sha256 "6a560e83aff982f331ddbcadfb3bd530c5896cd5b757dd6eb682133cc860ecb1"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "75316a2ff92ad29fb3d2ab4c660f3d4ef2901982826ee269f37a9e58df5cefe2"
@@ -15,7 +15,7 @@ class Sipp < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "libpcap"
   uses_from_macos "ncurses"

--- a/Formula/sipsak.rb
+++ b/Formula/sipsak.rb
@@ -4,6 +4,7 @@ class Sipsak < Formula
   url "https://github.com/nils-ohlmeier/sipsak/releases/download/0.9.8.1/sipsak-0.9.8.1.tar.gz"
   sha256 "c6faa022cd8c002165875d4aac83b7a2b59194f0491802924117fc6ac980c778"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "4525ec303fc0f5ffd3b752ccf1dcdc7fdb14921ad35d8e12109e257c47ce14fc"
@@ -13,7 +14,7 @@ class Sipsak < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "7a953aef939a2e020ceb548db309d98462b4b2ca0ea2e9f70c0f298a7f0dbd3c"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     ENV.append "CFLAGS", "-std=gnu89"

--- a/Formula/slowhttptest.rb
+++ b/Formula/slowhttptest.rb
@@ -4,7 +4,7 @@ class Slowhttptest < Formula
   url "https://github.com/shekyan/slowhttptest/archive/v1.8.2.tar.gz"
   sha256 "faa83dc45e55c28a88d3cca53d2904d4059fe46d86eca9fde7ee9061f37c0d80"
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/shekyan/slowhttptest.git", branch: "master"
 
   bottle do
@@ -20,7 +20,7 @@ class Slowhttptest < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     inreplace "configure.ac", "1.8.1", "1.8.2"

--- a/Formula/slrn.rb
+++ b/Formula/slrn.rb
@@ -4,7 +4,7 @@ class Slrn < Formula
   url "https://jedsoft.org/releases/slrn/slrn-1.0.3a.tar.bz2"
   sha256 "3ba8a4d549201640f2b82d53fb1bec1250f908052a7983f0061c983c634c2dac"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
   head "git://git.jedsoft.org/git/slrn.git", branch: "master"
 
   livecheck do
@@ -21,7 +21,7 @@ class Slrn < Formula
     sha256 x86_64_linux:  "e9f1013ef2eb1b03c54754621b7669de769a87f412f025d5f83d8c1ee2efe5c9"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "s-lang"
 
   def install
@@ -35,7 +35,7 @@ class Slrn < Formula
 
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}",
+                          "--with-ssl=#{Formula["openssl@3"].opt_prefix}",
                           "--with-slrnpull=#{var}/spool/news/slrnpull",
                           "--with-slang=#{HOMEBREW_PREFIX}"
     system "make", "all", "slrnpull"

--- a/Formula/sngrep.rb
+++ b/Formula/sngrep.rb
@@ -4,6 +4,7 @@ class Sngrep < Formula
   url "https://github.com/irontec/sngrep/archive/v1.4.9.tar.gz"
   sha256 "3c6f28b5c795a5b1844a8997aa430aba72e083c8bd52939990900450c5f4c85a"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "449af17f3cb8673ec2beb158ba5a48bfc620739bac89bce15eeaea4297c65972"
@@ -16,7 +17,7 @@ class Sngrep < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "ncurses" if DevelopmentTools.clang_build_version >= 1000
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "libpcap"
   uses_from_macos "ncurses"
@@ -29,7 +30,7 @@ class Sngrep < Formula
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/snort.rb
+++ b/Formula/snort.rb
@@ -5,6 +5,7 @@ class Snort < Formula
   mirror "https://fossies.org/linux/misc/snort3-3.1.13.0.tar.gz"
   sha256 "297c9fb6598f473c8aad1c544a6a9b241a74c084074801c035fc0c5cc24680ec"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/snort3/snort3.git", branch: "master"
 
   bottle do
@@ -27,7 +28,7 @@ class Snort < Formula
   depends_on "libdnet"
   depends_on "libpcap" # macOS version segfaults
   depends_on "luajit-openresty"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
   depends_on "xz" # for lzma.h
 

--- a/Formula/softhsm.rb
+++ b/Formula/softhsm.rb
@@ -4,6 +4,7 @@ class Softhsm < Formula
   url "https://dist.opendnssec.org/source/softhsm-2.6.1.tar.gz"
   sha256 "61249473054bcd1811519ef9a989a880a7bdcc36d317c9c25457fc614df475f2"
   license "BSD-2-Clause"
+  revision 1
 
   # We check the GitHub repo tags instead of https://dist.opendnssec.org/source/
   # since the aforementioned first-party URL has a tendency to lead to an
@@ -32,7 +33,7 @@ class Softhsm < Formula
     depends_on "pkg-config" => :build
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "sh", "./autogen.sh" if build.head?
@@ -42,7 +43,7 @@ class Softhsm < Formula
                           "--sysconfdir=#{etc}/softhsm",
                           "--localstatedir=#{var}",
                           "--with-crypto-backend=openssl",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}",
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}",
                           "--disable-gost"
     system "make", "install"
   end

--- a/Formula/spiped.rb
+++ b/Formula/spiped.rb
@@ -3,6 +3,7 @@ class Spiped < Formula
   homepage "https://www.tarsnap.com/spiped.html"
   url "https://www.tarsnap.com/spiped/spiped-1.6.1.tgz"
   sha256 "8d7089979db79a531a0ecc507b113ac6f2cf5f19305571eff1d3413e0ab33713"
+  revision 1
 
   livecheck do
     url :homepage
@@ -18,7 +19,7 @@ class Spiped < Formula
   end
 
   depends_on "bsdmake" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     man1.mkpath

--- a/Formula/squid.rb
+++ b/Formula/squid.rb
@@ -4,6 +4,7 @@ class Squid < Formula
   url "http://www.squid-cache.org/Versions/v4/squid-4.16.tar.xz"
   sha256 "7e00e891757c1c02dae546c9898f440c6031b684d8c243d6edab529076e3ba63"
   license "GPL-2.0"
+  revision 1
 
   livecheck do
     url "http://www.squid-cache.org/Versions/v4/"
@@ -26,7 +27,7 @@ class Squid < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     # https://stackoverflow.com/questions/20910109/building-squid-cache-on-os-x-mavericks

--- a/Formula/ssh-permit-a38.rb
+++ b/Formula/ssh-permit-a38.rb
@@ -4,7 +4,7 @@ class SshPermitA38 < Formula
   url "https://github.com/ierror/ssh-permit-a38/archive/v0.2.0.tar.gz"
   sha256 "cb8d94954c0e68eb86e3009d6f067b92464f9c095b6a7754459cfce329576bd9"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1
@@ -18,14 +18,14 @@ class SshPermitA38 < Formula
 
   depends_on "cmake" => :build
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
+    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/ssldump.rb
+++ b/Formula/ssldump.rb
@@ -3,7 +3,7 @@ class Ssldump < Formula
   homepage "https://ssldump.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/ssldump/ssldump/0.9b3/ssldump-0.9b3.tar.gz"
   sha256 "6422c16718d27c270bbcfcc1272c4f9bd3c0799c351f1d6dd54fdc162afdab1e"
-  revision 2
+  revision 3
 
   # This regex intentionally matches unstable versions, as only a beta version
   # (0.9b3) is available at the time of writing.
@@ -24,7 +24,7 @@ class Ssldump < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libpcap"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # reorder include files
   # https://sourceforge.net/p/ssldump/bugs/40/

--- a/Formula/sslscan.rb
+++ b/Formula/sslscan.rb
@@ -4,6 +4,7 @@ class Sslscan < Formula
   url "https://github.com/rbsec/sslscan/archive/2.0.10.tar.gz"
   sha256 "bb7bb0ff037aa5579b3ee0cf91aa41ab04ac073592b5d95ad3fab820f5000f6e"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/rbsec/sslscan.git", branch: "master"
 
   livecheck do
@@ -19,12 +20,12 @@ class Sslscan < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "4922f8701dfe20d818eee4fcf6ba010b7da4c927ad0389e00181eb993a4d0d71"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
-    # use `libcrypto.dylib|so` built from `openssl@1.1`
+    # use `libcrypto.dylib|so` built from `openssl@3`
     inreplace "Makefile", "static: openssl/libcrypto.a",
-                          "static: #{Formula["openssl@1.1"].opt_lib}/#{shared_library("libcrypto")}"
+                          "static: #{Formula["openssl@3"].opt_lib}/#{shared_library("libcrypto")}"
 
     system "make", "static"
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/starship.rb
+++ b/Formula/starship.rb
@@ -4,6 +4,7 @@ class Starship < Formula
   url "https://github.com/starship/starship/archive/v0.58.0.tar.gz"
   sha256 "8bd4cfad4bcf9694633f228de0c7dc6cfab6bb6955e2a7299ed28dd8c4d6f5e4"
   license "ISC"
+  revision 1
   head "https://github.com/starship/starship.git", branch: "master"
 
   bottle do
@@ -15,7 +16,7 @@ class Starship < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/strongswan.rb
+++ b/Formula/strongswan.rb
@@ -4,6 +4,7 @@ class Strongswan < Formula
   url "https://download.strongswan.org/strongswan-5.9.3.tar.bz2"
   sha256 "9325ab56a0a4e97e379401e1d942ce3e0d8b6372291350ab2caae0755862c6f7"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://download.strongswan.org/"
@@ -28,7 +29,7 @@ class Strongswan < Formula
     depends_on "pkg-config" => :build
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     args = %W[

--- a/Formula/stunnel.rb
+++ b/Formula/stunnel.rb
@@ -4,6 +4,7 @@ class Stunnel < Formula
   url "https://www.stunnel.org/downloads/stunnel-5.60.tar.gz"
   sha256 "c45d765b1521861fea9b03b425b9dd7d48b3055128c0aec673bba5ef9b8f787d"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.stunnel.org/downloads.html"
@@ -19,7 +20,7 @@ class Stunnel < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b03b0098fe618d67cbfccaa6aa23d09b7d7f490e968f221122ebb2b4d14db3d0"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -30,14 +31,14 @@ class Stunnel < Formula
                           "--mandir=#{man}",
                           "--disable-libwrap",
                           "--disable-systemd",
-                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-ssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
 
     # This programmatically recreates pem creation used in the tools Makefile
     # which would usually require interactivity to resolve.
     cd "tools" do
       system "dd", "if=/dev/urandom", "of=stunnel.rnd", "bs=256", "count=1"
-      system "#{Formula["openssl@1.1"].opt_bin}/openssl", "req",
+      system "#{Formula["openssl@3"].opt_bin}/openssl", "req",
         "-new", "-x509",
         "-days", "365",
         "-rand", "stunnel.rnd",

--- a/Formula/stuntman.rb
+++ b/Formula/stuntman.rb
@@ -4,6 +4,7 @@ class Stuntman < Formula
   url "http://www.stunprotocol.org/stunserver-1.2.16.tgz"
   sha256 "4479e1ae070651dfc4836a998267c7ac2fba4f011abcfdca3b8ccd7736d4fd26"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/jselbie/stunserver.git", branch: "master"
 
   livecheck do
@@ -21,7 +22,7 @@ class Stuntman < Formula
   end
 
   depends_on "boost" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "make"

--- a/Formula/tcpdump.rb
+++ b/Formula/tcpdump.rb
@@ -4,6 +4,7 @@ class Tcpdump < Formula
   url "https://www.tcpdump.org/release/tcpdump-4.99.1.tar.gz"
   sha256 "79b36985fb2703146618d87c4acde3e068b91c553fb93f021a337f175fd10ebe"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/the-tcpdump-group/tcpdump.git", branch: "master"
 
   livecheck do
@@ -20,7 +21,7 @@ class Tcpdump < Formula
   end
 
   depends_on "libpcap"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--prefix=#{prefix}",
@@ -33,7 +34,7 @@ class Tcpdump < Formula
     output = shell_output("#{bin}/tcpdump --help 2>&1")
     assert_match "tcpdump version #{version}", output
     assert_match "libpcap version #{Formula["libpcap"].version}", output
-    assert_match "OpenSSL #{Formula["openssl@1.1"].version}", output
+    assert_match "OpenSSL #{Formula["openssl@3"].version}", output
 
     match = "tcpdump: (cannot open BPF device) /dev/bpf0: Operation not permitted"
     on_linux do

--- a/Formula/tcpflow.rb
+++ b/Formula/tcpflow.rb
@@ -4,6 +4,7 @@ class Tcpflow < Formula
   url "https://downloads.digitalcorpora.org/downloads/tcpflow/tcpflow-1.6.1.tar.gz"
   sha256 "436f93b1141be0abe593710947307d8f91129a5353c3a8c3c29e2ba0355e171e"
   license "GPL-3.0"
+  revision 1
 
   livecheck do
     url "https://downloads.digitalcorpora.org/downloads/tcpflow/"
@@ -26,7 +27,7 @@ class Tcpflow < Formula
   end
 
   depends_on "boost" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "bzip2"
   uses_from_macos "libpcap"

--- a/Formula/tdlib.rb
+++ b/Formula/tdlib.rb
@@ -4,6 +4,7 @@ class Tdlib < Formula
   url "https://github.com/tdlib/td/archive/v1.7.0.tar.gz"
   sha256 "3daaf419f1738b7e0ac0e8a08f07e01a1faaf51175a59c0b113c15e30c69e173"
   license "BSL-1.0"
+  revision 1
   head "https://github.com/tdlib/td.git", branch: "master"
 
   bottle do
@@ -16,7 +17,7 @@ class Tdlib < Formula
 
   depends_on "cmake" => :build
   depends_on "gperf" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   uses_from_macos "zlib"

--- a/Formula/testssl.rb
+++ b/Formula/testssl.rb
@@ -4,20 +4,21 @@ class Testssl < Formula
   url "https://github.com/drwetter/testssl.sh/archive/3.0.5.tar.gz"
   sha256 "9de744fe0e51a03d42fa85e4b83340948baeaa7080427f90b0efd23e9106fece"
   license "GPL-2.0"
+  revision 1
   head "https://github.com/drwetter/testssl.sh.git", branch: "3.1dev"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "720715f209d47df4a0e54532a3d181e1294384855e709481e471244be517ea52"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     bin.install "testssl.sh"
     man1.install "doc/testssl.1"
     prefix.install "etc"
     env = {
-      PATH:                "#{Formula["openssl@1.1"].opt_bin}:$PATH",
+      PATH:                "#{Formula["openssl@3"].opt_bin}:$PATH",
       TESTSSL_INSTALL_DIR: prefix,
     }
     bin.env_script_all_files(libexec/"bin", env)

--- a/Formula/thrift@0.9.rb
+++ b/Formula/thrift@0.9.rb
@@ -4,6 +4,7 @@ class ThriftAT09 < Formula
   url "https://github.com/apache/thrift/archive/0.9.3.1.tar.gz"
   sha256 "1f7ca02d88a603f2845b2c7abcab74f8107dd7285056284d65241eb7965e143c"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "0b96eded35c6da92ea4fb6a2cbbc2c572838a9a7a0221161088adb77f8ccaa9f"
@@ -22,7 +23,7 @@ class ThriftAT09 < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "flex" => :build
 

--- a/Formula/tinc.rb
+++ b/Formula/tinc.rb
@@ -4,6 +4,7 @@ class Tinc < Formula
   url "https://tinc-vpn.org/packages/tinc-1.0.36.tar.gz"
   sha256 "40f73bb3facc480effe0e771442a706ff0488edea7a5f2505d4ccb2aa8163108"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.tinc-vpn.org/download/"
@@ -21,13 +22,13 @@ class Tinc < Formula
   end
 
   depends_on "lzo"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--sysconfdir=#{etc}",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/tiny-fugue.rb
+++ b/Formula/tiny-fugue.rb
@@ -5,7 +5,7 @@ class TinyFugue < Formula
   version "5.0b8"
   sha256 "3750a114cf947b1e3d71cecbe258cb830c39f3186c369e368d4662de9c50d989"
   license "GPL-2.0-or-later"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -25,7 +25,7 @@ class TinyFugue < Formula
   end
 
   depends_on "libnet"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   uses_from_macos "ncurses"

--- a/Formula/tomcat-native.rb
+++ b/Formula/tomcat-native.rb
@@ -5,6 +5,7 @@ class TomcatNative < Formula
   mirror "https://archive.apache.org/dist/tomcat/tomcat-connectors/native/1.2.31/source/tomcat-native-1.2.31-src.tar.gz"
   sha256 "acc0e6e342fbdda54b029564405322823c93d83f9d64363737c1cbcc3af1c1fd"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "c6f4dd11e7fbf16ad6f7e11b7d4c81e1ee6159bc025e0464430d920588fd1f24"
@@ -17,14 +18,14 @@ class TomcatNative < Formula
   depends_on "libtool" => :build
   depends_on "apr"
   depends_on "openjdk"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     cd "native" do
       system "./configure", "--prefix=#{prefix}",
                             "--with-apr=#{Formula["apr"].opt_prefix}",
                             "--with-java-home=#{Formula["openjdk"].opt_prefix}",
-                            "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}"
+                            "--with-ssl=#{Formula["openssl@3"].opt_prefix}"
 
       # fixes occasional compiling issue: glibtool: compile: specify a tag with `--tag'
       args = ["LIBTOOL=glibtool --tag=CC"]

--- a/Formula/trafficserver.rb
+++ b/Formula/trafficserver.rb
@@ -5,6 +5,7 @@ class Trafficserver < Formula
   mirror "https://archive.apache.org/dist/trafficserver/trafficserver-9.1.0.tar.bz2"
   sha256 "f1cb90bcf4afaba8ad1395c4d5a824b9909a5cac3abda74788540fdb48d8df21"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 catalina: "8eca27b1c4f7ac994d609270b426eaeb270f11fcedd450c37dcfc47a008a7fc1"
@@ -27,7 +28,7 @@ class Trafficserver < Formula
   depends_on "pkg-config" => :build
   depends_on "hwloc"
   depends_on macos: :mojave # `error: call to unavailable member function 'value': introduced in macOS 10.14`
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
   depends_on "yaml-cpp"
 
@@ -41,7 +42,7 @@ class Trafficserver < Formula
       --mandir=#{man}
       --localstatedir=#{var}
       --sysconfdir=#{etc}/trafficserver
-      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-openssl=#{Formula["openssl@3"].opt_prefix}
       --with-yaml-cpp=#{Formula["yaml-cpp"].opt_prefix}
       --with-group=admin
       --disable-silent-rules

--- a/Formula/u-boot-tools.rb
+++ b/Formula/u-boot-tools.rb
@@ -4,6 +4,7 @@ class UBootTools < Formula
   url "https://ftp.denx.de/pub/u-boot/u-boot-2021.07.tar.bz2"
   sha256 "312b7eeae44581d1362c3a3f02c28d806647756c82ba8c72241c7cdbe68ba77e"
   license all_of: ["GPL-2.0-only", "GPL-2.0-or-later", "BSD-3-Clause"]
+  revision 1
 
   livecheck do
     url "https://ftp.denx.de/pub/u-boot/"
@@ -19,7 +20,7 @@ class UBootTools < Formula
   end
 
   depends_on "coreutils" => :build # Makefile needs $(gdate)
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build

--- a/Formula/uftp.rb
+++ b/Formula/uftp.rb
@@ -4,6 +4,7 @@ class Uftp < Formula
   url "https://downloads.sourceforge.net/project/uftp-multicast/source-tar/uftp-5.0.tar.gz"
   sha256 "562f71ea5a24b615eb491f5744bad01e9c2e58244c1d6252d5ae98d320d308e0"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -19,10 +20,10 @@ class Uftp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "2d550e280c49503b83b5bc2f30092dedc67e8b0ff0937dcbc487e475c0f1ee02"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
-    system "make", "OPENSSL=#{Formula["openssl@1.1"].opt_prefix}", "DESTDIR=#{prefix}", "install"
+    system "make", "OPENSSL=#{Formula["openssl@3"].opt_prefix}", "DESTDIR=#{prefix}", "install"
     # the makefile installs into DESTDIR/usr/..., move everything up one and remove usr
     # the project maintainer was contacted via sourceforge on 12-Feb, he responded WONTFIX on 13-Feb
     prefix.install Dir["#{prefix}/usr/*"]

--- a/Formula/unshield.rb
+++ b/Formula/unshield.rb
@@ -4,7 +4,7 @@ class Unshield < Formula
   url "https://github.com/twogood/unshield/archive/1.4.3.tar.gz"
   sha256 "aa8c978dc0eb1158d266eaddcd1852d6d71620ddfc82807fe4bf2e19022b7bab"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/twogood/unshield.git", branch: "master"
 
   bottle do
@@ -17,7 +17,7 @@ class Unshield < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/Formula/urweb.rb
+++ b/Formula/urweb.rb
@@ -3,7 +3,7 @@ class Urweb < Formula
   homepage "http://www.impredicative.com/ur/"
   url "https://github.com/urweb/urweb/releases/download/20200209/urweb-20200209.tar.gz"
   sha256 "ac3010c57f8d90f09f49dfcd6b2dc4d5da1cdbb41cbf12cb386e96e93ae30662"
-  revision 4
+  revision 5
 
   bottle do
     sha256 big_sur:  "f50d69d970a627bff0607a8be0766c12bdc49394e457776731a5dfd40531f82f"
@@ -17,7 +17,7 @@ class Urweb < Formula
   depends_on "mlton" => :build
   depends_on "gmp"
   depends_on "icu4c"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # Patch to fix build for icu4c 68.2
   patch do
@@ -30,7 +30,7 @@ class Urweb < Formula
       --disable-debug
       --disable-dependency-tracking
       --disable-silent-rules
-      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-openssl=#{Formula["openssl@3"].opt_prefix}
       --prefix=#{prefix}
       SITELISP=$prefix/share/emacs/site-lisp/urweb
       ICU_INCLUDES=-I#{Formula["icu4c"].opt_include}

--- a/Formula/virtuoso.rb
+++ b/Formula/virtuoso.rb
@@ -4,6 +4,7 @@ class Virtuoso < Formula
   url "https://github.com/openlink/virtuoso-opensource/releases/download/v7.2.6.1/virtuoso-opensource-7.2.6.tar.gz"
   sha256 "38fd3c037aef62fcc7c28de5c0d6c2577d4bb19809e71421fc42093ed4d1c753"
   license "GPL-2.0-only"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 big_sur:      "d35c507e655a9b900986b609bb232f30c811cbfb4f3ec20d60d1146059ba5305"
@@ -22,7 +23,7 @@ class Virtuoso < Formula
 
   # If gawk isn't found, make fails deep into the process.
   depends_on "gawk" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build

--- a/Formula/web100clt.rb
+++ b/Formula/web100clt.rb
@@ -3,7 +3,7 @@ class Web100clt < Formula
   homepage "https://software.internet2.edu/ndt/"
   url "https://software.internet2.edu/sources/ndt/ndt-3.7.0.2.tar.gz"
   sha256 "bd298eb333d4c13f191ce3e9386162dd0de07cddde8fe39e9a74fde4e072cdd9"
-  revision 1
+  revision 2
 
   # This page gives a 403 Forbidden response over HTTPS, so we use HTTP.
   livecheck do
@@ -23,7 +23,7 @@ class Web100clt < Formula
 
   depends_on "i2util"
   depends_on "jansson"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   # fixes issue with new default secure strlcpy/strlcat functions in 10.9
   # https://github.com/ndt-project/ndt/issues/106
@@ -37,7 +37,7 @@ class Web100clt < Formula
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
 
     # we only want to build the web100clt client so we need
     # to change to the src directory before installing.

--- a/Formula/webfs.rb
+++ b/Formula/webfs.rb
@@ -3,7 +3,7 @@ class Webfs < Formula
   homepage "https://linux.bytesex.org/misc/webfs.html"
   url "https://www.kraxel.org/releases/webfs/webfs-1.21.tar.gz"
   sha256 "98c1cb93473df08e166e848e549f86402e94a2f727366925b1c54ab31064a62a"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1
@@ -15,7 +15,7 @@ class Webfs < Formula
     sha256 cellar: :any, sierra:        "9e678532e4546e4fabb9a96b9eb141769e00e330e15c9e5b453001141448c9fb"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   patch :p0 do
     url "https://github.com/Homebrew/formula-patches/raw/0518a6d1ed821aebf0de4de78e39b57d6e60e296/webfs/patch-ls.c"

--- a/Formula/wrk.rb
+++ b/Formula/wrk.rb
@@ -3,6 +3,7 @@ class Wrk < Formula
   homepage "https://github.com/wg/wrk"
   url "https://github.com/wg/wrk/archive/4.1.0.tar.gz"
   sha256 "6fa1020494de8c337913fd139d7aa1acb9a020de6f7eb9190753aa4b1e74271e"
+  revision 1
   head "https://github.com/wg/wrk.git", branch: "master"
 
   bottle do
@@ -15,7 +16,7 @@ class Wrk < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "12af637f910bcdb74321e372ebf0d2b11206cc1dde29938cc48cb3eb3b4a03b1"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_linux do
     depends_on "makedepend" => :build

--- a/Formula/xaric.rb
+++ b/Formula/xaric.rb
@@ -4,6 +4,7 @@ class Xaric < Formula
   url "https://xaric.org/software/xaric/releases/xaric-0.13.9.tar.gz"
   sha256 "cb6c23fd20b9f54e663fff7cab22e8c11088319c95c90904175accf125d2fc11"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://xaric.org/software/xaric/releases/"
@@ -17,14 +18,14 @@ class Xaric < Formula
     sha256 mojave:        "e8c40aad03fec80e9566a1bb9c7100cbb3a4e0fca3dbc9f79f65271d3e29631f"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "ncurses"
 
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/xidel.rb
+++ b/Formula/xidel.rb
@@ -4,6 +4,7 @@ class Xidel < Formula
   url "https://github.com/benibela/xidel/releases/download/Xidel_0.9.8/xidel-0.9.8.src.tar.gz"
   sha256 "72b5b1a2fc44a0a61831e268c45bc6a6c28e3533b5445151bfbdeaf1562af39c"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     rebuild 1
@@ -15,7 +16,7 @@ class Xidel < Formula
   disable! date: "2020-12-08", because: :unmaintained
 
   depends_on "fpc"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     cd "programs/internet/xidel" do

--- a/Formula/yubico-piv-tool.rb
+++ b/Formula/yubico-piv-tool.rb
@@ -4,6 +4,7 @@ class YubicoPivTool < Formula
   url "https://developers.yubico.com/yubico-piv-tool/Releases/yubico-piv-tool-2.2.1.tar.gz"
   sha256 "b7ede4ddc3d6e31de67b2e2ddcd319b22b40cc2e0973b9866d052a754493b14e"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     url "https://developers.yubico.com/yubico-piv-tool/Releases/"
@@ -25,7 +26,7 @@ class YubicoPivTool < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "check"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcsc-lite"
 
   def install

--- a/Formula/zabbix.rb
+++ b/Formula/zabbix.rb
@@ -4,6 +4,7 @@ class Zabbix < Formula
   url "https://cdn.zabbix.com/zabbix/sources/stable/5.4/zabbix-5.4.4.tar.gz"
   sha256 "de9985978cf9638d7cb208f7f65d93141b4e1256ead56df1b95d7bda41d6a672"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/zabbix/zabbix.git", branch: "master"
 
   bottle do
@@ -14,7 +15,7 @@ class Zabbix < Formula
     sha256 x86_64_linux:  "e5cd2090baa1c65ae91bbfea560f5075ef4c52eac14c4a051aa82fc0ce888c21"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   def install
@@ -24,7 +25,7 @@ class Zabbix < Formula
       --sysconfdir=#{etc}/zabbix
       --enable-agent
       --with-libpcre=#{Formula["pcre"].opt_prefix}
-      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-openssl=#{Formula["openssl@3"].opt_prefix}
     ]
 
     if OS.mac?

--- a/Formula/zbackup.rb
+++ b/Formula/zbackup.rb
@@ -3,7 +3,7 @@ class Zbackup < Formula
   homepage "http://zbackup.org"
   url "https://github.com/zbackup/zbackup/archive/1.4.4.tar.gz"
   sha256 "efccccd2a045da91576c591968374379da1dc4ca2e3dec4d3f8f12628fa29a85"
-  revision 18
+  revision 19
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "cedb77ca64655bb9ffe5cc97fee5cd7def3b433c6b9a83f06f05aa3894f0bc74"
@@ -15,7 +15,7 @@ class Zbackup < Formula
 
   depends_on "cmake" => :build
   depends_on "lzo"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "protobuf"
   depends_on "xz" # get liblzma compression algorithm library from XZutils
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

~~Needs https://github.com/Homebrew/brew/pull/11994 first.~~

~~Note that a standard bottle pull won't work due to the GitHub API limit of 250 commits per pull request, so this is for initial testing only. We'll likely have openssl@1.1 co-exist with openssl@3 but maybe everything will just build properly and we won't need to do anything special 🤷~~

Attempt to migrate all formulae that both depend directly on openssl and have no dependents themselves. This also gets us nicely below the 250 commit limit for pull requests.