### PR TITLE
terraform@0.11: use `OS.kernel_name`

### DIFF
--- a/Formula/terraform@0.11.rb
+++ b/Formula/terraform@0.11.rb
@@ -19,6 +19,7 @@ class TerraformAT011 < Formula
 
   depends_on "go@1.16" => :build
   depends_on "gox" => :build
+  depends_on arch: :x86_64
 
   on_linux do
     depends_on "zip" => :build
@@ -36,17 +37,15 @@ class TerraformAT011 < Formula
       ENV.delete "AWS_ACCESS_KEY"
       ENV.delete "AWS_SECRET_KEY"
 
-      os = if OS.mac?
-        "darwin"
-      else
-        "linux"
-      end
+      os = OS.kernel_name.downcase
+      arch = Hardware::CPU.intel? ? "amd64" : Hardware::CPU.arch.to_s
+
       ENV["XC_OS"] = os
-      ENV["XC_ARCH"] = "amd64"
+      ENV["XC_ARCH"] = arch
       system "go", "mod", "vendor" # Needed for Go 1.14+
       system "make", "tools", "bin"
 
-      bin.install "pkg/#{os}_amd64/terraform"
+      bin.install "pkg/#{os}_#{arch}/terraform"
       prefix.install_metafiles
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also, use `depends_on arch: :x86_64`. We can build a native arm64
binary, but then the test fails with the error

    No available provider "aws" plugins are compatible with this Terraform version.

Cf. #85027.