### PR TITLE
jthread: add livecheck

### DIFF
--- a/Formula/jthread.rb
+++ b/Formula/jthread.rb
@@ -1,8 +1,13 @@
 class Jthread < Formula
   desc "C++ class to make use of threads easy"
-  homepage "https://research.edm.uhasselt.be/jori/jthread"
+  homepage "https://research.edm.uhasselt.be/jori/page/CS/Jthread.html"
   url "https://research.edm.uhasselt.be/jori/jthread/jthread-1.3.3.tar.bz2"
   sha256 "17560e8f63fa4df11c3712a304ded85870227b2710a2f39692133d354ea0b64f"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?jthread[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "12a85b410fa6b4c3e47e518813e0907b09ea01ed917ecb39354488ba1afb8ee8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `jthread`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This PR also updates the `homepage`, as the existing URL goes through a series of redirections (HTTP headers and then an HTML `meta` redirect) before reaching the current homepage. [The `stable` URL is current and doesn't need to be updated.]