### PR TITLE
cbmc: remove Java-11 version fix from formula.

### DIFF
--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -16,8 +16,7 @@ class Cbmc < Formula
 
   depends_on "cmake" => :build
   depends_on "maven" => :build
-  # Java front-end fails to build with openjdk>=17
-  depends_on "openjdk@11" => :build
+  depends_on "openjdk" => :build
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
@@ -29,8 +28,6 @@ class Cbmc < Formula
   fails_with gcc: "5"
 
   def install
-    ENV["JAVA_HOME"] = Language::Java.java_home("11")
-
     args = []
     # Workaround borrowed from https://github.com/diffblue/cbmc/issues/4956
     args << "-DCMAKE_C_COMPILER=/usr/bin/clang" if OS.mac?


### PR DESCRIPTION
Previously we had an issue with some upstream changes to openJDK17
creating build problems for a library a part of CBMC depends on.
These are now fixed upstream, and `cbmc` (and by extension, `jbmc`)
can build with `openJDK` 17.

This should resolve issues described in https://github.com/diffblue/cbmc/issues/6343 and https://github.com/Homebrew/homebrew-core/pull/85260.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
