### PR TITLE
php-cs-fixer: add a wrapper script

### DIFF
--- a/Formula/php-cs-fixer.rb
+++ b/Formula/php-cs-fixer.rb
@@ -4,16 +4,22 @@ class PhpCsFixer < Formula
   url "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.3.2/php-cs-fixer.phar"
   sha256 "8a7cb6fcbf916f01d4b423b7850b4401bc687275011b6f437322679a4fc4613f"
   license "MIT"
+  revision 1
 
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "964e27354e1f618827381479ddebae75cc20b5ab3349f9a636c39eab9e7a3b4b"
   end
 
-  depends_on "php"
+  depends_on "php@8.0"
 
   def install
-    bin.install "php-cs-fixer.phar" => "php-cs-fixer"
+    libexec.install "php-cs-fixer.phar"
+
+    (bin/"php-cs-fixer").write <<~EOS
+      #!#{Formula["php@8.0"].opt_bin}/php
+      <?php require '#{libexec}/php-cs-fixer.phar';
+    EOS
   end
 
   test do
@@ -26,7 +32,6 @@ class PhpCsFixer < Formula
       $this->foo('homebrew rox');
     EOS
 
-    ENV["PHP_CS_FIXER_IGNORE_ENV"] = "1"
     system "#{bin}/php-cs-fixer", "fix", "test.php"
     assert compare_file("test.php", "correct_test.php")
   end

--- a/Formula/php-cs-fixer@2.rb
+++ b/Formula/php-cs-fixer@2.rb
@@ -4,6 +4,7 @@ class PhpCsFixerAT2 < Formula
   url "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.19.3/php-cs-fixer.phar"
   sha256 "64238c2940e273f6182abe5279fea0df3707ac3d18f30909f0ab4fb6f9018f94"
   license "MIT"
+  revision 1
 
   bottle do
     rebuild 1
@@ -11,10 +12,15 @@ class PhpCsFixerAT2 < Formula
   end
 
   keg_only :versioned_formula
-  depends_on "php"
+  depends_on "php@8.0"
 
   def install
-    bin.install "php-cs-fixer.phar" => "php-cs-fixer"
+    libexec.install "php-cs-fixer.phar"
+
+    (bin/"php-cs-fixer").write <<~EOS
+      #!#{Formula["php@8.0"].opt_bin}/php
+      <?php require '#{libexec}/php-cs-fixer.phar';
+    EOS
   end
 
   test do
@@ -25,7 +31,6 @@ class PhpCsFixerAT2 < Formula
       <?php $this->foo('homebrew rox');
     EOS
 
-    ENV["PHP_CS_FIXER_IGNORE_ENV"] = "1"
     system "#{bin}/php-cs-fixer", "fix", "test.php"
     assert compare_file("test.php", "correct_test.php")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Alternative to #89975.

This PR proposes to run PHP CS Fixer through a wrapper script that is pinned to a specific PHP binary. This allows us to pin PHP CS Fixer to `php@8.0` until PHP 8.1.0 is officially supported.