### PR TITLE
pyenv-which-ext: use /bin/ls for testing

### DIFF
--- a/Formula/pyenv-which-ext.rb
+++ b/Formula/pyenv-which-ext.rb
@@ -13,7 +13,6 @@ class PyenvWhichExt < Formula
   deprecate! date: "2021-03-18", because: :deprecated_upstream
 
   depends_on "pyenv"
-  uses_from_macos "python" => :test
 
   def install
     ENV["PREFIX"] = prefix
@@ -21,7 +20,6 @@ class PyenvWhichExt < Formula
   end
 
   test do
-    ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin" if OS.linux?
-    shell_output("eval \"$(pyenv init -)\" && pyenv which python")
+    shell_output("eval \"$(pyenv init -)\" && pyenv which ls")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This formulae was originally designed to support `pyenv which` other executables in `PATH` instead of just binaries installed by pyenv, thus no need to bother python. See #89871.