### PR TITLE
h3: fix ARM build

### DIFF
--- a/Formula/h3.rb
+++ b/Formula/h3.rb
@@ -15,10 +15,12 @@ class H3 < Formula
   depends_on "cmake" => :build
 
   def install
-    mkdir "build" do
-      system "cmake", "..", "-DBUILD_SHARED_LIBS=YES", *std_cmake_args
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DBUILD_SHARED_LIBS=ON",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
Fixes

    dyld[20197]: Library not loaded: @rpath/libh3.1.dylib
    Error: test failed
      Referenced from: /opt/homebrew/Cellar/h3/3.7.2/bin/geoToH3
      Reason: tried: '/usr/local/lib/libh3.1.dylib' (no such file), '/usr/lib/libh3.1.dylib' (no such file)

This supports bottling on Monterey.
