### PR TITLE
openjdk: try to reproduce java.lang.UnsatisfiedLinkError

### DIFF
--- a/Formula/aspectj.rb
+++ b/Formula/aspectj.rb
@@ -47,6 +47,7 @@ class Aspectj < Formula
       }
     EOS
     ENV["CLASSPATH"] = "#{libexec}/#{name}/lib/aspectjrt.jar:test.jar:testaspect.jar"
+    puts ENV["CLASSPATH"]
     system bin/"ajc", "-outjar", "test.jar", "Test.java"
     system bin/"ajc", "-outjar", "testaspect.jar", "-outxml", "TestAspect.aj"
     output = shell_output("#{bin}/aj Test")

--- a/Formula/beast.rb
+++ b/Formula/beast.rb
@@ -38,6 +38,9 @@ class Beast < Formula
   end
 
   test do
+    puts ENV["CLASSPATH"]
+    puts "--- xxx ---"
+
     cp pkgshare/"examples/TestXML/ClockModels/testUCRelaxedClockLogNormal.xml", testpath
 
     # Run fewer generations to speed up tests


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


Trying to reproduce the following error:
```
2021-09-03T16:46:19.1974383Z Picked up _JAVA_OPTIONS: -Duser.home=/home/linuxbrew/.cache/Homebrew/java_cache -Djava.io.tmpdir=/tmp
2021-09-03T16:46:19.1975436Z Error: Unable to load main class com.sun.tools.javac.Main in module jdk.compiler
2021-09-03T16:46:19.1977001Z 	java.lang.UnsatisfiedLinkError: /home/linuxbrew/.linuxbrew/Cellar/openjdk/16.0.2/libexec/lib/libnio.so: /home/linuxbrew/.linuxbrew/Cellar/openjdk/16.0.2/libexec/lib/libnio.so: undefined symbol: reuseport_available
```

I can't reproduce this locally but it happens a lot in Linux CI. Infer does use openjdk@11, so the idea is to mix openjdk versions and see what happens.