### PR TITLE
git-filter-repo: migrate to python@3.10

### DIFF
--- a/Formula/git-filter-repo.rb
+++ b/Formula/git-filter-repo.rb
@@ -6,12 +6,13 @@ class GitFilterRepo < Formula
   url "https://github.com/newren/git-filter-repo/releases/download/v2.33.0/git-filter-repo-2.33.0.tar.xz"
   sha256 "7bcf11da134bbd82a4171f7fb28a3ab7bc4d478fe8ec3a3d9580e4bbdc32e6e9"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "e6a31397b8642487d4fa6a5c8a80cfbdc8aba9cd4baab761296ac7a7fa06b7cd"
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   uses_from_macos "git", since: :catalina # git 2.22.0+ is required
 
   def install


### PR DESCRIPTION
git-filter-repo: migrate to python@3.10