### PR TITLE
libmpd: update homepage, add livecheck

### DIFF
--- a/Formula/libmpd.rb
+++ b/Formula/libmpd.rb
@@ -1,9 +1,14 @@
 class Libmpd < Formula
   desc "Higher level access to MPD functions"
-  homepage "https://gmpc.wikia.com/wiki/Gnome_Music_Player_Client"
+  homepage "https://gmpc.fandom.com/wiki/Gnome_Music_Player_Client"
   url "https://www.musicpd.org/download/libmpd/11.8.17/libmpd-11.8.17.tar.gz"
   sha256 "fe20326b0d10641f71c4673fae637bf9222a96e1712f71f170fca2fc34bf7a83"
   revision 1
+
+  livecheck do
+    url "https://www.musicpd.org/download/libmpd/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "782e0fccf8dbe605e9fd7740427335d5b7c2340f7506402c17b747560dea4852"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `libmpd`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.

This PR also updates the homepage, as it was redirecting from `gmpc.wikia.com` to `gmpc.fandom.com`.