### PR TITLE
ptunnel: add livecheck

### DIFF
--- a/Formula/ptunnel.rb
+++ b/Formula/ptunnel.rb
@@ -4,6 +4,11 @@ class Ptunnel < Formula
   url "https://www.cs.uit.no/~daniels/PingTunnel/PingTunnel-0.72.tar.gz"
   sha256 "b318f7aa7d88918b6269d054a7e26f04f97d8870f47bd49a76cb2c99c73407a4"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?PingTunnel[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "706c9eaf3a158032cf0f361ceee4779ef2afe74f515853405afd24cc9c6e8ade"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `ptunnel`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.