### PR TITLE
libssh2: add HTTP mirror

### DIFF
--- a/Formula/libssh2.rb
+++ b/Formula/libssh2.rb
@@ -2,6 +2,8 @@ class Libssh2 < Formula
   desc "C library implementing the SSH2 protocol"
   homepage "https://www.libssh2.org/"
   url "https://www.libssh2.org/download/libssh2-1.10.0.tar.gz"
+  mirror "https://github.com/libssh2/libssh2/releases/download/libssh2-1.10.0/libssh2-1.10.0.tar.gz"
+  mirror "http://download.openpkg.org/components/cache/libssh2/libssh2-1.10.0.tar.gz"
   sha256 "2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51"
   license "BSD-3-Clause"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

So we can install brewed curl with broken HTTPS.