### PR TITLE
lua: fix readline on Linux.

### DIFF
--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -4,6 +4,7 @@ class Lua < Formula
   url "https://www.lua.org/ftp/lua-5.4.3.tar.gz"
   sha256 "f8612276169e3bfcbcfb8f226195bfc6e466fe13042f1076cbde92b7ec96bbfb"
   license "MIT"
+  revision 1
 
   livecheck do
     url "https://www.lua.org/ftp/"
@@ -66,7 +67,7 @@ class Lua < Formula
     os = if OS.mac?
       "macosx"
     else
-      "linux"
+      "linux-readline"
     end
 
     system "make", os, "INSTALL_TOP=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The current formula fails to install Lua with `readline` support on Linux even though the Formula actually requires `readline` as a dependency.

```sh
> brew install lua
> lua
Lua 5.4.3  Copyright (C) 1994-2021 Lua.org, PUC-Rio
lua> 1 + 1
2
lua> ^[[A -- when we press the up key
```
The problem is caused during `Make`. To compile the formula with `readline` support in Linux, the recipe expects `linux-readline` as input. However, the Homebrew formula passes `linux` as the argument. This problem can be easily fixed by replacing `linux` with `linux-readline` in the Formula.

After that, we got the expected behaviour:

```sh
> brew install lua
> lua
Lua 5.4.3  Copyright (C) 1994-2021 Lua.org, PUC-Rio
lua> 1 + 1
2
lua> 1 + 1 -- when we press the up key
```

