### PR TITLE
flat_namespace_allowlist: add `xvid`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,4 +1,5 @@
 [
   "pypy",
-  "pypy3"
+  "pypy3",
+  "xvid"
 ]


### PR DESCRIPTION
This is needed for bottling on Monterey. The `xvid` configure script
passes `-flat_namepace` on all versions of macOS.
