### PR TITLE
libidn2: add HTTP mirror

### DIFF
--- a/Formula/libidn2.rb
+++ b/Formula/libidn2.rb
@@ -3,6 +3,7 @@ class Libidn2 < Formula
   homepage "https://www.gnu.org/software/libidn/#libidn2"
   url "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.2.tar.gz"
   mirror "https://ftpmirror.gnu.org/libidn/libidn2-2.3.2.tar.gz"
+  mirror "http://ftp.gnu.org/gnu/libidn/libidn2-2.3.2.tar.gz"
   sha256 "76940cd4e778e8093579a9d195b25fff5e936e9dc6242068528b437a76764f91"
   license any_of: ["GPL-2.0-or-later", "LGPL-3.0-or-later"]
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

So we can install brewed curl with broken HTTPS.