### PR TITLE
libksba: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libksba.rb
+++ b/Formula/libksba.rb
@@ -20,6 +20,12 @@ class Libksba < Formula
 
   depends_on "libgpg-error"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
Needed for bottling on Monterey.
