### PR TITLE
goenv: don't `inreplace` `init.bats` on HEAD installs

### DIFF
--- a/Formula/goenv.rb
+++ b/Formula/goenv.rb
@@ -18,13 +18,15 @@ class Goenv < Formula
   end
 
   def install
-    inreplace [
+    inreplace_files = [
       "libexec/goenv",
       "plugins/go-build/install.sh",
       "test/goenv.bats",
-      "test/init.bats",
       "test/test_helper.bash",
-    ], "/usr/local", HOMEBREW_PREFIX
+    ]
+    inreplace_files << "test/init.bats" unless build.head?
+    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
+
     prefix.install Dir["*"]
     %w[goenv-install goenv-uninstall go-build].each do |cmd|
       bin.install_symlink "#{prefix}/plugins/go-build/bin/#{cmd}"


### PR DESCRIPTION
init.bats no longer exists

see https://github.com/syndbg/goenv/issues/80#issuecomment-952895999

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
