### PR TITLE
objfw: update urls, add livecheck

### DIFF
--- a/Formula/objfw.rb
+++ b/Formula/objfw.rb
@@ -1,8 +1,13 @@
 class Objfw < Formula
   desc "Portable, lightweight framework for the Objective-C language"
-  homepage "https://heap.zone/objfw/"
-  url "https://heap.zone/objfw/downloads/objfw-0.90.2.tar.gz"
+  homepage "https://objfw.nil.im/doc/trunk/README.md"
+  url "https://objfw.nil.im/downloads/objfw-0.90.2.tar.gz"
   sha256 "4de24703d45638093a5196eba278a05b3643e8be0ae2eece5c81ba3e2c20bdbb"
+
+  livecheck do
+    url "https://objfw.nil.im/wiki?name=Releases"
+    regex(/href=.*?objfw[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 arm64_big_sur: "59dd4798a6017b6062614f70004c87feb3bbf7aecb9ac2165b5b6f92353c6361"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `objfw`. This PR adds a `livecheck` block that checks the first-party releases page, which links to the `stable` archive.

This PR also updates the `homepage` and `stable` URLs, as they redirect. The `stable` archive still redirects from `/downloads/objfw-0.90.2.tar.gz` to `/uv/releases/objfw-0.90.2.tar.gz` but the [Releases page](https://objfw.nil.im/wiki?name=Releases) links to the `/downloads/...` tarball, so I went with that URL. If we want to use the final `/uv/releases/...` URL, I'll update this accordingly.