### PR TITLE
ocaml 4.13.1 + patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/camlp5.rb
+++ b/Formula/camlp5.rb
@@ -1,16 +1,10 @@
 class Camlp5 < Formula
   desc "Preprocessor and pretty-printer for OCaml"
   homepage "https://camlp5.github.io/"
-  url "https://github.com/camlp5/camlp5/archive/rel8.00.tar.gz"
-  sha256 "906d5325798cd0985a634e9b6b5c76c6810f3f3b8e98b80a7c30b899082c2332"
+  url "https://github.com/camlp5/camlp5/archive/rel8.00.02.tar.gz"
+  sha256 "3c8c5c574b739cd9e4f0fd4881625ec4c67b456b64fc04ed2882e89a724577fd"
   license "BSD-3-Clause"
-  revision 1
   head "https://github.com/camlp5/camlp5.git", branch: "master"
-
-  livecheck do
-    url :homepage
-    regex(%r{The current distributed version is <b>v?(\d+(?:\.\d+)+)</b>}i)
-  end
 
   bottle do
     sha256 arm64_big_sur: "549ee3a8bfbc3b3d6f466087562d15fd1e1b1b092786c488ae3109c19b1ca50d"

--- a/Formula/infer.rb
+++ b/Formula/infer.rb
@@ -2,7 +2,7 @@ class Infer < Formula
   desc "Static analyzer for Java, C, C++, and Objective-C"
   homepage "https://fbinfer.com/"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/facebook/infer.git", branch: "main"
 
   stable do

--- a/Formula/lablgtk.rb
+++ b/Formula/lablgtk.rb
@@ -4,7 +4,7 @@ class Lablgtk < Formula
   url "https://github.com/garrigue/lablgtk/archive/2.18.11.tar.gz"
   sha256 "ff3c551df4e220b0c0fb9a3da6429413bff14f8fc93f4dd6807a35463982c863"
   license "LGPL-2.1"
-  revision 3
+  revision 4
 
   livecheck do
     url :stable

--- a/Formula/ocaml-findlib.rb
+++ b/Formula/ocaml-findlib.rb
@@ -4,7 +4,7 @@ class OcamlFindlib < Formula
   url "http://download.camlcity.org/download/findlib-1.9.1.tar.gz"
   sha256 "2b42b8bd54488d64c4bf3cb7054b4b37bd30c1dc12bd431ea1e4d7ad8a980fe2"
   license "MIT"
-  revision 1
+  revision 2
 
   livecheck do
     url "http://download.camlcity.org/download/"

--- a/Formula/ocaml-num.rb
+++ b/Formula/ocaml-num.rb
@@ -4,7 +4,7 @@ class OcamlNum < Formula
   url "https://github.com/ocaml/num/archive/v1.4.tar.gz"
   sha256 "015088b68e717b04c07997920e33c53219711dfaf36d1196d02313f48ea00f24"
   license "LGPL-2.1"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "f1f22afab148209110159c9fcbe9cdfd7f27ca6a25b55ddd11358c130da033fb"

--- a/Formula/ocaml-zarith.rb
+++ b/Formula/ocaml-zarith.rb
@@ -4,7 +4,7 @@ class OcamlZarith < Formula
   url "https://github.com/ocaml/Zarith/archive/release-1.12.tar.gz"
   sha256 "cc32563c3845c86d0f609c86d83bf8607ef12354863d31d3bffc0dacf1ed2881"
   license "LGPL-2.0-only"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "0c3cce93d88d87b8b128773e559179cb422b954e4454c25202b17b3445e4af0f"

--- a/Formula/ocaml.rb
+++ b/Formula/ocaml.rb
@@ -13,8 +13,8 @@
 class Ocaml < Formula
   desc "General purpose programming language in the ML family"
   homepage "https://ocaml.org/"
-  url "https://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0.tar.xz"
-  sha256 "39ee9db8dc1e3eb65473dd81a71fabab7cc253dbd7b85e9f9b5b28271319bec3"
+  url "https://github.com/ocaml/ocaml/archive/4.13.1.tar.gz"
+  sha256 "194c7988cc1fd1c64f53f32f2f7551e5309e44d914d6efc7e2e4d002296aeac4"
   license "LGPL-2.1-only" => { with: "OCaml-LGPL-linking-exception" }
   head "https://github.com/ocaml/ocaml.git", branch: "trunk"
 
@@ -65,14 +65,14 @@ class Ocaml < Formula
 end
 
 __END__
---- configure.orig	2021-10-24 09:34:12.145636659 +0800
-+++ configure	2021-10-24 09:34:30.504944693 +0800
-@@ -13644,7 +13644,7 @@
- if test x"$enable_shared" != "xno"; then :
+--- configure.orig	2021-10-24 10:17:12.574800005 +0800
++++ configure	2021-10-24 10:17:27.660562710 +0800
+@@ -14030,7 +14030,7 @@
    case $host in #(
    *-apple-darwin*) :
--    mksharedlib="$CC -shared -flat_namespace -undefined suppress \
-+    mksharedlib="$CC -shared -undefined dynamic_lookup \
-                    -Wl,-no_compact_unwind"
+     mksharedlib="$CC -shared \
+-                   -flat_namespace -undefined suppress -Wl,-no_compact_unwind \
++                   -undefined dynamic_lookup -Wl,-no_compact_unwind \
+                    \$(LDFLAGS)"
        shared_libraries_supported=true ;; #(
    *-*-mingw32) :

--- a/Formula/ocaml.rb
+++ b/Formula/ocaml.rb
@@ -35,6 +35,14 @@ class Ocaml < Formula
   # brew detection doesn't find, and so needs to be explicitly blocked.
   pour_bottle? only_if: :default_prefix
 
+  patch :p0, :DATA
+
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     ENV.deparallelize # Builds are not parallel-safe, esp. with many cores
 
@@ -55,3 +63,16 @@ class Ocaml < Formula
     assert_match HOMEBREW_PREFIX.to_s, shell_output("#{bin}/ocamlc -where")
   end
 end
+
+__END__
+--- configure.orig	2021-10-24 09:34:12.145636659 +0800
++++ configure	2021-10-24 09:34:30.504944693 +0800
+@@ -13644,7 +13644,7 @@
+ if test x"$enable_shared" != "xno"; then :
+   case $host in #(
+   *-apple-darwin*) :
+-    mksharedlib="$CC -shared -flat_namespace -undefined suppress \
++    mksharedlib="$CC -shared -undefined dynamic_lookup \
+                    -Wl,-no_compact_unwind"
+       shared_libraries_supported=true ;; #(
+   *-*-mingw32) :


### PR DESCRIPTION
This is needed for bottling on Monterey.
