### PR TITLE
cmu-sphinxbase: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/cmu-sphinxbase.rb
+++ b/Formula/cmu-sphinxbase.rb
@@ -1,9 +1,18 @@
 class CmuSphinxbase < Formula
   desc "Lightweight speech recognition engine for mobile devices"
   homepage "https://cmusphinx.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/cmusphinx/sphinxbase/0.8/sphinxbase-0.8.tar.gz"
-  sha256 "55708944872bab1015b8ae07b379bf463764f469163a8fd114cbb16c5e486ca8"
   license "BSD-2-Clause"
+
+  stable do
+    url "https://downloads.sourceforge.net/project/cmusphinx/sphinxbase/0.8/sphinxbase-0.8.tar.gz"
+    sha256 "55708944872bab1015b8ae07b379bf463764f469163a8fd114cbb16c5e486ca8"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+      sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+    end
+  end
 
   livecheck do
     url :stable


### PR DESCRIPTION
This is needed for bottling on Monterey.
