### PR TITLE
libcmph: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libcmph.rb
+++ b/Formula/libcmph.rb
@@ -13,6 +13,12 @@ class Libcmph < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "6b4a556fa47365d3ebf9312acddf3fc64921094161bd6d6e1bcda3df92be70cd"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
This is needed for bottling on Monterey.
