### PR TITLE
meson: audit the `inreplace` only for stable builds

### DIFF
--- a/Formula/meson.rb
+++ b/Formula/meson.rb
@@ -30,7 +30,8 @@ class Meson < Formula
       modules/python.py
     ].map { |f| mesonbuild/f }
 
-    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
+    # Passing `build.stable?` ensures a failed `inreplace` won't fail HEAD installs.
+    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX, build.stable?
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Head is a moving target that could break the `inreplace` at any point.
Instead of having to field PRs that fix the `inreplace` for `HEAD`
installs (with potential conditional logic adding to or removing from
the `inreplace_files` array), let's just silently ignore `inreplace`
failures on `HEAD` installs.