### PR TITLE
htpdate: update urls

### DIFF
--- a/Formula/htpdate.rb
+++ b/Formula/htpdate.rb
@@ -1,11 +1,11 @@
 class Htpdate < Formula
   desc "Synchronize time with remote web servers"
-  homepage "http://www.vervest.org/htp/"
-  url "http://www.vervest.org/htp/archive/c/htpdate-1.2.2.tar.xz"
+  homepage "https://www.vervest.org/htp/"
+  url "https://www.vervest.org/htp/archive/c/htpdate-1.2.2.tar.xz"
   sha256 "5f1f959877852abb3153fa407e8532161a7abe916aa635796ef93f8e4119f955"
 
   livecheck do
-    url "http://www.vervest.org/htp/download"
+    url "https://www.vervest.org/htp/?download"
     regex(/href=.*?htpdate[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the existing `homepage`, `stable`, and `livecheck` URLs to use HTTPS, as the server appears to support it.

Besides that, the existing `livecheck` block for `htpdate` is currently failing with a 404 error, as the URL for the first-party downloads page has moved from `www.vervest.org/htp/download` to `www.vervest.org/htp/?download`. This updates the URL accordingly.