### PR TITLE
phoon: update version, add livecheck

### DIFF
--- a/Formula/phoon.rb
+++ b/Formula/phoon.rb
@@ -2,8 +2,22 @@ class Phoon < Formula
   desc "Displays current or specified phase of the moon via ASCII art"
   homepage "https://www.acme.com/software/phoon/"
   url "https://www.acme.com/software/phoon/phoon_14Aug2014.tar.gz"
-  version "04A"
+  version "20140814"
   sha256 "bad9b5e37ccaf76a10391cc1fa4aff9654e54814be652b443853706db18ad7c1"
+  version_scheme 1
+
+  # We check the site using HTTP (rather than HTTPS) because this server
+  # produces the following cURL error on our Ubuntu CI:
+  #   curl: (56) GnuTLS recv error (-110): The TLS connection was non-properly
+  #   terminated.
+  # If/when this is resolved, we can update this to use `url :homepage`.
+  livecheck do
+    url "http://www.acme.com/software/phoon/"
+    regex(/href=.*?phoon[._-]v?(\d{1,2}[a-z]+\d{2,4})\.t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "ee678f636d233dc19da162128f46e9a9d4e77fcb8c1eaee2ec5f435c3c616aae"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR modifies the `phoon` formula to use a date-based version scheme, which corresponds to the only version information that the first-party website provides (the date in the archive file name) and aligns Homebrew with how [other package managers](https://repology.org/project/phoon/versions) handle these versions. This allows us to create a `livecheck` block for `phoon`, as it wouldn't work properly otherwise with the formula's strange `04A` version.

For context, the original PR to add the formula dates back to 2013-12-18 (Homebrew/legacy-homebrew#25316) and the `version` was set to `03A` at that time. If you check the closest [archive.org snapshot](https://web.archive.org/web/20140208024651/https://www.acme.com/software/phoon/) after this date (2014-02-08), the homepage doesn't mention anything about `03A` and the only version information comes from the file name (`phoon_29jun2005.tar.gz` at the time).

If you go back to the [first available snapshot on archive.org](https://web.archive.org/web/19970124211428/https://www.acme.com/software/phoon/) (1997-01-24), the archive file name is `phoon_01apr95.tar.Z`. The current archive file name is `phoon_14Aug2014.tar.gz`, so it seems like `phoon` has used an implicit date-based version scheme for as far back as we can see. The format has changed a bit over time but all the formats are parseable by `Date#parse`.

It's unclear where the `03A` version came from initially (not `phoon`'s website) but Homebrew is the only package manager using this version scheme. Additionally, when `phoon` was updated to `20140814` in Homebrew/legacy-homebrew#41383, the PR author was unsure what to do with the version, so they used `04A` and asked whether they should use `14Aug2014` instead. `04A` was accepted as "consistent with the previous versioning", despite upstream not using this version format.

Long story short, the `03A`/`04A` version scheme has been used in this formula from the beginning but upstream seems to have always used a date-based format. In this type of scenario, we use a `YYYYMMDD` version in formulae and this PR brings `phoon` in line.