### PR TITLE
git-ftp: update curl urls

### DIFF
--- a/Formula/git-ftp.rb
+++ b/Formula/git-ftp.rb
@@ -21,8 +21,8 @@ class GitFtp < Formula
   uses_from_macos "zlib"
 
   resource "curl" do
-    url "https://curl.haxx.se/download/curl-7.69.0.tar.bz2"
-    mirror "https://curl.askapache.com/download/curl-7.69.0.tar.bz2"
+    url "https://curl.se/download/curl-7.69.0.tar.bz2"
+    mirror "https://curl.askapache.com/curl-7.69.0.tar.bz2"
     sha256 "668d451108a7316cff040b23c79bc766e7ed84122074e44f662b8982f2e76739"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing URLs in the `git-ftp` resource block for `curl` are redirecting, so this PR updates the URLs to avoid the redirections. The `sha256` for the resource remains the same but it was technically modified, so I didn't label this as `CI-syntax-only`.