### PR TITLE
krb5: remove `inreplace` workaround

### DIFF
--- a/Formula/krb5.rb
+++ b/Formula/krb5.rb
@@ -30,15 +30,6 @@ class Krb5 < Formula
 
   def install
     cd "src" do
-      # Newer versions of clang are very picky about missing includes.
-      # One configure test fails because it doesn't #include the header needed
-      # for some functions used in the rest. The test isn't actually testing
-      # those functions, just using them for the feature they're
-      # actually testing. Adding the include fixes this.
-      # https://krbdev.mit.edu/rt/Ticket/Display.html?id=8928
-      inreplace "configure", "void foo1() __attribute__((constructor));",
-                             "#include <unistd.h>\nvoid foo1() __attribute__((constructor));"
-
       system "./configure", "--disable-debug",
                             "--disable-dependency-tracking",
                             "--disable-silent-rules",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream bug report says this should be fixed in the current
version.