### PR TITLE
openrtsp 2021.11.01

### DIFF
--- a/Formula/openrtsp.rb
+++ b/Formula/openrtsp.rb
@@ -1,11 +1,16 @@
 class Openrtsp < Formula
   desc "Command-line RTSP client"
   homepage "http://www.live555.com/openRTSP"
-  url "http://www.live555.com/liveMedia/public/live.2021.08.24.tar.gz"
-  mirror "https://download.videolan.org/pub/videolan/testing/contrib/live555/live.2021.08.24.tar.gz"
+  url "http://www.live555.com/liveMedia/public/live.2021.11.01.tar.gz"
+  mirror "https://download.videolan.org/pub/videolan/testing/contrib/live555/live.2021.11.01.tar.gz"
   # Keep a mirror as upstream tarballs are removed after each version
-  sha256 "ce95a1c79f6d18e959f9dc129b8529b711c60e76754acc285e60946303b923ec"
+  sha256 "abb649a344a1e84538d44ecaf4bc8c65b01b3c698480bac4706fc3043f60eda5"
   license "LGPL-3.0-or-later"
+
+  livecheck do
+    url "http://www.live555.com/liveMedia/public/"
+    regex(/href=.*?live[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any, arm64_monterey: "0cf9172bdeaee5b416338e01055474fb564ec224454beeca7286ede40349a1b4"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `openrtsp` to the latest version, `2021.11.01`.

Additionally, this PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The `openrtsp` homepage links to the page for the [liveMedia library](http://www.live555.com/liveMedia/), which links to the aforementioned directory listing page as the place to download the LIVE555 tarball (which both liveMedia and `openrtsp` are part of).