### PR TITLE
log4shib: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/log4shib.rb
+++ b/Formula/log4shib.rb
@@ -20,6 +20,12 @@ class Log4shib < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "136a804ca90390b69fd57818855efbeefe5d1c5a44fcd523dab57fa54194ca47"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make", "install"


### PR DESCRIPTION
This is needed for bottling on Monterey.
