### PR TITLE
apache-pulsar 2.8.1

### DIFF
--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -1,9 +1,9 @@
 class ApachePulsar < Formula
   desc "Cloud-native distributed messaging and streaming platform"
   homepage "https://pulsar.apache.org/"
-  url "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-2.8.0/apache-pulsar-2.8.0-src.tar.gz"
-  mirror "https://archive.apache.org/dist/pulsar/pulsar-2.8.0/apache-pulsar-2.8.0-src.tar.gz"
-  sha256 "0e161a81c62c7234c1e0c243bb6fe30046ec1cd01472618573ecdc2a73b1163b"
+  url "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-2.8.1/apache-pulsar-2.8.1-src.tar.gz"
+  mirror "https://archive.apache.org/dist/pulsar/pulsar-2.8.1/apache-pulsar-2.8.1-src.tar.gz"
+  sha256 "8e30d0414f840477cad8fc27a09904523f3ff039f7c8570feb6acca047661710"
   license "Apache-2.0"
   head "https://github.com/apache/pulsar.git", branch: "master"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `apache-pulsar` to the latest stable version, 2.8.1.

---

As an aside, livecheck is checking the Git tags by default instead of using the `Apache` strategy on the `stable` URL and this erroneously gives `2.9.0-candidate-1` (an unstable version) as the newest version. This is because the `stable` URL uses a different format than most Apache URLs (which use a `path` query string parameter instead of `filename`), so the URL currently isn't a match for the strategy.

I'll be creating a brew PR shortly to update the `Apache` strategy to handle this URL format, so this check will work properly without needing to add a `livecheck` block. It's technically possible to use the standard regex for Git tags like `1.2.3`/`v1.2.3` to restrict matching to the stable tags but we prefer to align the check with the `stable` URL when possible, so modifying the `Apache` strategy is the more appropriate route.