### PR TITLE
node@14: remove `c-ares` patch

### DIFF
--- a/Formula/node@14.rb
+++ b/Formula/node@14.rb
@@ -37,17 +37,6 @@ class NodeAT14 < Formula
     depends_on "macos-term-size"
   end
 
-  # Fix build with brewed c-ares.
-  # https://github.com/nodejs/node/pull/39739
-  #
-  # Remove when the following lands in a *c-ares* release:
-  # https://github.com/c-ares/c-ares/commit/7712fcd17847998cf1ee3071284ec50c5b3c1978
-  # https://github.com/c-ares/c-ares/pull/417
-  patch do
-    url "https://github.com/nodejs/node/commit/8699aa501c4d4e1567ebe8901e5ec80cadaa9323.patch?full_index=1"
-    sha256 "678643c79258372d5054d3da16bc0c5db17130f151f0e72b6e4f20817987aac9"
-  end
-
   def install
     # make sure subprocesses spawned by make are using our Python 3
     ENV["PYTHON"] = which("python3")


### PR DESCRIPTION
This is no longer needed after #88035. The patch only changes the
include path at compile time, so we don't need to publish new bottles
for this.
