### PR TITLE
git-lfs@2 2.13.3 (new formula)

### DIFF
--- a/Formula/git-lfs@2.rb
+++ b/Formula/git-lfs@2.rb
@@ -1,0 +1,42 @@
+class GitLfsAT2 < Formula
+  desc "Git extension for versioning large files"
+  homepage "https://github.com/git-lfs/git-lfs"
+  url "https://github.com/git-lfs/git-lfs/releases/download/v2.13.3/git-lfs-v2.13.3.tar.gz"
+  sha256 "f8bd7a06e61e47417eb54c3a0db809ea864a9322629b5544b78661edab17b950"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^v?(2(?:\.\d+)+)$/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "go" => :build
+  depends_on "ronn" => :build
+  depends_on "ruby" => :build
+
+  def install
+    ENV["GIT_LFS_SHA"] = ""
+    ENV["VERSION"] = version
+
+    (buildpath/"src/github.com/git-lfs/git-lfs").install buildpath.children
+    cd "src/github.com/git-lfs/git-lfs" do
+      system "make", "vendor"
+      system "make"
+      system "make", "man", "RONN=#{Formula["ronn"].bin}/ronn"
+
+      bin.install "bin/git-lfs"
+      man1.install Dir["man/*.1"]
+      man5.install Dir["man/*.5"]
+      doc.install Dir["man/*.html"]
+    end
+  end
+
+  test do
+    ENV.prepend_path "PATH", opt_bin
+    system "git", "init"
+    system "git", "lfs", "track", "test"
+    assert_match(/^test filter=lfs/, File.read(".gitattributes"))
+  end
+end


### PR DESCRIPTION
Not all git-lfs servers can cope with new protocol changes in git-lfs v3. Until they caught up, provide the previous git-lfs implementation as a versioned formula.

See: https://github.com/Homebrew/discussions/discussions/2219

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
