### PR TITLE
gcc: improve spec file

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -56,12 +56,6 @@ class Gcc < Formula
     sha256 "c0605179a856ca046d093c13cea4d2e024809ec2ad4bf3708543fc3d2e60504b"
   end
 
-  # https://gcc.gnu.org/pipermail/gcc-patches/2021-November/583031.html
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/de47854e6e26ec9d0ebb43d1ca23b7384f5d7aa5/gcc/gcc-11.2-rtl-bug.diff"
-    sha256 "8f04ffa663a2a0d1ab3b8ed894ccfdbaaabeff621fb4074c53f94b06c44ef378"
-  end
-
   def version_suffix
     if build.head?
       "HEAD"

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -15,7 +15,7 @@ class Gcc < Formula
   end
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
   revision 2
-  head "https://gcc.gnu.org/git/gcc.git"
+  head "https://gcc.gnu.org/git/gcc.git", branch: "master"
 
   # We can't use `url :stable` here due to the ARM-specific branch above.
   livecheck do
@@ -89,6 +89,7 @@ class Gcc < Formula
       --libdir=#{lib}/gcc/#{version_suffix}
       --disable-nls
       --enable-checking=release
+      --with-gcc-major-version-only
       --enable-languages=#{languages.join(",")}
       --program-suffix=-#{version_suffix}
       --with-gmp=#{Formula["gmp"].opt_prefix}

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -14,7 +14,7 @@ class Gcc < Formula
     sha256 "d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
   end
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
-  revision 1
+  revision 2
   head "https://gcc.gnu.org/git/gcc.git"
 
   # We can't use `url :stable` here due to the ARM-specific branch above.
@@ -233,6 +233,7 @@ class Gcc < Formula
       #     Noted that it should only be passed for the `gcc@*` formulae.
       #   * `-L#{HOMEBREW_PREFIX}/lib` instructs gcc to find the rest
       #     brew libraries.
+      # Note: *link will silently add #{libdir} first to the RPATH
       libdir = HOMEBREW_PREFIX/"lib/gcc/#{version_suffix}"
       specs.write specs_string + <<~EOS
         *cpp_unique_options:
@@ -242,9 +243,13 @@ class Gcc < Formula
         #{glibc_installed ? "-nostdlib -L#{libgcc}" : "+"} -L#{libdir} -L#{HOMEBREW_PREFIX}/lib
 
         *link:
-        + --dynamic-linker #{HOMEBREW_PREFIX}/lib/ld.so -rpath #{libdir} -rpath #{HOMEBREW_PREFIX}/lib
+        + --dynamic-linker #{HOMEBREW_PREFIX}/lib/ld.so -rpath #{libdir}
+
+        *homebrew_rpath:
+        -rpath #{HOMEBREW_PREFIX}/lib
 
       EOS
+      inreplace(specs, " %o ", "\\0%(homebrew_rpath) ")
     end
   end
 

--- a/Formula/libgccjit.rb
+++ b/Formula/libgccjit.rb
@@ -14,7 +14,8 @@ class Libgccjit < Formula
   end
   homepage "https://gcc.gnu.org/"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
-  head "https://gcc.gnu.org/git/gcc.git"
+  revision 1
+  head "https://gcc.gnu.org/git/gcc.git", branch: "master"
 
   livecheck do
     formula "gcc"
@@ -62,6 +63,7 @@ class Libgccjit < Formula
       --libdir=#{lib}/gcc/#{version.major}
       --disable-nls
       --enable-checking=release
+      --with-gcc-major-version-only
       --with-gmp=#{Formula["gmp"].opt_prefix}
       --with-mpfr=#{Formula["mpfr"].opt_prefix}
       --with-mpc=#{Formula["libmpc"].opt_prefix}


### PR DESCRIPTION
The current spec file adds:
/home/linuxbrew/.linuxbrew/lib/gcc/11
/home/linuxbrew/.linuxbrew/lib

in front of the rpath.
In the case $ORIGIN was used, this might be an issue.
For example openjdk relies on $ORIGIN to find libnet.so,
so putting our libnet.so in front of $ORIGIN breaks
openjdk at runtime.

This pull reauests moves #{HOMEBREW_PREFIX}/lib away from
the *link stanza. We do want to keep gcc 11 in front though,
to make sure gcc libs are always loaded first.

homebrew_rpath is needed to help the compiler find it's libraries.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
