### PR TITLE
elfutils: add livecheck

### DIFF
--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -5,6 +5,11 @@ class Elfutils < Formula
   sha256 "dc8d3e74ab209465e7f568e1b3bb9a5a142f8656e2b57d10049a73da2ae6b5a6"
   license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.0-only"]
 
+  livecheck do
+    url "https://sourceware.org/elfutils/ftp/"
+    regex(%r{href=(?:["']?v?(\d+(?:\.\d+)+)/?["' >]|.*?elfutils[._-]v?(\d+(?:\.\d+)+)\.t)}i)
+  end
+
   bottle do
     sha256 x86_64_linux: "648de1f95c8252a12a0148a6bac1b02d7a34e33a71aa92f22e26bb7c51250508"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `elfutils`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found, as the homepage doesn't link to versioned archive files (only `elfutils-latest.tar.bz2`).

If this approach becomes an issue in the future (e.g., a new version tarball is published far before the version is announced on the homepage), I can revisit this to modify the `livecheck` block to match the version from the release notes link text. I didn't take this approach here because we've run into issues with an unrelated formula where release notes aren't necessarily published for all releases, so I wanted to err on the side of caution.