### PR TITLE
center-im: update homepage, add livecheck

### DIFF
--- a/Formula/center-im.rb
+++ b/Formula/center-im.rb
@@ -1,9 +1,16 @@
 class CenterIm < Formula
   desc "Text-mode multi-protocol instant messaging client"
-  homepage "https://www.centerim.org/index.php/Main_Page"
+  homepage "https://github.com/petrpavlu/centerim5"
   url "https://www.centerim.org/download/releases/centerim-4.22.10.tar.gz"
   sha256 "93ce15eb9c834a4939b5aa0846d5c6023ec2953214daf8dc26c85ceaa4413f6e"
   revision 2
+
+  # Modify this to use `url :stable` if/when the formula is updated to use an
+  # archive from GitHub in the future.
+  livecheck do
+    url :homepage
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing [`center-im` homepage](https://www.centerim.org/index.php/Main_Page) contains the following content:

> ## Eviction notice
>
> This site has been shut down and the domain is going to be removed, so please redirect yourself to the [CenterIM 5 github homepage](https://github.com/petrpavlu/centerim5) for future reference.
>
> *Goodbye and thanks for all that fish.*

With that in mind, this PR updates the `homepage` to the GitHub project. This also adds a `livecheck` block that checks the GitHub repository's tags.

The latest version is `5.0.1` but the formula will need some work to be able to a 5.x version (beyond removing the patches). When I tested it, `configure` fails with the following error:

```
checking for PURPLE... no
configure: error: Package requirements (purple >= 2.7.0) were not met:

No package 'purple' found
```