### PR TITLE
rbenv 1.2.0

### DIFF
--- a/Formula/rbenv.rb
+++ b/Formula/rbenv.rb
@@ -1,8 +1,8 @@
 class Rbenv < Formula
   desc "Ruby version manager"
   homepage "https://github.com/rbenv/rbenv#readme"
-  url "https://github.com/rbenv/rbenv/archive/v1.1.2.tar.gz"
-  sha256 "80ad89ffe04c0b481503bd375f05c212bbc7d44ef5f5e649e0acdf25eba86736"
+  url "https://github.com/rbenv/rbenv/archive/v1.2.0.tar.gz"
+  sha256 "3f3a31b8a73c174e3e877ccc1ea453d966b4d810a2aadcd4d8c460bc9ec85e0c"
   license "MIT"
   head "https://github.com/rbenv/rbenv.git", branch: "master"
 
@@ -25,8 +25,6 @@ class Rbenv < Formula
       s.gsub! '"${BASH_SOURCE%/*}"/../libexec', libexec
       s.gsub! ":/usr/local/etc/rbenv.d", ":#{HOMEBREW_PREFIX}/etc/rbenv.d\\0" if HOMEBREW_PREFIX.to_s != "/usr/local"
     end
-
-    inreplace "libexec/rbenv-rehash", "$(command -v rbenv)", opt_bin/"rbenv"
 
     # Compile optional bash extension.
     system "src/configure"


### PR DESCRIPTION
The workaround was meant to hardcode the path to `rbenv` executable to prevent rbenv itself detecting the path to its executable and finding it under `/usr/local/Cellar/rbenv/VERSION/libexec/...`, which is a path we cannot rely on in the long term due to Homebrew's automatic cleanup.

However, the workaround is brittle:
- It's currently failing CI jobs, even those [unrelated to rbenv](https://github.com/Homebrew/homebrew-core/pull/84510#issuecomment-916511438);
- If the hardcoded path that's the result of `opt_bin/"rbenv"` makes it into a bottle, it's not guaranteed to match the `opt/bin` path on someone else's system. Such bottles would not be portable.

Reverts #75996 /cc @steinybot

I might try to come up with a permanent solution for this from within rbenv itself.