### PR TITLE
juman: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/juman.rb
+++ b/Formula/juman.rb
@@ -3,11 +3,7 @@ class Juman < Formula
   homepage "https://nlp.ist.i.kyoto-u.ac.jp/index.php?JUMAN"
   url "https://nlp.ist.i.kyoto-u.ac.jp/nl-resource/juman/juman-7.01.tar.bz2"
   sha256 "64bee311de19e6d9577d007bb55281e44299972637bd8a2a8bc2efbad2f917c6"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?juman[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  license "BSD-3-Clause"
 
   bottle do
     sha256 arm64_big_sur: "9b0c1166c946ef258a558961fa82660502d705bbbecf6b8735a805b093802432"

--- a/Formula/juman.rb
+++ b/Formula/juman.rb
@@ -20,6 +20,12 @@ class Juman < Formula
     sha256 yosemite:      "b2ccfe90011dead77ca0789cbdcdf30aa24e2ebcd3dd19c8d01b6adacbf7c816"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/juman.rb
+++ b/Formula/juman.rb
@@ -34,7 +34,8 @@ class Juman < Formula
   end
 
   test do
-    result = `echo \xe4\xba\xac\xe9\x83\xbd\xe5\xa4\xa7\xe5\xad\xa6 | juman | md5`.chomp
-    assert_equal "a5dd58c8ffa618649c5791f67149ab56", result
+    md5 = OS.mac? ? "md5" : "md5sum"
+    result = pipe_output(md5, pipe_output(bin/"juman", "\xe4\xba\xac\xe9\x83\xbd\xe5\xa4\xa7\xe5\xad\xa6"))
+    assert_equal "a5dd58c8ffa618649c5791f67149ab56", result.chomp.split.first
   end
 end


### PR DESCRIPTION
This is needed for bottling on Monterey.
