### PR TITLE
Fix several MariaDB URLs

### DIFF
--- a/Formula/mariadb@10.1.rb
+++ b/Formula/mariadb@10.1.rb
@@ -1,7 +1,7 @@
 class MariadbAT101 < Formula
   desc "Drop-in replacement for MySQL"
   homepage "https://mariadb.org/"
-  url "https://downloads.mariadb.org/f/mariadb-10.1.48/source/mariadb-10.1.48.tar.gz"
+  url "https://downloads.mariadb.com/MariaDB/mariadb-10.1.48/source/mariadb-10.1.48.tar.gz"
   sha256 "069d58b1e2c06bb1e6c31249eda34138f41fb8ae3dec7ecaeba8035812c87cf9"
   license "GPL-2.0-only"
 

--- a/Formula/mariadb@10.2.rb
+++ b/Formula/mariadb@10.2.rb
@@ -1,7 +1,7 @@
 class MariadbAT102 < Formula
   desc "Drop-in replacement for MySQL"
   homepage "https://mariadb.org/"
-  url "https://downloads.mariadb.org/f/mariadb-10.2.40/source/mariadb-10.2.40.tar.gz"
+  url "https://downloads.mariadb.com/MariaDB/mariadb-10.2.40/source/mariadb-10.2.40.tar.gz"
   sha256 "2fb5bbdb8c2c7afa01eecf3338001e338350a7efb1267af048e038c1ec658142"
   license "GPL-2.0-only"
 

--- a/Formula/mariadb@10.3.rb
+++ b/Formula/mariadb@10.3.rb
@@ -1,7 +1,7 @@
 class MariadbAT103 < Formula
   desc "Drop-in replacement for MySQL"
   homepage "https://mariadb.org/"
-  url "https://downloads.mariadb.org/f/mariadb-10.3.31/source/mariadb-10.3.31.tar.gz"
+  url "https://downloads.mariadb.com/MariaDB/mariadb-10.3.31/source/mariadb-10.3.31.tar.gz"
   sha256 "20421dfe5750f510ab0ee23420337332e6799cd38fa31332e2841dfa956eb771"
   license "GPL-2.0-only"
 

--- a/Formula/mariadb@10.4.rb
+++ b/Formula/mariadb@10.4.rb
@@ -1,7 +1,7 @@
 class MariadbAT104 < Formula
   desc "Drop-in replacement for MySQL"
   homepage "https://mariadb.org/"
-  url "https://downloads.mariadb.org/f/mariadb-10.4.21/source/mariadb-10.4.21.tar.gz"
+  url "https://downloads.mariadb.com/MariaDB/mariadb-10.4.21/source/mariadb-10.4.21.tar.gz"
   sha256 "94dd2e6f5d286de8a7dccffe984015d4253a0568281c7440e772cfbe098a291d"
   license "GPL-2.0-only"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fixes https://github.com/Homebrew/homebrew-core/issues/87751 by adjusting the URLs of four affected MariaDB formulae.
The old URLs only redirect to the download page now. This new URL format has been taken from [mariadb@10.5](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/mariadb@10.5.rb) (or higher), which already uses it.