### PR TITLE
openexr, imath: use `link_overwrite`, ilmbase: remove caveats

### DIFF
--- a/Formula/ilmbase.rb
+++ b/Formula/ilmbase.rb
@@ -28,13 +28,6 @@ class Ilmbase < Formula
     end
   end
 
-  def caveats
-    <<~EOS
-      `ilmbase` has been replaced by `imath`. You may want to `brew uninstall ilmbase`
-      or `brew unlink ilmbase` to prevent conflicts.
-    EOS
-  end
-
   test do
     (testpath/"test.cpp").write <<~'EOS'
       #include <ImathRoots.h>

--- a/Formula/imath.rb
+++ b/Formula/imath.rb
@@ -15,6 +15,10 @@ class Imath < Formula
 
   depends_on "cmake" => :build
 
+  # These used to be provided by `ilmbase`
+  link_overwrite "lib/libImath.dylib"
+  link_overwrite "lib/libImath.so"
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/openexr.rb
+++ b/Formula/openexr.rb
@@ -20,6 +20,13 @@ class Openexr < Formula
 
   uses_from_macos "zlib"
 
+  # These used to be provided by `ilmbase`
+  link_overwrite "include/OpenEXR"
+  link_overwrite "lib/libIex.dylib"
+  link_overwrite "lib/libIex.so"
+  link_overwrite "lib/libIlmThread.dylib"
+  link_overwrite "lib/libIlmThread.so"
+
   resource "exr" do
     url "https://github.com/openexr/openexr-images/raw/master/TestImages/AllHalfValues.exr"
     sha256 "eede573a0b59b79f21de15ee9d3b7649d58d8f2a8e7787ea34f192db3b3c84a4"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Using `link_overwrite` will fix `brew link` errors for users who might still have a non-keg-only version of `ilmbase` installed. Since we can avoid producing these errors for users, we no longer need the caveats in `ilmbase`.