### PR TITLE
apgdiff: add livecheck

### DIFF
--- a/Formula/apgdiff.rb
+++ b/Formula/apgdiff.rb
@@ -5,6 +5,11 @@ class Apgdiff < Formula
   sha256 "12d95fbb0b8188d7f90e7aaf8bdd29d0eecac26e08d6323624b5b7e3f7c7a3f7"
   license "MIT"
 
+  livecheck do
+    url "https://www.apgdiff.com/download.php"
+    regex(/href=.*?apgdiff[._-]v?(\d+(?:\.\d+)+)[._-]bin\.zip/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "014290d110ccaf01c6f52f02fa1c0a73df5cc0a53ee333e711d4c99140fecc58"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `apgdiff` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.