### PR TITLE
libgfshare: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libgfshare.rb
+++ b/Formula/libgfshare.rb
@@ -16,6 +16,12 @@ class Libgfshare < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "4439a61e14f81e80009ad0e85a4e2a8183c106161d29e232176faa061ba380ba"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
This is needed for bottling on Monterey.
