### PR TITLE
gnutls: update curl urls

### DIFF
--- a/Formula/gnutls.rb
+++ b/Formula/gnutls.rb
@@ -35,8 +35,8 @@ class Gnutls < Formula
     depends_on "autogen"
 
     resource "cacert" do
-      # homepage "http://curl.haxx.se/docs/caextract.html"
-      url "https://curl.haxx.se/ca/cacert-2020-01-01.pem"
+      # homepage "https://curl.se/docs/caextract.html"
+      url "https://curl.se/ca/cacert-2020-01-01.pem"
       mirror "https://gist.githubusercontent.com/dawidd6/16d94180a019f31fd31bc679365387bc/raw/ef02c78b9d6427585d756528964d18a2b9e318f7/cacert-2020-01-01.pem"
       sha256 "adf770dfd574a0d6026bfaa270cb6879b063957177a991d453ff1d302c02081f"
     end
@@ -138,7 +138,7 @@ class Gnutls < Formula
   end
 
   def linux_post_install
-    # Download and install cacert.pem from curl.haxx.se
+    # Download and install cacert.pem from curl.se
     cacert = resource("cacert")
     cacert.fetch
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`curl.haxx.se` redirects to `curl.se`, so this PR updates the URLs to avoid the redirection.

Though this modifies the `cacert` resource URL, I've tentatively labeled this as `CI-syntax-only` due to the long build time. I manually downloaded the `cacert` file at the updated URL and confirmed the `sha256` remains unchanged but feel free to change the PR labels and re-run CI, if necessary.

Once we've determined how to approach this on CI, I'll open PRs to do the same for the `openssl` formulae.