### PR TITLE
lilypond 2.22.1 (new formula)

### DIFF
--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -1,0 +1,63 @@
+class Lilypond < Formula
+  desc "Music engraving program"
+  homepage "https://lilypond.org"
+  url "https://lilypond.org/download/sources/v2.22/lilypond-2.22.1.tar.gz"
+  sha256 "72ac2d54c310c3141c0b782d4e0bef9002d5519cf46632759b1f03ef6969cc30"
+  license "GPL-3.0-or-later"
+
+  livecheck do
+    url "https://lilypond.org/source.html"
+    regex(/href=.*?lilypond[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  depends_on "bison" => :build # Lilypond requires bison 2.4.1 or above
+  depends_on "fontforge" => :build
+  depends_on "gettext" => :build
+  depends_on "glib" => :build
+  depends_on "perl" => :build
+  depends_on "pkg-config" => :build
+  depends_on "t1utils" => :build
+  depends_on "texinfo" => :build # lilypond requires texinfo 6.1 or above
+  depends_on "texlive" => :build
+
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "ghostscript"
+  depends_on "guile@2"
+  depends_on "pango"
+  depends_on "python@3.9"
+
+  uses_from_macos "flex" => :build
+
+  def install
+    system "./configure",
+            "--prefix=#{prefix}",
+            "--datadir=#{share}",
+            "--with-texgyre-dir=#{Formula["texlive"].opt_share}/texmf-dist/fonts/opentype/public/tex-gyre",
+            "--disable-documentation"
+    ENV.prepend_path "LTDL_LIBRARY_PATH", Formula["guile@2"].lib
+    system "make"
+    system "make", "install"
+
+    elisp.install share.glob("emacs/site-lisp/*.el")
+
+    libexec.install bin/"lilypond"
+
+    (bin/"lilypond").write_env_script libexec/"lilypond",
+      GUILE_WARN_DEPRECATED: "no",
+      LTDL_LIBRARY_PATH:     "#{Formula["guile@2"].opt_lib}:$LTDL_LIBRARY_PATH"
+  end
+
+  test do
+    (testpath/"test.ly").write <<~EOS
+      traLaLa = { c'4 d'4 }
+      #(define newLa (map ly:music-deep-copy
+        (list traLaLa traLaLa)))
+      #(define twice
+        (make-sequential-music newLa))
+      \\twice
+    EOS
+    system bin/"lilypond", "--loglevel=ERROR", "test.ly"
+    assert_predicate testpath/"test.pdf", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This is a pull request to include lilypond 2.22.1 as a formula. The lilypond cask is a 32bit version and it does not work on macOS Catalina or higher. This formula was successfully developed in macOS Big Sur 11.5.2.

There are some considerations:

* the replace in configure options is mandatory to solve conflict with other formula (emacs) and there is no flag to change it;
* guile 3 is not compatible with lilypond build;
* `brew audit --new lilypond` fails because the macOS provided `bison` and `texinfo` are older than the minimum version required to compile lilypond.

Jefferson Felix