### PR TITLE
argtable: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/argtable.rb
+++ b/Formula/argtable.rb
@@ -17,6 +17,12 @@ class Argtable < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "784464fba494301f0f28dfe309112e99267a2a9084243916283ba7c6e2db0a48"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
This is needed for bottling on Monterey.
