### PR TITLE
libvpx: enable shared library

### DIFF
--- a/Formula/libvpx.rb
+++ b/Formula/libvpx.rb
@@ -4,6 +4,7 @@ class Libvpx < Formula
   url "https://github.com/webmproject/libvpx/archive/v1.10.0.tar.gz"
   sha256 "85803ccbdbdd7a3b03d930187cb055f1353596969c1f92ebec2db839fa4f834a"
   license "BSD-3-Clause"
+  revision 1
   head "https://chromium.googlesource.com/webm/libvpx.git"
 
   bottle do
@@ -23,6 +24,7 @@ class Libvpx < Formula
       --disable-examples
       --disable-unit-tests
       --enable-pic
+      --enable-shared
       --enable-vp9-highbitdepth
     ]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Current bottle only has static library.
```console
❯ tree /usr/local/opt/libvpx/lib
/usr/local/opt/libvpx/lib
├── libvpx.a
└── pkgconfig
    └── vpx.pc
```

This also means all dependents (e.g. `ffmpeg`, `gst-plugins-good`, ...) were built with static library.
These dependents may actually be `depends_on "libvpx" => :build` right now.

**EDIT:** Enabled building dependents otherwise it will only test existing bottles with static libraries. Want to make sure dynamic libraries don't break anything.

---

Libraries after changes:
```console
❯ tree /usr/local/opt/libvpx/lib
/usr/local/opt/libvpx/lib
├── libvpx.6.dylib
├── libvpx.a
├── libvpx.dylib -> libvpx.6.dylib
└── pkgconfig
    └── vpx.pc
```