### PR TITLE
libimobiledevice-glue (new formula)

### DIFF
--- a/Formula/ideviceinstaller.rb
+++ b/Formula/ideviceinstaller.rb
@@ -3,7 +3,7 @@ class Ideviceinstaller < Formula
   homepage "https://www.libimobiledevice.org/"
   url "https://github.com/libimobiledevice/ideviceinstaller/releases/download/1.1.1/ideviceinstaller-1.1.1.tar.bz2"
   sha256 "deb883ec97f2f88115aab39f701b83c843e9f2b67fe02f5e00a9a7d6196c3063"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "30f56186281509d1f77d7a00cbcd1f313cd80135e3f9e2a235ca649f9a23e5f1"
@@ -15,7 +15,7 @@ class Ideviceinstaller < Formula
   end
 
   head do
-    url "https://git.sukimashita.com/ideviceinstaller.git"
+    url "https://git.libimobiledevice.org/ideviceinstaller.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build

--- a/Formula/ifuse.rb
+++ b/Formula/ifuse.rb
@@ -4,7 +4,7 @@ class Ifuse < Formula
   url "https://github.com/libimobiledevice/ifuse/archive/1.1.4.tar.gz"
   sha256 "2a00769e8f1d8bad50898b9d00baf12c8ae1cda2d19ff49eaa9bf580e5dbe78c"
   license "LGPL-2.1-or-later"
-  head "https://cgit.sukimashita.com/ifuse.git"
+  head "https://git.libimobiledevice.org/ifuse.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 catalina:     "cdce9fc5dbaf44641743b4a77434d340ae11cb8ed98f17b1a86a5653d2b6e1a2"

--- a/Formula/libimobiledevice-glue.rb
+++ b/Formula/libimobiledevice-glue.rb
@@ -1,0 +1,42 @@
+class LibimobiledeviceGlue < Formula
+  desc "Library with common system API code for libimobiledevice projects"
+  homepage "https://www.libimobiledevice.org/"
+  license "LGPL-2.1-or-later"
+  # Official Repo provides both a populated master and an empty main branch
+  head "https://git.libimobiledevice.org/libimobiledevice-glue.git", branch: "master"
+
+  # libimobiledevice-glue has no dedicated release version yet,
+  # so currently a HEAD-only package to fix the other libimobiledevice HEAD builds
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libplist"
+
+  def install
+    args = %W[
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+    ]
+
+    system "./autogen.sh", *args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include "libimobiledevice-glue/utils.h"
+
+      int main(int argc, char* argv[]) {
+        char *uuid = generate_uuid();
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-limobiledevice-glue-1.0", "-o", "test"
+    assert_equal 0, $CHILD_STATUS.exitstatus
+    system "./test"
+    assert_equal 0, $CHILD_STATUS.exitstatus
+  end
+end

--- a/Formula/libimobiledevice.rb
+++ b/Formula/libimobiledevice.rb
@@ -3,7 +3,7 @@ class Libimobiledevice < Formula
   homepage "https://www.libimobiledevice.org/"
   url "https://github.com/libimobiledevice/libimobiledevice/releases/download/1.3.0/libimobiledevice-1.3.0.tar.bz2"
   sha256 "53f2640c6365cd9f302a6248f531822dc94a6cced3f17128d4479a77bd75b0f6"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "41a64c9856f7845bb4c21bba4f42eb55c640301b59c032eb4db416db19ecf97d"
@@ -15,10 +15,12 @@ class Libimobiledevice < Formula
   end
 
   head do
-    url "https://git.libimobiledevice.org/libimobiledevice.git"
+    url "https://git.libimobiledevice.org/libimobiledevice.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
+    # Only future versions require this lib, so do not treat it as a main dependency yet
+    depends_on "libimobiledevice-glue"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/libirecovery.rb
+++ b/Formula/libirecovery.rb
@@ -15,10 +15,12 @@ class Libirecovery < Formula
   end
 
   head do
-    url "https://git.libimobiledevice.org/libirecovery.git"
+    url "https://git.libimobiledevice.org/libirecovery.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
+    # Only future versions require this lib, so do not treat it as a main dependency yet
+    depends_on "libimobiledevice-glue"
   end
 
   on_linux do

--- a/Formula/libplist.rb
+++ b/Formula/libplist.rb
@@ -3,7 +3,7 @@ class Libplist < Formula
   homepage "https://www.libimobiledevice.org/"
   url "https://github.com/libimobiledevice/libplist/archive/2.2.0.tar.gz"
   sha256 "7e654bdd5d8b96f03240227ed09057377f06ebad08e1c37d0cfa2abe6ba0cee2"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "ed9c2d665d5700c91f099bd433a38ba904b63eef4d3cdc47bd0f6b0229ac689a"
@@ -15,7 +15,7 @@ class Libplist < Formula
   end
 
   head do
-    url "https://git.sukimashita.com/libplist.git"
+    url "https://git.libimobiledevice.org/libplist.git", branch: "master"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/libusbmuxd.rb
+++ b/Formula/libusbmuxd.rb
@@ -4,7 +4,6 @@ class Libusbmuxd < Formula
   url "https://github.com/libimobiledevice/libusbmuxd/archive/2.0.2.tar.gz"
   sha256 "8ae3e1d9340177f8f3a785be276435869363de79f491d05d8a84a59efc8a8fdc"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
-  head "https://github.com/libimobiledevice/libusbmuxd.git"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "9cd9d1df802799e026f09775bbde2c4bf0557fb3e1f5919f14a5b0def0b0255e"
@@ -13,6 +12,12 @@ class Libusbmuxd < Formula
     sha256 cellar: :any,                 mojave:        "132ee76aa823e51abb97c92c53ab8a30819720ced7020080f949cf4fd937f6ea"
     sha256 cellar: :any,                 high_sierra:   "67c3d43cb2a1ebfd68fba1c9b51b419288fedefc93f101adeea1b5f6bdf1ad77"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b1f289531042024ef7fb1f87cad05f36a1c68ece14614266cf0564e32b3565ac"
+  end
+
+  head do
+    url "https://git.libimobiledevice.org/libusbmuxd.git", branch: "master"
+    # Only future versions require this lib, so do not treat it as a main dependency yet
+    depends_on "libimobiledevice-glue"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR adds the new [libimobiledevice-glue](https://github.com/libimobiledevice/libimobiledevice-glue) package required for future version of [libimobiledevice](https://github.com/libimobiledevice/) packages.
As it currently has no dedicated release and is currently only required for HEAD builds, this package also is currently a HEAD-only package, which is the only issue why this packet is not passing the audit test suite.

The packages requiring this new common API "glue" package have been updated as well to include this as a dependency; as it is currently only needed for HEAD-builds, the dependency has been added to the head section with a describing comment respectively.

Also all [libimobiledevice](https://github.com/libimobiledevice/) packages have been updated to point to the git repository URL as suggested by upstream.

Fixes #84699.