### PR TITLE
unittest-cpp: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/unittest-cpp.rb
+++ b/Formula/unittest-cpp.rb
@@ -1,9 +1,18 @@
 class UnittestCpp < Formula
   desc "Unit testing framework for C++"
   homepage "https://github.com/unittest-cpp/unittest-cpp"
-  url "https://github.com/unittest-cpp/unittest-cpp/releases/download/v2.0.0/unittest-cpp-2.0.0.tar.gz"
-  sha256 "1d1b118518dc200e6b87bbf3ae7bfd00a0cfc6be708255f98e5e3d627a7c9f98"
   license "MIT"
+
+  stable do
+    url "https://github.com/unittest-cpp/unittest-cpp/releases/download/v2.0.0/unittest-cpp-2.0.0.tar.gz"
+    sha256 "1d1b118518dc200e6b87bbf3ae7bfd00a0cfc6be708255f98e5e3d627a7c9f98"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "462837c9588ccf8f585d9d82af071bb91a59f2bf3ef155ccc863c416491cab68"


### PR DESCRIPTION
This is needed for bottling on Monterey.
