### PR TITLE
charge: call `deuniversalize_machos`

### DIFF
--- a/Formula/charge.rb
+++ b/Formula/charge.rb
@@ -21,7 +21,10 @@ class Charge < Formula
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
+
+    # Replace universal binaries with their native slices.
+    deuniversalize_machos
   end
 
   test do


### PR DESCRIPTION
This supports bottling on Monterey.

While we're here, let's replace the `Dir.[]` with `Pathname#glob` call,
as this is semantically more meaningful. `Dir` is meant to refer to
directories, but we are globbing over files.
