### PR TITLE
yaze-ag 2.51.1.1

### DIFF
--- a/Formula/yaze-ag.rb
+++ b/Formula/yaze-ag.rb
@@ -1,10 +1,14 @@
 class YazeAg < Formula
   desc "Yet Another Z80 Emulator (by AG)"
   homepage "http://www.mathematik.uni-ulm.de/users/ag/yaze-ag/"
-  url "http://www.mathematik.uni-ulm.de/users/ag/yaze-ag/devel/yaze-ag-2.40.5_with_keytrans.tar.gz"
-  version "2.40.5"
-  sha256 "d46c861eb0725b87dd5567062f277860b98d538fca477d8686f17b36ef39d9bd"
-  license "GPL-2.0"
+  url "http://www.mathematik.uni-ulm.de/users/ag/yaze-ag/devel/yaze-ag-2.51.1.1.tar.gz"
+  sha256 "9144d3f2522bc369fab3b215868ef504a86452a3636f1a3c435349ea1f57125f"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?yaze-ag[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 arm64_big_sur: "ee904628f8d8bdcafb50f18e4909d0d5a3cffe73f864ae66214fa91c8fabaa92"
@@ -17,9 +21,13 @@ class YazeAg < Formula
   end
 
   def install
-    inreplace "Makefile_solaris_gcc", "md5sum -b", "md5"
+    if OS.mac?
+      inreplace "Makefile_solaris_gcc-x86_64", "md5sum -b", "md5"
+      inreplace "Makefile_solaris_gcc-x86_64", /(LIBS\s+=\s+-lrt)/, '#\1'
+    end
+
     bin.mkpath
-    system "make", "-f", "Makefile_solaris_gcc",
+    system "make", "-f", "Makefile_solaris_gcc-x86_64",
                    "BINDIR=#{bin}",
                    "MANDIR=#{man1}",
                    "LIBDIR=#{lib}/yaze",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `yaze-ag` to the latest version, `2.51.1.1`. Things to note:

* `Makefile_solaris_gcc` doesn't exist anymore and the options are `Makefile_solaris_gcc-sparcv9` or `Makefile_solaris_gcc-x86_64`, so I went with the latter.
* It was necessary to comment out the `LIBS	      = -lrt` line in the Makefile to resolve a `ld: library not found for -lrt` error on macOS.
* The Makefile `inreplace` steps don't appear to be necessary on Linux (I only tested in a Homebrew/brew Docker container), so I put them behind `if OS.mac?`. We'll see how this goes on CI.

Besides that, this adds a `livecheck` block that checks the homepage, which links to the `stable` archive. Without this `livecheck` block, livecheck gives an `Unable to get version` error (as no strategies automatically apply to the formula's URLs).

Lastly, this updates the `license` from `GPL-2.0` to `GPL-2.0-or-later`, as the license comments in the source files contain the "or...later" language.

Edit: It would probably help if I didn't label this `CI-syntax-only`. Muscle memory...