### PR TITLE
genders: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/genders.rb
+++ b/Formula/genders.rb
@@ -20,6 +20,12 @@ class Genders < Formula
     sha256 cellar: :any, high_sierra:   "31a726904f22c156b763a8bc95bd3db6e85b8bc0cf7d8a82d584bb8684241f6c"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}", "--with-java-extensions=no"
     system "make", "install"


### PR DESCRIPTION
This is needed for bottling on Monterey.
