### PR TITLE
homeworlds: add livecheck

### DIFF
--- a/Formula/homeworlds.rb
+++ b/Formula/homeworlds.rb
@@ -7,6 +7,10 @@ class Homeworlds < Formula
   license "BSD-2-Clause"
   revision 2
 
+  livecheck do
+    skip "No version information available to check"
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "3abc2449ee3237a932c4250e0c36dbf76de53babb12a6cdfaac8b08e19552c20"
     sha256 cellar: :any,                 big_sur:       "81327f370fe9de62e68197c054d5929788aa4b32731769b053d4ab893f0aa631"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `homeworlds` formula simply uses a specific commit from the upstream GitHub repository, as there aren't any tagged versions. This PR adds a `livecheck` block that uses `skip`, as there isn't any version information to check. This prevents livecheck from unnecessarily checking the Git tags.