### PR TITLE
mesa: update livecheck

### DIFF
--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -10,8 +10,8 @@ class Mesa < Formula
   head "https://gitlab.freedesktop.org/mesa/mesa.git", branch: "main"
 
   livecheck do
-    url "https://www.mesa3d.org/news/"
-    regex(/>\s*Mesa v?(\d+(?:\.\d+)+) is released\s*</i)
+    url "https://mesa.freedesktop.org/archive/"
+    regex(/href=.*?mesa[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `mesa` returns `21.2.0` as the latest version instead of `21.2.1`. In https://github.com/Homebrew/homebrew-core/pull/83589#discussion_r694094219, I described our options and suggested that we simply check the directory listing page where the `stable` archive is found for now.

If this doesn't end up working well in practice (e.g., if there's a large gap between when release assets are published in the directory and when a version is announced), then I can create a complex `livecheck` block that checks the [mesa-announce mailing list archive](https://lists.freedesktop.org/archives/mesa-announce/). It's my hope that checking the directory listing page will be fine and we won't have to create a more complicated check. Time will tell!