### PR TITLE
adplug: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/adplug.rb
+++ b/Formula/adplug.rb
@@ -16,7 +16,7 @@ class Adplug < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libbinio"
-  
+
   uses_from_macos "texinfo" => :build
 
   resource "ksms" do

--- a/Formula/adplug.rb
+++ b/Formula/adplug.rb
@@ -22,6 +22,12 @@ class Adplug < Formula
     sha256 "2af9bfc390f545bc7f51b834e46eb0b989833b11058e812200d485a5591c5877"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/adplug.rb
+++ b/Formula/adplug.rb
@@ -16,6 +16,8 @@ class Adplug < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libbinio"
+  
+  uses_from_macos "texinfo" => :build
 
   resource "ksms" do
     url "http://advsys.net/ken/ksmsongs.zip"


### PR DESCRIPTION
This is needed for bottling on Monterey.
