### PR TITLE
libshout: bump revision for Linux and macOS >= 11.x

### DIFF
--- a/Formula/libshout.rb
+++ b/Formula/libshout.rb
@@ -5,6 +5,7 @@ class Libshout < Formula
   mirror "https://ftp.osuosl.org/pub/xiph/releases/libshout/libshout-2.4.5.tar.gz"
   sha256 "d9e568668a673994ebe3f1eb5f2bee06e3236a5db92b8d0c487e1c0f886a6890"
   license "LGPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/libshout/?C=M&O=D"
@@ -24,6 +25,23 @@ class Libshout < Formula
   depends_on "libvorbis"
   depends_on "speex"
   depends_on "theora"
+
+  # libshout's libtool.m4 doesn't properly support macOS >= 11.x (see
+  # libtool.rb formula). This causes the library to be linked with a flat
+  # namespace which might cause issues when dynamically loading the library with
+  # dlopen under some modes, see:
+  #
+  #  https://lists.gnupg.org/pipermail/gcrypt-devel/2021-September/005176.html
+  #
+  # We patch `configure` directly so we don't need additional build dependencies
+  # (e.g. autoconf, automake, libtool)
+  #
+  # Patch has been submitted upstream:
+  # https://gitlab.xiph.org/xiph/icecast-libshout/-/issues/2332
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
 
   def install
     system "./configure", *std_configure_args


### PR DESCRIPTION
Fixes:
linuxbrew@7af1d47076b7:~$ brew linkage --test libshout
Missing libraries:
  unexpected (libcrypto.so.1.1)
  unexpected (libshout.so.3)
  unexpected (libssl.so.1.1)

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
