### PR TITLE
Added feeling-blue-cpp to homebrew

### DIFF
--- a/Formula/feeling-blue-cpp.rb
+++ b/Formula/feeling-blue-cpp.rb
@@ -1,0 +1,18 @@
+class FeelingBlueCpp < Formula
+  desc "C++ library for BluetoothLE usage on MacOS or (soon) Windows"
+  homepage "https://github.com/seanngpack/feeling-blue-cpp/"
+  url "https://github.com/seanngpack/feeling-blue-cpp/archive/refs/tags/v1.1.0.tar.gz"
+  sha256 "65fa7d3933078940820851e9bf3798d6ffa230815a8abf448de723d077790a61"
+  license "MIT"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", "-S", "."
+    system "make", "install"
+  end
+
+  test do
+    system "brew", "test", "feeling-blue-cpp"
+  end
+end


### PR DESCRIPTION
Feeling blue is a C++ bluetoothLE library for macOS. This change simple adds it to homebrew.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [-]: Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)? *I used github desktop rather than the command line for adding the commit to my forked repo, so I put the explanation in the description*
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
