### PR TITLE
flat_namespace_allowlist: add open-mpi

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,4 +1,5 @@
 [
+  "open-mpi",
   "pypy",
   "pypy3",
   "tcl-tk",


### PR DESCRIPTION
This appears to be intentional. Upstream have already adopted the
Libtool patch (cf. open-mpi/ompi#8218), and commits where they add
`-flat_namespace` explicitly are not that old (e.g.
open-mpi/ompi@6164dc4960805b5502f86f9a2dccc5fc557e44d6).
