### PR TITLE
python@3.7: revision bump for testing dependents

### DIFF
--- a/Formula/python@3.7.rb
+++ b/Formula/python@3.7.rb
@@ -4,7 +4,7 @@ class PythonAT37 < Formula
   url "https://www.python.org/ftp/python/3.7.12/Python-3.7.12.tar.xz"
   sha256 "f77bf7fb47839f213e5cbf7827281078ea90de7e72b44f10d7ef385ea8c43210"
   license "Python-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://www.python.org/ftp/python/"


### PR DESCRIPTION
Let's test the dependents here, since they weren't tested in #80227.