### PR TITLE
pcre2: apple silicon jit support

### DIFF
--- a/Formula/pcre2.rb
+++ b/Formula/pcre2.rb
@@ -22,6 +22,9 @@ class Pcre2 < Formula
       sha256 "8d699f6c8ae085f50cf8823dcfadb8591f7ad8f9aa0db9666bd126bb625d7543"
       directory "src/sljit"
     end
+
+    # https://lists.gnu.org/archive/html/libtool-patches/2020-06/msg00001.html
+    patch :p0, :DATA
   end
 
   livecheck do
@@ -70,3 +73,28 @@ class Pcre2 < Formula
     system bin/"pcre2grep", "regular expression", prefix/"README"
   end
 end
+
+__END__
+--- configure.orig	2021-10-01 08:15:08.000000000 -0700
++++ configure	2021-10-20 12:44:47.000000000 -0700
+@@ -8733,16 +8733,11 @@
+       _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
+     darwin1.*)
+       _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-    darwin*) # darwin 5.x on
+-      # if running on 10.5 or later, the deployment target defaults
+-      # to the OS version, if on x86, and 10.4, the deployment
+-      # target defaults to 10.4. Don't you love it?
+-      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+-	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
+-	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+-	10.[012][,.]*)
++    darwin*)
++      case ${MACOSX_DEPLOYMENT_TARGET},$host in
++	10.[012],*|,*powerpc*)
+ 	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-	10.*)
++	*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;

--- a/Formula/pcre2.rb
+++ b/Formula/pcre2.rb
@@ -2,8 +2,9 @@ class Pcre2 < Formula
   desc "Perl compatible regular expressions library with a new API"
   homepage "https://www.pcre.org/"
   license "BSD-3-Clause"
+  revision 1
 
-  # Remove `stable` block when patch is no longer needed
+  # Remove `stable` block next release when patches are no longer needed
   stable do
     url "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.38/pcre2-10.38.tar.bz2"
     sha256 "7d95aa7c8a7b0749bf03c4bd73626ab61dece7e3986b5a57f5ec39eebef6b07c"
@@ -13,6 +14,13 @@ class Pcre2 < Formula
     patch do
       url "https://github.com/PhilipHazel/pcre2/commit/51ec2c9893e7dac762b70033b85f55801b01176c.patch?full_index=1"
       sha256 "0e91049d9d2afaff3169ddf8b0d95a9cd968793f2875af8064e0ab572c594007"
+    end
+
+    # enable JIT again in Apple Silicon with 11.2+ (sljit PR zherczeg/sljit#105)
+    patch :p2 do
+      url "https://github.com/zherczeg/sljit/commit/d6a0fa61e09266ad2e36d8ccd56f775e37b749e9.patch?full_index=1"
+      sha256 "8d699f6c8ae085f50cf8823dcfadb8591f7ad8f9aa0db9666bd126bb625d7543"
+      directory "src/sljit"
     end
   end
 
@@ -48,10 +56,8 @@ class Pcre2 < Formula
       --enable-pcre2-32
       --enable-pcre2grep-libz
       --enable-pcre2grep-libbz2
+      --enable-jit
     ]
-
-    # JIT not currently supported for Apple Silicon
-    args << "--enable-jit" unless Hardware::CPU.arm?
 
     system "./autogen.sh" if build.head?
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Apple Silicon support was released with pcre2 10.37, but then macOS
11.2 broke it.

Backport a  fix from the next release of pcre2 (from sljit) and enable
it back.