### PR TITLE
opensearch-dashboards: depend on `arch: :x86_64`

### DIFF
--- a/Formula/opensearch-dashboards.rb
+++ b/Formula/opensearch-dashboards.rb
@@ -12,6 +12,7 @@ class OpensearchDashboards < Formula
 
   depends_on "python@3.9" => :build
   depends_on "yarn" => :build
+  depends_on arch: :x86_64 # `node@10` does not support ARM
   depends_on "node@10" # Switch to `node` after https://github.com/opensearch-project/OpenSearch-Dashboards/issues/406
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?