### PR TITLE
spoof-mac: migrate to python@3.10

### DIFF
--- a/Formula/spoof-mac.rb
+++ b/Formula/spoof-mac.rb
@@ -6,7 +6,7 @@ class SpoofMac < Formula
   url "https://files.pythonhosted.org/packages/9c/59/cc52a4c5d97b01fac7ff048353f8dc96f217eadc79022f78455e85144028/SpoofMAC-2.1.1.tar.gz"
   sha256 "48426efe033a148534e1d4dc224c4f1b1d22299c286df963c0b56ade4c7dc297"
   license "MIT"
-  revision 3
+  revision 4
   head "https://github.com/feross/SpoofMAC.git", branch: "master"
 
   bottle do
@@ -17,7 +17,7 @@ class SpoofMac < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "a8ddf450bb422f354d77aaaed1a183909c6160fa8bcd93a43aaea8ba2f0ab583"
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "docopt" do
     url "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz"


### PR DESCRIPTION
spoof-mac: migrate to python@3.10