### PR TITLE
flat_namespace_allowlist: add bind

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -1,6 +1,7 @@
 [
   "adios2",
   "arpack",
+  "bind",
   "blast",
   "libvirt",
   "mpich",


### PR DESCRIPTION
This flag is passed intentionally on all macOS versions, and isn't
caused by the Libtool version detection bug.

See: https://gitlab.isc.org/isc-projects/bind9/-/commit/b60d7345edae90560721c20d705ab32563abccb6
