### PR TITLE
pax-construct: add livecheck

### DIFF
--- a/Formula/pax-construct.rb
+++ b/Formula/pax-construct.rb
@@ -1,9 +1,14 @@
 class PaxConstruct < Formula
   desc "Tools to setup and develop OSGi projects quickly"
-  homepage "https://ops4j1.jira.com/wiki/display/paxconstruct/Pax+Construct"
+  homepage "https://ops4j1.jira.com/wiki/spaces/paxconstruct/overview"
   url "https://search.maven.org/remotecontent?filepath=org/ops4j/pax/construct/scripts/1.6.0/scripts-1.6.0.zip"
   sha256 "fc832b94a7d095d5ee26b1ce4b3db449261f0154e55b34a7bc430cb685d51064"
   license "Apache-2.0"
+
+  livecheck do
+    url "https://search.maven.org/remotecontent?filepath=org/ops4j/pax/construct/scripts/maven-metadata.xml"
+    regex(%r{<version>\s*v?(\d+(?:\.\d+)+)\s*</version>}i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "7b033ca0a10e6011280fce831ec89b49717cf985137b4134caac26da3669c5a5"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `pax-construct`. This PR adds a `livecheck` block that checks the `maven-metadata.xml` file, which lists Maven versions. This aligns with the `stable` source.

This also updates the `homepage` to resolve the redirection from the existing `homepage` to the URL in this PR.