### PR TITLE
ldc: add comment explaining `test` block workaround

### DIFF
--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -79,7 +79,10 @@ class Ldc < Formula
   end
 
   test do
+    # Don't set CC=llvm_clang since that won't be in PATH,
+    # nor should it be used for the test.
     ENV.method(DevelopmentTools.default_compiler).call
+
     (testpath/"test.d").write <<~EOS
       import std.stdio;
       void main() {


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Setting `fails_with :gcc` will make `brew` set `CC=llvm_clang` during
the test block, but `llvm_clang` is a shim that won't be in `PATH` and
shouldn't be used for the test.

The workaround can look a little cryptic, so let's add a comment for a
little bit of context to explain what's going on here.