### PR TITLE
otf2: use http due to expired cert for homepage

### DIFF
--- a/Formula/otf2.rb
+++ b/Formula/otf2.rb
@@ -1,6 +1,6 @@
 class Otf2 < Formula
   desc "Open Trace Format 2 file handling library"
-  homepage "https://www.vi-hps.org/projects/score-p/"
+  homepage "http://www.vi-hps.org/projects/score-p/"
   url "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-2.3/otf2-2.3.tar.gz"
   sha256 "36957428d37c40d35b6b45208f050fb5cfe23c54e874189778a24b0e9219c7e3"
   license "BSD-3-Clause"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
update homepage to http one as the cert expired for the homepage, this would prevent the cert check issue.

```diff
- curl: (60) SSL certificate problem: certificate has expired
- Error: otf2: Unable to get versions
+ otf2 : 2.3 ==> 2.3
```