### PR TITLE
libnfnetlink: add livecheck

### DIFF
--- a/Formula/libnfnetlink.rb
+++ b/Formula/libnfnetlink.rb
@@ -5,6 +5,11 @@ class Libnfnetlink < Formula
   sha256 "f270e19de9127642d2a11589ef2ec97ef90a649a74f56cf9a96306b04817b51a"
   license "LGPL-2.1-or-later"
 
+  livecheck do
+    url "https://www.netfilter.org/projects/libnfnetlink/downloads.html"
+    regex(/href=.*?libnfnetlink[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "4cc0401b5074648aba2b0140000ad7728fafd440f8d100d6c868b6f5a9f524aa"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `libnfnetlink `. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.