### PR TITLE
simdjson: fix build on Linux

### DIFF
--- a/Formula/simdjson.rb
+++ b/Formula/simdjson.rb
@@ -15,6 +15,12 @@ class Simdjson < Formula
 
   depends_on "cmake" => :build
 
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5"
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DBUILD_SHARED_LIBS=ON"
     system "cmake", "--build", "build"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

With `gcc-5`, we see errors like:
```
 /tmp/simdjson-20210909-3101-103q6c0/simdjson-1.0.0/include/simdjson/generic/ondemand/document-inl.h:97:58: error: ambiguous template specialization ‘get<>’ for ‘simdjson::simdjson_result<simdjson::fallback::ondemand::array> simdjson::fallback::ondemand::document::get() &’
```

(e.g. https://github.com/Homebrew/homebrew-core/runs/3560482599?check_suite_focus=true)