### PR TITLE
depend on php

### DIFF
--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -18,7 +18,7 @@ class Composer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "742ce90ec5d5cb121c04930ebe928bf694bc75a87cfa37a56f0ca10a144fa821"
   end
 
-  uses_from_macos "php"
+  depends_on "php"
 
   # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
   on_macos do

--- a/Formula/phoronix-test-suite.rb
+++ b/Formula/phoronix-test-suite.rb
@@ -19,7 +19,7 @@ class PhoronixTestSuite < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "40c22f6775bbaa76dcca519e5ea051b0f358ed8327535170413fbd6355cee6e4"
   end
 
-  uses_from_macos "php"
+  depends_on "php"
 
   def install
     ENV["DESTDIR"] = buildpath/"dest"

--- a/Formula/php-code-sniffer.rb
+++ b/Formula/php-code-sniffer.rb
@@ -9,7 +9,7 @@ class PhpCodeSniffer < Formula
     sha256 cellar: :any_skip_relocation, all: "6c101138b9167ca64611091d5baed1eda0d8550830105e2d065d10201f47d77e"
   end
 
-  uses_from_macos "php"
+  depends_on "php"
 
   resource "phpcbf.phar" do
     url "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/3.6.1/phpcbf.phar"

--- a/Formula/php-cs-fixer.rb
+++ b/Formula/php-cs-fixer.rb
@@ -9,7 +9,7 @@ class PhpCsFixer < Formula
     sha256 cellar: :any_skip_relocation, all: "bdccc22b31bde4d2c8e83b203c7799393f2c5c689d2b7482898b16da07ba07e6"
   end
 
-  uses_from_macos "php", since: :catalina
+  depends_on "php"
 
   def install
     bin.install "php-cs-fixer.phar" => "php-cs-fixer"

--- a/Formula/php-cs-fixer@2.rb
+++ b/Formula/php-cs-fixer@2.rb
@@ -10,7 +10,7 @@ class PhpCsFixerAT2 < Formula
   end
 
   keg_only :versioned_formula
-  uses_from_macos "php", since: :el_capitan
+  depends_on "php"
 
   def install
     bin.install "php-cs-fixer.phar" => "php-cs-fixer"

--- a/Formula/phpbrew.rb
+++ b/Formula/phpbrew.rb
@@ -12,7 +12,7 @@ class Phpbrew < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "2665bd49848a852a87abfc444f8ef708e3ec8364b3e5c04f21c3d7ef7ed8bdde"
   end
 
-  uses_from_macos "php"
+  depends_on "php"
 
   # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
   on_macos do

--- a/Formula/psalm.rb
+++ b/Formula/psalm.rb
@@ -13,8 +13,7 @@ class Psalm < Formula
   end
 
   depends_on "composer" => :test
-
-  uses_from_macos "php"
+  depends_on "php"
 
   # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
   on_macos do

--- a/Formula/wp-cli.rb
+++ b/Formula/wp-cli.rb
@@ -18,7 +18,7 @@ class WpCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "a3538f32afa8bef557e659322b49734e90e0420cd96561ea56119f71d91d813c"
   end
 
-  uses_from_macos "php"
+  depends_on "php"
 
   # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
   on_macos do


### PR DESCRIPTION
Replace `uses_from_macos "php"` to `depends_on "php"`, since macOS Monterey [no longer comes with PHP](https://developer.apple.com/forums/thread/681907)
