### PR TITLE
pyenv-which-ext: test depend on python

### DIFF
--- a/Formula/pyenv-which-ext.rb
+++ b/Formula/pyenv-which-ext.rb
@@ -10,7 +10,10 @@ class PyenvWhichExt < Formula
     sha256 cellar: :any_skip_relocation, all: "47846141f51863aeda9dbc0578498ec9d550597581a392eeed1d71979156d3f4"
   end
 
+  deprecate! date: "2021-03-18", because: :deprecated_upstream
+
   depends_on "pyenv"
+  uses_from_macos "python" => :test
 
   def install
     ENV["PREFIX"] = prefix
@@ -18,6 +21,7 @@ class PyenvWhichExt < Formula
   end
 
   test do
+    ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin" if OS.linux?
     shell_output("eval \"$(pyenv init -)\" && pyenv which python")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Should fix test error in #89842 and #89760.