### PR TITLE
sxiv: deprecate

### DIFF
--- a/Formula/sxiv.rb
+++ b/Formula/sxiv.rb
@@ -16,6 +16,8 @@ class Sxiv < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "83e501a472f4a821202cfc62a9076c35655d340e127b6465384ceb9d535ddf86"
   end
 
+  deprecate! date: "2021-09-23", because: :repo_archived
+
   depends_on "giflib"
   depends_on "imlib2"
   depends_on "libexif"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `sxiv`](https://github.com/muennich/sxiv) was archived on 2021-09-23. This PR deprecates the formula accordingly.