### PR TITLE
swfmill: update homepage, add livecheck

### DIFF
--- a/Formula/swfmill.rb
+++ b/Formula/swfmill.rb
@@ -1,9 +1,14 @@
 class Swfmill < Formula
   desc "Processor of xml2swf and swf2xml"
-  homepage "https://swfmill.org"
+  homepage "https://www.swfmill.org/"
   url "https://www.swfmill.org/releases/swfmill-0.3.6.tar.gz"
   sha256 "db24f63963957faec02bb14b8b61cdaf7096774f8cfdeb9d3573e2e19231548e"
   license "GPL-2.0"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?swfmill[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "be6e61f096ab129607f537e0bc37fd87214f01cfbfa097ab4bfb348614ffa83c"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `swfmill`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This PR also updates the homepage to avoid the redirection from `swfmill.org` to `www.swfmill.org`.