### PR TITLE
workflows/tests: run `git clean` in container setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -209,6 +209,7 @@ jobs:
           docker exec --workdir "$TAP_PATH" ${{github.sha}} git fetch origin ${{github.sha}} '+refs/heads/*:refs/remotes/origin/*'
           docker exec --workdir "$TAP_PATH" ${{github.sha}} git remote set-head origin --auto
           docker exec --workdir "$TAP_PATH" ${{github.sha}} git checkout --force -B master FETCH_HEAD
+          docker exec --workdir "$TAP_PATH" ${{github.sha}} git clean -dfx
 
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
This resolves `brew doctor` errors due to uncommitted modifications in
the Linux container seen at #87793 and #87794.

------

The error seems to have gone away in newer PRs, but I'm opening this anyway just in case we still need it.