### PR TITLE
fits: depend on `x86_64`

### DIFF
--- a/Formula/fits.rb
+++ b/Formula/fits.rb
@@ -12,14 +12,24 @@ class Fits < Formula
     sha256 cellar: :any, mojave:        "70a94bc9728e70e82c57d726ec958880da89dd5af6c2d65ae4351e6cf7543366"
   end
 
+  # Installs pre-built x86_64 binaries
+  depends_on arch: :x86_64
   depends_on "openjdk"
 
   uses_from_macos "zlib"
 
   def install
-    libexec.install "lib",
-                    %w[tools xml],
-                    Dir["*.properties"]
+    # Remove Windows, PPC, and 32-bit Linux binaries
+    %w[macho elf exe].each do |ext|
+      (buildpath/"tools/exiftool/perl/t/images/EXE.#{ext}").unlink
+    end
+
+    # Remove Windows-only directories
+    %w[exiftool/windows file_utility_windows mediainfo/windows].each do |dir|
+      (buildpath/"tools"/dir).rmtree
+    end
+
+    libexec.install "lib", "tools", "xml", *buildpath.glob("*.properties")
 
     inreplace "fits-env.sh" do |s|
       s.gsub!(/^FITS_HOME=.*/, "FITS_HOME=#{libexec}")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula installs pre-built x86_64-only binaries.

While we're here, let's try to remove some stuff that we won't use (e.g.
Mach-O PPC, 32-bit Linux, Windows files).