### PR TITLE
ammonite-repl (2.13-240) Reversion to stable

### DIFF
--- a/Formula/ammonite-repl.rb
+++ b/Formula/ammonite-repl.rb
@@ -1,10 +1,13 @@
 class AmmoniteRepl < Formula
   desc "Ammonite is a cleanroom re-implementation of the Scala REPL"
   homepage "https://ammonite.io/"
-  url "https://github.com/lihaoyi/Ammonite/releases/download/2.4.0/3.0-2.4.0"
+  # Prefer 2.13-x.xx versions, until significant regression in 3.0-x.xx is resolved
+  # See https://github.com/com-lihaoyi/Ammonite/issues/1190
+  url "https://github.com/lihaoyi/Ammonite/releases/download/2.4.0/2.13-2.4.0"
   version "2.4.0"
-  sha256 "31bb222b2513c59849de6d94af987d69d4646ebd8f866bfda6847b7861f1c230"
+  sha256 "d85df9aa1588ea135bf8487d6530f39eaa35d7ac8decc64819572168020cdfa0"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "f2b390395d9d4f46892fca8aa84aa66c41e64c3187164d0acb70343cdb874aa0"
@@ -18,8 +21,15 @@ class AmmoniteRepl < Formula
     (bin/"amm").write_env_script libexec/"bin/amm", Language::Java.overridable_java_home_env
   end
 
+  # This test demonstrates the bug on 3.0-x.xx versions
+  # If/when it passes there, it should be safe to upgrade again
   test do
-    output = shell_output("#{bin}/amm -c 'print(\"hello world!\")'")
-    assert_equal "hello world!", output.lines.last
+    (testpath/"testscript.sc").write <<~EOS
+      #!/usr/bin/env amm
+      @main
+      def fn(): Unit = println("hello world!")
+    EOS
+    output = shell_output("#{bin}/amm #{testpath}/testscript.sc")
+    assert_equal "hello world!", output.lines.last.chomp
   end
 end


### PR DESCRIPTION
This commit reverts Ammonite-REPL from the Scala-3-based version, to
the Scala-2.13 version. It's still the same version of Ammonite, just
compiled against a different version of Scala.

This is because under Scala 3, one of Ammonite's core features is currently broken.
This commit also improves the formula test, to demonstrate the issue that fails against version 3.0-2.40 of ammonite-repl.

See also:
- https://github.com/Homebrew/discussions/discussions/2117
- https://github.com/com-lihaoyi/Ammonite/issues/1190

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
