### PR TITLE
smartypants: add livecheck

### DIFF
--- a/Formula/smartypants.rb
+++ b/Formula/smartypants.rb
@@ -4,6 +4,11 @@ class Smartypants < Formula
   url "https://daringfireball.net/projects/downloads/SmartyPants_1.5.1.zip"
   sha256 "2813a12d8dd23f091399195edd7965e130103e439e2a14f298b75b253616d531"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?SmartyPants[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "a1af00dbd1e4d6d42c6251fc9ca0cd36cce3370a9321f183e7f96a5bdebf8c6d"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `smartypants`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.