### PR TITLE
h2c: update test

### DIFF
--- a/Formula/h2c.rb
+++ b/Formula/h2c.rb
@@ -17,7 +17,7 @@ class H2c < Formula
     assert_match "h2c.pl [options] < file", shell_output("h2c --help")
 
     # test if h2c can convert HTTP headers to curl options.
-    assert_match "curl --head --http1.1 --header Accept: --header \"Shoesize: 12\" --user-agent \"moo\" https://curl.haxx.se/",
-      shell_output("echo 'HEAD  / HTTP/1.1\nHost: curl.haxx.se\nUser-Agent: moo\nShoesize: 12' | h2c")
+    assert_match "curl --head --http1.1 --header Accept: --header \"Shoesize: 12\" --user-agent \"moo\" https://example.com/",
+      shell_output("echo 'HEAD  / HTTP/1.1\nHost: example.com\nUser-Agent: moo\nShoesize: 12' | h2c")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing test for `h2c` references `curl.haxx.se`, which is now `curl.se`. Though this test doesn't make network requests, I'm in the process of updating references to `curl.haxx.se` in formulae.

This PR replaces references to `curl.haxx.se` in the test with `example.com`, as the latter is arguably more appropriate in a testing context. This doesn't make a functional difference and the test continues to work the same way.