### PR TITLE
Gtk4 4.4.1

### DIFF
--- a/Formula/gtk4.rb
+++ b/Formula/gtk4.rb
@@ -1,8 +1,8 @@
 class Gtk4 < Formula
   desc "Toolkit for creating graphical user interfaces"
   homepage "https://gtk.org/"
-  url "https://download.gnome.org/sources/gtk/4.4/gtk-4.4.0.tar.xz"
-  sha256 "e0a1508f441686c3a20dfec48af533b19a4b2e017c18eaee31dccdb7d292505b"
+  url "https://download.gnome.org/sources/gtk/4.4/gtk-4.4.1.tar.xz"
+  sha256 "0faada983dc6b0bc409cb34c1713c1f3267e67c093f86b1e3b17db6100a3ddf4"
   license "LGPL-2.0-or-later"
 
   livecheck do
@@ -41,6 +41,13 @@ class Gtk4 < Formula
     depends_on "libxkbcommon"
     depends_on "libxcursor"
   end
+
+  # This patch (embedded below) backports the upstream fix made by PR !4008
+  # (https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4008) to 4.4.1. It was
+  # unfortunately missed when the changes for 4.4.1 were reviewed but Gtk apps
+  # will crash on Apple Silicon Macs without it. The fix should be included in
+  # 4.6.0 when it is released, so this patch can be removed at that point.
+  patch :DATA
 
   def install
     args = std_meson_args + %w[
@@ -96,3 +103,19 @@ class Gtk4 < Formula
     assert_match version.to_s, shell_output("cat #{lib}/pkgconfig/gtk4.pc").strip
   end
 end
+__END__
+diff --git a/gdk/macos/gdkmacosglcontext.c b/gdk/macos/gdkmacosglcontext.c
+index cc0b5fa..9ab268a 100644
+--- a/gdk/macos/gdkmacosglcontext.c
++++ b/gdk/macos/gdkmacosglcontext.c
+@@ -227,8 +227,8 @@ gdk_macos_gl_context_real_realize (GdkGLContext  *context,
+ 
+   swapRect[0] = 0;
+   swapRect[1] = 0;
+-  swapRect[2] = surface->width;
+-  swapRect[3] = surface->height;
++  swapRect[2] = surface ? surface->width : 0;
++  swapRect[3] = surface ? surface->height : 0;
+ 
+   CGLSetParameter (cgl_context, kCGLCPSwapRectangle, swapRect);
+   CGLSetParameter (cgl_context, kCGLCPSwapInterval, &sync_to_framerate);


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Update to the recently released Gtk 4.4.1, including a patch that backports an upstream fix made by [upstream PR !4008](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4008) to 4.4.1. It was unfortunately missed when the changes for 4.4.1 were reviewed but Gtk apps will crash on Apple Silicon Macs without it.

Also see the discussion in [!88381](https://github.com/Homebrew/homebrew-core/pull/88381).