### PR TITLE
sonarqube: launch service with 'sonar console'

### DIFF
--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -40,7 +40,8 @@ class Sonarqube < Formula
   end
 
   service do
-    run [opt_bin/"sonar", "start"]
+    run [opt_bin/"sonar", "console"]
+    keep_alive true
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Sonarqube service is now launched with `sonar start` which exit immediately. This is not compatible with `launchd` nor with `brew services`. Running the service with `sonar run` allows to control it with `launchd` and `brew services`. I've also added `keep_alive true` as in the Tomcat formula.

Solves https://github.com/Homebrew/homebrew-core/issues/88993
