### PR TITLE
ibex: fix test for ARM (and maybe Linux)

### DIFF
--- a/Formula/ibex.rb
+++ b/Formula/ibex.rb
@@ -47,6 +47,9 @@ class Ibex < Formula
 
     cp_r (pkgshare/"examples").children, testpath
 
+    # The `makefile` is a bit broken for use outside of `/usr/local` installs.
+    ENV.append "CPPFLAGS", "-L#{lib} -L#{lib}/ibex/3rd"
+
     (1..8).each do |n|
       system "make", "lab#{n}"
       system "./lab#{n}"


### PR DESCRIPTION
We probably shouldn't be using the example `makefile` in the `test`
block since it doesn't seem to be completely portable. However, while
we're doing so, let's make sure this works for non-`/usr/local` prefixes
too.
