### PR TITLE
vilistextum: add livecheck

### DIFF
--- a/Formula/vilistextum.rb
+++ b/Formula/vilistextum.rb
@@ -5,6 +5,17 @@ class Vilistextum < Formula
   sha256 "3a16b4d70bfb144e044a8d584f091b0f9204d86a716997540190100c20aaf88d"
   license "GPL-2.0"
 
+  livecheck do
+    url "https://bhaak.net/vilistextum/download.html"
+    regex(/href=.*?vilistextum[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    strategy :page_match do |page, regex|
+      # Omit version with old scheme that is incorrectly treated as newest
+      # NOTE: This `strategy` block can be removed in the future if/when the
+      # download page only contains versions with three parts like 2.3.0.
+      page.scan(regex).map { |match| (version = match.first) == "2.22" ? nil : version }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "dfd4ab35a880dbac2c93e43eed5e0001093fad04c94c32f955c3f91822d84ccd"
     sha256 cellar: :any_skip_relocation, big_sur:       "c1107f3edeb308819c5b074f1ed2072583c3bc5a7800af162ab10ef460548f18"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `vilistextum `. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.

It's worth noting that the oldest version on the download page is `2.22`, which uses an older version scheme (two parts instead of three, like `2.3.0`). This version is treated as newest (22 > 6), so I've added a `strategy` block that manually omits it. If/when the download page is updated in the future to only contain versions with three parts (e.g., `2.3.0`), the `strategy` block can be removed.