### PR TITLE
zydis: update release tag revision

### DIFF
--- a/Formula/zydis.rb
+++ b/Formula/zydis.rb
@@ -3,7 +3,7 @@ class Zydis < Formula
   homepage "https://zydis.re"
   url "https://github.com/zyantific/zydis.git",
       tag:      "v3.2.0",
-      revision: "95365aec6927c36ecad33cc543430ab214260dc3"
+      revision: "746faa454c33c09e897504cc56b16d47d6fe89d5"
   license "MIT"
   head "https://github.com/zyantific/zydis.git", branch: "master"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Updated revision. Related to #88329.

From the [3.2.0 tag](https://github.com/zyantific/zydis/releases/tag/v3.2.0):
> Note: This was already published previously. If you just got a second notification for this, it's because something went wrong when placing the original tag on the right commit, and the corresponding release was deleted by GitHub when the tag was adjusted. No action is required and if you previously pulled from the old tag, you still have the latest released code. Sorry for the inconvenience!


