### PR TITLE
flat_namespace_allowlist: add `mhash`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,4 +1,5 @@
 [
+  "mhash",
   "pypy",
   "pypy3",
   "tcl-tk",


### PR DESCRIPTION
The Catalina bottles have also been built with the `-flat_namespace`
flag, so there is no bug in detection macOS 11+ in their `configure`
script.

That said, they seem to be using a very old version of the snippet that
generates macOS linker flags, so we'll probably want to report this one
upstream too.
