### PR TITLE
termshark: fix test

### DIFF
--- a/Formula/termshark.rb
+++ b/Formula/termshark.rb
@@ -82,7 +82,7 @@ class Termshark < Formula
     # seconds to provide ample time for termshark to load the pcap (there is
     # no external mechanism to tell when the load is complete).
     testcmds = [
-      "{ sleep 5s ; echo q ; echo ; } | ",
+      "{ sleep 5 ; echo q ; echo ; } | ",
       "socat - EXEC:'sh -c \\\"",
       "stty rows 50 cols 80 && ",
       "TERM=xterm ",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes the test in macOS 12 Monterey, which seems unhappy with the `sleep 5s` syntax.

Seen in https://github.com/Homebrew/homebrew-core/pull/88775.
