### PR TITLE
c2ffi llvm-11.0.0 (new formula)

### DIFF
--- a/Formula/c2ffi.rb
+++ b/Formula/c2ffi.rb
@@ -11,6 +11,12 @@ class C2ffi < Formula
   depends_on "llvm@11"
   depends_on "qt@5"
 
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5" # needs C++17
+
   def install
     ENV["LDFLAGS"] = "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
     system(

--- a/Formula/c2ffi.rb
+++ b/Formula/c2ffi.rb
@@ -1,0 +1,211 @@
+class C2ffi < Formula
+  desc "Clang-based FFI wrapper generator"
+  homepage "https://github.com/rpav/c2ffi"
+  url "https://github.com/rpav/c2ffi/archive/llvm-11.0.0.tar.gz"
+  version "llvm-11.0.0"
+  sha256 "7bc32f294c4d9e7e6ee3e04d45b1b8c04ae51872dbd90e8458c82c4cb98208e5"
+  license "LGPL-2.1-only"
+  head "https://github.com/rpav/c2ffi.git", branch: "llvm-11.0.0"
+
+  depends_on "cmake" => :build
+  depends_on "llvm@11"
+  depends_on "qt@5"
+
+  def install
+    ENV["LDFLAGS"] = "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+    system(
+      "cmake", "-S", ".", "-B", "build",
+      *std_cmake_args,
+      "-DBUILD_CONFIG=Release",
+      "-DCMAKE_C_COMPILER=#{Formula["llvm@11"].opt_bin/"clang"}",
+      "-DCMAKE_CXX_COMPILER=#{Formula["llvm@11"].opt_bin/"clang++"}"
+    )
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    testfile1 = testpath/"demo1.h"
+    testsource1 = <<~EOF
+      #define MAGIC_NUMBER 543
+      #define MIN_CARELESS(X, Y) (((X) < (Y)) ? (X) : (Y))
+      float foo(float a, float b);
+      void bar(int argv, char *args[]);
+    EOF
+    testfile1.write(testsource1)
+
+    testfile2 = testpath/"demo2.h"
+    testsource2 = <<~EOF
+      #include "demo1.h"
+      struct thing {
+        char first_initial;
+        char last_initial;
+        void *spooky_stuff;
+      };
+      typedef struct thing thing_t;
+      void *quux();
+    EOF
+    testfile2.write(testsource2)
+
+    expected_stdout = <<~EOF
+      [
+        {
+          "tag": "function",
+          "name": "foo",
+          "ns": 0,
+          "location": "./demo1.h:3:7",
+          "variadic": false,
+          "inline": false,
+          "storage-class": "none",
+          "parameters": [
+            {
+              "tag": "parameter",
+              "name": "a",
+              "type": {
+                "tag": ":float",
+                "bit-size": 32,
+                "bit-alignment": 32
+              }
+            },
+            {
+              "tag": "parameter",
+              "name": "b",
+              "type": {
+                "tag": ":float",
+                "bit-size": 32,
+                "bit-alignment": 32
+              }
+            }
+          ],
+          "return-type": {
+            "tag": ":float",
+            "bit-size": 32,
+            "bit-alignment": 32
+          }
+        },
+        {
+          "tag": "function",
+          "name": "bar",
+          "ns": 0,
+          "location": "./demo1.h:4:6",
+          "variadic": false,
+          "inline": false,
+          "storage-class": "none",
+          "parameters": [
+            {
+              "tag": "parameter",
+              "name": "argv",
+              "type": {
+                "tag": ":int",
+                "bit-size": 32,
+                "bit-alignment": 32
+              }
+            },
+            {
+              "tag": "parameter",
+              "name": "args",
+              "type": {
+                "tag": ":pointer",
+                "type": {
+                  "tag": ":pointer",
+                  "type": {
+                    "tag": ":char",
+                    "bit-size": 8,
+                    "bit-alignment": 8
+                  }
+                }
+              }
+            }
+          ],
+          "return-type": {
+            "tag": ":void"
+          }
+        },
+        {
+          "tag": "struct",
+          "ns": 0,
+          "name": "thing",
+          "id": 0,
+          "location": "./demo2.h:2:8",
+          "bit-size": 128,
+          "bit-alignment": 64,
+          "fields": [
+            {
+              "tag": "field",
+              "name": "first_initial",
+              "bit-offset": 0,
+              "bit-size": 8,
+              "bit-alignment": 8,
+              "type": {
+                "tag": ":char",
+                "bit-size": 8,
+                "bit-alignment": 8
+              }
+            },
+            {
+              "tag": "field",
+              "name": "last_initial",
+              "bit-offset": 8,
+              "bit-size": 8,
+              "bit-alignment": 8,
+              "type": {
+                "tag": ":char",
+                "bit-size": 8,
+                "bit-alignment": 8
+              }
+            },
+            {
+              "tag": "field",
+              "name": "spooky_stuff",
+              "bit-offset": 64,
+              "bit-size": 64,
+              "bit-alignment": 64,
+              "type": {
+                "tag": ":pointer",
+                "type": {
+                  "tag": ":void"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "tag": "typedef",
+          "ns": 0,
+          "name": "thing_t",
+          "location": "./demo2.h:7:22",
+          "type": {
+            "tag": ":struct",
+            "name": "thing",
+            "id": 1
+          }
+        },
+        {
+          "tag": "function",
+          "name": "quux",
+          "ns": 0,
+          "location": "./demo2.h:8:7",
+          "variadic": false,
+          "inline": false,
+          "storage-class": "none",
+          "parameters": [],
+          "return-type": {
+            "tag": ":pointer",
+            "type": {
+              "tag": ":void"
+            }
+          }
+        }
+      ]
+    EOF
+
+    require "json"
+    require "open3"
+
+    test_stdout, _, test_process = Open3.capture3(
+      "c2ffi", "--fail-on-error", "--std", "c99", "--lang", "c", "./demo2.h"
+    )
+    assert_equal test_process.exitstatus, 0
+    assert_equal JSON.parse(test_stdout), JSON.parse(expected_stdout)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/rpav/c2ffi

Note that C2FFI versioning is a bit weird; there are no version numbers, but each development branch is pegged at a specific LLVM version.

Perhaps this should be HEAD-only? Theoretically the authors could push multiple releases on the `llvm-11.0.0` branch.

Also, should it have an `@` name?

> You need to use the correct branch of c2ffi for your version of LLVM/Clang:
>
>  * Anything earlier: unsupported
> * 10.0.0: branch `llvm-10.0.0` _deprecated_
> * 11.0.0: branch `llvm-11.0.0` _current_
> * 12.0.0: branch `llvm-12.0.0` _testing_
>
> Developement [sic] will always take place in `llvm-X.Y`, according to the appropriate version of LLVM. The master branch has been removed. Check out the appropriate version for your LLVM.