### PR TITLE
libgccjit: apply patch for Monterey

### DIFF
--- a/Formula/libgccjit.rb
+++ b/Formula/libgccjit.rb
@@ -42,6 +42,12 @@ class Libgccjit < Formula
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
 
+  # Darwin 21 (Monterey) support
+  patch do
+    url "https://github.com/iains/gcc-darwin-arm64/commit/20f61faaed3b335d792e38892d826054d2ac9f15.patch?full_index=1"
+    sha256 "c0605179a856ca046d093c13cea4d2e024809ec2ad4bf3708543fc3d2e60504b"
+  end
+
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"


### PR DESCRIPTION
This is the same patch used in GCC.
