### PR TITLE
bit: fix audit failures

### DIFF
--- a/Formula/bit.rb
+++ b/Formula/bit.rb
@@ -6,6 +6,7 @@ class Bit < Formula
   url "https://registry.npmjs.org/bit-bin/-/bit-bin-14.8.8.tgz"
   sha256 "25d899bacd06d77fad41026a9b19cbe94c8fb986f5fe59ead7ccec9f60fd0ef9"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/teambit/bit.git", branch: "master"
 
   bottle do
@@ -16,13 +17,34 @@ class Bit < Formula
     sha256 high_sierra:   "2e2f871d7759adb7d2772a8ec319c3762c3e54e58625172f4ad44132cbdf3b2b"
   end
 
+  depends_on arch: :x86_64 # installs an x86_64 `node.napi.node`
   depends_on "node"
+
+  on_macos do
+    depends_on "terminal-notifier"
+  end
 
   conflicts_with "bit-git", because: "both install `bit` binaries"
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
+
+    # Remove vendored pre-built binary `terminal-notifier`
+    node_notifier_vendor_dir = libexec/"lib/node_modules/bit-bin/node_modules/node-notifier/vendor"
+    node_notifier_vendor_dir.rmtree # remove vendored pre-built binaries
+
+    if OS.mac?
+      terminal_notifier_dir = node_notifier_vendor_dir/"mac.noindex"
+      terminal_notifier_dir.mkpath
+
+      # replace vendored `terminal-notifier` with our own
+      terminal_notifier_app = Formula["terminal-notifier"].opt_prefix/"terminal-notifier.app"
+      ln_sf terminal_notifier_app.relative_path_from(terminal_notifier_dir), terminal_notifier_dir
+    end
+
+    # Replace universal binaries with their native slices.
+    deuniversalize_machos
   end
 
   test do


### PR DESCRIPTION
- replace vendored `terminal-notifier` with our own
- remove non-native slices of universal binaries

This supports bottling on Monterey.
