### PR TITLE
nauty: update livecheck

### DIFF
--- a/Formula/nauty.rb
+++ b/Formula/nauty.rb
@@ -9,6 +9,9 @@ class Nauty < Formula
   livecheck do
     url :homepage
     regex(/Current\s+?version:\s*?v?(\d+(?:\.\d+)+(?:r\d+)?)/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match.first.tr("R", "r") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `nauty` generally works as expected but the formula version (`2.7r3`) is being treated as newer than the version reported by livecheck (`2.7R3`) because of the difference in the letter case.

This PR adds a `strategy` block that replaces uppercase `R`s in the version string with a lowercase `r`, so `Version` comparison works predictably.