### PR TITLE
inso 2.3.2 (new formula)

### DIFF
--- a/Formula/inso.rb
+++ b/Formula/inso.rb
@@ -7,11 +7,33 @@ class Inso < Formula
   sha256 "3ae32671053f87957b508f40a2ffd5a610b03cae85ecffd801432c8288abcc03"
   license "MIT"
 
-  depends_on "curl"
   depends_on "node"
 
+  uses_from_macos "curl"
+
   def install
-    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    # std_npm_install_args includes --build-from-source when brew itself is run
+    # with the flag (as both CI does and formula developers are instructed to
+    # do)
+    #
+    # in the case of the combination of uses_from_macos "curl", and
+    # node-libcurl, that flags causes node-gyp to attempt to source Mac OS's
+    # own libcurl.dylib, which fails as system dylibs are not made available in
+    # such a way these days
+    #
+    # ignoring the --build-from-source flags below means that even in,
+    # situations where brew requires that flag, it will be ignored for the npm
+    # install command, and node will avoid attempting to source libcurl from
+    # Mac OS's private dylibs
+    npm_arguments = [
+      "npm",
+      "install",
+      Language::Node.std_npm_install_args(libexec).delete_if do |arg|
+        arg == "--build-from-source"
+      end,
+    ].flatten
+
+    system(*npm_arguments)
     bin.install_symlink Dir["#{libexec}/bin/*"]
 
     deuniversalize_machos

--- a/Formula/inso.rb
+++ b/Formula/inso.rb
@@ -7,9 +7,8 @@ class Inso < Formula
   sha256 "3ae32671053f87957b508f40a2ffd5a610b03cae85ecffd801432c8288abcc03"
   license "MIT"
 
+  depends_on "curl"
   depends_on "node"
-
-  uses_from_macos "curl"
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)

--- a/Formula/inso.rb
+++ b/Formula/inso.rb
@@ -1,0 +1,25 @@
+require "language/node"
+
+class Inso < Formula
+  desc "CLI for Insomnia"
+  homepage "https://insomnia.rest"
+  url "https://registry.npmjs.org/insomnia-inso/-/insomnia-inso-2.3.2.tgz"
+  sha256 "3ae32671053f87957b508f40a2ffd5a610b03cae85ecffd801432c8288abcc03"
+  license "MIT"
+
+  depends_on "node"
+
+  uses_from_macos "curl"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+
+    deuniversalize_machos
+  end
+
+  test do
+    output = pipe_output("#{bin}/inso --help 2>&1")
+    assert_match "Usage: inso", output
+  end
+end


### PR DESCRIPTION
This adds to Homebrew the ability to install the sister tool to the Insomnia (cask) desktop app, "inso", the Insomnia CLI.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
