### PR TITLE
ballerburg: add livecheck

### DIFF
--- a/Formula/ballerburg.rb
+++ b/Formula/ballerburg.rb
@@ -6,6 +6,11 @@ class Ballerburg < Formula
   license "GPL-3.0"
   head "https://git.tuxfamily.org/baller/baller.git", branch: "master"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?ballerburg[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "a82163254a4f1ff916e0d7ba0387914f529ffa67955495e146be69b5c2b2f31e"
     sha256 cellar: :any,                 big_sur:       "94691e7d7c914ce603ffdcf611159d2fd8fa63616f9f35f6bed3c58d72571bea"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ballerburg` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.