### PR TITLE
cloog: depend on `isl@0.18`, patch out `-flat_namespace`

### DIFF
--- a/Formula/cloog.rb
+++ b/Formula/cloog.rb
@@ -3,7 +3,7 @@ class Cloog < Formula
   homepage "http://www.bastoul.net/cloog/"
   url "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.4.tar.gz"
   sha256 "325adf3710ce2229b7eeb9e84d3b539556d093ae860027185e7af8a8b00a750e"
-  revision 3
+  revision 4
 
   livecheck do
     url "http://www.bastoul.net/cloog/download.php"
@@ -21,30 +21,22 @@ class Cloog < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gmp"
+  depends_on "isl@0.18"
 
-  resource "isl" do
-    url "https://libisl.sourceforge.io/isl-0.18.tar.xz"
-    mirror "https://deb.debian.org/debian/pool/main/i/isl/isl_0.18.orig.tar.xz"
-    sha256 "0f35051cc030b87c673ac1f187de40e386a1482a0cfdf2c552dd6031b307ddc4"
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
   end
 
   def install
-    resource("isl").stage do
-      system "./configure", "--disable-dependency-tracking",
-                            "--disable-silent-rules",
-                            "--prefix=#{libexec}",
-                            "--with-gmp=system",
-                            "--with-gmp-prefix=#{Formula["gmp"].opt_prefix}"
-      system "make", "install"
-    end
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           "--with-gmp=system",
                           "--with-gmp-prefix=#{Formula["gmp"].opt_prefix}",
                           "--with-isl=system",
-                          "--with-isl-prefix=#{libexec}"
+                          "--with-isl-prefix=#{Formula["isl@0.18"].opt_prefix}"
     system "make", "install"
   end
 


### PR DESCRIPTION
The vendored `isl@0.18` is affected by the `-flat_namespace` bug.
Instead of patching `isl@0.18` in two places, let's just fix the
`isl@0.18` formula and use it here.

We also patch out the `-flat_namespace` flag in the `configure` script
to bottle this on Monterey.
