### PR TITLE
python@3.9: revision bump (libffi 3.4.2)

### DIFF
--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -5,6 +5,7 @@ class PythonAT39 < Formula
   url "https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tar.xz"
   sha256 "f8145616e68c00041d1a6399b76387390388f8359581abc24432bb969b5e3c57"
   license "Python-2.0"
+  revision 1
 
   livecheck do
     url "https://www.python.org/ftp/python/"


### PR DESCRIPTION
This needs a revision bump after #80227.