### PR TITLE
ode: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/ode.rb
+++ b/Formula/ode.rb
@@ -20,6 +20,10 @@ class Ode < Formula
   depends_on "pkg-config" => :build
   depends_on "libccd"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  # We patch `libtool.m4` and not `configure` because we call `./bootstrap`.
+  patch :DATA
+
   def install
     inreplace "bootstrap", "libtoolize", "glibtoolize"
     system "./bootstrap"
@@ -48,3 +52,30 @@ class Ode < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git a/m4/libtool.m4 b/m4/libtool.m4
+index 10ab284..bfc1d56 100644
+--- a/m4/libtool.m4
++++ b/m4/libtool.m4
+@@ -1067,16 +1067,11 @@ _LT_EOF
+       _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
+     darwin1.*)
+       _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-    darwin*) # darwin 5.x on
+-      # if running on 10.5 or later, the deployment target defaults
+-      # to the OS version, if on x86, and 10.4, the deployment
+-      # target defaults to 10.4. Don't you love it?
+-      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+-	10.0,*86*-darwin8*|10.0,*-darwin[[91]]*)
+-	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+-	10.[[012]][[,.]]*)
++    darwin*)
++      case ${MACOSX_DEPLOYMENT_TARGET},$host in
++	10.[[012]],*|,*powerpc*)
+ 	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-	10.*)
++	*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;


### PR DESCRIPTION
This is needed for bottling on Monterey.
