### PR TITLE
haruhi-dl: update homepage

### DIFF
--- a/Formula/haruhi-dl.rb
+++ b/Formula/haruhi-dl.rb
@@ -2,7 +2,7 @@ class HaruhiDl < Formula
   include Language::Python::Virtualenv
 
   desc "Fork of youtube-dl, focused on bringing a fast, steady stream of updates"
-  homepage "https://haruhi.download"
+  homepage "https://git.sakamoto.pl/laudom/haruhi-dl"
   url "https://files.pythonhosted.org/packages/24/f2/a2d22274cfa8f09c849495e8a5106cf72365091b58d55a45c2c91d9f79b9/haruhi_dl-2021.8.1.tar.gz"
   sha256 "069dc4a5f82f98861a291c7edd8bb1ca01eb74602dd36220343a75cb7bb617a8"
   license "LGPL-3.0-or-later"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Previous homepage (https://haruhi.download) has an invalid certificate. The http version (http://haruhi.download) redirects to https://git.sakamoto.pl/laudom/haruhi-dl