### PR TITLE
workflows: update legacy formula exceptions

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -61,9 +61,9 @@ jobs:
               path: Formula/.+@.+
               except:
                 - Formula/openssl@1.1.rb
-                - Formula/openssl@3.0.rb
-                - Formula/python@3.9
-                - Formula/python-tk@3.9.rb
+                - Formula/openssl@3.rb
+                - Formula/python@3.10
+                - Formula/python-tk@3.10.rb
 
             - label: missing license
               path: Formula/.+


### PR DESCRIPTION
- `openssl@3.0` should be `openssl@3`
- Update latest `python` version to `3.10` (Ditto for `python-tk`)