### PR TITLE
bgrep: fix build for Linux

### DIFF
--- a/Formula/bgrep.rb
+++ b/Formula/bgrep.rb
@@ -18,7 +18,9 @@ class Bgrep < Formula
   end
 
   def install
-    system ENV.cc, ENV.cflags, "-o", "bgrep", "bgrep.c"
+    args = %w[bgrep.c -o bgrep]
+    args << ENV.cflags if ENV.cflags.present?
+    system ENV.cc, *args
     bin.install "bgrep"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Turns out the source archive also contains a very basic Makefile, but decided not to overhaul the install block too much so that we can keep old bottles.

Also looks like some older `gcc` versions don't like an empty parameter (it tries looking for a source file with empty name).