### PR TITLE
tarantool: use brewed libs & fix build on Monterey

### DIFF
--- a/Formula/tarantool.rb
+++ b/Formula/tarantool.rb
@@ -4,6 +4,7 @@ class Tarantool < Formula
   url "https://download.tarantool.org/tarantool/2.8/src/tarantool-2.8.2.0.tar.gz"
   sha256 "f2e966fc6b644254270fd84f78ccc4dd1434500a6986fe9361b34804acae7e10"
   license "BSD-2-Clause"
+  revision 1
   version_scheme 1
   head "https://github.com/tarantool/tarantool.git", branch: "master"
 
@@ -15,24 +16,22 @@ class Tarantool < Formula
 
   depends_on "cmake" => :build
   depends_on "icu4c"
+  depends_on "libyaml"
   depends_on "openssl@1.1"
   depends_on "readline"
+  depends_on "zstd"
 
   uses_from_macos "curl"
   uses_from_macos "ncurses"
 
+  # Fix build on Monterey.
+  # Remove with 2.9.
+  patch do
+    url "https://github.com/tarantool/tarantool/commit/11e87877df9001a4972019328592d79d55d1bb01.patch?full_index=1"
+    sha256 "af867163bc78a14498959a755d9e8733e4ae13d30dd51a69f7e9fdc46a46137a"
+  end
+
   def install
-    if MacOS.version >= :big_sur
-      sdk = MacOS.sdk_path_if_needed
-      lib_suffix = "tbd"
-    else
-      sdk = ""
-      lib_suffix = "dylib"
-    end
-
-    # Necessary for luajit to build on macOS Mojave (see luajit formula)
-    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
-
     # Avoid keeping references to Homebrew's clang/clang++ shims
     inreplace "src/trivia/config.h.cmake",
               "#define COMPILER_INFO \"@CMAKE_C_COMPILER@ @CMAKE_CXX_COMPILER@\"",
@@ -46,12 +45,27 @@ class Tarantool < Formula
     args << "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}"
     args << "-DREADLINE_ROOT=#{Formula["readline"].opt_prefix}"
     args << "-DENABLE_BUNDLED_LIBCURL=OFF"
-    args << "-DCURL_INCLUDE_DIR=#{sdk}/usr/include"
-    args << "-DCURL_LIBRARY=#{sdk}/usr/lib/libcurl.#{lib_suffix}"
-    args << "-DCURSES_NEED_NCURSES=TRUE"
-    args << "-DCURSES_NCURSES_INCLUDE_PATH=#{sdk}/usr/include"
-    args << "-DCURSES_NCURSES_LIBRARY=#{sdk}/usr/lib/libncurses.#{lib_suffix}"
-    args << "-DICONV_INCLUDE_DIR=#{sdk}/usr/include"
+    args << "-DENABLE_BUNDLED_LIBYAML=OFF"
+    args << "-DENABLE_BUNDLED_ZSTD=OFF"
+
+    if OS.mac?
+      if MacOS.version >= :big_sur
+        sdk = MacOS.sdk_path_if_needed
+        lib_suffix = "tbd"
+      else
+        sdk = ""
+        lib_suffix = "dylib"
+      end
+
+      args << "-DCURL_INCLUDE_DIR=#{sdk}/usr/include"
+      args << "-DCURL_LIBRARY=#{sdk}/usr/lib/libcurl.#{lib_suffix}"
+      args << "-DCURSES_NEED_NCURSES=ON"
+      args << "-DCURSES_NCURSES_INCLUDE_PATH=#{sdk}/usr/include"
+      args << "-DCURSES_NCURSES_LIBRARY=#{sdk}/usr/lib/libncurses.#{lib_suffix}"
+      args << "-DICONV_INCLUDE_DIR=#{sdk}/usr/include"
+    else
+      args << "-DCURL_ROOT=#{Formula["curl"].opt_prefix}"
+    end
 
     system "cmake", ".", *args
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also try fix Linux.

The use of brewed zstd also fixes arm64 builds.