### PR TITLE
brotli: set CMAKE_INSTALL_NAME_DIR

### DIFF
--- a/Formula/brotli.rb
+++ b/Formula/brotli.rb
@@ -6,6 +6,7 @@ class Brotli < Formula
   mirror "http://fresh-center.net/linux/misc/legacy/brotli-1.0.9.tar.gz"
   sha256 "f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46"
   license "MIT"
+  revision 1
   head "https://github.com/google/brotli.git", branch: "master"
 
   bottle do
@@ -22,7 +23,7 @@ class Brotli < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", ".", "-DCMAKE_INSTALL_NAME_DIR=#{opt_lib}", *std_cmake_args
     system "make", "VERBOSE=1"
     system "ctest", "-V"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


per discussion from https://github.com/Homebrew/discussions/discussions/2330