### PR TITLE
ircd-irc2: add livecheck

### DIFF
--- a/Formula/ircd-irc2.rb
+++ b/Formula/ircd-irc2.rb
@@ -5,6 +5,11 @@ class IrcdIrc2 < Formula
   version "2.11.2p3"
   sha256 "be94051845f9be7da0e558699c4af7963af7e647745d339351985a697eca2c81"
 
+  livecheck do
+    url "http://www.irc.org/ftp/irc/server/"
+    regex(/href=.*?irc[._-]?v?(\d+(?:\.\d+)+(?:p\d+)?)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 arm64_big_sur: "ed3eac7c4635484c94d12579948947bff1eb6a671846fcd9273dd5ed226759fa"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `ircd-irc2`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.