### PR TITLE
kyoto-cabinet: update urls

### DIFF
--- a/Formula/kyoto-cabinet.rb
+++ b/Formula/kyoto-cabinet.rb
@@ -1,7 +1,7 @@
 class KyotoCabinet < Formula
   desc "Library of routines for managing a database"
-  homepage "https://fallabs.com/kyotocabinet/"
-  url "https://fallabs.com/kyotocabinet/pkg/kyotocabinet-1.2.79.tar.gz"
+  homepage "https://dbmx.net/kyotocabinet/"
+  url "https://dbmx.net/kyotocabinet/pkg/kyotocabinet-1.2.79.tar.gz"
   sha256 "67fb1da4ae2a86f15bb9305f26caa1a7c0c27d525464c71fd732660a95ae3e1d"
   license "GPL-3.0-or-later"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs redirect from `fallabs.com` to `dbmx.net`. This PR updates these URLs to avoid the redirection.

This technically modifies the `stable` URL, so I haven't labelled this `CI-syntax-only`. For what it's worth, the `sha256` remains unchanged.