### PR TITLE
libdvbpsi: add livecheck

### DIFF
--- a/Formula/libdvbpsi.rb
+++ b/Formula/libdvbpsi.rb
@@ -5,6 +5,11 @@ class Libdvbpsi < Formula
   sha256 "02b5998bcf289cdfbd8757bedd5987e681309b0a25b3ffe6cebae599f7a00112"
   license "LGPL-2.1"
 
+  livecheck do
+    url "https://download.videolan.org/pub/libdvbpsi/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "a61aaac7ff201fdd38a929556c6a64a69993150891690f8ea9532e1b9c9c9ae3"
     sha256 cellar: :any,                 big_sur:       "255b960c43fac14b8a50af513ca3b2925cdfa0e71efa61d2eced2fd172fe8dff"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `libdvbpsi`. This PR adds a `livecheck` block that checks the directory listing page where version directories are found (containing the `stable` archive). The `libdvbpsi` homepage doesn't link directly to the `stable` archive and instead links to the version directory that contains it, so there isn't much value in checking the homepage over the directory listing page.