### PR TITLE
mariabackup: add --version to self-test

### DIFF
--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -187,6 +187,7 @@ class Mariadb < Formula
   end
 
   test do
+    system "#{bin}/mariabackup", "--version"
     (testpath/"mysql").mkpath
     (testpath/"tmp").mkpath
     system bin/"mysql_install_db", "--no-defaults", "--user=#{ENV["USER"]}",


### PR DESCRIPTION
Since installing mariadb recipe and testing that tool doesn't even display help, tought to add the binary to self-test of brew build.


```
$ brew install mariadb # installed mariadb: stable 10.6.4 (bottled)
$ mariabackup --version
Abort trap: 6
```

-----

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

