### PR TITLE
fennel: install Lua module

### DIFF
--- a/Formula/fennel.rb
+++ b/Formula/fennel.rb
@@ -12,8 +12,11 @@ class Fennel < Formula
   depends_on "lua"
 
   def install
-    system "make", "fennel"
+    system "make"
     bin.install "fennel"
+
+    lua = Formula["lua"]
+    (share/"lua"/lua.version.major_minor).install "fennel.lua"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This provides the Lua module for fennel in addition to the `fennel` executable, allowing users to `require("fennel")` from Lua scripts.