### PR TITLE
qrencode: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/qrencode.rb
+++ b/Formula/qrencode.rb
@@ -1,9 +1,18 @@
 class Qrencode < Formula
   desc "QR Code generation"
   homepage "https://fukuchi.org/works/qrencode/index.html.en"
-  url "https://fukuchi.org/works/qrencode/qrencode-4.1.1.tar.gz"
-  sha256 "da448ed4f52aba6bcb0cd48cac0dd51b8692bccc4cd127431402fca6f8171e8e"
   license "LGPL-2.1-or-later"
+
+  stable do
+    url "https://fukuchi.org/works/qrencode/qrencode-4.1.1.tar.gz"
+    sha256 "da448ed4f52aba6bcb0cd48cac0dd51b8692bccc4cd127431402fca6f8171e8e"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
 
   livecheck do
     url "https://fukuchi.org/works/qrencode/"


### PR DESCRIPTION
This is needed for bottling on Monterey.
