### PR TITLE
flat_namespace_allowlist: add `soapysdr`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -5,6 +5,7 @@
   "pypy",
   "pypy3",
   "scalapack",
+  "soapysdr",
   "tcl-tk",
   "xvid"
 ]


### PR DESCRIPTION
Upstream are using this flag on purpose. See pothosware/SoapySDR#28.
