### PR TITLE
csound: don't recommend `DYLD_FRAMEWORK_PATH`

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -113,8 +113,9 @@ class Csound < Formula
 
   def caveats
     <<~EOS
-      To use the Python bindings, you may need to add to #{shell_profile}:
-        export DYLD_FRAMEWORK_PATH="$DYLD_FRAMEWORK_PATH:#{opt_frameworks}"
+      To use the Python bindings, you may need to set:
+        export DYLD_FALLBACK_FRAMEWORK_PATH="$DYLD_FALLBACK_FRAMEWORK_PATH:#{opt_frameworks}"
+      Exercise caution when adding this to your #{shell_profile}.
 
       To use the Java bindings, you may need to add to #{shell_profile}:
         export CLASSPATH="#{opt_libexec}/csnd6.jar:."
@@ -166,7 +167,7 @@ class Csound < Formula
     EOS
     system bin/"csound", "--orc", "--syntax-check-only", "opcode-existence.orc"
 
-    with_env("DYLD_FRAMEWORK_PATH" => frameworks) do
+    with_env(DYLD_FALLBACK_FRAMEWORK_PATH: frameworks) do
       system Formula["python@3.9"].bin/"python3", "-c", "import ctcsound"
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Using `DYLD_FRAMEWORK_PATH` causes the linker to ignore framework
install names, which we don't want. Adding this to your shell profile is
almost certainly not a good idea either.