### PR TITLE
wayland, wayland-protocols: add livecheck

### DIFF
--- a/Formula/wayland-protocols.rb
+++ b/Formula/wayland-protocols.rb
@@ -5,6 +5,11 @@ class WaylandProtocols < Formula
   sha256 "6c0af1915f96f615927a6270d025bd973ff1c58e521e4ca1fc9abfc914633f76"
   license "MIT"
 
+  livecheck do
+    url "https://wayland.freedesktop.org/releases.html"
+    regex(/href=.*?wayland-protocols[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "46ff9ea4c52643e3a0c7291e4dcf3badcb3adc64648e6c3e3c949fdca53b4f49"
   end

--- a/Formula/wayland.rb
+++ b/Formula/wayland.rb
@@ -5,6 +5,11 @@ class Wayland < Formula
   sha256 "baccd902300d354581cd5ad3cc49daa4921d55fb416a5883e218750fef166d15"
   license "MIT"
 
+  livecheck do
+    url "https://wayland.freedesktop.org/releases.html"
+    regex(/href=.*?wayland[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "6ed08aad2d77799e6631db5419442b10cfb937731928b874dc2daa83cae77886"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `wayland` and `wayland-protocols`. This PR adds a `livecheck` block that checks the first-party "Releases" page, which links to their respective `stable` archives.