### PR TITLE
vespa-cli: update livecheck

### DIFF
--- a/Formula/vespa-cli.rb
+++ b/Formula/vespa-cli.rb
@@ -8,7 +8,8 @@ class VespaCli < Formula
 
   livecheck do
     url :stable
-    regex(/^vespa[._-](\d+(?:\.\d+)+)(?:-\d+)?$/i)
+    regex(%r{href=.*?/tag/\D*?(\d+(?:\.\d+)+)(?:-\d+)?["' >]}i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream has said that it's best to check the "Latest" release on GitHub for `vespa-cli` (see: https://github.com/Homebrew/homebrew-core/pull/85661#issuecomment-926089263), as tags are created 2-4 times a week for new versions of Vespa and these don't necessarily include changes to `vespa-cli`. GitHub releases have attached `vespa-cli` artifacts, so this makes sense and will avoid unnecessary version bumps.

This PR updates the existing `livecheck` block to use the `GithubLatest` strategy, as it's the correct approach here. Vespa is also switching from a tag format like `vespa-7.469.18-1` to `v7.469.18`, so I created a regex that will match both formats (and optionally omit any trailing `-1`).