### PR TITLE
log4cpp: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/log4cpp.rb
+++ b/Formula/log4cpp.rb
@@ -22,6 +22,12 @@ class Log4cpp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "fa93ce1f4cce44107a131667b2350814eb79a762c63c8bd4f35d283f21a25a10"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
This is needed for bottling on Monterey.
