### PR TITLE
gpgme: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/gpgme.rb
+++ b/Formula/gpgme.rb
@@ -24,6 +24,12 @@ class Gpgme < Formula
   depends_on "libassuan"
   depends_on "libgpg-error"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
 


### PR DESCRIPTION
This is needed for bottling on Monterey.
