### PR TITLE
yaze-ag: update urls

### DIFF
--- a/Formula/yaze-ag.rb
+++ b/Formula/yaze-ag.rb
@@ -1,8 +1,8 @@
 class YazeAg < Formula
   desc "Yet Another Z80 Emulator (by AG)"
-  homepage "http://www.mathematik.uni-ulm.de/users/ag/yaze-ag/"
-  url "http://www.mathematik.uni-ulm.de/users/ag/yaze-ag/devel/yaze-ag-2.51.1.1.tar.gz"
-  sha256 "9144d3f2522bc369fab3b215868ef504a86452a3636f1a3c435349ea1f57125f"
+  homepage "https://www.mathematik.uni-ulm.de/users/ag/yaze-ag/"
+  url "https://www.mathematik.uni-ulm.de/users/ag/yaze-ag/devel/yaze-ag-2.51.1.1.tar.gz"
+  sha256 "0bcbb394b882bec91317c5fc08b7260a329b815b3fa4b50e669e1fc1ae49f5e4"
   license "GPL-2.0-or-later"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing www.mathematik.uni-ulm.de URLs in the `yaze-ag` formula are redirecting from HTTP to HTTPS, so this PR updates them to avoid the redirections.

Besides that, it was necessary to update the `sha256`, as it presumably [changed upstream on 2021-10-03 when Windows binaries were produced for 2.51.1.1](https://www.mathematik.uni-ulm.de/users/ag/yaze-ag/devel/ChangeLog.html) after the final release of 2.51.1.1 on 2021-08-23.