### PR TITLE
jetty: add comment for `x86_64` dependency

### DIFF
--- a/Formula/jetty.rb
+++ b/Formula/jetty.rb
@@ -18,6 +18,7 @@ class Jetty < Formula
     sha256 cellar: :any, mojave:        "e8777d929a1655066acee7b4467241db035911c971da87619bb2df7b68db4b57"
   end
 
+  # Ships a pre-built x86_64-only `libsetuid-osx.so`.
   depends_on arch: :x86_64
   depends_on "openjdk"
 


### PR DESCRIPTION
We should probably document this here so that hopefully someone can fix
this at some point.
