### PR TITLE
rdiff-backup: migrate to python@3.10

### DIFF
--- a/Formula/rdiff-backup.rb
+++ b/Formula/rdiff-backup.rb
@@ -4,7 +4,7 @@ class RdiffBackup < Formula
   url "https://github.com/rdiff-backup/rdiff-backup/releases/download/v2.0.5/rdiff-backup-2.0.5.tar.gz"
   sha256 "2bb7837b4a9712b6efaebfa7da8ed6348ffcb02fcecff0e19d8fff732e933b87"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -20,7 +20,7 @@ class RdiffBackup < Formula
   end
 
   depends_on "librsync"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     system "python3", "setup.py", "build", "--librsync-dir=#{prefix}"


### PR DESCRIPTION
rdiff-backup: migrate to python@3.10