### PR TITLE
rhino: update livecheck

### DIFF
--- a/Formula/rhino.rb
+++ b/Formula/rhino.rb
@@ -7,8 +7,10 @@ class Rhino < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
-    regex(%r{href=.*?/tag/.*?>Rhino (\d+(?:\.\d+)+)<}i)
+    regex(/^(?:Rhino[._-]?)v?(\d+(?:[._]\d+)+)[._-]Release$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.tr("_", ".") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `rhino` uses the `GithubLatest` strategy and matches the version from the release heading but this is now giving an `Unable to get versions` error. This is because GitHub recently changed the release page HTML and now the page for a particular release no longer includes a link to the tag on the release heading.

We currently only use the `GithubLatest` strategy when it's both correct and necessary. In this case, the "latest" release is correct but using `GithubLatest` isn't necessary, as it's possible to use the `Git` strategy to obtain the newest version from the tags. This `livecheck` block was from an earlier time (before the `GithubLatest` strategy and guidance existed) and it has simply been adapted and carried over since then.

This PR updates the `livecheck` block accordingly and also adds a `strategy` block to modify the tag version (e.g., `Rhino1_7_13_Release`) into the formula version format (e.g., `1.7.13`).

---

The Git tag format seems to have fluctuated a bit over time, so this approach may fail in the future. If/when that happens, it may be necessary to return to the `GithubLatest` strategy and use a regex like `/>\s*Rhino (\d+(?:\.\d+)+)\s*</i` to match the version from the release heading.