### PR TITLE
deheader: add livecheck

### DIFF
--- a/Formula/deheader.rb
+++ b/Formula/deheader.rb
@@ -9,6 +9,11 @@ class Deheader < Formula
   revision 3
   head "https://gitlab.com/esr/deheader.git"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?deheader[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "c796513f79f19f17be962e08802c9542d0dcddbe7fffdc44e2c66538c704a325"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `deheader` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.