### PR TITLE
ola: fix python installation and update license

### DIFF
--- a/Formula/ola.rb
+++ b/Formula/ola.rb
@@ -3,8 +3,8 @@ class Ola < Formula
   homepage "https://www.openlighting.org/ola/"
   url "https://github.com/OpenLightingProject/ola/releases/download/0.10.8/ola-0.10.8.tar.gz"
   sha256 "102aa3114562a2a71dbf7f77d2a0fb9fc47acc35d6248a70b6e831365ca71b13"
-  license "GPL-2.0"
-  revision 2
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
+  revision 3
   head "https://github.com/OpenLightingProject/ola.git", branch: "master"
 
   bottle do
@@ -31,10 +31,6 @@ class Ola < Formula
   end
 
   def install
-    xy = Language::Python.major_minor_version Formula["python@3.9"].bin/"python3"
-    protobuf_pth = Formula["protobuf@3.6"].opt_lib/"python#{xy}/site-packages/homebrew-protobuf.pth"
-    (buildpath/".brew_home/Library/Python/#{xy}/lib/python/site-packages").install_symlink protobuf_pth
-
     args = %W[
       --disable-fatal-warnings
       --disable-dependency-tracking
@@ -43,9 +39,11 @@ class Ola < Formula
       --disable-unittests
       --enable-python-libs
       --enable-rdm-tests
+      --with-python_prefix=#{prefix}
+      --with-python_exec_prefix=#{prefix}
     ]
 
-    ENV["PYTHON"] = Formula["python@3.9"].bin/"python3"
+    ENV["PYTHON"] = "python3"
     system "autoreconf", "-fvi"
     system "./configure", *args
     system "make", "install"
@@ -53,5 +51,6 @@ class Ola < Formula
 
   test do
     system bin/"ola_plugin_info"
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "from ola.ClientWrapper import ClientWrapper"
   end
 end

--- a/Formula/ola.rb
+++ b/Formula/ola.rb
@@ -50,7 +50,7 @@ class Ola < Formula
   end
 
   test do
-    system bin/"ola_plugin_info"
+    system bin/"ola_plugin_state", "-h"
     system Formula["python@3.9"].opt_bin/"python3", "-c", "from ola.ClientWrapper import ClientWrapper"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`ola` was failing to build on master with this error (spotted in https://github.com/Homebrew/homebrew-core/pull/85282):
```
mkdir: /usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/ola: Operation not permitted
```

Pointing to Python `opt_lib` instead of `lib` and using the version of `protobuf` matching the dependency seems to do the trick. I added a test for the Python plugin to be sure I didn't break anything.

I also updated the license to match the [upstream license](https://github.com/OpenLightingProject/ola/blob/master/LICENCE).
