### PR TITLE
one-ml: update urls, add livecheck

### DIFF
--- a/Formula/one-ml.rb
+++ b/Formula/one-ml.rb
@@ -1,10 +1,15 @@
 class OneMl < Formula
   desc "Reboot of ML, unifying its core and (now first-class) module layers"
-  homepage "https://www.mpi-sws.org/~rossberg/1ml/"
-  url "https://www.mpi-sws.org/~rossberg/1ml/1ml-0.1.zip"
+  homepage "https://people.mpi-sws.org/~rossberg/1ml/"
+  url "https://people.mpi-sws.org/~rossberg/1ml/1ml-0.1.zip"
   sha256 "64c40c497f48355811fc198a2f515d46c1bb5031957b87f6a297822b07bb9c9a"
   license "Apache-2.0"
   revision 2
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?1ml[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `one-ml`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

Besides that, this updates the `homepage` and `stable` URLs, as they were redirecting from `www.mpi-sws.org` to `people.mpi-sws.org`. I haven't used the `CI-syntax-only` label here, as the `stable` URL was technically modified (though the `sha256` remains the same).