### PR TITLE
libstatgrab: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libstatgrab.rb
+++ b/Formula/libstatgrab.rb
@@ -22,6 +22,12 @@ class Libstatgrab < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "8984abcb585701a695fedbebd0c13cd61b08b95240c22485c75e2aac1575c57a"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
This is needed for bottling on Monterey.
