### PR TITLE
openjdk: bump revision for gcc, fixes RPATH issue

### DIFF
--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -4,6 +4,7 @@ class Openjdk < Formula
   url "https://github.com/openjdk/jdk17u/archive/jdk-17.0.1-ga.tar.gz"
   sha256 "f27e2f3fd2dcfd144f875e610e7d6c2d9d957e1be96e4f865307b6df381cf7a9"
   license "GPL-2.0-only" => { with: "Classpath-exception-2.0" }
+  revision 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
Fixes java.lang.UnsatisfiedLinkError
See #84886

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
