### PR TITLE
libgpg-error: update configure/libtool.m4 to support macOS >= 11.x

### DIFF
--- a/Formula/libgpg-error.rb
+++ b/Formula/libgpg-error.rb
@@ -4,6 +4,7 @@ class LibgpgError < Formula
   url "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.42.tar.bz2"
   sha256 "fc07e70f6c615f8c4f590a8e37a9b8dd2e2ca1e9408f8e60459c67452b925e23"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libgpg-error/"
@@ -17,6 +18,22 @@ class LibgpgError < Formula
     sha256 mojave:        "ef3446809a6b3d9da0f5d4a45b9d2c21a7bf4549d14cc785843f4f969f13ea39"
     sha256 x86_64_linux:  "b862b10316313dabc9ddc7774e37c41c0700b886d361b86a1485052287b73fd0"
   end
+
+  # libgpg-error's libtool.m4 doesn't properly support macOS >= 11.x (see
+  # libtool.rb formula). This causes the library to be linked with a flat
+  # namespace which might cause issues when dynamically loading the library with
+  # dlopen under some modes, see:
+  #
+  #  https://lists.gnupg.org/pipermail/gcrypt-devel/2021-September/005176.html
+  #
+  # We patch `configure` directly so we don't need additional build dependencies
+  # (e.g. autoconf, automake, libtool)
+  #
+  # This patch has been applied upstream so it can be removed in the next
+  # release.
+  #
+  # https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git;a=commit;h=a3987e44970505a5540f9702c1e41292c22b69cf
+  patch :DATA
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -33,3 +50,28 @@ class LibgpgError < Formula
     system "#{bin}/gpg-error-config", "--libs"
   end
 end
+
+__END__
+--- libgpg-error-1.42/configure.orig	2021-09-26 09:39:54.000000000 -0700
++++ libgpg-error-1.42/configure	2021-09-26 09:40:56.000000000 -0700
+@@ -8427,16 +8427,11 @@
+       _lt_dar_allow_undefined='${wl}-undefined ${wl}suppress' ;;
+     darwin1.*)
+       _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
+-    darwin*) # darwin 5.x on
+-      # if running on 10.5 or later, the deployment target defaults
+-      # to the OS version, if on x86, and 10.4, the deployment
+-      # target defaults to 10.4. Don't you love it?
+-      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+-	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
+-	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
+-	10.[012]*)
++    darwin*)
++      case ${MACOSX_DEPLOYMENT_TARGET},$host in
++        10.[012],*|,*powerpc*)
+ 	  _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
+-	10.*)
++	*)
+ 	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;


### PR DESCRIPTION
libgpg-error's libtool.m4 doesn't properly support macOS >= 11.x (see libtool.rb formula). This causes the library to be linked with a flat namespace which might cause issues when dynamically loading the library with dlopen under some modes, see:

  https://lists.gnupg.org/pipermail/gcrypt-devel/2021-September/005176.html

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
