### PR TITLE
libzip: fix dependencies

### DIFF
--- a/Formula/libzip.rb
+++ b/Formula/libzip.rb
@@ -4,6 +4,7 @@ class Libzip < Formula
   url "https://libzip.org/download/libzip-1.8.0.tar.xz"
   sha256 "f0763bda24ba947e80430be787c4b068d8b6aa6027a26a19923f0acfa3dac97e"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url "https://libzip.org/download/"
@@ -19,18 +20,30 @@ class Libzip < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "zstd"
 
   uses_from_macos "zip" => :test
   uses_from_macos "bzip2"
-  uses_from_macos "openssl"
   uses_from_macos "xz"
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "openssl@1.1"
+  end
 
   conflicts_with "libtcod", "minizip-ng",
     because: "libtcod, libzip and minizip-ng install a `zip.h` header"
 
   def install
-    system "cmake", ".", *std_cmake_args
+    crypto_args = %w[
+      -DENABLE_GNUTLS=OFF
+      -DENABLE_MBEDTLS=OFF
+    ]
+    crypto_args << "-DENABLE_OPENSSL=OFF" if OS.mac? # Use CommonCrypto instead.
+    system "cmake", ".", *std_cmake_args,
+                         *crypto_args,
+                         "-DBUILD_REGRESS=OFF",
+                         "-DBUILD_EXAMPLES=OFF"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

* libzip does not use OpenSSL on macOS - it uses CommonCrypto.
* Fix the usage of OpenSSL 3 instead of 1.1 (the whole dep tree needs to move at the same time).
* Supply crypto flags so that we don't opportunistically link to an SSL library we don't want.
* Enable zstd support.
* Don't waste time building examples and regression testing.
