### PR TITLE
gimme-aws-creds: make rust build-only dependency

### DIFF
--- a/Formula/gimme-aws-creds.rb
+++ b/Formula/gimme-aws-creds.rb
@@ -17,8 +17,9 @@ class GimmeAwsCreds < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d66bb53ac6aafbf7c00e612101bf589763a41e56be1c5766c415ac87cd0db8ff"
   end
 
+  depends_on "rust" => :build
+
   depends_on "python@3.10"
-  depends_on "rust"
   depends_on "six"
 
   uses_from_macos "libffi"


### PR DESCRIPTION
Rust is only needed at build time, not runtime.
When people install from a bottle they don't need rust.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I don't want to have rust installed when installing gimme-aws-creds from a bottle. It is only needed at build time.

This was already tried to be fixed in #85081 but because of the PR scope it was not merged.
I hope given the scope of this PR that's not an issue.