### PR TITLE
quotatool: add livecheck

### DIFF
--- a/Formula/quotatool.rb
+++ b/Formula/quotatool.rb
@@ -5,6 +5,11 @@ class Quotatool < Formula
   sha256 "e53adc480d54ae873d160dc0e88d78095f95d9131e528749fd982245513ea090"
   license "GPL-2.0"
 
+  livecheck do
+    url "https://quotatool.ekenberg.se/index.php?node=download"
+    regex(/href=.*?quotatool[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "33cf581ce810cb4704669a05ee01b5cc963008f02393db65453ef06216ed257f"
     sha256 cellar: :any_skip_relocation, big_sur:       "e5dbc4f83caec774f6f05d65515c51bd8963c28415020698666d534030e91b23"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `quotatool`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.