### PR TITLE
mosh: fix OpenSSL dependency

### DIFF
--- a/Formula/mosh.rb
+++ b/Formula/mosh.rb
@@ -42,12 +42,14 @@ class Mosh < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl"
   depends_on "protobuf"
 
   uses_from_macos "ncurses"
-  uses_from_macos "openssl"
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "openssl@1.1" # Uses CommonCrypto on macOS
+  end
 
   def install
     ENV.cxx11


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This does not use OpenSSL from macOS - it uses CommonCrypto.

Fixes an issue where OpenSSL 3 was used when it should have been OpenSSL 1.1.

The existing bottles use OpenSSL 1.1 so new bottles shouldn't be needed for this change alone.