### PR TITLE
clipsafe: add livecheck

### DIFF
--- a/Formula/clipsafe.rb
+++ b/Formula/clipsafe.rb
@@ -5,6 +5,11 @@ class Clipsafe < Formula
   sha256 "7a70b4f467094693a58814a42d272e98387916588c6337963fa7258bda7a3e48"
   revision 1
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?clipsafe[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, catalina:    "1a8a00c232a748d9b45271239043f5d155666acfdcb79670efc816e26c740221"
     sha256 cellar: :any_skip_relocation, mojave:      "c3c42621d02672ee0cabd443b871760320c1b82ba61b48bca61076acab10d097"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `clipsafe`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.