### PR TITLE
isc-dhcp: remove explicitly specified `version`

### DIFF
--- a/Formula/isc-dhcp.rb
+++ b/Formula/isc-dhcp.rb
@@ -2,7 +2,6 @@ class IscDhcp < Formula
   desc "Production-grade DHCP solution"
   homepage "https://www.isc.org/dhcp"
   url "https://ftp.isc.org/isc/dhcp/4.4.2-P1/dhcp-4.4.2-P1.tar.gz"
-  version "4.4.2-P1"
   sha256 "b05e04337539545a8faa0d6ac518defc61a07e5aec66a857f455e7f218c85a1a"
   license "MPL-2.0"
 
@@ -21,24 +20,24 @@ class IscDhcp < Formula
 
   def install
     # use one dir under var for all runtime state.
-    dhcpd_dir = var+"dhcpd"
+    dhcpd_dir = var/"dhcpd"
 
     # Change the locations of various files to match Homebrew
     # we pass these in through CFLAGS since some cannot be changed
     # via configure args.
     path_opts = {
-      "_PATH_DHCPD_CONF"    => etc+"dhcpd.conf",
-      "_PATH_DHCLIENT_CONF" => etc+"dhclient.conf",
-      "_PATH_DHCPD_DB"      => dhcpd_dir+"dhcpd.leases",
-      "_PATH_DHCPD6_DB"     => dhcpd_dir+"dhcpd6.leases",
-      "_PATH_DHCLIENT_DB"   => dhcpd_dir+"dhclient.leases",
-      "_PATH_DHCLIENT6_DB"  => dhcpd_dir+"dhclient6.leases",
-      "_PATH_DHCPD_PID"     => dhcpd_dir+"dhcpd.pid",
-      "_PATH_DHCPD6_PID"    => dhcpd_dir+"dhcpd6.pid",
-      "_PATH_DHCLIENT_PID"  => dhcpd_dir+"dhclient.pid",
-      "_PATH_DHCLIENT6_PID" => dhcpd_dir+"dhclient6.pid",
-      "_PATH_DHCRELAY_PID"  => dhcpd_dir+"dhcrelay.pid",
-      "_PATH_DHCRELAY6_PID" => dhcpd_dir+"dhcrelay6.pid",
+      "_PATH_DHCPD_CONF"    => etc/"dhcpd.conf",
+      "_PATH_DHCLIENT_CONF" => etc/"dhclient.conf",
+      "_PATH_DHCPD_DB"      => dhcpd_dir/"dhcpd.leases",
+      "_PATH_DHCPD6_DB"     => dhcpd_dir/"dhcpd6.leases",
+      "_PATH_DHCLIENT_DB"   => dhcpd_dir/"dhclient.leases",
+      "_PATH_DHCLIENT6_DB"  => dhcpd_dir/"dhclient6.leases",
+      "_PATH_DHCPD_PID"     => dhcpd_dir/"dhcpd.pid",
+      "_PATH_DHCPD6_PID"    => dhcpd_dir/"dhcpd6.pid",
+      "_PATH_DHCLIENT_PID"  => dhcpd_dir/"dhclient.pid",
+      "_PATH_DHCLIENT6_PID" => dhcpd_dir/"dhclient6.pid",
+      "_PATH_DHCRELAY_PID"  => dhcpd_dir/"dhcrelay.pid",
+      "_PATH_DHCRELAY6_PID" => dhcpd_dir/"dhcrelay6.pid",
     }
 
     path_opts.each do |symbol, path|
@@ -50,7 +49,8 @@ class IscDhcp < Formula
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--localstatedir=#{dhcpd_dir}"
+                          "--localstatedir=#{dhcpd_dir}",
+                          "--sysconfdir=#{etc}"
 
     ENV.deparallelize { system "make", "-C", "bind" }
 
@@ -58,15 +58,6 @@ class IscDhcp < Formula
     inreplace "Makefile", "SUBDIRS = ${top_srcdir}/bind", "SUBDIRS = "
     system "make"
     system "make", "install"
-
-    # rename all the installed sample etc/* files so they don't clobber
-    # any existing config files at symlink time.
-    Dir.open("#{prefix}/etc") do |dir|
-      dir.each do |f|
-        file = "#{dir.path}/#{f}"
-        File.rename(file, "#{file}.sample") if File.file?(file)
-      end
-    end
 
     # create the state dir and lease files else dhcpd will not start up.
     dhcpd_dir.mkpath
@@ -76,8 +67,8 @@ class IscDhcp < Formula
     end
 
     # dhcpv6 plists
-    (prefix+"homebrew.mxcl.dhcpd6.plist").write plist_dhcpd6
-    (prefix+"homebrew.mxcl.dhcpd6.plist").chmod 0644
+    (prefix/"homebrew.mxcl.dhcpd6.plist").write plist_dhcpd6
+    (prefix/"homebrew.mxcl.dhcpd6.plist").chmod 0644
   end
 
   def caveats
@@ -149,7 +140,7 @@ class IscDhcp < Formula
   end
 
   test do
-    cp etc/"dhcpd.conf.example.sample", testpath/"dhcpd.conf"
+    cp etc/"dhcpd.conf.example", testpath/"dhcpd.conf"
     system sbin/"dhcpd", "-cf", "#{testpath}/dhcpd.conf", "-t"
   end
 end


### PR DESCRIPTION
Fixes

    ==> FAILED
    isc-dhcp:
      * Stable: version 4.4.2-P1 is redundant with version scanned from URL
    Error: 1 problem in 1 formula detected

While we're here:

- clean up some outdated style
- install configuration files into `etc` rather than `prefix/"etc"`
  because it's not necessary and users find this confusing (cf.
  Homebrew/discussions#2338)
