### PR TITLE
geogram: update stable

### DIFF
--- a/Formula/geogram.rb
+++ b/Formula/geogram.rb
@@ -1,14 +1,11 @@
 class Geogram < Formula
   desc "Programming library of geometric algorithms"
   homepage "http://alice.loria.fr/software/geogram/doc/html/index.html"
-  url "https://gforge.inria.fr/frs/download.php/file/38361/geogram_1.7.6.tar.gz"
-  sha256 "4456d65baa014e9eb0352675f76eca260ed97eb386d23bc5c13af419dc2e8142"
+  # Homepage links to gforge.inria.fr for downloads, which gives a 403 response.
+  # We're using a GitHub tarball unless/until upstream finds a new home.
+  url "https://github.com/alicevision/geogram/archive/v1.7.6.tar.gz"
+  sha256 "e988c39d7a7323bb4dc73a7a90816717f3dad3696aabeefe044a37e97bbed59d"
   license all_of: ["BSD-3-Clause", :public_domain, "LGPL-3.0-or-later", "MIT"]
-
-  livecheck do
-    url "https://gforge.inria.fr/frs/?group_id=5833"
-    regex(/href=.*?geogram[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

INRIA Forge (gforge.inria.fr) has [reached its end of life](https://web.archive.org/web/20210610090406/https://gforge.inria.fr/forum/forum.php?forum_id=11543) and is giving a 403 response for any requests, so the `stable` URL for `geogram` doesn't work anymore. The download link on the `homepage` still links to gforge.inria.fr and the description for the latest release on the GitHub mirror also contains a link to gforge.inria.fr.

This PR updates the `stable` URL to use an autogenerated tarball from the GitHub mirror unless/until upstream finds a new place to host release tarballs. The formula builds/tests fine [on macOS] using the GitHub tarball without any changes to the `install` block.

Past that, I've removed the `livecheck` block, as the `Git` strategy works fine with the `stable` URL by default. The existing `livecheck` block was giving an `Unable to get versions` error due to the `403 Forbidden` response from gforge.inria.fr and this PR fixes this issue.