### PR TITLE
wget2 2.0.0 (new formula)

### DIFF
--- a/Formula/wget2.rb
+++ b/Formula/wget2.rb
@@ -33,6 +33,9 @@ class Wget2 < Formula
   depends_on "xz"
   depends_on "zstd"
 
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
   def install
     # bootstrap only for git repo
     if build.head?
@@ -56,6 +59,8 @@ class Wget2 < Formula
                           "--without-libmicrohttpd"
     if build.head?
       system "make"
+    elsif os.linux?
+      system "make", "LIBS+=-lgpgme"
     else
       system "make", "LIBS+=-framework CoreFoundation"
     end

--- a/Formula/wget2.rb
+++ b/Formula/wget2.rb
@@ -57,10 +57,8 @@ class Wget2 < Formula
                           "--without-libpcre",
                           "--without-libpcre2",
                           "--without-libmicrohttpd"
-    if build.head?
+    if build.head? || !OS.mac?
       system "make"
-    elsif OS.linux?
-      system "make", "LIBS+=-lgpgme"
     else
       system "make", "LIBS+=-framework CoreFoundation"
     end

--- a/Formula/wget2.rb
+++ b/Formula/wget2.rb
@@ -1,0 +1,67 @@
+class Wget2 < Formula
+  desc "Multithreaded metalink/file/website downloader"
+  homepage "https://gitlab.com/gnuwget/wget2/"
+  url "https://ftp.gnu.org/gnu/wget/wget2-2.0.0.tar.gz"
+  sha256 "4fe2fba0abb653ecc1cc180bea7f04212c17e8fe05c85aaac8baeac4cd241544"
+  license "GPL-3.0-or-later"
+
+  # NOTE: no optional or recommended
+  head do
+    url "https://gitlab.com/gnuwget/wget2.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+    depends_on "lzip" => :build
+  end
+
+  # Question: which are required for running and which are build-only?
+  # python, tar, texinfo, libz, libiconv, flex are provided by macOS, not writting requirements for Linux now
+  # what compress do we need?
+  # disable PCRE/PCRE2 since wget did that
+  depends_on "brotli" => :build
+  depends_on "gettext" => :build
+  depends_on "gnutls" => :build # libgnutls
+  depends_on "gpgme" => :build # automatic signature verification
+  depends_on "libidn2" => :build
+  depends_on "libpsl" => :build
+  depends_on "nettle" => :build
+  depends_on "nghttp2" => :build # HTTP/2 support
+  depends_on "pkg-config" => :build # this is just recommended, but Wget use it, so listed
+  depends_on "rsync" => :build
+  depends_on "xz" => :build
+  depends_on "zstd" => :build
+
+  def install
+    # bootstrap only for git repo
+    if build.head?
+      system "./bootstrap", "--skip-po"
+      # else
+      # linker error if we do not manually link CoreFoundation.framework or libgcrypt
+      # this should work, but it didn't. We have to pass to make on command-line
+      # ENV["LIBS"] = "-framework CoreFoundation"
+    end
+
+    # should we disable libidn, libpsl, or specify ssl to use openssl here?
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--disable-doc",
+                          "--without-included-regex",
+                          "--without-libhsts",
+                          "--without-libidn",
+                          "--without-libpcre",
+                          "--without-libpcre2",
+                          "--without-libmicrohttpd"
+    if build.head?
+      system "make"
+    else
+      system "make", "LIBS+=-framework CoreFoundation"
+    end
+    system "make", "install"
+  end
+
+  test do
+    system bin/"wget2", "-O", "/dev/null", "https://www.example.org/"
+  end
+end

--- a/Formula/wget2.rb
+++ b/Formula/wget2.rb
@@ -3,7 +3,7 @@ class Wget2 < Formula
   homepage "https://gitlab.com/gnuwget/wget2/"
   url "https://ftp.gnu.org/gnu/wget/wget2-2.0.0.tar.gz"
   sha256 "4fe2fba0abb653ecc1cc180bea7f04212c17e8fe05c85aaac8baeac4cd241544"
-  license "GPL-3.0-or-later"
+  license all_of: ["GPL-3.0-or-later", "LGPL-3.0-or-later"]
 
   # NOTE: no optional or recommended
   head do
@@ -12,25 +12,26 @@ class Wget2 < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
-    depends_on "lzip" => :build
   end
 
   # Question: which are required for running and which are build-only?
   # python, tar, texinfo, libz, libiconv, flex are provided by macOS, not writting requirements for Linux now
   # what compress do we need?
   # disable PCRE/PCRE2 since wget did that
-  depends_on "brotli" => :build
+  depends_on "pkg-config" => :build # this is just recommended, but Wget use it, so listed
+  depends_on "rsync" => :build
+
+  depends_on "brotli"
   depends_on "gettext"
   depends_on "gnutls" # libgnutls
   depends_on "gpgme" # automatic signature verification
   depends_on "libidn2"
   depends_on "libpsl"
-  depends_on "nettle" => :build
+  depends_on "lzip"
+  depends_on "nettle"
   depends_on "nghttp2" # HTTP/2 support
-  depends_on "pkg-config" => :build # this is just recommended, but Wget use it, so listed
-  depends_on "rsync" => :build
-  depends_on "xz" => :build
-  depends_on "zstd" => :build
+  depends_on "xz"
+  depends_on "zstd"
 
   def install
     # bootstrap only for git repo

--- a/Formula/wget2.rb
+++ b/Formula/wget2.rb
@@ -59,7 +59,7 @@ class Wget2 < Formula
                           "--without-libmicrohttpd"
     if build.head?
       system "make"
-    elsif os.linux?
+    elsif OS.linux?
       system "make", "LIBS+=-lgpgme"
     else
       system "make", "LIBS+=-framework CoreFoundation"

--- a/Formula/wget2.rb
+++ b/Formula/wget2.rb
@@ -47,8 +47,7 @@ class Wget2 < Formula
     end
 
     # should we disable libidn, libpsl, or specify ssl to use openssl here?
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-dependency-tracking",
+    system "./configure", *std_configure_args,
                           "--disable-silent-rules",
                           "--disable-doc",
                           "--without-included-regex",
@@ -57,11 +56,7 @@ class Wget2 < Formula
                           "--without-libpcre",
                           "--without-libpcre2",
                           "--without-libmicrohttpd"
-    if build.head? || !OS.mac?
-      system "make"
-    else
-      system "make", "LIBS+=-framework CoreFoundation"
-    end
+    system "make"
     system "make", "install"
   end
 

--- a/Formula/wget2.rb
+++ b/Formula/wget2.rb
@@ -20,13 +20,13 @@ class Wget2 < Formula
   # what compress do we need?
   # disable PCRE/PCRE2 since wget did that
   depends_on "brotli" => :build
-  depends_on "gettext" => :build
-  depends_on "gnutls" => :build # libgnutls
-  depends_on "gpgme" => :build # automatic signature verification
-  depends_on "libidn2" => :build
-  depends_on "libpsl" => :build
+  depends_on "gettext"
+  depends_on "gnutls" # libgnutls
+  depends_on "gpgme" # automatic signature verification
+  depends_on "libidn2"
+  depends_on "libpsl"
   depends_on "nettle" => :build
-  depends_on "nghttp2" => :build # HTTP/2 support
+  depends_on "nghttp2" # HTTP/2 support
   depends_on "pkg-config" => :build # this is just recommended, but Wget use it, so listed
   depends_on "rsync" => :build
   depends_on "xz" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
GNU Wget2 is the successor of GNU Wget, a file and recursive website downloader.

Designed and written from scratch it wraps around libwget, that provides the basic functions needed by a web client.

Wget2 works multi-threaded and uses many features to allow fast operation.

In many cases Wget2 downloads much faster than Wget1.x due to HTTP zlib compression, parallel connections and use of If-Modified-Since HTTP header.

This PR proposed to add a new formula `wget2`, which is a successor of the original `wget` formula. There exists a predecessor PR [#36855](https://github.com/Homebrew/homebrew-core/pull/36855), and since then the `wget2` development had resumed after two years of inactive, and have recently released the first stable version 2.0.0 (see [News](https://gitlab.com/gnuwget/wget2/-/blob/master/NEWS)). Therefore this PR retried the effort to add the formula.

### Why `wget2` instead of `wget@2` or updating exist `wget` formula?
The original `wget` development had not stopped, and the two projects are parallel so that `wget2` is not aimed to fully replace the original `wget` 1.x. Also, this seems to be more appropriate for a new formula instead of a versioned one.

### Caveats
There are a lot of requirements listed in their [README](https://gitlab.com/gnuwget/wget2), and many of them are optional or recommended. Since Homebrew does not add `:recommended` or `:optional` requirements anymore, the `depends_on` clauses are written to reduce those requirements as much as possible.

### Issues
1. I don't know what requirements are required for running... currently all the requirements are marked `:build`.
2. What optional features should we allow? The original requirements stated the following:
```
python (recommended for faster bootstrap)
pkg-config >= 0.28 (recommended)
doxygen (for creating the documentation)
pandoc (for creating the wget2 man page)
liblzma >= 5.1.1alpha (optional, if you want HTTP lzma decompression)
libbz2 >= 1.0.6 (optional, if you want HTTP bzip2 decompression)
libbrotlidec/libbrotli >= 1.0.0 (optional, if you want HTTP brotli decompression)
libzstd >= 1.3.0 (optional, if you want HTTP zstd decompression
libnghttp2 >= 1.3.0 (optional, if you want HTTP/2 support)
libmicrohttpd >= 0.9.51 (optional, if you want to run the test suite)
lzip (optional, if you want to build distribution tarballs)
lcov (optional, for coverage reports)
libgpgme >= 0.4.2 (optional, for automatic signature verification)
libpcre | libpcre2 (optional, for filtering by PCRE|PCRE2 regex)
libhsts (optional, to support HSTS preload lists)
libwolfssl (optional, to support WolfSSL instead of GnuTLS)
```

Following the steps of [#36855](https://github.com/Homebrew/homebrew-core/pull/36855), I wrote that HTTP/2 support (`libnghttp2`) and signature (`libgpgme`) seems natural to be supported by default. However I'm not sure about others.

Some information:
- Original `wget` disables PCRE/PCRE2 (`libpcre`, `libpcre2`) and `libpsl` support, and specify `openssl@1.1` as SSL provider ([here](https://github.com/Homebrew/homebrew-core/blob/master/Formula/wget.rb)). (Should we specify SSL too or leave it to default as `gnutls`)?
- I included all the compression options (LZMA in `xz`, `zstd`, `brotli`, and macOS-provided `zlib`), but they can be disabled with `--without-xxx` arguments too.
- `pkg-config` is only recommended, but original `wget` used it so I listed it here.

### Document and manpages
A weird issue will arise if we generate documents (by remove `--disable-doc` and add `pandoc`, `doxygen` and `graphviz` as requirements):
```
sed: 1: "/# Wget2/,/^#/{/^# </!d}": extra characters at the end of d command
fatal: not a git repository (or any of the parent directories): .git
pandoc -s -f markdown -t texinfo -o ./wget2.texi ./wget2.md
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
/bin/sh '/private/tmp/wget2-20210927-86386-1ma64mm/wget2-2.0.0/build-aux/missing' makeinfo --force -o ./wget2.info ./wget2.texi
./wget2.texi:3: warning: unrecognized encoding name `UTF-8'.
fatal: not a git repository (or any of the parent directories): .git
```
I do not understand why this will happen, so the documentation and manpages are just disabled. Help on the issue is really appreciated.

### `CoreFoundation.framework`
Interestingly, only when directly build with distributed tarballs (instead of cloning repo), if we do not specify `-framework CoreFoundation` in `LIBS`, there will be link errors. Building with `--HEAD` do not need such settings. Also setting `ENV["LIBS"]` does not work either, and it must be passed using command-line argument to `make`. I have create issue about this on the upstream, and they haven't responded yet.

### Feature list
For reference. The output of `./configure --help` contains the following:
```
Optional Features:
  --disable-option-checking  ignore unrecognized --enable/--with options
  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
  --enable-silent-rules   less verbose build output (undo: "make V=1")
  --disable-silent-rules  verbose build output (undo: "make V=0")
  --enable-dependency-tracking
                          do not reject slow dependency extractors
  --disable-dependency-tracking
                          speeds up one-time build
  --disable-largefile     omit support for large files
  --enable-threads={isoc|posix|isoc+posix|windows}
                          specify multithreading API
  --disable-threads       build without multithread safety
  --enable-cross-guesses={conservative|risky}
                          specify policy for cross-compilation guesses
  --disable-rpath         do not hardcode runtime library paths
  --enable-code-coverage  Whether to enable code coverage support
  --enable-shared[=PKGS]  build shared libraries [default=yes]
  --enable-static[=PKGS]  build static libraries [default=yes]
  --enable-fast-install[=PKGS]
                          optimize for fast installation [default=yes]
  --disable-libtool-lock  avoid locking (might break parallel builds)
  --enable-manywarnings   Turn on extra compiler warnings (for developers)
  --disable-manylibs      Generate small libraries of libwget functionality
                          groups
  --enable-fuzzing        Turn on fuzzing build (for developers)
  --enable-fsanitize-ubsan
                          Turn on Undefined Behavior Sanitizer (for
                          developers)
  --enable-fsanitize-asan Turn on Address Sanitizer (for developers) (mutually
                          exclusive with Memory/Thread sanitizer or Valgrind
                          tests)
  --enable-fsanitize-msan Turn on Memory Sanitizer (for developers) (mutually
                          exclusive with Address/Thread sanitizer or Valgrind
                          tests)
  --enable-fsanitize-tsan Turn on Thread Sanitizer (for developers) (mutually
                          exclusive with Address/Memory sanitizer or Valgrind
                          tests)
  --enable-assert         Enable assertions in code (for developers)
  --disable-xattr         disable support for POSIX Extended Attributes
  --disable-nls           do not use Native Language Support
  --disable-doc           don t generate any documentation
  --enable-valgrind-tests enable using Valgrind for tests (mutually exclusive
                          with Address/Memory/Thread sanitizer)

Optional Packages:
  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
  --with-linux-crypto     use Linux kernel cryptographic API (if available)
  --with-openssl          use libcrypto hash routines. Valid ARGs are: 'yes',
                          'no', 'auto' => use if any version available,
                          'auto-gpl-compat' => use if gpl compatible version
                          available, 'optional' => use if available and warn
                          if not available; default is 'no'. Note also
                          --with-linux-crypto, which will enable use of kernel
                          crypto routines, which have precedence
  --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
  --with-libiconv-prefix[=DIR]  search for libiconv in DIR/include and DIR/lib
  --without-libiconv-prefix     don't search for libiconv in includedir and libdir
  --without-included-regex
                          don't compile regex; this is the default on systems
                          with recent-enough versions of the GNU C Library
                          (use with caution on other systems).
  --with-gcov=GCOV        use given GCOV for coverage (GCOV=gcov).
  --with-pic[=PKGS]       try to use only PIC/non-PIC objects [default=use
                          both]
  --with-aix-soname=aix|svr4|both
                          shared library versioning (aka "SONAME") variant to
                          provide on AIX, [default=aix].
  --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
  --with-sysroot[=DIR]    Search for dependent libraries within DIR (or the
                          compiler's sysroot if not specified).
  --with-libintl-prefix[=DIR]  search for libintl in DIR/include and DIR/lib
  --without-libintl-prefix     don't search for libintl in includedir and libdir
  --with-ssl              Use SSL/TLS with specified library. Options:
                          'gnutls' (default), 'openssl', 'wolfssl' or 'none'
  --without-libpsl        disable support for libpsl cookie checking
  --without-libhsts       disable support for libhsts checking
  --without-libnghttp2    disable support for libnghttp2
  --without-bzip2         disable bzip2 compression support
  --without-gpgme         support signature verification with gpgme
  --with-gpgme-prefix=PFX prefix where GPGME is installed (optional)
  --without-zlib          disable gzip compression support
  --without-lzma          disable LZMA compression support
  --without-brotlidec     disable Brotli compression support
  --without-zstd          disable Zstandard compression support
  --without-lzip          disable lzip compression support
  --without-libidn2       disable IDN2 support
  --without-libidn        disable IDN support
  --without-libpcre2      disable support for libpcre2
  --without-libpcre       disable support for libpcre
  --without-libmicrohttpd disable support for libmicrohttpd
  --without-plugin-support
                          Disable plugin support
```
and I disabled `libidn`, `libpcre`, `libpcre2`, `libmicrohttpd`, `libhsts` for now.