### PR TITLE
arpack: add `arpack-ng` alias

### DIFF
--- a/Aliases/arpack-ng
+++ b/Aliases/arpack-ng
@@ -1,0 +1,1 @@
+../Formula/arpack.rb


### PR DESCRIPTION
The upstream project is called `arpack-ng`, so it would probably be
useful if `brew install arpack-ng` worked (instead of suggesting that
the user install `aircrack-ng`).
