### PR TITLE
xtitle: update urls, add license and livecheck

### DIFF
--- a/Formula/xtitle.rb
+++ b/Formula/xtitle.rb
@@ -1,8 +1,14 @@
 class Xtitle < Formula
   desc "Set window title and icon for your X terminal"
-  homepage "https://www.cs.indiana.edu/~kinzler/xtitle/"
-  url "https://www.cs.indiana.edu/~kinzler/xtitle/xtitle-1.0.4.tgz"
+  homepage "https://kinzler.com/me/xtitle/"
+  url "https://kinzler.com/me/xtitle/xtitle-1.0.4.tgz"
   sha256 "cadddef1389ba1c5e1dc7dd861545a5fe11cb397a3f692cd63881671340fcc15"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?xtitle[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "c463ee3a0d4e7e17b1dbcdced8c6ed5eb50d2815a56cc28ac037848735fe1803"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `xtitle`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This PR also updates the `homepage` and `stable` URLs, as `www.cs.indiana.edu/~kinzler/` redirects to `legacy.cs.indiana.edu/~kinzler/` and all the links on the page point to `kinzler.com` instead. This situation is the same as `align`, where I updated the URLs in the same fashion in #81933.

Lastly, this adds `license "GPL-2.0-or-later"` , as the `homepages`'s "GPL Copyright" section states:

> `xtitle`
> Copyright © 1993-2014 Stephen B Kinzler
> 
> This program is free software; you can redistribute it and/or modify it under the terms of the [GNU General Public License](http://kinzler.com/me/xtitle/src/COPYING) as published by the [Free Software Foundation](http://www.fsf.org/); either version 2 of the License, or any later version.
> 
> This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
> 
> You should have received a copy of the GNU General Public License along with this program (see the file ["COPYING"](https://kinzler.com/me/xtitle/src/COPYING)); if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA