### PR TITLE
ejabberd: add livecheck

### DIFF
--- a/Formula/ejabberd.rb
+++ b/Formula/ejabberd.rb
@@ -5,6 +5,11 @@ class Ejabberd < Formula
   sha256 "0e90cfd6c03191ca8aef344b9d543a038e272770be14c2288d83cc4d34825868"
   license "GPL-2.0-only"
 
+  livecheck do
+    url "https://www.process-one.net/en/ejabberd/downloads/"
+    regex(/href=.*?ejabberd[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_monterey: "4b54e5246a1a00c93856d1786eb4067b3883f4293d3fb91a7345441fdc90ba76"
     sha256 cellar: :any, arm64_big_sur:  "c22a2bd2a9dfcbbdc1e6df1ea63ae25924234f1ddd4cb5f4b016fc2013b97487"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ejabberd` (from the `head` URL) and successfully identifies the latest version at the moment. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the download page for `ejabberd` Community Server (linked from the `homepage`), which links to the `stable` archive.