### PR TITLE
git-credential-libsecret 2.33.0 (new formula)

### DIFF
--- a/Formula/git-credential-libsecret.rb
+++ b/Formula/git-credential-libsecret.rb
@@ -1,0 +1,37 @@
+class GitCredentialLibsecret < Formula
+  desc "Git helper for accessing credentials via libsecret"
+  homepage "https://git-scm.com"
+  # NOTE: Please keep these values in sync with git.rb when updating.
+  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.33.0.tar.xz"
+  sha256 "bf3c6ab5f82e072aad4768f647cfb1ef60aece39855f83f080f9c0222dd20c4f"
+  license "GPL-2.0-or-later"
+  head "https://github.com/git/git.git", branch: "master"
+
+  livecheck do
+    formula "git"
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "libsecret"
+
+  def install
+    cd "contrib/credential/libsecret" do
+      system "make"
+      bin.install "git-credential-libsecret"
+    end
+  end
+
+  test do
+    input = <<~EOS
+      protocol=https
+      username=Homebrew
+      password=123
+    EOS
+    output = <<~EOS
+      username=Homebrew
+      password=123
+    EOS
+    assert_equal output, pipe_output("#{bin}/git-credential-libsecret get", input, 1)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
