### PR TITLE
singular: regenerate `configure`

### DIFF
--- a/Formula/singular.rb
+++ b/Formula/singular.rb
@@ -22,13 +22,23 @@ class Singular < Formula
     depends_on "libtool" => :build
   end
 
+  # We need `autoconf`, `automake`, and `libtool` to regenerate `configure`
+  # to fix erroneous use of the `-flat_namespace` flag, since upstream generate
+  # it from a patched `libtool.m4`. Reported at:
+  # <TBD>
+  # Remove these dependencies when this issue is resolved.
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "gmp"
   depends_on "mpfr"
   depends_on "ntl"
   depends_on "python@3.10"
 
   def install
-    system "./autogen.sh" if build.head?
+    # Restrict the `autogen.sh` call to head installs when we
+    # no longer need to regenerate `configure`. See comment above.
+    system "./autogen.sh" # if build.head?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
This should fix mistaken uses of the `-flat_namespace` flag on Big Sur
and newer.

Upstream use a patched `libtool.m4` to regenerate `configure`, so none
of our patches apply. We can use our version of `libtool.m4` by calling
`autogen.sh` unconditionally.

Reported upstream at TBD.
