### PR TITLE
ranger: add missing command 'rifle'

### DIFF
--- a/Formula/ranger.rb
+++ b/Formula/ranger.rb
@@ -6,7 +6,7 @@ class Ranger < Formula
   url "https://ranger.github.io/ranger-1.9.3.tar.gz"
   sha256 "ce088a04c91c25263a9675dc5c43514b7ec1b38c8ea43d9a9d00923ff6cdd251"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/ranger/ranger.git", branch: "master"
 
   bottle do
@@ -24,6 +24,18 @@ class Ranger < Formula
     libexec.install "ranger.py", "ranger"
     rewrite_shebang detected_python_shebang, libexec/"ranger.py"
     bin.install_symlink libexec/"ranger.py" => "ranger"
+
+    (buildpath/"rifle.py").write <<~EOS
+      #!/usr/bin/python -O
+      import sys
+      from ranger.ext import rifle
+      sys.exit(rifle.main())
+    EOS
+    chmod 0700, buildpath/"rifle.py"
+    libexec.install "rifle.py"
+    rewrite_shebang detected_python_shebang, libexec/"rifle.py"
+    bin.install_symlink libexec/"rifle.py" => "rifle"
+
     doc.install "examples"
   end
 


### PR DESCRIPTION
Update 1: force pushed. Forgot to bump up the revision number.

---

Define an entry for command/executable 'rifle'. Fixes Homebrew/homebrew-core#86796 and Homebrew/homebrew-core#34347.

Running the `rifle.py` in `#{libexec}/ranger/ext/rifle.py` doesn't work. Cause `ranger` is not really installed into the brewed python, but running as a python file by it. To make sure pkg `ranger` being found in `sys.path`. We must define a helper under `#{libexec}`, where is the pkg resources `ranger/` stored. (Put it in another way, make sure `#{libexec}` is used as the working directory and `ranger/` within is recognized.)

```
❯ tree libexec -L 1
libexec
├── ranger/
├── ranger.py*
└── rifle.py*  # helper added by this PR

1 directory, 2 files
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
