### PR TITLE
trash-cli: migrate to python@3.10

### DIFF
--- a/Formula/trash-cli.rb
+++ b/Formula/trash-cli.rb
@@ -6,6 +6,7 @@ class TrashCli < Formula
   url "https://files.pythonhosted.org/packages/43/ed/ba5970572a6fd1332b8949b4c256954cd18d38764866504aa63f4322957b/trash-cli-0.21.7.24.tar.gz"
   sha256 "6cda4be92e19817fdd691fd8a9c5fa041c3b98761848ba353f0fd73cf1fe2710"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/andreafrancia/trash-cli.git", branch: "master"
 
   bottle do
@@ -16,7 +17,7 @@ class TrashCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "852161d4c6340611f9e9de8b1c0c18e6420cb8cdac99ecb0ec2b06223efebee5"
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   conflicts_with "macos-trash", because: "both install a `trash` binary"
   conflicts_with "trash", because: "both install a `trash` binary"


### PR DESCRIPTION
trash-cli: migrate to python@3.10