### PR TITLE
bioperl: update livecheck

### DIFF
--- a/Formula/bioperl.rb
+++ b/Formula/bioperl.rb
@@ -6,9 +6,13 @@ class Bioperl < Formula
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   head "https://github.com/bioperl/bioperl-live.git", branch: "master"
 
+  # We specifically match versions with three numeric parts because upstream
+  # documentation mentions that release versions have three parts and there are
+  # older tarballs with fewer than three parts that we need to omit for version
+  # comparison to work correctly.
   livecheck do
     url :stable
-    regex(/href=.*?>BioPerl-(\d+\.\d+\.\d+)\.t/i)
+    regex(/href=["']?BioPerl[._-]v?(\d+\.\d+\.\d+)(?:\.?_\d+)?\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `bioperl` correctly identifies the latest version from the directory listing page where the `stable` archive is found. However, this needs a couple tweaks to bring it in line with livecheck regex standards.

Additionally, the existing regex misses the `1.7.0` release, since the related tarballs all include a numeric suffix (`BioPerl-1.7.0._1.tar.gz` and `BioPerl-1.7.0._2.tar.gz`) and the regex only matches tarballs without a numeric suffix (e.g., `BioPerl-1.7.7.tar.gz`).

This PR updates the regex to bring it in line with livecheck regex standards and to also match tarballs that have a numeric suffix (e.g., `BioPerl-1.7.0._2.tar.gz`, `BioPerl-1.6.0_6.tar.gz`). The numeric suffix is omitted from the version capture group, so livecheck will continue to return versions like `1.6.0` (instead of `1.6.0_6`). 