### PR TITLE
tesseract: fix `#include <version>` bug

### DIFF
--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -48,6 +48,13 @@ class Tesseract < Formula
     sha256 "7b9bd14aba7d5e30df686fbb6f71782a97f48f81b32dc201a1b75afe6de747d6"
   end
 
+  # Fix `#include <version>` bug with newer Xcode.
+  # https://github.com/tesseract-ocr/tesseract/issues/3447
+  patch do
+    url "https://github.com/tesseract-ocr/tesseract/commit/6dc4b184b1ebf2e68461f6b63f63a033bc7245f7.patch?full_index=1"
+    sha256 "a2e64ce125c93c05e7ec6c9dd47845b605d1b95a4d00d1c40a6ee706c5029ca3"
+  end
+
   def install
     # explicitly state leptonica header location, as the makefile defaults to /usr/local/include,
     # which doesn't work for non-default homebrew location


### PR DESCRIPTION
This applies an upstream patch to fix the build failure, and is needed
for bottling on Monterey.
