### PR TITLE
pazpar2 1.14.1

### DIFF
--- a/Formula/pazpar2.rb
+++ b/Formula/pazpar2.rb
@@ -1,13 +1,12 @@
 class Pazpar2 < Formula
   desc "Metasearching middleware webservice"
   homepage "https://www.indexdata.com/resources/software/pazpar2/"
-  url "https://ftp.indexdata.com/pub/pazpar2/pazpar2-1.14.0.tar.gz"
-  sha256 "3b0012450c66d6932009ac0decb72436690cc939af33e2ad96c0fec85863d13d"
+  url "https://ftp.indexdata.com/pub/pazpar2/pazpar2-1.14.1.tar.gz"
+  sha256 "9baf590adb52cd796eccf01144eeaaf7353db1fd05ae436bdb174fe24362db53"
   license "GPL-2.0-or-later"
-  revision 4
 
   livecheck do
-    url :homepage
+    url "https://ftp.indexdata.com/pub/pazpar2/"
     regex(/href=.*?pazpar2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
@@ -19,7 +18,7 @@ class Pazpar2 < Formula
   end
 
   head do
-    url "https://github.com/indexdata/pazpar2.git"
+    url "https://github.com/indexdata/pazpar2.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates `pazpar2` to the latest version, 1.14.1.

This also updates the `livecheck` block URL to check the directory listing page where the `stable` archive is found. The `homepage` previously linked to the `stable` archive but that link has been removed and livecheck is giving an `Unable to get versions` error. The "All files and versions" link on the `homepage` points to the directory listing page, so this is the download location for source archives.

Lastly, this adds `branch: "master"` after the `head` URL, to resolve the audit error.