### PR TITLE
mariadb-connector-odbc 3.1.14

### DIFF
--- a/Formula/mariadb-connector-odbc.rb
+++ b/Formula/mariadb-connector-odbc.rb
@@ -1,13 +1,17 @@
 class MariadbConnectorOdbc < Formula
   desc "Database driver using the industry standard ODBC API"
-  homepage "https://downloads.mariadb.org/connector-odbc/"
-  url "https://downloads.mariadb.org/f/connector-odbc-3.1.13/mariadb-connector-odbc-3.1.13-src.tar.gz"
-  sha256 "29aa6b8b49971050b341be86f5e130d126c4c296d965aaa6a1559745164b82aa"
+  homepage "https://mariadb.org/download/?tab=connector&prod=connector-odbc"
+  url "https://downloads.mariadb.com/Connectors/odbc/connector-odbc-3.1.14/mariadb-connector-odbc-3.1.14-src.tar.gz"
+  mirror "https://fossies.org/linux/misc/mariadb-connector-odbc-3.1.14-src.tar.gz/"
+  sha256 "06ed87398f70eb17f15856f961ea26af9f03b2d5615766ce7857f8285c380f68"
   license "LGPL-2.1-or-later"
 
+  # https://mariadb.org/download/ sometimes lists an older version as newest,
+  # so we check the JSON data used to populate the mariadb.com downloads page
+  # (which lists GA releases).
   livecheck do
-    url :homepage
-    regex(/Download (\d+(?:\.\d+)+) Stable Now!/i)
+    url "https://mariadb.com/downloads_data.json"
+    regex(/href=.*?mariadb-connector-odbc[._-]v?(\d+(?:\.\d+)+)-src\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Like the `mariadb` formulae, the `stable` URL for `mariadb-connector-odbc` no longer works and simply redirects to `https://mariadb.org/download/`. This PR updates the URLs while also bumping the formula to the latest GA version listed on the [mariadb.com downloads page](https://mariadb.com/downloads/).

As mentioned in #88497, one odd part of this is that the [mariadb.org download page](https://mariadb.org/download/) lists 3.1.13 as the latest stable version, whereas mariadb.com lists 3.1.14 as the latest GA version. Fossies mirrors version 3.1.14, so it seems like the mariadb.org version information maybe isn't kept up to date but someone who's familiar with MariaDB would have to weigh in on this situation.

In the interim time, this PR uses version 3.1.14 and updates the `livecheck` block to check the JSON data that's used on the mariadb.com downloads page. This also adds a Fossies `mirror`, to align with the `mariadb-connector-c` formula.