### PR TITLE
snapcraft: revision bump (libffi 3.4.2)

### DIFF
--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -7,6 +7,7 @@ class Snapcraft < Formula
       tag:      "5.0",
       revision: "54781044a8f858258e90fa4acfd32e750362deee"
   license "GPL-3.0-only"
+  revision 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
Spotted in #87200. See also #87225.