### PR TITLE
stanford-corenlp 4.3.1

### DIFF
--- a/Formula/stanford-corenlp.rb
+++ b/Formula/stanford-corenlp.rb
@@ -1,13 +1,16 @@
 class StanfordCorenlp < Formula
   desc "Java suite of core NLP tools"
   homepage "https://stanfordnlp.github.io/CoreNLP/"
-  url "https://nlp.stanford.edu/software/stanford-corenlp-4.2.2.zip"
-  sha256 "42f0bd84b815b15658a17aeabe5ab8c5ba1d4e5a3785969fe7be8588209f02cc"
+  url "https://nlp.stanford.edu/software/stanford-corenlp-4.3.1.zip"
+  sha256 "d21ec1dfc2f2888cffd8a0fcb47cb5d899ec518fe1f28d902819065d16511424"
   license "GPL-2.0-or-later"
 
+  # The first-party website only links to an unversioned archive file from
+  # nlp.stanford.edu (stanford-corenlp-latest.zip), so we match the version
+  # in the Maven link instead.
   livecheck do
     url :homepage
-    regex(/href=.*?stanford-corenlp[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+    regex(%r{href=.*?/stanford-corenlp/v?(\d+(?:\.\d+)+)/jar}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `stanford-corenlp` to the newest stable version, 4.3.1.

Besides that, the existing `livecheck` block is giving an `Unable to get versions` error. This is because the homepage has been modified to link to an unversioned zip file from nlp.stanford.edu (`stanford-corenlp-latest.zip`), whereas it used to link to a versioned zip file (e.g., `stanford-corenlp-4.2.2.zip`).

This PR updates the regex to match the version from the Maven link on the homepage instead. It's technically possible to match the version from the inner `Download CoreNLP 4.3.1` text of the unversioned zip file link (e.g., `/href=.*?stanford-corenlp-latest\.zip[^>]*?>[^<]*?v?(\d+(?:\.\d+)+)[^<]*?</i`) but this has a greater chance of breaking, so we should only use it as a backup plan if we can't match the versioned Maven link in the future.