### PR TITLE
little-cms: update livecheck

### DIFF
--- a/Formula/little-cms.rb
+++ b/Formula/little-cms.rb
@@ -7,8 +7,7 @@ class LittleCms < Formula
   revision 1
 
   livecheck do
-    url :stable
-    regex(%r{url=.*?/lcms[._-]v?(1(?:\.\d+)+)\.t}i)
+    skip "1.x versions are no longer developed"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The latest 1.x version of `little-cms` (`1.19`) was released on 2009-11-16 and there have only been 2.x releases from that point onward. Since 1.x versions aren't being developed/maintained alongside 2.x, we only need to check for `little-cms2` versions, not `little-cms`.

This PR replaces the `livecheck` block body with a `skip` call, to ensure the formula is skipped. [Without a `livecheck` block, the `Sourceforge` strategy would be used on the `stable` URL by default.]