### PR TITLE
gucharmap: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/gucharmap.rb
+++ b/Formula/gucharmap.rb
@@ -21,6 +21,12 @@ class Gucharmap < Formula
   depends_on "python@3.9" => :build
   depends_on "gtk+3"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
     ENV.append_path "PYTHONPATH", "#{Formula["libxml2"].opt_lib}/python#{xy}/site-packages"


### PR DESCRIPTION
This is needed for bottling on Monterey.
