### PR TITLE
freeipmi: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/freeipmi.rb
+++ b/Formula/freeipmi.rb
@@ -16,6 +16,12 @@ class Freeipmi < Formula
   depends_on "argp-standalone"
   depends_on "libgcrypt"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     # Hardcode CPP_FOR_BUILD to work around cpp shim issue:
     # https://github.com/Homebrew/brew/issues/5153


### PR DESCRIPTION
This is needed for bottling on Monterey.
