### PR TITLE
libfreefare: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/libfreefare.rb
+++ b/Formula/libfreefare.rb
@@ -26,6 +26,12 @@ class Libfreefare < Formula
     sha256 "20d592c11e559d0a5f02f7ed56da370e39439feebd971be11b064d58ea85777f"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
This is needed for bottling on Monterey.
