### PR TITLE
scotch: adding pt-scotch

### DIFF
--- a/Formula/scotch.rb
+++ b/Formula/scotch.rb
@@ -1,8 +1,8 @@
 class Scotch < Formula
   desc "Package for graph partitioning, graph clustering, and sparse matrix ordering"
   homepage "https://gitlab.inria.fr/scotch/scotch"
-  url "https://gitlab.inria.fr/scotch/scotch/-/archive/v6.1.1/scotch-v6.1.1.tar.bz2"
-  sha256 "543ab2f8998658e5a6123231bfb3736cfbb939f330c656f8a7913d967a933f00"
+  url "https://gitlab.inria.fr/scotch/scotch/-/archive/v6.1.2/scotch-v6.1.2.tar.bz2"
+  sha256 "6e820a64cc2105749e3d1dfbfc9aed33597a85927b6f56d073a6ef602724ea2d"
   license "CECILL-C"
   head "https://gitlab.inria.fr/scotch/scotch.git", branch: "master"
 
@@ -20,7 +20,7 @@ class Scotch < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f93fe6e8bcdb31271f7d082915061d6fa2b9e415611a6f52929dbb45a48dd847"
   end
 
-  depends_on "open-mpi" => :build
+  depends_on "open-mpi"
 
   uses_from_macos "bison"
   uses_from_macos "flex"
@@ -29,25 +29,26 @@ class Scotch < Formula
   def install
     cd "src"
     (buildpath/"src").install_symlink "Make.inc/Makefile.inc.i686_mac_darwin10" => "Makefile.inc"
-    system "make"
+
+    inreplace "Makefile.inc" do |s|
+      s.change_make_var! "CCS", ENV.cc
+      s.change_make_var! "CCP", "mpicc"
+      s.change_make_var! "CCD", "mpicc"
+    end
+
+    system "make", "scotch", "ptscotch"
     system "make", "prefix=#{prefix}", "install"
+
+    pkgshare.install "check/test_strat_seq.c"
+    pkgshare.install "check/test_strat_par.c"
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
-      #include <stdlib.h>
-      #include <stdio.h>
-
-      #include <scotch.h>
-      int main(void) {
-        int major, minor, patch;
-        SCOTCH_version(&major, &minor, &patch);
-        printf("%d.%d.%d", major, minor, patch);
-        return 0;
-      }
-    EOS
-
-    system ENV.cc, "test.c", "-L#{lib}", "-lscotch"
-    assert_match version.to_s, shell_output("./a.out")
+    system ENV.cc, pkgshare/"test_strat_seq.c", "-o", "test_strat_seq", "-lm", "-lpthread",
+           "-I#{include}", "-L#{lib}", "-lscotch", "-lscotcherr"
+    system "mpicc", pkgshare/"test_strat_par.c", "-o", "test_strat_par", "-lm", "-lpthread",
+           "-lmpi", "-I#{include}", "-L#{lib}", "-lscotch", "-lptscotch", "-lptscotcherr"
+    assert_match "Sequential mapping strategy, SCOTCH_STRATDEFAULT", shell_output("./test_strat_seq")
+    assert_match "Parallel mapping strategy, SCOTCH_STRATDEFAULT", shell_output("./test_strat_par")
   end
 end

--- a/Formula/scotch.rb
+++ b/Formula/scotch.rb
@@ -44,10 +44,10 @@ class Scotch < Formula
   end
 
   test do
-    system ENV.cc, pkgshare/"test_strat_seq.c", "-o", "test_strat_seq", "-lm", "-lpthread",
-           "-I#{include}", "-L#{lib}", "-lscotch", "-lscotcherr"
-    system "mpicc", pkgshare/"test_strat_par.c", "-o", "test_strat_par", "-lm", "-lpthread",
-           "-lmpi", "-I#{include}", "-L#{lib}", "-lscotch", "-lptscotch", "-lptscotcherr"
+    system ENV.cc, pkgshare/"test_strat_seq.c", "-o", "test_strat_seq",
+           "-I#{include}", "-L#{lib}", "-lscotch", "-lscotcherr", "-lm", "-pthread"
+    system "mpicc", pkgshare/"test_strat_par.c", "-o", "test_strat_par",
+           "-I#{include}", "-L#{lib}", "-lptscotch", "-lscotch", "-lptscotcherr", "-lm", "-pthread"
     assert_match "Sequential mapping strategy, SCOTCH_STRATDEFAULT", shell_output("./test_strat_seq")
     assert_match "Parallel mapping strategy, SCOTCH_STRATDEFAULT", shell_output("./test_strat_par")
   end

--- a/Formula/scotch.rb
+++ b/Formula/scotch.rb
@@ -38,12 +38,12 @@ class Scotch < Formula
       system "make", "scotch", "ptscotch"
       system "make", "prefix=#{prefix}", "install"
 
+      pkgshare.install "check/test_strat_seq.c"
       pkgshare.install "check/test_strat_par.c"
     end
   end
 
   test do
-    # Scotch library test
     (testpath/"test.c").write <<~EOS
       #include <stdlib.h>
       #include <stdio.h>
@@ -58,7 +58,10 @@ class Scotch < Formula
     system ENV.cc, "test.c", "-L#{lib}", "-lscotch"
     assert_match version.to_s, shell_output("./a.out")
 
-    # PT-scotch library test
+    system ENV.cc, pkgshare/"test_strat_seq.c", "-o", "test_strat_seq",
+           "-I#{include}", "-L#{lib}", "-lscotch", "-lscotcherr", "-lm", "-pthread"
+    assert_match "Sequential mapping strategy, SCOTCH_STRATDEFAULT", shell_output("./test_strat_seq")
+
     system "mpicc", pkgshare/"test_strat_par.c", "-o", "test_strat_par",
            "-I#{include}", "-L#{lib}", "-lptscotch", "-lscotch", "-lptscotcherr", "-lm", "-pthread"
     assert_match "Parallel mapping strategy, SCOTCH_STRATDEFAULT", shell_output("./test_strat_par")

--- a/Formula/scotch.rb
+++ b/Formula/scotch.rb
@@ -37,7 +37,7 @@ class Scotch < Formula
 
       system "make", "scotch", "ptscotch"
       system "make", "prefix=#{prefix}", "install"
- 
+
       pkgshare.install "check/test_strat_par.c"
     end
   end
@@ -57,7 +57,7 @@ class Scotch < Formula
     EOS
     system ENV.cc, "test.c", "-L#{lib}", "-lscotch"
     assert_match version.to_s, shell_output("./a.out")
-    
+
     # PT-scotch library test
     system "mpicc", pkgshare/"test_strat_par.c", "-o", "test_strat_par",
            "-I#{include}", "-L#{lib}", "-lptscotch", "-lscotch", "-lptscotcherr", "-lm", "-pthread"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adding back pt-scotch. See https://github.com/Homebrew/homebrew-core/blob/6095bab4530021e426f2e547618acaf124e53604/Formula/scotch.rb#L23
Dropped `-DSCOTCH_PTHREAD` to avoid potential MPI issue.