### PR TITLE
qwt-qt5: update livecheck

### DIFF
--- a/Formula/qwt-qt5.rb
+++ b/Formula/qwt-qt5.rb
@@ -6,8 +6,7 @@ class QwtQt5 < Formula
   license "LGPL-2.1-only" => { with: "Qwt-exception-1.0" }
 
   livecheck do
-    url :stable
-    regex(%r{url=.*?/qwt[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    formula "qwt"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `qwt-qt5` is the same as `qwt` and they also share the same `stable` URL. This PR updates the `livecheck` block to simply use `formula "qwt"`, as `qwt` is the canonical formula and `qwt-qt5` is a variant. This will automatically align the check for `qwt-qt5` with `qwt`, so we won't have to manually keep it in parity.