### PR TITLE
clutter-gst: change homepage url

### DIFF
--- a/Formula/clutter-gst.rb
+++ b/Formula/clutter-gst.rb
@@ -1,6 +1,6 @@
 class ClutterGst < Formula
   desc "ClutterMedia interface using GStreamer for video and audio"
-  homepage "https://developer.gnome.org/clutter-gst/"
+  homepage "https://gitlab.gnome.org/GNOME/clutter-gst"
   url "https://download.gnome.org/sources/clutter-gst/3.0/clutter-gst-3.0.27.tar.xz"
   sha256 "fe69bd6c659d24ab30da3f091eb91cd1970026d431179b0724f13791e8ad9f9d"
   revision 1


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
One more from Gnome. Again pointed homepage to the GitLab repo. Related to #88329 