### PR TITLE
apr: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -37,9 +37,11 @@ class Apr < Formula
     sha256 "24189d95ab1e9523d481694859b277c60ca29bfec1300508011794a78dfed127"
   end
 
-  def install
-    ENV["SED"] = "sed" # prevent libtool from hardcoding sed path from superenv
+  # Fix -flat_namespace being used on Big Sur and later.
+  # We patch `libtool.m4` directly because we call `autoconf`.
+  patch :DATA
 
+  def install
     # https://bz.apache.org/bugzilla/show_bug.cgi?id=57359
     # The internal libtool throws an enormous strop if we don't do...
     ENV.deparallelize
@@ -51,17 +53,16 @@ class Apr < Formula
     system "make", "install"
 
     # Install symlinks so that linkage doesn't break for reverse dependencies.
-    (libexec/"lib").install_symlink Dir["#{lib}/#{shared_library("*")}"]
+    # Remove at version/revision bump from version 1.7.0 revision 2.
+    (libexec/"lib").install_symlink lib.glob(shared_library("*"))
 
-    rm Dir["#{lib}/*.{la,exp}"]
+    rm lib.glob("*.{la,exp}")
 
     # No need for this to point to the versioned path.
     inreplace bin/"apr-#{version.major}-config", prefix, opt_prefix
 
-    if OS.linux?
-      # Avoid references to the Homebrew shims directory
-      inreplace prefix/"build-#{version.major}/libtool", Superenv.shims_path, "/usr/bin"
-    end
+    # Avoid references to the Homebrew shims directory
+    inreplace prefix/"build-#{version.major}/libtool", Superenv.shims_path, "/usr/bin" if OS.linux?
   end
 
   test do
@@ -78,3 +79,30 @@ class Apr < Formula
     assert_equal version.to_s, shell_output("./test")
   end
 end
+
+__END__
+diff --git a/build/libtool.m4 b/build/libtool.m4
+index e86a682..c1c342f 100644
+--- a/build/libtool.m4
++++ b/build/libtool.m4
+@@ -1067,16 +1067,11 @@ _LT_EOF
+       _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
+     darwin1.*)
+       _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-    darwin*) # darwin 5.x on
+-      # if running on 10.5 or later, the deployment target defaults
+-      # to the OS version, if on x86, and 10.4, the deployment
+-      # target defaults to 10.4. Don't you love it?
+-      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+-	10.0,*86*-darwin8*|10.0,*-darwin[[91]]*)
+-	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+-	10.[[012]][[,.]]*)
++    darwin*)
++      case ${MACOSX_DEPLOYMENT_TARGET},$host in
++	10.[[012]],*|,*powerpc*)
+ 	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-	10.*)
++	*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;


### PR DESCRIPTION
We patch `libtool.m4` instead of using our usual patches because we call
`autoconf`.

This is needed for bottling on Monterey.
