### PR TITLE
brotli: add patch to remove bad flag from pkg-config files

### DIFF
--- a/Formula/brotli.rb
+++ b/Formula/brotli.rb
@@ -19,6 +19,15 @@ class Brotli < Formula
 
   depends_on "cmake" => :build
 
+  # Drop -R compiler flag from pkg-config files: it was meant to set rpath,
+  # which we don't need; and it isn't a real compiler flag, which causes
+  # linking of other software against brotli to fail on GCC before GCC 11.
+  # Remove upon next release.
+  patch do
+    url "https://github.com/google/brotli/commit/09b0992b6acb7faa6fd3b23f9bc036ea117230fc.patch?full_index=1"
+    sha256 "2e9e4b961a53bbd68435e3894cc93b12f1a3489924c242735e18374276f20d75"
+  end
+
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "VERBOSE=1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

brotli adds a flag to its pkg-config files that’s meant to set rpath. But neither does Homebrew need (or want) this, nor does it actually work in some/all compilers. At worst, it causes build failures when other software tries to link to any of the brotli libraries.

Upstream has dropped the flag. They have a [pending PR](https://github.com/google/brotli/pull/917) for a new release, but it’s been in limbo for a while, so maybe it’s good to have the patch in Homebrew for the time being.

Admittedly, the scope of problems that this fixes may be limited and is hard to judge:
* Hard build errors occur with GCC older than GCC 11. In particular, Homebrew’s `gcc` is now GCC 11 and does not produce errors. Practically speaking, this is limited to Linuxbrew with system GCC.
* There may or may not be subtle delayed issues if the flag actually succeeds with GCC 11 and sets rpath.
* I don’t know whether there is any difference at all with Clang. Clang’s docs say it has its own `-R` flag that enables a compiler remark, so _maybe_ it gobbles up the `-R/path/...`, sees it as an unfamiliar remark name and silently discards it.

I don’t know if this warrants a `revision` bump, as this isn’t a functional change (if this is accepted at all). I suppose it would be safest to bump if rpaths may pose a real concern. Otherwise, other formulæ shouldn’t need a rebuild/reinstall as nothing else would change, but `brotli` itself should still get reinstalled by `brew upgrade`.