### PR TITLE
heimdal: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/heimdal.rb
+++ b/Formula/heimdal.rb
@@ -37,6 +37,12 @@ class Heimdal < Formula
     sha256 "444a88755a89ffa2a5424ab4ed1d11dca61808ebef57e81243424619a9e8627c"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 


### PR DESCRIPTION
This is needed for bottling on Monterey.
