### PR TITLE
sproxy: add livecheck

### DIFF
--- a/Formula/sproxy.rb
+++ b/Formula/sproxy.rb
@@ -4,6 +4,11 @@ class Sproxy < Formula
   url "http://download.joedog.org/sproxy/sproxy-1.02.tar.gz"
   sha256 "29b84ba66112382c948dc8c498a441e5e6d07d2cd5ed3077e388da3525526b72"
 
+  livecheck do
+    url "http://download.joedog.org/sproxy/"
+    regex(/href=.*?sproxy[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "2558b7f1308c8bc08667c8e51d40b1c8df05280fa8c5f003f6dec07561089c2e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `sproxy`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.

The `homepage` mentions the latest version (`1.02`) but the linked archive is `sproxy-latest.tar.gz` and I prefer not to match versions from loosely-formatted text when a better alternative is available. The "[Downloads](http://download.joedog.org/)" link in the navbar points to the directory listing, so this acts as a downloads page anyway.