### PR TITLE
ceres-solver: add livecheck

### DIFF
--- a/Formula/ceres-solver.rb
+++ b/Formula/ceres-solver.rb
@@ -7,6 +7,11 @@ class CeresSolver < Formula
   revision 4
   head "https://ceres-solver.googlesource.com/ceres-solver.git", branch: "master"
 
+  livecheck do
+    url "http://ceres-solver.org/installation.html"
+    regex(/href=.*?ceres-solver[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "1b729631e1d4e35fa8cdb4e38daeab4db1900273bb3b3a97800d6609c9048011"
     sha256 cellar: :any,                 monterey:      "e331ba4a260953f79cc693e323515cd11047e181c104affded4e9c60a93fd3f7"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ceres-solver` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the first-party "Installation" page, which links to the `stable` archive.