### PR TITLE
aterm: fix URL and deprecate

### DIFF
--- a/Formula/aterm.rb
+++ b/Formula/aterm.rb
@@ -1,8 +1,9 @@
 class Aterm < Formula
   desc "Annotated Term for tree-like ADT exchange"
-  homepage "https://strategoxt.org/Tools/ATermFormat"
-  url "http://www.meta-environment.org/releases/aterm-2.8.tar.gz"
+  homepage "https://web.archive.org/web/20180902175600/meta-environment.org/Meta-Environment/ATerms.html"
+  url "https://web.archive.org/web/20150503094402/meta-environment.org/releases/aterm-2.8.tar.gz"
   sha256 "bab69c10507a16f61b96182a06cdac2f45ecc33ff7d1b9ce4e7670ceeac504ef"
+  license "BSD-3-Clause"
 
   bottle do
     rebuild 1
@@ -15,6 +16,8 @@ class Aterm < Formula
     sha256 cellar: :any, el_capitan:    "5140e20287eda941f8756dfdaf377663f84f6872d1ca3f6d70e04b554591d11a"
     sha256 cellar: :any, yosemite:      "d12bebbfa2e764abb9cfac1aecd6fc04e58f83eadf0fb3db298d5be03d7f8dca"
   end
+
+  deprecate! date: "2021-11-03", because: :unmaintained
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

#88329

Links I found:

- https://github.com/cwi-swat/aterms/tree/master/aterm
  - `aterm.pc.in` indicates that there was a 2.9 release, but I couldn't find a tarball.
  - `reconf` script requires [meta-build-env](https://github.com/cwi-swat/meta-environment/tree/master/meta-build-env)
- https://web.archive.org/web/20151024040317/http://www.meta-environment.org/releases/
- https://web.archive.org/web/20010702144931/http://www.cwi.nl/projects/MetaEnv/aterm/
- https://web.archive.org/web/20041221221754/http://www.cwi.nl/htbin/sen1/twiki/bin/view/SEN1/ATerm