### PR TITLE
ser2net: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/ser2net.rb
+++ b/Formula/ser2net.rb
@@ -24,6 +24,12 @@ class Ser2net < Formula
   resource "gensio" do
     url "https://downloads.sourceforge.net/project/ser2net/ser2net/gensio-2.1.4.tar.gz"
     sha256 "1f5a29aabfb35886893cfda5cd78192db67e96de796dbf9758dbecd4077a3fd8"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
   end
 
   def install


### PR DESCRIPTION
This is needed for bottling on Monterey.
