### PR TITLE
libswiften: update homepage, add livecheck

### DIFF
--- a/Formula/libswiften.rb
+++ b/Formula/libswiften.rb
@@ -1,9 +1,14 @@
 class Libswiften < Formula
   desc "C++ library for implementing XMPP applications"
-  homepage "https://swift.im/swiften"
+  homepage "https://swift.im/swiften.html"
   url "https://swift.im/downloads/releases/swift-4.0/swift-4.0.tar.gz"
   sha256 "50b7b2069005b1474147110956f66fdde0afb2cbcca3d3cf47de56dc61217319"
   revision 4
+
+  livecheck do
+    url "https://swift.im/downloads.html"
+    regex(/href=.*?swift[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, catalina:    "919e570b27576a942a2dd08c190f188cf8f0deb00950dc0b5956478da38091ed"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `libswiften`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive. The latest version is `4.0.2` but it fails to build due to a syntax error, so I didn't handle the update in this same PR.

This also updates the `homepage`, as it redirects from `https://swift.im/swiften` to `https://swift.im/swiften.html`.