### PR TITLE
gsl: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/gsl.rb
+++ b/Formula/gsl.rb
@@ -14,6 +14,12 @@ class Gsl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "0b83d664557598a1bbf7bfdde1fd93ea17a5d199af45fef4a1cfeb0e3102a594"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     ENV.deparallelize
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"


### PR DESCRIPTION
This is needed for bottling on Monterey.
