### PR TITLE
mockery: fix version prefix

### DIFF
--- a/Formula/mockery.rb
+++ b/Formula/mockery.rb
@@ -4,6 +4,7 @@ class Mockery < Formula
   url "https://github.com/vektra/mockery/archive/v2.9.4.tar.gz"
   sha256 "9c490eaa5dd509581e7c272d6af22b17c22b2915267e242ce927f17850ff4a59"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/vektra/mockery.git", branch: "master"
 
   bottle do
@@ -17,14 +18,14 @@ class Mockery < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/vektra/mockery/v2/pkg/config.SemVer=#{version}")
+    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/vektra/mockery/v2/pkg/config.SemVer=v#{version}")
   end
 
   test do
     output = shell_output("#{bin}/mockery --keeptree 2>&1", 1)
-    assert_match "Starting mockery dry-run=false version=#{version}", output
+    assert_match "Starting mockery dry-run=false version=v#{version}", output
 
     output = shell_output("#{bin}/mockery --all --dry-run 2>&1")
-    assert_match "INF Walking dry-run=true version=#{version}", output
+    assert_match "INF Walking dry-run=true version=v#{version}", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This fix adds a prefix `v` to the version config, as in the build flags of the official repo https://github.com/vektra/mockery/blob/master/.goreleaser.yml#L10

Currently the version output of the binary from homebrew is not consistent with the one from [mockery repo](https://github.com/vektra/mockery) (when running `mockery --version` command and when generating mock files)

- Mockery release version:
```sh
$ mockery --version
v2.9.4
```
- Brew version:
```sh
$ mockery --version
2.9.4
```