### PR TITLE
openfst: update urls

### DIFF
--- a/Formula/openfst.rb
+++ b/Formula/openfst.rb
@@ -1,12 +1,12 @@
 class Openfst < Formula
   desc "Library for weighted finite-state transducers"
-  homepage "http://www.openfst.org/twiki/bin/view/FST/WebHome"
-  url "http://openfst.org/twiki/pub/FST/FstDownload/openfst-1.8.1.tar.gz"
+  homepage "https://www.openfst.org/twiki/bin/view/FST/WebHome"
+  url "https://openfst.org/twiki/pub/FST/FstDownload/openfst-1.8.1.tar.gz"
   sha256 "24fb53b72bb687e3fa8ee96c72a31ff2920d99b980a0a8f61dda426fca6713f0"
   license "Apache-2.0"
 
   livecheck do
-    url "http://www.openfst.org/twiki/bin/view/FST/FstDownload"
+    url "https://www.openfst.org/twiki/bin/view/FST/FstDownload"
     regex(/href=.*?openfst[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The www.openfst.org URLs in the `openfst` formula redirect from HTTP to HTTPS, so this PR updates them to avoid the redirections.