### PR TITLE
getdns: fix dependencies

### DIFF
--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -4,6 +4,7 @@ class Getdns < Formula
   url "https://getdnsapi.net/releases/getdns-1-7-0/getdns-1.7.0.tar.gz"
   sha256 "ea8713ce5e077ac76b1418ceb6afd25e6d4e39e9600f6f5e81d3a3a13a60f652"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/getdnsapi/getdns.git", branch: "develop"
 
   # We check the GitHub releases instead of https://getdnsapi.net/releases/,
@@ -23,8 +24,10 @@ class Getdns < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "libev"
   depends_on "libevent"
   depends_on "libidn2"
+  depends_on "libuv"
   depends_on "openssl@1.1"
   depends_on "unbound"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Linkage failures found in the `nghttp2` PR.

`libev` is already linked. Also added `libuv` since it can be picked up opportunistically.
