### PR TITLE
vespa-cli 7.462.20 (new formula)

### DIFF
--- a/Formula/vespa-cli.rb
+++ b/Formula/vespa-cli.rb
@@ -1,0 +1,33 @@
+class VespaCli < Formula
+  desc "Command-line tool for Vespa.ai"
+  homepage "https://vespa.ai"
+  url "https://github.com/vespa-engine/vespa/archive/refs/tags/vespa-7.462.20-1.tar.gz"
+  version "7.462.20"
+  sha256 "87e309fbdac0bef174ef3ac1bf094d551a54dd2da57ecc52e19880d0d81a9cda"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    cd "client/go" do
+      with_env(VERSION: version.to_s) do
+        system "make", "all", "manpages"
+      end
+      bin.install "bin/vespa"
+      man1.install Dir["share/man/man1/vespa*.1"]
+      (bash_completion/"vespa").write Utils.safe_popen_read(bin/"vespa", "completion", "bash")
+      (fish_completion/"vespa.fish").write Utils.safe_popen_read(bin/"vespa", "completion", "fish")
+      (zsh_completion/"_vespa").write Utils.safe_popen_read(bin/"vespa", "completion", "zsh")
+    end
+  end
+
+  test do
+    with_env(VESPA_CLI_HOME: testpath) do
+      assert_match "vespa version #{version}", shell_output("#{bin}/vespa version")
+      query = "yql=select * from sources * where title contains 'foo';"
+      assert_match "Error: Request failed", shell_output("#{bin}/vespa query -t local '#{query}' hits=5")
+      system "#{bin}/vespa", "config", "set", "target", "cloud"
+      assert_match "target = cloud", shell_output("#{bin}/vespa config get target")
+    end
+  end
+end

--- a/Formula/vespa-cli.rb
+++ b/Formula/vespa-cli.rb
@@ -22,12 +22,11 @@ class VespaCli < Formula
   end
 
   test do
-    with_env(VESPA_CLI_HOME: testpath) do
-      assert_match "vespa version #{version}", shell_output("#{bin}/vespa version")
-      query = "yql=select * from sources * where title contains 'foo';"
-      assert_match "Error: Request failed", shell_output("#{bin}/vespa query -t local '#{query}' hits=5")
-      system "#{bin}/vespa", "config", "set", "target", "cloud"
-      assert_match "target = cloud", shell_output("#{bin}/vespa config get target")
-    end
+    ENV["VESPA_CLI_HOME"] = testpath.to_s
+    assert_match "vespa version #{version}", shell_output("#{bin}/vespa version")
+    query = "yql=select * from sources * where title contains 'foo';"
+    assert_match "Error: Request failed", shell_output("#{bin}/vespa query -t local '#{query}' hits=5")
+    system "#{bin}/vespa", "config", "set", "target", "cloud"
+    assert_match "target = cloud", shell_output("#{bin}/vespa config get target")
   end
 end

--- a/Formula/vespa-cli.rb
+++ b/Formula/vespa-cli.rb
@@ -1,7 +1,7 @@
 class VespaCli < Formula
   desc "Command-line tool for Vespa.ai"
   homepage "https://vespa.ai"
-  url "https://github.com/vespa-engine/vespa/archive/refs/tags/vespa-7.462.20-1.tar.gz"
+  url "https://github.com/vespa-engine/vespa/archive/vespa-7.462.20-1.tar.gz"
   version "7.462.20"
   sha256 "87e309fbdac0bef174ef3ac1bf094d551a54dd2da57ecc52e19880d0d81a9cda"
   license "Apache-2.0"

--- a/Formula/vespa-cli.rb
+++ b/Formula/vespa-cli.rb
@@ -22,7 +22,7 @@ class VespaCli < Formula
   end
 
   test do
-    ENV["VESPA_CLI_HOME"] = testpath.to_s
+    ENV["VESPA_CLI_HOME"] = testpath
     assert_match "vespa version #{version}", shell_output("#{bin}/vespa version")
     query = "yql=select * from sources * where title contains 'foo';"
     assert_match "Error: Request failed", shell_output("#{bin}/vespa query -t local '#{query}' hits=5")


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is the official command-line tool for working with Vespa (https://vespa.ai). It supports working with local Vespa installations as well as the Vespa Cloud service.

Regarding the explicit `version` field: The tags in https://github.com/vespa-engine/vespa/ are not ideal. I think they're RPM package versions, where the trailing `-1` is epoch. However, the official version number should not include this.

I could've done:
```
version "7.462.20"
url "https://github.com/vespa-engine/vespa/archive/refs/tags/vespa-#{version}-1.tar.gz"
 ```

but then `brew audit` complains.

FYI @bratseth