### PR TITLE
csmith: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/csmith.rb
+++ b/Formula/csmith.rb
@@ -17,6 +17,12 @@ class Csmith < Formula
     sha256 cellar: :any, yosemite:      "277a9e03f3bfdd03f1e3136ef867604c7f6c4f9763346223bb41b47f0fa72f0d"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
This is needed for bottling on Monterey.
