### PR TITLE
sqoop: remove livecheck

### DIFF
--- a/Formula/sqoop.rb
+++ b/Formula/sqoop.rb
@@ -7,12 +7,6 @@ class Sqoop < Formula
   sha256 "64111b136dbadcb873ce17e09201f723d4aea81e5e7c843e400eb817bb26f235"
   license "Apache-2.0"
 
-  # The regex here avoids x.99 releases, as they're pre-release versions.
-  livecheck do
-    url :stable
-    regex(%r{href=["']?v?((?!\d+\.9\d+)\d+(?:\.\d+)+)/?["' >]}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "04de1ca8398879433620c8bb66cda1c959fb3b724e6ed7638fd7e26d6e132483"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`sqoop` was deprecated in #85245, as the project has been deprecated upstream. This PR removes the `livecheck` block, so the formula is automatically skipped as deprecated.