### PR TITLE
theora: remove `using: :homebrew_curl`

### DIFF
--- a/Formula/theora.rb
+++ b/Formula/theora.rb
@@ -1,7 +1,7 @@
 class Theora < Formula
   desc "Open video compression format"
   homepage "https://www.theora.org/"
-  url "https://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.bz2", using: :homebrew_curl
+  url "https://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.bz2"
   mirror "https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-1.1.1.tar.bz2"
   sha256 "b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc"
   license "BSD-3-Clause"


### PR DESCRIPTION
Just a test to see what exactly the error this is meant to avoid was.