### PR TITLE
xctool: fix build with newer macOS versions

### DIFF
--- a/Formula/xctool.rb
+++ b/Formula/xctool.rb
@@ -24,7 +24,8 @@ class Xctool < Formula
                "SYMROOT=build",
                "-IDEBuildLocationStyle=Custom",
                "-IDECustomDerivedDataLocation=#{buildpath}",
-               "XT_INSTALL_ROOT=#{libexec}"
+               "XT_INSTALL_ROOT=#{libexec}",
+               "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
     bin.install_symlink "#{libexec}/bin/xctool"
   end
 


### PR DESCRIPTION
This sets a deployment target of `10.7`, which breaks the build on Big
Sur and newer.
