### PR TITLE
fluxctl: fix revision mismatch

### DIFF
--- a/Formula/fluxctl.rb
+++ b/Formula/fluxctl.rb
@@ -5,7 +5,6 @@ class Fluxctl < Formula
       tag:      "1.24.1",
       revision: "13b3e660ed198b81a9dcd11457664827294074b8"
   license "Apache-2.0"
-  revision 1
 
   livecheck do
     url :stable

--- a/Formula/fluxctl.rb
+++ b/Formula/fluxctl.rb
@@ -3,8 +3,9 @@ class Fluxctl < Formula
   homepage "https://github.com/fluxcd/flux"
   url "https://github.com/fluxcd/flux.git",
       tag:      "1.24.1",
-      revision: "3b794b7063337a604290f538dcad65621cabda35"
+      revision: "13b3e660ed198b81a9dcd11457664827294074b8"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

From upstream release notes:

> A first attempt to publish this release on 2021-09-08 failed due to issues with github-release, so it was re-tagged on 2021-09-09 with changes to the CI job that resolved the issue.

Closes #85035. Needed for #84935.