### PR TITLE
couchpotatoserver: deprecate

### DIFF
--- a/Formula/couchpotatoserver.rb
+++ b/Formula/couchpotatoserver.rb
@@ -11,6 +11,8 @@ class Couchpotatoserver < Formula
     sha256 cellar: :any_skip_relocation, all: "f8c2e92a584c48ec2a693d5e7e4cf48ef29fe40b3501668d0205357b4c901c8c"
   end
 
+  deprecate! date: "2021-09-30", because: :repo_archived
+
   def install
     prefix.install_metafiles
     inreplace_files = %w[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `couchpotatoserver`](https://github.com/CouchPotato/CouchPotatoServer) was archived sometime between 2021-08-01 and now. This PR deprecates the formula accordingly.