### PR TITLE
varnish: set varnish vmod_path and vcl_path options to opt paths

### DIFF
--- a/Formula/varnish.rb
+++ b/Formula/varnish.rb
@@ -5,6 +5,7 @@ class Varnish < Formula
   mirror "https://fossies.org/linux/www/varnish-7.0.0.tgz"
   sha256 "8c7a5c0b1f36bc70bcbc9a48830835249e895fb8951f0363110952148cbae087"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     url "https://varnish-cache.org/releases/"
@@ -25,13 +26,27 @@ class Varnish < Formula
   depends_on "sphinx-doc" => :build
   depends_on "pcre2"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}"
-    system "make", "install"
+
+    # flags to set the paths used by varnishd to load VMODs and VCL,
+    # pointing to the ${HOMEBREW_PREFIX}/ shared structure so other packages
+    # can install VMODs and VCL.
+    ENV.append_to_cflags "-DVARNISH_VMOD_DIR='\"#{HOMEBREW_PREFIX}/lib/varnish/vmods\"'"
+    ENV.append_to_cflags "-DVARNISH_VCL_DIR='\"#{pkgetc}:#{HOMEBREW_PREFIX}/share/varnish/vcl\"'"
+
+    system "make", "install", "CFLAGS=#{ENV.cflags}"
+
     (etc/"varnish").install "etc/example.vcl" => "default.vcl"
     (var/"varnish").mkpath
   end


### PR DESCRIPTION
Other packagings of extensions for varnish need to be able to install in such paths. Fixes #86449

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
