### PR TITLE
launch4j: build from source

### DIFF
--- a/Formula/launch4j.rb
+++ b/Formula/launch4j.rb
@@ -1,18 +1,25 @@
 class Launch4j < Formula
   desc "Cross-platform Java executable wrapper"
   homepage "https://launch4j.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/launch4j/launch4j-3/3.14/launch4j-3.14-macosx-x86.tgz"
-  version "3.14"
-  sha256 "caed147c560551bcf46d1a894083808e58de62941b268ef58ca803ed09736675"
+  url "https://git.code.sf.net/p/launch4j/git.git",
+      tag:      "Release_launch4j-3_14",
+      revision: "46db737fd1885203fb098f4368cd5cf5c6792373"
   license all_of: ["BSD-3-Clause", "MIT"]
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "b35bb3862964983d4993c79741d8b85d8accf264f7a281af53d2626c64235e3d"
   end
 
+  depends_on "ant" => :build
+  depends_on arch: :x86_64
+  # Installs a pre-built `ld` and `windres` file with linkage to zlib
+  depends_on :macos
   depends_on "openjdk"
 
   def install
+    system "ant", "compile"
+    system "ant", "jar"
     libexec.install Dir["*"] - ["src", "web"]
     bin.write_jar_script libexec/"launch4j.jar", "launch4j"
   end


### PR DESCRIPTION
Fixes:
Full audit launch4j --git --skip-style output
  launch4j:
    * Binaries built for a non-native architecture were installed into launch4j's prefix.
      The offending files are:
        /opt/homebrew/Cellar/launch4j/3.14_1/libexec/bin/ld	(x86_64)
        /opt/homebrew/Cellar/launch4j/3.14_1/libexec/bin/windres	(x86_64)

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
