### PR TITLE
libsvg: fix test

### DIFF
--- a/Formula/libsvg.rb
+++ b/Formula/libsvg.rb
@@ -125,16 +125,10 @@ class Libsvg < Formula
       }
     EOS
 
-    flags = %W[
-      -I#{include}
-      -L#{lib}
-      -lsvg
-    ]
-    on_linux do
-      flags << "-lpng"
-      flags << "-ljpeg"
-    end
-    system ENV.cc, "test.c", "-o", "test", *flags
+    system ENV.cc, "test.c", "-o", "test",
+                   "-I#{include}", "-L#{lib}", "-lsvg",
+                   "-L#{Formula["libpng"].opt_lib}", "-lpng",
+                   "-L#{Formula["jpeg"].opt_lib}", "-ljpeg"
     assert_equal "1\n2\n3\n4\n5\n6\nSUCCESS\n", shell_output("./test")
   end
 end


### PR DESCRIPTION
Fixes

    dyld[48596]: symbol not found in flat namespace '_jpeg_CreateDecompress'

I'm actually confused as to how this test ever passed.

This supports bottling on Monterey.
