### PR TITLE
screenfetch: pour bottle only in default prefixes

### DIFF
--- a/Formula/screenfetch.rb
+++ b/Formula/screenfetch.rb
@@ -16,6 +16,10 @@ class Screenfetch < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6f7e61ea4717eef72e68b006bcef5d6ff1aab08f7ba25f0a5c6b8e014ffb530b"
   end
 
+  # `screenfetch` contains references to `/usr/local` that
+  # are erronously relocated in non-default prefixes.
+  pour_bottle? only_if: :default_prefix
+
   def install
     bin.install "screenfetch-dev" => "screenfetch"
     man1.install "screenfetch.1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `screenfetch` script contains this snippet:

    if [ -d "/usr/local/bin" ]; then
        loc_pkgs=$(ls -l /usr/local/bin/ | grep -cv "\(../Cellar/\|brew\)")
        pkgs=$((loc_pkgs - offset));
    fi
    if type -p port >/dev/null 2>&1; then
        port_pkgs=$(port installed 2>/dev/null | wc -l)
        pkgs=$((pkgs + (port_pkgs - offset)))
    fi
    if type -p brew >/dev/null 2>&1; then
        brew_pkgs=$(brew list -1 2>/dev/null | wc -l)
        pkgs=$((pkgs + brew_pkgs))
    fi

The first `/usr/local` references intends to specifically exclude a
Homebrew installation (via the `-v` flag). However, this will get
replaced with `HOMEBREW_PREFIX` on Intel macOS, which isn't correct for
non-default prefixes.
