### PR TITLE
openslide: use HTTPS for resource URL

### DIFF
--- a/Formula/openslide.rb
+++ b/Formula/openslide.rb
@@ -27,7 +27,7 @@ class Openslide < Formula
   depends_on "openjpeg"
 
   resource "svs" do
-    url "http://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/CMU-1-Small-Region.svs"
+    url "https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/CMU-1-Small-Region.svs"
     sha256 "ed92d5a9f2e86df67640d6f92ce3e231419ce127131697fbbce42ad5e002c8a7"
   end
 


### PR DESCRIPTION
Fixes

    ==> FAILED
    openslide:
      * Stable resource "svs": The source URL http://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/CMU-1-Small-Region.svs should use HTTPS rather than HTTP
    Error: 1 problem in 1 formula detected
