### PR TITLE
fstrm: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/fstrm.rb
+++ b/Formula/fstrm.rb
@@ -1,9 +1,18 @@
 class Fstrm < Formula
   desc "Frame Streams implementation in C"
   homepage "https://github.com/farsightsec/fstrm"
-  url "https://dl.farsightsecurity.com/dist/fstrm/fstrm-0.6.1.tar.gz"
-  sha256 "bca4ac1e982a2d923ccd24cce2c98f4ceeed5009694430f73fc0dcebca8f098f"
   license "MIT"
+
+  stable do
+    url "https://dl.farsightsecurity.com/dist/fstrm/fstrm-0.6.1.tar.gz"
+    sha256 "bca4ac1e982a2d923ccd24cce2c98f4ceeed5009694430f73fc0dcebca8f098f"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "409e20e264b28337487a22ff762e8f7d1b4dc81bea1cd131c6d673a978d94e2f"


### PR DESCRIPTION
This is needed for bottling on Monterey.
