### PR TITLE
flat_namespace_allowlist: add `libvirt`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,6 +1,7 @@
 [
   "arpack",
   "blast",
+  "libvirt",
   "mpich",
   "open-mpi",
   "pypy",


### PR DESCRIPTION
The use of the `-flat_namespace` flag is not due to the usual Libtool
bug. See libvirt/libvirt@740f181c4771aeb5dd1b19999fef0f2466406565.

Fixes CI failure in #88656.