### PR TITLE
yaz: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/yaz.rb
+++ b/Formula/yaz.rb
@@ -1,9 +1,18 @@
 class Yaz < Formula
   desc "Toolkit for Z39.50/SRW/SRU clients/servers"
   homepage "https://www.indexdata.com/resources/software/yaz/"
-  url "https://ftp.indexdata.com/pub/yaz/yaz-5.31.0.tar.gz"
-  sha256 "864d4476d1578ac132782b3d4e2eb96391bd88f7ae3040ddcb1556aba6fe0d15"
   license "BSD-3-Clause"
+
+  stable do
+    url "https://ftp.indexdata.com/pub/yaz/yaz-5.31.0.tar.gz"
+    sha256 "864d4476d1578ac132782b3d4e2eb96391bd88f7ae3040ddcb1556aba6fe0d15"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
 
   livecheck do
     url :homepage


### PR DESCRIPTION
This is needed for bottling on Monterey.
