### PR TITLE
pnpm: Do not mangle /usr/local/bin or /opt/homebrew/bin (Homebrew's prefix bin)

### DIFF
--- a/Formula/pnpm.rb
+++ b/Formula/pnpm.rb
@@ -23,7 +23,7 @@ class Pnpm < Formula
   depends_on "node"
 
   def install
-    npmrc = if OS.mac? ? "global-bin-dir = ${HOME}/Library/pnpm\n" : "global-bin-dir = ${HOME}/.local/pnpm\n"
+    npmrc = OS.mac? ? "global-bin-dir = ${HOME}/Library/pnpm\n" : "global-bin-dir = ${HOME}/.local/pnpm\n"
     (prefix/"etc/npmrc").write npmrc
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]

--- a/Formula/pnpm.rb
+++ b/Formula/pnpm.rb
@@ -45,7 +45,6 @@ class Pnpm < Formula
   end
 
   test do
-    pnpm_path = nil
     pnpm_path = OS.mac? ? testpath/"Library/pnpm" : testpath/".local/pnpm"
     pnpm_path.mkpath
     ENV.prepend_path "PATH", pnpm_path

--- a/Formula/pnpm.rb
+++ b/Formula/pnpm.rb
@@ -23,9 +23,8 @@ class Pnpm < Formula
   depends_on "node"
 
   def install
-    (prefix/"etc").mkpath
-    (prefix/"etc/npmrc").atomic_write "global-bin-dir = ${HOME}/Library/pnpm\n" if OS.mac?
-    (prefix/"etc/npmrc").atomic_write "global-bin-dir = ${HOME}/.local/pnpm\n" if OS.linux?
+    npmrc = if OS.mac? ? "global-bin-dir = ${HOME}/Library/pnpm\n" : "global-bin-dir = ${HOME}/.local/pnpm\n"
+    (prefix/"etc/npmrc").write npmrc
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
@@ -47,9 +46,7 @@ class Pnpm < Formula
 
   test do
     pnpm_path = nil
-    pnpm_path = testpath/"Library/pnpm" if OS.mac?
-    pnpm_path = testpath/".local/pnpm" if OS.linux?
-    assert !pnpm_path.nil?, "cannot determine os"
+    pnpm_path = OS.mac? ? testpath/"Library/pnpm" : testpath/".local/pnpm"
     pnpm_path.mkpath
     ENV.prepend_path "PATH", pnpm_path
     system "#{bin}/pnpm", "env", "use", "--global", "16"


### PR DESCRIPTION
This is a sub PR of #82892.

With this config, pnpm will install global package's executables into ~/Library/pnpm (macOS) or ~/.local/pnpm (Linux) by default.
This config allows pnpm to provide the command `pnpm env use --global 16` safely with Homebrew.
Refer to https://github.com/pnpm/pnpm/pull/3762.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
