### PR TITLE
cracklib: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/cracklib.rb
+++ b/Formula/cracklib.rb
@@ -28,6 +28,12 @@ class Cracklib < Formula
     sha256 "ec25ac4a474588c58d901715512d8902b276542b27b8dd197e9c2ad373739ec4"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
This is needed for bottling on Monterey.
