### PR TITLE
tsduck 3.28-2551 (new formula)

### DIFF
--- a/Formula/tsduck.rb
+++ b/Formula/tsduck.rb
@@ -1,0 +1,25 @@
+class Tsduck < Formula
+  desc "MPEG Transport Stream Toolkit"
+  homepage "https://tsduck.io/"
+  url "https://github.com/tsduck/tsduck/archive/v3.28-2551.tar.gz"
+  sha256 "ff39c9b97e17a5ae06556a119e24783427a86b1bb5ac75c7ba0340c7bd07d02d"
+  license "BSD-2-Clause"
+  head "https://github.com/tsduck/tsduck.git", branch: "master"
+
+  depends_on "dos2unix" => :build
+  depends_on "gnu-sed" => :build
+  depends_on "grep" => :build
+  depends_on "openjdk" => :build
+  depends_on "librist"
+  depends_on "pcsc-lite"
+  depends_on "srt"
+
+  def install
+    system "make", "NOGITHUB=1", "NOTEST=1", "-j8"
+    system "make", "NOGITHUB=1", "NOTEST=1", "install", "SYSPREFIX=#{prefix}"
+  end
+
+  test do
+    assert_match "TSDuck - The MPEG Transport Stream Toolkit", shell_output("#{bin}/tsp --version 2>&1")
+  end
+end

--- a/Formula/tsduck.rb
+++ b/Formula/tsduck.rb
@@ -15,11 +15,31 @@ class Tsduck < Formula
   depends_on "srt"
 
   def install
-    system "make", "NOGITHUB=1", "NOTEST=1", "-j8"
+    system "make", "NOGITHUB=1", "NOTEST=1"
     system "make", "NOGITHUB=1", "NOTEST=1", "install", "SYSPREFIX=#{prefix}"
   end
 
   test do
     assert_match "TSDuck - The MPEG Transport Stream Toolkit", shell_output("#{bin}/tsp --version 2>&1")
+    input = shell_output("#{bin}/tsp --list=input 2>&1")
+    assert_match "craft:", input
+    assert_match "file:", input
+    assert_match "hls:", input
+    assert_match "http:", input
+    assert_match "srt:", input
+    assert_match "rist:", input
+    output = shell_output("#{bin}/tsp --list=output 2>&1")
+    assert_match "ip:", output
+    assert_match "file:", output
+    assert_match "hls:", output
+    assert_match "srt:", output
+    assert_match "rist:", output
+    packet = shell_output("#{bin}/tsp --list=packet 2>&1")
+    assert_match "fork:", packet
+    assert_match "tables:", packet
+    assert_match "analyze:", packet
+    assert_match "sdt:", packet
+    assert_match "timeshift:", packet
+    assert_match "nitscan:", packet
   end
 end

--- a/Formula/tsduck.rb
+++ b/Formula/tsduck.rb
@@ -13,8 +13,10 @@ class Tsduck < Formula
   depends_on "librist"
   depends_on "pcsc-lite"
   depends_on "srt"
+  uses_from_macos "curl"
 
   def install
+    ENV.append_to_cflags "-I#{Formula["pcsc-lite"].opt_include}/PCSC" if OS.linux?
     system "make", "NOGITHUB=1", "NOTEST=1"
     system "make", "NOGITHUB=1", "NOTEST=1", "install", "SYSPREFIX=#{prefix}"
   end
@@ -22,24 +24,16 @@ class Tsduck < Formula
   test do
     assert_match "TSDuck - The MPEG Transport Stream Toolkit", shell_output("#{bin}/tsp --version 2>&1")
     input = shell_output("#{bin}/tsp --list=input 2>&1")
-    assert_match "craft:", input
-    assert_match "file:", input
-    assert_match "hls:", input
-    assert_match "http:", input
-    assert_match "srt:", input
-    assert_match "rist:", input
+    %w[craft file hls http srt rist].each do |str|
+      assert_match "#{str}:", input
+    end
     output = shell_output("#{bin}/tsp --list=output 2>&1")
-    assert_match "ip:", output
-    assert_match "file:", output
-    assert_match "hls:", output
-    assert_match "srt:", output
-    assert_match "rist:", output
+    %w[ip file hls srt rist].each do |str|
+      assert_match "#{str}:", output
+    end
     packet = shell_output("#{bin}/tsp --list=packet 2>&1")
-    assert_match "fork:", packet
-    assert_match "tables:", packet
-    assert_match "analyze:", packet
-    assert_match "sdt:", packet
-    assert_match "timeshift:", packet
-    assert_match "nitscan:", packet
+    %w[fork tables analyze sdt timeshift nitscan].each do |str|
+      assert_match "#{str}:", packet
+    end
   end
 end


### PR DESCRIPTION
TSDuck (https://tsduck.io/) is the MPEG Transport Stream Toolkit,
a general-purpose toolbox for Digital TV Engineers working on
transport streams (MPEG-TS). TSDuck is an extensible set of
command-line tools, plugins and development libraries in C++,
Python and Java.

TSDuck is available on macOS, Linux and Windows. Until now, it has
been available on macOS through Homebrew using a third-party tap
("brew tap tsduck/tsduck") since September 2017. Given the maturity
of the project and activity around it, it seems appropriate to move
it to Homebrew core.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
