### PR TITLE
goproxy: fix test

### DIFF
--- a/Formula/goproxy.rb
+++ b/Formula/goproxy.rb
@@ -29,8 +29,7 @@ class Goproxy < Formula
       sleep 1
       ENV["GOPROXY"] = "http://#{bind_address}"
       test_module = "github.com/spf13/cobra"
-      # Using `system "go", "get", ...` will not get past `brew audit`
-      shell_output("go get #{test_module}")
+      system "go", "get", test_module
     ensure
       Process.kill("SIGINT", server.pid)
       Process.wait(server.pid)

--- a/Formula/goproxy.rb
+++ b/Formula/goproxy.rb
@@ -25,14 +25,16 @@ class Goproxy < Formula
   test do
     bind_address = "127.0.0.1:#{free_port}"
     begin
-      server = IO.popen("#{bin}/goproxy -proxy=https://goproxy.io -listen=#{bind_address}")
+      server = IO.popen("#{bin}/goproxy -proxy=https://goproxy.io -listen=#{bind_address}", err: [:child, :out])
       sleep 1
       ENV["GOPROXY"] = "http://#{bind_address}"
-      output = shell_output("go get -v github.com/spf13/cobra 2>&1")
-      assert_match "github.com/spf13/cobra", output
+      test_module = "github.com/spf13/cobra"
+      # Using `system "go", "get", ...` will not get past `brew audit`
+      shell_output("go get #{test_module}")
     ensure
       Process.kill("SIGINT", server.pid)
       Process.wait(server.pid)
     end
+    assert_match test_module, server.read
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes the test.

The former version of the test asserted against the output of `go get -v ...`, which basically just tested if the given Go module was already installed on the system or not. This test asserts against the `goproxy` log output instead, which is written to `STDERR`.

Seen in https://github.com/Homebrew/homebrew-core/pull/88775.