### PR TITLE
libcanberra: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libcanberra.rb
+++ b/Formula/libcanberra.rb
@@ -1,8 +1,17 @@
 class Libcanberra < Formula
   desc "Implementation of XDG Sound Theme and Name Specifications"
-  homepage "http://0pointer.de/lennart/projects/libcanberra/"
-  url "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz"
-  sha256 "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
+  homepage "https://0pointer.de/lennart/projects/libcanberra/"
+
+  stable do
+    url "https://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz"
+    sha256 "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+      sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+    end
+  end
 
   livecheck do
     url :homepage


### PR DESCRIPTION
This is needed for bottling on Monterey.
