### PR TITLE
mockserver: update urls

### DIFF
--- a/Formula/mockserver.rb
+++ b/Formula/mockserver.rb
@@ -1,13 +1,13 @@
 class Mockserver < Formula
   desc "Mock HTTP server and proxy"
   homepage "https://www.mock-server.com/"
-  url "https://oss.sonatype.org/content/repositories/releases/org/mock-server/mockserver-netty/5.11.2/mockserver-netty-5.11.2-brew-tar.tar"
+  url "https://search.maven.org/remotecontent?filepath=org/mock-server/mockserver-netty/5.11.2/mockserver-netty-5.11.2-brew-tar.tar"
   sha256 "1758bb80c3e5cd250b55757a53105db7b03ff1b05d2dfca501ce5795feff8756"
   license "Apache-2.0"
 
   livecheck do
-    url "https://oss.sonatype.org/content/repositories/releases/org/mock-server/mockserver-netty/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url "https://search.maven.org/remotecontent?filepath=org/mock-server/mockserver-netty/maven-metadata.xml"
+    regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `stable` URL redirects to Maven and the [first-party "Downloads" page](https://www.mock-server.com/where/downloads.html) also links to Maven (not the existing `stable` source). This PR updates the `stable` URL to use a typical Maven URL like we use in other formulae. Both the existing `stable` URL and the new Maven URL both resolve to the same URL. The tarball is the same and the `sha256` is unchanged but this technically modifies the `stable` URL, so I'm not labeling this `CI-syntax-only`.

This PR also updates the `livecheck` block to align with the new `stable` source, using the typical approach we use for Maven formulae. [If we end up with enough formulae doing this, I may just create a `Maven` strategy in livecheck to save us the trouble.]