### PR TITLE
supermodel: add livecheck

### DIFF
--- a/Formula/supermodel.rb
+++ b/Formula/supermodel.rb
@@ -5,6 +5,11 @@ class Supermodel < Formula
   sha256 "ecaf3e7fc466593e02cbf824b722587d295a7189654acb8206ce433dcff5497b"
   head "https://svn.code.sf.net/p/model3emu/code/trunk"
 
+  livecheck do
+    url "https://www.supermodel3.com/Download.html"
+    regex(/href=.*?Supermodel[._-]v?(\d+(?:\.\d+)+[a-z]?)[._-]Src\.zip/i)
+  end
+
   bottle do
     rebuild 1
     sha256 arm64_big_sur: "ad8d438a1f18582da559bc8474e8219b81c695afba907bd99f40c1d960957687"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `supermodel`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.