### PR TITLE
spdx-sbom-generator 0.0.13 (new formula)

### DIFF
--- a/Formula/spdx-sbom-generator.rb
+++ b/Formula/spdx-sbom-generator.rb
@@ -1,0 +1,30 @@
+class SpdxSbomGenerator < Formula
+  desc "Support CI generation of SBOMs via golang tooling"
+  homepage "https://github.com/spdx/spdx-sbom-generator"
+  url "https://github.com/spdx/spdx-sbom-generator/archive/refs/tags/v0.0.13.tar.gz"
+  sha256 "7d088f136a53d1f608b1941362c568d78cc6279df9c1bdb3516de075cb7f10c3"
+  license any_of: ["Apache-2.0", "CC-BY-4.0"]
+
+  depends_on "go" => [:build, :test]
+
+  def install
+    target = if Hardware::CPU.arm?
+      "build-mac-arm64"
+    elsif OS.mac?
+      "build-mac"
+    else
+      "build"
+    end
+
+    system "make", target
+
+    bin.install "bin/spdx-sbom-generator"
+  end
+
+  test do
+    system "go", "mod", "init", "example.com/tester"
+
+    assert_equal "panic: runtime error: index out of range [0] with length 0",
+                 shell_output("#{bin}/spdx-sbom-generator 2>&1", 2).split("\n")[3]
+  end
+end


### PR DESCRIPTION
This commit adds Formula/spdx-sbom-generator.rb that includes the required
functionality to build and install the spdx-sbom-generator cli tool.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
