### PR TITLE
ffmpeg: depend on `librist`

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -6,7 +6,7 @@ class Ffmpeg < Formula
   # None of these parts are used by default, you have to explicitly pass `--enable-gpl`
   # to configure to activate them. In this case, FFmpeg's license changes to GPL v2+.
   license "GPL-2.0-or-later"
-  revision 2
+  revision 3
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   livecheck do
@@ -34,6 +34,7 @@ class Ffmpeg < Formula
   depends_on "lame"
   depends_on "libass"
   depends_on "libbluray"
+  depends_on "librist"
   depends_on "libsoxr"
   depends_on "libvidstab"
   depends_on "libvorbis"
@@ -83,6 +84,7 @@ class Ffmpeg < Formula
       --enable-libmp3lame
       --enable-libopus
       --enable-librav1e
+      --enable-librist
       --enable-librubberband
       --enable-libsnappy
       --enable-libsrt

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -37,6 +37,7 @@ class Ffmpeg < Formula
   depends_on "librist"
   depends_on "libsoxr"
   depends_on "libvidstab"
+  depends_on "libvmaf"
   depends_on "libvorbis"
   depends_on "libvpx"
   depends_on "opencore-amr"
@@ -91,6 +92,7 @@ class Ffmpeg < Formula
       --enable-libtesseract
       --enable-libtheora
       --enable-libvidstab
+      --enable-libvmaf
       --enable-libvorbis
       --enable-libvpx
       --enable-libwebp
@@ -120,6 +122,13 @@ class Ffmpeg < Formula
 
     # Needs corefoundation, coremedia, corevideo
     args << "--enable-videotoolbox" if OS.mac?
+
+    # Replace hardcoded default VMAF model path
+    %w[doc/filters.texi libavfilter/vf_libvmaf.c].each do |f|
+      inreplace f, "/usr/local/share/model", HOMEBREW_PREFIX/"share/libvmaf/model"
+      # Since libvmaf v2.0.0, `.pkl` model files have been deprecated in favor of `.json` model files.
+      inreplace f, "vmaf_v0.6.1.pkl", "vmaf_v0.6.1.json"
+    end
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
RIST is open source alternatief for SRT. The development of RIST is not determined by a company. RIST package already exists in Homebrew: https://formulae.brew.sh/formula/librist
