### PR TITLE
mirror 1.2 (new formula)

### DIFF
--- a/Formula/mirror.rb
+++ b/Formula/mirror.rb
@@ -1,0 +1,24 @@
+class Mirror < Formula
+  version = "1.2"
+  desc "Command-line tool for fiddling with display mirroring: on/off/toggle"
+  homepage "https://fabiancanas.com/open-source/mirror-displays"
+  url "https://github.com/fcanas/mirror-displays/releases/download/v#{version}/mirror.zip"
+  sha256 "3a44b1e65fdbcd15ba93ec1a1af97e205c8d274cb0272a40940add9f62853e2f"
+  license "GPL-3.0-or-later"
+
+  resource "source" do
+    url "https://github.com/fcanas/mirror-displays/archive/refs/tags/v#{version}.tar.gz"
+    sha256 "96db4c12e8f6606db9822af54da35daaae0bff6853df7347cefdccd07a7e6acc"
+  end
+
+  def install
+    bin.install "mirror"
+    resource("source").stage do
+      man1.install "mirror.1"
+    end
+  end
+
+  test do
+    assert_match "Mirror Displays version #{version}", shell_output("#{bin}/mirror -h")
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is the CLI companion to [the mirrordisplays Cask](https://formulae.brew.sh/cask/mirrordisplays).

The following audit error remains on Apple Silicon:

```
mirror:
  * Binaries built for a non-native architecture were installed into mirror's prefix.
    The offending files are:
      /opt/homebrew/Cellar/mirror/1.2/bin/mirror	(x86_64)
Error: 1 problem in 1 formula detected
```

Upstream doesn't provide an arm64 binary. Compiling from source might be an option, though the x86_64 binary works just fine under Rosetta on Apple Silicon without anything special (`mirror` just works without any ceremony), and upstream doesn't provide a compile script or instructions (but it's just one C++ file so presumably it's not too hard to figure out).

Finally, I used the (perhaps confusing) strategy of [using a "version" variable instead of using the "version" method](https://github.com/Homebrew/homebrew-core/pull/89526/files#diff-85f2701508ae53ee19278e1b3d0016e1227d5eadc0afb8ce26c683cea72a6441R2) because calling "version" inside the resource to generate a URL yielded an empty string.