### PR TITLE
libstatgrab: update urls and license, add livecheck

### DIFF
--- a/Formula/libstatgrab.rb
+++ b/Formula/libstatgrab.rb
@@ -1,10 +1,18 @@
 class Libstatgrab < Formula
   desc "Provides cross-platform access to statistics about the system"
-  homepage "https://www.i-scream.org/libstatgrab/"
-  url "https://ftp.i-scream.org/pub/i-scream/libstatgrab/libstatgrab-0.92.1.tar.gz"
+  homepage "https://libstatgrab.org/"
+  url "https://github.com/libstatgrab/libstatgrab/releases/download/LIBSTATGRAB_0_92_1/libstatgrab-0.92.1.tar.gz"
   mirror "https://www.mirrorservice.org/pub/i-scream/libstatgrab/libstatgrab-0.92.1.tar.gz"
   sha256 "5688aa4a685547d7174a8a373ea9d8ee927e766e3cc302bdee34523c2c5d6c11"
-  license "GPL-2.0"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
+
+  livecheck do
+    url :stable
+    regex(/^LIBSTATGRAB[._-]v?(\d+(?:[._]\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.tr("_", ".") }
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "ce70f4a494445f8afde960c4ceea838e48b98fcf4c4d9513f705afae83193433"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `homepage` for `libstatgrab` as it was redirecting from `https://www.i-scream.org/libstatgrab/` to `https://libstatgrab.org/`.

Though the `stable` URL still resolves, the current homepage links to GitHub for release downloads instead, so I've also updated the `stable` URL to use a release download from GitHub. The `sha256` is unchanged but I've omitted the `CI-syntax-only` label, as this technically modifies the `stable` URL.

This also updates the license, as some of the source files contain a `GPL-2.0-or-later` license comment and others contain a `LGPL-2.1-or-later` license comment.

Lastly, this adds a `livecheck` block that checks the GitHub repository tags and uses a `strategy` block to replace underscores with dots in the version part of tags like `LIBSTATGRAB_0_92_1`.