### PR TITLE
opendbx: add livecheck

### DIFF
--- a/Formula/opendbx.rb
+++ b/Formula/opendbx.rb
@@ -5,6 +5,13 @@ class Opendbx < Formula
   sha256 "2246a03812c7d90f10194ad01c2213a7646e383000a800277c6fb8d2bf81497c"
   revision 2
 
+  # The download page includes a `libopendbx` development release, so we use a
+  # leading forward slash to only match `opendbx` versions.
+  livecheck do
+    url "https://linuxnetworks.de/doc/index.php?title=OpenDBX/Download"
+    regex(%r{href=.*?/opendbx[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+
   bottle do
     sha256 arm64_big_sur: "a849ec13147c5cb08b03376eae868b6c82ec075a60388bf7e6742fbb9f56b467"
     sha256 big_sur:       "80d655556c77aeb341dd0fc52d70e61dfd8a3518cf689bcb68af6f0aacc04bd5"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for ``opendbx. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.

One thing to note is that the download page also contains a `libopendbx` development release, so the regex uses a leading forward slash to only match the stable `opendbx` archive file.