### PR TITLE
Gtk4 4.5.0

### DIFF
--- a/Formula/gtk4.rb
+++ b/Formula/gtk4.rb
@@ -1,8 +1,8 @@
 class Gtk4 < Formula
   desc "Toolkit for creating graphical user interfaces"
   homepage "https://gtk.org/"
-  url "https://download.gnome.org/sources/gtk/4.4/gtk-4.4.0.tar.xz"
-  sha256 "e0a1508f441686c3a20dfec48af533b19a4b2e017c18eaee31dccdb7d292505b"
+  url "https://download.gnome.org/sources/gtk/4.5/gtk-4.5.0.tar.xz"
+  sha256 "78a3158094f1e35c0ae6fde895321c0eca60cf9af8578b918bb7c7e1a16c10ea"
   license "LGPL-2.0-or-later"
 
   livecheck do
@@ -20,6 +20,7 @@ class Gtk4 < Formula
 
   depends_on "docbook" => :build
   depends_on "docbook-xsl" => :build
+  depends_on "docutils" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build

--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -1,8 +1,8 @@
 class Pango < Formula
   desc "Framework for layout and rendering of i18n text"
   homepage "https://www.pango.org/"
-  url "https://download.gnome.org/sources/pango/1.48/pango-1.48.10.tar.xz"
-  sha256 "21e1f5798bcdfda75eabc4280514b0896ab56f656d4e7e66030b9a2535ecdc98"
+  url "https://download.gnome.org/sources/pango/1.49/pango-1.49.2.tar.xz"
+  sha256 "9d67612c58be86b118d2dbf28498f4e6395033b658cdfd6787a9b4b368055fd6"
   license "LGPL-2.0-or-later"
   head "https://gitlab.gnome.org/GNOME/pango.git", branch: "main"
 
@@ -31,7 +31,7 @@ class Pango < Formula
       system "meson", *std_meson_args,
                       "-Ddefault_library=both",
                       "-Dintrospection=enabled",
-                      "-Duse_fontconfig=true",
+                      "-Dfontconfig=enabled",
                       ".."
       system "ninja", "-v"
       system "ninja", "install", "-v"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
```
gtk4:
  * 4.5.0 is a development release
```
-----

I only realized that 4.5.0 is an unstable release after I put in the work to update the formula. I still decided to open this PR because the [Gtk issue #4279](https://gitlab.gnome.org/GNOME/gtk/-/issues/4279) causes Gtk4 applications to crash when OpenGL rendering is used on Apple Silicon Macs. Due to a separate issue, the Cairo-based rendering fallback seems to produce entirely black windows, rendering Gtk 4.4 unusable on M1 Macs. This issue has been [fixed](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4008) for Gtk 4.5, but the fix has as of yet not been backported to the 4.4 branch.

As this is my first contribution to homebrew, I am unsure whether an unstable release would be admissible under those circumstances. My guess is that it is not, but wanted to bring this to your attention anyway.