### PR TITLE
massdns: Fix URL

### DIFF
--- a/Formula/massdns.rb
+++ b/Formula/massdns.rb
@@ -1,7 +1,7 @@
 class Massdns < Formula
   desc "High-performance DNS stub resolver"
   homepage "https://github.com/blechschmidt/massdns"
-  url "https://github.com/blechschmidt/massdns/archive/1.0.0.tar.gz"
+  url "https://github.com/blechschmidt/massdns/archive/v1.0.0.tar.gz"
   sha256 "0eba00a03e74a02a78628819741c75c2832fb94223d0ff632249f2cc55d0fdbb"
   license "GPL-3.0-only"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Related to https://github.com/Homebrew/homebrew-core/issues/88329.
This PR fixes the URL of `massdns`.