### PR TITLE
nvm: fix caveat string interpolation

### DIFF
--- a/Formula/nvm.rb
+++ b/Formula/nvm.rb
@@ -29,8 +29,8 @@ class Nvm < Formula
       configuration file:
 
         export NVM_DIR="$HOME/.nvm"
-        [ -s "#{opt_prefix}/nvm.sh" ] && \. "#{opt_prefix}/nvm.sh"  # This loads nvm
-        [ -s "#{opt_prefix}/etc/bash_completion.d/nvm" ] && \. "#{opt_prefix}/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
+        [ -s "#{opt_prefix}/nvm.sh" ] && \\. "#{opt_prefix}/nvm.sh"  # This loads nvm
+        [ -s "#{opt_prefix}/etc/bash_completion.d/nvm" ] && \\. "#{opt_prefix}/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
 
       You can set $NVM_DIR to any location, but leaving it unchanged from
       #{prefix} will destroy any nvm-installed Node installations

--- a/Formula/nvm.rb
+++ b/Formula/nvm.rb
@@ -21,10 +21,6 @@ class Nvm < Formula
       nvm via Homebrew is unsupported by them and you should check any
       problems against the standard nvm install method prior to reporting.
 
-      You should create NVM's working directory if it doesn't exist:
-
-        mkdir ~/.nvm
-
       Add the following to #{shell_profile} or your desired shell
       configuration file:
 

--- a/Formula/nvm.rb
+++ b/Formula/nvm.rb
@@ -21,12 +21,15 @@ class Nvm < Formula
       nvm via Homebrew is unsupported by them and you should check any
       problems against the standard nvm install method prior to reporting.
 
+      You should create NVM's working directory if it doesn't exist:
+         mkdir ~/.nvm
+      
       Add the following to #{shell_profile} or your desired shell
       configuration file:
 
-        export NVM_DIR="#{opt_prefix}/nvm"
-        [ -s "$NVM_DIR/nvm.sh" ] && \\. "$NVM_DIR/nvm.sh"  # This loads nvm
-        [ -s "$NVM_DIR/etc/bash_completion.d/nvm" ] && \\. "$NVM_DIR/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
+        export NVM_DIR="$HOME/.nvm"
+        [ -s "#{opt_prefix}/nvm.sh" ] && \\. "#{opt_prefix}/nvm.sh"  # This loads nvm
+        [ -s "#{opt_prefix}/etc/bash_completion.d/nvm" ] && \\. "#{opt_prefix}/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
 
       You can set $NVM_DIR to any location, but leaving it unchanged from
       #{prefix} will destroy any nvm-installed Node installations

--- a/Formula/nvm.rb
+++ b/Formula/nvm.rb
@@ -28,9 +28,9 @@ class Nvm < Formula
       Add the following to #{shell_profile} or your desired shell
       configuration file:
 
-        export NVM_DIR="$HOME/.nvm"
-        [ -s "#{opt_prefix}/nvm.sh" ] && \\. "#{opt_prefix}/nvm.sh"  # This loads nvm
-        [ -s "#{opt_prefix}/etc/bash_completion.d/nvm" ] && \\. "#{opt_prefix}/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
+        export NVM_DIR="#{opt_prefix}/nvm"
+        [ -s "$NVM_DIR/nvm.sh" ] && \\. "$NVM_DIR/nvm.sh"  # This loads nvm
+        [ -s "$NVM_DIR/etc/bash_completion.d/nvm" ] && \\. "$NVM_DIR/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
 
       You can set $NVM_DIR to any location, but leaving it unchanged from
       #{prefix} will destroy any nvm-installed Node installations

--- a/Formula/nvm.rb
+++ b/Formula/nvm.rb
@@ -23,7 +23,7 @@ class Nvm < Formula
 
       You should create NVM's working directory if it doesn't exist:
 
-         mkdir ~/.nvm
+        mkdir ~/.nvm
 
       Add the following to #{shell_profile} or your desired shell
       configuration file:

--- a/Formula/nvm.rb
+++ b/Formula/nvm.rb
@@ -22,8 +22,9 @@ class Nvm < Formula
       problems against the standard nvm install method prior to reporting.
 
       You should create NVM's working directory if it doesn't exist:
+
          mkdir ~/.nvm
-      
+
       Add the following to #{shell_profile} or your desired shell
       configuration file:
 


### PR DESCRIPTION
It seems that the "\" is eaten by the shell string interpolator. So the message displayed was:

```
[ -s "#{opt_prefix}/nvm.sh" ] && . "#{opt_prefix}/nvm.sh"  # This loads nvm
```

But what must be added to the shell configuration file should be:

```
[ -s "#{opt_prefix}/nvm.sh" ] && \. "#{opt_prefix}/nvm.sh"  # This loads nvm
```

As mentioned in: https://github.com/nvm-sh/nvm#manual-install
