### PR TITLE
spice-protocol: remove unrecognised flag

### DIFF
--- a/Formula/spice-protocol.rb
+++ b/Formula/spice-protocol.rb
@@ -29,7 +29,7 @@ class SpiceProtocol < Formula
 
   def install
     mkdir "build" do
-      system "meson", *std_meson_args, "-Dwith-docs=false", ".."
+      system "meson", *std_meson_args, ".."
       system "ninja", "-v"
       system "ninja", "install", "-v"
     end


### PR DESCRIPTION
Fixes

    ../meson.build:4:0: ERROR: Unknown options: "with-docs"
