### PR TITLE
rfcstrip: add livecheck

### DIFF
--- a/Formula/rfcstrip.rb
+++ b/Formula/rfcstrip.rb
@@ -4,6 +4,11 @@ class Rfcstrip < Formula
   url "https://trac.tools.ietf.org/tools/rfcstrip/rfcstrip-1.03.tgz"
   sha256 "db5cccb14b2dfdb5e0e3b4ac98d5af29d1f2f647787bcd470a866e02173d4e5b"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?rfcstrip[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "4756e7bca511bbeaeea367e84a845854cd86079ec2d66c6a505b91e7431313a0"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `rfcstrip`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.