### PR TITLE
pktanon: add livecheck

### DIFF
--- a/Formula/pktanon.rb
+++ b/Formula/pktanon.rb
@@ -5,6 +5,14 @@ class Pktanon < Formula
   sha256 "db3f437bcb8ddb40323ddef7a9de25a465c5f6b4cce078202060f661d4b97ba3"
   revision 2
 
+  # The regex below matches development versions, as a stable version isn't yet
+  # available. If stable versions appear in the future, we should modify the
+  # regex to omit development versions (i.e., remove `(?:[._-]dev)?`).
+  livecheck do
+    url "https://www.tm.uka.de/software/pktanon/download/index.html"
+    regex(/href=.*?pktanon[._-]v?(\d+(?:\.\d+)+)(?:[._-]dev)?\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "e853faa62dd62e2663e5d9b551e79cd492927baab2b472aca01d981a6ef7913c"
     sha256 cellar: :any, big_sur:       "53338eaa0e9e00d44d1084d7aee1aacfd498b568c5a145edc8da2da4b7054177"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `pktanon`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.

For what it's worth, only development versions of `pktanon` are available, so the `regex` has to match these versions by necessity. If/when stable versions are published in the future, the `regex` should be modified to only match stable versions ((i.e., removing the `(?:[._-]dev)?` part).