### PR TITLE
libnghttp2: add livecheck

### DIFF
--- a/Formula/libnghttp2.rb
+++ b/Formula/libnghttp2.rb
@@ -8,6 +8,10 @@ class Libnghttp2 < Formula
   sha256 "2379ebeff7b02e14b9a414551d73540ddce5442bbecda2748417e8505916f3e7"
   license "MIT"
 
+  livecheck do
+    formula "nghttp2"
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "75ed9aea6aad424ff9406f7c8849d340d5f2fb36b05c9352f8416201fe03d1df"
     sha256 cellar: :any,                 big_sur:       "6edccdb5f700fa3602caa4ed902c18cdab02e64f33bdaf318a867b30b972a472"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags from the `stable` URL repository and successfully identifies the latest version.

This PR adds a `livecheck` block that uses `formula "nghttp2"`, to ensure the checks for these formulae are kept in parity. If a `livecheck` block is added to `nghttp2` in the future, the `libnghttp2` formula will automatically use the same check without needing any changes.

Just to be clear, we only use the `formula` livecheck DSL method when a canonical formula exists among multiple formulae using the same `stable` URL, as is the case here.