### PR TITLE
python@3.10: revision bump (libffi 3.4.2)

### DIFF
--- a/Formula/python@3.10.rb
+++ b/Formula/python@3.10.rb
@@ -5,7 +5,7 @@ class PythonAT310 < Formula
   url "https://www.python.org/ftp/python/3.10.0/Python-3.10.0.tgz"
   sha256 "c4e0cbad57c90690cb813fb4663ef670b4d0f587d8171e2c42bd4c9245bd2758"
   license "Python-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://www.python.org/ftp/python/"


### PR DESCRIPTION
This needs a revision bump after #80227.