### PR TITLE
toml11 3.7.0 (new formula)

### DIFF
--- a/Formula/toml11.rb
+++ b/Formula/toml11.rb
@@ -1,0 +1,36 @@
+class Toml11 < Formula
+  desc "TOML for Modern C++"
+  homepage "https://github.com/ToruNiina/toml11"
+  url "https://github.com/ToruNiina/toml11/archive/refs/tags/v3.7.0.tar.gz"
+  sha256 "a0b6bec77c0e418eea7d270a4437510884f2fe8f61e7ab121729624f04c4b58e"
+  license "MIT"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.toml").write <<~EOS
+      test_str = "a test string"
+    EOS
+
+    (testpath/"test.cpp").write <<~EOS
+      #include "toml.hpp"
+      #include <iostream>
+
+      int main(int argc, char** argv) {
+          const auto data = toml::parse("test.toml");
+          const auto test_str = toml::find<std::string>(data, "test_str");
+          std::cout << "test_str = " << test_str << std::endl;
+          return 0;
+      }
+    EOS
+
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", "-I#{include}"
+    assert_equal "test_str = a test string\n", shell_output("./test")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

toml11 is a TOML library for C++11 (or later). This adds the latest release, 3.7.0 as a new formula.