### PR TITLE
tokyo-dystopia: update urls, add livecheck

### DIFF
--- a/Formula/tokyo-dystopia.rb
+++ b/Formula/tokyo-dystopia.rb
@@ -1,9 +1,14 @@
 class TokyoDystopia < Formula
   desc "Lightweight full-text search system"
-  homepage "https://fallabs.com/tokyodystopia/"
-  url "https://fallabs.com/tokyodystopia/tokyodystopia-0.9.15.tar.gz"
+  homepage "https://dbmx.net/tokyodystopia/"
+  url "https://dbmx.net/tokyodystopia/tokyodystopia-0.9.15.tar.gz"
   sha256 "28b43c592a127d1c9168eac98f680aa49d1137b4c14b8d078389bbad1a81830a"
   license "LGPL-2.1"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?tokyodystopia[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "9e0c8988268eec1f5fe33f5d7f494f636c64690f417e179e37a83f9b4880b315"
@@ -22,7 +27,6 @@ class TokyoDystopia < Formula
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make"
-    system "make", "check"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs for `tokyo-dystopia` redirect from `fallabs.com` to `dbmx.net`. This PR updates these URLs to avoid the redirection.

This technically modifies the `stable` URL, so I haven't labelled this `CI-syntax-only`. For what it's worth, the `sha256` remains unchanged.

Additionally, livecheck gives an `Unable to get versions` error for `tokyo-dystopia` by default. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

Lastly, this removes the `system "make", "check"` step in the `install` block, to resolve the following `brew audit` error:

```
* 30: col 5: Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
```