### PR TITLE
sollya: update stable, add livecheck

### DIFF
--- a/Formula/sollya.rb
+++ b/Formula/sollya.rb
@@ -1,9 +1,14 @@
 class Sollya < Formula
   desc "Library for safe floating-point code development"
   homepage "https://www.sollya.org/"
-  url "https://gforge.inria.fr/frs/download.php/file/37749/sollya-7.0.tar.gz"
+  url "https://www.sollya.org/releases/sollya-7.0/sollya-7.0.tar.gz"
   sha256 "30487b8242fb40ba0f4bc2ef23a8ef216477e57b1db277712fde1f53ceebb92a"
   revision 1
+
+  livecheck do
+    url "https://www.sollya.org/download.php"
+    regex(/href=.*?sollya[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "e85099273aa58bed86a2f3f5cecd630d6ef34733eb82781db493baf17e3beecb"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `sollya`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.

This PR also updates the `stable` URL to use the tarball from the first-party website. It wasn't clear to me why the formula didn't use this tarball when it was introduced but this helps to align the `livecheck` block and the `stable` source. If there's a compelling reason for using the tarball from `gforge.inria.fr` instead, I'll remove the change to `stable`. For what it's worth, this is the same tarball in both places (i.e., they both have the same `sha256`).