### PR TITLE
dropbear: add livecheck

### DIFF
--- a/Formula/dropbear.rb
+++ b/Formula/dropbear.rb
@@ -5,6 +5,11 @@ class Dropbear < Formula
   sha256 "48235d10b37775dbda59341ac0c4b239b82ad6318c31568b985730c788aac53b"
   license "MIT"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?dropbear[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "c358a02ddb77666f1a523422e27f6805186a07d73cc5a20faf9b4fb134f64e29"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "c8681650c799bb023d972a9cc0dc9c07fd0ce37fc6f801a4b990af151f364b3b"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `dropbear` (from the `head` URL) and successfully identifies the latest version at the moment. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.