### PR TITLE
spring-roo: deprecate

### DIFF
--- a/Formula/spring-roo.rb
+++ b/Formula/spring-roo.rb
@@ -5,14 +5,11 @@ class SpringRoo < Formula
   version "2.0.0"
   sha256 "37819adf23b221a4544a7b1e6853b67f695fb915f5a1d433760e04fb4b5d7263"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?spring-roo[._-]v?(\d+(?:\.\d+)+)\.RELEASE\.zip/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "a81e84e71bc6ef221f312d8854cd852a7052516d3fbd6ea98820ddcd12e0d061"
   end
+
+  deprecate! date: "2021-11-18", because: :repo_archived
 
   def install
     rm Dir["bin/*.bat"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `spring-roo` homepage doesn't appear to have been updated anytime recently, as it doesn't list the 2.0.0 release (from 2018-05-09) and instead lists an older 2.0.0.M1 pre-release (seemingly from 2015-06-08) alongside the 1.3.2 release (from 2015-09-01). The [related GitHub repository](https://github.com/spring-projects/spring-roo) has been recently moved to spring-attic and is now archived. The [`README`](https://github.com/spring-attic/spring-roo/blob/master/README.adoc) was updated on 2021-11-18 (before the repository was archived) to add the following message at the top:

> VMware has ended active development of this project, this repository will no longer be updated.

This PR deprecates the `spring-roo` formula accordingly and removes the `livecheck` block (so it will be automatically skipped as deprecated).