### PR TITLE
openmotif: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/openmotif.rb
+++ b/Formula/openmotif.rb
@@ -35,6 +35,12 @@ class Openmotif < Formula
   conflicts_with "lesstif",
     because: "both Lesstif and Openmotif are complete replacements for each other"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     if OS.linux?
       # This patch is needed for Ubuntu 16.04 LTS, which uses


### PR DESCRIPTION
This is needed for bottling on Monterey.
