### PR TITLE
minetest: update livecheck

### DIFF
--- a/Formula/minetest.rb
+++ b/Formula/minetest.rb
@@ -15,7 +15,7 @@ class Minetest < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `minetest` is using the `GithubLatest` strategy but it's giving an `Unable to get versions` error because the "latest" release on GitHub is `5.4.2-android` and the default strategy regex doesn't match a tag with an extension beyond the numeric version. The aforementioned release is Android-only and shouldn't be used in the formula, so using a modified version of the strategy regex in the `livecheck` block isn't appropriate and wouldn't resolve this issue.

We only use the `GithubLatest` strategy when it's both correct and necessary. Its use in this formula was a holdover from an earlier time and neither of these criteria is currently true. In this case, checking the Git tags using the standard regex for tags like `1.2.3`/`v1.2.3` is sufficient to identify the latest stable version for our purposes (`5.4.1`) and this PR updates the `livecheck` block accordingly.