### PR TITLE
conserver: update stable, livecheck

### DIFF
--- a/Formula/conserver.rb
+++ b/Formula/conserver.rb
@@ -1,14 +1,14 @@
 class Conserver < Formula
   desc "Allows multiple users to watch a serial console at the same time"
   homepage "https://www.conserver.com/"
-  url "https://github.com/conserver/conserver/releases/download/v8.2.6/conserver-8.2.6.tar.gz"
+  url "https://github.com/bstansell/conserver/releases/download/v8.2.6/conserver-8.2.6.tar.gz"
   sha256 "33b976a909c6bce8a1290810e26e92bfa16c39bca19e1f8e06d5d768ae940734"
   license "BSD-3-Clause"
   revision 1
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `stable` URL for `conserver` redirects from the conserver/conserver GitHub repository to [bstansell/conserver](https://github.com/bstansell/conserver), which is the current location. Bryan Stansell (bstansell) is the maintainer for `conserver` and the [first-party website](https://www.conserver.com/) also links to the bstansell/conserver repository. Looking back at the [latest available archive.org snapshot of the conserver/conserver repository](https://web.archive.org/web/20180617160859/https://github.com/conserver/conserver/) before the switch, the `README` also mentions Bryan Stansell as the maintainer of `conserver`.

With that in mind, this PR updates the `stable` URL to avoid the redirection. This technically modifies the `stable` URL (the `sha256` remains the same), so I haven't labeled this `CI-syntax-only`.

---

This PR also modifies the existing `livecheck` block to check the Git tags instead of using the `GithubLatest` strategy. We can correctly match the latest version from the Git tags using the standard regex for tags like `1.2.3`/`v1.2.3` (which avoids tags like `vGNAC-6.16` in the repository), so the `GithubLatest` strategy isn't necessary. We currently only use the `GithubLatest` strategy when it's both correct and necessary. 

For what it's worth, the existing `livecheck` block is an old check that was created before the `GithubLatest` strategy even existed. That is to say, there isn't a specific reason why the `GithubLatest` strategy was used here and it's appropriate to check the Git tags instead.