### PR TITLE
ledger: add Python support

### DIFF
--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -24,9 +24,10 @@ class Ledger < Formula
 
   depends_on "cmake" => :build
   depends_on "boost"
+  depends_on "boost-python3"
   depends_on "gmp"
   depends_on "mpfr"
-  depends_on "python@3.10"
+  depends_on "python@3.9"
 
   uses_from_macos "groff"
 
@@ -40,13 +41,18 @@ class Ledger < Formula
 
   def install
     ENV.cxx11
-    ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin"
+    ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin"
+
+    xy = Language::Python.major_minor_version Formula["python@3.9"].bin/"python3"
+    site_packages = lib/"python#{xy}/site-packages"
+    inreplace "src/CMakeLists.txt", "DESTINATION ${Python_SITEARCH}", "DESTINATION #{site_packages}"
 
     args = %W[
       --jobs=#{ENV.make_jobs}
       --output=build
       --prefix=#{prefix}
       --boost=#{Formula["boost"].opt_prefix}
+      --python
       --
       -DBUILD_DOCS=1
       -DBUILD_WEB_DOCS=1
@@ -58,6 +64,7 @@ class Ledger < Formula
     system "./acprep", "opt", "make", "install", *args
 
     (pkgshare/"examples").install Dir["test/input/*.dat"]
+    (pkgshare/"test").install Dir["test/python/*.py"]
     pkgshare.install "contrib"
     elisp.install Dir["lisp/*.el", "lisp/*.elc"]
     bash_completion.install pkgshare/"contrib/ledger-completion.bash"
@@ -65,6 +72,7 @@ class Ledger < Formula
 
   test do
     balance = testpath/"output"
+    system bin/"ledger", "python", "#{pkgshare}/test/JournalTest.py"
     system bin/"ledger",
       "--args-only",
       "--file", "#{pkgshare}/examples/sample.dat",


### PR DESCRIPTION
Python support was removed in aee990481a3a5c6484fdbd77b64f30dd2216a5ca. Adding
back in now that there is Python 3 support.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Downgraded to Python 3.9 because that is what `boost-python3` seems to be running on. Followed [this](https://stackoverflow.com/questions/66497187/cmake-install-pybind11-bindings-using-homebrew-formula) StackOverflow answer to get CMake to install the Python shared library in the right place.