### PR TITLE
djview4: fix arm64 compilation

### DIFF
--- a/Formula/djview4.rb
+++ b/Formula/djview4.rb
@@ -32,7 +32,8 @@ class Djview4 < Formula
                           "--prefix=#{prefix}",
                           "--with-x=no",
                           "--disable-nsdejavu",
-                          "--disable-desktopfiles"
+                          "--disable-desktopfiles",
+                          "--with-tiff=#{Formula["libtiff"].opt_prefix}"
     system "make", "CC=#{ENV.cc}", "CXX=#{ENV.cxx}"
 
     # From the djview4.8 README:


### PR DESCRIPTION
Due to the fact that /opt/homebrew is a non-standard location
configure gets mixed up. Simple fix is provided

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
