### PR TITLE
libupnp: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libupnp.rb
+++ b/Formula/libupnp.rb
@@ -18,6 +18,12 @@ class Libupnp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "43231a7cdf7f0b91510dbd5a94d9f120e4f9cbea9d0b7805878a2986218fd207"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     args = %W[
       --disable-debug


### PR DESCRIPTION
This is needed for bottling on Monterey.
