### PR TITLE
youtubeuploader 21.05 (new formula)

### DIFF
--- a/Formula/youtubeuploader.rb
+++ b/Formula/youtubeuploader.rb
@@ -6,17 +6,10 @@ class Youtubeuploader < Formula
   license "Apache-2.0"
   head "https://github.com/porjo/youtubeuploader.git", branch: "master"
 
-  depends_on "dep" => :build
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    path = buildpath/"src/github.com/porjo/youtubeuploader"
-    path.install Dir["*"]
-    cd path do
-      system "go", "build", "-a", "-ldflags", "-s -X main.appVersion=#{version}", "-o", "#{bin}/youtubeuploader"
-      prefix.install_metafiles
-    end
+    system "go", "build", *std_go_args(ldflags: "-s -X main.appVersion=#{version}")
   end
 
   test do

--- a/Formula/youtubeuploader.rb
+++ b/Formula/youtubeuploader.rb
@@ -1,0 +1,54 @@
+class Youtubeuploader < Formula
+  desc "Scripted uploads to Youtube"
+  homepage "https://github.com/porjo/youtubeuploader"
+  url "https://github.com/porjo/youtubeuploader/archive/21.05.tar.gz"
+  sha256 "cc087e05e9a31408a6941030cdb933e6e52d619960e765dbb3d91e3661d3dc98"
+  license "Apache-2.0"
+  head "https://github.com/porjo/youtubeuploader.git", branch: "master"
+
+  depends_on "dep" => :build
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    path = buildpath/"src/github.com/porjo/youtubeuploader"
+    path.install Dir["*"]
+    cd path do
+      system "go", "build", "-a", "-ldflags", "-s -X main.appVersion=#{version}", "-o", "#{bin}/youtubeuploader"
+      prefix.install_metafiles
+    end
+  end
+
+  test do
+    # Version
+    assert_match version.to_s, shell_output("#{bin}/youtubeuploader -version")
+
+    # OAuth
+    (testpath/"client_secrets.json").write <<~EOS
+      {
+        "installed": {
+          "client_id": "foo_client_id",
+          "client_secret": "foo_client_secret",
+          "redirect_uris": [
+            "http://localhost:8080/oauth2callback",
+            "https://localhost:8080/oauth2callback"
+           ],
+          "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+          "token_uri": "https://accounts.google.com/o/oauth2/token"
+        }
+      }
+    EOS
+
+    (testpath/"request.token").write <<~EOS
+      {
+        "access_token": "test",
+        "token_type": "Bearer",
+        "refresh_token": "test",
+        "expiry": "2020-01-01T00:00:00.000000+00:00"
+      }
+    EOS
+
+    output = shell_output("#{bin}/youtubeuploader -filename #{test_fixtures("test.m4a")} 2>&1", 1)
+    assert_match "oauth2: cannot fetch token: 401 Unauthorized", output.strip
+  end
+end


### PR DESCRIPTION
This pull request adds a formula for `youtubeuploader`, a cross-platform command line tool for [YouTube](https://youtube.com) uploads.

The project is hosted on GitHub:
https://github.com/porjo/youtubeuploader

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
