### PR TITLE
libart: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libart.rb
+++ b/Formula/libart.rb
@@ -23,6 +23,12 @@ class Libart < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1b28ae4a3601b0bace6e40c19e616e2e321f17231a378241dae4aa9db9764d75"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
This is needed for bottling on Monterey.
