### PR TITLE
fastbit: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/fastbit.rb
+++ b/Formula/fastbit.rb
@@ -28,6 +28,12 @@ class Fastbit < Formula
     sha256 "e1198caf262a125d2216d70cfec80ebe98d122760ffa5d99d34fc33646445390"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+  end
+
   def install
     ENV.cxx11
     system "./configure", "--disable-debug",


### PR DESCRIPTION
This is needed for bottling on Monterey.
