### PR TITLE
fox: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/fox.rb
+++ b/Formula/fox.rb
@@ -36,6 +36,12 @@ class Fox < Formula
   depends_on "mesa"
   depends_on "mesa-glu"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     # Needed for libxft to find ftbuild2.h provided by freetype
     ENV.append "CPPFLAGS", "-I#{Formula["freetype"].opt_include}/freetype2"


### PR DESCRIPTION
This is needed for bottling on Monterey.
