### PR TITLE
cbmc: remove `cmake` compiler designation.

### DIFF
--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -29,8 +29,6 @@ class Cbmc < Formula
 
   def install
     args = []
-    # Workaround borrowed from https://github.com/diffblue/cbmc/issues/4956
-    args << "-DCMAKE_C_COMPILER=/usr/bin/clang" if OS.mac?
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -28,9 +28,7 @@ class Cbmc < Formula
   fails_with gcc: "5"
 
   def install
-    args = []
-
-    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 


### PR DESCRIPTION
We now have incorporated this as part of an upstream change to make
compilation on osX more straightforward, so this is now redundant.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
