### PR TITLE
six: migrate to python@3.10

### DIFF
--- a/Formula/six.rb
+++ b/Formula/six.rb
@@ -4,7 +4,7 @@ class Six < Formula
   url "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
   sha256 "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "02ff012017a8eec787fccf3ae46c45b6681faec6a2f2160a5ff15aafb5af0894"
@@ -14,6 +14,7 @@ class Six < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "dee4622aebde5a4458f7fb814e9d91b591318c1ccd78f1657c3ae8e6dc047dcd"
   end
 
+  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.7" => [:build, :test] unless Hardware::CPU.arm?
   depends_on "python@3.8" => [:build, :test]
   depends_on "python@3.9" => [:build, :test]


### PR DESCRIPTION
six: migrate to python@3.10