### PR TITLE
flat_namespace_allowlist: add `hdf5-mpi`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -4,6 +4,7 @@
   "bind",
   "blast",
   "coq",
+  "hdf5-mpi",
   "libvirt",
   "mpich",
   "omniorb",


### PR DESCRIPTION
The `-flat_namespace` flag is inherited from `open-mpi`. See
`ompi-fort.pc`, which contains:

    Cflags: -I${includedir}     -Wl,-flat_namespace -Wl,-commons,use_dylibs  -I${libdir}

This is needed for bottling on Monterey.
