### PR TITLE
gnupg: use `killall gpg-agent` in `post_install`

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -62,7 +62,7 @@ class Gnupg < Formula
 
   def post_install
     (var/"run").mkpath
-    quiet_system "gpgconf", "--reload", "all"
+    quiet_system "killall", "gpg-agent"
   end
 
   test do


### PR DESCRIPTION
`gpgconf --reload all` was supposed to be a more graceful way to do
this, but it seems to not work properly. Let's change this back to the
old `killall gpg-agent` call.
