### PR TITLE
mjpegtools: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/mjpegtools.rb
+++ b/Formula/mjpegtools.rb
@@ -16,6 +16,12 @@ class Mjpegtools < Formula
   depends_on "pkg-config" => :build
   depends_on "jpeg"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--enable-simd-accel",


### PR DESCRIPTION
This is needed for bottling on Monterey.
