### PR TITLE
Fix bug for "nginx: invalid option: "off;"

### DIFF
--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -143,7 +143,7 @@ class Nginx < Formula
   end
 
   service do
-    run [opt_bin/"nginx", "-g", "daemon off;"]
+    run [opt_bin/"nginx", "-g", "'daemon off;'"]
     keep_alive false
     working_dir HOMEBREW_PREFIX
   end


### PR DESCRIPTION
If you create a service file with a ExecStart containing "daemon off;" without the single quotes around it, then it gives an "invalid option" error.

Fix for this is adding singe quotes around it like this: [opt_bin/"nginx", "-g", "'daemon off;'"]

Reference URL's:
https://github.com/nginxinc/docker-nginx/issues/41
https://nginx.org/en/docs/ngx_core_module.html#daemon

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
