### PR TITLE
cvsutils: add livecheck

### DIFF
--- a/Formula/cvsutils.rb
+++ b/Formula/cvsutils.rb
@@ -5,6 +5,11 @@ class Cvsutils < Formula
   sha256 "174bb632c4ed812a57225a73ecab5293fcbab0368c454d113bf3c039722695bb"
   license "GPL-2.0"
 
+  livecheck do
+    url "https://www.red-bean.com/cvsutils/releases/"
+    regex(/href=.*?cvsutils[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b2a9644fe70816d7ca61c0497ce3baad7a81596e69254cf9d7d775d9e430f7f9"
     sha256 cellar: :any_skip_relocation, big_sur:       "f7173229e45bd423c11d21800ddf636afdb0903fff09e0514b21a3065ce8fba3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `cvsutils`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The homepage links to the directory listing page instead of linking to the latest tarball, so this acts as a download page.