### PR TITLE
dovecot: update livecheck

### DIFF
--- a/Formula/dovecot.rb
+++ b/Formula/dovecot.rb
@@ -6,7 +6,7 @@ class Dovecot < Formula
   license all_of: ["BSD-3-Clause", "LGPL-2.1-or-later", "MIT", "Unicode-DFS-2016", :public_domain]
 
   livecheck do
-    url "https://dovecot.org/download"
+    url "https://www.dovecot.org/download/"
     regex(/href=.*?dovecot[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `livecheck` block URL for `dovecot`, as it redirects from `dovecot.org` to `www.dovecot.org`.

The `homepage` and `stable` URLs give a 200 (OK) response when using `dovecot.org` or `www.dovecot.org` and they don't redirect like the download page. Some of the links on the website (like the download page used in the `livecheck` block) point to `www.dovecot.org` and some point to `dovecot.org`, so I'm leaving the other URLs alone until the upstream website becomes consistent or they start redirecting to the `www` subdomain.