### PR TITLE
curl: fix link error on x86_64 macOS Monterey

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -1,13 +1,23 @@
 class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server"
   homepage "https://curl.se"
-  url "https://curl.se/download/curl-7.79.1.tar.bz2"
-  mirror "https://github.com/curl/curl/releases/download/curl-7_79_1/curl-7.79.1.tar.bz2"
-  mirror "http://fresh-center.net/linux/www/curl-7.79.1.tar.bz2"
-  mirror "http://fresh-center.net/linux/www/legacy/curl-7.79.1.tar.bz2"
-  sha256 "de62c4ab9a9316393962e8b94777a570bb9f71feb580fb4475e412f2f9387851"
   license "curl"
   revision 1
+
+  stable do
+    url "https://curl.se/download/curl-7.79.1.tar.bz2"
+    mirror "https://github.com/curl/curl/releases/download/curl-7_79_1/curl-7.79.1.tar.bz2"
+    mirror "http://fresh-center.net/linux/www/curl-7.79.1.tar.bz2"
+    mirror "http://fresh-center.net/linux/www/legacy/curl-7.79.1.tar.bz2"
+    sha256 "de62c4ab9a9316393962e8b94777a570bb9f71feb580fb4475e412f2f9387851"
+
+    # Fix link error on x86_64 macOS Monterey.
+    # Remove with the next version.
+    patch do
+      url "https://github.com/curl/curl/commit/20e980f85b0ea67b0821a807e73d57b281462564.patch?full_index=1"
+      sha256 "80071d9fb836fa859243a6deef00a5142c0c7f1124802f679bd8b7514fefa903"
+    end
+  end
 
   livecheck do
     url "https://curl.se/download/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We're not quite ready to bottle this since we still need to bottle some more dependencies first but let's get the patch ready anyway.