### PR TITLE
tests: set timeout via flags only on self-hosted runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,7 +156,7 @@ jobs:
         runner: ${{fromJson(needs.setup_tests.outputs.runners)}}
       fail-fast: ${{fromJson(needs.setup_tests.outputs.fail-fast)}}
     runs-on: ${{matrix.runner}}
-    timeout-minutes: ${{fromJson(needs.setup_tests.outputs.timeout-minutes)}}
+    timeout-minutes: ${{ (matrix.runner == 'ubuntu-latest' && 360) || fromJson(needs.setup_tests.outputs.timeout-minutes) }}
     defaults:
       run:
         shell: /bin/bash -e {0}


### PR DESCRIPTION
We're not particularly constrained (yet?) in our use of GitHub runners,
so we probably don't need to cut jobs short when using them. This would
be useful for PRs such as #89617 where the macOS runners finish in under
an hour, but the Linux runner requires more than an hour to complete.
