### PR TITLE
mediaconch: update livecheck

### DIFF
--- a/Formula/mediaconch.rb
+++ b/Formula/mediaconch.rb
@@ -7,7 +7,7 @@ class Mediaconch < Formula
 
   livecheck do
     url "https://mediaarea.net/MediaConch/Download/Source"
-    regex(/href=.*?MediaConch[._-]CLI[._-]v?(\d+(?:\.\d+)+)[._-]GNU[._-]FromSource\.t/i)
+    regex(/href=.*?mediaconch[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the existing `livecheck` block for `mediaconch` to check the download page for source files. This aligns the `livecheck` block with the approach used in other mediaarea.net formulae, to keep these consistent.