### PR TITLE
mhash: regenerate `configure`

### DIFF
--- a/Formula/mhash.rb
+++ b/Formula/mhash.rb
@@ -21,7 +21,13 @@ class Mhash < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "32a5e81c29e8407754448e5aa7f1f8ea2328bc5ce266ab5f3b350e3174373900"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
   def install
+    # Regenerate the very old configure script that isn't suitable for modern macOS.
+    system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
Their configure script is very old and isn't suitable for modern
versions of macOS. Let's fix that by regenerating it with Autotools.

This is needed for bottling on Monterey.

Closes #87800.
