### PR TITLE
gopls: update livecheck

### DIFF
--- a/Formula/gopls.rb
+++ b/Formula/gopls.rb
@@ -8,7 +8,7 @@ class Gopls < Formula
   livecheck do
     url :stable
     strategy :github_latest
-    regex(%r{href=.*?/tag/(?:gopls%2F)?v?(\d+(?:\.\d+)+)["' >]}i)
+    regex(%r{(?:content|href)=.*?/tag/(?:gopls%2F)?v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `gopls` isn't working as expected due to the recent changes in GitHub release HTML. This PR updates the regex accordingly. Related to #88329.

---

From a quick test, it seems like this may not affect formulae using the default `GithubLatest` regex but I'll open a PR to update the strategy regex to use `(?:content|href)` in a bit, just to be safe.

In the future, I plan to update the `GithubLatest` strategy to identify the tag from the HTTP `location` header (so we don't have to follow the redirection) and to allow a `livecheck` block to optionally follow the redirection when we need to check content on the release page. This relies on the forthcoming `options` PR, so it's something that will come afterward.