### PR TITLE
chakra: update flags

### DIFF
--- a/Formula/chakra.rb
+++ b/Formula/chakra.rb
@@ -15,10 +15,13 @@ class Chakra < Formula
   depends_on "cmake" => :build
   depends_on "icu4c"
 
+  uses_from_macos "llvm" => :build
+
   def install
     args = [
       "--lto-thin",
-      "--icu=#{Formula["icu4c"].opt_include}",
+      "--arch=#{Hardware::CPU.arch}",
+      "--custom-icu=#{Formula["icu4c"].opt_include}",
       "--extra-defines=U_USING_ICU_NAMESPACE=1", # icu4c 61.1 compatibility
       "-j=#{ENV.make_jobs}",
       "-y",


### PR DESCRIPTION
`--icu` is a legacy flag that still works but has now been replaced by
`--custom-icu`. Let's update it in case upstream drop support for the
legacy flag.

While we're here, let's pass `--arch` (might help ARM build), and add an
LLVM dependency on Linux (might help Linux build).
