### PR TITLE
glooctl 1.8.15

### DIFF
--- a/Formula/glooctl.rb
+++ b/Formula/glooctl.rb
@@ -1,15 +1,17 @@
 class Glooctl < Formula
   desc "Envoy-Powered API Gateway"
   homepage "https://docs.solo.io/gloo/latest/"
+  # NOTE: Please wait until the newest stable release is finished building and
+  # no longer marked as "Pre-release" before creating a PR for a new version.
   url "https://github.com/solo-io/gloo.git",
-      tag:      "v1.8.14",
-      revision: "3e2c4c69a65c853fab63aef9a936e060d7409a12"
+      tag:      "v1.8.15",
+      revision: "fc72632fba84c07370bb928f503fa40a6b9da6f3"
   license "Apache-2.0"
-  head "https://github.com/solo-io/gloo.git"
+  head "https://github.com/solo-io/gloo.git", branch: "master"
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `glooctl` to the latest stable version, `1.8.15`.

---

This also updates the `livecheck` block to return to checking Git tags using the standard regex for tags like `1.2.3`/`v1.2.3`. We recently switched from this approach to using the `GithubLatest` strategy for `glooctl` in #85014 but this check is now giving an `Unable to get versions` error because the "latest" release on GitHub is an unstable version (`v1.9.0-beta17`).

This means we can't rely on the "latest" release always being a stable version with `glooctl`. Even if that wasn't an issue, there's a chance that "latest" could be the newest version from a different minor (e.g., `v1.7.21` instead of `v1.8.15`), as new 1.7.x versions are still published and there was recently a 1.7.x release after a 1.8.x release (and a later-published release is generally treated as "latest" in this scenario). Either way, the result from the `GithubLatest` strategy isn't correct, so we shouldn't use it (i.e., we only use it when it's both necessary and correct).

The reason we switched to the `GithubLatest` strategy is because upstream marks a new version as "Pre-release" until the release assets are finished building. From a `livecheck` perspective, there isn't really a good way around this and we just have to rely on maintainers/contributors waiting until the release is done building before creating a PR. [The other alternative is checking the first page of GitHub releases but the latest stable version can easily be pushed off the first page by unstable versions and versions from a lower minor, so that approach has its own problems (and this is why we don't allow it in general).]

With this in mind, I've also added a related comment above the `stable` URL. This won't help when folks run `brew bump-formula-pr` without looking at the formula but it will hopefully make it clear to PR reviewers that it's appropriate to wait and re-run CI after the upstream build finishes and the version is no longer labeled as "Pre-release".