### PR TITLE
lttng-ust: add livecheck

### DIFF
--- a/Formula/lttng-ust.rb
+++ b/Formula/lttng-ust.rb
@@ -5,6 +5,11 @@ class LttngUst < Formula
   sha256 "bcd0f064b6ca88c72d84e760eac3472ae5c828411c634435922bee9fce359fc7"
   license all_of: ["LGPL-2.1-only", "MIT", "GPL-2.0-only", "BSD-3-Clause", "BSD-2-Clause", "GPL-3.0-or-later"]
 
+  livecheck do
+    url "https://lttng.org/download/"
+    regex(/href=.*?lttng-ust[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "2a1aaa6c23382092d5f4e8422dd1db1330b46a80631c63bb4f3441d04dc30244"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

~This PR updates `lttng-ust` to the latest version, 2.13.0. Adding `pkg-config` as a build dependency was necessary for this to successfully build when I tested it in our Linux Docker container.~

By default, livecheck gives an `Unable to get versions` error for `lttng-ust`. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.