### PR TITLE
flat_namespace_allowlist: add `omniorb`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,6 +1,7 @@
 [
   "arpack",
   "mpich",
+  "omniorb",
   "open-mpi",
   "pypy",
   "pypy3",


### PR DESCRIPTION
Use of the `-flat_namespace` flag does not come from the Libtool bug,
and omniORB's build system is a bit too complex for me to be comfortable
trying a patch.

I've reported this issue via email to the omniORB-dev mailing list. I'll
amend this commit with a link when the archive is updated.
