### PR TITLE
mame: update livecheck

### DIFF
--- a/Formula/mame.rb
+++ b/Formula/mame.rb
@@ -14,7 +14,7 @@ class Mame < Formula
   livecheck do
     url :stable
     strategy :github_latest
-    regex(%r{release-header.*?/releases/tag/mame[._-]?\d+(?:\.\d+)*["' >]>MAME v?(\d+(?:\.\d+)+)}im)
+    regex(/>\s*MAME v?(\d+(?:\.\d+)+)/im)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `mame` checks the main heading for the "latest" release on GitHub, since the Git tag format doesn't include dots (`mame0236`) and we try to avoid naively inserting dots to create a version from numbers alone.

This check is currently broken because the HTML for release pages changed, so the regex no longer matches the release heading. This PR updates the `regex` to loosen it while hopefully still matching only the release heading text. This works for now but we can always revisit it in the future if the looseness causes problems.

This also indirectly fixes the check for `rom-tools`, since that formula references the `livecheck` block in the `mame` formula (as requested here: https://github.com/Homebrew/homebrew-core/issues/87708#issuecomment-954479304).