### PR TITLE
graphviz: keep `gvmap.sh`

### DIFF
--- a/Formula/graphviz.rb
+++ b/Formula/graphviz.rb
@@ -57,8 +57,6 @@ class Graphviz < Formula
     system "./configure", *args
     system "make"
     system "make", "install"
-
-    (bin/"gvmap.sh").unlink
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We removed this in eee74850824510afa828e2d25fed7aa1af44f80a because it
was non-executable but being installed into `bin`. It should be
executable now, so there's no reason to remove it.

This also makes it less awkward that we're installing a `gvmap.sh.1`
without also installing the thing the manpage is for.

I've omitted the revision bump because no one else seems to be looking
for this. Everyone else can get the script at the next version bump.