### PR TITLE
mariadb-connector-c 3.2.4

### DIFF
--- a/Formula/mariadb-connector-c.rb
+++ b/Formula/mariadb-connector-c.rb
@@ -1,15 +1,18 @@
 class MariadbConnectorC < Formula
   desc "MariaDB database connector for C applications"
-  homepage "https://downloads.mariadb.org/connector-c/"
-  url "https://downloads.mariadb.org/f/connector-c-3.2.3/mariadb-connector-c-3.2.3-src.tar.gz"
-  mirror "https://fossies.org/linux/misc/mariadb-connector-c-3.2.3-src.tar.gz"
-  sha256 "b6aa38656438e092242a95d01d3a80a5ce95c7fc02ec81009f4f0f46262331f4"
+  homepage "https://mariadb.org/download/?tab=connector&prod=connector-c"
+  url "https://downloads.mariadb.com/Connectors/c/connector-c-3.2.4/mariadb-connector-c-3.2.4-src.tar.gz"
+  mirror "https://fossies.org/linux/misc/mariadb-connector-c-3.2.4-src.tar.gz/"
+  sha256 "81fd5e7c800d8524d9cc5bcfa037ff5ac154361fe89e8103d406fb8768f3b5d1"
   license "LGPL-2.1-or-later"
-  head "https://github.com/mariadb-corporation/mariadb-connector-c.git"
+  head "https://github.com/mariadb-corporation/mariadb-connector-c.git", branch: "3.2"
 
+  # https://mariadb.org/download/ sometimes lists an older version as newest,
+  # so we check the JSON data used to populate the mariadb.com downloads page
+  # (which lists GA releases).
   livecheck do
-    url "https://downloads.mariadb.org/connector-c/+releases/"
-    regex(%r{href=.*?connector-c/v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url "https://mariadb.com/downloads_data.json"
+    regex(/href=.*?mariadb-connector-c[._-]v?(\d+(?:\.\d+)+)-src\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Like the `mariadb` formulae, the `stable` URL for `mariadb-connector-c` no longer works and simply redirects to `https://mariadb.org/download/`. This PR updates the URLs while also bumping the formula to the latest GA version listed on the [mariadb.com downloads page](https://mariadb.com/downloads/).

One odd part of this is that the [mariadb.org download page](https://mariadb.org/download/) lists 3.2.0 as "Beta" and 3.1.13 as the latest stable version, whereas mariadb.com lists 3.2.4 as the latest GA version. Similarly, mariadb.org lists 3.1.13 as the latest stable version of the ODBC connector but mariadb.com gives 3.1.14 as the latest GA version. Fossies mirrors versions 3.2.4 and 3.1.14 respectively, so it seems like the mariadb.org version information maybe isn't kept up to date but someone who's familiar with MariaDB would have to weigh in on this situation.

In the interim time, this PR uses version 3.2.4 and updates the `livecheck` block to check the JSON data that's used on the mariadb.com downloads page. Past that, it was necessary to add `branch: "3.2"` to the `head` URL to satisfy the related audit but this will presumably need to be updated in the future if/when the default branch changes in the future.