### PR TITLE
postgrest: add livecheck

### DIFF
--- a/Formula/postgrest.rb
+++ b/Formula/postgrest.rb
@@ -7,6 +7,11 @@ class Postgrest < Formula
   revision 1
   head "https://github.com/PostgREST/postgrest.git", branch: "main"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "bd989403d46a8f5fa86ad41e813fb48e06ec60d6b4052f6bc5a3168c22671ba6"
     sha256 cellar: :any,                 arm64_big_sur:  "a505a99c6f164a72936e18584d9a172204be89694934adc2a4d168c33ae8f91a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `postgrest` but it's currently giving a prerelease version as newest (`9.0.0-a1`) instead of `8.0.0`.

Unfortunately, we can't fix this using a regex at the moment. Another prerelease version, `v8.0.0.20211102`, will be matched by the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`) and treated as newest. It's possible to craft the regex (or use a `strategy` block) to only match versions where the fourth numeric part is fewer than 6-8 digits but this may be a bit fragile.

I think using the `GithubLatest` strategy makes sense for now (since the latest versions are using new unstable tag formats) and we can revisit this in the future. If upstream doesn't create another unstable tag like `v8.0.0.20211102` after `v9.0.0` is stable, then we could switch back to checking Git tags if we use the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`), as this would omit unstable releases like `v9.0.0-a1`.