### PR TITLE
brotli: add HTTP mirror

### DIFF
--- a/Formula/brotli.rb
+++ b/Formula/brotli.rb
@@ -2,6 +2,8 @@ class Brotli < Formula
   desc "Generic-purpose lossless compression algorithm by Google"
   homepage "https://github.com/google/brotli"
   url "https://github.com/google/brotli/archive/v1.0.9.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/brotli-1.0.9.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/legacy/brotli-1.0.9.tar.gz"
   sha256 "f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46"
   license "MIT"
   head "https://github.com/google/brotli.git", branch: "master"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

So we can install brewed curl with broken HTTPS.