### PR TITLE
lean: make lean install lean 4

### DIFF
--- a/Formula/lean.rb
+++ b/Formula/lean.rb
@@ -1,25 +1,10 @@
 class Lean < Formula
-  desc "Theorem prover"
-  homepage "https://leanprover-community.github.io/"
-  url "https://github.com/leanprover-community/lean/archive/v3.30.0.tar.gz"
-  sha256 "402b89ff4d368fd6597dd87c521fd2fe456c6b2b90c99d85f57523661bdd94be"
+  desc "Theorem Prover"
+  homepage "https://leanprover.github.io/"
+  url "https://github.com/leanprover/lean4/archive/v4.0.0-m2.tar.gz"
+  sha256 "e550b018a1fe8bbf18fbc275a332ce3ad436565bd6465aa0c96976fd3ae32a02"
   license "Apache-2.0"
-  head "https://github.com/leanprover-community/lean.git"
-
-  # The Lean 3 repository (https://github.com/leanprover/lean/) is archived
-  # and there won't be any new releases. Lean 4 is being developed but is still
-  # a work in progress: https://github.com/leanprover/lean4
-  livecheck do
-    skip "Lean 3 is archived; add a new check once Lean 4 is stable"
-  end
-
-  bottle do
-    sha256 cellar: :any,                 arm64_big_sur: "dce6ff86967540c830fa6aecb39e1dcb3dd54beaa0a524ef373e405dbb6f514a"
-    sha256 cellar: :any,                 big_sur:       "a10756134d6e97923dc0425d02a8b1ee0a49b4758f49f27e03282887071cde6f"
-    sha256 cellar: :any,                 catalina:      "014297ad90fee979d9e726fc08d13edd2adab94986541cd67172f62f845aaea5"
-    sha256 cellar: :any,                 mojave:        "386b72209c9b4fdea4f1ee0a5cded5560bd276e4b9e297c4e4586efbb03c4e74"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4d866e92baca2a841cec6605bcbe9e6246fb5f90edbc5c5e054a15c3afd6d69a"
-  end
+  head "https://github.com/leanprover/lean4.git"
 
   depends_on "cmake" => :build
   depends_on "coreutils"
@@ -30,9 +15,9 @@ class Lean < Formula
   conflicts_with "elan-init", because: "`lean` and `elan-init` install the same binaries"
 
   def install
-    mkdir "src/build" do
-      system "cmake", "..", *std_cmake_args
-      system "make", "install"
+    mkdir "build/release" do
+      system "cmake", "../..", *std_cmake_args
+      system "make", "-j#{ENV.make_jobs}", "install"
     end
   end
 
@@ -40,14 +25,11 @@ class Lean < Formula
     (testpath/"hello.lean").write <<~EOS
       def id' {α : Type} (x : α) : α := x
 
-      inductive tree (α : Type) : Type
-      | node : α → list tree → tree
-
       example (a b : Prop) : a ∧ b -> b ∧ a :=
-      begin
-          intro h, cases h,
-          split, repeat { assumption }
-      end
+      by
+        intro h
+        cases h
+        exact ⟨by assumption, by assumption⟩
     EOS
     system bin/"lean", testpath/"hello.lean"
     system bin/"leanpkg", "help"

--- a/Formula/lean@3.rb
+++ b/Formula/lean@3.rb
@@ -1,0 +1,39 @@
+class LeanAT3 < Formula
+  desc "Theorem Prover"
+  homepage "https://leanprover-community.github.io/"
+  url "https://github.com/leanprover-community/lean/archive/v3.32.1.tar.gz"
+  sha256 "67acd4969baea6f4ed24dd7148ff10924c5de881fee133926414aeabf4cb53e2"
+  license "Apache-2.0"
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "coreutils"
+  depends_on "gmp"
+  depends_on "jemalloc"
+  depends_on macos: :mojave
+
+  def install
+    mkdir "src/build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "-j#{ENV.make_jobs}", "install"
+    end
+  end
+
+  test do
+    (testpath/"hello.lean").write <<~EOS
+      def id' {α : Type} (x : α) : α := x
+
+      inductive tree (α : Type) : Type
+      | node : α → list tree → tree
+
+      example (a b : Prop) : a ∧ b -> b ∧ a :=
+      begin
+          intro h, cases h,
+          split, repeat { assumption }
+      end
+    EOS
+    system bin/"lean", testpath/"hello.lean"
+    system bin/"leanpkg", "help"
+  end
+end


### PR DESCRIPTION
Then moves lean(3) to lean@3, and bumps it to the latest version.

(As part of that, reenables livecheck, since the community repo
is still for now, active).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

@carlocab let me know what you think about this