### PR TITLE
sqlline 1.11.0 (new formula)

### DIFF
--- a/Formula/sqlline.rb
+++ b/Formula/sqlline.rb
@@ -1,0 +1,18 @@
+class Sqlline < Formula
+  desc "Command-line shell for issuing SQL to relational databases via JDBC"
+  homepage "https://github.com/julianhyde/sqlline"
+  url "https://search.maven.org/remotecontent?filepath=sqlline/sqlline/1.11.0/sqlline-1.11.0-jar-with-dependencies.jar"
+  sha256 "725dbbe1e6b42399ad3741c522c8351d706c0b06623390ad425729f82901d4da"
+  license "BSD-3-Clause"
+
+  depends_on "openjdk"
+
+  def install
+    libexec.install "sqlline-#{version}-jar-with-dependencies.jar"
+    bin.write_jar_script libexec/"sqlline-#{version}-jar-with-dependencies.jar", "sqlline"
+  end
+
+  test do
+    assert_match "sqlline version #{version}\n", shell_output("#{bin}/sqlline -e '!quit' 2>&1")
+  end
+end


### PR DESCRIPTION
This PR adds a formula for Sqlline, which is a command-line shell for
issuing SQL to relational databases via JDBC.

The Sqlline project is hosted on Github at: https://github.com/julianhyde/sqlline

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
