### PR TITLE
rpki-client 7.5 (new formula)

### DIFF
--- a/Formula/rpki-client.rb
+++ b/Formula/rpki-client.rb
@@ -1,0 +1,31 @@
+class RpkiClient < Formula
+  desc "OpenBSD portable rpki-client"
+  homepage "https://www.rpki-client.org/index.html"
+  url "https://ftp.openbsd.org/pub/OpenBSD/rpki-client/rpki-client-7.5.tar.gz"
+  sha256 "e956c0af4973539f725d26526669a6d01800436053b0257c1d069a42c384b2ab"
+  license "ISC"
+
+  depends_on "pkg-config" => :build
+  depends_on "libressl"
+  depends_on :macos
+
+  def install
+    system "./configure", *std_configure_args,
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--sysconfdir=#{etc}",
+                          "--localstatedir=#{var}"
+    system "make", "install"
+  end
+
+  def post_install
+    # make the var/db,cache/rpki-client dirs
+    (var/"db/rpki-client").mkpath
+    (var/"cache/rpki-client").mkpath
+  end
+
+  test do
+    assert_match "fts_read ta:", shell_output("#{sbin}/rpki-client -n -d . -R . 2>&1 | tail -1")
+  end
+end


### PR DESCRIPTION
This is a simple port of rpki-client-portable from OpenBSD, which itself
pulls in rpki-client and creates the portable version from it. It has
a dependency on libressl and installs some certification products into
the HOMEBREW_PREFIX path because they are probably shared assets for other
RPKI validation tools.

The option of having the ARIN Trust Anchor Locator (TAL) file is carried in the caveats block, its user choice post-install (or other non-standard trust anchors like AS0, but this is the most important one)

No patches or diffs to code had to be made, to get this to compile on OSX Big Sur.

I believe I met the checklist below:

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
