### PR TITLE
glooctl: update livecheck

### DIFF
--- a/Formula/glooctl.rb
+++ b/Formula/glooctl.rb
@@ -9,7 +9,7 @@ class Glooctl < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
update livecheck to avoid pre-release `1.8.15`

---

![image](https://user-images.githubusercontent.com/1580956/132910604-8400391f-2b30-4061-8ee6-c14224e4898e.png)
