### PR TITLE
thrax: update urls

### DIFF
--- a/Formula/thrax.rb
+++ b/Formula/thrax.rb
@@ -2,13 +2,13 @@ class Thrax < Formula
   include Language::Python::Shebang
 
   desc "Tools for compiling grammars into finite state transducers"
-  homepage "http://www.openfst.org/twiki/bin/view/GRM/Thrax"
-  url "http://www.openfst.org/twiki/pub/GRM/ThraxDownload/thrax-1.3.6.tar.gz"
+  homepage "https://www.openfst.org/twiki/bin/view/GRM/Thrax"
+  url "https://www.openfst.org/twiki/pub/GRM/ThraxDownload/thrax-1.3.6.tar.gz"
   sha256 "5f00a2047674753cba6783b010ab273366dd3dffc160bdb356f7236059a793ba"
   license "Apache-2.0"
 
   livecheck do
-    url "http://www.openfst.org/twiki/bin/view/GRM/ThraxDownload"
+    url "https://www.openfst.org/twiki/bin/view/GRM/ThraxDownload"
     regex(/href=.*?thrax[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage`, `stable`, and `livecheck` block URLs redirect from HTTP to HTTPS. This PR updates these URLs accordingly to avoid the redirection.

This technically modifies the `stable` URL (`sha256` is unchanged), so I haven't labeled this as `CI-syntax-only`.