### PR TITLE
aom: add dependencies to enable all aomenc --tune= values

### DIFF
--- a/Formula/aom.rb
+++ b/Formula/aom.rb
@@ -5,6 +5,7 @@ class Aom < Formula
       tag:      "v3.1.2",
       revision: "ae2be8030200925895fa6e98bd274ffdb595cbf6"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "cab48a0f87dce96cd34be83f306c76b1b12ffdc36924f66db4e5b23c7d02ed9b"
@@ -15,7 +16,10 @@ class Aom < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
   depends_on "yasm" => :build
+  depends_on "jpeg-xl"
+  depends_on "libvmaf"
 
   resource "bus_qcif_15fps.y4m" do
     url "https://media.xiph.org/video/derf/y4m/bus_qcif_15fps.y4m"
@@ -25,6 +29,8 @@ class Aom < Formula
   def install
     mkdir "macbuild" do
       args = std_cmake_args.concat(["-DCMAKE_INSTALL_RPATH=#{rpath}",
+                                    "-DCONFIG_TUNE_BUTTERAUGLI=1",
+                                    "-DCONFIG_TUNE_VMAF=1",
                                     "-DENABLE_DOCS=off",
                                     "-DENABLE_EXAMPLES=on",
                                     "-DENABLE_TESTDATA=off",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`aomenc` (part of `aom`) is a video encoder that supports the following values for `--tune` (visible in `--help` regardless of build configuration):

```
--tune=<arg> Distortion metric tuned with
               psnr, ssim, vmaf_with_preprocessing, vmaf_without_preprocessing, vmaf, vmaf_neg, butteraugli
```

But VMAF requires libvmaf, and Butteraugli requires libjxl from `jpeg-xl`. Either option is a much better metric than the built-in PSNR and SSIM, and using them should improve the visual quality of the output. To enable this, add those dependencies.