### PR TITLE
kanif: update urls and license

### DIFF
--- a/Formula/kanif.rb
+++ b/Formula/kanif.rb
@@ -1,14 +1,9 @@
 class Kanif < Formula
   desc "Cluster management and administration tool"
-  homepage "http://taktuk.gforge.inria.fr/kanif/"
-  url "https://gforge.inria.fr/frs/download.php/26773/kanif-1.2.2.tar.gz"
+  homepage "https://web.archive.org/web/20200523045112/https://taktuk.gforge.inria.fr/kanif/"
+  url "https://deb.debian.org/debian/pool/main/k/kanif/kanif_1.2.2.orig.tar.gz"
   sha256 "3f0c549428dfe88457c1db293cfac2a22b203f872904c3abf372651ac12e5879"
-  license "GPL-2.0"
-
-  livecheck do
-    url "https://gforge.inria.fr/frs/?group_id=274"
-    regex(/href=.*?kanif[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "cfc06314d243173b2b0f0de1188570adde896ef6002dcbb75e7ce9fe056ae172"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

INRIA Forge (gforge.inria.fr) has [reached end of life](https://web.archive.org/web/20210610090406/https://gforge.inria.fr/forum/forum.php?forum_id=11543) and is giving a 403 response for any requests, so the `homepage` and `stable` URLs for `kanif` don't work anymore. This PR updates the `homepage` to use an archive.org snapshot and switches the `stable` URL to the `orig` tarball from Debian (same `sha256` as the existing tarball).

I've also removed the `livecheck` block, as there aren't any sources that we could/should check for new versions. `brew livecheck` will give an `Unable to get versions` error but this is fine for now, as it's not checking any URLs. [I'm tentatively thinking about expanding `Livecheck::SkipConditions` in the future to automatically skip formulae that have a Debian `stable` URL (this can be overridden by a `livecheck` block), so this situation would be handled without needing to manually add a `livecheck` block that uses `skip`.]

Lastly, this updates the `license` from `GPL-2.0` to `GPL-2.0-or-later`, referencing various source files that contain a comment like:

```
###############################################################################
#                                                                             #
#  kanif, a TakTuk wrapper for cluster management.                            #
#  Perl implementation, copyright(C) 2007 Guillaume Huard.                    #
#                                                                             #
#  This program is free software; you can redistribute it and/or modify       #
#  it under the terms of the GNU General Public License as published by       #
#  the Free Software Foundation; either version 2 of the License, or          #
#  (at your option) any later version.                                        #
#                                                                             #
#  This program is distributed in the hope that it will be useful,            #
#  but WITHOUT ANY WARRANTY; without even the implied warranty of             #
#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              #
#  GNU General Public License for more details.                               #
#                                                                             #
#  You should have received a copy of the GNU General Public License          #
#  along with this program; if not, write to the Free Software                #
#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA #
#                                                                             #
#  Contact: Guillaume.Huard@imag.fr                                           #
#           ENSIMAG - Laboratoire ID                                          #
#           51 avenue Jean Kuntzmann                                          #
#           38330 Montbonnot Saint Martin                                     #
#                                                                             #
###############################################################################
```