### PR TITLE
cloudflare-wrangler: add head build

### DIFF
--- a/Formula/cloudflare-wrangler.rb
+++ b/Formula/cloudflare-wrangler.rb
@@ -4,6 +4,7 @@ class CloudflareWrangler < Formula
   url "https://github.com/cloudflare/wrangler/archive/v1.19.3.tar.gz"
   sha256 "0e1a598c362564395f53d91a1b6225881e55492c3df554475d7d0dbc2a4db06d"
   license any_of: ["Apache-2.0", "MIT"]
+  head "https://github.com/cloudflare/wrangler.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "fd4f8cb1b47941301023218fb1426ea3d9310ff2e50ae57b1cd7f4ad6a897183"


### PR DESCRIPTION
Add an unstable option (HEAD) as detailed here: https://docs.brew.sh/Formula-Cookbook#unstable-versions-head

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Added an unstable option for this formula, as [documented here](https://docs.brew.sh/Formula-Cookbook#unstable-versions-head). Edited, built, tested and audited in the [Homebrew docker container](https://hub.docker.com/r/homebrew/brew) according to instructions here. Unfortunately, it wouldn't push up to my fork correctly, so I used the GitHub interface. Apologies if this causes issues.