### PR TITLE
liblqr: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/liblqr.rb
+++ b/Formula/liblqr.rb
@@ -1,11 +1,20 @@
 class Liblqr < Formula
   desc "C/C++ seam carving library"
   homepage "https://liblqr.wikidot.com/"
-  url "https://github.com/carlobaldassi/liblqr/archive/v0.4.2.tar.gz"
-  sha256 "1019a2d91f3935f1f817eb204a51ec977a060d39704c6dafa183b110fd6280b0"
   license "LGPL-3.0"
   revision 1
   head "https://github.com/carlobaldassi/liblqr.git"
+
+  stable do
+    url "https://github.com/carlobaldassi/liblqr/archive/v0.4.2.tar.gz"
+    sha256 "1019a2d91f3935f1f817eb204a51ec977a060d39704c6dafa183b110fd6280b0"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+      sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+    end
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
This is needed for bottling on Monterey.
