### PR TITLE
cpl: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/cpl.rb
+++ b/Formula/cpl.rb
@@ -6,7 +6,7 @@ class Cpl < Formula
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://www.eso.org/sci/software/cpl/download.html"
+    url "https://ftp.eso.org/pub/dfs/pipelines/libraries/cpl/"
     regex(/href=.*?cpl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/cpl.rb
+++ b/Formula/cpl.rb
@@ -24,6 +24,19 @@ class Cpl < Formula
 
   conflicts_with "gdal", because: "both install cpl_error.h"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    directory "libcext"
+  end
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
This is needed for bottling on Monterey.
