### PR TITLE
Lilypond 2.22.1 (new formula)

### DIFF
--- a/Formula/dblatex.rb
+++ b/Formula/dblatex.rb
@@ -5,8 +5,6 @@ class Dblatex < Formula
   sha256 "56fee45ef3c242c4800bad20c5aeb934b31ba0894bdf86275b60b2e7b2f4cb8e"
   license "GPL-2.0-or-later"
 
-  revision 1
-
   depends_on "imagemagick"
 
   def install

--- a/Formula/dblatex.rb
+++ b/Formula/dblatex.rb
@@ -1,0 +1,21 @@
+class Dblatex < Formula
+  desc "Transform DocBook XML to LaTeX"
+  homepage "https://dblatex.sourceforge.io"
+  url "https://files.pythonhosted.org/packages/a8/1c/a07b54389399ac0c014c175936eb142f562468c607150a2df3e94d365611/dblatex-0.3.10.tar.bz2"
+  sha256 "56fee45ef3c242c4800bad20c5aeb934b31ba0894bdf86275b60b2e7b2f4cb8e"
+  license "GPL-2.0-or-later"
+
+  revision 1
+
+  depends_on "imagemagick"
+
+  def install
+    ENV.append_path "PATH", "/Library/TeX/texbin"
+    system "/usr/bin/python", "setup.py", "install", "--prefix=#{prefix}"
+    inreplace bin/"dblatex", "#!/usr/bin/env python", "#!/usr/bin/python"
+  end
+
+  test do
+    system bin/"dblatex", "-v"
+  end
+end

--- a/Formula/extractpdfmark.rb
+++ b/Formula/extractpdfmark.rb
@@ -1,0 +1,23 @@
+class Extractpdfmark < Formula
+  desc "Extract page mode and named destinations as PDFmark from PDF"
+  homepage "https://www.ctan.org/pkg/extractpdfmark"
+  url "https://mirrors.ctan.org/support/extractpdfmark.zip"
+  version "1.1.0"
+  sha256 "f4a5ec1c6944e896bc52f2af9231e98a2c5b68f076ef9341146b829815366b28"
+  license "GPL-3.0-or-later"
+
+  revision 1
+
+  depends_on "poppler" => :build
+  depends_on "gettext"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/extractpdfmark", "--version"
+  end
+end

--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -41,7 +41,7 @@ class Lilypond < Formula
     sha256 "66eed7ca2dfbf44665aa34cb80559f4a90807d46858ccf76c34f9ac1701cfa27"
   end
 
-  resource "tex-resources" do 
+  resource "tex-resources" do
     url "https://github.com/jsfelix/homebrew-core/releases/download/v2.22.1/tex-resources.tar.gz"
     sha256 "b662ee0fc506bdeae6ed8cfebface09337d27fa06203f2f9c862e26b63f93490"
   end

--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -1,19 +1,3 @@
-class MacTeXRequirement < Requirement
-  fatal true
-
-  satisfy { Dir.exist?("/Library/TeX") }
-
-  def message
-    <<~EOS
-      MacTeX is required. Install it with brew install --cask mactex-no-gui
-    EOS
-  end
-
-  def display_s
-    "MacTeX"
-  end
-end
-
 class Lilypond < Formula
   desc "Music notation for everyone"
   homepage "https://lilypond.org"
@@ -35,7 +19,6 @@ class Lilypond < Formula
   depends_on "glib" => :build
   depends_on "guile@2" => :build
   depends_on "imagemagick" => :build
-  depends_on MacTeXRequirement => :build
   depends_on "make" => :build
   depends_on "pango" => :build
   depends_on "pkg-config" => :build
@@ -58,6 +41,11 @@ class Lilypond < Formula
     sha256 "66eed7ca2dfbf44665aa34cb80559f4a90807d46858ccf76c34f9ac1701cfa27"
   end
 
+  resource "tex-resources" do 
+    url "https://github.com/jsfelix/homebrew-core/releases/download/v2.22.1/tex-resources.tar.gz"
+    sha256 "b662ee0fc506bdeae6ed8cfebface09337d27fa06203f2f9c862e26b63f93490"
+  end
+
   def install
     system "./autogen.sh", "--noconfigure"
 
@@ -68,12 +56,15 @@ class Lilypond < Formula
     mkdir "build" do
       resource("font-urw").stage buildpath/"urw"
 
-      ENV.append_path "PATH", "/Library/TeX/texbin"
+      resource("tex-resources").stage buildpath/"tex-resources"
+
+      ENV.append_path "PATH", "#{buildpath}/tex-resources/bin/universal-darwin"
 
       system "../configure",
              "--prefix=#{prefix}",
-             "--with-texgyre-dir=/Library/TeX/Root/texmf-dist/fonts/opentype/public/tex-gyre",
-             "--with-urwotf-dir=#{buildpath}/urw/fonts"
+             "--with-texgyre-dir=#{buildpath}/tex-resources/texmf-dist/fonts/opentype/public/tex-gyre",
+             "--with-urwotf-dir=#{buildpath}/urw/fonts",
+             "--disable-documentation"
 
       ENV.prepend_path "LTDL_LIBRARY_PATH", Formula["guile@2"].lib
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a pull request to include lilypond 2.22.1 as a formula. The lilypond cask is a 32bit version and it does not work on macOS Catalina or higher. This formula was successfully developed in macOS Big Sur 11.5.2.

There is just a consideration about `brew audit --new lilypond`: bison and texinfo provided by macOS have a version that is not compatible with lilypond build setup.

Jefferson Felix
