### PR TITLE
hardlink: remove livecheck

### DIFF
--- a/Formula/hardlink.rb
+++ b/Formula/hardlink.rb
@@ -5,11 +5,6 @@ class Hardlink < Formula
   sha256 "e8c93dfcb24aeb44a75281ed73757cb862cc63b225d565db1c270af9dbb7300f"
   license "MIT"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?hardlink[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "fe5acfbc7a123db425beb0257ca23f4286b3260bd76b81027ee7528cc05bfdfd"
     sha256 cellar: :any,                 big_sur:       "1c2d9bd0578affd02e5b3ea25f09167665f555b652254cea27aabf1b704bf294"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`hardlink` was deprecated in #81765, as it has been merged into `util-linux`. This PR removes the `livecheck` block from the formula, so it will automatically skipped as deprecated.