### PR TITLE
thrax: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/thrax.rb
+++ b/Formula/thrax.rb
@@ -29,6 +29,12 @@ class Thrax < Formula
 
   fails_with gcc: "5"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     system "./configure", *std_configure_args
     system "make", "install"


### PR DESCRIPTION
This is needed for bottling on Monterey.
