### PR TITLE
guile: fix loading dynamic libraries

### DIFF
--- a/Formula/guile.rb
+++ b/Formula/guile.rb
@@ -5,6 +5,7 @@ class Guile < Formula
   mirror "https://ftpmirror.gnu.org/guile/guile-3.0.7.tar.xz"
   sha256 "f57d86c70620271bfceb7a9be0c81744a033f08adc7ceba832c9917ab3e691b7"
   license "LGPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_big_sur: "1943b7ddae69e16cf1b9f81505bfb20129b988d7bffc40460088d29c518a960a"
@@ -33,6 +34,14 @@ class Guile < Formula
   depends_on "readline"
 
   uses_from_macos "gperf"
+
+  # This patch fixes an issue where Guile >= 3.0.6 doesn't properly load dynamic
+  # libraries on macOS.
+  # To be removed after Guile 3.0.8 is released.
+  patch do
+    url "https://git.savannah.gnu.org/cgit/guile.git/patch/?id=1f100a4f20c3a6e57922fb26fce212997e2a03cb"
+    sha256 "a5adf2586b30381cf24524c7fc0364115f7cb1f568d2b69a9f3fb49ad8355b55"
+  end
 
   def install
     # Avoid superenv shim


### PR DESCRIPTION
This patch has been accepted upstream. In guile >= 3.0.6 dynamic libraries are
not properly loaded on macOS.

https://git.savannah.gnu.org/cgit/guile.git/commit/?id=1f100a4f20c3a6e57922fb26fce212997e2a03cb

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
