### PR TITLE
cantata 2.4.2 (new formula)

### DIFF
--- a/Formula/cantata.rb
+++ b/Formula/cantata.rb
@@ -1,0 +1,46 @@
+class Cantata < Formula
+  desc "Qt5 Graphical MPD Client"
+  homepage "https://github.com/CDrummond/cantata"
+  url "https://github.com/CDrummond/cantata/archive/v2.4.2.tar.gz"
+  sha256 "6d2e18200fb4e268dbacacf0e5a3a674fe1a3517ad6708c02dc829c2ffb1d3ba"
+  license "GPL-3.0-or-later"
+  head "https://github.com/CDrummond/cantata.git", branch: "master"
+
+  depends_on "cmake" => :build
+  # Enable optional support for MTP devices.
+  depends_on "libmtp" => :build
+  depends_on "qt@5" => :build
+  # Enable optional support for tag editing and track organization.
+  depends_on "taglib" => :build
+
+  on_linux do
+    depends_on "gcc"
+  end
+  fails_with gcc: "5"
+
+  def install
+    if OS.mac?
+      cd "mac" do
+        system "./createicon.sh"
+      end
+    end
+
+    ENV["Qt5_DIR"] = Formula["qt@5"].opt_lib/"cmake"
+    ENV.prepend_path "CMAKE_PREFIX_PATH", Formula["qt@5"].opt_lib/"cmake/Qt5Widgets"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+    bin.install_symlink prefix/"Cantata.app/Contents/MacOS/cantata" if OS.mac?
+  end
+
+  def caveats
+    <<~EOS
+      Cantata.app was installed to:
+        #{opt_prefix}
+    EOS
+  end
+
+  test do
+    assert_match "cantata #{version}", shell_output("#{bin/"cantata"} -v ")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As discussed in Homebrew/discussions#1370 and CDrummond/cantata#1671, the Cantata maintainer is no longer providing precompiled binaries for Cantata releases. Therefore, the `cantata` cask (https://formulae.brew.sh/cask/cantata) cannot be updated beyond `v2.3.2`, which was released in August 2018.

This adds a core formula to supercede the cask distribution. The formula builds a `.app` bundle, and the user is informed via caveats that they may wish to link it to their system directory. A symlink to the `cantata` binary is also exposed directly in the formula's `bin/` directory.

~A patch is applied to fix the application's theming on MacOS. This change has also been merged into Cantata master (CDrummond/cantata#1692), but not yet included in a release.~

#3331 provides some precedent for this sort of migration. As with `gedit`, I imagine we'd also want to sunset the `cantata` cask if this PR is accepted.