### PR TITLE
topgrade: remove livecheck

### DIFF
--- a/Formula/topgrade.rb
+++ b/Formula/topgrade.rb
@@ -5,11 +5,6 @@ class Topgrade < Formula
   sha256 "c60dd5ae7d1d3bcfe941ead9f088c4b0413b9a4561fb9154429faf86a43e0983"
   license "GPL-3.0-or-later"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "22e7687003f291523b7d9c896e20187a1fb6e5342a749c6b26aabb369ca9df05"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "a51ced540a584c8290d7f209150a158c5ace60641696b76279a6065df12e14ec"


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#88524

---

Upstream [removed the dev release `99.99.99`](https://github.com/r-darwish/topgrade/issues/793#issuecomment-956481542) so this livecheck is no longer applicable, thus removing it.