### PR TITLE
asciidoc: update homepage

### DIFF
--- a/Formula/asciidoc.rb
+++ b/Formula/asciidoc.rb
@@ -6,7 +6,7 @@ class Asciidoc < Formula
   url "https://github.com/asciidoc-py/asciidoc-py/archive/9.1.1.tar.gz"
   sha256 "914dfc1542c30bd47faa0aaaae0985cb57d0ca584015729ccd1b94d90da3a616"
   license "GPL-2.0-only"
-  revision 2
+  revision 1
   head "https://github.com/asciidoc-py/asciidoc-py.git", branch: "main"
 
   livecheck do

--- a/Formula/asciidoc.rb
+++ b/Formula/asciidoc.rb
@@ -2,11 +2,11 @@ class Asciidoc < Formula
   include Language::Python::Shebang
 
   desc "Formatter/translator for text files to numerous formats. Includes a2x"
-  homepage "https://asciidoc.org/"
+  homepage "https://asciidoc-py.github.io/"
   url "https://github.com/asciidoc-py/asciidoc-py/archive/9.1.1.tar.gz"
   sha256 "914dfc1542c30bd47faa0aaaae0985cb57d0ca584015729ccd1b94d90da3a616"
   license "GPL-2.0-only"
-  revision 1
+  revision 2
   head "https://github.com/asciidoc-py/asciidoc-py.git", branch: "main"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Updates the homepage for asciidoc. The old URL (https://asciidoc.org) currently redirects to the new one, but at some point the old URL will be switched over to some other content as determined by the AsciiDoc WG.