### PR TITLE
yq: add livecheck and head

### DIFF
--- a/Formula/yq.rb
+++ b/Formula/yq.rb
@@ -4,6 +4,12 @@ class Yq < Formula
   url "https://github.com/mikefarah/yq/archive/v4.13.5.tar.gz"
   sha256 "c0d637e7d7d5f370960af713e0f7e769e1b0876f71a844373d0307cbba68c4b2"
   license "MIT"
+  head "https://github.com/mikefarah/yq.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "a37867d759db29a715ba0dae55e9885baf9bb7e7c36b2834d158512c4d65b70f"
@@ -21,9 +27,9 @@ class Yq < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
 
-    (bash_completion/"yq").write Utils.safe_popen_read("#{bin}/yq", "shell-completion", "bash")
-    (zsh_completion/"_yq").write Utils.safe_popen_read("#{bin}/yq", "shell-completion", "zsh")
-    (fish_completion/"yq.fish").write Utils.safe_popen_read("#{bin}/yq", "shell-completion", "fish")
+    (bash_completion/"yq").write Utils.safe_popen_read(bin/"yq", "shell-completion", "bash")
+    (zsh_completion/"_yq").write Utils.safe_popen_read(bin/"yq", "shell-completion", "zsh")
+    (fish_completion/"yq.fish").write Utils.safe_popen_read(bin/"yq", "shell-completion", "fish")
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Upstream has added several tags like `releaseTest-manpage8` that are confusing the livecheck

Before
```console
$ brew livecheck yq
yq : 4.13.5 ==> 8
```

After
```console
$ brew livecheck yq
yq : 4.13.5 ==> 4.13.5
```