### PR TITLE
libcsv: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libcsv.rb
+++ b/Formula/libcsv.rb
@@ -18,6 +18,12 @@ class Libcsv < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "a66bd666958e3125f08377688cf86c94cd38e077bedea9a70cb17c721794211f"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make"


### PR DESCRIPTION
This is needed for bottling on Monterey.
