### PR TITLE
sonarqube: allow to run on Apple Silicon

### DIFF
--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -16,16 +16,17 @@ class Sonarqube < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "5bd7b5e142d30a1caf30979e5e077f462e076540c514505d354df4625e2be67d"
   end
 
-  depends_on "java-service-wrapper" => :build
+  depends_on "java-service-wrapper"
   depends_on "openjdk@11"
 
   conflicts_with "sonarqube-lts", because: "both install the same binaries"
 
   def install
     # Use Java Service Wrapper 3.5.46 which is Apple Silicon compatible
+    # Java Service Wrapper doesn't support the  wrapper binary to be symlinked, so it's copied
     jsw_libexec = Formula["java-service-wrapper"].opt_libexec
-    cp jsw_libexec/"lib/wrapper.jar", "#{buildpath}/lib/jsw/wrapper-3.5.46.jar"
-    cp jsw_libexec/"lib/libwrapper.dylib", "#{buildpath}/bin/macosx-universal-64/lib/"
+    ln_s jsw_libexec/"lib/wrapper.jar", "#{buildpath}/lib/jsw/wrapper-3.5.46.jar"
+    ln_s jsw_libexec/"lib/libwrapper.dylib", "#{buildpath}/bin/macosx-universal-64/lib/"
     cp jsw_libexec/"bin/wrapper", "#{buildpath}/bin/macosx-universal-64/"
     cp jsw_libexec/"scripts/App.sh.in", "#{buildpath}/bin/macosx-universal-64/sonar.sh"
     sonar_sh_file = "bin/macosx-universal-64/sonar.sh"

--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -17,30 +17,24 @@ class Sonarqube < Formula
   end
 
   depends_on "openjdk@11"
-  # Sonarqube ships pre-built x86_64 java-service-wrapper binaries, use arm64 binaries
-  # from Homebrew built java-service-wrapper
-  on_macos do
-    depends_on "java-service-wrapper" => :build if Hardware::CPU.arm?
-  end
+  depends_on "java-service-wrapper" => :build
 
   conflicts_with "sonarqube-lts", because: "both install the same binaries"
 
   def install
-    if OS.mac? && Hardware::CPU.arm?
-      # Use Java Service Wrapper 3.5.46 which is Apple Silicon compatible
-      jsw_libexec = Formula["java-service-wrapper"].opt_libexec
-      cp jsw_libexec/"lib/wrapper.jar", "#{buildpath}/lib/jsw/wrapper-3.5.46.jar"
-      cp jsw_libexec/"lib/libwrapper.dylib", "#{buildpath}/bin/macosx-universal-64/lib/"
-      cp jsw_libexec/"bin/wrapper", "#{buildpath}/bin/macosx-universal-64/"
-      cp jsw_libexec/"scripts/App.sh.in", "#{buildpath}/bin/macosx-universal-64/sonar.sh"
-      sonar_sh_file = "bin/macosx-universal-64/sonar.sh"
-      inreplace sonar_sh_file, "@app.name@", "SonarQube"
-      inreplace sonar_sh_file, "@app.long.name@", "SonarQube"
-      inreplace sonar_sh_file, "../conf/wrapper.conf", "../../conf/wrapper.conf"
-      inreplace "conf/wrapper.conf", "wrapper-3.2.3.jar", "wrapper-3.5.46.jar"
-      rm "lib/jsw/wrapper-3.2.3.jar"
-      rm "bin/macosx-universal-64/lib/libwrapper.jnilib"
-    end
+    # Use Java Service Wrapper 3.5.46 which is Apple Silicon compatible
+    jsw_libexec = Formula["java-service-wrapper"].opt_libexec
+    cp jsw_libexec/"lib/wrapper.jar", "#{buildpath}/lib/jsw/wrapper-3.5.46.jar"
+    cp jsw_libexec/"lib/libwrapper.dylib", "#{buildpath}/bin/macosx-universal-64/lib/"
+    cp jsw_libexec/"bin/wrapper", "#{buildpath}/bin/macosx-universal-64/"
+    cp jsw_libexec/"scripts/App.sh.in", "#{buildpath}/bin/macosx-universal-64/sonar.sh"
+    sonar_sh_file = "bin/macosx-universal-64/sonar.sh"
+    inreplace sonar_sh_file, "@app.name@", "SonarQube"
+    inreplace sonar_sh_file, "@app.long.name@", "SonarQube"
+    inreplace sonar_sh_file, "../conf/wrapper.conf", "../../conf/wrapper.conf"
+    inreplace "conf/wrapper.conf", "wrapper-3.2.3.jar", "wrapper-3.5.46.jar"
+    rm "lib/jsw/wrapper-3.2.3.jar"
+    rm "bin/macosx-universal-64/lib/libwrapper.jnilib"
 
     # Delete native bin directories for other systems
     remove, keep = if OS.mac?

--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -16,8 +16,8 @@ class Sonarqube < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "5bd7b5e142d30a1caf30979e5e077f462e076540c514505d354df4625e2be67d"
   end
 
-  depends_on "openjdk@11"
   depends_on "java-service-wrapper" => :build
+  depends_on "openjdk@11"
 
   conflicts_with "sonarqube-lts", because: "both install the same binaries"
 

--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -17,9 +17,10 @@ class Sonarqube < Formula
   end
 
   depends_on "openjdk@11"
-  # Sonarqube ships pre-built x86_64 java-service-wrapper binaries, use arm64 binaries from Homebrew java-service-wrapper
-  if OS.mac? && Hardware::CPU.arm?
-    depends_on "java-service-wrapper" => :build
+  # Sonarqube ships pre-built x86_64 java-service-wrapper binaries, use arm64 binaries
+  # from Homebrew built java-service-wrapper
+  on_macos do
+    depends_on "java-service-wrapper" => :build if Hardware::CPU.arm?
   end
 
   conflicts_with "sonarqube-lts", because: "both install the same binaries"
@@ -27,10 +28,11 @@ class Sonarqube < Formula
   def install
     if OS.mac? && Hardware::CPU.arm?
       # Use Java Service Wrapper 3.5.46 which is Apple Silicon compatible
-      cp Formula["java-service-wrapper"].opt_libexec/"lib/wrapper.jar", "#{buildpath}/lib/jsw/wrapper-3.5.46.jar"
-      cp Formula["java-service-wrapper"].opt_libexec/"lib/libwrapper.dylib", "#{buildpath}/bin/macosx-universal-64/lib/"
-      cp Formula["java-service-wrapper"].opt_libexec/"bin/wrapper", "#{buildpath}/bin/macosx-universal-64/"
-      cp Formula["java-service-wrapper"].opt_libexec/"scripts/App.sh.in", "#{buildpath}/bin/macosx-universal-64/sonar.sh"
+      jsw_libexec = Formula["java-service-wrapper"].opt_libexec
+      cp jsw_libexec/"lib/wrapper.jar", "#{buildpath}/lib/jsw/wrapper-3.5.46.jar"
+      cp jsw_libexec/"lib/libwrapper.dylib", "#{buildpath}/bin/macosx-universal-64/lib/"
+      cp jsw_libexec/"bin/wrapper", "#{buildpath}/bin/macosx-universal-64/"
+      cp jsw_libexec/"scripts/App.sh.in", "#{buildpath}/bin/macosx-universal-64/sonar.sh"
       sonar_sh_file = "bin/macosx-universal-64/sonar.sh"
       inreplace sonar_sh_file, "@app.name@", "SonarQube"
       inreplace sonar_sh_file, "@app.long.name@", "SonarQube"

--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -17,7 +17,6 @@ class Sonarqube < Formula
   end
 
   # sonarqube ships pre-built x86_64 binaries
-  depends_on arch: :x86_64
   depends_on "openjdk@11"
 
   conflicts_with "sonarqube-lts", because: "both install the same binaries"
@@ -41,6 +40,15 @@ class Sonarqube < Formula
   service do
     run [opt_bin/"sonar", "console"]
     keep_alive true
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        Wrapper's native library are not yet available for Apple silicon.
+        System signals will not be handled correctly on this architecture.
+      EOS
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Sonarqube 9.1.0.47736 uses [Java Service Wrapper](https://wrapper.tanukisoftware.com/doc/english/home.html) 3.2.3 which doesn't have native libraries for Apple Silicon. This cause a warning on startup:
```
WARNING - Unable to load the Wrapper's native library because none of the
          following files:
            libwrapper-macosx-aarch64-64.dylib
            libwrapper-macosx-universal-64.dylib
            libwrapper.dylib
          could be located on the following java.library.path:
            /opt/homebrew/Cellar/sonarqube/9.1.0.47736/libexec/bin/macosx-universal-64/./lib
          Please see the documentation for the wrapper.java.library.path
          configuration property.
          System signals will not be handled correctly.
```

but this does not prevent to use Sonarqube on Apple Silicon. Java analysis works perfectly well. The only problem I observed is that the output of `brew services list` is not accurate. This will be probably solved when upstream will upgrade Java Service Wrapper to 3.5.46 which support Apple Silicon.
