### PR TITLE
lilypond 2.22.1 (new formula)

### DIFF
--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -25,7 +25,7 @@ class Lilypond < Formula
   depends_on "python@3.9"
 
   uses_from_macos "flex" => :build
-  uses_from_macos "m4"
+  uses_from_macos "m4" => :build
 
   resource "bison" do
     url "https://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.xz"

--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -32,8 +32,8 @@ class Lilypond < Formula
     sha256 "67d68ce1e22192050525643fc0a7a22297576682bef6a5c51446903f5aeef3cf"
   end
 
-  resource "font-urw" do
-    url "https://github.com/ArtifexSoftware/urw-base35-fonts/archive/20200910.tar.gz"
+  resource "urw-fonts" do
+    url "https://github.com/jsfelix/lilypond-build-deps/releases/download/v2.22.1/urw-base35-fonts-20200910.tar.gz"
     sha256 "e0d9b7f11885fdfdc4987f06b2aa0565ad2a4af52b22e5ebf79e1a98abd0ae2f"
   end
 
@@ -43,7 +43,7 @@ class Lilypond < Formula
   end
 
   resource "tex-build-dep" do
-    url "https://github.com/jsfelix/homebrew-core/releases/download/v2.22.1/tex-build-dep.tar.gz"
+    url "https://github.com/jsfelix/lilypond-build-deps/releases/download/v2.22.1/tex-build-dep-20210909.tar.gz"
     sha256 "18132bb70b109c6d0399095bc0acaf2616bf9edbd401af4a966eb3807b47797a"
   end
 
@@ -71,7 +71,7 @@ class Lilypond < Formula
       "elispdir = $(datadir)/emacs/site-lisp/lilypond"
 
     mkdir "build" do
-      resource("font-urw").stage buildpath/"urw"
+      resource("urw-fonts").stage buildpath/"urw"
 
       resource("tex-build-dep").stage buildpath/"tex-build-dep"
 

--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -5,8 +5,6 @@ class Lilypond < Formula
   sha256 "72ac2d54c310c3141c0b782d4e0bef9002d5519cf46632759b1f03ef6969cc30"
   license "GPL-3.0-or-later"
 
-  depends_on :arch => :x86_64
-  
   depends_on "autoconf" => :build
   depends_on "fontforge" => :build
   depends_on "gettext" => :build
@@ -15,6 +13,8 @@ class Lilypond < Formula
   depends_on "pkg-config" => :build
   depends_on "t1utils" => :build
   depends_on "texi2html" => :build
+
+  depends_on arch: :x86_64
 
   depends_on "fontconfig"
   depends_on "freetype"

--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -5,6 +5,8 @@ class Lilypond < Formula
   sha256 "72ac2d54c310c3141c0b782d4e0bef9002d5519cf46632759b1f03ef6969cc30"
   license "GPL-3.0-or-later"
 
+  depends_on :arch => :x86_64
+  
   depends_on "autoconf" => :build
   depends_on "fontforge" => :build
   depends_on "gettext" => :build
@@ -22,7 +24,9 @@ class Lilypond < Formula
   depends_on "pango"
   depends_on "python@3.9"
 
+  uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
+  uses_from_macos "texinfo" => :build
 
   resource "font-urw" do
     url "https://github.com/ArtifexSoftware/urw-base35-fonts/archive/20200910.tar.gz"

--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -1,0 +1,70 @@
+class Lilypond < Formula
+  desc "Music notation for everyone"
+  homepage "https://lilypond.org"
+  url "https://lilypond.org/download/sources/v2.22/lilypond-2.22.1.tar.gz"
+  sha256 "72ac2d54c310c3141c0b782d4e0bef9002d5519cf46632759b1f03ef6969cc30"
+  license "GPL-3.0-or-later"
+
+  depends_on "autoconf" => :build
+  depends_on "fontforge" => :build
+  depends_on "gettext" => :build
+  depends_on "glib" => :build
+  depends_on "imagemagick" => :build
+  depends_on "pkg-config" => :build
+  depends_on "t1utils" => :build
+  depends_on "texi2html" => :build
+
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "ghostscript"
+  depends_on "guile@2"
+  depends_on :macos
+  depends_on "pango"
+  depends_on "python@3.9"
+
+  uses_from_macos "flex" => :build
+
+  resource "font-urw" do
+    url "https://github.com/ArtifexSoftware/urw-base35-fonts/archive/20200910.tar.gz"
+    sha256 "e0d9b7f11885fdfdc4987f06b2aa0565ad2a4af52b22e5ebf79e1a98abd0ae2f"
+  end
+
+  resource "tex-build-dep" do
+    url "https://github.com/jsfelix/homebrew-core/releases/download/v2.22.1/tex-build-dep.tar.gz"
+    sha256 "ec72500b4ca61b5dbd6b7dd52e05afb574afc6409d0282907d0951b8e287ae0f"
+  end
+
+  def install
+    system "./autogen.sh", "--noconfigure"
+
+    inreplace "config.make.in",
+      %r{^\s*elispdir\s*=\s*\$\(datadir\)/emacs/site-lisp\s*$},
+      "elispdir = $(datadir)/emacs/site-lisp/lilypond"
+    inreplace "lily/parser.yy", "%define parse.error verbose", "// %define parse.error verbose"
+
+    mkdir "build" do
+      resource("font-urw").stage buildpath/"urw"
+
+      resource("tex-build-dep").stage buildpath/"tex-build-dep"
+
+      ENV.prepend_path "PATH", "#{buildpath}/tex-build-dep/bin/universal-darwin"
+
+      system "../configure",
+             "--prefix=#{prefix}",
+             "--with-texgyre-dir=#{buildpath}/tex-build-dep/texmf-dist/fonts/opentype/public/tex-gyre",
+             "--with-urwotf-dir=#{buildpath}/urw/fonts",
+             "--disable-documentation"
+
+      ENV.prepend_path "LTDL_LIBRARY_PATH", Formula["guile@2"].lib
+
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.ly").write "\\relative { c' d e f g a b c }"
+    system bin/"lilypond", "--loglevel=ERROR", "test.ly"
+    assert_predicate testpath/"test.pdf", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a pull request to include lilypond 2.22.1 as a formula. The lilypond cask is a 32bit version and it does not work on macOS Catalina or higher. This formula was successfully developed in macOS Big Sur 11.5.2.

There are some considerations:
-  there are binary files in tex-build-dep.tar.gz that is used only to build lilypond - it is part of TeX, a free distributable and open source document production system and lilypond build depends on it;
- the replace in configure options is mandatory to solve conflict with other formula (emacs) and there is no flag to change it;
- guile 3 is not compatible with lilypond build.


Jefferson Felix
