### PR TITLE
clamav: fix config directory and add ncurses for Linux

### DIFF
--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -5,6 +5,7 @@ class Clamav < Formula
   mirror "https://fossies.org/linux/misc/clamav-0.104.0.tar.gz"
   sha256 "a079d64cd55d6184510adfe0f341b2f278f7fb1bcc080d28d374298160f19cb2"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/Cisco-Talos/clamav-devel.git", branch: "main"
 
   livecheck do
@@ -31,6 +32,7 @@ class Clamav < Formula
   uses_from_macos "bzip2"
   uses_from_macos "curl"
   uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   on_macos do
@@ -40,15 +42,15 @@ class Clamav < Formula
   skip_clean "share/clamav"
 
   def install
-    args = std_cmake_args + %w[
+    args = std_cmake_args + %W[
+      -DAPP_CONFIG_DIRECTORY=#{etc}/clamav
       -DENABLE_JSON_SHARED=ON
       -DENABLE_STATIC_LIB=ON
       -DENABLE_SHARED_LIB=ON
       -DENABLE_EXAMPLES=OFF
       -DENABLE_TESTS=OFF
+      -DENABLE_MILTER=OFF
     ]
-
-    args << "-DENABLE_MILTER=OFF" if OS.linux?
 
     system "cmake", "-S", ".", "-B", "build", *args
     system "cmake", "--build", "build"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Changes:
1. Fix issue from https://github.com/Homebrew/discussions/discussions/2113 where config directory is no longer long-term location.
2. Saw `ncurses` is linked on macOS, so add for Linux
3. Since `ENABLE_MILTER=OFF` is default on macOS, can simplify logic to apply on all OS.