### PR TITLE
elasticseach@6: make formula compatible with m1 macs

### DIFF
--- a/Formula/elasticsearch@6.rb
+++ b/Formula/elasticsearch@6.rb
@@ -4,6 +4,7 @@ class ElasticsearchAT6 < Formula
   url "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-6.8.13.tar.gz"
   sha256 "e3a41d1a58898c18e9f80d45b1bf9f413779bdda9621027a6fe87f3a0f59ec90"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:      "5a169338be55587bc70f8d297a5ade7ab075540935af491d1eee1ec9e64cc200"
@@ -14,8 +15,7 @@ class ElasticsearchAT6 < Formula
 
   keg_only :versioned_formula
 
-  depends_on arch: :x86_64 # openjdk@8 is not supported on ARM
-  depends_on "openjdk@8"
+  depends_on "openjdk"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"
@@ -43,6 +43,11 @@ class ElasticsearchAT6 < Formula
       s.sub!(%r{#\s*path\.logs: /path/to.+$}, "path.logs: #{var}/log/elasticsearch/")
     end
 
+    inreplace "#{libexec}/config/jvm.options" do |s|
+      s.gsub! "logs/gc.log", "#{var}/log/elasticsearch/gc.log"
+      s.gsub! "10-:-XX:UseAVX=2", "# 10-:-XX:UseAVX=2" if Hardware::CPU.arm?
+    end
+
     # Move config files into etc
     (etc/"elasticsearch").install Dir[libexec/"config/*"]
     (libexec/"config").rmtree
@@ -51,7 +56,7 @@ class ElasticsearchAT6 < Formula
                 libexec/"bin/elasticsearch-keystore",
                 libexec/"bin/elasticsearch-plugin",
                 libexec/"bin/elasticsearch-translog"
-    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("1.8"))
+    bin.env_script_all_files(libexec/"bin", Language::Java.overridable_java_home_env)
   end
 
   def post_install


### PR DESCRIPTION
From the distribution file readme:

> You need to have a recent version of Java installed.

Which the latest openjdk provides while being compatible with both x86 and m1 macs.