### PR TITLE
workflows/dispatch-build-bottle: allow an array of runners

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -1,10 +1,10 @@
-name: Dispatch build bottle (for a single OS/version)
+name: Dispatch build bottle (for chosen OS versions)
 
 on:
   workflow_dispatch:
     inputs:
       runner:
-        description: Build runner (macOS version or Linux)
+        description: Build runner(s) (macOS version or Linux)
         required: true
       formula:
         description: Formula name
@@ -31,8 +31,25 @@ env:
   HOMEBREW_RELOCATE_RPATHS: 1
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      runners: ${{steps.runner-matrix.outputs.result}}
+    steps:
+      - name: Prepare runner matrix
+        id: runner-matrix
+        uses: actions/github-script@v5
+        with:
+          script: |
+            return context.payload.inputs.runner.split(",")
+                                                .map(s => s.trim())
+                                                .filter(Boolean);
   bottle:
-    runs-on: ${{github.event.inputs.runner}}
+    needs: prepare
+    strategy:
+      matrix:
+        runner: ${{fromJson(needs.prepare.outputs.runners)}}
+    runs-on: ${{matrix.runner}}
     timeout-minutes: ${{fromJson(github.event.inputs.timeout)}}
     defaults:
       run:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Not sure how to really test this before merging.