### PR TITLE
tnftp, tnftpd: use CDN instead of FTP

### DIFF
--- a/Formula/tnftp.rb
+++ b/Formula/tnftp.rb
@@ -1,7 +1,8 @@
 class Tnftp < Formula
   desc "NetBSD's FTP client"
-  homepage "https://ftp.netbsd.org/pub/NetBSD/misc/tnftp/"
-  url "https://ftp.netbsd.org/pub/NetBSD/misc/tnftp/tnftp-20210827.tar.gz"
+  homepage "https://cdn.netbsd.org/pub/NetBSD/misc/tnftp/"
+  url "https://cdn.netbsd.org/pub/NetBSD/misc/tnftp/tnftp-20210827.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.netbsd.org/pub/NetBSD/misc/tnftp/tnftp-20210827.tar.gz"
   sha256 "101901e90b656c223ec8106370dd0d783fb63d26aa6f0b2a75f40e86a9f06ea2"
   license "BSD-4-Clause"
 

--- a/Formula/tnftpd.rb
+++ b/Formula/tnftpd.rb
@@ -1,7 +1,8 @@
 class Tnftpd < Formula
   desc "NetBSD's FTP server"
-  homepage "https://ftp.netbsd.org/pub/NetBSD/misc/tnftp/"
-  url "https://ftp.netbsd.org/pub/NetBSD/misc/tnftp/tnftpd-20200704.tar.gz"
+  homepage "https://cdn.netbsd.org/pub/NetBSD/misc/tnftp/"
+  url "https://cdn.netbsd.org/pub/NetBSD/misc/tnftp/tnftpd-20200704.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.netbsd.org/pub/NetBSD/misc/tnftp/tnftpd-20200704.tar.gz"
   sha256 "92de915e1b4b7e4bd403daac5d89ce67fa73e49e8dda18e230fa86ee98e26ab7"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

#88329

ftp.netbsd.org is flaky (#84466) so use cdn.netbsd.org instead.
mirrorservice.org mirrors ftp.netbsd.org (but not cdn.netbsd.org)

https://www.netbsd.org/mirrors/