### PR TITLE
pandocomatic: delete redundant bottles

### DIFF
--- a/Formula/pandocomatic.rb
+++ b/Formula/pandocomatic.rb
@@ -6,12 +6,7 @@ class Pandocomatic < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "a7049bd282b595c4b5f8b8bf2ae1142d3f36081b316360f0e3235dc6e5500757"
-    sha256 cellar: :any_skip_relocation, big_sur:       "a7049bd282b595c4b5f8b8bf2ae1142d3f36081b316360f0e3235dc6e5500757"
-    sha256 cellar: :any_skip_relocation, catalina:      "a7049bd282b595c4b5f8b8bf2ae1142d3f36081b316360f0e3235dc6e5500757"
-    sha256 cellar: :any_skip_relocation, mojave:        "1c51680618ae42fe46954499c83137ad5fa1ecee95030b66015aafb0ddd2f9e6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1c51680618ae42fe46954499c83137ad5fa1ecee95030b66015aafb0ddd2f9e6"
-    sha256 cellar: :any_skip_relocation, all:           "edde182eb548bb6cf6fc909820e0c9f7377592ab70be9342cbcb13a75a8e421e"
+    sha256 cellar: :any_skip_relocation, all: "edde182eb548bb6cf6fc909820e0c9f7377592ab70be9342cbcb13a75a8e421e"
   end
 
   depends_on "pandoc"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A bottle for `all` was added in 6b7e29a8799e5246f9fc38a23eaf03630442a915 while bottling formulae for macOS Monterey. There may be other formulae that have redundant bottles too.