### PR TITLE
glktermw: add livecheck

### DIFF
--- a/Formula/glktermw.rb
+++ b/Formula/glktermw.rb
@@ -5,6 +5,11 @@ class Glktermw < Formula
   version "1.0.4"
   sha256 "5968630b45e2fd53de48424559e3579db0537c460f4dc2631f258e1c116eb4ea"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?glktermw[._-]v?(?:\d+(?:\.\d+)*)\.t[^>]+?>\s*?GlkTerm library v?(\d+(?:\.\d+)+)/im)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "c24eb437d3ffab00f829aec8fa2bec0846d97bd6cf34d8801235746aca61760c"
     sha256 cellar: :any_skip_relocation, big_sur:       "d68c298b6f2c6a8b4275207809d3e075a3d8a0f4545660c3474803073385781e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `glktermw`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive. The `stable` archive file doesn't include dots in the version (i.e., `104` instead of `1.0.4`), so we match the version from the text inside link to the `stable` archive on the homepage.

The reason why we don't naively insert dots using a `strategy` block is because this won't work correctly when one or more of the version parts is longer than one digit (e.g., `12.3.4`, `1.23.4`, `1.2.34`, `12.34.5` etc.). If you check the [`homepage`](https://www.eblong.com/zarf/glk/), XGlk library 0.4.11 (`xglk-0411.tar.Z`) already demonstrates this issue. If we naively inserted dots between every digit for a version like that, we would get `0.4.1.1` instead of `0.4.11`.