### PR TITLE
terminal-notifier: build a native binary

### DIFF
--- a/Formula/terminal-notifier.rb
+++ b/Formula/terminal-notifier.rb
@@ -20,7 +20,8 @@ class TerminalNotifier < Formula
   depends_on :macos
 
   def install
-    xcodebuild "-project", "Terminal Notifier.xcodeproj",
+    xcodebuild "-arch", Hardware::CPU.arch,
+               "-project", "Terminal Notifier.xcodeproj",
                "-target", "terminal-notifier",
                "SYMROOT=build",
                "-verbose",


### PR DESCRIPTION
This builds a universal binary otherwise. Needed for bottling on
Monterey.
