### PR TITLE
mecab-unidic-extended: add livecheck

### DIFF
--- a/Formula/mecab-unidic-extended.rb
+++ b/Formula/mecab-unidic-extended.rb
@@ -5,6 +5,14 @@ class MecabUnidicExtended < Formula
   url "https://dotsrc.dl.osdn.net/osdn/unidic/58338/unidic-mecab_kana-accent-2.1.2_src.zip"
   sha256 "70793cacda81b403eda71736cc180f3144303623755a612b13e1dffeb6554591"
 
+  # The OSDN releases page asynchronously fetches separate HTML for each
+  # release, so we can't easily check the related archive file names.
+  # NOTE: If/when a new version appears, please manually check the releases
+  # page to confirm an appropriate archive is available for this formula.
+  livecheck do
+    formula "mecab-unidic"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "3afff6a9a967b7c92eb79ca6efcaf3289596c331214ba6130989d757cd7757b2"
     sha256 cellar: :any_skip_relocation, big_sur:       "7566096a08a09b4c695c2f59766dc3d8ed5156d87180a3da1d504be9e038a30b"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `mecab-unidic-extended`. This PR adds a `livecheck` block that uses the check from `mecab-unidic`, as that's the canonical formula and `mecab-unidic-extended` is an alternative.

I've used this approach because the [OSDN releases page](https://osdn.net/projects/unidic/releases/) only contains release version information and doesn't contain the HTML for the release archive links. This is fine for `mecab-unidic` but with `mecab-unidic-extended`, we want to make sure that we're using an archive like `unidic-mecab_kana-accent-2.1.2_src.zip`, not `unidic-mecab-2.1.2_src.zip`.

This isn't possible without creating a complex `strategy` block that collects the release information and fetches the HTML for each individual release until it finds one with an extended archive. This involves two requests at a minimum but could involve more if newer releases don't include an extended archive. While this is technically possible, I don't feel that it's worth the effort just yet based on the current `mecab-unidic-extended` situation.

The most recent `mecab-unidic` release is from 2013-03-14, so it's unlikely this will be updated anytime soon. With that in mind, I'm fine borrowing the check from `mecab-unidic` and we can revisit this `livecheck` block if a new version ever appears. Until then, I've left a comment before the `livecheck` block to explain the need to manually verify that an extended archive exists for a release if/when one ever appears in the future.