### PR TITLE
cypher-shell 4.3.0

### DIFF
--- a/Formula/cypher-shell.rb
+++ b/Formula/cypher-shell.rb
@@ -6,6 +6,11 @@ class CypherShell < Formula
   license "GPL-3.0-only"
   version_scheme 1
 
+  livecheck do
+    url "https://neo4j.com/download-center/"
+    regex(/href=.*?cypher-shell[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "d0feb61b9ddf8a28c96f029727b1ce694fe6cfce030e9ba2be96da616c001bb9"
   end

--- a/Formula/cypher-shell.rb
+++ b/Formula/cypher-shell.rb
@@ -1,9 +1,9 @@
 class CypherShell < Formula
   desc "Command-line shell where you can execute Cypher against Neo4j"
-  homepage "https://github.com/neo4j/cypher-shell"
-  url "https://github.com/neo4j/cypher-shell/releases/download/4.2.2/cypher-shell.zip"
-  sha256 "b57623b045a252e3b46f4bb0c7db4bc5ddb080f248bb866fc27023a7c9118b91"
-  license "GPL-3.0"
+  homepage "https://neo4j.com"
+  url "https://dist.neo4j.org/cypher-shell/cypher-shell-4.3.0.zip"
+  sha256 "bd61dd4cffcfc8935bc3cf06b4d3591eda46d56d43dd0b88e494ccd518d105d1"
+  license "GPL-3.0-only"
   version_scheme 1
 
   bottle do


### PR DESCRIPTION
- bump `cypher-shell` to`4.3.0`
- change url to `https://dist.neo4j.org/cypher-shell`