### PR TITLE
cityhash: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/cityhash.rb
+++ b/Formula/cityhash.rb
@@ -17,6 +17,12 @@ class Cityhash < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f381c56f8063574fc86fa4eace73e99bf9be10155f90c1881362e70aea75826a"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
This is needed for bottling on Monterey.
