### PR TITLE
neovim-qt 0.2.16.1 (new formula)

### DIFF
--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -4,7 +4,7 @@ class NeovimQt < Formula
   url "https://github.com/equalsraf/neovim-qt/archive/v0.2.16.1.tar.gz"
   sha256 "971d4597b40df2756b313afe1996f07915643e8bf10efe416b64cc337e4faf2a"
   license "ISC"
-  head "https://github.com/equalsraf/neovim-qt.git"
+  head "https://github.com/equalsraf/neovim-qt.git", branch: "master"
 
   depends_on "cmake" => :build
   depends_on "neovim-remote" => :test

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -13,14 +13,9 @@ class NeovimQt < Formula
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
-    #system "cmake", "--build", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
     system "cmake", "--install", "build"
-
     if OS.mac?
-      prefix.install "bin/nvim-qt.app"
       bin.install_symlink prefix/"nvim-qt.app/Contents/MacOS/nvim-qt"
-    else
-      bin.install "bin/nvim-qt"
     end
   end
 

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -37,8 +37,8 @@ class NeovimQt < Formula
     # testfile.write("Hello World from Vim!!")
 
     testfile = testpath/"test.txt"
-    testserver = "localhost:9999"
-    #testserver = testpath/"nvim.sock"
+    #testserver = "localhost:9999"
+    testserver = testpath/"nvim.sock"
 
     testcommand = "s/Vim/Neovim/g"
     testinput = "Hello World from Vim!!"
@@ -47,8 +47,11 @@ class NeovimQt < Formula
 
     nvr_opts = ["--nostart", "--servername", testserver]
 
+    puts "#{bin}/nvim-qt --nofork -- --listen #{testserver}"
     nvimqt_pid = spawn bin/"nvim-qt", "--nofork", "--", "--listen", testserver
-    system "nvr", *nvr_opts, "--remote", testfile, "-c", testcommand, "-c", "w"
+    system "nvr", *nvr_opts, "--remote", testfile
+    system "nvr", *nvr_opts, "-c", testcommand
+    system "nvr", *nvr_opts, "-c", "w"
     assert_equal testexpected, testfile.read.chomp
     system "nvr", *nvr_opts, "-c", "call GuiClose()"
     Process.wait nvimqt_pid

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -58,8 +58,6 @@ class NeovimQt < Formula
     system "nvr", *nvr_opts, "-c", "call GuiClose()"
     Process.wait nvimqt_pid
 
-    # system "sh", "-c", "nvr --servername #{testserver} --remote '#{testfile}' -c '#{testcommand}' -c 'call GuiClose()' || true"
-    # system "nvr", "--servername", testserver, "--remote", testfile, "-c", testcommand, "-c", "w", "-c", "call GuiClose()", "-c", "qa"
     # system "nvr", "--nostart", "--servername", testserver, "--remote", testfile, "-c", testcommand, "-c", "wq"
     # system "nvr", "--servername", testserver, "-c", "call GuiClose()", "-c", "qa"
 

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -27,6 +27,7 @@ class NeovimQt < Formula
   end
 
   test do
+    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"] # qt.qpa.xcb: could not connect to display
     # Same test as Formula/neovim.rb
 
     # testfile = testpath/"test.txt"

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -16,7 +16,7 @@ class NeovimQt < Formula
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
     if OS.mac?
-      bin.install_symlink prefix/"nvim-qt.app/Contents/MacOS/nvim-qt"
+      bin.install_symlink prefix/"bin/nvim-qt.app/Contents/MacOS/nvim-qt"
     end
   end
 

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -11,17 +11,21 @@ class NeovimQt < Formula
   depends_on "neovim"
   depends_on "qt@5"
 
-  def install
-    mkdir "build" do
-      system "cmake", "..", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
-      system "make"
+  on_linux do
+    depends_on "gcc"
+  end
 
-      if OS.mac?
-        prefix.install "bin/nvim-qt.app"
-        bin.install_symlink prefix/"nvim-qt.app/Contents/MacOS/nvim-qt"
-      else
-        bin.install "bin/nvim-qt"
-      end
+  fails_with gcc: "5" # Qt needs GCC
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
+    system "cmake", "--build", "build"
+
+    if OS.mac?
+      prefix.install "build/bin/nvim-qt.app"
+      bin.install_symlink prefix/"nvim-qt.app/Contents/MacOS/nvim-qt"
+    else
+      bin.install "build/bin/nvim-qt"
     end
   end
 
@@ -50,7 +54,7 @@ class NeovimQt < Formula
 
     puts "#{bin}/nvim-qt --nofork -- --listen #{testserver}"
     nvimqt_pid = spawn bin/"nvim-qt", "--nofork", "--", "--listen", testserver
-    sleep 2.0
+    sleep 10
     system "nvr", *nvr_opts, "--remote", testfile
     system "nvr", *nvr_opts, "-c", testcommand
     system "nvr", *nvr_opts, "-c", "w"

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -1,0 +1,44 @@
+class NeovimQt < Formula
+  desc "Neovim GUI, in Qt5"
+  homepage "https://github.com/equalsraf/neovim-qt"
+  url "https://github.com/equalsraf/neovim-qt/archive/v0.2.16.1.tar.gz"
+  sha256 "971d4597b40df2756b313afe1996f07915643e8bf10efe416b64cc337e4faf2a"
+  head "https://github.com/equalsraf/neovim-qt.git"
+
+  depends_on "cmake" => :build
+  # depends_on "neovim-remove" => :test
+  depends_on "neovim"
+  depends_on "qt@5"
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
+      system "make"
+
+      if OS.mac?
+        prefix.install "bin/nvim-qt.app"
+        bin.install_symlink prefix/"nvim-qt.app/Contents/MacOS/nvim-qt"
+      else
+        bin.install "bin/nvim-qt"
+      end
+    end
+  end
+
+  test do
+    # Same test as Formula/neovim.rb
+    testfile = testpath/"test.txt"
+    testfile.write("Hello World from Vim!!")
+    system bin/"nvim-qt", "--nofork", testfile, "--", "-i", "NONE", "-u", "NONE", "+s/Vim/Neovim/g", "+wq"
+    assert_equal "Hello World from Neovim!!", testfile.read.chomp
+
+    # (testpath/"test.txt").write("Hello World from Vim!!")
+    # testfile = testpath/"test.txt"
+    # testhost = "localhost:9999"
+    # testfile.write("Hello World from Vim!!")
+    # nvim_pid = nvim_pid = spawn bin/"nvim", "-i", "NONE", "-u", "NONE", "--headless", "--listen", testhost
+    # system bin/"nvim-qt", "--server", testhost, testfile
+    # system bin/"nvr", "--servername", testhost, "--remote", testfile, "-c", "+s/Vim/Neovim/g", "-c", "q"
+    # assert_equal "Hello World from Neovim!!", testfile.read.chomp
+  end
+
+end

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -26,20 +26,13 @@ class NeovimQt < Formula
   end
 
   test do
-    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"] # qt.qpa.xcb: could not connect to display
+    # Disable tests in CI environment:
+    #   qt.qpa.xcb: could not connect to display
+    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
     # Same test as Formula/neovim.rb
 
-    # testfile = testpath/"test.txt"
-    # testfile.write("Hello World from Vim!!")
-    # system bin/"nvim-qt", "--nofork", testfile, "--", "-i", "NONE", "-u", "NONE", "+s/Vim/Neovim/g", "+wq"
-    # assert_equal "Hello World from Neovim!!", testfile.read.chomp
-
-    # testfile = testpath/"test.txt"
-    # testserver = "localhost:9999"
-    # testfile.write("Hello World from Vim!!")
-
     testfile = testpath/"test.txt"
-    # testserver = "localhost:9999"
     testserver = testpath/"nvim.sock"
 
     testcommand = "s/Vim/Neovim/g"
@@ -58,21 +51,5 @@ class NeovimQt < Formula
     assert_equal testexpected, testfile.read.chomp
     system "nvr", *nvr_opts, "-c", "call GuiClose()"
     Process.wait nvimqt_pid
-
-    # system "sh", "-c", "nvr --servername #{testserver} --remote '#{testfile}' -c '#{testcommand}' -c 'call GuiClose()' || true"
-    # system "nvr", "--servername", testserver, "--remote", testfile, "-c", testcommand, "-c", "w", "-c", "call GuiClose()", "-c", "qa"
-    # system "nvr", "--nostart", "--servername", testserver, "--remote", testfile, "-c", testcommand, "-c", "wq"
-    # system "nvr", "--servername", testserver, "-c", "call GuiClose()", "-c", "qa"
-
-    # nvim_pid = nvim_pid = spawn "nvim", "-i", "NONE", "-u", "NONE", "--headless", "--listen", testserver
-    # nvimqt_pid = spawn bin/"nvim-qt", "--server", testserver
-    # sleep(1.0)
-    # system "nvr", "--servername", testserver, "--remote", testfile, "-c", "s/Vim/Neovim/g", "-c", "w"
-    # #system "nvr", "--servername", testserver, "-c", "call GuiClose()"
-    # system "nvr", "--servername", testserver, "-c", "call rpcnotify(0, 'Gui', 'Close', v:exiting)"
-    # Process.wait nvimqt_pid
-    # system "nvr", "--servername", testserver, "-c", "q"
-    # Process.wait nvim_pid
-    # assert_equal "Hello World from Neovim!!", testfile.read.chomp
   end
 end

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -11,6 +11,12 @@ class NeovimQt < Formula
   depends_on "neovim"
   depends_on "qt@5"
 
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5"
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
     system "cmake", "--build", "build"

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -15,8 +15,10 @@ class NeovimQt < Formula
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
+
     if OS.mac?
-      bin.install_symlink prefix/"bin/nvim-qt.app/Contents/MacOS/nvim-qt"
+      prefix.install bin/"nvim-qt.app"
+      bin.install_symlink prefix/"nvim-qt.app/Contents/MacOS/nvim-qt"
     end
   end
 
@@ -37,9 +39,9 @@ class NeovimQt < Formula
 
     nvr_opts = ["--nostart", "--servername", testserver]
 
-    puts "#{bin}/nvim-qt --nofork -- --listen #{testserver}"
+    ohai "#{bin}/nvim-qt --nofork -- --listen #{testserver}"
     nvimqt_pid = spawn bin/"nvim-qt", "--nofork", "--", "--listen", testserver
-    sleep 2.0
+    sleep 10
     system "nvr", *nvr_opts, "--remote", testfile
     system "nvr", *nvr_opts, "-c", testcommand
     system "nvr", *nvr_opts, "-c", "w"

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -6,7 +6,7 @@ class NeovimQt < Formula
   head "https://github.com/equalsraf/neovim-qt.git"
 
   depends_on "cmake" => :build
-  # depends_on "neovim-remove" => :test
+  depends_on "neovim-remote" => :test
   depends_on "neovim"
   depends_on "qt@5"
 
@@ -26,19 +26,50 @@ class NeovimQt < Formula
 
   test do
     # Same test as Formula/neovim.rb
-    testfile = testpath/"test.txt"
-    testfile.write("Hello World from Vim!!")
-    system bin/"nvim-qt", "--nofork", testfile, "--", "-i", "NONE", "-u", "NONE", "+s/Vim/Neovim/g", "+wq"
-    assert_equal "Hello World from Neovim!!", testfile.read.chomp
 
-    # (testpath/"test.txt").write("Hello World from Vim!!")
     # testfile = testpath/"test.txt"
-    # testhost = "localhost:9999"
     # testfile.write("Hello World from Vim!!")
-    # nvim_pid = nvim_pid = spawn bin/"nvim", "-i", "NONE", "-u", "NONE", "--headless", "--listen", testhost
-    # system bin/"nvim-qt", "--server", testhost, testfile
-    # system bin/"nvr", "--servername", testhost, "--remote", testfile, "-c", "+s/Vim/Neovim/g", "-c", "q"
+    # system bin/"nvim-qt", "--nofork", testfile, "--", "-i", "NONE", "-u", "NONE", "+s/Vim/Neovim/g", "+wq"
     # assert_equal "Hello World from Neovim!!", testfile.read.chomp
+
+    # testfile = testpath/"test.txt"
+    # testserver = "localhost:9999"
+    # testfile.write("Hello World from Vim!!")
+
+    testfile = testpath/"test.txt"
+    testserver = "localhost:9999"
+    #testserver = testpath/"nvim.sock"
+
+    testcommand = "s/Vim/Neovim/g"
+    testinput = "Hello World from Vim!!"
+    testexpected = "Hello World from Neovim!!"
+    testfile.write(testinput)
+
+    nvr_opts = ["--nostart", "--servername", testserver]
+
+    nvimqt_pid = spawn bin/"nvim-qt", "--nofork", "--", "--listen", testserver
+    system "nvr", *nvr_opts, "--remote", testfile, "-c", testcommand, "-c", "w"
+    assert_equal testexpected, testfile.read.chomp
+    system "nvr", *nvr_opts, "-c", "call GuiClose()"
+    Process.wait nvimqt_pid
+
+    #system "sh", "-c", "nvr --servername #{testserver} --remote '#{testfile}' -c '#{testcommand}' -c 'call GuiClose()' || true"
+    #system "nvr", "--servername", testserver, "--remote", testfile, "-c", testcommand, "-c", "w", "-c", "call GuiClose()", "-c", "qa"
+    #system "nvr", "--nostart", "--servername", testserver, "--remote", testfile, "-c", testcommand, "-c", "wq"
+    #system "nvr", "--servername", testserver, "-c", "call GuiClose()", "-c", "qa"
+
+
+    # nvim_pid = nvim_pid = spawn "nvim", "-i", "NONE", "-u", "NONE", "--headless", "--listen", testserver
+    # nvimqt_pid = spawn bin/"nvim-qt", "--server", testserver
+    # sleep(1.0)
+    # system "nvr", "--servername", testserver, "--remote", testfile, "-c", "s/Vim/Neovim/g", "-c", "w"
+    # #system "nvr", "--servername", testserver, "-c", "call GuiClose()"
+    # system "nvr", "--servername", testserver, "-c", "call rpcnotify(0, 'Gui', 'Close', v:exiting)"
+    # Process.wait nvimqt_pid
+    # system "nvr", "--servername", testserver, "-c", "q"
+    # Process.wait nvim_pid
+    # assert_equal "Hello World from Neovim!!", testfile.read.chomp
+
   end
 
 end

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -2,6 +2,7 @@ class NeovimQt < Formula
   desc "Neovim GUI, in Qt5"
   homepage "https://github.com/equalsraf/neovim-qt"
   url "https://github.com/equalsraf/neovim-qt/archive/v0.2.16.1.tar.gz"
+  license "ISC"
   sha256 "971d4597b40df2756b313afe1996f07915643e8bf10efe416b64cc337e4faf2a"
   head "https://github.com/equalsraf/neovim-qt.git"
 
@@ -49,6 +50,7 @@ class NeovimQt < Formula
 
     puts "#{bin}/nvim-qt --nofork -- --listen #{testserver}"
     nvimqt_pid = spawn bin/"nvim-qt", "--nofork", "--", "--listen", testserver
+    sleep 2.0
     system "nvr", *nvr_opts, "--remote", testfile
     system "nvr", *nvr_opts, "-c", testcommand
     system "nvr", *nvr_opts, "-c", "w"

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -12,17 +12,15 @@ class NeovimQt < Formula
   depends_on "qt@5"
 
   def install
-    mkdir "build" do
-      system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
-      #system "cmake", "--build", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
-      system "cmake", "--install", "build"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
+    #system "cmake", "--build", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
+    system "cmake", "--install", "build"
 
-      if OS.mac?
-        prefix.install "bin/nvim-qt.app"
-        bin.install_symlink prefix/"nvim-qt.app/Contents/MacOS/nvim-qt"
-      else
-        bin.install "bin/nvim-qt"
-      end
+    if OS.mac?
+      prefix.install "bin/nvim-qt.app"
+      bin.install_symlink prefix/"nvim-qt.app/Contents/MacOS/nvim-qt"
+    else
+      bin.install "bin/nvim-qt"
     end
   end
 

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -2,8 +2,8 @@ class NeovimQt < Formula
   desc "Neovim GUI, in Qt5"
   homepage "https://github.com/equalsraf/neovim-qt"
   url "https://github.com/equalsraf/neovim-qt/archive/v0.2.16.1.tar.gz"
-  license "ISC"
   sha256 "971d4597b40df2756b313afe1996f07915643e8bf10efe416b64cc337e4faf2a"
+  license "ISC"
   head "https://github.com/equalsraf/neovim-qt.git"
 
   depends_on "cmake" => :build
@@ -38,7 +38,7 @@ class NeovimQt < Formula
     # testfile.write("Hello World from Vim!!")
 
     testfile = testpath/"test.txt"
-    #testserver = "localhost:9999"
+    # testserver = "localhost:9999"
     testserver = testpath/"nvim.sock"
 
     testcommand = "s/Vim/Neovim/g"
@@ -58,11 +58,10 @@ class NeovimQt < Formula
     system "nvr", *nvr_opts, "-c", "call GuiClose()"
     Process.wait nvimqt_pid
 
-    #system "sh", "-c", "nvr --servername #{testserver} --remote '#{testfile}' -c '#{testcommand}' -c 'call GuiClose()' || true"
-    #system "nvr", "--servername", testserver, "--remote", testfile, "-c", testcommand, "-c", "w", "-c", "call GuiClose()", "-c", "qa"
-    #system "nvr", "--nostart", "--servername", testserver, "--remote", testfile, "-c", testcommand, "-c", "wq"
-    #system "nvr", "--servername", testserver, "-c", "call GuiClose()", "-c", "qa"
-
+    # system "sh", "-c", "nvr --servername #{testserver} --remote '#{testfile}' -c '#{testcommand}' -c 'call GuiClose()' || true"
+    # system "nvr", "--servername", testserver, "--remote", testfile, "-c", testcommand, "-c", "w", "-c", "call GuiClose()", "-c", "qa"
+    # system "nvr", "--nostart", "--servername", testserver, "--remote", testfile, "-c", testcommand, "-c", "wq"
+    # system "nvr", "--servername", testserver, "-c", "call GuiClose()", "-c", "qa"
 
     # nvim_pid = nvim_pid = spawn "nvim", "-i", "NONE", "-u", "NONE", "--headless", "--listen", testserver
     # nvimqt_pid = spawn bin/"nvim-qt", "--server", testserver
@@ -74,7 +73,5 @@ class NeovimQt < Formula
     # system "nvr", "--servername", testserver, "-c", "q"
     # Process.wait nvim_pid
     # assert_equal "Hello World from Neovim!!", testfile.read.chomp
-
   end
-
 end

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -13,6 +13,7 @@ class NeovimQt < Formula
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
+    system "cmake", "--build", "build"
     system "cmake", "--install", "build"
     if OS.mac?
       bin.install_symlink prefix/"nvim-qt.app/Contents/MacOS/nvim-qt"

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -13,7 +13,8 @@ class NeovimQt < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "-S", ".", "--build", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
+      system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
+      #system "cmake", "--build", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
       system "cmake", "--install", "build"
 
       if OS.mac?

--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -13,9 +13,8 @@ class NeovimQt < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
-      system "make", "all"
-      system "make", "install"
+      system "cmake", "-S", ".", "--build", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"
+      system "cmake", "--install", "build"
 
       if OS.mac?
         prefix.install "bin/nvim-qt.app"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Note: the application works fine (I've been using it on my own Tap for a while), but `brew test` fails, possibly due to some adverse interaction with the test sandbox:

```
% brew test neovim-qt
==> Testing neovim-qt
==> /usr/local/Cellar/neovim-qt/0.2.16.1/bin/nvim-qt --help
Killing child processes...
Error: neovim-qt: failed
Failure while executing; `/usr/bin/sandbox-exec -f /private/tmp/homebrew20210919-19842-p1ejzs.sb /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/bin/ruby -W1 -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/neovim-qt.rb` was terminated by uncaught signal TERM.
/usr/local/Homebrew/Library/Homebrew/sandbox.rb:142:in `exec'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/test.rb:102:in `block (2 levels) in test'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:45:in `block (3 levels) in safe_fork'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:37:in `fork'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:37:in `block (2 levels) in safe_fork'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:34:in `open'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:34:in `block in safe_fork'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/lib/ruby/2.6.0/tmpdir.rb:93:in `mktmpdir'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:33:in `safe_fork'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/test.rb:90:in `block in test'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/test.rb:45:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/test.rb:45:in `test'
/usr/local/Homebrew/Library/Homebrew/brew.rb:129:in `<main>'
```