### PR TITLE
flat_namespace_allowlist: add `arpack` and `scalapack`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,7 +1,9 @@
 [
+  "arpack",
   "open-mpi",
   "pypy",
   "pypy3",
+  "scalapack",
   "tcl-tk",
   "xvid"
 ]


### PR DESCRIPTION
Neither project actually sets the `-flat_namespace` flag themselves.
Instead, this is inherited from `open-mpi`:

```
❯ pkg-config ompi-fort --cflags
-Wl,-flat_namespace -Wl,-commons,use_dylibs -I/usr/local/Cellar/open-mpi/4.1.1_2/include -I/usr/local/Cellar/open-mpi/4.1.1_2/lib
```
