### PR TITLE
rig: fix ARM build

### DIFF
--- a/Formula/rig.rb
+++ b/Formula/rig.rb
@@ -16,9 +16,10 @@ class Rig < Formula
   end
 
   def install
-    system "make"
+    system "make", "PREFX=#{prefix}", "MANDIR=#{man}"
     bin.install "rig"
-    pkgshare.install Dir["data/*"]
+    man6.install "rig.6"
+    pkgshare.install buildpath.glob("data/*")
   end
 
   test do


### PR DESCRIPTION
We need to pass `PREFIX` to avoid hardcoding a `/usr/local` prefix. This
should fix the build on ARM and support bottling on Monterey.
