### PR TITLE
colima 0.2.1 (new formula)

### DIFF
--- a/Formula/colima.rb
+++ b/Formula/colima.rb
@@ -23,7 +23,7 @@ class Colima < Formula
     end
     bash_completion.install buildpath/"colima.bash" => "colima"
     zsh_completion.install buildpath/"colima.zsh" => "_colima"
-    zsh_completion.install buildpath/"colima.fish"
+    fish_completion.install buildpath/"colima.fish"
   end
 
   test do

--- a/Formula/colima.rb
+++ b/Formula/colima.rb
@@ -18,12 +18,9 @@ class Colima < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "./cmd/colima"
 
-    ["bash", "zsh", "fish"].each do |shell|
-      (buildpath/"colima.#{shell}").write Utils.safe_popen_read(bin/"colima", "completion", shell)
-    end
-    bash_completion.install buildpath/"colima.bash" => "colima"
-    zsh_completion.install buildpath/"colima.zsh" => "_colima"
-    fish_completion.install buildpath/"colima.fish"
+    (bash_completion/"colima").write Utils.safe_popen_read(bin/"colima", "completion", "bash")
+    (zsh_completion/"_colima").write Utils.safe_popen_read(bin/"colima", "completion", "zsh")
+    (fish_completion/"colima.fish").write Utils.safe_popen_read(bin/"colima", "completion", "fish")
   end
 
   test do

--- a/Formula/colima.rb
+++ b/Formula/colima.rb
@@ -2,13 +2,14 @@ class Colima < Formula
   desc "Container runtimes on MacOS with minimal setup"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
   url "https://github.com/abiosoft/colima.git",
-      tag:      "v0.2.1",
-      revision: "28236769c47ab71dd378d56f6cc73f769fd2f503"
+      tag:      "v0.2.2",
+      revision: "b2c7697bee2d73e995f156fe8e9870eb246c07e6"
   license "MIT"
   head "https://github.com/abiosoft/colima.git", branch: "main"
 
   depends_on "go" => :build
   depends_on "lima"
+  depends_on :macos
 
   def install
     project = "github.com/abiosoft/colima"

--- a/Formula/colima.rb
+++ b/Formula/colima.rb
@@ -16,10 +16,10 @@ class Colima < Formula
       -X #{project}/config.appVersion=#{version}
       -X #{project}/config.revision=#{Utils.git_head}
     ]
-    system "go", "build", "-ldflags", ldflags.join(" "), "-o", bin/"colima", "./cmd/colima"
+    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "./cmd/colima"
 
     ["bash", "zsh", "fish"].each do |shell|
-      (buildpath/"colima.#{shell}").write(`#{bin}/colima completion #{shell}`)
+      (buildpath/"colima.#{shell}").write Utils.safe_popen_read(bin/"colima", "completion", shell)
     end
     bash_completion.install buildpath/"colima.bash" => "colima"
     zsh_completion.install buildpath/"colima.zsh" => "_colima"

--- a/Formula/colima.rb
+++ b/Formula/colima.rb
@@ -1,0 +1,33 @@
+class Colima < Formula
+  desc "Container runtimes on MacOS with minimal setup"
+  homepage "https://github.com/abiosoft/colima/blob/main/README.md"
+  url "https://github.com/abiosoft/colima.git",
+      tag:      "v0.2.1",
+      revision: "28236769c47ab71dd378d56f6cc73f769fd2f503"
+  license "MIT"
+  head "https://github.com/abiosoft/colima.git", branch: "main"
+
+  depends_on "go" => :build
+  depends_on "lima"
+
+  def install
+    project = "github.com/abiosoft/colima"
+    ldflags = %W[
+      -X #{project}/config.appVersion=#{version}
+      -X #{project}/config.revision=#{Utils.git_head}
+    ]
+    system "go", "build", "-ldflags", ldflags.join(" "), "-o", bin/"colima", "./cmd/colima"
+
+    ["bash", "zsh", "fish"].each do |shell|
+      (buildpath/"colima.#{shell}").write(`#{bin}/colima completion #{shell}`)
+    end
+    bash_completion.install buildpath/"colima.bash" => "colima"
+    zsh_completion.install buildpath/"colima.zsh" => "_colima"
+    zsh_completion.install buildpath/"colima.fish"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/colima version 2>&1")
+    assert_match "colima is not running", shell_output("#{bin}/colima status 2>&1", 1)
+  end
+end


### PR DESCRIPTION
This adds a formula for colima - tool for bootstrapping
docker/containerd environment in Mac OS.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
