### PR TITLE
ioke: deprecate

### DIFF
--- a/Formula/ioke.rb
+++ b/Formula/ioke.rb
@@ -13,6 +13,8 @@ class Ioke < Formula
     sha256 cellar: :any_skip_relocation, all: "f78a97e3add6cfc850a4e26c1adc46214b8ac9918a27ccc846b25d433f6b8ac0"
   end
 
+  deprecate! date: "2021-11-24", because: :unmaintained
+
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
The upstream website has a broken ssl certificate

Last updates are from 2009
There are also some broken links on the website,
and I did not find a way to contact upstream.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
