### PR TITLE
joshua: update homepage, add livecheck

### DIFF
--- a/Formula/joshua.rb
+++ b/Formula/joshua.rb
@@ -1,9 +1,14 @@
 class Joshua < Formula
   desc "Statistical machine translation decoder"
-  homepage "https://joshua.incubator.apache.org/"
+  homepage "https://cwiki.apache.org/confluence/display/JOSHUA/"
   url "https://cs.jhu.edu/~post/files/joshua-6.0.5.tgz"
   sha256 "972116a74468389e89da018dd985f1ed1005b92401907881a14bdcc1be8bd98a"
   revision 1
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?joshua[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d9a3dcdc2356e269c23318dd304ec54fa172306d100b274c04a7e78440573987"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `joshua`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This PR also updates the `homepage` to resolve the redirection from https://joshua.incubator.apache.org/ to https://cwiki.apache.org/confluence/display/JOSHUA/. The former URL uses a `meta` element to redirect rather than an HTTP `location` header.