### PR TITLE
add caveat to starship formula to add lines .zshrc

### DIFF
--- a/Formula/starship.rb
+++ b/Formula/starship.rb
@@ -39,6 +39,16 @@ class Starship < Formula
     (fish_completion/"starship.fish").write fish_output
   end
 
+  def caveats
+    <<~EOS
+      Add the following to your .zshrc:
+
+        autoload -U promptinit; promptinit
+        prompt spaceship
+
+    EOS
+  end
+
   test do
     ENV["STARSHIP_CONFIG"] = ""
     assert_equal "[1;32m❯[0m ", shell_output("#{bin}/starship module character")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hello all, I am updating caveats per spaceship-prompt/spaceship-prompt#1047 in the [starship repo](https://github.com/spaceship-prompt/spaceship-prompt) to add a caveat that instructs the user to add something to their `.zshrc`. Please let me know if there are any steps I need to complete to get this merged. Thanks!