### PR TITLE
lilypond: fix build from HEAD

### DIFF
--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -28,6 +28,8 @@ class Lilypond < Formula
   head do
     url "https://git.savannah.gnu.org/git/lilypond.git", branch: "master"
     mirror "https://github.com/lilypond/lilypond.git"
+
+    depends_on "autoconf" => :build
   end
 
   depends_on "bison" => :build # bison >= 2.4.1 is required
@@ -48,6 +50,7 @@ class Lilypond < Formula
   uses_from_macos "perl" => :build
 
   def install
+    system "./autogen.sh", "--noconfigure" if build.head?
     system "./configure",
             "--prefix=#{prefix}",
             "--datadir=#{share}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR fixes build from HEAD, as it needs to run `./autogen.sh` first. It does not affect the bottles.
