### PR TITLE
yamcha: add livecheck

### DIFF
--- a/Formula/yamcha.rb
+++ b/Formula/yamcha.rb
@@ -5,6 +5,11 @@ class Yamcha < Formula
   sha256 "413d4fc0a4c13895f5eb1468e15c9d2828151882f27aea4daf2399c876be27d5"
   license "LGPL-2.1"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?yamcha[._-]v?(\d+(?:\.\d+)+)\.t/im)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any, big_sur:     "18f032ddd520debefef3e67422089660c9222e1a8098d4c9b5128cb7a517e87a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `yamcha`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.