### PR TITLE
chadwick: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/chadwick.rb
+++ b/Formula/chadwick.rb
@@ -19,6 +19,12 @@ class Chadwick < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "a384612258d503ddcdf39abc98c60e3cfdad289aaaad89169ee18f6f4e596639"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make"


### PR DESCRIPTION
This is needed for bottling on Monterey.
