### PR TITLE
mpvdovi 0.1.0 (new formula)

### DIFF
--- a/Formula/mp4dovi.rb
+++ b/Formula/mp4dovi.rb
@@ -1,0 +1,19 @@
+class Mp4dovi < Formula
+  desc "Change Dolby Vision codec in MP4 files from dvhe to dvh1"
+  homepage "https://github.com/rixtox/mp4dovi"
+  url "https://github.com/rixtox/mp4dovi/archive/refs/tags/v0.1.1.tar.gz"
+  sha256 "969703be54566fbaa586979ed2e80c68ea1db7f5e0870ac039ec1f33087b6d8d"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args, "-o", "mp4dovi", "mp4dovi.go"
+    bin.install "mp4dovi"
+  end
+
+  test do
+    # no test for now as a mp4 encoded in dvhe must be supplied
+    system "true"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?: No tests since a mp4 file is required
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I would like to add a small and simple tool [mp4dovi](https://github.com/rixtox/mp4dovi) by [rixtox](https://github.com/rixtox).

As few media player is able to play back video with Dolby Vision: See discussion on mpv: https://github.com/mpv-player/mpv/issues/7326.

I came across with a small yet useful tool that would take a mp4 in dvhe to dvh1, making it playable with TV.app and QuickTime player in recent updates. [The use of a hex editor to modiy such marker is not always enough.](https://forum.makemkv.com/forum/viewtopic.php?t=18602&start=3450)

Granted that it will only be used for some video ppl on macOS and is a very small tool with only a few lines of code but it is very useful for datahoarder or movie fans on macos to be able to play back the Dolby Vision videos. I hope someone in need could find this useful.

BTW, it requires a go version >= 1.17 but I am not sure how to set that in the ruby file.

Thx
