### PR TITLE
gitwatch: extend `sleep` in `test`

### DIFF
--- a/Formula/gitwatch.rb
+++ b/Formula/gitwatch.rb
@@ -21,9 +21,9 @@ class Gitwatch < Formula
     repo = testpath/"repo"
     system "git", "init", repo
     pid = spawn "gitwatch", "-m", "Update", repo, pgroup: true
-    sleep 5
+    sleep 15
     touch repo/"file"
-    sleep 5
+    sleep 15
     begin
       assert_match "Update", shell_output("git -C #{repo} log -1")
     ensure


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes CI failure in #84157.