### PR TITLE
libkml: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libkml.rb
+++ b/Formula/libkml.rb
@@ -33,6 +33,12 @@ class Libkml < Formula
     sha256 "c39995a1c1ebabc1692dc6be698d68e18170230d71d5a0ce426d8f41bdf0dc72"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
This is needed for bottling on Monterey.
