### PR TITLE
libvpx: fix build on Monterey.

### DIFF
--- a/Formula/libvpx.rb
+++ b/Formula/libvpx.rb
@@ -27,6 +27,10 @@ class Libvpx < Formula
       --enable-vp9-highbitdepth
     ]
 
+    # `configure` misdetects Monterey as `generic-gnu`.
+    # Reported via email to https://groups.google.com/a/webmproject.org/group/codec-devel
+    args << "--target=#{Hardware::CPU.arch}-darwin20-gcc" if OS.mac? && MacOS.version >= :monterey
+
     if Hardware::CPU.intel?
       ENV.runtime_cpu_detection
       args << "--enable-runtime-cpu-detect"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `configure` script misdetects macOS 12 as `generic-gnu`. The correct
target should be `*-darwin21-gcc`, but `configure` doesn't recognise
this yet.

In the meantime, let's pretend we're running on Big Sur.

Reported to the project mailing list at
https://groups.google.com/a/webmproject.org/group/codec-devel.