### PR TITLE
primesieve: set `CMAKE_INSTALL_RPATH`

### DIFF
--- a/Formula/primesieve.rb
+++ b/Formula/primesieve.rb
@@ -15,10 +15,9 @@ class Primesieve < Formula
   depends_on "cmake" => :build
 
   def install
-    mkdir "build" do
-      system "cmake", "..", *std_cmake_args
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_INSTALL_RPATH=#{rpath}", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
This will fix the build on ARM, allow the bottles to work in
non-default prefixes, and supports bottling on Monterey.
