### PR TITLE
cgif 0.0.2 (new formula)

### DIFF
--- a/Formula/cgif.rb
+++ b/Formula/cgif.rb
@@ -1,0 +1,34 @@
+class Cgif < Formula
+  desc "GIF encoder written in C"
+  homepage "https://github.com/dloebl/cgif"
+  url "https://github.com/dloebl/cgif/archive/refs/tags/V0.0.2.tar.gz"
+  sha256 "679e8012b9fe387086e6b3bcc42373dbc66fb26f8d070d7a1d23f39d42842258"
+  license "MIT"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+
+  def install
+    mkdir "build" do
+      system "meson", *std_meson_args, "..", "-Dtests=false"
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+    end
+  end
+
+  test do
+    (testpath/"try.c").write <<~EOS
+      #include <cgif.h>
+      int main() {
+        CGIF_Config config = {0};
+        CGIF *cgif;
+
+        cgif = cgif_newgif(&config);
+
+        return 0;
+      }
+    EOS
+    system ENV.cc, "try.c", "-L#{lib}", "-lcgif", "-o", "try"
+    system "./try"
+  end
+end


### PR DESCRIPTION
cgif is a GIF write library. It's small, fast, portable, has no
dependencies, and has good test coverage.

It has been adopted by libvips 8.12 to replace the imagemagick-based writer we
used previously. Writing with cgif is typically 2x faster and needs 10x less
memory.

We're hoping to get this cgif formula into homebrew in advance of the release
of libvips 8.12:

https://www.libvips.org/2021/11/14/What's-new-in-8.12.html

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
