### PR TITLE
libde265: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libde265.rb
+++ b/Formula/libde265.rb
@@ -14,6 +14,12 @@ class Libde265 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "9c77fa36a474fb41cb046ea5215313b160e5b61ac206b268574f75d2cac1ab18"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     extra_args = []
     extra_args << "--build=aarch64-apple-darwin#{OS.kernel_version}" if Hardware::CPU.arm?


### PR DESCRIPTION
This is needed for bottling on Monterey.
