### PR TITLE
kanif: add livecheck

### DIFF
--- a/Formula/kanif.rb
+++ b/Formula/kanif.rb
@@ -5,6 +5,11 @@ class Kanif < Formula
   sha256 "3f0c549428dfe88457c1db293cfac2a22b203f872904c3abf372651ac12e5879"
   license "GPL-2.0"
 
+  livecheck do
+    url "https://gforge.inria.fr/frs/?group_id=274"
+    regex(/href=.*?kanif[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "cfc06314d243173b2b0f0de1188570adde896ef6002dcbb75e7ce9fe056ae172"
     sha256 cellar: :any_skip_relocation, big_sur:       "ea9c4a641227762b26e89a7015aa328d16fdfdb23796c29abcdb83ab19638b59"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `kanif`. This PR adds a `livecheck` block that checks the download page where the `stable` archive is found.