### PR TITLE
vstr: add livecheck

### DIFF
--- a/Formula/vstr.rb
+++ b/Formula/vstr.rb
@@ -5,6 +5,11 @@ class Vstr < Formula
   sha256 "d33bcdd48504ddd21c0d53e4c2ac187ff6f0190d04305e5fe32f685cee6db640"
   license "LGPL-2.1"
 
+  livecheck do
+    url "http://www.and.org/vstr/latest/"
+    regex(/href=.*?vstr[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, big_sur:     "cc1c69c834bde35ed9e0df8178e8e65d9ba5703fbf2cf896290aed6a7433c4b3"
     sha256 cellar: :any, catalina:    "adbf13e88473af357032472ac09af1230667c5010089089a3c223819ef74c7f6"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `vstr`. This PR adds a `livecheck` block that checks the "latest" directory listing page, which links to the `stable` archive. The homepage doesn't link to tarballs and instead links to the "latest" directory listing page as the place to download files.