### PR TITLE
maven@3.6 3.6.3 (new formula)

### DIFF
--- a/Formula/maven@3.6.rb
+++ b/Formula/maven@3.6.rb
@@ -1,4 +1,4 @@
-class Maven < Formula
+class MavenAT36 < Formula
   desc "Java-based project management"
   homepage "https://maven.apache.org/"
   url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz"
@@ -9,9 +9,11 @@ class Maven < Formula
 
   bottle :unneeded
 
-  depends_on "openjdk"
+  keg_only :versioned_formula
 
-  conflicts_with "mvnvm", because: "also installs a 'mvn' executable"
+  # 3.1+ are not EOL yet, 3.6.X is in widespread use: https://maven.apache.org/docs/history.html
+
+  depends_on "openjdk"
 
   def install
     # Remove windows files

--- a/Formula/maven@3.6.rb
+++ b/Formula/maven@3.6.rb
@@ -1,0 +1,63 @@
+class Maven < Formula
+  desc "Java-based project management"
+  homepage "https://maven.apache.org/"
+  url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz"
+  sha256 "26ad91d751b3a9a53087aefa743f4e16a17741d3915b219cf74112bf87a438c5"
+  license "Apache-2.0"
+  revision 1
+
+  bottle :unneeded
+
+  depends_on "openjdk"
+
+  conflicts_with "mvnvm", because: "also installs a 'mvn' executable"
+
+  def install
+    # Remove windows files
+    rm_f Dir["bin/*.cmd"]
+
+    # Fix the permissions on the global settings file.
+    chmod 0644, "conf/settings.xml"
+
+    libexec.install Dir["*"]
+
+    # Leave conf file in libexec. The mvn symlink will be resolved and the conf
+    # file will be found relative to it
+    Pathname.glob("#{libexec}/bin/*") do |file|
+      next if file.directory?
+
+      basename = file.basename
+      next if basename.to_s == "m2.conf"
+
+      (bin/basename).write_env_script file, Language::Java.overridable_java_home_env
+    end
+  end
+
+  test do
+    (testpath/"pom.xml").write <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>org.homebrew</groupId>
+        <artifactId>maven-test</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <properties>
+          <maven.compiler.source>1.8</maven.compiler.source>
+          <maven.compiler.target>1.8</maven.compiler.target>
+          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        </properties>
+      </project>
+    EOS
+    (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<~EOS
+      package org.homebrew;
+      public class MavenTest {
+        public static void main(String[] args) {
+          System.out.println("Testing Maven with Homebrew!");
+        }
+      }
+    EOS
+    system "#{bin}/mvn", "compile", "-Duser.home=#{testpath}"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Have not checked locally, GH actions can do that for me. Commits contain prose, not 1980s vintage formatting. Learned from bad changes in prior PR #86188 and advice from @SMillerDev on that PR (thanks!). Confirmed 3.1+ are not end of life, but all 3.0.X and older are deprecated and entirely unsupported. Maven is a tool that you tend to build your stack around and stick with for a long time. Our stack is pretty good and can work with 3.8.1 and 3.6.X but current 3.8.2 is broken for us (and 3.5, 3.3, 3.2 that are already included in homebrew core are too old for us). 