### PR TITLE
vitess 12.0.0

### DIFF
--- a/Formula/vitess.rb
+++ b/Formula/vitess.rb
@@ -1,8 +1,8 @@
 class Vitess < Formula
   desc "Database clustering system for horizontal scaling of MySQL"
   homepage "https://vitess.io"
-  url "https://github.com/vitessio/vitess/archive/v10.0.2.tar.gz"
-  sha256 "f9446e717f05e0b42dcb652e0758e1e6949d287464942418c140269b875963da"
+  url "https://github.com/vitessio/vitess/archive/v12.0.0.tar.gz"
+  sha256 "f20f84014236fc89b993d76facb08b7ade85121e1ef94db42503ce9e3aff6adf"
   license "Apache-2.0"
 
   bottle do
@@ -18,20 +18,16 @@ class Vitess < Formula
   depends_on "go" => :build
   depends_on "etcd"
 
-  # Fixes build failure on Darwin, see: https://github.com/vitessio/vitess/pull/7787
-  # Remove in v11.0.0
-  patch do
-    url "https://github.com/vitessio/vitess/commit/7efa6aa4cd3b68ccd45d46e5f1d13a4a7f9bde7d.patch?full_index=1"
-    sha256 "625290343b23688c5ac885246ed43808b865ae16005565d88791f4f733c24ce0"
-  end
-
   def install
     system "make", "install-local", "PREFIX=#{prefix}", "VTROOT=#{buildpath}"
     pkgshare.install "examples"
   end
 
   test do
+    ENV["ETCDCTL_API"] = "2"
     etcd_server = "localhost:#{free_port}"
+    cell = "testcell"
+
     fork do
       exec Formula["etcd"].opt_bin/"etcd", "--enable-v2=true",
                                            "--data-dir=#{testpath}/etcd",
@@ -40,11 +36,37 @@ class Vitess < Formula
     end
     sleep 3
 
+    fork do
+      exec Formula["etcd"].opt_bin/"etcdctl", "--endpoints", "http://#{etcd_server}",
+                                    "mkdir", testpath/"global"
+    end
+    sleep 1
+
+    fork do
+      exec Formula["etcd"].opt_bin/"etcdctl", "--endpoints", "http://#{etcd_server}",
+                                    "mkdir", testpath/cell
+    end
+    sleep 1
+
+    fork do
+      exec bin/"vtctl", "-topo_implementation", "etcd2",
+                        "-topo_global_server_address", etcd_server,
+                        "-topo_global_root", testpath/"global",
+                        "VtctldCommand", "AddCellInfo",
+                        "--root", testpath/cell,
+                        "--server-address", etcd_server,
+                        cell
+    end
+    sleep 1
+
     port = free_port
     fork do
       exec bin/"vtgate", "-topo_implementation", "etcd2",
                          "-topo_global_server_address", etcd_server,
                          "-topo_global_root", testpath/"global",
+                         "-tablet_types_to_wait", "PRIMARY,REPLICA",
+                         "-cell", cell,
+                         "-cells_to_watch", cell,
                          "-port", port.to_s
     end
     sleep 3


### PR DESCRIPTION
Upgrade to the latest GA release of 12.0.0 and fix unit test as `vtgate` now verifies the cell information.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
