### PR TITLE
powerman: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/powerman.rb
+++ b/Formula/powerman.rb
@@ -1,9 +1,18 @@
 class Powerman < Formula
   desc "Control (remotely and in parallel) switched power distribution units"
   homepage "https://code.google.com/p/powerman/"
-  url "https://github.com/chaos/powerman/releases/download/2.3.26/powerman-2.3.26.tar.gz"
-  sha256 "19e213127f468b835165b8e2082ff2dfff62d6832f3332160f2c6ba8b2d286ad"
   license "GPL-2.0"
+
+  stable do
+    url "https://github.com/chaos/powerman/releases/download/2.3.26/powerman-2.3.26.tar.gz"
+    sha256 "19e213127f468b835165b8e2082ff2dfff62d6832f3332160f2c6ba8b2d286ad"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
 
   bottle do
     sha256 arm64_big_sur: "fad852bdb968ec275c82d4973145d05cd92103d9b144d622304fd70a18ec1989"


### PR DESCRIPTION
This is needed for bottling on Monterey.
