### PR TITLE
gtksourceviewmm: change homepage url

### DIFF
--- a/Formula/gtksourceviewmm.rb
+++ b/Formula/gtksourceviewmm.rb
@@ -1,6 +1,6 @@
 class Gtksourceviewmm < Formula
   desc "C++ bindings for gtksourceview"
-  homepage "https://developer.gnome.org/gtksourceviewmm/"
+  homepage "https://gitlab.gnome.org/GNOME/gtksourceviewmm"
   url "https://download.gnome.org/sources/gtksourceviewmm/2.10/gtksourceviewmm-2.10.3.tar.xz"
   sha256 "0000df1b582d7be2e412020c5d748f21c0e6e5074c6b2ca8529985e70479375b"
   license "LGPL-2.1-or-later"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Set the homepage to the GitLab repo, because project no longer seems to be on their website. Related to issue #88329