### PR TITLE
dante: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/dante.rb
+++ b/Formula/dante.rb
@@ -17,6 +17,12 @@ class Dante < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "19ae4553c91fc1991fd495f3b3e25d92fa7cbd59bd7d32f8fc71444f02bbbee5"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-silent-rules",


### PR DESCRIPTION
This is needed for bottling on Monterey.
