### PR TITLE
librist: add livecheck

### DIFF
--- a/Formula/librist.rb
+++ b/Formula/librist.rb
@@ -6,6 +6,11 @@ class Librist < Formula
   license "BSD-2-Clause"
   head "https://code.videolan.org/rist/librist.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "33edba89ab01a727ae17d5c76742a20e61030c0dc5b46c5063a07fd31ec16214"
     sha256 cellar: :any,                 big_sur:       "32ca4949e0b34daff4eac02cef3fc018a08a29b531a16c5199c5549317292b84"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `librist` but the built-in prerelease version filtering doesn't filter out the `-RC` tags (e.g., `v0.2.0-RC6`). There's room to improve the built-in prerelease version filtering but, in the interim time, this PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which will omit the unstable version tags.