### PR TITLE
yazpp: update livecheck url

### DIFF
--- a/Formula/yazpp.rb
+++ b/Formula/yazpp.rb
@@ -6,7 +6,7 @@ class Yazpp < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url :homepage
+    url "https://ftp.indexdata.com/pub/yazpp/"
     regex(/href=.*?yazpp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Update livecheck url as the homepage does not have the stable artifact url anymore, hence, switching the url to the first party artifact url. 

relates to #86971