### PR TITLE
Podman: Fix docs make target

### DIFF
--- a/Formula/podman.rb
+++ b/Formula/podman.rb
@@ -42,7 +42,12 @@ class Podman < Formula
       bin.install "bin/gvproxy"
     end
 
-    system "make", "install-podman-remote-#{os}-docs"
+    if build.head?
+      system "make", "podman-remote-#{os}-docs"
+    else
+      system "make", "install-podman-remote-#{os}-docs"
+    end
+
     man1.install Dir["docs/build/remote/#{os}/*.1"]
 
     bash_completion.install "completions/bash/podman"


### PR DESCRIPTION
Fix the make target for podman-remote docs. It has changed from `install-podman-remote-#{os}-docs` to `podman-remote-#{os}-docs`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
