### PR TITLE
nylon: add livecheck

### DIFF
--- a/Formula/nylon.rb
+++ b/Formula/nylon.rb
@@ -6,6 +6,10 @@ class Nylon < Formula
   license "BSD-3-Clause"
   revision 2
 
+  livecheck do
+    skip "No version information available to check"
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "26d58c80e5db471ca253930300316cfc77dd1b53fae4ebd38502a48e69d4af8a"
     sha256 cellar: :any,                 big_sur:       "dffadaeddcde173302400dfc71686048edf9944a3543ac578ce634d9f283870d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `nylon`. This PR adds a `livecheck` block that skips the formula, as the first-party website doesn't provide version information for `nylon` and the GitHub repository doesn't contain any tags.