### PR TITLE
flat_namespace_allowlist: add `adios2`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,4 +1,5 @@
 [
+  "adios2",
   "arpack",
   "blast",
   "libvirt",


### PR DESCRIPTION
The `-flat_namespace` flag used to compile `libadios2_fortran_mpi` is
inherited from `open-mpi`. None of the other libraries were built with
the flag.
