### PR TITLE
python-markdown: migrate to python@3.10

### DIFF
--- a/Formula/python-markdown.rb
+++ b/Formula/python-markdown.rb
@@ -6,6 +6,7 @@ class PythonMarkdown < Formula
   url "https://files.pythonhosted.org/packages/49/02/37bd82ae255bb4dfef97a4b32d95906187b7a7a74970761fca1360c4ba22/Markdown-3.3.4.tar.gz"
   sha256 "31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/Python-Markdown/markdown.git", branch: "master"
 
   bottle do
@@ -16,7 +17,7 @@ class PythonMarkdown < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b513443497e90f6932d03abce5d7c186a02478ba7700c730798dde2973aa1dd6"
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
python-markdown: migrate to python@3.10