### PR TITLE
tractorgen: update urls and license, add livecheck

### DIFF
--- a/Formula/tractorgen.rb
+++ b/Formula/tractorgen.rb
@@ -1,9 +1,14 @@
 class Tractorgen < Formula
   desc "Generates ASCII tractor art"
-  homepage "http://www.kfish.org/software/tractorgen/"
-  url "http://www.kfish.org/software/tractorgen/dl/tractorgen-0.31.7.tar.gz"
+  homepage "http://www.vergenet.net/~conrad/software/tractorgen/"
+  url "http://www.vergenet.net/~conrad/software/tractorgen/dl/tractorgen-0.31.7.tar.gz"
   sha256 "469917e1462c8c3585a328d035ac9f00515725301a682ada1edb3d72a5995a8f"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?tractorgen[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "cc7c0c6f2a31533393973e0931d984d1ceff57e2ee1f49c03a8633d33ecfde7b"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `tractorgen`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This PR also updates the `homepage` and `stable` URLs to use `www.vergenet.net`. The existing `homepage` linked to the related [GitHub repository](https://github.com/kfish/tractorgen/) which links to `www.vergenet.net` as the place to check for updates and news. The `sha256` for the `stable` archive remains the same but the URL was modified, so I didn't label this as `CI-syntax-only`.

Lastly, this updates the `license` from `GPL-2.0` to `GPL-2.0-or-later`, referencing the `homepage` and GitHub repository, which both state:

> This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version. See the file [COPYING](http://www.vergenet.net/~conrad/software/tractorgen/dl/COPYING) for details.