### PR TITLE
git: fix OpenSSL dependency

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -25,11 +25,11 @@ class Git < Formula
 
   uses_from_macos "curl"
   uses_from_macos "expat"
-  uses_from_macos "openssl"
   uses_from_macos "zlib"
 
   on_linux do
     depends_on "linux-headers@4.4"
+    depends_on "openssl@1.1" # Uses CommonCrypto on macOS
   end
 
   resource "html" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Git does not use OpenSSL from macOS.

Fixes incorrect usage of OpenSSL 3 as a dependency - the bottles are built with OpenSSL 1.1 (and hence why we don't to ship need new bottles).