### PR TITLE
libquvi: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libquvi.rb
+++ b/Formula/libquvi.rb
@@ -31,6 +31,12 @@ class Libquvi < Formula
     sha256 "b8d17d53895685031cd271cf23e33b545ad38cad1c3bddcf7784571382674c65"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["lua@5.1"].opt_libexec/"lib/pkgconfig"
 


### PR DESCRIPTION
This is needed for bottling on Monterey.
