### PR TITLE
libquantum 1.0.0 (downgrade)

### DIFF
--- a/Formula/libquantum.rb
+++ b/Formula/libquantum.rb
@@ -1,9 +1,15 @@
 class Libquantum < Formula
   desc "C library for the simulation of quantum mechanics"
   homepage "http://www.libquantum.de/"
-  url "http://www.libquantum.de/files/libquantum-1.1.1.tar.gz"
-  sha256 "d8e3c4407076558f87640f1e618501ec85bc5f4c5a84db4117ceaec7105046e5"
+  url "http://www.libquantum.de/files/libquantum-1.0.0.tar.gz"
+  sha256 "b0f1a5ec9768457ac9835bd52c3017d279ac99cc0dffe6ce2adf8ac762997b2c"
   license "GPL-3.0-or-later"
+  version_scheme 1
+
+  livecheck do
+    url "http://www.libquantum.de/downloads"
+    regex(/href=.*?libquantum[._-]v?(\d+\.[02468](?:\.\d+)*)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "1788ce1a3fad430fe6579257b4f8144fc72dea392510f170a0c8f0c213d70d80"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`libquantum` was updated to `1.1.1` in #51156 but this a development release according to the first-party download page's explanation of their stable/development version scheme:

> Starting from version 1.0.0, libquantum comes in two flavors. Stable releases have even minor version numbers, while development versions have odd minor version numbers. New features are introduced in the development releases first, so expect untested code and frequent API changes. Stable releases contain only bug fixes until a new minor stable version is released.

With that in mind, this PR downgrades `libquantum` to the newest stable version, `1.0.0`.

This PR also adds a `livecheck` block that checks the first-party download page and uses a regex that only matches stable versions (those with an even-numbered minor).