### PR TITLE
classads: add livecheck

### DIFF
--- a/Formula/classads.rb
+++ b/Formula/classads.rb
@@ -4,6 +4,11 @@ class Classads < Formula
   url "https://ftp.cs.wisc.edu/condor/classad/c++/classads-1.0.10.tar.gz"
   sha256 "cde2fe23962abb6bc99d8fc5a5cbf88f87e449b63c6bca991d783afb4691efb3"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?classads[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any,                 big_sur:      "dcc6e15e209b41868d0e328ca0d65aac6416c923b494f53f1259ed97b64f4b33"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `classads`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.