### PR TITLE
dockerize: invoke `go build` directly

### DIFF
--- a/Formula/dockerize.rb
+++ b/Formula/dockerize.rb
@@ -1,9 +1,8 @@
 class Dockerize < Formula
   desc "Utility to simplify running applications in docker containers"
   homepage "https://github.com/jwilder/dockerize"
-  url "https://github.com/jwilder/dockerize.git",
-      tag:      "v0.6.1",
-      revision: "7c5cd7c34dcf1c81f6b4db132ebceabdaae17153"
+  url "https://github.com/jwilder/dockerize/archive/v0.6.1.tar.gz"
+  sha256 "c21cea3e6bb33a2e280c28d3521b8f177c78e875b475763fcb9bd7a545e21688"
   license "MIT"
 
   bottle do
@@ -22,17 +21,15 @@ class Dockerize < Formula
     ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/jwilder/dockerize").install buildpath.children
     ENV.append_path "PATH", buildpath/"bin"
+
     cd "src/github.com/jwilder/dockerize" do
-      system "make", "dist"
-      if OS.mac?
-        bin.install "dist/darwin/amd64/dockerize"
-      else
-        bin.install "dist/linux/amd64/dockerize"
-      end
+      system "make", "deps"
+      system "go", "build", *std_go_args(ldflags: "-s -w -X main.buildVersion=#{version}")
     end
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/dockerize --version")
     system "#{bin}/dockerize", "-wait", "https://www.google.com/", "-wait-retry-interval=1s", "-timeout", "5s"
   end
 end


### PR DESCRIPTION
While we're here, let's see if we can get this to build a native binary
on ARM.
