### PR TITLE
lammps 20210929-update1

### DIFF
--- a/Formula/lammps.rb
+++ b/Formula/lammps.rb
@@ -1,23 +1,28 @@
 class Lammps < Formula
   desc "Molecular Dynamics Simulator"
   homepage "https://lammps.sandia.gov/"
-  url "https://github.com/lammps/lammps/archive/stable_29Sep2021.tar.gz"
+  url "https://github.com/lammps/lammps/archive/stable_29Sep2021_update1.tar.gz"
   # lammps releases are named after their release date. We transform it to
   # YYYY-MM-DD (year-month-day) so that we get a sane version numbering.
   # We only track stable releases as announced on the LAMMPS homepage.
-  version "2021-09-29"
-  sha256 "2dff656cb21fd9a6d46c818741c99d400cfb1b12102604844663b655fb2f893d"
+  version "20210929-update1"
+  sha256 "5000b422c9c245b92df63507de5aa2ea4af345ea1f00180167aaa084b711c27c"
   license "GPL-2.0-only"
-  revision 1
+
   # The `strategy` block below is used to massage upstream tags into the
   # YYYY-MM-DD format we use in the `version`. This is necessary for livecheck
   # to be able to do proper `Version` comparison.
   livecheck do
     url :stable
-    regex(%r{href=.*?/tag/stable[._-](\d{1,2}\w+\d{2,4})["' >]}i)
-    strategy :github_latest do |page, regex|
-      date_str = page[regex, 1]
-      date_str.present? ? Date.parse(date_str).to_s : []
+    regex(/^stable[._-](\d{1,2}\w+\d{2,4})(?:[._-](update\d*))?$/i)
+    strategy :git do |tags, regex|
+      tags.map do |tag|
+        match = tag.match(regex)
+        next if match.blank? || match[1].blank?
+
+        date_str = Date.parse(match[1]).strftime("%Y%m%d")
+        match[2].present? ? "#{date_str}-#{match[2]}" : date_str
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`lammps` upstream has released an update for the 29 September 2021 stable release (fixing bugs and compatibility issues) and this PR updates the formula to this version. ~The related `lammps-29Sep2021.tar.gz ` tarball in the first-party site's [tars](https://download.lammps.org/tars/) directory has been quietly updated, so I left the `version` at `2021-09-29` and simply bumped the `revision`. Let me know if there are any qualms about this approach.~ Per the discussion below, there's support for using a `20210929-update1` version format in this context.

Past that, the `livecheck` block is currently broken since the tag for the "latest" version on GitHub is `stable_29Sep2021_update1` instead of the expected `stable_29Sep2021` format. We only use the `GithubLatest` strategy when it's both correct and necessary and, though it's correct, it doesn't appear to be necessary to use it here. This PR updates the `livecheck` block to check the Git tags instead, matching both tag formats ~but only capturing the date part of tags like `stable_29Sep2021_update1`~ and capturing both the date and optional `update` string.

~This means that `livecheck` won't be able to detect these rare update versions but there's no way for us to do this unless we use a `version` format like `2021-09-29-update1`. If we decide that the optional update string should be part of the `version`, I'll update the `livecheck` block to capture and include this in version strings.~