### PR TITLE
titan-server: update version, add livecheck

### DIFF
--- a/Formula/titan-server.rb
+++ b/Formula/titan-server.rb
@@ -2,7 +2,13 @@ class TitanServer < Formula
   desc "Distributed graph database"
   homepage "https://thinkaurelius.github.io/titan/"
   url "http://s3.thinkaurelius.com/downloads/titan/titan-1.0.0-hadoop1.zip"
+  version "1.0.0"
   sha256 "67538e231db5be75821b40dd026bafd0cd7451cdd7e225a2dc31e124471bb8ef"
+
+  livecheck do
+    url "https://github.com/thinkaurelius/titan.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "fc2d13173bd41bf1167fdecdff4f638e62cf91c2fbfb20aa19c91163ec465c81"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `titan-server`. This PR adds a `livecheck` block that checks the Git tags, as the homepage links to GitHub repository as the place to find download information.

Downloads are found on the "[Downloads](https://github.com/thinkaurelius/titan/wiki/Downloads)" wiki page but there hasn't been a release since 2015/2016, so I've opted for checking the Git tags. My thinking is that the downloads page has the potential to vary if a new release is created after such a long period of time, whereas the Git tags should be reliable. We can always revisit this if/when a new version is released and this `livecheck` block should help to alert us to this, at the very least.

---

Past that, this adds `version "1.0.0"` because the version is parsed from the `stable` URL as `1` from the trailing `-hadoop1` text in the filename. It's a coincidence that this is currently `1` and the version is `1.0.0` but this would be incorrect with a different version, so it's important to set the correct version.

I didn't label this as `CI-syntax-only` in case we need new bottles for `1.0.0`.