### PR TITLE
libunwind: add livecheck

### DIFF
--- a/Formula/libunwind.rb
+++ b/Formula/libunwind.rb
@@ -5,6 +5,11 @@ class Libunwind < Formula
   sha256 "90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017"
   license "MIT"
 
+  livecheck do
+    url "https://download.savannah.nongnu.org/releases/libunwind/"
+    regex(/href=.*?libunwind[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, x86_64_linux: "0dbcc161bfb5d2e20743f2bfcbf2fcf0e5583662f91d6c2ab4b0e0bea2e26a1d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `libunwind`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. [The [first-party download page](https://www.nongnu.org/libunwind/download.html) contains outdated version information and links to the related directory listing page as the place to download files.]