### PR TITLE
llvm, halide, lit: migrate to Python 3.10

### DIFF
--- a/Formula/halide.rb
+++ b/Formula/halide.rb
@@ -4,6 +4,7 @@ class Halide < Formula
   url "https://github.com/halide/Halide/archive/v13.0.1.tar.gz"
   sha256 "8d4b0ad622ef0ff9e28770cd950baf45a055d1229131be44f8e6333a548183f9"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable
@@ -22,7 +23,7 @@ class Halide < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "llvm"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     mkdir "build" do

--- a/Formula/lit.rb
+++ b/Formula/lit.rb
@@ -6,16 +6,27 @@ class Lit < Formula
   url "https://files.pythonhosted.org/packages/f7/fc/aba44ef618619519d4fb56e604163fd85f4b598a4fd8a105e32e4e456798/lit-13.0.0.tar.gz"
   sha256 "4da976f3d114e4ba6ba06cbe660ce1393230f4519c4df15b90bc1840f00e4195"
   license "Apache-2.0" => { with: "LLVM-exception" }
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "0cc9d6acafc45e2cbf37ec1ec2ad3947d55a805529822db741b4d4d70aedbe6a"
   end
 
   depends_on "llvm" => :test
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     system "python3", *Language::Python.setup_install_args(prefix)
+
+    # Install symlinks so that `import lit` works with multiple versions of Python
+    python_versions = Formula.names
+                             .select { |name| name.start_with? "python@" }
+                             .map { |py| py.delete_prefix("python@") }
+                             .reject { |xy| xy == Language::Python.major_minor_version("python3") }
+    site_packages = Language::Python.site_packages("python3").delete_prefix("lib/")
+    python_versions.each do |xy|
+      (lib/"python#{xy}/site-packages").install_symlink (lib/site_packages).children
+    end
   end
 
   test do
@@ -43,6 +54,15 @@ class Lit < Formula
     EOS
 
     system bin/"lit", "-v", "."
+
+    if OS.mac?
+      ENV.prepend_path "PYTHONPATH", prefix/Language::Python.site_packages("python3")
+    else
+      python = deps.reject { |d| d.build? || d.test? }
+                   .find { |d| d.name.match?(/^python@\d+(\.\d+)*$/) }
+                   .to_formula
+      ENV.prepend_path "PATH", python.opt_bin
+    end
     system "python3", "-c", "import lit"
   end
 end

--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -1,8 +1,12 @@
 [
   "anjuta",
+  "coin3d",
+  "gjs",
   "hive",
   "mpv",
   "predictionio",
+  "pyside",
+  "pyside@2",
   "sqoop",
   "watchman"
 ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

To dodge the versioned dependency conflict audit, I've added `coind3d`,
`gjs`, `pyside` and `pyside@2` to the allowlist. It's very unlikely that
these formulae use LLVM's Python bindings. LLVM is keg-only, and we
don't modify `PYTHONPATH`, so these formulae shouldn't even be able to
find LLVM's Python bindings. Also migrating these formulae would require
adding a ridiculous number of formulae to this PR. (cf. #87277)

However, just in case, I've also installed LLVM's Python bindings for
multiple versions of Python3. (This doesn't include LLDB, which has
linkage with the Python framework, which ties it to a specific Python
version.)

While we're here:
- remove duplication from the installed Xcode toolchain
- fix some version references so that they work for HEAD installs too

We clean up the duplication by installing the Xcode toolchain manually.

Closes #87483.