### PR TITLE
t-rec: fix test

### DIFF
--- a/Formula/t-rec.rb
+++ b/Formula/t-rec.rb
@@ -22,14 +22,11 @@ class TRec < Formula
   end
 
   test do
-    # let's fetch the window id
-    o = shell_output("#{bin}/t-rec -l | tail -1").strip
-    win_id = o.split(/\s|\n/)[-1]
-    # verify that it's an appropriate id
-    assert_equal win_id && Integer(win_id).positive?, true
-
-    # verify also error behaviour, as suggested
     o = shell_output("WINDOWID=999999 #{bin}/t-rec 2>&1", 1).strip
-    assert_equal "Error: Cannot grab screenshot from CGDisplay of window id 999999", o
+    if OS.mac?
+      assert_equal "Error: Cannot grab screenshot from CGDisplay of window id 999999", o
+    else
+      assert_equal "Error: Display parsing error", o
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`t-rec -l` gives the following error in CI (#89410, #89488):

```
Error: Cannot get window list results from low level C-API call `CGWindowListCopyWindowInfo` -> null
```

This is probably because the CI runners are headless.