### PR TITLE
gst-plugins-ugly: fix unrecognised flag

### DIFF
--- a/Formula/gst-plugins-ugly.rb
+++ b/Formula/gst-plugins-ugly.rb
@@ -37,7 +37,7 @@ class GstPluginsUgly < Formula
   def install
     args = std_meson_args + %w[
       -Damrnb=disabled
-      -Damwrbdec=disabled
+      -Damrwbdec=disabled
     ]
 
     mkdir "build" do


### PR DESCRIPTION
The build now fails with

    ../meson.build:1:0: ERROR: Unknown options: "amwrbdec"

The new release of meson probably made unrecognised flags an error. This
is needed for bottling on Monterey.
