### PR TITLE
notcurses 2.4.4

### DIFF
--- a/Formula/notcurses.rb
+++ b/Formula/notcurses.rb
@@ -1,8 +1,8 @@
 class Notcurses < Formula
   desc "Blingful character graphics/TUI library"
   homepage "https://nick-black.com/dankwiki/index.php/Notcurses"
-  url "https://github.com/dankamongmen/notcurses/archive/refs/tags/v2.4.3.tar.gz"
-  sha256 "3405b0af37820570c808478c7cf0965a5b1117a0394bf95e123a4f05ad3fe15a"
+  url "https://github.com/dankamongmen/notcurses/archive/refs/tags/v2.4.4.tar.gz"
+  sha256 "dcd084b8ff516defd10840936aebec9b822fb622f0232cc79be7b8826252aad5"
 
   license "Apache-2.0"
 
@@ -20,7 +20,6 @@ class Notcurses < Formula
   depends_on "ffmpeg"
   depends_on "libunistring"
   depends_on "ncurses"
-  depends_on "readline"
   uses_from_macos "zlib"
 
   fails_with gcc: "5"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
From the [release notes](https://github.com/dankamongmen/notcurses/releases/tag/v2.4.4):
> Notcurses no longer uses libreadline, as it was realized to be incompatible with the new input system. `ncdirect_readline()` has been rewritten to work without libreadline, which means it's now always available (readline was an optional dependency). `NCDIRECT_OPTION_INHIBIT_CBREAK` should _not_ be used with `ncdirect_readline()`, or else it can't implement line-editing keybindings. Packagers, please stop supplying `-DUSE_READLINE` to CMake, and drop libreadline from Notcurses dependencies.