### PR TITLE
rasqal: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/rasqal.rb
+++ b/Formula/rasqal.rb
@@ -24,6 +24,12 @@ class Rasqal < Formula
   depends_on "pkg-config" => :build
   depends_on "raptor"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--with-html-dir=#{share}/doc",


### PR DESCRIPTION
This is needed for bottling on Monterey.
