### PR TITLE
cpptest: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/cpptest.rb
+++ b/Formula/cpptest.rb
@@ -15,6 +15,12 @@ class Cpptest < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "ebb0d38cb3fb4038067867b4b10ff93cdc330528dc0f163d4af0a87a427a7375"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
This is needed for bottling on Monterey.
