### PR TITLE
libunistring: add HTTP mirror

### DIFF
--- a/Formula/libunistring.rb
+++ b/Formula/libunistring.rb
@@ -3,6 +3,7 @@ class Libunistring < Formula
   homepage "https://www.gnu.org/software/libunistring/"
   url "https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
   mirror "https://ftpmirror.gnu.org/libunistring/libunistring-0.9.10.tar.xz"
+  mirror "http://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
   sha256 "eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7"
   license any_of: ["GPL-2.0-only", "LGPL-3.0-or-later"]
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

So we can install brewed curl with broken HTTPS.