### PR TITLE
jabba: fix test java path on macOS and add head branch

### DIFF
--- a/Formula/jabba.rb
+++ b/Formula/jabba.rb
@@ -4,7 +4,7 @@ class Jabba < Formula
   url "https://github.com/shyiko/jabba/archive/0.11.2.tar.gz"
   sha256 "33874c81387f03fe1a27c64cb6fb585a458c1a2c1548b4b86694da5f81164355"
   license "Apache-2.0"
-  head "https://github.com/shyiko/jabba.git"
+  head "https://github.com/shyiko/jabba.git", branch: "master"
 
   bottle do
     rebuild 3
@@ -39,11 +39,8 @@ class Jabba < Formula
     ENV["JABBA_HOME"] = testpath/"jabba_home"
 
     system bin/"jabba", "install", jdk_version
-    jdk_path = if OS.mac?
-      "#{jdk_path}/Contents/Home"
-    else
-      shell_output("#{bin}/jabba which #{jdk_version}").strip
-    end
+    jdk_path = shell_output("#{bin}/jabba which #{jdk_version}").strip
+    jdk_path += "/Contents/Home" if OS.mac?
     assert_match version_check,
                  shell_output("#{jdk_path}/bin/java -version 2>&1")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
