### PR TITLE
enet: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/enet.rb
+++ b/Formula/enet.rb
@@ -15,6 +15,12 @@ class Enet < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f0531f7c9cb6c994d6a38b07ac6e303f81a8a4194dd7daaa6d6aec1d25155afb"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
This is needed for bottling on Monterey.
