### PR TITLE
stone 2.4

### DIFF
--- a/Formula/stone.rb
+++ b/Formula/stone.rb
@@ -1,8 +1,13 @@
 class Stone < Formula
   desc "TCP/IP packet repeater in the application layer"
   homepage "https://www.gcd.org/sengoku/stone/"
-  url "https://www.gcd.org/sengoku/stone/stone-2.3e.tar.gz"
-  sha256 "b2b664ee6771847672e078e7870e56b886be70d9ff3d7b20d0b3d26ee950c670"
+  url "https://www.gcd.org/sengoku/stone/stone-2.4.tar.gz"
+  sha256 "d5dc1af6ec5da503f2a40b3df3fe19a8fbf9d3ce696b8f46f4d53d2ac8d8eb6f"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?stone[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "a91a4ebc8ed1aaa5ad7095fb0098ea3bedec1c1df5628c817bb3e056be206ca1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `stone` to the latest version, `2.4`. This also adds a `livecheck` block that checks the `homepage`, as this formula can't be checked by default.

This doesn't appear to have a Linux bottle, so I've added the `CI-force-linux` label to see how it goes. Edit: Failed to build on Linux, so I removed the label.