### PR TITLE
libb2: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libb2.rb
+++ b/Formula/libb2.rb
@@ -15,6 +15,12 @@ class Libb2 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "4e12bfdb9ca31174e1f644bd68f89f7de0354b7661569b59cde6c8a6de2d8a24"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     # SSE detection is broken on arm64 macos
     # https://github.com/BLAKE2/libb2/issues/36


### PR DESCRIPTION
This is needed for bottling on Monterey.
