### PR TITLE
avimetaedit: add livecheck

### DIFF
--- a/Formula/avimetaedit.rb
+++ b/Formula/avimetaedit.rb
@@ -4,6 +4,11 @@ class Avimetaedit < Formula
   url "https://mediaarea.net/download/binary/avimetaedit/1.0.2/AVIMetaEdit_CLI_1.0.2_GNU_FromSource.tar.bz2"
   sha256 "e0b83e17460d0202a54f637cb673a0c03460704e6c2cff0c2e34222efb2c11ca"
 
+  livecheck do
+    url "https://mediaarea.net/AVIMetaEdit/Download/Source"
+    regex(/href=.*?avimetaedit[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "e9e10cf64f7d87cdc85102dffea61ac546b0877896ff721a55857a2e80eb0475"
     sha256 cellar: :any_skip_relocation, big_sur:       "c8cbab65b9f81a1015a5550b042fcc91471b288d8e256723be694f5caf402767"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `avimetaedit`. This PR adds a `livecheck` block that checks download page for a source archive. The first-party website doesn't link to the archive file we're using as `stable`, so this is closest we can get.

The main difference between these two archive files is that the one we're currently using in the formula (`AVIMetaEdit_CLI_1.0.2_GNU_FromSource.tar.bz2`) contains a `configure` file, etc. With `avimetaedit_1.0.2.tar.xz`, we would have include some additional build dependencies and generate the `configure` file. There isn't really a compelling reason to switch yet, so I've left this alone for now and we can revisit it if/when a new version is released in the future.