### PR TITLE
urweb: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/urweb.rb
+++ b/Formula/urweb.rb
@@ -25,6 +25,12 @@ class Urweb < Formula
     sha256 "8ec1ec5bec95e9feece8ff4e9c0435ada0ba2edbe48439fb88af4d56adcf2b3e"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     args = %W[
       --disable-debug


### PR DESCRIPTION
This is needed for bottling on Monterey.
