### PR TITLE
verapdf 1.19.198 (new formula)

### DIFF
--- a/Formula/verapdf.rb
+++ b/Formula/verapdf.rb
@@ -1,0 +1,31 @@
+class Verapdf < Formula
+  desc "Industry supported, open source PDF/A validation GUI and CUI"
+  homepage "https://software.verapdf.org/"
+  url "https://github.com/veraPDF/veraPDF-apps/archive/refs/tags/v1.19.198.tar.gz"
+  sha256 "6a29db1e015db51f31eac46da47ce10ac8b953971b142d440ed89323eede9f7d"
+  license any_of: ["GPL-3.0-or-later", "MPL-2.0"]
+
+  depends_on "maven" => :build
+  depends_on "openjdk@11"
+
+  def install
+    ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix
+
+    system "mvn", "--projects", "greenfield-apps,gui", "clean", "package"
+    libexec.install Dir["greenfield-apps/target/greenfield-apps-*-SNAPSHOT.jar"].first => "greenfield-apps-#{version}.jar"
+    (bin/"verapdf").write <<~EOS
+      #!/bin/bash
+      export JAVA_HOME="#{Language::Java.overridable_java_home_env("11")[:JAVA_HOME]}"
+      exec "${JAVA_HOME}/bin/java" -classpath "#{libexec/"greenfield-apps-#{version}.jar"}" org.verapdf.apps.GreenfieldCliWrapper "$@"
+    EOS
+    (bin/"verapdf-gui").write <<~EOS
+      #!/bin/bash
+      export JAVA_HOME="#{Language::Java.overridable_java_home_env("11")[:JAVA_HOME]}"
+      exec "${JAVA_HOME}/bin/java" -classpath "#{libexec/"greenfield-apps-#{version}.jar"}" org.verapdf.apps.GreenfieldGuiWrapper --frameScale 1.0 "$@"
+    EOS
+  end
+
+  test do
+    system bin/"verapdf", "--version"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

veraPDF has multiple repositories and [the main repository](https://github.com/veraPDF/veraPDF-library) has 188 stars so that I suppose veraPDF is eligible to be a Formula.
[The apps repository](https://github.com/veraPDF/veraPDF-apps) is subsidiary and does not meet the criteria of `brew audit --new`, though.