### PR TITLE
librcsc: add livecheck

### DIFF
--- a/Formula/librcsc.rb
+++ b/Formula/librcsc.rb
@@ -5,6 +5,11 @@ class Librcsc < Formula
   url "https://dotsrc.dl.osdn.net/osdn/rctools/51941/librcsc-4.1.0.tar.gz"
   sha256 "1e8f66927b03fb921c5a2a8c763fb7297a4349c81d1411c450b180178b46f481"
 
+  livecheck do
+    url "https://osdn.net/projects/rctools/releases/"
+    regex(%r{value=.*?/rel/rctools/librcsc/v?(\d+(?:\.\d+)+)["']}i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_big_sur: "833fe11162a367e783177275011d5156933cb33c29c34d423237a253214f5552"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `librcsc`. This PR adds a `livecheck` block that checks the OSDN release page for the project, which contains `librcsc` version information in part of the HTML. The links that you see on the page aren't present in the HTML, so we can't obtain versions from tarball filenames like we normally would and have to use a slightly different approach.