### PR TITLE
pev: fix checksum

### DIFF
--- a/Formula/pev.rb
+++ b/Formula/pev.rb
@@ -2,7 +2,7 @@ class Pev < Formula
   desc "PE analysis toolkit"
   homepage "https://pev.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/pev/pev-0.81/pev-0.81.tar.gz"
-  sha256 "921b2831ca956aedc272d8580b2ff1a2cb54fb895cabeb81c907fe62b6ac83fb"
+  sha256 "4192691c57eec760e752d3d9eca2a1322bfe8003cfc210e5a6b52fca94d5172b"
   license "GPL-2.0-or-later"
   head "https://github.com/merces/pev.git", branch: "master"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Related to #88329.
[According](https://github.com/merces/pev/issues/157#issuecomment-762504018) to the author the tarball was updated a few days after (18.01.2021) the initial release (12.01.2021) using the same filename. The changes don't affect the binary itself (no rebuild needed).