### PR TITLE
libgnomecanvas: change homepage url

### DIFF
--- a/Formula/libgnomecanvas.rb
+++ b/Formula/libgnomecanvas.rb
@@ -1,6 +1,6 @@
 class Libgnomecanvas < Formula
   desc "Highlevel, structured graphics library"
-  homepage "https://developer.gnome.org/libgnomecanvas/2.30/"
+  homepage "https://gitlab.gnome.org/Archive/libgnomecanvas"
   url "https://download.gnome.org/sources/libgnomecanvas/2.30/libgnomecanvas-2.30.3.tar.bz2"
   sha256 "859b78e08489fce4d5c15c676fec1cd79782f115f516e8ad8bed6abcb8dedd40"
   revision 5


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
I set the homepage to the GitLab repo, because project no longer seems to be on their website. Note that repo is archived and last commit was 9 years ago. Related to issue #88329