### PR TITLE
zeek: add livecheck

### DIFF
--- a/Formula/zeek.rb
+++ b/Formula/zeek.rb
@@ -8,6 +8,11 @@ class Zeek < Formula
   revision 1
   head "https://github.com/zeek/zeek.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 arm64_monterey: "d02836b583b2b3934e2d8223d07a2717eea4c6938a9733770a6e22e92750b0c3"
     sha256 arm64_big_sur:  "1f2b6ade33c459c14955fb497c2be5219f54d61cb39ef011d2478cddfb06789d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `zeek` but it's giving `4.1.1-docker` as the latest version instead of `4.1.1`. This PR adds a `livecheck` block that uses the standard regex for tags like `1.2.3`/`v1.2.3`, which will avoid unwanted tags like `v4.1.1-docker`, unstable releases (e.g., `v4.2.0-dev`, `v4.1.0-beta`, `v4.1.0-rc1`, etc.), and unrelated tags (e.g., `robin/hilti-paper, etc.).