### PR TITLE
libstfl: deprecate as upstream repo/website is gone

### DIFF
--- a/Formula/libstfl.rb
+++ b/Formula/libstfl.rb
@@ -6,11 +6,6 @@ class Libstfl < Formula
   license "LGPL-3.0-or-later"
   revision 13
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?stfl[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "0b1fd6b1765f50e9761dbdeac4f600cdb93be3e3a43e50c26fd4f5fa6ba334ea"
     sha256 cellar: :any,                 big_sur:       "76ddf39817cb57cd96f41b932f9f26cbe2d351ef5d8bbb3a28fe400bab623326"
@@ -18,6 +13,8 @@ class Libstfl < Formula
     sha256 cellar: :any,                 mojave:        "ad965ea1d3ccce63a01d2951182a5f9a87c81a08d72ff99a509e5977d68c49a0"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "877cdb8227cbb5322b392b55cce951a46f6f5af2f8545998e72fb9daaf7b2117"
   end
+
+  deprecate! date: "2021-11-25", because: :repo_removed
 
   depends_on "python@3.9" => [:build, :test]
   depends_on "swig" => :build

--- a/Formula/libstfl.rb
+++ b/Formula/libstfl.rb
@@ -14,7 +14,7 @@ class Libstfl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "877cdb8227cbb5322b392b55cce951a46f6f5af2f8545998e72fb9daaf7b2117"
   end
 
-  deprecate! date: "2021-11-25", because: :repo_removed
+  deprecate! date: "2021-11-26", because: :repo_removed
 
   depends_on "python@3.9" => [:build, :test]
   depends_on "swig" => :build

--- a/Formula/newsboat.rb
+++ b/Formula/newsboat.rb
@@ -14,6 +14,8 @@ class Newsboat < Formula
     sha256 x86_64_linux:  "a8e76829cb365ae43de0e3aa6d442c1a95378abb59a19f6a2f006f0910e3d44b"
   end
 
+  deprecate! date: "2021-11-26", because: "libstfl is deprecated"
+
   depends_on "asciidoctor" => :build
   depends_on "pkg-config" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
==> Analytics
install: 304 (30 days), 1,067 (90 days), 6,013 (365 days)
install-on-request: 126 (30 days), 529 (90 days), 2,855 (365 days)
build-error: 0 (30 days)

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
