### PR TITLE
pyside@2: stop copying qt@5 tools

### DIFF
--- a/Formula/pyside@2.rb
+++ b/Formula/pyside@2.rb
@@ -4,7 +4,7 @@ class PysideAT2 < Formula
   url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.2-src/pyside-setup-opensource-src-5.15.2.tar.xz"
   sha256 "b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-3.0-only"]
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any, arm64_monterey: "2da0d4e6f5578894be86e636e1c3e38c77d55fa822de1e8af8452568aaf3d521"
@@ -21,6 +21,12 @@ class PysideAT2 < Formula
   depends_on "llvm"
   depends_on "python@3.9"
   depends_on "qt@5"
+
+  # Don't copy qt@5 tools.
+  patch do
+    url "https://src.fedoraproject.org/rpms/python-pyside2/raw/009100c67a63972e4c5252576af1894fec2e8855/f/pyside2-tools-obsolete.patch"
+    sha256 "ede69549176b7b083f2825f328ca68bd99ebf8f42d245908abd320093bac60c9"
+  end
 
   def install
     xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
@@ -57,8 +63,7 @@ class PysideAT2 < Formula
       Xml
     ]
 
-    # QT web engine is currently not supported on Apple
-    # silicon. Re-enable it once it has been enabled in the qt.rb.
+    # Qt web engine is not supported on Apple Silicon.
     modules << "WebEngineWidgets" unless Hardware::CPU.arm?
 
     modules.each { |mod| system Formula["python@3.9"].opt_bin/"python3", "-c", "import PySide2.Qt#{mod}" }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Notably `bin/uic` and `bin/rcc`. This will hopefully stop `pyside@2` requiring revision bumps when `qt@5` is revision bumped.
