### PR TITLE
envoy: remove linux build

### DIFF
--- a/Formula/envoy.rb
+++ b/Formula/envoy.rb
@@ -9,10 +9,10 @@ class Envoy < Formula
   license "Apache-2.0"
 
   # Apple M1/arm64 is pending envoyproxy/envoy#16482
+  # Linux is unsupported due to complexity, frequent maintenance and long build times.
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:      "5d242c76931465e1bebc4ac62742bcdd68a42334679cc69f8c058e1f7b4147a1"
     sha256 cellar: :any_skip_relocation, catalina:     "48e53aac4dc4b8c7603141b711730427a5ca94ce4d3e3ce572c1c01cd96ad9f2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "deab2f6221196615ee138102d6496f849b85a11880fcf5b783ec30e07ed78419"
   end
 
   depends_on "automake" => :build
@@ -23,24 +23,6 @@ class Envoy < Formula
   depends_on "ninja" => :build
   depends_on macos: :catalina
 
-  on_linux do
-    # GCC added as a test dependency to work around Homebrew issue. Otherwise `brew test` fails.
-    # CompilerSelectionError: envoy cannot be built with any available compilers.
-    depends_on "gcc@9" => [:build, :test]
-    depends_on "python@3.9" => :build
-  end
-
-  # https://github.com/envoyproxy/envoy/tree/main/bazel#supported-compiler-versions
-  fails_with gcc: "5"
-  fails_with gcc: "6"
-  # GCC 10 build fails at external/com_google_absl/absl/container/internal/inlined_vector.h:469:5:
-  # error: '<anonymous>.absl::inlined_vector_internal::Storage<char, 128, std::allocator<char> >::data_'
-  # is used uninitialized in this function [-Werror=uninitialized]
-  fails_with gcc: "10"
-  # GCC 11 build fails at external/boringssl/src/crypto/curve25519/curve25519.c:503:57:
-  # error: argument 2 of type 'const uint8_t[32]' with mismatched bound [-Werror=array-parameter=]
-  fails_with gcc: "11"
-
   # Work around xcode 12 incompatibility until envoyproxy/envoy#17393
   patch do
     url "https://github.com/envoyproxy/envoy/commit/3b49166dc0841b045799e2c37bdf1ca9de98d5b1.patch?full_index=1"
@@ -48,11 +30,7 @@ class Envoy < Formula
   end
 
   def install
-    env_path = if OS.mac?
-      "#{HOMEBREW_PREFIX}/bin:/usr/bin:/bin"
-    else
-      "#{Formula["python@3.9"].opt_libexec}/bin:#{env_path}"
-    end
+    env_path = "#{HOMEBREW_PREFIX}/bin:/usr/bin:/bin"
     args = %W[
       --compilation_mode=opt
       --curses=no


### PR DESCRIPTION
I don't expect this change to be universally popular. However, I think
it is the most pragmatic way to isolate the impact of envoy on
maintainers and end users. Specifically, this removes the linux build
and in doing so removes fragile and complex configuration. It also will
reduce the time to land new versions on OS/x.

I believe this is justified beyond the technical dept recovered. Envoy
is not often installed on linux with homebrew. To the degree it can be
used, it can't be used on arm64 which is a supported Envoy platform on
Linux. The few using linuxbrew have other options including the official
docker images, func-e, and in the future, formal system packages and
tarballs.

Once we remove this, maintaining homebrew envoy's primary audience, OS/x
is easier and faster. We can focus energy on what's not available
elsewhere: a macOS build of Envoy. We can focus on the larger audience
which extends larger still when Envoy completes arm64+osx (likely in
version 1.21). Maintainers do not have to run very long linux builds
anymore, and CI resources can be conserved for projects more often used.

More details on the discussion are here, but I'm raising this PR as a
call to action. If the homebrew leads decide it is better to keep trying
to build on Linux, the main impact is continued longer and more complex
work to release new versions to end users. That's not the worst outcome,
but I believe they deserve better, hence this issue.

See https://github.com/Homebrew/discussions/discussions/2271

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
