### PR TITLE
universal_binary_allowlist: remove `openjdk`

### DIFF
--- a/audit_exceptions/universal_binary_allowlist.json
+++ b/audit_exceptions/universal_binary_allowlist.json
@@ -17,7 +17,6 @@
   "marp-cli",
   "netlify-cli",
   "node-sass",
-  "openjdk",
   "openjdk@11",
   "serverless",
   "sourcery",


### PR DESCRIPTION
This formula no longer installs universal binaries as of #85174.