### PR TITLE
gssdp: Fix build for Linux

### DIFF
--- a/Formula/gssdp.rb
+++ b/Formula/gssdp.rb
@@ -18,13 +18,10 @@ class Gssdp < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
+  depends_on "vala" => :build
   depends_on "gettext"
   depends_on "glib"
   depends_on "libsoup"
-
-  on_linux do
-    depends_on "vala"
-  end
 
   def install
     mkdir "build" do

--- a/Formula/gssdp.rb
+++ b/Formula/gssdp.rb
@@ -22,6 +22,10 @@ class Gssdp < Formula
   depends_on "glib"
   depends_on "libsoup"
 
+  on_linux do
+    depends_on "vala"
+  end
+
   def install
     mkdir "build" do
       system "meson", *std_meson_args, "-Dsniffer=false", ".."


### PR DESCRIPTION
Fixes:
../vala/meson.build:1:0: ERROR: Program 'vapigen' not found

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
