### PR TITLE
gtk+: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/gtk+.rb
+++ b/Formula/gtk+.rb
@@ -6,6 +6,12 @@ class Gtkx < Formula
   stable do
     url "https://download.gnome.org/sources/gtk+/2.24/gtk+-2.24.33.tar.xz"
     sha256 "ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
   end
 
   livecheck do


### PR DESCRIPTION
This is needed for bottling on Monterey.
