### PR TITLE
fontconfig: force --disable-docs option

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -52,6 +52,8 @@ class Fontconfig < Formula
     sha256 "1dbe6247786c75f2b3f5a7e21133a3f9c09189f59fff08b2df7cb15389b0e405"
   end
 
+  option "without-docs", "Skip building the fontconfig docs (e.g. if docbook2pdf is not installed)"
+
   def install
     font_dirs = %w[
       /System/Library/Fonts
@@ -69,7 +71,8 @@ class Fontconfig < Formula
                           "--with-add-fonts=#{font_dirs.join(",")}",
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}",
-                          "--sysconfdir=#{etc}"
+                          "--sysconfdir=#{etc}",
+                          ("--disable-docs" if build.without? "docs")
     system "make", "install", "RUN_FC_CACHE_TEST=false"
   end
 

--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -52,8 +52,6 @@ class Fontconfig < Formula
     sha256 "1dbe6247786c75f2b3f5a7e21133a3f9c09189f59fff08b2df7cb15389b0e405"
   end
 
-  option "without-docs", "Skip building the fontconfig docs (e.g. if docbook2pdf is not installed)"
-
   def install
     font_dirs = %w[
       /System/Library/Fonts
@@ -72,7 +70,7 @@ class Fontconfig < Formula
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}",
                           "--sysconfdir=#{etc}",
-                          ("--disable-docs" if build.without? "docs")
+                          "--disable-docs"
     system "make", "install", "RUN_FC_CACHE_TEST=false"
   end
 

--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -65,12 +65,12 @@ class Fontconfig < Formula
     ENV["UUID_CFLAGS"] = "-I#{Formula["util-linux"].include}" if OS.linux?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--disable-docs",
                           "--enable-static",
                           "--with-add-fonts=#{font_dirs.join(",")}",
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}",
-                          "--sysconfdir=#{etc}",
-                          "--disable-docs"
+                          "--sysconfdir=#{etc}"
     system "make", "install", "RUN_FC_CACHE_TEST=false"
   end
 


### PR DESCRIPTION
The `without-docs` option which adds `--disable-docs` to the configure step was removed in this commit https://github.com/Homebrew/homebrew-core/commit/0643a07a30b6c3bd69c16860a179c428c29f3e73
However, this option is still needed as people don't always have docbook2pdf installed

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
