### PR TITLE
libxls 1.6.2 (new formula)

### DIFF
--- a/Formula/libxls.rb
+++ b/Formula/libxls.rb
@@ -5,9 +5,18 @@ class Libxls < Formula
   sha256 "5dacc34d94bf2115926c80c6fb69e4e7bd2ed6403d51cff49041a94172f5e371"
   license "BSD-2-Clause"
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
+    # Add program prefix `lib` to prevent conflict with another Unix tool `xls2csv`.
+    # Arch and Fedora do the same.
     system "./configure", *std_configure_args, "--disable-silent-rules", "--program-prefix=lib"
     system "make", "install"
+    pkgshare.install "test/files/test2.xls"
   end
 
   test do
@@ -22,7 +31,7 @@ class Libxls < Formula
       {
           xlsWorkBook* pWB;
           xls_error_t code = LIBXLS_OK;
-          pWB = xls_open_file(argv[1],"UTF-8", &code);
+          pWB = xls_open_file(argv[1], "UTF-8", &code);
           if (pWB == NULL) {
               return 1;
           }
@@ -37,6 +46,6 @@ class Libxls < Formula
     EOS
 
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lxlsreader", "-o", "test"
-    system "./test"
+    system "./test", pkgshare/"test2.xls"
   end
 end

--- a/Formula/libxls.rb
+++ b/Formula/libxls.rb
@@ -1,0 +1,42 @@
+class Libxls < Formula
+  desc "Read binary Excel files from C/C++"
+  homepage "https://github.com/libxls/libxls"
+  url "https://github.com/libxls/libxls/releases/download/v1.6.2/libxls-1.6.2.tar.gz"
+  sha256 "5dacc34d94bf2115926c80c6fb69e4e7bd2ed6403d51cff49041a94172f5e371"
+  license "BSD-2-Clause"
+
+  def install
+    system "./configure", *std_configure_args, "--disable-silent-rules", "--program-prefix=lib"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <string.h>
+      #include <ctype.h>
+      #include <xls.h>
+
+      int main(int argc, char *argv[])
+      {
+          xlsWorkBook* pWB;
+          xls_error_t code = LIBXLS_OK;
+          pWB = xls_open_file(argv[1],"UTF-8", &code);
+          if (pWB == NULL) {
+              return 1;
+          }
+          if (code != LIBXLS_OK) {
+              return 2;
+          }
+          if (pWB->sheets.count != 3) {
+              return 3;
+          }
+          return 0;
+      }
+    EOS
+
+    system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lxlsreader", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
I'd like to add `libxls` to get Excel reading support in `sc-im`. I'll submit a follow-up PR if we merge it with an appropriate dependency for `sc-im`.

Problems:

```
% brew audit --new-formula libxls
libxls:
  * Libraries were compiled with a flat namespace.
    This can cause linker errors due to name collisions, and
    is often due to a bug in detecting the macOS version.
      /opt/homebrew/Cellar/libxls/1.6.2/lib/libxlsreader.8.dylib
Error: 1 problem in 1 formula detected
```

Any hints what might be a problem?

Also for `test` block, I don't know how to reference a file from libxls's package itself (there's a sample file `test/file/test2.xls` that I'd like to use).  In case it's impossible: https://github.com/Homebrew/brew/pull/12392 <- I've pushed a simple fixture which is actually the same file.


I'm on Big Sur.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
