### PR TITLE
aspectj 1.9.7

### DIFF
--- a/Formula/aspectj.rb
+++ b/Formula/aspectj.rb
@@ -1,13 +1,13 @@
 class Aspectj < Formula
   desc "Aspect-oriented programming for Java"
   homepage "https://www.eclipse.org/aspectj/"
-  url "https://www.eclipse.org/downloads/download.php?r=1&file=/tools/aspectj/aspectj-1.9.6.jar"
-  sha256 "afec62c03fe154adeecf9cd599ce033fff258d1d373a82511e5df54f79ab03e2"
-  revision 1
+  url "https://github.com/eclipse/org.aspectj/releases/download/V1_9_7/aspectj-1.9.7.jar"
+  sha256 "c6b83cf272ce71a81a02c1529e760286196fe842a1741aa42494c3ce1501bd3a"
+  license "EPL-2.0"
 
   livecheck do
-    url "https://www.eclipse.org/aspectj/downloads.php"
-    regex(%r{Latest Stable Release.*?href=.*?/aspectj[._-]v?(\d+(?:\.\d+)+)\.jar}im)
+    url :stable
+    regex(/^v?(\d+(?:_\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
From their website:
Latest Stable Release
From 1.9.7 onwards, AspectJ releases are now available from GitHub.
See the releases page here.

Update livecheck accordingly

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
