### PR TITLE
sleuthkit: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/sleuthkit.rb
+++ b/Formula/sleuthkit.rb
@@ -29,8 +29,13 @@ class Sleuthkit < Formula
 
   conflicts_with "ffind", because: "both install a `ffind` executable"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
-    ENV["SED"] = "/usr/bin/sed" if OS.mac?
     ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
     ENV["ANT_FOUND"] = Formula["ant"].opt_bin/"ant"
     ENV.append_to_cflags "-DNDEBUG"


### PR DESCRIPTION
While we're here, also get rid of the unnecessary `sed` shim fix.

This is needed for bottling on Monterey.
