### PR TITLE
bas55: add livecheck

### DIFF
--- a/Formula/bas55.rb
+++ b/Formula/bas55.rb
@@ -5,6 +5,11 @@ class Bas55 < Formula
   sha256 "566097e216dab029d51afefdacf7806f249d57d117ca3e875e27c6cf61098ee0"
   license "MIT"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?bas55[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "ab48670d6620654c1e88b8076d9c9805e6f6b2fde8f1d8773ac96fd5bd234789"
     sha256 cellar: :any_skip_relocation, big_sur:       "c9a50cf6904cafd3a75cbb762ea68d3545eadc832be0b2c0313aaadf03dfe453"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `bas55`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.