### PR TITLE
macosvpn: build a native binary

### DIFF
--- a/Formula/macosvpn.rb
+++ b/Formula/macosvpn.rb
@@ -21,7 +21,7 @@ class Macosvpn < Formula
   depends_on xcode: ["11.1", :build]
 
   def install
-    xcodebuild "SYMROOT=build"
+    xcodebuild "-arch", Hardware::CPU.arch, "SYMROOT=build"
     bin.install "build/Release/macosvpn"
   end
 


### PR DESCRIPTION
This is needed for bottling on Monterey.
