### PR TITLE
ldc: add a build dependency on LLVM

### DIFF
--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -25,6 +25,8 @@ class Ldc < Formula
   depends_on "llvm@12"
 
   uses_from_macos "libxml2" => :build
+  # CompilerSelectionError: ldc cannot be built with any available compilers.
+  uses_from_macos "llvm" => [:build, :test]
 
   fails_with :gcc
 
@@ -48,7 +50,9 @@ class Ldc < Formula
   end
 
   def llvm
-    deps.map(&:to_formula).find { |f| f.name.match? "^llvm" }
+    deps.reject { |d| d.build? || d.test? }
+        .map(&:to_formula)
+        .find { |f| f.name.match? "^llvm" }
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is because of the `fails_with :gcc`, whose behaviour changed with
Homebrew/homebrew-test-bot#675. Note that this didn't come up in #85898.

CC @Bo98