### PR TITLE
cpr: update git url and homepage links

### DIFF
--- a/Formula/cpr.rb
+++ b/Formula/cpr.rb
@@ -1,9 +1,8 @@
 class Cpr < Formula
   desc "C++ Requests, a spiritual port of Python Requests"
   homepage "https://docs.libcpr.org/"
-  url "https://github.com/libcpr/cpr.git",
-      tag:      "1.6.2",
-      revision: "f4622efcb59d84071ae11404ae61bd821c1c344b"
+  url "https://github.com/libcpr/cpr/archive/1.6.2.tar.gz"
+  sha256 "c45f9c55797380c6ba44060f0c73713fbd7989eeb1147aedb8723aa14f3afaa3"
   license "MIT"
   head "https://github.com/libcpr/cpr.git", branch: "master"
 

--- a/Formula/cpr.rb
+++ b/Formula/cpr.rb
@@ -1,11 +1,11 @@
 class Cpr < Formula
   desc "C++ Requests, a spiritual port of Python Requests"
-  homepage "https://whoshuu.github.io/cpr/"
-  url "https://github.com/whoshuu/cpr.git",
+  homepage "https://docs.libcpr.org/"
+  url "https://github.com/libcpr/cpr.git",
       tag:      "1.6.2",
       revision: "f4622efcb59d84071ae11404ae61bd821c1c344b"
   license "MIT"
-  head "https://github.com/whoshuu/cpr.git", branch: "master"
+  head "https://github.com/libcpr/cpr.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "6b725644e68fd8fd18ee1624248de28bff8e0c206d566852a4821714fed3099e"


### PR DESCRIPTION
The repository for cpr has moved to the libcpr org, and the homepage link `https://whoshuu.github.io/cpr/` no longer works -- the site that was originally there has moved to `https://docs.libcpr.org/`

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Might be a bit before I'm on a mac again to try the test commands. I ran them using Linuxbrew and they passed.