### PR TITLE
clang-format@11 11.1.0 (new formula)

### DIFF
--- a/Formula/clang-format@11.rb
+++ b/Formula/clang-format@11.rb
@@ -1,0 +1,37 @@
+class ClangFormatAT11 < Formula
+  desc "Formatting tools for C, C++, Obj-C, Java, JavaScript, TypeScript"
+  homepage "https://clang.llvm.org/docs/ClangFormat.html"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/llvm-11.1.0.src.tar.xz"
+  sha256 "ce8508e318a01a63d4e8b3090ab2ded3c598a50258cc49e2625b9120d4c03ea5"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
+  resource "clang" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.1.0/clang-11.1.0.src.tar.xz"
+    sha256 "0a8288f065d1f57cb6d96da4d2965cbea32edc572aa972e466e954d17148558b"
+  end
+
+  def install
+    (buildpath/"tools/clang").install resource("clang")
+
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build", "--target", "clang-format"
+
+    bin.install buildpath/"build/bin/clang-format" => "clang-format-11"
+    bin.install buildpath/"tools/clang/tools/clang-format/git-clang-format" => "git-clang-format-11"
+  end
+
+  test do
+    # NB: below C code is messily formatted on purpose.
+    (testpath/"test.c").write <<~EOS
+      int         main(char *args) { \n   \t printf("hello"); }
+    EOS
+
+    assert_equal "int main(char *args) { printf(\"hello\"); }\n",
+        shell_output("#{bin}/clang-format-11 -style=Google test.c")
+  end
+end

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -4,6 +4,7 @@
   "bash-completion@2",
   "cairomm@1.14",
   "clang-format@8",
+  "clang-format@11",
   "gcc@4.9",
   "gcc@5",
   "gcc@6",


### PR DESCRIPTION
clang-format 12+ is buggy, and 8 is too old.

Formula based on [clang-format@8](https://github.com/Homebrew/homebrew-core/blob/master/Formula/clang-format@8.rb)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
