### PR TITLE
webp: enable gif2webp support

### DIFF
--- a/Formula/webp.rb
+++ b/Formula/webp.rb
@@ -4,6 +4,7 @@ class Webp < Formula
   url "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.2.1.tar.gz"
   sha256 "808b98d2f5b84e9b27fdef6c5372dac769c3bda4502febbfa5031bd3c4d7d018"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "e7c4198414dc89198e7b823d6e7193986a6d1cc104f7651934b216b369759d0a"
@@ -22,6 +23,7 @@ class Webp < Formula
     depends_on "libtool" => :build
   end
 
+  depends_on "giflib"
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
@@ -30,7 +32,6 @@ class Webp < Formula
     system "./autogen.sh" if build.head?
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking",
-                          "--disable-gif",
                           "--disable-gl",
                           "--enable-libwebpdecoder",
                           "--enable-libwebpdemux",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

gif2webp support was previously removed in https://github.com/Homebrew/homebrew-core/commit/1ff82aa48367ebda0ac209f1fe9da0b759fb87f4 with no comment or linked issue suggesting why it was done.

This seems to have only a little overhead to compilation time and overall size.

It seems [I'm not the only one](https://github.com/Homebrew/discussions/discussions/471) who's asked about this feature being missing.