### PR TITLE
lilv: fix homepage url

### DIFF
--- a/Formula/lilv.rb
+++ b/Formula/lilv.rb
@@ -1,6 +1,6 @@
 class Lilv < Formula
   desc "C library to use LV2 plugins"
-  homepage "https://drobilla.net/software/lilv/"
+  homepage "https://drobilla.net/software/lilv.html"
   url "https://download.drobilla.net/lilv-0.24.12.tar.bz2"
   sha256 "26a37790890c9c1f838203b47f5b2320334fe92c02a4d26ebbe2669dbd769061"
   license "ISC"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Small change in homepage URL. Related to issue #88329