### PR TITLE
style-check: add livecheck

### DIFF
--- a/Formula/style-check.rb
+++ b/Formula/style-check.rb
@@ -5,6 +5,13 @@ class StyleCheck < Formula
   sha256 "2ae806fcce9e3b80162c64634422dc32d7f0e6f8a81ba5bc7879358744b4e119"
   license "GPL-2.0"
 
+  # The homepage links to an unversioned tarball (style-check-current.tar.gz)
+  # and the GitHub repository (https://github.com/nspring/style-check) has no
+  # tags.
+  livecheck do
+    skip "No version information available to check"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "225c5a3dd8f66d7b42f60d165aa7190e252f4432bf0c41cfed8216746bbbbfef"
     sha256 cellar: :any_skip_relocation, big_sur:       "ad0fe7316475b3384c68b37f288a76e9e20933fe382dd28c3e93944ecb3cf52d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `style-check`. This PR adds a `livecheck` block that skips the formula, as there isn't any available version information to check.

The homepage simply links to an unversioned tarball (`style-check-current.tar.gz`) instead of a versioned tarball like we use in the formula (`style-check-0.14.tar.gz`). I couldn't find anywhere on the website that lists version information. The [related GitHub repository](https://github.com/nspring/style-check) doesn't contain any tags, so we're better off simply skipping this.