### PR TITLE
qt: fix build with assimp 5.1

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -93,6 +93,14 @@ class Qt < Formula
 
   fails_with gcc: "5"
 
+  # Fix build with assimp 5.1.
+  # Remove with 6.3.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/0bfbbefc45142ec9be248ed66229782138bc7bc1/qt/qtquick3d-assimp-5.1.patch"
+    sha256 "31ae338ebcea3e423f3f10b9bc470ba3b46b0e35dd2b5ae1c067025f6bc0c109"
+    directory "qtquick3d"
+  end
+
   # Fix build with Xcode 13+ and a performance regression. Already merged and should be removed in next release.
   patch :DATA
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
