### PR TITLE
duck: revision bump (libffi 3.4.2)

### DIFF
--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -4,6 +4,7 @@ class Duck < Formula
   url "https://dist.duck.sh/duck-src-7.10.2.35432.tar.gz"
   sha256 "8f5885799a10b0e06ed0587198dbecce63b08fa609778e84673b34faccfea40b"
   license "GPL-3.0-only"
+  revision 1
   head "https://svn.cyberduck.io/trunk/"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Part of issue seen in https://github.com/Homebrew/discussions/discussions/2298

Giving revision bump a try first. Could be incompatibility with newer `libffi`, in which case would need a different solution.

Not sure why this wasn't detected in `libffi` PR.
```console
❯ otool -L /usr/local/Cellar/duck/7.10.2.35432/libexec/Contents/Frameworks/libjnidispatch.dylib
/usr/local/Cellar/duck/7.10.2.35432/libexec/Contents/Frameworks/libjnidispatch.dylib:
	/usr/local/opt/duck/libexec/Contents/Frameworks/libjnidispatch.dylib (compatibility version 6.0.0, current version 6.1.1)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1775.118.101)
	/usr/local/opt/libffi/lib/libffi.7.dylib (compatibility version 9.0.0, current version 9.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.100.5)
```