### PR TITLE
lammps: add `yes-basic` build option

### DIFF
--- a/Formula/lammps.rb
+++ b/Formula/lammps.rb
@@ -51,7 +51,7 @@ class Lammps < Formula
         end
 
         system "make", "yes-basic"
-    
+
         system "make", variant,
                        "LMP_INC=-DLAMMPS_GZIP",
                        "FFT_INC=-DFFT_FFTW3 -I#{Formula["fftw"].opt_include}",

--- a/Formula/lammps.rb
+++ b/Formula/lammps.rb
@@ -7,6 +7,7 @@ class Lammps < Formula
   # We only track stable releases as announced on the LAMMPS homepage.
   version "2021-09-29"
   sha256 "2dff656cb21fd9a6d46c818741c99d400cfb1b12102604844663b655fb2f893d"
+  revision 1
   license "GPL-2.0-only"
 
   # The `strategy` block below is used to massage upstream tags into the

--- a/Formula/lammps.rb
+++ b/Formula/lammps.rb
@@ -7,9 +7,8 @@ class Lammps < Formula
   # We only track stable releases as announced on the LAMMPS homepage.
   version "2021-09-29"
   sha256 "2dff656cb21fd9a6d46c818741c99d400cfb1b12102604844663b655fb2f893d"
-  revision 1
   license "GPL-2.0-only"
-
+  revision 1
   # The `strategy` block below is used to massage upstream tags into the
   # YYYY-MM-DD format we use in the `version`. This is necessary for livecheck
   # to be able to do proper `Version` comparison.

--- a/Formula/lammps.rb
+++ b/Formula/lammps.rb
@@ -50,6 +50,8 @@ class Lammps < Formula
           system "make", "no-#{package}"
         end
 
+        system "make", "yes-basic"
+    
         system "make", variant,
                        "LMP_INC=-DLAMMPS_GZIP",
                        "FFT_INC=-DFFT_FFTW3 -I#{Formula["fftw"].opt_include}",


### PR DESCRIPTION
add "yes-basic" build option to restore functionality of previous homebrew version of Lammps

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
