### PR TITLE
suite-sparse: remove `tbb` dependency

### DIFF
--- a/Formula/suite-sparse.rb
+++ b/Formula/suite-sparse.rb
@@ -11,6 +11,7 @@ class SuiteSparse < Formula
     "GPL-3.0-only",
     any_of: ["LGPL-3.0-or-later", "GPL-2.0-or-later"],
   ]
+  revision 1
 
   livecheck do
     url :stable
@@ -28,24 +29,24 @@ class SuiteSparse < Formula
   depends_on "cmake" => :build
   depends_on "metis"
   depends_on "openblas"
-  depends_on "tbb"
 
   uses_from_macos "m4"
 
   conflicts_with "mongoose", because: "suite-sparse vendors libmongoose.dylib"
 
   def install
-    mkdir "GraphBLAS/build" do
-      system "cmake", "..", *std_cmake_args
-    end
-
     args = [
       "INSTALL=#{prefix}",
       "BLAS=-L#{Formula["openblas"].opt_lib} -lopenblas",
       "LAPACK=$(BLAS)",
       "MY_METIS_LIB=-L#{Formula["metis"].opt_lib} -lmetis",
       "MY_METIS_INC=#{Formula["metis"].opt_include}",
+      "CMAKE_OPTIONS=#{std_cmake_args.join(" ")}",
+      "JOBS=#{ENV.make_jobs}",
     ]
+
+    # Parallelism is managed through the `JOBS` make variable and not with `-j`.
+    ENV.deparallelize
     system "make", "library", *args
     system "make", "install", *args
     lib.install Dir["**/*.a"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

SuiteSparse is not compatible with the latest version of TBB. See
DrTimothyAldenDavis/SuiteSparse#72.

We didn't encounter any problems in CI about this because the build just
carried on as if TBB were not installed, and this makes SPQR slower than
it should be.