### PR TITLE
dvanalyzer: add livecheck

### DIFF
--- a/Formula/dvanalyzer.rb
+++ b/Formula/dvanalyzer.rb
@@ -4,6 +4,11 @@ class Dvanalyzer < Formula
   url "https://mediaarea.net/download/binary/dvanalyzer/1.4.2/DVAnalyzer_CLI_1.4.2_GNU_FromSource.tar.bz2"
   sha256 "d2f3fdd98574f7db648708e1e46b0e2fa5f9e6e12ca14d2dfaa77c13c165914c"
 
+  livecheck do
+    url "https://mediaarea.net/DVAnalyzer/Download/Source"
+    regex(/href=.*?dvanalyzer[._-]?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "2c3394dede8aedd03611a44ab7f0e9c0cf65de9343eea185575234571da63b76"
     sha256 cellar: :any_skip_relocation, big_sur:       "c82268f8073ce66058329a7f3e17a8dffba0d811f82c1eb33a6a45144693bf17"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `dvanalyzer`. This PR adds a `livecheck` block that checks the download page for source files, which links to the `stable` archive.

One thing to note, is that the regex matches against a different `dvanalyzer` tarball than the one used in the formula. Some of the source download pages for other mediaarea.net software only provides a link to the tarball like `dvanalyzer_1.4.2.tar.bz2` instead of the `DVAnalyzer_GUI_1.4.2_GNU_FromSource.tar.bz2` tarball we use in the formula. Checking the former may be more reliable over time, so I've opted to go that route for the time being.