### PR TITLE
jhiccup: update livecheck

### DIFF
--- a/Formula/jhiccup.rb
+++ b/Formula/jhiccup.rb
@@ -6,7 +6,7 @@ class Jhiccup < Formula
 
   livecheck do
     url :homepage
-    regex(/href=.*?jHiccup[._-]v?(\d+(?:\.\d+)+)-dist\.zip/i)
+    regex(/href=.*?jHiccup[._-]v?(\d+(?:\.\d+)+)-dist(?:-\d+)?\.zip/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `jhiccup` gives an `Unable to get versions` error, as the archive file linked on the `homepage` unexpectedly contains a trailing digit in the filename (`jHiccup-2.0.10-dist-1.zip` instead of the previous `jHiccup-2.0.10-dist.zip`). This PR updates the `livecheck` block regex to be able to match filenames both with and without a trailing digit in the filename.