### PR TITLE
sleef: Also build inline headers

### DIFF
--- a/Formula/sleef.rb
+++ b/Formula/sleef.rb
@@ -18,7 +18,7 @@ class Sleef < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", "-DBUILD_TESTS=OFF", *std_cmake_args
+      system "cmake", "..", "-DBUILD_INLINE_HEADERS=TRUE", "-DBUILD_TESTS=OFF", *std_cmake_args
       system "make", "install"
     end
   end


### PR DESCRIPTION
As described in https://sleef.org/compile.xhtml#inline.

This generates _additional_ header files (rather than changing the standard ones). So, IMHO I see no reason not to enable it, since they can simply be ignored by users who don't need them. I assume this option disabled by default because it increases the build time.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
