### PR TITLE
mpd: remove unrecognised option

### DIFF
--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -55,7 +55,6 @@ class Mpd < Formula
 
     args = std_meson_args + %W[
       --sysconfdir=#{etc}
-      -Dlibwrap=disabled
       -Dmad=disabled
       -Dmpcdec=disabled
       -Dsoundcloud=disabled


### PR DESCRIPTION
The `libwrap` option was removed in
MusicPlayerDaemon/MPD@22e6d95c4bbae15dd7f635eabe5fdde1ce06ba73.

This supports bottling on Monterey.
