### PR TITLE
opentracing-cpp: set `CMAKE_INSTALL_RPATH`

### DIFF
--- a/Formula/opentracing-cpp.rb
+++ b/Formula/opentracing-cpp.rb
@@ -16,7 +16,7 @@ class OpentracingCpp < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", ".", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "make", "install"
     pkgshare.install "example/tutorial/tutorial-example.cpp"
     pkgshare.install "example/tutorial/text_map_carrier.h"


### PR DESCRIPTION
This should fix the build on ARM and enable the bottle for use in
non-default prefixes.
