### PR TITLE
libvirt 7.9.0

### DIFF
--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -1,8 +1,8 @@
 class Libvirt < Formula
   desc "C virtualization API"
   homepage "https://www.libvirt.org"
-  url "https://libvirt.org/sources/libvirt-7.8.0.tar.xz"
-  sha256 "a727cd0a47bfa24fa7de2874d23f3a9f9f02ceb6b49ba15288f6d9a098b19921"
+  url "https://libvirt.org/sources/libvirt-7.9.0.tar.xz"
+  sha256 "829cf2b5f574279c40f0446e1168815d3f36b89710560263ca2ce70256f72e8c"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
   head "https://github.com/libvirt/libvirt.git", branch: "master"
 
@@ -54,6 +54,7 @@ class Libvirt < Formula
         --sysconfdir=#{etc}
         -Ddriver_esx=enabled
         -Ddriver_qemu=enabled
+        -Ddriver_network=enabled
         -Dinit_script=none
       ]
       system "meson", *std_meson_args, *args, ".."


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
I'm getting the following error which I'm not sure how to fix it.
```
libvirt:
  * Libraries were compiled with a flat namespace.
    This can cause linker errors due to name collisions, and
    is often due to a bug in detecting the macOS version.
      /usr/local/Cellar/libvirt/7.9.0/lib/libvirt.0.dylib
Error: 1 problem in 1 formula detected
```

But it looks like this was an [expected behavior](https://github.com/libvirt/libvirt/commit/740f181c4771aeb5dd1b19999fef0f2466406565) 

-----
