### PR TITLE
fsh: add livecheck

### DIFF
--- a/Formula/fsh.rb
+++ b/Formula/fsh.rb
@@ -5,6 +5,11 @@ class Fsh < Formula
   sha256 "9600882648966272c264cf3f1c41c11c91e704f473af43d8d4e0ac5850298826"
   license "GPL-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?fsh[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "b68fa920622faedc3241756ed4b5b3498d58a8ff8cb2a236fee0eb7ebc7a1883"
     sha256 cellar: :any_skip_relocation, big_sur:       "64ff82df619631ff9e4642c5fc5c27d1d1d94da82f36c2a0492090489278a957"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `fsh`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.