### PR TITLE
Java Service Wrapper 3.5.46 (new formula)

### DIFF
--- a/Formula/java-service-wrapper.rb
+++ b/Formula/java-service-wrapper.rb
@@ -7,6 +7,9 @@ class JavaServiceWrapper < Formula
 
   depends_on "ant" => :build
   depends_on "openjdk@11" => :build
+  on_linux do
+    depends_on "cunit" => :build
+  end
 
   def install
     ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix

--- a/Formula/java-service-wrapper.rb
+++ b/Formula/java-service-wrapper.rb
@@ -5,8 +5,8 @@ class JavaServiceWrapper < Formula
   sha256 "82e1d0c85488d1389d02e3abe3359a7f759119e356e3e3abd6c6d67615ae5ad8"
   license "GPL-2.0-only"
 
-  depends_on "openjdk@11" => :build
   depends_on "ant" => :build
+  depends_on "openjdk@11" => :build
 
   def install
     ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix

--- a/Formula/java-service-wrapper.rb
+++ b/Formula/java-service-wrapper.rb
@@ -10,6 +10,7 @@ class JavaServiceWrapper < Formula
 
   def install
     ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix
+    # Default javac target version is 1.4, use 1.6 which is the minimum available on openjdk@11
     system "ant", "-Dbits=64", "-Djavac.target.version=1.6"
     libexec.install "lib", "bin", "src/bin" => "scripts"
   end

--- a/Formula/java-service-wrapper.rb
+++ b/Formula/java-service-wrapper.rb
@@ -1,0 +1,19 @@
+class JavaServiceWrapper < Formula
+  desc "Simplify the deployment, launch and monitoring of Java applications"
+  homepage "https://wrapper.tanukisoftware.com/"
+  url "https://downloads.sourceforge.net/project/wrapper/wrapper_src/Wrapper_3.5.46_20210903/wrapper_3.5.46_src.tar.gz"
+  sha256 "82e1d0c85488d1389d02e3abe3359a7f759119e356e3e3abd6c6d67615ae5ad8"
+  license "GPL-2.0-only"
+
+  depends_on "openjdk@11" => :build
+
+  def install
+    ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix
+    system "ant", "-Dbits=64", "-Djavac.target.version=1.6"
+    libexec.install "lib", "bin", "src/bin" => "scripts"
+  end
+
+  test do
+    shell_output("#{libexec}/bin/testwrapper status", 1)
+  end
+end

--- a/Formula/java-service-wrapper.rb
+++ b/Formula/java-service-wrapper.rb
@@ -6,6 +6,7 @@ class JavaServiceWrapper < Formula
   license "GPL-2.0-only"
 
   depends_on "openjdk@11" => :build
+  depends_on "ant" => :build
 
   def install
     ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix

--- a/Formula/java-service-wrapper.rb
+++ b/Formula/java-service-wrapper.rb
@@ -16,6 +16,7 @@ class JavaServiceWrapper < Formula
   end
 
   test do
-    shell_output("#{libexec}/bin/testwrapper status", 1)
+    output = shell_output("#{libexec}/bin/testwrapper status", 1)
+    assert_match("Test Wrapper Sample Application", output)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Java Service Wrapper 3.5.46 is the fist Apple silicon compatible version. It can be used to start Sonarqube on Apple Silicon as discussed in https://github.com/Homebrew/homebrew-core/pull/88380