### PR TITLE
six: build an `all` bottle

### DIFF
--- a/Formula/six.rb
+++ b/Formula/six.rb
@@ -15,18 +15,32 @@ class Six < Formula
   end
 
   depends_on "python@3.10" => [:build, :test]
-  depends_on "python@3.7" => [:build, :test] unless Hardware::CPU.arm?
   depends_on "python@3.8" => [:build, :test]
   depends_on "python@3.9" => [:build, :test]
 
+  def pythons
+    deps.map(&:to_formula).sort_by(&:version)
+  end
+
   def install
-    deps.map(&:to_formula).each do |python|
+    pythons.each do |python|
       system python.opt_bin/"python3", *Language::Python.setup_install_args(prefix)
     end
   end
 
+  def caveats
+    python_versions = pythons.map { |p| p.version.major_minor }
+                             .map(&:to_s)
+                             .join(", ")
+
+    <<~EOS
+      This formula provides the `six` module for Python #{python_versions}.
+      If you need `six` for a different version of Python, use pip.
+    EOS
+  end
+
   test do
-    deps.map(&:to_formula).each do |python|
+    pythons.each do |python|
       system python.opt_bin/"python3", "-c", <<~EOS
         import six
         assert not six.PY2


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We do this by dropping the build for `python@3.7`. No formulae in
Homebrew/core need `six` built for `python@3.7`. Having an `all` bottle
guarantees that no user has to build this formula from source, even if
they are on an old version of macOS. (This would be especially unpleasant
for those users, who will also need to build each Python version from source.)

I've omitted the revision bump; I don't think there's a need to force a
reinstall for this change.