### PR TITLE
darksky-weather: replace test

### DIFF
--- a/Formula/darksky-weather.rb
+++ b/Formula/darksky-weather.rb
@@ -20,14 +20,13 @@ class DarkskyWeather < Formula
   def install
     project = "github.com/genuinetools/weather"
     ldflags = ["-s -w",
-               "-X #{project}/version.GITCOMMIT=homebrew",
+               "-X #{project}/version.GITCOMMIT=#{tap.user.downcase}",
                "-X #{project}/version.VERSION=v#{version}"]
-    system "go", "build", *std_go_args, "-ldflags", ldflags.join(" ")
-    mv bin/"darksky-weather", bin/"weather"
+    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "-o", bin/"weather"
   end
 
   test do
-    output = shell_output("#{bin}/weather")
-    assert_match "Current weather is", output
+    # A functional test often errors out, so we stick to checking the version.
+    assert_match "v#{version}", shell_output("#{bin}/weather version")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula constantly causes CI failures in Go PRs (e.g. #88775)
because checking the weather makes a network call that returns 403.

Let's replace the test with one that just checks the version. It's a bad
test, but it's better than the flaky one.