### PR TITLE
opentsdb: update livecheck

### DIFF
--- a/Formula/opentsdb.rb
+++ b/Formula/opentsdb.rb
@@ -7,7 +7,7 @@ class Opentsdb < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the existing `livecheck` block for `opentsdb` to check the Git tags (using the standard regex for tags like `1.2.3`/`v1.2.3`) instead of using the `GithubLatest` strategy.

This `livecheck` block was originally created years ago (before the strategy existed) but we currently only use the `GithubLatest` strategy when it's both correct and necessary. In this case, checking the Git tags is sufficient to identify the latest version, so `GithubLatest` isn't necessary.