### PR TITLE
kytea: add livecheck

### DIFF
--- a/Formula/kytea.rb
+++ b/Formula/kytea.rb
@@ -5,6 +5,11 @@ class Kytea < Formula
   sha256 "534a33d40c4dc5421f053c71a75695c377df737169f965573175df5d2cff9f46"
   license "Apache-2.0"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?kytea[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "e6507d77b03cee09e01eed90d0eb1c724c8acce9ffb7ad0d75a4dfc7ba434fe8"
     sha256 big_sur:       "2efc4bc6d1c77859c5012819331672e30b9e8c4491c696aac132e8356e08b483"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `kytea`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.