### PR TITLE
libnghttp2: fix conflict error on upgrading

### DIFF
--- a/Formula/gettext.rb
+++ b/Formula/gettext.rb
@@ -1,10 +1,10 @@
 class Gettext < Formula
   desc "GNU internationalization (i18n) and localization (l10n) library"
   homepage "https://www.gnu.org/software/gettext/"
-  url "https://ftp.gnu.org/gnu/gettext/gettext-0.21.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gettext/gettext-0.21.tar.xz"
-  mirror "http://ftp.gnu.org/gnu/gettext/gettext-0.21.tar.xz"
-  sha256 "d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192"
+  url "https://ftp.gnu.org/gnu/gettext/gettext-0.21.tar.gz"
+  mirror "https://ftpmirror.gnu.org/gettext/gettext-0.21.tar.gz"
+  mirror "http://ftp.gnu.org/gnu/gettext/gettext-0.21.tar.gz"
+  sha256 "c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12"
   license "GPL-3.0-or-later"
 
   bottle do

--- a/Formula/libnghttp2.rb
+++ b/Formula/libnghttp2.rb
@@ -2,9 +2,10 @@ class Libnghttp2 < Formula
   desc "HTTP/2 C Library"
   homepage "https://nghttp2.org/"
   # Keep in sync with nghttp2.
-  url "https://github.com/nghttp2/nghttp2/releases/download/v1.45.1/nghttp2-1.45.1.tar.xz"
+  url "https://github.com/nghttp2/nghttp2/releases/download/v1.45.1/nghttp2-1.45.1.tar.gz"
   mirror "http://fresh-center.net/linux/www/nghttp2-1.45.1.tar.gz"
-  sha256 "abdc4addccadbc7d89abe27c4d6427d78e57d139f69c1f45749227393c68bf79"
+  mirror "http://fresh-center.net/linux/www/legacy/nghttp2-1.45.1.tar.gz"
+  sha256 "2379ebeff7b02e14b9a414551d73540ddce5442bbecda2748417e8505916f3e7"
   license "MIT"
 
   bottle do
@@ -24,6 +25,13 @@ class Libnghttp2 < Formula
   end
 
   depends_on "pkg-config" => :build
+
+  # These used to live in `nghttp2`.
+  link_overwrite "include/nghttp2"
+  link_overwrite "lib/libnghttp2.a"
+  link_overwrite "lib/libnghttp2.dylib"
+  link_overwrite "lib/libnghttp2.14.dylib"
+  link_overwrite "lib/pkgconfig/libnghttp2.pc"
 
   def install
     system "autoreconf", "-ivf" if build.head?

--- a/Formula/libunistring.rb
+++ b/Formula/libunistring.rb
@@ -1,10 +1,10 @@
 class Libunistring < Formula
   desc "C string library for manipulating Unicode strings"
   homepage "https://www.gnu.org/software/libunistring/"
-  url "https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
-  mirror "https://ftpmirror.gnu.org/libunistring/libunistring-0.9.10.tar.xz"
-  mirror "http://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz"
-  sha256 "eb8fb2c3e4b6e2d336608377050892b54c3c983b646c561836550863003c05d7"
+  url "https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.gz"
+  mirror "https://ftpmirror.gnu.org/libunistring/libunistring-0.9.10.tar.gz"
+  mirror "http://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.gz"
+  sha256 "a82e5b333339a88ea4608e4635479a1cfb2e01aafb925e1290b65710d43f610b"
   license any_of: ["GPL-2.0-only", "LGPL-3.0-or-later"]
 
   bottle do

--- a/Formula/nghttp2.rb
+++ b/Formula/nghttp2.rb
@@ -2,8 +2,8 @@ class Nghttp2 < Formula
   desc "HTTP/2 C Library"
   homepage "https://nghttp2.org/"
   # Keep in sync with libnghttp2.
-  url "https://github.com/nghttp2/nghttp2/releases/download/v1.45.1/nghttp2-1.45.1.tar.xz"
-  sha256 "abdc4addccadbc7d89abe27c4d6427d78e57d139f69c1f45749227393c68bf79"
+  url "https://github.com/nghttp2/nghttp2/releases/download/v1.45.1/nghttp2-1.45.1.tar.gz"
+  sha256 "2379ebeff7b02e14b9a414551d73540ddce5442bbecda2748417e8505916f3e7"
   license "MIT"
   revision 1
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/pull/86291#issuecomment-934394872
