### PR TITLE
bat-extras: build all bottle

### DIFF
--- a/Formula/bat-extras.rb
+++ b/Formula/bat-extras.rb
@@ -18,11 +18,12 @@ class BatExtras < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1c94dd7dd7e3d29f1493267a300b3d6a1f309560f341ec24990d708e3aca3759"
   end
 
-  depends_on "bat"      => :test
-  depends_on "ripgrep"  => :test
+  depends_on "bat" => [:build, :test]
+  depends_on "shfmt" => :build
+  depends_on "ripgrep" => :test
 
   def install
-    system "./build.sh", "--prefix=#{prefix}", "--install"
+    system "./build.sh", "--prefix=#{prefix}", "--minify", "all", "--install"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The diff between macOS and Linux bottles (which is where the difference is) is some comment lines being present in one but not the others. The install process uses `sed` to strip some comments out, so I suspect the difference is caused by BSD `sed` vs GNU `sed`.

I tried forcing use of `gnu-sed` (`gsed`) in macOS but the lines in question still had the same difference. So instead try enabling minifying with `shfmt` to just strip all comments entirely.

This minification process expects for the `bat` binary to be present at build-time since the path of the binary (in this case `Formula["bat"].opt_bin/"bat"`) gets written into the script to avoid a run-time interpolation.