### PR TITLE
Re-add maven 3.8.1 as a distinct version because 3.8.2 is broken/buggy...

### DIFF
--- a/Formula/maven@3.8.1.rb
+++ b/Formula/maven@3.8.1.rb
@@ -1,0 +1,73 @@
+class Maven < Formula
+  desc "Java-based project management"
+  homepage "https://maven.apache.org/"
+  url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz"
+  sha256 "b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
+  license "Apache-2.0"
+
+  livecheck do
+    url "https://maven.apache.org/download.cgi"
+    regex(/href=.*?apache-maven[._-]v?(\d+(?:\.\d+)+)-bin\.t/i)
+  end
+
+  bottle do
+    sha256 cellar: :any,                 arm64_big_sur: "bb95e2849040358e1e30b918c5cfdcfb78535915d834f32f0f5fcb39231a87f6"
+    sha256 cellar: :any,                 big_sur:       "f894602e16a46f6d40a259c860d8f9d5103baac5681d1803349eaf5b6771f527"
+    sha256 cellar: :any,                 catalina:      "f894602e16a46f6d40a259c860d8f9d5103baac5681d1803349eaf5b6771f527"
+    sha256 cellar: :any,                 mojave:        "f894602e16a46f6d40a259c860d8f9d5103baac5681d1803349eaf5b6771f527"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fb05503b1a17a40a22060c04caab17ac630ba985194600065f746e9924a363bf"
+  end
+
+  depends_on "openjdk"
+
+  conflicts_with "mvnvm", because: "also installs a 'mvn' executable"
+
+  def install
+    # Remove windows files
+    rm_f Dir["bin/*.cmd"]
+
+    # Fix the permissions on the global settings file.
+    chmod 0644, "conf/settings.xml"
+
+    libexec.install Dir["*"]
+
+    # Leave conf file in libexec. The mvn symlink will be resolved and the conf
+    # file will be found relative to it
+    Pathname.glob("#{libexec}/bin/*") do |file|
+      next if file.directory?
+
+      basename = file.basename
+      next if basename.to_s == "m2.conf"
+
+      (bin/basename).write_env_script file, Language::Java.overridable_java_home_env
+    end
+  end
+
+  test do
+    (testpath/"pom.xml").write <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>org.homebrew</groupId>
+        <artifactId>maven-test</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <properties>
+          <maven.compiler.source>1.8</maven.compiler.source>
+          <maven.compiler.target>1.8</maven.compiler.target>
+          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        </properties>
+      </project>
+    EOS
+    (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<~EOS
+      package org.homebrew;
+      public class MavenTest {
+        public static void main(String[] args) {
+          System.out.println("Testing Maven with Homebrew!");
+        }
+      }
+    EOS
+    system "#{bin}/mvn", "compile", "-Duser.home=#{testpath}"
+  end
+end

--- a/Formula/maven@3.8.1.rb
+++ b/Formula/maven@3.8.1.rb
@@ -21,8 +21,6 @@ class MavenAT381 < Formula
 
   depends_on "openjdk"
 
-  keg_only maven@3.8.1
-
   def install
     # Remove windows files
     rm_f Dir["bin/*.cmd"]

--- a/Formula/maven@3.8.1.rb
+++ b/Formula/maven@3.8.1.rb
@@ -1,4 +1,4 @@
-class Maven < Formula
+class MavenAT381 < Formula
   desc "Java-based project management"
   homepage "https://maven.apache.org/"
   url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz"

--- a/Formula/maven@3.8.1.rb
+++ b/Formula/maven@3.8.1.rb
@@ -21,7 +21,7 @@ class Maven < Formula
 
   depends_on "openjdk"
 
-  conflicts_with "mvnvm", because: "also installs a 'mvn' executable"
+  keg_only maven@3.8.1
 
   def install
     # Remove windows files


### PR DESCRIPTION
...and no 3.6 versions are available her (which are also all fine AFAIK).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I didn't check the commit one because I strongly believe that prose should dominate and illegibly short messages based on 80 char wide terminals without modern support are an anti pattern. However if forced at virtual gun point, I'll comply.

I didn't check the others as I didn't do them, but the file is lifted from the most recent version in history with:

```
cd Formula
git checkout 225b9036c0db7c4439de7ee540a07baa481dc2ae -- maven.rb
cp maven.rb maven@3.8.1.rb 
git checkout HEAD -- maven.rb
git add maven@3.8.1.rb
git commit -m ""
```

And thus it can be verified with:

```
cd Formula
git checkout 225b9036c0db7c4439de7ee540a07baa481dc2ae -- maven.rb
diff maven.rb maven@3.8.1.rb 
``` 

And clean up with `git reset --hard HEAD` once happy. 

I think 3.6 should be there, too, and can add it to the same PR or do a new one for that if that's acceptable

I know why it's not present - the popularity statistics, but they don't tell the whole story, a lot of big orgs are running horribly out dated versions of tools like this and it's important to support the last few recent versions in case of bugs like this one in 3.8.2. Hopefully 3.8.3 comes along with a fix soon. :-) 