### PR TITLE
cups: add livecheck

### DIFF
--- a/Formula/cups.rb
+++ b/Formula/cups.rb
@@ -8,6 +8,11 @@ class Cups < Formula
   license "Apache-2.0"
   head "https://github.com/OpenPrinting/cups.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^(?:release[._-])?v?(\d+(?:\.\d+)+(?:op\d*)?)$/i)
+  end
+
   bottle do
     sha256 arm64_monterey: "b1ae2e3f161a90bd0e5b38ba2111c924e2d380abcd7119c556a9495d12be1d92"
     sha256 arm64_big_sur:  "ac83d0ea52bebcdb2eff93c6ccbaf29c14369a7d2643bf3a85780ed34c13e0a4"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `cups` but it's currently reporting an unstable version as newest (`2.4b1`). This PR adds a `livecheck` block that uses a version of the standard regex for Git tags like `1.2.3`/`v1.2.3` which has been modified to allow for an optional `release-` prefix and to also allow a suffix like `op1`. With this change, livecheck correctly gives `2.3.3op2` as the latest version.