### PR TITLE
ca-certificates: build an `all` bottle

### DIFF
--- a/Formula/ca-certificates.rb
+++ b/Formula/ca-certificates.rb
@@ -2,8 +2,6 @@ class CaCertificates < Formula
   desc "Mozilla CA certificate store"
   homepage "https://curl.se/docs/caextract.html"
   url "https://curl.se/ca/cacert-2021-09-30.pem"
-  # Ideally we'd have a HTTP mirror, but a GitHub-hosted one is second best.
-  mirror "https://raw.githubusercontent.com/Homebrew/formula-patches/7b48d2482eecb5aa64f591f79eda46565d0da29d/ca-certificates/cacert-2021-09-30.pem"
   sha256 "f524fc21859b776e18df01a87880efa198112214e13494275dbcbd9bcb71d976"
   license "MPL-2.0"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is needed for users on older versions of macOS who might not be
able to download the CA cert from curl.se.