### PR TITLE
mysql@5.7: fix build on Monterey

### DIFF
--- a/Formula/mysql@5.7.rb
+++ b/Formula/mysql@5.7.rb
@@ -29,12 +29,18 @@ class MysqlAT57 < Formula
     depends_on "pkg-config" => :build
   end
 
-  def datadir
-    var/"mysql"
+  # Fix build on Monterey.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/fcbea58e245ea562fbb749bfe6e1ab178fd10025/mysql/monterey.diff"
+    sha256 "6709edb2393000bd89acf2d86ad0876bde3b84f46884d3cba7463cd346234f6f"
   end
 
   # Fixes loading of VERSION file, backported from mysql/mysql-server@51675dd
   patch :DATA
+
+  def datadir
+    var/"mysql"
+  end
 
   def install
     if OS.linux?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://bugs.mysql.com/bug.php?id=105464