### PR TITLE
docker-machine: deprecate

### DIFF
--- a/Formula/docker-machine.rb
+++ b/Formula/docker-machine.rb
@@ -15,6 +15,8 @@ class DockerMachine < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f08e7ba29eb793a79b8126631485ee4100cf07b9e1e5654a7c4db8c2d229d5af"
   end
 
+  deprecate! date: "2021-09-30", because: :repo_archived
+
   depends_on "automake" => :build
   depends_on "go" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `docker-machine`](https://github.com/docker/machine) was archived sometime between 2021-09-05 and now. This PR deprecates the formula accordingly.