### PR TITLE
vgmstream: update urls

### DIFF
--- a/Formula/vgmstream.rb
+++ b/Formula/vgmstream.rb
@@ -1,14 +1,14 @@
 class Vgmstream < Formula
   desc "Library for playing streamed audio formats from video games"
-  homepage "https://hcs64.com/vgmstream.html"
-  url "https://github.com/losnoco/vgmstream.git",
+  homepage "https://vgmstream.org"
+  url "https://github.com/vgmstream/vgmstream.git",
       tag:      "r1050-3448-g77cc431b",
       revision: "77cc431be77846f95eccca49170878434935622f"
   version "r1050-3448-g77cc431b"
   license "ISC"
   revision 2
   version_scheme 1
-  head "https://github.com/losnoco/vgmstream.git", branch: "master"
+  head "https://github.com/vgmstream/vgmstream.git", branch: "master"
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `stable` and `head` URLs for `vgmstream` redirect from the losnoco/vgmstream GitHub repository to vgmstream/vgmstream. The homepage also links to the `vgmstream/vgmstream` repository. With this in mind, this PR updates the `stable` and `head` URLs to point to the current repository and avoid the redirection.

For what it's worth, a newer `r1640` version is available but it failed to build when I tested it locally. It wasn't immediately clear to me what the problem was, so I decided to handle these URL changes independently.