### PR TITLE
bzrtools: remove livecheck

### DIFF
--- a/Formula/bzrtools.rb
+++ b/Formula/bzrtools.rb
@@ -5,16 +5,6 @@ class Bzrtools < Formula
   mirror "https://deb.debian.org/debian/pool/main/b/bzrtools/bzrtools_2.6.0.orig.tar.gz"
   sha256 "8b17fbba61dafc8dbefe1917a2ce084a8adc7650dee60add340615270dfb7f58"
 
-  # https://launchpad.net/bzrtools/ doesn't provide the latest version, so we
-  # can't currently use the `Launchpad` strategy for this. Instead, we have to
-  # replicate the behavior of the Launchpad strategy here while checking the
-  # `/stable/` page.
-  livecheck do
-    url "https://launchpad.net/bzrtools/stable/"
-    strategy :page_match
-    regex(%r{<div class="version">\s*Latest version is (.+)\s*</div>}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "27337af0179d9a1a9897def816bfc6c9e85df08186bdb72918bc6327c2b7c2db"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `bzrtools` formula is currently deprecated as unsupported, so this PR removes the existing `livecheck` block. Without the `livecheck` block, this will be automatically skipped as deprecated.