### PR TITLE
ko: don't require docker to test

### DIFF
--- a/Formula/ko.rb
+++ b/Formula/ko.rb
@@ -14,7 +14,6 @@ class Ko < Formula
   end
 
   depends_on "go" => :build
-  depends_on "docker" => :test
 
   def install
     system "go", "build", *std_go_args, "-ldflags",
@@ -24,9 +23,5 @@ class Ko < Formula
   test do
     output = shell_output("#{bin}/ko login reg.example.com -u brew -p test 2>&1")
     assert_match "logged in via #{testpath}/.docker/config.json", output
-
-    ENV["KO_DOCKER_REPO"] = "ko.local"
-    output = shell_output("#{bin}/ko run github.com/mattmoor/examples/http/cmd/helloworld 2>&1", 1)
-    assert_match "failed to publish images", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The deleted test doesn't actually require Docker at all, it simply fails to build an image and checks that the image failed to build. This is effectively no more helpful for checking the installation of `ko` than the existing `ko login` test. By not requiring Docker to test, the [public formula docs](https://formulae.brew.sh/formula/ko) make it clearer that Docker isn't required to install or use `ko`.