### PR TITLE
dotenv-linter: fix checksum

### DIFF
--- a/Formula/dotenv-linter.rb
+++ b/Formula/dotenv-linter.rb
@@ -2,7 +2,7 @@ class DotenvLinter < Formula
   desc "Lightning-fast linter for .env files written in Rust"
   homepage "https://dotenv-linter.github.io"
   url "https://github.com/dotenv-linter/dotenv-linter/archive/v3.1.1.tar.gz"
-  sha256 "6cef2d5ea947f786d7259c3adfb6071fd77909e2889e4721805b4ac50166930c"
+  sha256 "662856500db625c34b14f699a5e6f64af7fed0b2e06b6b8fee47103b637f1435"
   license "MIT"
   head "https://github.com/dotenv-linter/dotenv-linter.git"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Related to #88329.
To fix the build chain after tagging `3.1.1`, https://github.com/dotenv-linter/dotenv-linter/pull/439 has been merged and the release has been re-tagged a day after the initial tagging. There's no rebuild needed.