### PR TITLE
postgresql@9.6: remove livecheck

### DIFF
--- a/Formula/postgresql@9.6.rb
+++ b/Formula/postgresql@9.6.rb
@@ -5,11 +5,6 @@ class PostgresqlAT96 < Formula
   sha256 "a849f798401ab8c6dfa653ebbcd853b43f2200b4e3bc1ea3cb5bec9a691947b9"
   license "PostgreSQL"
 
-  livecheck do
-    url "https://ftp.postgresql.org/pub/source/"
-    regex(%r{href=["']?v?(9\.6(?:\.\d+)*)/?["' >]}i)
-  end
-
   bottle do
     sha256 arm64_monterey: "3c95a141a51cffc75768bc1f0c536031fe273f9458e02882ef057acd4b20a6cc"
     sha256 arm64_big_sur:  "0f79f7033fdb3a2491e28964e60c053f9c4fdc195a85f0ea67abb469cc8e0ef7"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The deprecation for `postgresql@9.6` is now in effect, so this PR removes the `livecheck` block accordingly. Without the `livecheck` block, `brew livecheck` will automatically skip the formula as deprecated.