### PR TITLE
git-revise: Fetch HEAD version from `main` branch

### DIFF
--- a/Formula/git-revise.rb
+++ b/Formula/git-revise.rb
@@ -7,7 +7,7 @@ class GitRevise < Formula
   sha256 "21e89eba6602e8bea38b34ac6ec747acba2aee876f2e73ca0472476109e82bf4"
   license "MIT"
   revision 2
-  head "https://github.com/mystor/git-revise.git"
+  head "https://github.com/mystor/git-revise.git", revision: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "51ea42f3af7218aa18e655dc10892c646f394be2ac50a4a51879cd5e1aad059f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
There's no proper release in a while, but the default branch was changed, with the old branch still existing.
With this change `--HEAD` installs will indeed use the latest code.