### PR TITLE
sigrok-cli 0.7.2 (new formula)

### DIFF
--- a/Formula/sigrok-cli.rb
+++ b/Formula/sigrok-cli.rb
@@ -1,0 +1,38 @@
+class SigrokCli < Formula
+  desc "Sigrok command-line interface to use logic analyzers and more"
+  homepage "https://sigrok.org/"
+  url "https://sigrok.org/download/source/sigrok-cli/sigrok-cli-0.7.2.tar.gz"
+  sha256 "71d0443f36897bf565732dec206830dbea0f2789b6601cf10536b286d1140ab8"
+  license "GPL-3.0-or-later"
+
+  livecheck do
+    url "https://sigrok.org/wiki/Downloads"
+    regex(/href=.*?sigrok-cli[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  head do
+    url "git://sigrok.org/sigrok-cli", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "libsigrok"
+  depends_on "libsigrokdecode"
+
+  def install
+    system "./autogen.sh" if build.head?
+    mkdir "build" do
+      system "../configure", *std_configure_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    # Make sure that we can capture samples from the demo device
+    system "#{bin}/sigrok-cli", "-d", "demo", "--samples", "1"
+  end
+end


### PR DESCRIPTION
Sigrok is an open source driver for several popular logic analyzers,
oscilloscopes, DMMs, and more. This formula contains the command line
interface to Sigrok.

Signed-off-by: Andreas Sandberg <andreas@sandberg.uk>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
