### PR TITLE
drill, duckscript, grin-wallet, ncspot, oha, trunk, volta: fix OpenSSL dependency

### DIFF
--- a/Formula/drill.rb
+++ b/Formula/drill.rb
@@ -15,12 +15,15 @@ class Drill < Formula
   end
 
   depends_on "rust" => :build
-  uses_from_macos "openssl"
+
+  on_linux do
+    depends_on "openssl@1.1" # Uses Secure Transport on macOS
+  end
 
   conflicts_with "ldns", because: "both install a `drill` binary"
 
   def install
-    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix if OS.linux?
     system "cargo", "install", *std_cargo_args
   end
 

--- a/Formula/duckscript.rb
+++ b/Formula/duckscript.rb
@@ -16,10 +16,9 @@ class Duckscript < Formula
 
   depends_on "rust" => :build
 
-  uses_from_macos "openssl"
-
   on_linux do
     depends_on "pkg-config" => :build
+    depends_on "openssl@1.1" # Uses Secure Transport on macOS
   end
 
   def install

--- a/Formula/grin-wallet.rb
+++ b/Formula/grin-wallet.rb
@@ -15,10 +15,10 @@ class GrinWallet < Formula
   depends_on "rust" => :build
 
   uses_from_macos "llvm" => :build # for libclang
-  uses_from_macos "openssl"
 
   on_linux do
     depends_on "pkg-config" => :build
+    depends_on "openssl@1.1" # Uses Secure Transport on macOS
   end
 
   # Fix build on Rust 1.53.0+. Remove in the next release.

--- a/Formula/ncspot.rb
+++ b/Formula/ncspot.rb
@@ -18,13 +18,13 @@ class Ncspot < Formula
   depends_on "portaudio"
 
   uses_from_macos "ncurses"
-  uses_from_macos "openssl"
 
   on_linux do
     depends_on "pkg-config" => :build
     depends_on "alsa-lib"
     depends_on "dbus"
     depends_on "libxcb"
+    depends_on "openssl@1.1" # Uses Secure Transport on macOS
   end
 
   def install

--- a/Formula/oha.rb
+++ b/Formula/oha.rb
@@ -16,10 +16,9 @@ class Oha < Formula
 
   depends_on "rust" => :build
 
-  uses_from_macos "openssl"
-
   on_linux do
     depends_on "pkg-config" => :build
+    depends_on "openssl@1.1" # Uses Secure Transport on macOS
   end
 
   def install

--- a/Formula/trunk.rb
+++ b/Formula/trunk.rb
@@ -16,7 +16,6 @@ class Trunk < Formula
 
   depends_on "rust" => :build
 
-  uses_from_macos "openssl"
   uses_from_macos "zlib"
 
   on_linux do

--- a/Formula/volta.rb
+++ b/Formula/volta.rb
@@ -21,10 +21,9 @@ class Volta < Formula
 
   depends_on "rust" => :build
 
-  uses_from_macos "openssl"
-
   on_linux do
     depends_on "pkg-config" => :build
+    depends_on "openssl@1.1" # Uses Secure Transport on macOS
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

None of these use OpenSSL from macOS.

The link between them is that while they do have the `openssl-sys` crate in their Cargo lockfile, this is only via the `native-tls` crate which does not use `openssl-sys` on macOS - it uses Security.framework instead. See https://github.com/sfackler/rust-native-tls/blob/v0.2.8/Cargo.toml.

Trunk doesn't even use `openssl-sys` at all anymore from what I can see.

This PR fixes an issue where these pulled in OpenSSL 3 when they were actually built with OpenSSL 1.1.

All the existing bottles were from before the OpenSSL 3 update so they should be ok.
