### PR TITLE
hyperestraier: update urls, add livecheck

### DIFF
--- a/Formula/hyperestraier.rb
+++ b/Formula/hyperestraier.rb
@@ -1,9 +1,14 @@
 class Hyperestraier < Formula
   desc "Full-text search system for communities"
-  homepage "https://fallabs.com/hyperestraier/"
-  url "https://fallabs.com/hyperestraier/hyperestraier-1.4.13.tar.gz"
+  homepage "https://dbmx.net/hyperestraier/"
+  url "https://dbmx.net/hyperestraier/hyperestraier-1.4.13.tar.gz"
   sha256 "496f21190fa0e0d8c29da4fd22cf5a2ce0c4a1d0bd34ef70f9ec66ff5fbf63e2"
   license "LGPL-2.1"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?hyperestraier[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, big_sur:     "98338e8f67c7cba1df436607f09415415e39a38f695805ddd94720326eae9212"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs for `hyperestraier` redirect from `fallabs.com` to `dbmx.net`. This PR modifies these URLs to avoid the redirection.

This PR also adds a `livecheck` block that checks the homepage, which links to the `stable` archive. Without this, livecheck gives an `Unable to get versions` error by default.

I haven't labelled this as `CI-syntax-only`, as this technically modifies the `stable` URL. The `sha256` remains the same, for what it's worth.