### PR TITLE
cloog: update `isl` resource url

### DIFF
--- a/Formula/cloog.rb
+++ b/Formula/cloog.rb
@@ -23,7 +23,7 @@ class Cloog < Formula
   depends_on "gmp"
 
   resource "isl" do
-    url "http://isl.gforge.inria.fr/isl-0.18.tar.xz"
+    url "https://libisl.sourceforge.io/isl-0.18.tar.xz"
     mirror "https://deb.debian.org/debian/pool/main/i/isl/isl_0.18.orig.tar.xz"
     sha256 "0f35051cc030b87c673ac1f187de40e386a1482a0cfdf2c552dd6031b307ddc4"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

INRIA Forge has reached end of life and gforge.inria.fr URLs now return a 403 response. This PR updates the `isl` resource URL to use the same archive file from SourceForge, which is the source the `isl` formula uses.