### PR TITLE
libbinio: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libbinio.rb
+++ b/Formula/libbinio.rb
@@ -13,6 +13,12 @@ class Libbinio < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "5d8b2aeba35080348293ad101e8f4751c17e1d5b9e53adcc7e539f571bc19b01"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--infodir=#{info}"


### PR DESCRIPTION
This is needed for bottling on Monterey.
