### PR TITLE
berkeley-db@4: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/berkeley-db@4.rb
+++ b/Formula/berkeley-db@4.rb
@@ -22,6 +22,13 @@ class BerkeleyDbAT4 < Formula
     sha256 "86111b0965762f2c2611b302e4a95ac8df46ad24925bbb95a1961542a1542e40"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+    directory "dist"
+  end
+
   def install
     # BerkeleyDB dislikes parallel builds
     ENV.deparallelize


### PR DESCRIPTION
This is needed for bottling on Monterey.
