### PR TITLE
systemc: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/systemc.rb
+++ b/Formula/systemc.rb
@@ -20,6 +20,12 @@ class Systemc < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "fbf3d2f9781a9d146d9b03ea4fbc36584331b3adfdbec24df0a7446e9420a0f0"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
This is needed for bottling on Monterey.
