### PR TITLE
synscan: add livecheck

### DIFF
--- a/Formula/synscan.rb
+++ b/Formula/synscan.rb
@@ -6,6 +6,11 @@ class Synscan < Formula
   license "GPL-2.0-or-later"
   revision 1
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?synscan[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "86677760d68a0a9efc11560003b4291ff8510b55a03f76a06916c989ec1aa428"
     sha256 cellar: :any,                 big_sur:       "df49f836a6552dfba8d127e53d4a87cf50030c63ab906dd1f5c40f549d32bf86"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `synscan`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.