### PR TITLE
cheapglk: add livecheck

### DIFF
--- a/Formula/cheapglk.rb
+++ b/Formula/cheapglk.rb
@@ -6,6 +6,11 @@ class Cheapglk < Formula
   sha256 "2753562a173b4d03ae2671df2d3c32ab7682efd08b876e7e7624ebdc8bf1510b"
   license "MIT"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?cheapglk[._-]v?(?:\d+(?:\.\d+)*)\.t[^>]+?>\s*?CheapGlk library v?(\d+(?:\.\d+)+)/im)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "73f43be61554255b8b1bb6f2e185b567eca2c868f0c65ddf8a53020fddd8e35a"
     sha256 cellar: :any_skip_relocation, big_sur:       "9b3b09b201d58788157377de21147fc1dab74635912c3592626e9575905d9061"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `cheapglk`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This `livecheck` block borrows the approach from `glkterm`/`glktermw`, as the tarball filenames don't include dots in the versions and naively inserting a dot between each number will cause problems if any of the parts of the version contain more than one digit. This issue can already be seen with the XGlk library 0.4.11 tarball filename, `xglk-0411.tar.Z`.