### PR TITLE
libantlr3c: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libantlr3c.rb
+++ b/Formula/libantlr3c.rb
@@ -18,6 +18,12 @@ class Libantlr3c < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "acd166cf59163343b31b229124ddf4e982c4fa42b196ec443b5ff8b02e12566a"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     args = ["--disable-dependency-tracking",
             "--disable-antlrdebug",


### PR DESCRIPTION
This is needed for bottling on Monterey.
