### PR TITLE
cri-tools 1.22.0 (new formula)

### DIFF
--- a/Formula/cri-tools.rb
+++ b/Formula/cri-tools.rb
@@ -1,0 +1,34 @@
+class CriTools < Formula
+  desc "CLI and validation tools for Kubelet Container Runtime Interface (CRI)"
+  homepage "https://github.com/kubernetes-sigs/cri-tools"
+  url "https://github.com/kubernetes-sigs/cri-tools/archive/v1.22.0.tar.gz"
+  sha256 "76fc230a73dd7e8183f499c88effaf734540808f2f90287031a85d0a4d8512d9"
+  license "Apache-2.0"
+  head "https://github.com/kubernetes-sigs/cri-tools.git", branch: "master"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["BINDIR"] = bin
+
+    if build.head?
+      system "make", "install"
+    else
+      system "make", "install", "VERSION=#{version}"
+    end
+
+    output = Utils.safe_popen_read("#{bin}/crictl", "completion", "bash")
+    (bash_completion/"crictl").write output
+
+    output = Utils.safe_popen_read("#{bin}/crictl", "completion", "zsh")
+    (zsh_completion/"_crictl").write output
+
+    output = Utils.safe_popen_read("#{bin}/crictl", "completion", "fish")
+    (fish_completion/"crictl.fish").write output
+  end
+
+  test do
+    assert_match "crictl version", shell_output("#{bin}/crictl --version 2>&1")
+    assert_match "critest version", shell_output("#{bin}/critest --version 2>&1")
+  end
+end

--- a/Formula/cri-tools.rb
+++ b/Formula/cri-tools.rb
@@ -28,7 +28,12 @@ class CriTools < Formula
   end
 
   test do
-    assert_match "crictl version", shell_output("#{bin}/crictl --version 2>&1")
-    assert_match "critest version", shell_output("#{bin}/critest --version 2>&1")
+    crictl_output = shell_output(
+      "#{bin}/crictl --runtime-endpoint unix:///var/run/nonexistent.sock --timeout 10ms info 2>&1", 1
+    )
+    assert_match "context deadline exceeded", crictl_output
+
+    critest_output = shell_output("#{bin}/critest --ginkgo.dryRun 2>&1")
+    assert_match "PASS", critest_output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/kubernetes-sigs/cri-tools contains two tools, namely `crictl` and `critest`, that can become handy on macos to test custom container runtimes

It was requested a few months ago in https://github.com/kubernetes-sigs/cri-tools/issues/587

This formula provides this specific release https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.22.0

-----

`BINDIR` envvar is set in the formula so that `make install` installs the binary in the right place

See rule in https://github.com/kubernetes-sigs/cri-tools/blob/v1.22.0/Makefile#L90-L92

`VERSION` envvar is only necessary when there is no git repository to fetch the version from

See version inference in https://github.com/kubernetes-sigs/cri-tools/blob/v1.22.0/Makefile#L35-L37