### PR TITLE
Remove unneeded `uses_from_macos "git"`

### DIFF
--- a/Formula/gitleaks.rb
+++ b/Formula/gitleaks.rb
@@ -16,8 +16,6 @@ class Gitleaks < Formula
 
   depends_on "go" => :build
 
-  uses_from_macos "git"
-
   def install
     ldflags = "-X github.com/zricethezav/gitleaks/v#{version.major}/cmd.Version=#{version}"
     system "go", "build", *std_go_args(ldflags: ldflags)

--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -33,7 +33,6 @@ class Sile < Formula
   depends_on "openssl@1.1"
 
   uses_from_macos "expat"
-  uses_from_macos "git"
   uses_from_macos "zlib"
 
   resource "stdlib" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew` requires a `git` installation, so there's no need to also install an extra one unless the formula actually needs a new version of Git (e.g. `git-filter-repo`).