### PR TITLE
folly: Add FOLLY_HAVE_INT128_T compilation option

### DIFF
--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -55,6 +55,9 @@ class Folly < Formula
         -DFOLLY_USE_JEMALLOC=OFF
       ]
 
+      # Enable 128-bit integer macros and templates.
+      args += %w[-DFOLLY_HAVE_INT128_T=ON] if OS.mac?
+
       system "cmake", "..", *args, "-DBUILD_SHARED_LIBS=ON"
       system "make"
       system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
