### PR TITLE
versioned_dependencies_conflicts_allowlist: remove watchman

### DIFF
--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -3,6 +3,5 @@
   "hive",
   "mpv",
   "predictionio",
-  "sqoop",
-  "watchman"
+  "sqoop"
 ]


### PR DESCRIPTION
I can't reproduce the audit failure locally even with `watchman`
removed, so maybe it's no longer needed.
