### PR TITLE
osc: migrate to python@3.10

### DIFF
--- a/Formula/osc.rb
+++ b/Formula/osc.rb
@@ -6,6 +6,7 @@ class Osc < Formula
   url "https://github.com/openSUSE/osc/archive/0.174.0.tar.gz"
   sha256 "9be35b347fa07ac1235aa364b0e1229c00d5e98e202923d7a8a796e3ca2756ad"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/openSUSE/osc.git", branch: "master"
 
   bottle do
@@ -18,7 +19,7 @@ class Osc < Formula
 
   depends_on "swig" => :build
   depends_on "openssl@1.1"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   uses_from_macos "curl"
 


### PR DESCRIPTION
osc: migrate to python@3.10