### PR TITLE
gdk-pixbuf: fix meson flags

### DIFF
--- a/Formula/gdk-pixbuf.rb
+++ b/Formula/gdk-pixbuf.rb
@@ -46,13 +46,15 @@ class GdkPixbuf < Formula
               "-DGDK_PIXBUF_LIBDIR=\"@0@\"'.format('#{HOMEBREW_PREFIX}/lib')"
 
     args = std_meson_args + %w[
-      -Dx11=false
-      -Ddocs=false
-      -Dgir=true
       -Drelocatable=false
       -Dnative_windows_loaders=false
       -Dinstalled_tests=false
       -Dman=false
+      -Dgtk_doc=false
+      -Dpng=true
+      -Dtiff=true
+      -Djpeg=true
+      -Dintrospection=enabled
     ]
 
     ENV["DESTDIR"] = "/"


### PR DESCRIPTION
The `x11` option has been removed. The `gir` boolean has been replaced
with the `introspection` feature (which is why we pass `enabled` instead
of `true`).

While we're here:
- `docs` is deprecated and has been replaced with the `man` and
  `gtk_doc` options.
- let's be explicit about enabling `tiff` and `png` (these are existing
  dependencies) to make sure the build doesn't silently ignore not being
  able to find/use them.

Closes #88660.
