### PR TITLE
befunge93: add livecheck

### DIFF
--- a/Formula/befunge93.rb
+++ b/Formula/befunge93.rb
@@ -7,6 +7,11 @@ class Befunge93 < Formula
   license "BSD-3-Clause"
   head "https://github.com/catseye/Befunge-93.git", branch: "master"
 
+  livecheck do
+    url "https://catseye.tc/distribution/Befunge-93_distribution"
+    regex(/href=.*?befunge-93[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "05324749e9d37d4bdf4b6737ddcc2f48489755c60a38752f4cf8dc51e1b93085"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `befunge93` (from the `head` URL) and successfully identifies the latest version (albeit, with an underscore instead of a dot in the version). However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.