### PR TITLE
podman: bump gvproxy component, fix head install

### DIFF
--- a/Formula/podman.rb
+++ b/Formula/podman.rb
@@ -1,11 +1,23 @@
 class Podman < Formula
   desc "Tool for managing OCI containers and pods"
   homepage "https://podman.io/"
-  url "https://github.com/containers/podman/archive/v3.4.0.tar.gz"
-  sha256 "558dcc8fbf72095aa1ec8abeb84ca2093dd0d51b77f0115ef855e640e2f03146"
   license "Apache-2.0"
   revision 2
-  head "https://github.com/containers/podman.git", branch: "main"
+
+  stable do
+    url "https://github.com/containers/podman/archive/v3.4.0.tar.gz"
+    sha256 "558dcc8fbf72095aa1ec8abeb84ca2093dd0d51b77f0115ef855e640e2f03146"
+
+    patch do
+      url "https://github.com/containers/podman/commit/cd4e10fdf93009f8ecba5f0c82c1c2a4a46f3e4f.patch?full_index=1"
+      sha256 "d173f27ff530022244cc6895bfd08fbb7546e1457b2edee0854732200aabfde5"
+    end
+
+    resource "gvproxy" do
+      url "https://github.com/containers/gvisor-tap-vsock/archive/v0.2.0.tar.gz"
+      sha256 "a54da74d6ad129a1c8fed3802ba8651cce37b123ee0e771b0d35889dae4751fc"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "03f38f5d89276c5b448812e4add56822e9e85c912d8fd078d87c0606b781cc5b"
@@ -14,19 +26,17 @@ class Podman < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "e56623493f090b800054d70a611b087528576b3ba3cb9efd59bcd549497beebe"
   end
 
+  head do
+    url "https://github.com/containers/podman.git", branch: "main"
+
+    resource "gvproxy" do
+      url "https://github.com/containers/gvisor-tap-vsock.git", branch: "main"
+    end
+  end
+
   depends_on "go" => :build
   depends_on "go-md2man" => :build
   depends_on "qemu"
-
-  resource "gvproxy" do
-    url "https://github.com/containers/gvisor-tap-vsock/archive/v0.2.0.tar.gz"
-    sha256 "a54da74d6ad129a1c8fed3802ba8651cce37b123ee0e771b0d35889dae4751fc"
-  end
-
-  patch do
-    url "https://github.com/containers/podman/commit/cd4e10fdf93009f8ecba5f0c82c1c2a4a46f3e4f.patch?full_index=1"
-    sha256 "d173f27ff530022244cc6895bfd08fbb7546e1457b2edee0854732200aabfde5"
-  end
 
   def install
     os = if OS.mac?

--- a/Formula/podman.rb
+++ b/Formula/podman.rb
@@ -4,7 +4,7 @@ class Podman < Formula
   url "https://github.com/containers/podman/archive/v3.4.0.tar.gz"
   sha256 "558dcc8fbf72095aa1ec8abeb84ca2093dd0d51b77f0115ef855e640e2f03146"
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/containers/podman.git", branch: "main"
 
   bottle do
@@ -19,8 +19,8 @@ class Podman < Formula
   depends_on "qemu"
 
   resource "gvproxy" do
-    url "https://github.com/containers/gvisor-tap-vsock/archive/v0.1.0.tar.gz"
-    sha256 "e1e1bec2fc42039da1ae68d382d4560a27c04bbe2aae535837294dd6773e88e0"
+    url "https://github.com/containers/gvisor-tap-vsock/archive/v0.2.0.tar.gz"
+    sha256 "a54da74d6ad129a1c8fed3802ba8651cce37b123ee0e771b0d35889dae4751fc"
   end
 
   patch do
@@ -44,7 +44,7 @@ class Podman < Formula
     end
 
     resource("gvproxy").stage do
-      system "make"
+      system "make", "gvproxy"
       libexec.install "bin/gvproxy"
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Includes https://github.com/containers/gvisor-tap-vsock/releases/tag/v0.2.0
