### PR TITLE
gtk+3: patches for macOS 12

### DIFF
--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -4,6 +4,7 @@ class Gtkx3 < Formula
   url "https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.30.tar.xz"
   sha256 "ba75bfff320ad1f4cfbee92ba813ec336322cc3c660d406aad014b07087a3ba9"
   license "LGPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -44,6 +45,20 @@ class Gtkx3 < Formula
     depends_on "libxkbcommon"
     depends_on "xorgproto"
     depends_on "wayland-protocols"
+  end
+
+  # Patch to fix new coordinate system in macOS 12
+  # Remove in next minor release
+  patch do
+    url "https://gitlab.gnome.org/GNOME/gtk/-/commit/36315cbe2b3c9d1c1b7508d9494a251eddbc4452.diff"
+    sha256 "880b3ac53c7b2947e68e4842a14c00de3c3dcd278db504ece6b74f6eac2a447b"
+  end
+
+  # Patch to fix detection of Quartz on macOS 12
+  # Remove in next minor release
+  patch do
+    url "https://gitlab.gnome.org/GNOME/gtk/-/commit/a752e338381bc37dbe8d4c04ec23e4f6fd911b30.diff"
+    sha256 "ffb088e94eb4ff320fab948b531908b661f26892280f31e4247259cee0d8ceb9"
   end
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

gtk+3 3.24.30 is completely broken when running on macOS 12: windows don't display, or display entirely black.

- Upstream issue: https://gitlab.gnome.org/GNOME/gtk/-/issues/4342
- Homebrew report against gedit: https://github.com/Homebrew/homebrew-core/issues/88743

A combination of two upstream patches (committed to the 3.24 branch) is needed to fix this:

- one to deal with the inverse vertical scaling of coordinates on Monterey (otherwise, the content is drawn outside the window, and the window remains black)
- one to deal with Quartz feature detection (otherwise, the windows don't get the proper Quartz attributes, and you cannot interact with them)

With both patches, `gtk3-demo` now run fines again.
