### PR TITLE
JPdfBookmarks 2.5.2 (new formula)

### DIFF
--- a/Formula/jpdfbookmarks.rb
+++ b/Formula/jpdfbookmarks.rb
@@ -16,7 +16,7 @@ class Jpdfbookmarks < Formula
     test_bookmark = "Test/1,Black,notBold,notItalic,open,FitPage"
     (testpath/"in.txt").write(test_bookmark)
 
-    system "#{bin}/jpdfbookmarks", test_fixtures("test.pdf"), "-a", "in.txt", "-o", "out.pdf"
+    system bin/"jpdfbookmarks", test_fixtures("test.pdf"), "-a", "in.txt", "-o", "out.pdf"
     assert_predicate testpath/"out.pdf", :exist?
 
     assert_equal test_bookmark, shell_output("#{bin}/jpdfbookmarks out.pdf -d").strip

--- a/Formula/jpdfbookmarks.rb
+++ b/Formula/jpdfbookmarks.rb
@@ -1,0 +1,24 @@
+class Jpdfbookmarks < Formula
+  desc "Create and edit bookmarks on existing PDF files"
+  homepage "https://sourceforge.net/projects/jpdfbookmarks/"
+  url "https://downloads.sourceforge.net/project/jpdfbookmarks/JPdfBookmarks-2.5.2/jpdfbookmarks-2.5.2.tar.gz"
+  sha256 "8ab51c20414591632e48ad3817e6c97e9c029db8aaeff23d74c219718cfe19f9"
+  license "GPL-3.0-or-later"
+
+  depends_on "openjdk"
+
+  def install
+    libexec.install Dir["jpdfbookmarks.jar", "lib"]
+    bin.write_jar_script libexec/"jpdfbookmarks.jar", "jpdfbookmarks"
+  end
+
+  test do
+    test_bookmark = "Test/1,Black,notBold,notItalic,open,FitPage"
+    (testpath/"in.txt").write(test_bookmark)
+
+    system "#{bin}/jpdfbookmarks", test_fixtures("test.pdf"), "-a", "in.txt", "-o", "out.pdf"
+    assert_predicate testpath/"out.pdf", :exist?
+
+    assert_equal test_bookmark, shell_output("#{bin}/jpdfbookmarks out.pdf -d").strip
+  end
+end


### PR DESCRIPTION
JPdfBookmarks allows you to create and edit bookmarks of PDF files.
It has both a CLI and a GUI, and supports pdfmarks (in contrast to
pdftk and others).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`brew test` outputs
`Picked up _JAVA_OPTIONS: -Duser.home=/Users/ian/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp`
I am not sure if this is an issue. It disappears when I remove the `shell_output` call.