### PR TITLE
gawk: symlink gnuman => man

### DIFF
--- a/Formula/gawk.rb
+++ b/Formula/gawk.rb
@@ -5,6 +5,7 @@ class Gawk < Formula
   mirror "https://ftpmirror.gnu.org/gawk/gawk-5.1.0.tar.xz"
   sha256 "cf5fea4ac5665fd5171af4716baab2effc76306a9572988d5ba1078f196382bd"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_monterey: "d7b02e74ff4139241e646470b8a45ce75ceadae78cc1ccee6f49bc57682f3682"
@@ -40,6 +41,7 @@ class Gawk < Formula
 
     (libexec/"gnubin").install_symlink bin/"gawk" => "awk"
     (libexec/"gnuman/man1").install_symlink man1/"gawk.1" => "awk.1"
+    libexec.install_symlink "gnuman" => "man"
   end
 
   test do


### PR DESCRIPTION
This commit brings gawk into line with formulae for other GNU utilities which all symlink `gnuman` into `man` so that the `man` command can automatically find the man page for `gawk` when we put `/usr/local/opt/gawk/libexec/gnubin` in `PATH`.

A simple `ls` command show that formulae for many other GNU utilities are already doing this.  For example:

<pre><code><strong>$ ls -l /usr/local/opt/coreutils/libexec</strong>
drwxr-xr-x   3 luangong admin   96 Mar  5  2020 coreutils
drwxr-xr-x 108 luangong admin 3456 Mar  5  2020 gnubin
drwxr-xr-x   3 luangong admin   96 Mar  5  2020 gnuman
lrwxr-xr-x   1 luangong admin    6 Mar  5  2020 <strong>man -> gnuman</strong>
</code></pre>

but gawk’s `man` directory is missing:

<pre><code><strong>$ ls -l /usr/local/opt/gawk/libexec</strong>
drwxr-xr-x 4 luangong admin 128 Apr 14  2020 awk
drwxr-xr-x 3 luangong admin  96 Apr 14  2020 gnubin
drwxr-xr-x 3 luangong admin  96 Apr 14  2020 gnuman
</code></pre>

The `man` command automatically searches for man pages in some “nearby locations” of the corresponding entries in the `PATH` if the `MANPATH` variable is not set (see `/etc/man.conf` and the section titled “SEARCH PATH FOR MANUAL PAGES” in the man page of `man`).  For example, if you add `/usr/local/opt/coreutils/libexec/gnubin` to `PATH` and leave `MANPATH` unset, the `man` command will automatically look for man pages in `/usr/local/opt/coreutils/libexec/man`.  This allows us to just add `bin` directories of GNU utilities to `PATH` without also explicitly adding their man page locations to `MANPATH`.

```bash
export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"

# The following line is not needed if the MANPATH variable is unset.
export MANPATH="/usr/local/opt/coreutils/libexec/man:$MANPATH"
```

See https://scriptingosx.com/2017/05/where-paths-come-from/ for more detailed explanations.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?