### PR TITLE
mandoc: rename `soelim` to `bsdsoelim`

### DIFF
--- a/Formula/mandoc.rb
+++ b/Formula/mandoc.rb
@@ -4,6 +4,7 @@ class Mandoc < Formula
   url "https://mandoc.bsd.lv/snapshots/mandoc-1.14.6.tar.gz"
   sha256 "8bf0d570f01e70a6e124884088870cbed7537f36328d512909eb10cd53179d9c"
   license "ISC"
+  revision 1
   head "anoncvs@mandoc.bsd.lv:/cvs", using: :cvs
 
   livecheck do
@@ -42,6 +43,7 @@ class Mandoc < Formula
       "BINM_APROPOS=bsdapropos",
       "BINM_WHATIS=bsdwhatis",
       "BINM_MAKEWHATIS=bsdmakewhatis", # default is "makewhatis".
+      "BINM_SOELIM=bsdsoelim", # conflicts with groff's soelim
 
       # These are names for *section 7* pages only. Several other pages are
       # prefixed "mandoc_", similar to the "groff_" pages.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`mandoc`'s `soelim` conflicts with `groff`'s `soelim`. Let's fix that by
renaming the binary here to `bsdsoelim`. This is consistent with the
formula's renaming scheme for other binaries (e.g. `apropos` is
`bsdapropos`).
