### PR TITLE
libgcrypt: update configure/libtool.m4 to support macOS >= 11.x

### DIFF
--- a/Formula/libgcrypt.rb
+++ b/Formula/libgcrypt.rb
@@ -4,6 +4,7 @@ class Libgcrypt < Formula
   url "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.9.4.tar.bz2"
   sha256 "ea849c83a72454e3ed4267697e8ca03390aee972ab421e7df69dfe42b65caaf7"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libgcrypt/"
@@ -19,6 +20,22 @@ class Libgcrypt < Formula
   end
 
   depends_on "libgpg-error"
+
+  # libgcrypt's libtool.m4 doesn't properly support macOS >= 11.x (see
+  # libtool.rb formula). This causes the library to be linked with a flat
+  # namespace which might cause issues when dynamically loading the library with
+  # dlopen under some modes, see:
+  #
+  #  https://lists.gnupg.org/pipermail/gcrypt-devel/2021-September/005176.html
+  #
+  # We patch `configure` directly so we don't need additional build dependencies
+  # (e.g. autoconf, automake, libtool)
+  #
+  # This patch has been applied upstream so it can be removed in the next
+  # release.
+  #
+  # https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgcrypt.git;a=commit;h=c9cebf3d1824d6ec90fd864a744bb81c97ac7d31
+  patch :DATA
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -48,3 +65,28 @@ class Libgcrypt < Formula
     assert_match "0e824ce7c056c82ba63cc40cffa60d3195b5bb5feccc999a47724cc19211aef6", output
   end
 end
+
+__END__
+--- libgcrypt-1.9.4/configure.orig	2021-09-26 09:29:50.000000000 -0700
++++ libgcrypt-1.9.4/configure	2021-09-26 09:30:54.000000000 -0700
+@@ -8378,16 +8378,11 @@
+       _lt_dar_allow_undefined='${wl}-undefined ${wl}suppress' ;;
+     darwin1.*)
+       _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
+-    darwin*) # darwin 5.x on
+-      # if running on 10.5 or later, the deployment target defaults
+-      # to the OS version, if on x86, and 10.4, the deployment
+-      # target defaults to 10.4. Don't you love it?
+-      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+-	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
+-	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
+-	10.[012]*)
++    darwin*)
++      case ${MACOSX_DEPLOYMENT_TARGET},$host in
++        10.[[012]],*|,*powerpc*)
+ 	  _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
+-	10.*)
++	*)
+ 	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;


### PR DESCRIPTION
libgcrypt's libtool.m4 doesn't properly support macOS >= 11.x (see libtool.rb formula). This causes the library to be linked with a flat namespace which might cause issues when dynamically loading the library with dlopen under some modes, see:

  https://lists.gnupg.org/pipermail/gcrypt-devel/2021-September/005176.html

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
