### PR TITLE
getmail: use HTTPS

### DIFF
--- a/Formula/getmail.rb
+++ b/Formula/getmail.rb
@@ -1,7 +1,7 @@
 class Getmail < Formula
   desc "Extensible mail retrieval system with POP3, IMAP4, SSL support"
-  homepage "http://pyropus.ca/software/getmail/"
-  url "http://pyropus.ca/software/getmail/old-versions/getmail-5.15.tar.gz"
+  homepage "https://pyropus.ca/software/getmail/"
+  url "https://pyropus.ca/software/getmail/old-versions/getmail-5.15.tar.gz"
   sha256 "d453805ffc3f8fe2586ee705733bd666777e53693125fdb149494d22bd14162a"
   license "GPL-2.0-only"
 


### PR DESCRIPTION
This supports bottling on Monterey.
