### PR TITLE
git-ftp: de-vendor `curl`

### DIFF
--- a/Formula/git-ftp.rb
+++ b/Formula/git-ftp.rb
@@ -4,6 +4,7 @@ class GitFtp < Formula
   url "https://github.com/git-ftp/git-ftp/archive/1.6.0.tar.gz"
   sha256 "088b58d66c420e5eddc51327caec8dcbe8bddae557c308aa739231ed0490db01"
   license "GPL-3.0"
+  revision 1
   head "https://github.com/git-ftp/git-ftp.git", branch: "develop"
 
   bottle do
@@ -16,39 +17,15 @@ class GitFtp < Formula
   end
 
   depends_on "pandoc" => :build
+  depends_on "curl"
   depends_on "libssh2"
 
   uses_from_macos "zlib"
 
-  resource "curl" do
-    url "https://curl.se/download/curl-7.69.0.tar.bz2"
-    mirror "https://curl.askapache.com/curl-7.69.0.tar.bz2"
-    sha256 "668d451108a7316cff040b23c79bc766e7ed84122074e44f662b8982f2e76739"
-  end
-
   def install
-    resource("curl").stage do
-      system "./configure", "--disable-debug",
-                            "--disable-dependency-tracking",
-                            "--disable-silent-rules",
-                            "--prefix=#{libexec}",
-                            "--disable-ares",
-                            "--with-darwinssl",
-                            "--with-libssh2",
-                            "--without-brotli",
-                            "--without-ca-bundle",
-                            "--without-ca-path",
-                            "--without-gssapi",
-                            "--without-libmetalink",
-                            "--without-librtmp"
-      system "make", "install"
-    end
-
     system "make", "prefix=#{prefix}", "install"
     system "make", "-C", "man", "man"
     man1.install "man/git-ftp.1"
-    (libexec/"bin").install bin/"git-ftp"
-    (bin/"git-ftp").write_env_script(libexec/"bin/git-ftp", PATH: "#{libexec}/bin:$PATH")
   end
 
   test do


### PR DESCRIPTION
The vendored `curl` is woefully out of date, and should use the formula.

This was added in 431fec3f9bfde190289b61c6f26db07c80d4c187 because
`git-ftp` needed a version of `curl` compiled with `libssh2`, and it was
unclear whether the `--with-libssh2` option would survive the removal of
options.

Conveniently, our `curl` is compiled with `libssh2`, so this formula can
just depend on our `curl` without any further changes.

This enables bottling on Monterey, because the vendored `curl` has a
`configure` script bitten by the `-flat_namespace` bug.
