### PR TITLE
Adds headers required for erlang / elixir

### DIFF
--- a/Formula/wxwidgets.rb
+++ b/Formula/wxwidgets.rb
@@ -33,6 +33,7 @@ class Wxwidgets < Formula
   def install
     args = [
       "--prefix=#{prefix}",
+      "--enable-compat28",
       "--enable-clipboard",
       "--enable-controls",
       "--enable-dataviewctrl",


### PR DESCRIPTION
Without the 28 compat flag elixir/erlang could not be compiled (via asdf/kerl) and the wx based gui supervisor tool would not run if wx support was removed during compilation

`brew audit --strict` returns an unrelated warning (wrong license, which is wrong now and I did not change that bit, if this PR passes I will attempt to fix that in a followup PR)

See
* https://erlang.org/doc/installation_guide/INSTALL.html#Advanced-configuration-and-build-of-ErlangOTP_Building_Building-with-wxErlang
* https://elixirforum.com/t/observer-start-crashes-erlang-vm/36875/18
* https://stackoverflow.com/questions/67576487/fix-the-erlang-observer-on-osx-with-dark-mode
* https://github.com/asdf-vm/asdf-erlang/issues/95
* https://github.com/asdf-vm/asdf-erlang/issues/203

* * * 

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
