### PR TITLE
sile 0.12.0

### DIFF
--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -1,8 +1,8 @@
 class Sile < Formula
   desc "Modern typesetting system inspired by TeX"
   homepage "https://sile-typesetter.org"
-  url "https://github.com/sile-typesetter/sile/releases/download/v0.11.1/sile-0.11.1.tar.xz"
-  sha256 "a3e627d543bf07ff43ff06cacdbceb8f37aa056a31af25e68f706ad33f497d19"
+  url "https://github.com/sile-typesetter/sile/releases/download/v0.12.0/sile-0.12.0.tar.xz"
+  sha256 "c983a2b32d171ba392191eb29de2c3b433452d6cb514f270b17a7b3889fb6de6"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
[Upstream release](https://github.com/sile-typesetter/sile/releases/tag/v0.12.0)

No dependency changes since last release.

One new **optional** dependency, the new MATH typesetting package defaults to *Libertinus Serif*. Since Homebrew doesn't install even the current body text default *Gentium Plus*, I guess installing the optional math font is out of the cards. It is available in Homebrew Fonts if people are looking for it.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
