### PR TITLE
taktuk: update urls

### DIFF
--- a/Formula/taktuk.rb
+++ b/Formula/taktuk.rb
@@ -1,14 +1,9 @@
 class Taktuk < Formula
   desc "Deploy commands to (a potentially large set of) remote nodes"
-  homepage "https://taktuk.gforge.inria.fr/"
-  url "https://gforge.inria.fr/frs/download.php/file/37055/taktuk-3.7.7.tar.gz"
+  homepage "https://web.archive.org/web/20200806133931/https://taktuk.gforge.inria.fr/"
+  url "https://deb.debian.org/debian/pool/main/t/taktuk/taktuk_3.7.7.orig.tar.gz"
   sha256 "56a62cca92670674c194e4b59903e379ad0b1367cec78244641aa194e9fe893e"
   license "GPL-2.0-or-later"
-
-  livecheck do
-    url "https://gforge.inria.fr/frs/?group_id=274"
-    regex(/href=.*?taktuk[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "d9743ff8c715d03d4549f09850a2029c135e72859d0518d94b44b3aa51f7abf6"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

INRIA Forge (gforge.inria.fr) has [reached end of life](https://web.archive.org/web/20210610090406/https://gforge.inria.fr/forum/forum.php?forum_id=11543) and is giving a 403 response for any requests, so the `homepage` and `stable` URLs for `taktuk` don't work anymore. This PR updates the `homepage` to use an archive.org snapshot and switches the `stable` URL to the `orig` tarball from Debian (same `sha256` as the existing tarball).

Past that, I've removed the `livecheck` block, as there aren't any sources that we could/should check for new versions. `brew livecheck` will give an `Unable to get versions` error but this is fine for now, as it's not checking any URLs. [I'm tentatively thinking about expanding `Livecheck::SkipConditions` in the future to automatically skip formulae that have a Debian `stable` URL (this can be overridden by a `livecheck` block), so this situation would be handled without needing to manually add a `livecheck` block that uses `skip`.]