### PR TITLE
dash: add livecheck

### DIFF
--- a/Formula/dash.rb
+++ b/Formula/dash.rb
@@ -6,6 +6,11 @@ class Dash < Formula
   license "BSD-3-Clause"
   head "https://git.kernel.org/pub/scm/utils/dash/dash.git"
 
+  livecheck do
+    url "http://gondor.apana.org.au/~herbert/dash/files/"
+    regex(/href=.*?dash[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "12e8257cfc5dda342cf5df3579e4d75d6c7da1c3e5188ea2bd632f66ca9291dc"
     sha256 cellar: :any_skip_relocation, big_sur:       "a7eafa8a473d2bfd1d9fbc207ed863d5765189b6662341420bee8a78cc6d4360"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck cycles through the formula URLs and ends up checking the Git repository tags from `head`. The trouble is that the highest tag version is `0.5.11.4` but the newest tarball is `0.5.11.5`.

This PR addresses the issue by adding a `livecheck` block that checks the directory listing page where the `stable` archive is found (the homepage links to this page). This is preferable compared to checking the Git tags anyway, as it aligns the check with the stable source.