### PR TITLE
mariadb: update livecheck

### DIFF
--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -5,9 +5,18 @@ class Mariadb < Formula
   sha256 "75bf9b147a95d38160d01a73b098d50a1960563b46d16a235971fff64d99643c"
   license "GPL-2.0-only"
 
+  # This uses a placeholder regex to satisfy the `PageMatch` strategy
+  # requirement. In the future, this will be updated to use a `Json` strategy
+  # and we can remove the unused regex at that time.
   livecheck do
-    url "https://downloads.mariadb.org/"
-    regex(/Download v?(\d+(?:\.\d+)+) Stable Now/i)
+    url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"
+    regex(/unused/i)
+    strategy :page_match do |page|
+      json = JSON.parse(page)
+      json["releases"]&.map do |release|
+        release["status"].include?("stable") ? release["release_number"] : nil
+      end
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `mariadb` is broken and giving an `Unable to get versions` error. This PR updates it to check the JSON data used to populate the versions on the [first-party download page](https://mariadb.org/download/).

This `livecheck` block uses a `strategy` block instead of a regex, as we need to parse the JSON data, iterate through the releases, and only match the ones where the `status` field is `"stable"`. It's technically possible to do this with a regex but it's lengthy (and potentially error-prone) because we have to account for the `status` field coming before or after the `release_number` field.

Past that, I'll be adding a `Json` strategy in the future that will allow us to omit the `JSON#parse` call and I'll update this block again when the strategy is available in the future. For the time being, this `livecheck` block includes an unused placeholder regex to satisfy the `PageMatch` strategy requirement.

---

It looks like other MariaDB checks are broken, too, so I'll work on creating follow-up PRs to fix them later today.