### PR TITLE
sic: fix source URL

### DIFF
--- a/Formula/sic.rb
+++ b/Formula/sic.rb
@@ -4,7 +4,7 @@ class Sic < Formula
   url "https://dl.suckless.org/tools/sic-1.2.tar.gz"
   sha256 "ac07f905995e13ba2c43912d7a035fbbe78a628d7ba1c256f4ca1372fb565185"
   license "MIT"
-  head "https://git.suckless.org/sic.git", branch: "master"
+  head "https://git.suckless.org/sic", branch: "master", using: :git
 
   livecheck do
     url "https://dl.suckless.org/tools/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
