### PR TITLE
argocd: update version to v2.1.3 and include UI build

### DIFF
--- a/Formula/argocd.rb
+++ b/Formula/argocd.rb
@@ -2,8 +2,8 @@ class Argocd < Formula
   desc "GitOps Continuous Delivery for Kubernetes"
   homepage "https://argoproj.io"
   url "https://github.com/argoproj/argo-cd.git",
-      tag:      "v2.1.2",
-      revision: "7af9dfb3524c13e941ab604e36e49a617fe47d2e"
+      tag:      "v2.1.3",
+      revision: "d855831540e51d8a90b1006d2eb9f49ab1b088af"
   license "Apache-2.0"
 
   bottle do
@@ -15,8 +15,17 @@ class Argocd < Formula
   end
 
   depends_on "go" => :build
+  depends_on "node@14" => :build
+  depends_on "yarn" => :build
 
   def install
+    system "make", "dep-ui-local"
+    with_env(
+      NODE_ENV:        "production",
+      NODE_ONLINE_ENV: "online",
+    ) do
+      system "yarn", "--cwd", "ui", "build"
+    end
     system "make", "cli-local"
     bin.install "dist/argocd"
 

--- a/Formula/argocd.rb
+++ b/Formula/argocd.rb
@@ -1,6 +1,6 @@
 class Argocd < Formula
   desc "GitOps Continuous Delivery for Kubernetes"
-  homepage "https://argoproj.io"
+  homepage "https://argoproj.github.io/cd"
   url "https://github.com/argoproj/argo-cd.git",
       tag:      "v2.1.3",
       revision: "d855831540e51d8a90b1006d2eb9f49ab1b088af"


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

PR bumps Argo CD version to v2.1.3 and add the UI build step to enable `argocd admin dashboard` command (see [docs](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_admin_dashboard/))