### PR TITLE
go@1.15: deprecate

### DIFF
--- a/Formula/go@1.15.rb
+++ b/Formula/go@1.15.rb
@@ -6,11 +6,6 @@ class GoAT115 < Formula
   sha256 "0662ae3813330280d5f1a97a2ee23bbdbe3a5a7cfa6001b24a9873a19a0dc7ec"
   license "BSD-3-Clause"
 
-  livecheck do
-    url "https://golang.org/dl/"
-    regex(/href=.*?go[._-]?v?(1\.15(?:\.\d+)*)[._-]src\.t/i)
-  end
-
   bottle do
     sha256 big_sur:      "964306dbdbee74e9a1cf731e20132e49ad7827dd6baeaf75382337c854e15cd2"
     sha256 catalina:     "9ef40146c7742f26d93e612f7bef94dc4bfcde58d962f1fd2ec1fe441c12a09b"
@@ -19,6 +14,8 @@ class GoAT115 < Formula
   end
 
   keg_only :versioned_formula
+
+  deprecate! date: "2021-08-16", because: :unsupported
 
   depends_on arch: :x86_64
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Per the [Go release policy](https://golang.org/doc/devel/release#policy), "Each major Go release is supported until there are two newer major releases." With the release of Go 1.17 on 2021-08-16, 1.15 is unsupported.

This PR deprecates the `go@1.15` formula and removes the `livecheck` block accordingly (so it will be automatically skipped as deprecated).