### PR TITLE
autogen: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/autogen.rb
+++ b/Formula/autogen.rb
@@ -26,6 +26,12 @@ class Autogen < Formula
 
   uses_from_macos "libxml2"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     # Uses GNU-specific mktemp syntax: https://sourceforge.net/p/autogen/bugs/189/
     inreplace %w[agen5/mk-stamps.sh build-aux/run-ag.sh config/mk-shdefs.in], "mktemp", "gmktemp"


### PR DESCRIPTION
Needed for bottling on Monterey.
