### PR TITLE
vespa-cli: add livecheck

### DIFF
--- a/Formula/vespa-cli.rb
+++ b/Formula/vespa-cli.rb
@@ -6,6 +6,11 @@ class VespaCli < Formula
   sha256 "87e309fbdac0bef174ef3ac1bf094d551a54dd2da57ecc52e19880d0d81a9cda"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^vespa[._-](\d+(?:\.\d+)+)(?:-\d+)?$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "2545137bd5211b28a97ad6b63b19f5c89abc61512424a05fdb115a07dad0f17b"
     sha256 cellar: :any_skip_relocation, big_sur:       "04245ebcc2c5c9d2792fc166ad08829c6b4f48281333a4eeeeba8d8b57d5947e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `vespa-cli` and this correctly returns versions but almost all of the tags contain a `-1` suffix that's manually omitted from the formula `version`. As a result, livecheck will always treat the upstream tag version as newer than the formula version, since `Version` comparison ignores delimiters and the numeric suffix looks like another digit (basically `7.462.20.1` vs. `7.462.20`).

This PR adds a `livecheck` block with a regex that omits the trailing `-1` from the capture group, so livecheck versions match the formula version format and will be compared correctly.