### PR TITLE
notcurses 2.4.5

### DIFF
--- a/Formula/notcurses.rb
+++ b/Formula/notcurses.rb
@@ -1,8 +1,8 @@
 class Notcurses < Formula
   desc "Blingful character graphics/TUI library"
   homepage "https://nick-black.com/dankwiki/index.php/Notcurses"
-  url "https://github.com/dankamongmen/notcurses/archive/refs/tags/v2.4.4.tar.gz"
-  sha256 "dcd084b8ff516defd10840936aebec9b822fb622f0232cc79be7b8826252aad5"
+  url "https://github.com/dankamongmen/notcurses/archive/refs/tags/v2.4.5.tar.gz"
+  sha256 "e006c8d0a19d148d1fa779803e19145a7d8c5f1bf1f8e9e5d2c14a5e0d860343"
 
   license "Apache-2.0"
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Nice, I see y'all already dropped the readline dependency with 2.4.4. This is a fairly important update to 2.4.4, solving a number of problems: https://github.com/dankamongmen/notcurses/releases/tag/v2.4.5. Primary among these were 2.4.4's failure to start in certain cursor locations, and backspace no longer being honored in several terminals. Several older bugs were also found and resolved, including an invalid memory access in `ncplane_reparent_family()` and `ncplane_dup()` generating garbage when run on a root plane.