### PR TITLE
gcc: fix for Monterey

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -20,7 +20,7 @@ class Gcc < Formula
     end
   end
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
-  revision 2
+  revision 3
   head "https://gcc.gnu.org/git/gcc.git", branch: "master"
 
   # We can't use `url :stable` here due to the ARM-specific branch above.
@@ -57,6 +57,15 @@ class Gcc < Formula
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
+
+  # Fix for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102992
+  # Working around a macOS Monterey bug
+  if MacOS.version == :monterey
+    patch do
+      url "https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=fabe8cc41e9b01913e2016861237d1d99d7567bf"
+      sha256 "9d3c2c91917cdc37d11385bdeba005cd7fa89efdbdf7ca38f7de3f6fa8a8e51b"
+    end
+  end
 
   def version_suffix
     if build.head?


### PR DESCRIPTION
This is a fix for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102992
which is actually a macOS Monterey bug, but this implements a workaround for GCC.
https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=fabe8cc41e9b01913e2016861237d1d99d7567bf

This will allow bottling of some formulas that this issue broke, including hdf5
Because this is in addition to other Monterey fixes committed recently, let's go for a revision bump.