### PR TITLE
librist 0.2.6 (new formula)

### DIFF
--- a/Formula/librist.rb
+++ b/Formula/librist.rb
@@ -1,0 +1,24 @@
+class Librist < Formula
+  desc "Reliable Internet Stream Transport (RIST)"
+  homepage "https://code.videolan.org/rist/"
+  url "https://code.videolan.org/rist/librist/-/archive/v0.2.6/librist-v0.2.6.tar.gz"
+  sha256 "88b35b86af1ef3d306f33674f2d9511a27d3ff4ec76f20d3a3b3273b79a4521d"
+  license "BSD-2-Clause"
+  head "https://code.videolan.org/rist/librist.git", branch: "master"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "cjson"
+  depends_on "cmocka"
+  depends_on "mbedtls"
+
+  def install
+    ENV.append "LDFLAGS", "-Wl,-rpath,#{rpath}"
+    system "meson", *std_meson_args, "build", ".", "--default-library", "both"
+    system "ninja", "install", "-C", "build"
+  end
+
+  test do
+    assert_match "Starting ristsender", shell_output("#{bin}/ristsender 2>&1", 1)
+  end
+end


### PR DESCRIPTION
Proposed formula for RIST, the "Reliable Internet Stream Transport".
According to the authors, RIST is a "new Specification for multi-vendor
interoperable professional video delivery over the Internet". RIST will
be used by VLC and ffmpeg in their current or next versions.

The code is hosted at https://code.videolan.org/rist

This formula installs the RIST library, its header files and a few basic
test tools which are provided with the library.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
