### PR TITLE
libaio: add head, livecheck

### DIFF
--- a/Formula/libaio.rb
+++ b/Formula/libaio.rb
@@ -4,6 +4,18 @@ class Libaio < Formula
   url "https://pagure.io/libaio/archive/libaio-0.3.112/libaio-libaio-0.3.112.tar.gz"
   sha256 "b7cf93b29bbfb354213a0e8c0e82dfcf4e776157940d894750528714a0af2272"
   license "LGPL-2.1-or-later"
+  head "https://pagure.io/libaio.git", branch: "master"
+
+  # This regex only captures the first three numeric parts of the version
+  # (e.g., 0.3.110) and omits the optional trailing number (e.g., 0.3.110-1 or
+  # 0-3-107.1).
+  livecheck do
+    url :head
+    regex(/^libaio[._-]v?(\d+(?:[.-]\d+){1,2})(?:[.-]\d+)*$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.tr("-", ".") }
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "259d47affeaf26f081c49737f2121dc63ac5692c9752ecab4f1e333c81d19b53"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `libaio`. This PR adds a `head` URL and `livecheck` block that checks the Git tags. I ran `brew install --head libaio` in a Linux Docker container and it built/tested fine.

One thing to note is that this regex only captures the first three numeric parts of the version (e.g., `0.3.110`) and omits the optional trailing number (e.g., `0.3.110-1` or `0-3-107.1`). This assumes that we would only use `0.3.93` for the version if the upstream tag is `0-3-93.4`.

The desired version format was a bit unclear to me since there are limited revisions of this formula (unfortunately none with a four-part version) and repology.org simply uses the first three numeric parts. If the optional trailing fourth numeric part is meaningful for us (i.e., something we would include in the formula `version`), then I'll rework the regex and `strategy` block accordingly. Thoughts on this?