### PR TITLE
arangodb: update stable, add livecheck

### DIFF
--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -1,10 +1,15 @@
 class Arangodb < Formula
   desc "Multi-Model NoSQL Database"
   homepage "https://www.arangodb.com/"
-  url "https://download.arangodb.com/Source/ArangoDB-3.8.1.tar.gz"
-  sha256 "31a17e09cd7fdec94430b8a97864009f24a142e35cdf185068fe148ae781c3a9"
+  url "https://download.arangodb.com/Source/ArangoDB-3.8.1.tar.bz2"
+  sha256 "5396eae2b4793bead7f38f97573ea4abc03efcc5d20cd6550c359c2a4613d1af"
   license "Apache-2.0"
   head "https://github.com/arangodb/arangodb.git", branch: "devel"
+
+  livecheck do
+    url "https://www.arangodb.com/download-major/source/"
+    regex(/href=.*?ArangoDB[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 big_sur:  "f895aba7329d3bf1f7dc40c6eac687320d722015fd237a0d61c2f320c5f27bf1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `arangodb` (from the `head` URL) and successfully identifies the latest version at the moment. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the first-party download page for source files, which links to the `stable` archive.

This also updates the `stable` URL to use the `tar.bz2` archive, which is 32 MB smaller. The `sha256` corresponds to the one presented on the [first-party download page for source files](https://www.arangodb.com/download-major/source/), for what it's worth.

~Lastly, this adds `branch: "master"` to the `starter` resource, to resolve the audit error.~