### PR TITLE
ratfor: add livecheck

### DIFF
--- a/Formula/ratfor.rb
+++ b/Formula/ratfor.rb
@@ -4,6 +4,11 @@ class Ratfor < Formula
   url "http://www.dgate.org/ratfor/tars/ratfor-1.05.tar.gz"
   sha256 "826278c5cec11f8956984f146e982137e90b0722af5dde9e8c5bf1fef614853c"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?ratfor[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "86d1de3e075edcc1e493b46fc7186bd21906644ba69a7032f3bc827487eb9449"
     sha256 cellar: :any_skip_relocation, big_sur:       "0d9bfcd885197bf8bbfbd38469cd831e16f2dceb6cb6155acf075f0dfebcf095"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `ratfor`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.