### PR TITLE
sc-im: add XLSX and ODS support 

### DIFF
--- a/Formula/sc-im.rb
+++ b/Formula/sc-im.rb
@@ -4,6 +4,7 @@ class ScIm < Formula
   url "https://github.com/andmarti1424/sc-im/archive/v0.8.2.tar.gz"
   sha256 "7f00c98601e7f7709431fb4cbb83707c87016a3b015d48e5a7c2f018eff4b7f7"
   license "BSD-4-Clause"
+  revision 1
   head "https://github.com/andmarti1424/sc-im.git", branch: "main"
 
   bottle do
@@ -14,6 +15,9 @@ class ScIm < Formula
     sha256 x86_64_linux:  "fc3af3d6197b5e2c768266c82efe9b55e80a645d1288cfd9caea53ed353516fc"
   end
 
+  depends_on "libxlsxwriter"
+  depends_on "libxml2"
+  depends_on "libzip"
   depends_on "ncurses"
 
   uses_from_macos "bison" => :build


### PR DESCRIPTION
Do note that sc-im has a bug with its ODS import functionality that may result in data loss: https://github.com/andmarti1424/sc-im/issues/606

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
