### PR TITLE
proper: provide path for use in erlang

### DIFF
--- a/Formula/proper.rb
+++ b/Formula/proper.rb
@@ -21,6 +21,14 @@ class Proper < Formula
   def install
     system "make"
     prefix.install Dir["_build/default/lib/proper/ebin", "include"]
+    (prefix/"proper-#{version.major_minor}").install_symlink prefix/"ebin", include
+  end
+
+  def caveats
+    <<~EOS
+      To use PropEr in Erlang, you may need:
+        export ERL_LIBS=#{opt_prefix}/proper-#{version.major_minor}
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Erlang apparently needs to be able to find a path ending in
`proper-$version`, so let's provide one.

See Homebrew/discussions#2537.