### PR TITLE
apache-archiva: fix non-native binaries 

### DIFF
--- a/Formula/apache-archiva.rb
+++ b/Formula/apache-archiva.rb
@@ -4,17 +4,43 @@ class ApacheArchiva < Formula
   url "https://www.apache.org/dyn/closer.lua?path=archiva/2.2.5/binaries/apache-archiva-2.2.5-bin.tar.gz"
   mirror "https://archive.apache.org/dist/archiva/2.2.5/binaries/apache-archiva-2.2.5-bin.tar.gz"
   sha256 "01119af2d9950eacbcce0b7f8db5067b166ad26c1e1701bef829105441bb6e29"
-  license "Apache-2.0"
+  license all_of: ["Apache-2.0", "GPL-2.0-only"]
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "7be56a181bec0957d8f4f2936e99a98f737b3f7e146a3f7384b13d9e824919ad"
   end
 
+  depends_on "ant" => :build
+  depends_on "openjdk@8" => :build
+  depends_on arch: :x86_64 # openjdk@8 doesn't support ARM
   depends_on "openjdk"
+
+  on_linux do
+    depends_on "cunit" => :build
+  end
+
+  resource "wrapper" do
+    url "https://downloads.sourceforge.net/project/wrapper/wrapper_src/Wrapper_3.5.46_20210903/wrapper_3.5.46_src.tar.gz"
+    sha256 "82e1d0c85488d1389d02e3abe3359a7f759119e356e3e3abd6c6d67615ae5ad8"
+  end
 
   def install
     libexec.install Dir["*"]
+    rm_f Dir["#{libexec}/bin/wrapper*"]
+    rm_f Dir["#{libexec}/lib/libwrapper*"]
     (bin/"archiva").write_env_script libexec/"bin/archiva", JAVA_HOME: Formula["openjdk"].opt_prefix
+
+    resource("wrapper").stage do
+      # Use openjdk@8, fixes: error: Target option 1.4 is no longer supported. Use 7 or later.
+      ENV["JAVA_HOME"] = Formula["openjdk@8"].opt_prefix
+      ENV["ANT_HOME"] = Formula["ant"].opt_libexec
+      system "./build64.sh"
+      libexec.install "bin/wrapper" => "#{libexec}/bin/wrapper"
+      libext = OS.mac? ? "jnilib" : "so"
+      libexec.install "lib/libwrapper.#{libext}" => "#{libexec}/lib/libwrapper.#{libext}"
+      libexec.install "lib/wrapper.jar" => "#{libexec}/lib/wrapper.jar"
+    end
   end
 
   def post_install


### PR DESCRIPTION
This just ships a bunch of pre-compiled binaries and is not built from source.
This was already known in https://github.com/Homebrew/homebrew-core/pull/12427#issuecomment-294190196

Fixes:
    * Binaries built for a non-native architecture were installed into apache-archiva's prefix.
      The offending files are:
        /opt/homebrew/Cellar/apache-archiva/2.2.5_1/libexec/bin/wrapper-macosx-universal-32	(universal)
        /opt/homebrew/Cellar/apache-archiva/2.2.5_1/libexec/bin/wrapper-macosx-universal-64	(universal)
        /opt/homebrew/Cellar/apache-archiva/2.2.5_1/libexec/lib/libwrapper-macosx-universal-32.jnilib	(universal)
        /opt/homebrew/Cellar/apache-archiva/2.2.5_1/libexec/lib/libwrapper-macosx-universal-64.jnilib	(universal)

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
