### PR TITLE
jpeg-xl: build & install man pages

### DIFF
--- a/Formula/jpeg-xl.rb
+++ b/Formula/jpeg-xl.rb
@@ -4,6 +4,7 @@ class JpegXl < Formula
   url "https://gitlab.com/wg1/jpeg-xl/-/archive/v0.5/jpeg-xl-v0.5.tar.bz2"
   sha256 "43ae213b9ff28f672beb4f50dbee0834be2afe0015a62bf525d35ee2e7e89d6c"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "96c7e3fb74af26795318c88c155f39d9a83dbebcbc7f1a60484b6a5e08271ddf"
@@ -12,6 +13,7 @@ class JpegXl < Formula
     sha256 cellar: :any, mojave:        "7801c452701a99cfb8fb8b78192c345a01070492285acabd6746cc40314765e0"
   end
 
+  depends_on "asciidoc" => :build
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "brotli"
@@ -45,6 +47,10 @@ class JpegXl < Formula
   end
 
   def install
+    # When building man pages, a2x calls xmllint --nonet,
+    # which needs this to find the schema or fails otherwise.
+    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
+
     resources.each { |r| r.stage buildpath/"third_party"/r.name }
     mkdir "build" do
       system "cmake", "..", "-DBUILD_TESTING=OFF", *std_cmake_args


### PR DESCRIPTION
The current formula installs no man pages. This adds man pages for `cjxl(1)` and `djxl(1)`.

This also fixes building from source (on some setups), because CMake is eager to find Python and a2x (part of `asciidoc`) when they’re installed, but then a2x fails to actually run if `depends_on "asciidoc"` is missing:

```
[  0%] Generating cjxl.1
/usr/local/bin/python3.9 /usr/local/bin/a2x --format manpage --destination-dir=".../jpeg-xl-v0.5/build" .../jpeg-xl-v0.5/doc/man/cjxl.txt
a2x: ERROR: unable to find asciidoc: asciidoc

gmake[2]: *** [CMakeFiles/manpages.dir/build.make:77: cjxl.1] Error 1
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?