### PR TITLE
asn1c: Fix homepage

### DIFF
--- a/Formula/asn1c.rb
+++ b/Formula/asn1c.rb
@@ -1,6 +1,6 @@
 class Asn1c < Formula
   desc "Compile ASN.1 specifications into C source code"
-  homepage "https://lionet.info/asn1c/blog/"
+  homepage "http://www.lionet.info/asn1c/"
   url "https://github.com/vlm/asn1c/releases/download/v0.9.28/asn1c-0.9.28.tar.gz"
   sha256 "8007440b647ef2dd9fb73d931c33ac11764e6afb2437dbe638bb4e5fc82386b9"
   license "BSD-2-Clause"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Related to #88329.
They seem to have changed some stuff on their servers, so their homepage is no longer available via HTTPS and only under the `www.` subdomain. The blog is not found anyway.