### PR TITLE
watchman: rename branch from master to main

### DIFF
--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -4,7 +4,7 @@ class Watchman < Formula
   url "https://github.com/facebook/watchman/archive/v2021.08.30.00.tar.gz"
   sha256 "3aa05179b70ef3bace7a8c162a4d9259c92bf78902e753f235c913419aca32e6"
   license "Apache-2.0"
-  head "https://github.com/facebook/watchman.git", branch: "master"
+  head "https://github.com/facebook/watchman.git", branch: "main"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "277fd35266869dfa8fb403126bc73985e15b69f9160d27b341d4790a4cea76b8"


### PR DESCRIPTION
We recently switched our main branch from "master" to "main" and that has broken Homebrew's ability to build from HEAD. This commit fixes that.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
