### PR TITLE
vcsh: build an `all` bottle

### DIFF
--- a/Formula/vcsh.rb
+++ b/Formula/vcsh.rb
@@ -17,11 +17,13 @@ class Vcsh < Formula
   patch :DATA
 
   def install
-    # Set GIT, and GREP to prevent
-    # hardcoding shim references and absolute paths
+    # Set GIT, SED, and GREP to prevent
+    # hardcoding shim references and absolute paths.
+    # We set this even where we have no shims because
+    # the hardcoded absolute path might not be portable.
     system "./configure", "--with-zsh-completion-dir=#{zsh_completion}",
                           "--with-bash-completion-dir=#{bash_completion}",
-                          "GIT=git", "GREP=grep",
+                          "GIT=git", "SED=sed", "GREP=grep",
                           *std_configure_args
     system "make", "install"
 


### PR DESCRIPTION
It turns out that setting `SED` isn't just useful for avoiding shim
references. It's also useful for making sure that `vcsh` does not
hardcode the full path to `sed`, because this differs between macOS
(`/usr/bin/sed`) and Linux (`/bin/sed`, which might not be portable).

Let's reinstate passing `SED` to make sure our bottles are
platform-independent.
