### PR TITLE
pax-runner 1.9.0

### DIFF
--- a/Formula/pax-runner.rb
+++ b/Formula/pax-runner.rb
@@ -1,9 +1,14 @@
 class PaxRunner < Formula
   desc "Tool to provision OSGi bundles"
-  homepage "https://ops4j1.jira.com/"
-  url "https://search.maven.org/remotecontent?filepath=org/ops4j/pax/runner/pax-runner-assembly/1.8.6/pax-runner-assembly-1.8.6-jdk15.tar.gz"
-  version "1.8.6"
-  sha256 "42a650efdedcb48dca89f3e4272a9e2e1dcc6bc84570dbb176b5e578ca1ce2d4"
+  homepage "https://ops4j1.jira.com/wiki/spaces/paxrunner/overview"
+  url "https://search.maven.org/remotecontent?filepath=org/ops4j/pax/runner/pax-runner-assembly/1.9.0/pax-runner-assembly-1.9.0-jdk15.tar.gz"
+  version "1.9.0"
+  sha256 "b1ff2039dc1e73b6957653d967d6ee028f9c79d663b9031a6b77a49932352dc1"
+
+  livecheck do
+    url "https://search.maven.org/remotecontent?filepath=org/ops4j/pax/runner/pax-runner-assembly/maven-metadata.xml"
+    regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "cdaa1633b1cc5310e7e6d5edd558316c794d37869976494d6b1b4d465ce1129d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `pax-runner` to the latest version on Maven, `1.9.0`.

This PR also adds a `livecheck` block that checks the `maven-metadata.xml` file for `org/ops4j/pax/runner/pax-runner-assembly`, as livecheck gives an `Unable to get versions` error by default.