### PR TITLE
nats-server: fix test

### DIFF
--- a/Formula/nats-server.rb
+++ b/Formula/nats-server.rb
@@ -25,15 +25,17 @@ class NatsServer < Formula
 
   test do
     port = free_port
+    http_port = free_port
     fork do
       exec bin/"nats-server",
            "--port=#{port}",
+           "--http_port=#{http_port}",
            "--pid=#{testpath}/pid",
            "--log=#{testpath}/log"
     end
     sleep 3
 
-    assert_match version.to_s, shell_output("curl localhost:#{port}")
+    assert_match version.to_s, shell_output("curl localhost:#{http_port}/varz")
     assert_predicate testpath/"log", :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes the failing test, seen in https://github.com/Homebrew/homebrew-core/pull/88775.

More details about the `varz` endpoint are available at the [nats-server docs](https://docs.nats.io/nats-server/configuration/monitoring#general-information). 