### PR TITLE
szip: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/szip.rb
+++ b/Formula/szip.rb
@@ -23,6 +23,12 @@ class Szip < Formula
 
   conflicts_with "libaec", because: "libaec provides a replacement for szip"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
This is needed for bottling on Monterey.
