### PR TITLE
goredo: simplify formula

### DIFF
--- a/Formula/goredo.rb
+++ b/Formula/goredo.rb
@@ -2,7 +2,6 @@ class Goredo < Formula
   desc "Go implementation of djb's redo, a Makefile replacement that sucks less"
   homepage "http://www.goredo.cypherpunks.ru/"
   url "http://www.goredo.cypherpunks.ru/download/goredo-1.14.0.tar.zst"
-  version "1.14.0"
   sha256 "17608c98b39e0030043b1862edb0ae7c162da3743ddf87330db0301a4fd61bf5"
   license "GPL-3.0-only"
 
@@ -20,16 +19,15 @@ class Goredo < Formula
   end
 
   depends_on "go" => :build
-  depends_on "zstd" => :build
 
   def install
-    goredo_prefix = "goredo-#{version}"
-    system "tar", "--use-compress-program", "unzstd", "-xvf", "#{goredo_prefix}.tar.zst"
-    cd "#{goredo_prefix}/src" do
+    cd "src" do
       system "go", "build", *std_go_args, "-mod=vendor"
     end
+
+    ENV.prepend_path "PATH", bin
     cd bin do
-      system "./goredo", "-symlinks"
+      system "goredo", "-symlinks"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew` now knows how to unpack `.tar.zst` files since
Homebrew/brew@58e34293554a827e717a7383940c2e57c2d0b360, so let's
simplify the formula accordingly.

Also, remove the unnecessary `version` specification, and fix the formula
so it produces slightly nicer symlinks (e.g. `redo -> goredo` instead of `redo -> ./goredo`).