### PR TITLE
llvm: test build for Linux

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -30,6 +30,7 @@ class Llvm < Formula
   # See: Homebrew/homebrew-core/issues/35513
   depends_on "cmake" => :build
   depends_on "swig" => :build
+  depends_on :linux
   depends_on "python@3.9"
 
   uses_from_macos "libedit"


### PR DESCRIPTION
Let's try to see what's wrong with this... Doing `depends_on :linux` to avoid tying up macOS runners.