### PR TITLE
bacula-fd: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/bacula-fd.rb
+++ b/Formula/bacula-fd.rb
@@ -20,6 +20,12 @@ class BaculaFd < Formula
   conflicts_with "bareos-client",
     because: "both install a `bconsole` executable"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     # CoreFoundation is also used alongside IOKit
     inreplace "configure", '"-framework IOKit"',


### PR DESCRIPTION
This is needed for bottling on Monterey.
