### PR TITLE
cweb: update livecheck

### DIFF
--- a/Formula/cweb.rb
+++ b/Formula/cweb.rb
@@ -6,7 +6,7 @@ class Cweb < Formula
 
   livecheck do
     url :stable
-    regex(/^cweb[._-]v?(\d+(?:\.\d+)+)/i)
+    regex(/^cweb[._-]v?(\d+(?:\.\d+)+[a-z]*?)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #89397, as it was merged before I had a chance to review it. The existing regex in the `livecheck` block won't properly handle versions like `3.64c`/`3.64aa`, as the trailing letters are omitted from the capture group (i.e. `3.64aa` is treated as `3.64`). Looking at past version bump PRs for `cweb`, the trailing letter(s) in the version are meaningful.

This PR updates the regex to include optional trailing letters in the capture group and adds `$` at the end of the regex to bring it in line with the prevailing regex pattern for Git tags.