### PR TITLE
crf++: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/crf++.rb
+++ b/Formula/crf++.rb
@@ -25,6 +25,12 @@ class Crfxx < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "3cc105b0deaa5661ba6cde2ac18b289ef676aacfad93f569e659d1ce6035127f"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "CXXFLAGS=#{ENV.cflags}", "install"


### PR DESCRIPTION
This is needed for bottling on Monterey.
