### PR TITLE
jxrlib: use debian project page for homepage

### DIFF
--- a/Formula/jxrlib.rb
+++ b/Formula/jxrlib.rb
@@ -1,6 +1,6 @@
 class Jxrlib < Formula
   desc "Tools for JPEG-XR image encoding/decoding"
-  homepage "https://archive.codeplex.com/?p=jxrlib"
+  homepage "https://tracker.debian.org/pkg/jxrlib"
   url "https://deb.debian.org/debian/pool/main/j/jxrlib/jxrlib_1.1.orig.tar.gz"
   sha256 "c7287b86780befa0914f2eeb8be2ac83e672ebd4bd16dc5574a36a59d9708303"
   license "BSD-2-Clause"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As codeplex.com has been shutdown and removed, let's use
github.com project URL as the new homepage.

relates to #88329
