### PR TITLE
seexpr: fix ARM build

### DIFF
--- a/Formula/seexpr.rb
+++ b/Formula/seexpr.rb
@@ -23,7 +23,7 @@ class Seexpr < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args, "-DUSE_PYTHON=FALSE"
+      system "cmake", "..", *std_cmake_args, "-DUSE_PYTHON=FALSE", "-DCMAKE_INSTALL_RPATH=#{rpath}"
       system "make", "doc"
       system "make", "install"
     end


### PR DESCRIPTION
We need to set `CMAKE_INSTALL_RPATH` so that `seexpr` can find its own
libraries.
