### PR TITLE
flat_namespace_allowlist: add `tcl-tk`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,5 +1,6 @@
 [
   "pypy",
   "pypy3",
+  "tcl-tk",
   "xvid"
 ]


### PR DESCRIPTION
This is needed for bottling on Monterey. The library built with the
`-flat_namespace` flag is built that way on Catalina too.

This seems intentional, as most of the other libraries have a two-level
namespace.
