### PR TITLE
openssh: set ldns path for installation using `brew extract --version` with prefix

### DIFF
--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -6,7 +6,6 @@ class Openssh < Formula
   version "8.8p1"
   sha256 "4590890ea9bb9ace4f71ae331785a3a5823232435161960ed5fc86588f331fe9"
   license "SSH-OpenSSH"
-  revision 1
 
   livecheck do
     url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/"
@@ -68,7 +67,7 @@ class Openssh < Formula
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}/ssh
-      --with-ldns=#{bin}/ldns
+      --with-ldns=#{prefix}/bin/ldns
       --with-libedit
       --with-kerberos5
       --with-pam

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -6,6 +6,7 @@ class Openssh < Formula
   version "8.8p1"
   sha256 "4590890ea9bb9ace4f71ae331785a3a5823232435161960ed5fc86588f331fe9"
   license "SSH-OpenSSH"
+  revision 1
 
   livecheck do
     url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/"
@@ -67,7 +68,7 @@ class Openssh < Formula
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}/ssh
-      --with-ldns
+      --with-ldns=#{bin}/ldns
       --with-libedit
       --with-kerberos5
       --with-pam


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
  - Not Github Issue and no longer than 50 chars in commit message, but the commit message explains all and here is the discussion for this PR: https://github.com/Homebrew/discussions/discussions/2249
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
https://github.com/Homebrew/discussions/discussions/2249

As you can see in the discussion in the URL above, I was making dmg file for Mac OS CI environment.
I know the installation of the older version of dependencies is against the brew policy [#](https://discourse.brew.sh/t/has-brew-install-force-formula-raw-path-been-taken-out/8793/6), 
but for the reliable distribution of the iOS build image, I got no way but using non-`/usr/bin` prefix and and fixing the versions of dependencies.

The failure in the installation of `openssh` occurs when configuring `openssh` installation before `make install`.
The print-out portion of the error messages in the discussion can be found from [here](https://github.com/openssh/openssh-portable/blob/master/configure.ac#L1582-L1627).

The error has never shown in any versions of `openssh` after I set the ldns path after `--with-ldns` flag in the formula. 
(Seems like it tries to find `ldns` from the default prefix, but not sure...)