### PR TITLE
hexo: call `deuniversalize_machos`

### DIFF
--- a/Formula/hexo.rb
+++ b/Formula/hexo.rb
@@ -22,6 +22,9 @@ class Hexo < Formula
     mkdir_p libexec/"lib"
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
+
+    # Replace universal binaries with their native slices.
+    deuniversalize_machos
   end
 
   test do


### PR DESCRIPTION
This is needed for bottling on Monterey.
