### PR TITLE
flickcurl: add livecheck

### DIFF
--- a/Formula/flickcurl.rb
+++ b/Formula/flickcurl.rb
@@ -5,6 +5,11 @@ class Flickcurl < Formula
   sha256 "ff42a36c7c1c7d368246f6bc9b7d792ed298348e5f0f5d432e49f6803562f5a3"
   license any_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?flickcurl[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "49065801b7dfe7880206948a41c58ae5f190b50e3acbbe7d14ff24d29a30db0c"
     sha256 cellar: :any,                 big_sur:       "90c210da66773047b62e3f5922382d97a7da8d4b17b178b25149a07d910c6f4a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `flickcurl`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.