### PR TITLE
libbsd: add livecheck

### DIFF
--- a/Formula/libbsd.rb
+++ b/Formula/libbsd.rb
@@ -5,6 +5,11 @@ class Libbsd < Formula
   sha256 "ff95cf8184151dacae4247832f8d4ea8800fa127dbd15033ecfe839f285b42a1"
   license "BSD-3-Clause"
 
+  livecheck do
+    url "https://libbsd.freedesktop.org/releases/"
+    regex(/href=.*?libbsd[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "47ff83f8f952f71030f61444df19635a5eb3d98edc346be4ee3955efc8f7d4fa"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


By default, livecheck gives an `Unable to get versions` error for `libbsd`. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. [The homepage links to the directory listing page as the place to download release tarballs.]