### PR TITLE
dbxml: add livecheck

### DIFF
--- a/Formula/dbxml.rb
+++ b/Formula/dbxml.rb
@@ -5,6 +5,11 @@ class Dbxml < Formula
   sha256 "a8fc8f5e0c3b6e42741fa4dfc3b878c982ff8f5e5f14843f6a7e20d22e64251a"
   revision 3
 
+  livecheck do
+    url "https://www.oracle.com/database/technologies/related/berkeleydb-downloads.html"
+    regex(/href=.*?dbxml[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "04e8d59d289cdfeded395a021516b357e5bb63eed09e49aca28ed262c8c31128"
     sha256 big_sur:       "e53e40e0184768fdac585276000c0224a04cfa9284ce94be1ab80380d2b79965"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `dbxml`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.