### PR TITLE
flat_namespace_allowlist: add `blast`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,5 +1,6 @@
 [
   "arpack",
+  "blast",
   "mpich",
   "open-mpi",
   "pypy",


### PR DESCRIPTION
The `-flat_namespace` flag is passed regardless of the OS version, so
this isn't affected by the usual Libtool bug that we patch.
