### PR TITLE
pyenv-which-ext: disable since redundant

### DIFF
--- a/Formula/pyenv-which-ext.rb
+++ b/Formula/pyenv-which-ext.rb
@@ -10,6 +10,8 @@ class PyenvWhichExt < Formula
     sha256 cellar: :any_skip_relocation, all: "47846141f51863aeda9dbc0578498ec9d550597581a392eeed1d71979156d3f4"
   end
 
+  disable! date: "2021-03-18", because: :deprecated_upstream
+
   depends_on "pyenv"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
pyenv/pyenv-which-ext is not maintained since 2019, also no longer needed after pyenv/pyenv@cdecf14 (which came out with pyenv 1.2.24, thus the disable date). See pyenv/pyenv#1930.

There is no need to use or maintain this formulae any more.