### PR TITLE
sqoop: deprecate as project retired upstream

### DIFF
--- a/Formula/sqoop.rb
+++ b/Formula/sqoop.rb
@@ -17,6 +17,9 @@ class Sqoop < Formula
     sha256 cellar: :any_skip_relocation, all: "04de1ca8398879433620c8bb66cda1c959fb3b724e6ed7638fd7e26d6e132483"
   end
 
+  # See https://attic.apache.org/projects/sqoop.html
+  deprecate! date: "2021-06-16", because: :deprecated_upstream
+
   depends_on "coreutils"
   depends_on "hadoop"
   depends_on "hbase"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Deprecation date set to meeting date when project termination was decided: https://whimsy.apache.org/board/minutes/Sqoop.html

Stable URL doesn't work and redirects to attic URL. However, audit prevents using archive.apache.org as stable URL.