### PR TITLE
firefoxpwa: Add OpenSSL as a Linux dependency to fix Linux installation

### DIFF
--- a/Formula/firefoxpwa.rb
+++ b/Formula/firefoxpwa.rb
@@ -15,6 +15,11 @@ class Firefoxpwa < Formula
 
   depends_on "rust" => :build
 
+  on_linux do
+    depends_on "pkg-config" => :build
+    depends_on "openssl@1.1"
+  end
+
   def install
     cd "native"
 


### PR DESCRIPTION


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

FirefoxPWA on Linux depends on the `openssl` crate which depends on the system's OpenSSL. However, OpenSSL wasn't added as a dependency which could cause problems on Linux. This PR adds OpenSSL (and `pkg-config` at build-time) as a dependency so installation on Linux should always succeed.

This should also make it possible to correctly build and publish a Linux bottle. I don't know if this bottle will be automatically published if the Linux build succeeds, but please enable it if needed.