### PR TITLE
vgrep: downgrade version

### DIFF
--- a/Formula/vgrep.rb
+++ b/Formula/vgrep.rb
@@ -1,9 +1,10 @@
 class Vgrep < Formula
   desc "User-friendly pager for grep"
   homepage "https://github.com/vrothberg/vgrep"
-  url "https://github.com/vrothberg/vgrep/archive/v5.2.2.tar.gz"
-  sha256 "5132ef6b254bfb8535b4021c297aaeafa1e641de5ab3d1ba0e1748586f97d192"
+  url "https://github.com/vrothberg/vgrep/archive/v2.5.5.tar.gz"
+  sha256 "6272ca460549813231bc046e6fde7e94baec03f66c4b8f88b197af7d70556013"
   license "GPL-3.0-only"
+  version_scheme 1
   head "https://github.com/vrothberg/vgrep.git", branch: "main"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Related to #88329.
Version 5.2.2 was released unintentionally (see https://github.com/vrothberg/vgrep/issues/158), so 2.5.2 is the correct version. In the meantime ~2.5.3~ 2.5.5 has been released, so this PR includes that version.