### PR TITLE
elasticsearch@6: add arm64 bottle

### DIFF
--- a/Formula/elasticsearch@6.rb
+++ b/Formula/elasticsearch@6.rb
@@ -7,10 +7,12 @@ class ElasticsearchAT6 < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, big_sur:      "91758d6c8c408f7b478d9907b4b0585413b1574df2e8a6d48b281ea38f735be4"
-    sha256 cellar: :any_skip_relocation, catalina:     "91758d6c8c408f7b478d9907b4b0585413b1574df2e8a6d48b281ea38f735be4"
-    sha256 cellar: :any_skip_relocation, mojave:       "91758d6c8c408f7b478d9907b4b0585413b1574df2e8a6d48b281ea38f735be4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "c82ecdafef4805227c40d58feff43a4faa21e0ff0b97420c315453a3c14e2117"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "b987b991e8699f56d690ea05491e18dba2c9a860c93803eb63cbfd8cb98fda2d"
+    sha256 cellar: :any_skip_relocation, big_sur:       "91758d6c8c408f7b478d9907b4b0585413b1574df2e8a6d48b281ea38f735be4"
+    sha256 cellar: :any_skip_relocation, catalina:      "91758d6c8c408f7b478d9907b4b0585413b1574df2e8a6d48b281ea38f735be4"
+    sha256 cellar: :any_skip_relocation, mojave:        "91758d6c8c408f7b478d9907b4b0585413b1574df2e8a6d48b281ea38f735be4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c82ecdafef4805227c40d58feff43a4faa21e0ff0b97420c315453a3c14e2117"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
This is a follow up from https://github.com/Homebrew/homebrew-core/pull/84914 

It adds the binary bottle for arm64.