### PR TITLE
jello: migrate to python@3.10

### DIFF
--- a/Formula/jello.rb
+++ b/Formula/jello.rb
@@ -6,6 +6,7 @@ class Jello < Formula
   url "https://files.pythonhosted.org/packages/9e/8c/c625f0d6c824cf955a29d6d3df537fe310c4b65ead63afbb77ec10a1c729/jello-1.4.4.tar.gz"
   sha256 "c42d5202282fa10b57f5830b8e4a74da7a75d585f000b812bbfd90bff28c2bfc"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d3d3e11871eabe0bfe95e772a269adac4a07d1496e627631e71b91d59377ace9"
@@ -14,7 +15,7 @@ class Jello < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "7b214228da50b700cffea3a060c1345e0e4d0761e5b7c23d47a61cfaf0a1afc4"
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "Pygments" do
     url "https://files.pythonhosted.org/packages/ba/6e/7a7c13c21d8a4a7f82ccbfe257a045890d4dbf18c023f985f565f97393e3/Pygments-2.9.0.tar.gz"


### PR DESCRIPTION
jello: migrate to python@3.10