### PR TITLE
freetds: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/freetds.rb
+++ b/Formula/freetds.rb
@@ -1,9 +1,18 @@
 class Freetds < Formula
   desc "Libraries to talk to Microsoft SQL Server and Sybase databases"
   homepage "https://www.freetds.org/"
-  url "https://www.freetds.org/files/stable/freetds-1.3.3.tar.gz"
-  sha256 "a21a0aa351185049e11e237a795a61e3ca68d2e798259b3b5ea4a9797d5a5535"
   license "LGPL-2.0-or-later"
+
+  stable do
+    url "https://www.freetds.org/files/stable/freetds-1.3.3.tar.gz"
+    sha256 "a21a0aa351185049e11e237a795a61e3ca68d2e798259b3b5ea4a9797d5a5535"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
 
   livecheck do
     url "https://www.freetds.org/files/stable/"


### PR DESCRIPTION
This is needed for bottling on Monterey.
