### PR TITLE
gecode: re-enable gecode gist

### DIFF
--- a/Formula/minizinc.rb
+++ b/Formula/minizinc.rb
@@ -4,6 +4,7 @@ class Minizinc < Formula
   url "https://github.com/MiniZinc/libminizinc/archive/2.5.5.tar.gz"
   sha256 "c6c81fa8bdc2d7f8c8d851e5a4b936109f5d996abd8c6f809539f753581c6288"
   license "MPL-2.0"
+  revision 1
   head "https://github.com/MiniZinc/libminizinc.git", branch: "develop"
 
   bottle do
@@ -17,6 +18,12 @@ class Minizinc < Formula
   depends_on "cmake" => :build
   depends_on "cbc"
   depends_on "gecode"
+
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5"
 
   def install
     mkdir "build" do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----

Gecode Gist is a graphical tool to explore the search tree that is central to Gecode's search process. As a constraint programming environment, exploring the way in which Gecode tries to find solutions is often invaluable, and Gecode Gist is a much used part of Gecode, both when used as a Library and part of MiniZinc.

The possibility to use Gecode Gist using a Homebrew installation was removed with the removal of the Qt option in 67cbc222f67ec7c480efc9cc3209ddf88922a056, when all options were removed from Homebrew's core formulae. It is my belief that adding the ability to use Gecode Gist into this formula will improve the usability of this formula. It would likely avoid many users having to install Gecode again separately to use it with Gist, and, apart from the space of the installed dependency, it does not cause any overhead in the Gecode library.

(This PR is part of an effort to ensure that Homebrew users that use MiniZinc and its environment, will have the same experience as when downloading the MiniZinc bundle manually.)
