### PR TITLE
isl@0.18: update urls

### DIFF
--- a/Formula/isl@0.18.rb
+++ b/Formula/isl@0.18.rb
@@ -1,13 +1,13 @@
 class IslAT018 < Formula
   desc "Integer Set Library for the polyhedral model"
-  homepage "http://isl.gforge.inria.fr"
+  homepage "https://libisl.sourceforge.io/"
   # NOTE: Always use tarball instead of git tag for stable version.
   #
   # Currently isl detects its version using source code directory name
   # and update isl_version() function accordingly.  All other names will
   # result in isl_version() function returning "UNKNOWN" and hence break
   # package detection.
-  url "http://isl.gforge.inria.fr/isl-0.18.tar.xz"
+  url "https://libisl.sourceforge.io/isl-0.18.tar.xz"
   mirror "https://deb.debian.org/debian/pool/main/i/isl/isl_0.18.orig.tar.xz"
   sha256 "0f35051cc030b87c673ac1f187de40e386a1482a0cfdf2c552dd6031b307ddc4"
   license "MIT"
@@ -33,7 +33,7 @@ class IslAT018 < Formula
                           "--prefix=#{prefix}",
                           "--with-gmp=system",
                           "--with-gmp-prefix=#{Formula["gmp"].opt_prefix}"
-    system "make", "check"
+    system "make"
     system "make", "install"
     (share/"gdb/auto-load").install Dir["#{lib}/*-gdb.py"]
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Though `isl@0.18` is deprecated, this PR updates the `homepage` and `stable` URLs to align with the `isl` formula, as INRIA Forge has reached end of life and these URLs now return a 403 response.

This also brings the `install` steps in line with the `isl` formula, resolving the `Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks` audit error.