### PR TITLE
libssh2: update urls

### DIFF
--- a/Formula/libssh2.rb
+++ b/Formula/libssh2.rb
@@ -1,12 +1,12 @@
 class Libssh2 < Formula
   desc "C library implementing the SSH2 protocol"
-  homepage "https://libssh2.org/"
-  url "https://libssh2.org/download/libssh2-1.10.0.tar.gz"
+  homepage "https://www.libssh2.org/"
+  url "https://www.libssh2.org/download/libssh2-1.10.0.tar.gz"
   sha256 "2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51"
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://libssh2.org/download/"
+    url "https://www.libssh2.org/download/"
     regex(/href=.*?libssh2[._-]v?(\d+(?:\.\d+)+)\./i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage`, `stable`, and `livecheck` URLs redirect from `libssh2.org` to `www.libssh2.org`. This PR updates them to avoid this redirection.

Since this technically modifies the `stable` URL, I'm not running this as `CI-syntax-only`. I built/tested this locally and the `sha256` remains the same, for what it's worth.