### PR TITLE
pprint: fix test on Linux

### DIFF
--- a/Formula/pprint.rb
+++ b/Formula/pprint.rb
@@ -12,7 +12,14 @@ class Pprint < Formula
     sha256 cellar: :any_skip_relocation, high_sierra: "8d6d70f63ecea106323bdd852c1c896f32bf9895c3164680b594c0f8a30c1561"
   end
 
+  depends_on "catch2" => :test
   depends_on macos: :high_sierra # needs C++17
+
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5"
 
   def install
     include.install "include/pprint.hpp"
@@ -22,7 +29,10 @@ class Pprint < Formula
   test do
     cp_r pkgshare/"test", testpath
     cd "test" do
-      system ENV.cxx, "--std=c++17", "-I#{testpath}/test", "main.cpp", "-o", "tests"
+      rm "catch.hpp" # The bundled Catch2 is too old to work on Apple Silicon
+      system ENV.cxx, "main.cpp", "--std=c++17",
+             "-I#{testpath}/test", "-I#{Formula["catch2"].opt_include}/catch2",
+             "-o", "tests"
       system "./tests"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `gcc` dependency is only really used in the `test` block, but it's not going to work at runtime without a C++17-capable compiler anyways, so it's here as a runtime dependency.

While we're here, rebuild all bottles and see if we can get an `all` bottle.