### PR TITLE
Sigrok

### DIFF
--- a/Formula/libsigrok.rb
+++ b/Formula/libsigrok.rb
@@ -1,0 +1,134 @@
+class Libsigrok < Formula
+  desc "Drivers for logic analyzers and other supported devices"
+  homepage "https://sigrok.org/"
+  # libserialport is LGPL3+
+  # fw-fx2lafw is GPL-2.0-or-later and LGPL-2.1-or-later"
+  license all_of: ["GPL-3.0-or-later", "LGPL-3.0-or-later", "GPL-2.0-or-later", "LGPL-2.1-or-later"]
+  revision 1
+
+  stable do
+    url "git://sigrok.org/libsigrok",
+        tag:      "libsigrok-0.5.2",
+        revision: "a6b07d7e28fe445afccf36922ef7d20e63e54fe6"
+    sha256 "4d341f90b6220d3e8cb251dacf726c41165285612248f2c52d15df4590a1ce3c"
+
+    resource "libserialport" do
+      url "git://sigrok.org/libserialport",
+          tag:      "libserialport-0.1.1",
+          revision: "348a6d353af8ac142f68fbf9fe0f4d070448d945"
+    end
+
+    resource "fw-fx2lafw" do
+      url "git://sigrok.org/sigrok-firmware-fx2lafw",
+          tag:      "sigrok-firmware-fx2lafw-0.1.7",
+          revision: "b6ec4813b592757e39784b9b370f3b12ae876954"
+    end
+  end
+
+  livecheck do
+    url :head
+    regex(/^libsigrok-(\d+(?:\.\d+)+)$/i)
+  end
+
+  head do
+    url "git://sigrok.org/libsigrok", branch: "master"
+
+    resource "libserialport" do
+      url "git://sigrok.org/libserialport", branch: "master"
+    end
+
+    resource "fw-fx2lafw" do
+      url "git://sigrok.org/sigrok-firmware-fx2lafw", branch: "master"
+    end
+  end
+
+  depends_on "autoconf" => :build
+  depends_on "autoconf-archive" => :build
+  depends_on "automake" => :build
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "sdcc" => :build
+  depends_on "swig" => :build
+  depends_on "glib"
+  depends_on "glibmm@2.66"
+  depends_on "hidapi"
+  depends_on "libftdi"
+  depends_on "libusb"
+  depends_on "libzip"
+  depends_on "nettle"
+  depends_on "numpy"
+  depends_on "pygobject3"
+  depends_on "python@3.9"
+
+  resource "fw-fx2lafw" do
+    url "https://sigrok.org/download/binary/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-bin-0.1.7.tar.gz"
+    sha256 "c876fd075549e7783a6d5bfc8d99a695cfc583ddbcea0217d8e3f9351d1723af"
+  end
+
+  def install
+    resource("fw-fx2lafw").stage do
+      system "./autogen.sh"
+      mkdir "build" do
+        system "../configure", "--prefix=#{prefix}"
+        system "make", "install"
+      end
+    end
+
+    resource("libserialport").stage do
+      system "./autogen.sh"
+      mkdir "build" do
+        system "../configure", "--prefix=#{prefix}"
+        system "make", "install"
+      end
+    end
+
+    # We need to use the Makefile to generate all of the dependencies
+    # for setup.py, so the easiest way to make the Python libraries
+    # work is to adjust setup.py's arguments here.
+    inreplace "Makefile.am" do |s|
+      s.gsub!(/^(setup_py =.*setup\.py .*)/, "\\1 --no-user-cfg")
+      s.gsub!(/(\$\(setup_py\) install)/, "\\1 --single-version-externally-managed --record=installed.txt")
+    end
+
+    system "./autogen.sh"
+    mkdir "build" do
+      ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
+      ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
+      args = %W[
+        --prefix=#{prefix}
+        --disable-java
+        --disable-ruby
+      ]
+      system "../configure", *args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <libsigrok/libsigrok.h>
+
+      int main() {
+        struct sr_context *ctx;
+        if (sr_init(&ctx) != SR_OK) {
+           exit(EXIT_FAILURE);
+        }
+        if (sr_exit(ctx) != SR_OK) {
+           exit(EXIT_FAILURE);
+        }
+        return 0;
+      }
+    EOS
+    flags = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs libsigrok").strip.split
+    system ENV.cc, *flags, "test.c", "-o", "test"
+    system "./test"
+
+    system Formula["python@3.9"].opt_bin/"python3", "-c", <<~EOS
+      import sigrok.core as sr
+      sr.Context_create()
+    EOS
+  end
+end

--- a/Formula/libsigrokdecode.rb
+++ b/Formula/libsigrokdecode.rb
@@ -1,0 +1,77 @@
+class Libsigrokdecode < Formula
+  desc "Drivers for logic analyzers and other supported devices"
+  homepage "https://sigrok.org/"
+  license "GPL-3.0-or-later"
+  revision 1
+
+  stable do
+    url "git://sigrok.org/libsigrokdecode",
+        tag:      "libsigrokdecode-0.5.3",
+        revision: "97991a3919da6a07c4c87308ae66fb441bd512e3"
+
+    # Apply commit 9b0ad5177bd692f7556a4756bdbd2da81d9c34ce to add
+    # support for Python 3.9.
+    patch :DATA
+  end
+
+  livecheck do
+    url :head
+    regex(/^libsigrokdecode-(\d+(?:\.\d+)+)$/i)
+  end
+
+  head do
+    url "git://sigrok.org/libsigrokdecode", branch: "master"
+  end
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "python@3.9"
+
+  def install
+    system "./autogen.sh"
+    mkdir "build" do
+      system "../configure", "--prefix=#{prefix}"
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <libsigrokdecode/libsigrokdecode.h>
+
+      int main() {
+        if (srd_init(NULL) != SRD_OK) {
+           exit(EXIT_FAILURE);
+        }
+        if (srd_exit() != SRD_OK) {
+           exit(EXIT_FAILURE);
+        }
+        return 0;
+      }
+    EOS
+    flags = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs libsigrokdecode").strip.split
+    system ENV.cc, *flags, "test.c", "-o", "test"
+    system "./test"
+  end
+end
+
+__END__
+diff --git a/configure.ac b/configure.ac
+index 5b432ea..4802f35 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -93,7 +93,7 @@ SR_PKG_CHECK_SUMMARY([srd_pkglibs_summary])
+ # first, since usually only that variant will add "-lpython3.8".
+ # https://docs.python.org/3/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build
+ SR_PKG_CHECK([python3], [SRD_PKGLIBS],
+-	[python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
++	[python-3.9-embed], [python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
+ AS_IF([test "x$sr_have_python3" = xno],
+ 	[AC_MSG_ERROR([Cannot find Python 3 development headers.])])
+ 

--- a/Formula/sigrok-cli.rb
+++ b/Formula/sigrok-cli.rb
@@ -1,0 +1,40 @@
+class SigrokCli < Formula
+  desc "Sigrok command-line interface to use logic analyzers and more"
+  homepage "https://sigrok.org/"
+  license "GPL-3.0-or-later"
+  revision 1
+
+  stable do
+    url "git://sigrok.org/sigrok-cli",
+        tag:      "sigrok-cli-0.7.2",
+        revision: "b584f959edb788f1731d5a304badf241ac21bf65"
+  end
+
+  livecheck do
+    url :head
+    regex(/^sigrok-cli-(\d+(?:\.\d+)+)$/i)
+  end
+
+  head do
+    url "git://sigrok.org/sigrok-cli", branch: "master"
+  end
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "libsigrok"
+
+  def install
+    system "./autogen.sh"
+    mkdir "build" do
+      system "../configure", "--prefix=#{prefix}"
+      system "make", "install"
+    end
+  end
+
+  test do
+    system "#{bin}/sigrok-cli", "-L"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This pull request adds formulas for Sigrok. Sigrok is a driver and set of applications to control logic analyzers, oscilloscopes, DMMs, and other lab instruments. This pull request contains the following formulas:

- libsigrok: This is the main Sigrok driver. This formula includes libserialport and open source firmware for various FX2-based logic analyzers.
- libsigrokdecode: This is protocol decoder library used by Sigrok. It contains support for multiple protocols such as I2C and SPI.
- sigrok: This is the main formula containing the command line interface for Sigrok.