### PR TITLE
libdc1394: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libdc1394.rb
+++ b/Formula/libdc1394.rb
@@ -14,6 +14,12 @@ class Libdc1394 < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/b8275aa07f/libdc1394/capture.patch"
       sha256 "6e3675b7fb1711c5d7634a76d723ff25e2f7ae73cd1fbf3c4e49ba8e5dcf6c39"
     end
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+      sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+    end
   end
 
   bottle do


### PR DESCRIPTION
This is needed for bottling on Monterey.
