### PR TITLE
cdlabelgen: add livecheck

### DIFF
--- a/Formula/cdlabelgen.rb
+++ b/Formula/cdlabelgen.rb
@@ -4,6 +4,11 @@ class Cdlabelgen < Formula
   url "https://www.aczoom.com/pub/tools/cdlabelgen-4.3.0.tgz"
   sha256 "94202a33bd6b19cc3c1cbf6a8e1779d7c72d8b3b48b96267f97d61ced4e1753f"
 
+  livecheck do
+    url "https://www.aczoom.com/pub/tools/"
+    regex(/href=.*?cdlabelgen[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:     "8c1096a23f2ce2b8db912fcb9786c2f9d76b7ece60d2269512e90fa9505d0d9e"
     sha256 cellar: :any_skip_relocation, catalina:    "5facce52a8f22279160a388513b2a9406f427f3ab231e119fbc0b074dc7028f9"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `cdlabelgen`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The homepage currently links to a beta version, so it's necessary to check the directory listing page directly to identify the latest stable version.