### PR TITLE
imap-uw: Build shared library on Linux.

### DIFF
--- a/Formula/imap-uw.rb
+++ b/Formula/imap-uw.rb
@@ -28,6 +28,13 @@ class ImapUw < Formula
 
   on_linux do
     depends_on "linux-pam"
+
+    # This patch is from Debian, for building shared c-client library on Linux
+    # https://salsa.debian.org/holmgren/uw-imap/tree/master/debian/patches
+    patch do
+      url "https://salsa.debian.org/holmgren/uw-imap/raw/master/debian/patches/1001_shlibs.patch"
+      sha256 "9dfc0eb969e87a12daa50fe7418c9863749abf1ae36bafc7a67d6ba5cba8747e"
+    end
   end
 
   # Two patches below are from Debian, to fix OpenSSL 1.1 compatibility
@@ -57,12 +64,14 @@ class ImapUw < Formula
     # Skip IPv6 warning on Linux as libc should be IPv6 safe.
     touch "ip6"
 
-    target = if OS.mac?
-      "oxp"
+    if OS.mac?
+      system "make", "oxp"
     else
-      "ldb"
+      system "make", "ldbs"
+      lib.install "c-client/libc-client.so"
+      system "make", "clean"
+      system "make", "ldb"
     end
-    system "make", target
 
     # email servers:
     sbin.install "imapd/imapd", "ipopd/ipop2d", "ipopd/ipop3d"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds support to build `imap-uw` on Linux with a shared library `libc-client.so` in addition to the already existing static one. This is done using the `ldbs` target which is added by patch `1001_shlibs` from Debian.