### PR TITLE
kcgi: add livecheck

### DIFF
--- a/Formula/kcgi.rb
+++ b/Formula/kcgi.rb
@@ -1,9 +1,14 @@
 class Kcgi < Formula
   desc "Minimal CGI and FastCGI library for C/C++"
-  homepage "https://kristaps.bsd.lv/kcgi"
+  homepage "https://kristaps.bsd.lv/kcgi/"
   url "https://kristaps.bsd.lv/kcgi/snapshots/kcgi-0.12.5.tgz"
   sha256 "06ed033de3723651d76e2fac1c2442aaa3a28ac231cbfda4142dfb8782cab363"
   license "ISC"
+
+  livecheck do
+    url "https://kristaps.bsd.lv/kcgi/snapshots/"
+    regex(/href=.*?kcgi[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f822435b05a2e98b0bef784360c4e323ca7f6e9567673f0f2be4aa2f8e6d07b8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `kcgi`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. I've taken this approach because the homepage only provides the latest version in loose text and the referenced tarball is unversioned (`kcgi.tgz`).

Besides that, this PR updates the `homepage` to include a trailing forward slash (`/`) to avoid a redirection.