### PR TITLE
mesa: remove livecheck

### DIFF
--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -8,11 +8,6 @@ class Mesa < Formula
   license "MIT"
   head "https://gitlab.freedesktop.org/mesa/mesa.git", branch: "main"
 
-  livecheck do
-    url "https://mesa.freedesktop.org/archive/"
-    regex(/href=.*?mesa[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 arm64_big_sur: "647680c6c57f129e8a468a24b1e3a292806e58678268eaaa7c041850e959b46a"
     sha256 big_sur:       "0a32b4ff6af04519287fcc66da4942dc312bd42729ddfaa88014dea8fa8ccb23"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #85078, where I updated the `livecheck` block for `mesa` to check the directory listing page where the `stable` archive is found (as there's no guarantee that a news post will be created for each release). At the time, I failed to notice that livecheck uses the same URL and regex by default, so this PR removes the redundant `livecheck` block.