### PR TITLE
openssl@3 3.0.0 (new formula)

### DIFF
--- a/Aliases/openssl
+++ b/Aliases/openssl
@@ -1,1 +1,1 @@
-../Formula/openssl@1.1.rb
+../Formula/openssl@3.rb

--- a/Formula/openssl@3.rb
+++ b/Formula/openssl@3.rb
@@ -1,0 +1,189 @@
+class OpensslAT3 < Formula
+  desc "Cryptography and SSL/TLS Toolkit"
+  homepage "https://openssl.org/"
+  url "https://www.openssl.org/source/openssl-3.0.0.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-3.0.0.tar.gz"
+  sha256 "59eedfcb46c25214c9bd37ed6078297b4df01d012267fe9e9eee31f61bc70536"
+  license "Apache-2.0"
+
+  livecheck do
+    url "https://www.openssl.org/source/"
+    regex(/href=.*?openssl[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  keg_only :shadowed_by_macos, "macOS provides LibreSSL"
+
+  on_linux do
+    resource "cacert" do
+      # homepage "http://curl.haxx.se/docs/caextract.html"
+      url "https://curl.se/ca/cacert-2021-07-05.pem"
+      mirror "https://gist.githubusercontent.com/jonchang/b13c60cd50bdd91fd12a034ea53e39d5/raw/e1c430fd9ab59ed34212083537be0da974c26555/cacert-2021-07-05.pem"
+      sha256 "a3b534269c6974631db35f952e8d7c7dbf3d81ab329a232df575c2661de1214a"
+    end
+
+    resource "Test::Harness" do
+      url "https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.42.tar.gz"
+      sha256 "0fd90d4efea82d6e262e6933759e85d27cbcfa4091b14bf4042ae20bab528e53"
+    end
+
+    resource "Test::More" do
+      url "https://cpan.metacpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302186.tar.gz"
+      sha256 "2895c8da7c3fe632e5714c7cc548705202cdbf3afcbc0e929bc5e6a5172265d4"
+    end
+
+    resource "ExtUtils::MakeMaker" do
+      url "https://cpan.metacpan.org/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.62.tar.gz"
+      sha256 "5022ad857fd76bd3f6b16af099fe2324639d9932e08f21e891fb313d9cae1705"
+    end
+  end
+
+  # SSLv2 died with 1.1.0, so no-ssl2 no longer required.
+  # SSLv3 & zlib are off by default with 1.1.0 but this may not
+  # be obvious to everyone, so explicitly state it for now to
+  # help debug inevitable breakage.
+  def configure_args
+    args = %W[
+      --prefix=#{prefix}
+      --openssldir=#{openssldir}
+      --libdir=#{lib}
+      no-ssl3
+      no-ssl3-method
+      no-zlib
+    ]
+    on_linux do
+      args += (ENV.cflags || "").split
+      args += (ENV.cppflags || "").split
+      args += (ENV.ldflags || "").split
+      args << "enable-md2"
+    end
+    args
+  end
+
+  def install
+    if OS.linux?
+      ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+
+      %w[ExtUtils::MakeMaker Test::Harness Test::More].each do |r|
+        resource(r).stage do
+          system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+          system "make", "PERL5LIB=#{ENV["PERL5LIB"]}", "CC=#{ENV.cc}"
+          system "make", "install"
+        end
+      end
+    end
+
+    # This could interfere with how we expect OpenSSL to build.
+    ENV.delete("OPENSSL_LOCAL_CONFIG_DIR")
+
+    # This ensures where Homebrew's Perl is needed the Cellar path isn't
+    # hardcoded into OpenSSL's scripts, causing them to break every Perl update.
+    # Whilst our env points to opt_bin, by default OpenSSL resolves the symlink.
+    ENV["PERL"] = Formula["perl"].opt_bin/"perl" if which("perl") == Formula["perl"].opt_bin/"perl"
+
+    arch_args = []
+    if OS.mac?
+      arch_args += %W[darwin64-#{Hardware::CPU.arch}-cc enable-ec_nistp_64_gcc_128]
+    elsif Hardware::CPU.intel?
+      arch_args << (Hardware::CPU.is_64_bit? ? "linux-x86_64" : "linux-elf")
+    elsif Hardware::CPU.arm?
+      arch_args << (Hardware::CPU.is_64_bit? ? "linux-aarch64" : "linux-armv4")
+    end
+
+    openssldir.mkpath
+    system "perl", "./Configure", *(configure_args + arch_args)
+    system "make"
+    system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
+    system "make", "test"
+  end
+
+  def openssldir
+    etc/"openssl@3"
+  end
+
+  def post_install
+    if OS.mac?
+      macos_post_install
+    else
+      linux_post_install
+    end
+  end
+
+  def macos_post_install
+    ohai "Regenerating CA certificate bundle from keychain, this may take a while..."
+
+    keychains = %w[
+      /Library/Keychains/System.keychain
+      /System/Library/Keychains/SystemRootCertificates.keychain
+    ]
+
+    certs_list = `/usr/bin/security find-certificate -a -p #{keychains.join(" ")}`
+    certs = certs_list.scan(
+      /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m,
+    )
+
+    # Check that the certificate has not expired
+    valid_certs = certs.select do |cert|
+      IO.popen("#{bin}/openssl x509 -inform pem -checkend 0 -noout &>/dev/null", "w") do |openssl_io|
+        openssl_io.write(cert)
+        openssl_io.close_write
+      end
+
+      $CHILD_STATUS.success?
+    end
+
+    # Check that the certificate is trusted in keychain
+    trusted_certs = begin
+      tmpfile = Tempfile.new
+
+      valid_certs.select do |cert|
+        tmpfile.rewind
+        tmpfile.write cert
+        tmpfile.truncate cert.size
+        tmpfile.flush
+        IO.popen("/usr/bin/security verify-cert -l -L -R offline -c #{tmpfile.path} &>/dev/null")
+
+        $CHILD_STATUS.success?
+      end
+    ensure
+      tmpfile&.close!
+    end
+
+    openssldir.mkpath
+    (openssldir/"cert.pem").atomic_write(trusted_certs.join("\n") << "\n")
+  end
+
+  def linux_post_install
+    # Download and install cacert.pem from curl.haxx.se
+    cacert = resource("cacert")
+    cacert.fetch
+    rm_f openssldir/"cert.pem"
+    filename = Pathname.new(cacert.url).basename
+    openssldir.install cacert.files(filename => "cert.pem")
+  end
+
+  def caveats
+    <<~EOS
+      A CA file has been bootstrapped using certificates from the system
+      keychain. To add additional certificates, place .pem files in
+        #{openssldir}/certs
+
+      and run
+        #{opt_bin}/c_rehash
+    EOS
+  end
+
+  test do
+    # Make sure the necessary .cnf file exists, otherwise OpenSSL gets moody.
+    assert_predicate pkgetc/"openssl.cnf", :exist?,
+            "OpenSSL requires the .cnf file for some functionality"
+
+    # Check OpenSSL itself functions as expected.
+    (testpath/"testfile.txt").write("This is a test file")
+    expected_checksum = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0ff81339148249"
+    system bin/"openssl", "dgst", "-sha256", "-out", "checksum.txt", "testfile.txt"
+    open("checksum.txt") do |f|
+      checksum = f.read(100).split("=").last.strip
+      assert_equal checksum, expected_checksum
+    end
+  end
+end

--- a/audit_exceptions/provided_by_macos_depends_on_allowlist.json
+++ b/audit_exceptions/provided_by_macos_depends_on_allowlist.json
@@ -4,5 +4,6 @@
   "libressl",
   "llvm",
   "openblas",
-  "openssl@1.1"
+  "openssl@1.1",
+  "openssl@3"
 ]

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -20,6 +20,7 @@
   "lua@5.1",
   "numpy@1.16",
   "openssl@1.1",
+  "openssl@3",
   "pangomm@2.46",
   "pyqt@5",
   "python@3.9",

--- a/style_exceptions/make_check_allowlist.json
+++ b/style_exceptions/make_check_allowlist.json
@@ -14,6 +14,7 @@
   "nettle",
   "open-mpi",
   "openssl@1.1",
+  "openssl@3",
   "pcre",
   "protobuf",
   "wolfssl",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I've separated the commit adding `openssl@3` from #84822, and made minor modifications.

I haven't removed `openssl@1.1` because it's still supported until 11 September 2023. I think we can migrate formulae to this version of OpenSSL in separate PRs so we can ship this version to users who want to use it ASAP.