### PR TITLE
nvm: NVM_DIR is default to $HOME/.nvm

### DIFF
--- a/Formula/nvm.rb
+++ b/Formula/nvm.rb
@@ -4,6 +4,7 @@ class Nvm < Formula
   url "https://github.com/creationix/nvm/archive/v0.39.1.tar.gz"
   sha256 "4b6f6af05f94839b1116d661adb7d3af4ac17a7f10c280cdf84be084c7ab3b61"
   license "MIT"
+  revision 1
   head "https://github.com/nvm-sh/nvm.git", branch: "master"
 
   bottle do
@@ -11,7 +12,17 @@ class Nvm < Formula
   end
 
   def install
-    prefix.install "nvm.sh", "nvm-exec"
+    (prefix/"nvm.sh").write <<~EOS
+      # $NVM_DIR should be "$HOME/.nvm" by default to avoid user-installed nodes destroyed every update
+      [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
+      \\. #{libexec}/nvm.sh
+      # "nvm exec" and certain 3rd party scripts expect "nvm.sh" and "nvm-exec" to exist under $NVM_DIR
+      [ -e "$NVM_DIR" ] || mkdir -p "$NVM_DIR"
+      [ -e "$NVM_DIR/nvm.sh" ] || ln -s #{opt_libexec}/nvm.sh "$NVM_DIR/nvm.sh"
+      [ -e "$NVM_DIR/nvm-exec" ] || ln -s #{opt_libexec}/nvm-exec "$NVM_DIR/nvm-exec"
+    EOS
+    libexec.install "nvm.sh", "nvm-exec"
+    prefix.install_symlink libexec/"nvm-exec"
     bash_completion.install "bash_completion" => "nvm"
   end
 


### PR DESCRIPTION
## What
The default NVM_DIR should be $HOME/.nvm not to destroy user-installed nodes on upgrades.
nvm.sh and nvm-exec are expected to be in NVM_DIR so that the shim script symlinks them into NVM_DIR.
This would reduce bug reports to upstream.
https://github.com/Homebrew/homebrew-core/pull/86702#issuecomment-937170891

## How
The existing `nvm.sh` is replaced with a shim script and `nvm.sh` from upstream is moved to `libexec`.
The shim script is basically loading `nvm.sh` with some additional operation to make things safer.
What the shim script does is as follows:
* If `$NVM_DIR` is not set, set it to `$HOME/.nvm`, which the upstream recommends as `$NVM_DIR`.
* Load `nvm.sh` placed in libexec. Note that this shim script will be generated every version so the path includes Cellar. Backslash in front of `.` is to avoid `alias .=something`
* If `$NVM_DIR` does not exist, create the directory on `$NVM_DIR`.
* If `$NVM_DIR/nvm.sh` does not exist, create a symlink at `$NVM_DIR/nvm.sh` to the Homebrew-provided `nvm.sh`. The upstream recommends nvm.sh should be under $NVM_DIR. Note that this symlink will be created only for the first time so that the link uses opt_prefix.
* If `$NVM_DIR/nvm-exec` does not exist, create a symlink at `$NVM_DIR/nvm-exec` to the Homebrew-provided `nvm.sh`. The upstream recommends nvm-exec should be under $NVM_DIR. Note that this symlink will be created only for the first time so that the link uses opt_prefix.

For those who set `$NVM_DIR` to `/usr/local/opt/nvm`, create a symlink at `#{prefix}/nvm-exec` to `#{libexec}/nvm-exec`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
