### PR TITLE
pkg-config-wrapper: add livecheck

### DIFF
--- a/Formula/pkg-config-wrapper.rb
+++ b/Formula/pkg-config-wrapper.rb
@@ -6,6 +6,11 @@ class PkgConfigWrapper < Formula
   license "MIT"
   head "https://github.com/influxdata/pkg-config.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "132d305934de84c9d98d82912312f0cbb7204dbf203277730fd1ef2238ee5621"
     sha256 cellar: :any_skip_relocation, big_sur:       "0c13ac5e30bafee95d4190ba733305bf481195299cc07d665bf25c7b34183f63"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `pkg-config-wrapper` and this currently works as expected (returning `0.2.8` as the newest version). However, there's a weird one-off tag in the results (`v0.1.1-one-crate`) that we wouldn't want to match, so this PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3` to only match the tags we want.