### PR TITLE
reop: add livecheck

### DIFF
--- a/Formula/reop.rb
+++ b/Formula/reop.rb
@@ -5,6 +5,10 @@ class Reop < Formula
   mirror "https://bo.mirror.garr.it/OpenBSD/distfiles/reop-2.1.1.tgz"
   sha256 "fa8ae058c51efec5bde39fab15b4275e6394d9ab1dd2190ffdba3cf9983fdcac"
 
+  livecheck do
+    skip "No longer developed"
+  end
+
   bottle do
     sha256 cellar: :any, arm64_big_sur: "2f19ce5ab996a6d2cf7e5152160f0f0298e3c19eed633a9c52c0d548b2be0017"
     sha256 cellar: :any, big_sur:       "125c56793715854faa4c1785f48e119a364ea3fb3239ea7edc4d885b6071099f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `reop`. This PR adds a `livecheck` block to skip the formula, as `reop` is no longer being developed. The homepage states:

> Development is now halted. Fixing the remaining problems is quite challenging to do securely. A future better version of reop would be incompatible with existing releases. (This doesn’t mean they are insecure, just that the design doesn’t accommodate new features easily.) The current release accomplishes what I set out to accomplish. With that in mind, I think it’s best to stop here. Maybe someday I’ll give it another go, but for now, adios.