### PR TITLE
elm-format: specify ghc version in stack setup

### DIFF
--- a/Formula/elm-format.rb
+++ b/Formula/elm-format.rb
@@ -29,7 +29,7 @@ class ElmFormat < Formula
     # in Homebrew. Try using Homebrew `ghc` on update. Optionally, consider adding `ghcup`
     # as a lighter-weight alternative to `haskell-stack` for installing particular ghc version.
     jobs = ENV.make_jobs
-    ENV.deparallelize { system "stack", "setup", "-j#{jobs}", "--stack-root", buildpath/".stack" }
+    ENV.deparallelize { system "stack", "-j#{jobs}", "setup", "8.10.4", "--stack-root", buildpath/".stack" }
     ENV.prepend_path "PATH", Dir[buildpath/".stack/programs/*/ghc-*/bin"].first
     system "cabal", "v2-update"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Default version by resolver ends up picking up newer ghc-8.10.7.
Required version is specified in non-Stack-aware config file (cabal.project).
So, just directly specify this version during setup.