### PR TITLE
flat_namespace_allowlist: add `mpich`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,5 +1,6 @@
 [
   "arpack",
+  "mpich",
   "open-mpi",
   "pypy",
   "pypy3",


### PR DESCRIPTION
See pmodels/mpich@fcbe6bd1e7795b2f213db7959d20e882abecd075.
