### PR TITLE
hashpump: migrate to python@3.10

### DIFF
--- a/Formula/hashpump.rb
+++ b/Formula/hashpump.rb
@@ -4,7 +4,7 @@ class Hashpump < Formula
   url "https://github.com/bwall/HashPump/archive/v1.2.0.tar.gz"
   sha256 "d002e24541c6604e5243e5325ef152e65f9fcd00168a9fa7a06ad130e28b811b"
   license "MIT"
-  revision 5
+  revision 6
 
   livecheck do
     url :stable
@@ -21,7 +21,7 @@ class Hashpump < Formula
   end
 
   depends_on "openssl@1.1"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   # Remove on next release
   patch do


### PR DESCRIPTION
hashpump: migrate to python@3.10