### PR TITLE
pgtune: add livecheck

### DIFF
--- a/Formula/pgtune.rb
+++ b/Formula/pgtune.rb
@@ -10,6 +10,11 @@ class Pgtune < Formula
   # 0.9.3 does not have settings for PostgreSQL 9.x, but the trunk does
   head "https://github.com/gregs1104/pgtune.git", branch: "master"
 
+  livecheck do
+    url "https://ftp.postgresql.org/pub/projects/pgFoundry/pgtune/pgtune/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "99d46ab0880d22bb3a19faf759bde25d51dd0e4c5c1890d6bf0e253a9042e09f"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `pgtune`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found (albeit, in a version directory).