### PR TITLE
jq: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/jq.rb
+++ b/Formula/jq.rb
@@ -1,9 +1,18 @@
 class Jq < Formula
   desc "Lightweight and flexible command-line JSON processor"
   homepage "https://stedolan.github.io/jq/"
-  url "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz"
-  sha256 "5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72"
   license "MIT"
+
+  stable do
+    url "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz"
+    sha256 "5de8c8e29aaa3fb9cc6b47bb27299f271354ebb72514e3accadc7d38b5bbaa72"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
 
   livecheck do
     url :stable


### PR DESCRIPTION
This is needed for bottling on Monterey.
