### PR TITLE
fastd: fix meson flags

### DIFF
--- a/Formula/fastd.rb
+++ b/Formula/fastd.rb
@@ -32,7 +32,7 @@ class Fastd < Formula
 
   def install
     mkdir "build" do
-      system "meson", "-DENABLE_LTO=ON", *std_meson_args, ".."
+      system "meson", "-Db_lto=true", *std_meson_args, ".."
       system "ninja"
       system "ninja", "install"
     end


### PR DESCRIPTION
The upstream documentation say that the correct way to enable LTO is to
pass `-Db_lto=true`.

This supports bottling on Monterey.
