### PR TITLE
libvmaf: install models

### DIFF
--- a/Formula/libvmaf.rb
+++ b/Formula/libvmaf.rb
@@ -4,6 +4,7 @@ class Libvmaf < Formula
   url "https://github.com/Netflix/vmaf/archive/v2.3.0.tar.gz"
   sha256 "d8dcc83f8e9686e6855da4c33d8c373f1735d87294edbd86ed662ba2f2f89277"
   license "BSD-2-Clause-Patent"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "d3b57e128a6781ec6a929e59c90e15113ffaff44f922cb48aab82bbc7fb9524c"
@@ -25,6 +26,7 @@ class Libvmaf < Formula
       system "ninja", "-vC", "build"
       system "ninja", "-vC", "build", "install"
     end
+    pkgshare.install "model"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In ffmpeg, the default model path is hardcoded: `/usr/local/share/model/vmaf_v0.6.1.pkl`
Once the models are installed in this formula, we may follow up by injecting the actual path in the ffmpeg formula 