### PR TITLE
ldns: fix broken ABI version from broken SDK detection

### DIFF
--- a/Formula/dnsperf.rb
+++ b/Formula/dnsperf.rb
@@ -4,6 +4,7 @@ class Dnsperf < Formula
   url "https://www.dns-oarc.net/files/dnsperf/dnsperf-2.7.1.tar.gz"
   sha256 "9b4d72aab6713ecab6946ea3d4b69ec694c5749c3a115fc4a006e989c8ed4875"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :homepage

--- a/Formula/freeswitch.rb
+++ b/Formula/freeswitch.rb
@@ -2,7 +2,7 @@ class Freeswitch < Formula
   desc "Telephony platform to route various communication protocols"
   homepage "https://freeswitch.org"
   license "MPL-1.1"
-  revision 3
+  revision 4
   head "https://github.com/signalwire/freeswitch.git"
 
   stable do

--- a/Formula/ldns.rb
+++ b/Formula/ldns.rb
@@ -4,7 +4,7 @@ class Ldns < Formula
   url "https://nlnetlabs.nl/downloads/ldns/ldns-1.7.1.tar.gz"
   sha256 "8ac84c16bdca60e710eea75782356f3ac3b55680d40e1530d7cea474ac208229"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
 
   # https://nlnetlabs.nl/downloads/ldns/ since the first-party site has a
   # tendency to lead to an `execution expired` error.
@@ -37,6 +37,7 @@ class Ldns < Formula
       --with-pyldns
       PYTHON_SITE_PKG=#{lib}/python3.9/site-packages
       --disable-dane-verify
+      --without-xcode-sdk
     ]
 
     # Fixes: ./contrib/python/ldns_wrapper.c:2746:10: fatal error: 'ldns.h' file not found

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -6,6 +6,7 @@ class Openssh < Formula
   version "8.7p1"
   sha256 "7ca34b8bb24ae9e50f33792b7091b3841d7e1b440ff57bc9fabddf01e2ed1e24"
   license "SSH-OpenSSH"
+  revision 1
 
   livecheck do
     url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently the ABI version of `ldns` is incorrectly set to 0 in all our bottles except Big Sur. This causes issues like https://github.com/Homebrew/discussions/discussions/78.

This is because upstream's SDK detection system is buggy and regularly fails to find the correct SDK. When this happens `-isysroot` is passed with a blank value, which means it passes the sequence `-isysroot -version-info 3:0:0`. This takes` -version-info` as the sysroot and thus fails to actually set the ABI version as intended.

Luckily setting the SDK here is not necessary as our superenv will deal with it.

Because we're fixing the ABI version here, this should require revision bumps in dependents.