### PR TITLE
datafusion 5.0 (new formula)

### DIFF
--- a/Formula/datafusion.rb
+++ b/Formula/datafusion.rb
@@ -1,0 +1,19 @@
+class Datafusion < Formula
+  desc "Apache Arrow DataFusion and Ballista query engines"
+  homepage "https://arrow.apache.org/datafusion"
+  url "https://github.com/apache/arrow-datafusion/archive/refs/tags/5.0.0.tar.gz"
+  sha256 "7ba05bba8b7ea3b1f7ff6b3d1b1a3413a81540c57342ef331d51a07ad4a7b7a8"
+  license "Apache-2.0"
+  head "https://github.com/apache/arrow-datafusion.git", branch: "master"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "datafusion-cli")
+  end
+
+  test do
+    (testpath/"datafusion_test.sql").write("select 1+2 as n;")
+    assert_equal "[{\"n\":3}]", shell_output("#{bin}/datafusion-cli -q --format json -f datafusion_test.sql").strip
+  end
+end


### PR DESCRIPTION
add Apache Arrow Datafusion engine's CLI i.e. datafusion-cli to brew

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
