### PR TITLE
profanity: update `inreplace` comment

### DIFF
--- a/Formula/profanity.rb
+++ b/Formula/profanity.rb
@@ -47,10 +47,16 @@ class Profanity < Formula
 
     # `configure` hardcodes `/usr/local/opt/readline`, which isn't portable.
     # https://github.com/profanity-im/profanity/issues/1612
+    # Remove in version 0.12.0.
     inreplace "configure", "/usr/local/opt/readline", Formula["readline"].opt_prefix
+
+    # We need to pass `BREW` to `configure` to make sure it can be found inside the sandbox in non-default
+    # prefixes. `configure` knows to check `/opt/homebrew` and `/usr/local`, but the sanitised build
+    # environment will prevent any other `brew` installations from being found.
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "BREW=#{HOMEBREW_BREW_FILE}"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream have merged the fix in profanity-im/profanity#1617. When that
fix is included in a release, we need to pass the location of `brew` to
`configure` because `brew` won't be in `PATH` for the build.

`configure` still knows to check `/opt/homebrew` and `/usr/local` for
`brew`, so our builds should be fine without this. However, the bottle
is not relocatable so this is needed for anyone building from source in
a non-default prefix.

This is only needed for `HEAD` builds for now, but we'll need it in the next version.