### PR TITLE
qcachegrind: fix on Linux

### DIFF
--- a/Formula/qcachegrind.rb
+++ b/Formula/qcachegrind.rb
@@ -23,18 +23,26 @@ class Qcachegrind < Formula
   depends_on "qt@5"
 
   def install
-    spec = (ENV.compiler == :clang) ? "macx-clang" : "macx-g++"
+    args = ["-config", "release", "-spec"]
+    spec = if OS.linux?
+      "linux-g++"
+    elsif ENV.compiler == :clang
+      "macx-clang"
+    else
+      "macx-g++"
+    end
     spec << "-arm64" if Hardware::CPU.arm?
-    cd "qcachegrind" do
-      system "#{Formula["qt@5"].opt_bin}/qmake", "-spec", spec,
-                                               "-config", "release"
-      system "make"
+    args << spec
 
+    qt5 = Formula["qt@5"].opt_prefix
+    system "#{qt5}/bin/qmake", *args
+    system "make"
+    cd "qcachegrind" do
       if OS.mac?
         prefix.install "qcachegrind.app"
         bin.install_symlink prefix/"qcachegrind.app/Contents/MacOS/qcachegrind"
       else
-        bin.install "qcachegrind/qcachegrind"
+        bin.install "qcachegrind"
       end
     end
   end

--- a/Formula/qcachegrind.rb
+++ b/Formula/qcachegrind.rb
@@ -31,8 +31,7 @@ class Qcachegrind < Formula
   def install
     args = ["-config", "release", "-spec"]
     os = OS.mac? ? "macx" : OS.kernel_name.downcase
-    compiler = case ENV.compiler.to_s.split("-").first
-    when :gcc
+    compiler = if ENV.compiler.to_s.start_with?("gcc")
       "g++"
     else
       ENV.compiler

--- a/Formula/qcachegrind.rb
+++ b/Formula/qcachegrind.rb
@@ -31,7 +31,7 @@ class Qcachegrind < Formula
   def install
     args = ["-config", "release", "-spec"]
     os = OS.mac? ? "macx" : OS.kernel_name.downcase
-    compiler = case ENV.compiler
+    compiler = case ENV.compiler.to_s.split("-").first
     when :gcc
       "g++"
     else

--- a/Formula/qcachegrind.rb
+++ b/Formula/qcachegrind.rb
@@ -31,11 +31,7 @@ class Qcachegrind < Formula
   def install
     args = ["-config", "release", "-spec"]
     os = OS.mac? ? "macx" : OS.kernel_name.downcase
-    compiler = if ENV.compiler.to_s.start_with?("gcc")
-      "g++"
-    else
-      ENV.compiler
-    end
+    compiler = ENV.compiler.to_s.start_with?("gcc") ? "g++" : ENV.compiler
     arch = Hardware::CPU.intel? ? "" : "-#{Hardware::CPU.arch}"
     args << "#{os}-#{compiler}#{arch}"
 


### PR DESCRIPTION
qwt.ru formula used as example for 26-38 lines (with addition of linux-g++)
cd do end block reduced, so now bin.install in linux is aslo working

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
