### PR TITLE
fabric-installer: add livecheck

### DIFF
--- a/Formula/fabric-installer.rb
+++ b/Formula/fabric-installer.rb
@@ -5,6 +5,13 @@ class FabricInstaller < Formula
   sha256 "192d60fb544a45edca589a4f73d9d3df93a7f7b68a407c0403e9e1802faf7668"
   license "Apache-2.0"
 
+  # The first-party download page (https://fabricmc.net/use/) uses JavaScript
+  # to create download links, so we check the related JSON data for versions.
+  livecheck do
+    url "https://meta.fabricmc.net/v2/versions/installer"
+    regex(/["']url["']:\s*["'][^"']*?fabric-installer[._-]v?(\d+(?:\.\d+)+)\.jar/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "4c309d182810665ba504617c038a5af04bc3c6aba5b04034753227bda46ff78b"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `fabric-installer`. This PR adds a `livecheck` block that checks the JSON data that's used to render download links on the [first-party download page](https://fabricmc.net/use/) using JavaScript. The related JSON data contains URLs for the `jar` files used as `stable` in the formula. To be clear, we have to use this approach because no version information is present in the HTML and it's rendered in the browser from the JSON data instead.