### PR TITLE
bash: improve livecheck

### DIFF
--- a/Formula/bash.rb
+++ b/Formula/bash.rb
@@ -39,11 +39,15 @@ class Bash < Formula
     regex(/href=.*?bash[._-]v?(\d+(?:\.\d+)+)\.t/i)
     strategy :gnu do |page, regex|
       # Match versions from files
-      versions = page.scan(regex).flatten.uniq.sort
+      versions = page.scan(regex)
+                     .flatten
+                     .uniq
+                     .map { |v| Version.new(v) }
+                     .sort
       next versions if versions.blank?
 
       # Assume the last-sorted version is newest
-      newest_version = Version.new(versions.last)
+      newest_version = versions.last
 
       # Simply return the found versions if there isn't a patches directory
       # for the "newest" version


### PR DESCRIPTION
Instead of sorting the scanned versions lexicographically, assuming the
last one is the latest, and casting that into a `Version` object, we can
cast all the scanned versions into `Version` objects and sort those.

This will make detecting the newest version a bit more reliable, at
least insofar as lexicographic sorting differs from version sorting.
