### PR TITLE
Update versioned_dependencies_conflicts_allowlist.json

### DIFF
--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -1,8 +1,6 @@
 [
   "anjuta",
-  "fdroidserver",
   "hive",
   "predictionio",
-  "sqoop",
-  "visp"
+  "sqoop"
 ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Update versioned dependencies allowlist following @carlocab suggestion in #65831. I didn't remove `sqoop` and `predictionio` because they are still present in homebrew-core, although deprecated.