### PR TITLE
ip_relay: add livecheck

### DIFF
--- a/Formula/ip_relay.rb
+++ b/Formula/ip_relay.rb
@@ -4,6 +4,11 @@ class IpRelay < Formula
   url "http://www.stewart.com.au/ip_relay/ip_relay-0.71.tgz"
   sha256 "0cf6c7db64344b84061c64e848e8b4f547b5576ad28f8f5e67163fc0382d9ed3"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?ip_relay[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "35934dd4047dc1c1966fca089d71bc870e23f5a6370368fad9861ff3e3f76064"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `ip_relay`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.