### PR TITLE
libnetfilter-queue: add livecheck

### DIFF
--- a/Formula/libnetfilter-queue.rb
+++ b/Formula/libnetfilter-queue.rb
@@ -5,6 +5,11 @@ class LibnetfilterQueue < Formula
   sha256 "f9ff3c11305d6e03d81405957bdc11aea18e0d315c3e3f48da53a24ba251b9f5"
   license "LGPL-2.0-or-later"
 
+  livecheck do
+    url "https://www.netfilter.org/projects/libnetfilter_queue/downloads.html"
+    regex(/href=.*?libnetfilter_queue[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "bdf2add88a3b0b9bd7be4498abbf4a7caa052e2bac225908cffbc2b46d39ee66"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `libnetfilter-queue`. This PR adds a `livecheck` block that checks the first-party downloads page, which links to the `stable` archive.