### PR TITLE
tcpsplit: add livecheck

### DIFF
--- a/Formula/tcpsplit.rb
+++ b/Formula/tcpsplit.rb
@@ -4,6 +4,11 @@ class Tcpsplit < Formula
   url "https://www.icir.org/mallman/software/tcpsplit/tcpsplit-0.2.tar.gz"
   sha256 "885a6609d04eb35f31f1c6f06a0b9afd88776d85dec0caa33a86cef3f3c09d1d"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?tcpsplit[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f40f957faef51ed496030a97cda8ca0eb0716826969872185080bb8e94780f36"
     sha256 cellar: :any_skip_relocation, big_sur:       "49781c99d1496c5c0c8ec3e56e2edc604f5e8643f36e93b0ff8b974d448363d1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `tcpsplit`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.