### PR TITLE
ioke: add livecheck

### DIFF
--- a/Formula/ioke.rb
+++ b/Formula/ioke.rb
@@ -4,6 +4,11 @@ class Ioke < Formula
   url "https://ioke.org/dist/ioke-P-ikj-0.4.0.tar.gz"
   sha256 "701d24d8a8d0901cde64f11c79605c21d43cafbfb2bdd86765b664df13daec7c"
 
+  livecheck do
+    url "https://ioke.org/download.html"
+    regex(/href=.*?ioke-P-ikj[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "f78a97e3add6cfc850a4e26c1adc46214b8ac9918a27ccc846b25d433f6b8ac0"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `ioke`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.