### PR TITLE
pacman4console: deprecate

### DIFF
--- a/Formula/pacman4console.rb
+++ b/Formula/pacman4console.rb
@@ -5,11 +5,6 @@ class Pacman4console < Formula
   sha256 "9a5c4a96395ce4a3b26a9896343a2cdf488182da1b96374a13bf5d811679eb90"
   license "GPL-2.0"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?pacman[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256                               arm64_big_sur: "b9f6328a3b683121a3ef8cfb48d6db7c6a25ba07f73a006430298ca7fc5bf658"
     sha256                               big_sur:       "299dbf7613b12c270c398dc9aa3255eb5f987331c4a1ace1f1ef811bb6070514"
@@ -21,6 +16,9 @@ class Pacman4console < Formula
     sha256                               yosemite:      "0177bce0045d06947a44cd810e3af8abdf2853981fe8564782a83474fc45f727"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "a75b6bd17159e6e36dff479cb8b4f72cd20b4b84b0e76a619a1e07a1649c7a23"
   end
+
+  # The Google Sites website is no longer available.
+  deprecate! date: "2021-10-23", because: :unmaintained
 
   uses_from_macos "ncurses"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [Google Sites website for `pacman4console`](https://sites.google.com/site/doctormike/pacman.html) is no longer accessible (it gives a `WebspaceNotFound` error), so the `homepage` and `stable` URLs don't work anymore. This PR deprecates the formula as `:unmaintained`.