### PR TITLE
rfcmarkup 1.129

### DIFF
--- a/Formula/rfcmarkup.rb
+++ b/Formula/rfcmarkup.rb
@@ -1,8 +1,14 @@
 class Rfcmarkup < Formula
   desc "Add HTML markup and links to internet-drafts and RFCs"
   homepage "https://tools.ietf.org/tools/rfcmarkup/"
-  url "https://tools.ietf.org/tools/rfcmarkup/rfcmarkup-1.119.tgz"
-  sha256 "46c5522f3cba0d430019a60de0e995adbc12f055970b6b341f45181cf8deed8e"
+  url "https://tools.ietf.org/tools/rfcmarkup/rfcmarkup-1.129.tgz"
+  sha256 "369d1b1e6ed27930150b7b0e51a5fc4e068a8980c59924abc0ece10758c6cfd7"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url :homepage
+    regex(%r{>\s*Version:\s*</i>\s*v?(\d+(?:\.\d+)+)}im)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "7e74ed6e344dd26f4bb0674b13bf65b9333c29ac7f3552627578b98eb97be599"
@@ -14,6 +20,8 @@ class Rfcmarkup < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:    "a15f3c6be0c5eb4b38c4801c6151d4a12b2f206ab6e9c7f11dd0cd94ba7f9e9d"
     sha256 cellar: :any_skip_relocation, yosemite:      "5eaeed274aca3e64cbc2407a6b9b531efed736fec325d15109b308bdbea971b4"
   end
+
+  depends_on :macos # Due to Python 2
 
   def install
     bin.install "rfcmarkup"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `rfcmarkup` to the latest version, `1.129`.

This PR also adds a `livecheck` block that checks the `<i>Version:</i> 1.129` text on the homepage. This appears to be the only place where the version is referenced, as I couldn't find any links to the `stable` tarball (I simply updated the existing URL and checked to see that it resolved).

Additionally, this adds `license "GPL-2.0-or-later"`, as the `homepage` contains a "COPYRIGHT" section that uses the "or...later" language:

> Copyright 2002 Henrik Levkowetz
> 
> This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
> 
> This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MER‐ CHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
> 
> You should be able to retrieve a copy of the GNU General Public License from http://www.gnu.org/licenses/gpl.txt; if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA