### PR TITLE
cbmc: use openjdk@11 as JBMC build fails with JDK 17

### DIFF
--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -5,6 +5,7 @@ class Cbmc < Formula
       tag:      "cbmc-5.38.0",
       revision: "667858fb799e82df7f6cafca53b13ed996824b64"
   license "BSD-4-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "6ae0c663a340ee634c711112bf3ef842e2aa7673c3a4d8e41b5a3128206eb9b5"
@@ -16,10 +17,12 @@ class Cbmc < Formula
 
   depends_on "cmake" => :build
   depends_on "maven" => :build
-  depends_on "openjdk" => :build
+  # Java front-end fails to build with openjdk>=17
+  depends_on "openjdk@11" => :build
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
+  uses_from_macos "m4" => :build
 
   on_linux do
     depends_on "gcc"
@@ -28,21 +31,18 @@ class Cbmc < Formula
   fails_with gcc: "5"
 
   def install
-    args = []
+    ENV["JAVA_HOME"] = Language::Java.java_home("11")
 
+    args = []
     # Workaround borrowed from https://github.com/diffblue/cbmc/issues/4956
     args << "-DCMAKE_C_COMPILER=/usr/bin/clang" if OS.mac?
-    # Java front-end fails to build on ARM
-    args << "-DWITH_JBMC=OFF" if Hardware::CPU.arm?
 
-    mkdir "build" do
-      system "cmake", "..", *args, *std_cmake_args
-      system "cmake", "--build", "."
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
 
     # lib contains only `jar` files
-    libexec.install lib unless Hardware::CPU.arm?
+    libexec.install lib
   end
 
   test do

--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -22,7 +22,6 @@ class Cbmc < Formula
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
-  uses_from_macos "m4" => :build
 
   on_linux do
     depends_on "gcc"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
