### PR TITLE
dwatch: add livecheck

### DIFF
--- a/Formula/dwatch.rb
+++ b/Formula/dwatch.rb
@@ -5,6 +5,11 @@ class Dwatch < Formula
   sha256 "ba093d11414e629b4d4c18c84cc90e4eb079a3ba4cfba8afe5026b96bf25d007"
   license "GPL-2.0"
 
+  livecheck do
+    url "https://siag.nu/pub/dwatch/"
+    regex(/href=.*?dwatch[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 2
     sha256 arm64_big_sur: "d685c1a752eea0246f6d5f5cc26a6594f36f1950112a3ed65934a52eb37185e9"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `dwatch`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The `homepage` links to the directory listing page as the place to find downloads.