### PR TITLE
c-ares: update homepage, stable

### DIFF
--- a/Formula/c-ares.rb
+++ b/Formula/c-ares.rb
@@ -1,8 +1,8 @@
 class CAres < Formula
   desc "Asynchronous DNS library"
-  homepage "https://c-ares.haxx.se/"
+  homepage "https://c-ares.org/"
   # Check whether patch for `node.rb` can be removed at version bump
-  url "https://c-ares.haxx.se/download/c-ares-1.17.2.tar.gz"
+  url "https://c-ares.org/download/c-ares-1.17.2.tar.gz"
   sha256 "4803c844ce20ce510ef0eb83f8ea41fa24ecaae9d280c468c582d2bb25b3913d"
   license "MIT"
   head "https://github.com/c-ares/c-ares.git", branch: "main"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates the `homepage` and `stable` URLs for `c-ares`, as they're redirecting from `c-ares.haxx.se` to `c-ares.org`.

Though this technically modifies the `stable` URL, I'm labeling this as `CI-syntax-only`, as it will take a long time on CI (the first run was cancelled after an hour). The `sha256` is unchanged and I've built/tested this locally, so it should be fine. If we absolutely want this to run on CI, we'll need to use `CI-long-timeout` (and `CI-no-bottle`) but I'm not sure it's worth it.