### PR TITLE
cargo-outdated: depend on Rust only at build time

### DIFF
--- a/Formula/cargo-outdated.rb
+++ b/Formula/cargo-outdated.rb
@@ -14,9 +14,9 @@ class CargoOutdated < Formula
     sha256 cellar: :any, mojave:        "328e96693648cd956cbe001f87d527a45cbe4318e3e4f1f2b28d89d44681f852"
   end
 
+  depends_on "rust" => [:build, :test]
   depends_on "libgit2"
   depends_on "openssl@1.1"
-  depends_on "rust"
 
   # Update `libgit2-sys` crate for Libgit2 1.2.0 support
   # https://github.com/kbknapp/cargo-outdated/issues/279


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
