### PR TITLE
asciidoc: migrate to python@3.10

### DIFF
--- a/Formula/asciidoc.rb
+++ b/Formula/asciidoc.rb
@@ -6,6 +6,7 @@ class Asciidoc < Formula
   url "https://github.com/asciidoc-py/asciidoc-py/archive/9.1.1.tar.gz"
   sha256 "914dfc1542c30bd47faa0aaaae0985cb57d0ca584015729ccd1b94d90da3a616"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/asciidoc-py/asciidoc-py.git", branch: "main"
 
   livecheck do
@@ -20,7 +21,7 @@ class Asciidoc < Formula
   depends_on "autoconf" => :build
   depends_on "docbook-xsl" => :build
   depends_on "docbook"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   depends_on "source-highlight"
 
   uses_from_macos "libxml2" => :build


### PR DESCRIPTION
asciidoc: migrate to python@3.10