### PR TITLE
flyway: update livecheck

### DIFF
--- a/Formula/flyway.rb
+++ b/Formula/flyway.rb
@@ -6,8 +6,8 @@ class Flyway < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://flywaydb.org/documentation/usage/maven/"
-    regex(/&lt;version&gt;.*?v?(\d+(?:\.\d+)+)&lt;/im)
+    url "https://search.maven.org/remotecontent?filepath=org/flywaydb/flyway-commandline/maven-metadata.xml"
+    regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `flyway` is currently giving an `Unable to get versions` error because the documentation page currently presents a beta version as latest (which livecheck automatically omits). This PR updates the `livecheck` block to check the `maven-metadata.xml` file, which contains all available versions on Maven. This correctly approach returns `7.15.0` as the newest stable version.