### PR TITLE
abcde: add livecheck

### DIFF
--- a/Formula/abcde.rb
+++ b/Formula/abcde.rb
@@ -7,6 +7,11 @@ class Abcde < Formula
   revision 1
   head "https://git.einval.com/git/abcde.git", branch: "master"
 
+  livecheck do
+    url "https://abcde.einval.com/download/"
+    regex(/href=.*?abcde[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "4240ff000419b4ca9c0d275d70fccb10255ea17718906768892ba3a2d7ecb444"
     sha256 cellar: :any,                 big_sur:       "c9668232e677e92b51210a0563c2156f030837b1fb221de60d16c83c466620b2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `abcde` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source when possible. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The homepage links to this page as the canonical download location.