### PR TITLE
kahip: fixes the building issue when metis is present

### DIFF
--- a/Formula/kahip.rb
+++ b/Formula/kahip.rb
@@ -1,8 +1,8 @@
 class Kahip < Formula
   desc "Karlsruhe High Quality Partitioning"
   homepage "https://algo2.iti.kit.edu/documents/kahip/index.html"
-  url "https://github.com/KaHIP/KaHIP/archive/v3.11.tar.gz"
-  sha256 "347575d48c306b92ab6e47c13fa570e1af1e210255f470e6aa12c2509a8c13e3"
+  url "https://github.com/KaHIP/KaHIP/archive/v3.12.tar.gz"
+  sha256 "df923b94b552772d58b4c1f359b3f2e4a05f7f26ab4ebd00a0ab7d2579f4c257"
   license "MIT"
   head "https://github.com/KaHIP/KaHIP.git"
 
@@ -16,19 +16,10 @@ class Kahip < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "metis"
   depends_on "open-mpi"
 
-  on_macos do
-    depends_on "gcc"
-  end
-
   def install
-    if OS.mac?
-      gcc_major_ver = Formula["gcc"].any_installed_version.major
-      ENV["CC"] = Formula["gcc"].opt_bin/"gcc-#{gcc_major_ver}"
-      ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{gcc_major_ver}"
-    end
-
     mkdir "build" do
       system "cmake", *std_cmake_args, ".."
       system "make", "install"


### PR DESCRIPTION
Fixes the building issue when when metis is present https://github.com/Homebrew/homebrew-core/issues/88730
Adding metis dependency so the building result is consistent.
No longer requires gcc.
Bump to v3.12.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
