### PR TITLE
cgl: update livecheck

### DIFF
--- a/Formula/cgl.rb
+++ b/Formula/cgl.rb
@@ -7,8 +7,7 @@ class Cgl < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
-    regex(%r{href=.*?/tag/(?:releases%2F)?v?(\d+(?:\.\d+)+)["' >]}i)
+    regex(%r{^releases/v?(\d+(?:\.\d+)+)$}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `cgl` uses the `GithubLatest` strategy and a regex intended to match the version from the heading link on the "latest" release page but this is giving an `Unable to get versions` error. This is because GitHub recently changed the release page HTML and it no longer includes a tag link on the release heading.

We currently only use the `GithubLatest` strategy when it's both correct and necessary. In this case, the "latest" release is correct but using `GithubLatest` isn't necessary, as it's possible to use the `Git` strategy to obtain the newest version from the tags. This `livecheck` block was from an earlier time (before the `GithubLatest` strategy and guidance around it existed), where we were using this approach more freely.

This PR updates the `livecheck` block accordingly to replace `strategy :github_latest` with an appropriate regex for matching version tags like `releases/0.60.3`.