### PR TITLE
dispatch-build-bottle: upload failed bottles

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -64,6 +64,7 @@ jobs:
           echo sender=${{github.event.sender.login}}
           echo formula=${{github.event.inputs.formula}}
           echo runner=${{github.event.inputs.runner}}
+          echo timeout=${{github.event.inputs.timeout}}
           echo issue=${{github.event.inputs.issue}}
           echo upload=${{github.event.inputs.upload}}
           echo wheezy=${{github.event.inputs.wheezy}}
@@ -164,6 +165,22 @@ jobs:
           count=$(ls *.json | wc -l | xargs echo -n)
           echo "$count bottles"
           echo "::set-output name=count::$count"
+          failures=$(ls failed/*.json | wc -l | xargs echo -n)
+          echo "$failures failed bottles"
+          echo "::set-output name=failures::$failures"
+
+      - name: Upload failed bottles
+        if: always() && steps.bottles.outputs.failures > 0
+        uses: actions/upload-artifact@main
+        with:
+          name: bottles-${{ matrix.runner }}
+          path: bottles/failed
+
+      # Must be run before the `Upload bottles` step so that failed
+      # bottles are not included in the `bottles` artifact.
+      - name: Delete failed bottles
+        if: always()
+        run: rm -rvf bottles/failed
 
       - name: Upload bottles to GitHub Actions
         if: always() && steps.bottles.outputs.count > 0


### PR DESCRIPTION
This is useful for examining built bottles that somehow failed the tests
for some other reason. (e.g. https://github.com/Homebrew/homebrew-core/issues/87708#issuecomment-951088501)

This change is identical to the code that's already in `tests.yml`:

https://github.com/Homebrew/homebrew-core/blob/ce050467b21b326320b8dfe5f13c5d42039f79da/.github/workflows/tests.yml#L300-L315

While we're here, let's also echo the timeout, since this is useful to
know while a job is running.
