### PR TITLE
Install PHP CS Fixer from source instead of PHAR

### DIFF
--- a/Formula/php-cs-fixer.rb
+++ b/Formula/php-cs-fixer.rb
@@ -1,18 +1,27 @@
 class PhpCsFixer < Formula
   desc "Tool to automatically fix PHP coding standards issues"
   homepage "https://cs.symfony.com/"
-  url "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.3.2/php-cs-fixer.phar"
-  sha256 "8a7cb6fcbf916f01d4b423b7850b4401bc687275011b6f437322679a4fc4613f"
+  url "https://github.com/FriendsOfPHP/PHP-CS-Fixer/archive/refs/tags/v3.3.2.tar.gz"
+  sha256 "12d4109a589c730f34591862d016eb058432a010e7f125a4f5be7efb5ffff9c3"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "c9979da8cbb781fd78fd4a79d36a4be3fd0b8e2bbdff1e89b66e930a0452f0eb"
   end
 
+  depends_on "composer" => :build
   depends_on "php"
 
   def install
-    bin.install "php-cs-fixer.phar" => "php-cs-fixer"
+    system "composer", "config", "platform.php", Formula["php"].version.to_s
+    system "composer", "update"
+
+    inreplace "php-cs-fixer", "#!/usr/bin/env php", "#!#{Formula["php"].opt_bin}/php"
+
+    prefix.install Dir["*"]
+
+    bin.install_symlink prefix/"php-cs-fixer"
   end
 
   test do

--- a/Formula/php-cs-fixer@2.rb
+++ b/Formula/php-cs-fixer@2.rb
@@ -1,19 +1,28 @@
 class PhpCsFixerAT2 < Formula
   desc "Tool to automatically fix PHP coding standards issues"
   homepage "https://cs.symfony.com/"
-  url "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.19.3/php-cs-fixer.phar"
-  sha256 "64238c2940e273f6182abe5279fea0df3707ac3d18f30909f0ab4fb6f9018f94"
+  url "https://github.com/FriendsOfPHP/PHP-CS-Fixer/archive/refs/tags/v2.19.3.tar.gz"
+  sha256 "32c63d1c8cb34a9683958721cf2a9eee2f6231e541758641f416091c9bf650aa"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "62f0ceae3aec334450704706f22b62d66dc966347a4a7c3324566e530746ffea"
   end
 
   keg_only :versioned_formula
+  depends_on "composer" => :build
   depends_on "php"
 
   def install
-    bin.install "php-cs-fixer.phar" => "php-cs-fixer"
+    system "composer", "config", "platform.php", Formula["php"].version.to_s
+    system "composer", "update"
+
+    inreplace "php-cs-fixer", "#!/usr/bin/env php", "#!#{Formula["php"].opt_bin}/php"
+
+    prefix.install Dir["*"]
+
+    bin.install_symlink prefix/"php-cs-fixer"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR proposes to install PHP CS Fixer from the source distribution and patch the main scripts shebang file. This will allow us to pin PHP CS Fixer to `php@8.0` when bumping PHP to 8.1.0 in #89973.