### PR TITLE
pianod 376

### DIFF
--- a/Formula/pianod.rb
+++ b/Formula/pianod.rb
@@ -1,10 +1,14 @@
 class Pianod < Formula
   desc "Pandora client with multiple control interfaces"
   homepage "https://deviousfish.com/pianod/"
-  url "https://deviousfish.com/Downloads/pianod2/Devel/pianod2-301.tar.gz"
-  sha256 "d6fa01d786af65fe3b4e6f4f97fa048db6619b9443e23f655d3ea8ab4766caee"
+  url "https://deviousfish.com/Downloads/pianod2/pianod2-376.tar.gz"
+  sha256 "ac00655c1e3c7507ff89f283d8c339510f50e9ddd5a44cb1df7ebcb2e147e6d1"
   license "MIT"
-  revision 1
+
+  livecheck do
+    url "https://deviousfish.com/Downloads/pianod2/"
+    regex(/href=.*?pianod2[._-]v?(\d+(?:\.\d+)*)\.t/i)
+  end
 
   bottle do
     sha256 arm64_big_sur: "75ead4e63a967f75b1348d5f3edc024fb18b64298546ca6574aeba99c043237c"
@@ -20,15 +24,22 @@ class Pianod < Formula
   depends_on "libao"
   depends_on "libgcrypt"
 
+  on_macos do
+    depends_on "ncurses"
+  end
+
   on_linux do
     # pianod uses avfoundation on macOS, ffmpeg on Linux
     depends_on "ffmpeg"
+    depends_on "gcc"
     depends_on "gnutls"
     depends_on "libbsd"
   end
 
+  fails_with gcc: "5"
+
   def install
-    ENV["OBJCXXFLAGS"] = "-std=c++11"
+    ENV["OBJCXXFLAGS"] = "-std=c++14"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `pianod` to the latest stable version, `376`.

I added `depends_on "ncurses"` in an `on_macos` block, as the `make install` step was failing on macOS with the following error:

```
In file included from utility.cpp:364:
./failurecounter.h:50:32: error: use of undeclared identifier 'tiparm'
            green = setcolor ? tiparm (setcolor, 2) : "";
                               ^
./failurecounter.h:51:30: error: use of undeclared identifier 'tiparm'
            red = setcolor ? tiparm (setcolor, 1) : "";
                             ^
./failurecounter.h:52:33: error: use of undeclared identifier 'tiparm'
            yellow = setcolor ? tiparm (setcolor, 3) : "";
                                ^
3 errors generated.
make[2]: *** [utility_test-utility.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [install-recursive] Error 1
make: *** [install-recursive] Error 1
```

To be clear, `uses_from_macos "ncurses"` didn't resolve the error (on macOS 11.6). I also tried doing an `inreplace` to add `#include <stdarg.h>` to `src/common/failurecounter.h` but that didn't resolve the issue either. If there's a better way of approaching this, I'm open to suggestions.

Additionally, I updated `OBJCXXFLAGS` to `-std=c++14`, as this is what the upstream [macOS install instructions](https://deviousfish.com/pianod/Documentation/install.html#macosformerlymacosx) mention.

Past that, this adds a `livecheck` block that checks the directory listing page where stable archives are found. We can't reliably check the homepage, as it links to the stable archive (`pianod2-376.tar.gz`) in the `Devel` directory instead of in the parent directory where stable archives are located. As a result, we can't distinguish between the stable release and the development release on the homepage (they both use the same filename format) and it's necessary to check the directory listing page directly.