### PR TITLE
ocaml: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/ocaml.rb
+++ b/Formula/ocaml.rb
@@ -35,6 +35,17 @@ class Ocaml < Formula
   # brew detection doesn't find, and so needs to be explicitly blocked.
   pour_bottle? only_if: :default_prefix
 
+  # Remove use of -flat_namespace. Upstreamed at
+  # https://github.com/ocaml/ocaml/pull/10723
+  # We embed a patch here so we don't have to regenerate configure.
+  patch :p0, :DATA
+
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
     ENV.deparallelize # Builds are not parallel-safe, esp. with many cores
 
@@ -55,3 +66,16 @@ class Ocaml < Formula
     assert_match HOMEBREW_PREFIX.to_s, shell_output("#{bin}/ocamlc -where")
   end
 end
+
+__END__
+--- configure.orig	2021-10-24 09:34:12.145636659 +0800
++++ configure	2021-10-24 09:34:30.504944693 +0800
+@@ -13644,7 +13644,7 @@
+ if test x"$enable_shared" != "xno"; then :
+   case $host in #(
+   *-apple-darwin*) :
+-    mksharedlib="$CC -shared -flat_namespace -undefined suppress \
++    mksharedlib="$CC -shared -undefined dynamic_lookup \
+                    -Wl,-no_compact_unwind"
+       shared_libraries_supported=true ;; #(
+   *-*-mingw32) :


### PR DESCRIPTION
We apply two patches: one of our generic Libtool patches, and a patch
upstreamed upstreamed at ocaml/ocaml#10723. We embed a patch here to
avoid having to regenerate `configure`, which we would need to do to use
the upstreamed patch.

This is needed for bottling on Monterey.
