### PR TITLE
telnet: fix build on Monterey

### DIFF
--- a/Formula/telnet.rb
+++ b/Formula/telnet.rb
@@ -40,11 +40,15 @@ class Telnet < Formula
       libtelnet_dst.install "build/Release/usr/local/include/libtelnet/"
     end
 
+    # Workaround for
+    # error: 'vfork' is deprecated: Use posix_spawn or fork
+    ENV.append_to_cflags "-Wno-deprecated-declarations"
+    ENV.append_to_cflags "-isystembuild/Products/"
     system "make", "-C", "telnet.tproj",
                    "OBJROOT=build/Intermediates",
                    "SYMROOT=build/Products",
                    "DSTROOT=build/Archive",
-                   "CFLAGS=$(CC_Flags) -isystembuild/Products/",
+                   "CFLAGS=$(CC_Flags) #{ENV.cflags}",
                    "LDFLAGS=$(LD_Flags) -Lbuild/Products/",
                    "RC_ARCHS=#{Hardware::CPU.arch}",
                    "install"


### PR DESCRIPTION
Clang seems to error on deprecated declarations by default now, so we
need to disable that to get this to compile.
