### PR TITLE
cuba: disable due to checksum mismatch

### DIFF
--- a/Formula/cuba.rb
+++ b/Formula/cuba.rb
@@ -17,6 +17,8 @@ class Cuba < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "abd47d8d13cfefdaf542675e465b717cb95e8b1a8ba0ca2c3745bbcf0c6bd1d0"
   end
 
+  disable! date: "2021-11-22", because: :checksum_mismatch
+
   def install
     ENV.deparallelize # Makefile does not support parallel build
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
Upstream does not respon anymore.
As we don't konw if they have been compromised, we prefer to
disable this formula until further news, as we lost trust in upstream.

See also #88857

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
