### PR TITLE
mpfr: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/mpfr.rb
+++ b/Formula/mpfr.rb
@@ -1,10 +1,19 @@
 class Mpfr < Formula
   desc "C library for multiple-precision floating-point computations"
   homepage "https://www.mpfr.org/"
-  url "https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/mpfr/mpfr-4.1.0.tar.xz"
-  sha256 "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"
   license "LGPL-3.0-or-later"
+
+  stable do
+    url "https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz"
+    mirror "https://ftpmirror.gnu.org/mpfr/mpfr-4.1.0.tar.xz"
+    sha256 "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "9df11560dd3650ffae35c134cef6e0e91aad0e862f5c8895c568b828cf0598d5"


### PR DESCRIPTION
This is needed for bottling on Monterey.
