### PR TITLE
htmlcxx: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/htmlcxx.rb
+++ b/Formula/htmlcxx.rb
@@ -14,6 +14,12 @@ class Htmlcxx < Formula
     sha256 x86_64_linux:  "ba29d98077036799d68c6c6dc56e0e7fa28aee700a89f4128a2d10a29d1ab39e"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
This is needed for bottling on Monterey.
