### PR TITLE
libgnomecanvas: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libgnomecanvas.rb
+++ b/Formula/libgnomecanvas.rb
@@ -19,6 +19,12 @@ class Libgnomecanvas < Formula
   depends_on "libart"
   depends_on "libglade"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-static",

--- a/Formula/libgnomecanvas.rb
+++ b/Formula/libgnomecanvas.rb
@@ -12,6 +12,8 @@ class Libgnomecanvas < Formula
     sha256 cellar: :any, mojave:        "bedab86245aa4185fc9c009496ec2d0fc0d1ea53074493db08afc81bdf424a60"
   end
 
+  deprecate! date: "2021-11-03", because: :repo_archived
+
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"


### PR DESCRIPTION
This is needed for bottling on Monterey.
