### PR TITLE
aom: fix flag mixup

### DIFF
--- a/Formula/aom.rb
+++ b/Formula/aom.rb
@@ -5,6 +5,7 @@ class Aom < Formula
       tag:      "v3.2.0",
       revision: "287164de79516c25c8c84fd544f67752c170082a"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "ac1d39d09f271f9180b0dea4fd638d5c0b30d971f58486f8db0ab90875433aa7"
@@ -46,7 +47,7 @@ class Aom < Formula
     if OS.mac?
       args += [
         "-DCONFIG_TUNE_BUTTERAUGLI=1",
-        "-DCONFIG_RUNTIME_CPU_DETECT=1",
+        "-DCONFIG_TUNE_VMAF=1",
       ]
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See #87258.