### PR TITLE
dhcping: use HTTPS

### DIFF
--- a/Formula/dhcping.rb
+++ b/Formula/dhcping.rb
@@ -1,7 +1,7 @@
 class Dhcping < Formula
   desc "Perform a dhcp-request to check whether a dhcp-server is running"
-  homepage "http://www.mavetju.org/unix/general.php"
-  url "http://www.mavetju.org/download/dhcping-1.2.tar.gz"
+  homepage "https://www.mavetju.org/unix/general.php"
+  url "https://www.mavetju.org/download/dhcping-1.2.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/d/dhcping/dhcping_1.2.orig.tar.gz"
   sha256 "32ef86959b0bdce4b33d4b2b216eee7148f7de7037ced81b2116210bc7d3646a"
 


### PR DESCRIPTION
This supports bottling on Monterey.
