### PR TITLE
gperftools: apply patch for Monterey

### DIFF
--- a/Formula/gperftools.rb
+++ b/Formula/gperftools.rb
@@ -1,9 +1,20 @@
 class Gperftools < Formula
   desc "Multi-threaded malloc() and performance analysis tools"
   homepage "https://github.com/gperftools/gperftools"
-  url "https://github.com/gperftools/gperftools/releases/download/gperftools-2.9.1/gperftools-2.9.1.tar.gz"
-  sha256 "ea566e528605befb830671e359118c2da718f721c27225cbbc93858c7520fee3"
   license "BSD-3-Clause"
+  revision 1
+
+  stable do
+    url "https://github.com/gperftools/gperftools/releases/download/gperftools-2.9.1/gperftools-2.9.1.tar.gz"
+    sha256 "ea566e528605befb830671e359118c2da718f721c27225cbbc93858c7520fee3"
+
+    # Fix segfaults on Monterey.
+    # https://github.com/gperftools/gperftools/pull/1315
+    patch do
+      url "https://github.com/gperftools/gperftools/commit/1000c64559ad5f624bec4d08657209d755c0a02a.patch?full_index=1"
+      sha256 "93f58cb6fe6d0e22a7aadc1ad2ee60a45743e862e398387213024acad83de319"
+    end
+  end
 
   livecheck do
     url :stable
@@ -73,5 +84,20 @@ class Gperftools < Formula
     EOS
     system ENV.cc, "test.c", "-L#{lib}", "-ltcmalloc", "-o", "test"
     system "./test"
+
+    (testpath/"segfault.c").write <<~EOS
+      #include <stdio.h>
+      #include <stdlib.h>
+
+      int main()
+      {
+        void *ptr = malloc(128);
+        if (ptr == NULL) return 1;
+        free(ptr);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "segfault.c", "-L#{lib}", "-ltcmalloc", "-o", "segfault"
+    system "./segfault"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Simple programs segfault when linked with tcmalloc. Patch taken from
gperftools/gperftools#1315.

Closes #88758.