### PR TITLE
zbackup: deprecate

### DIFF
--- a/Formula/zbackup.rb
+++ b/Formula/zbackup.rb
@@ -13,6 +13,9 @@ class Zbackup < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "32bbbc5a45c4080a4ef11da4e318c13f60ca4f9884a3c145f9e4897c67e82d6a"
   end
 
+  # No new commits since 2016, no sign a activity since 2020
+  deprecate! date: "2021-10-21", because: :unmaintained
+
   depends_on "cmake" => :build
   depends_on "lzo"
   depends_on "openssl@1.1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Blocks #85282

Download counts:
install: 5 (30 days), 21 (90 days), 223 (365 days)
install-on-request: 5 (30 days), 21 (90 days), 222 (365 days)
