### PR TITLE
kerl 2.2.3

### DIFF
--- a/Formula/kerl.rb
+++ b/Formula/kerl.rb
@@ -1,8 +1,8 @@
 class Kerl < Formula
   desc "Easy building and installing of Erlang/OTP instances"
   homepage "https://github.com/kerl/kerl"
-  url "https://github.com/kerl/kerl/archive/2.2.2.tar.gz"
-  sha256 "54c896ed694383cb09f0fa23c0d26c435c9ced3895424c6a7b5fed1c22eb9842"
+  url "https://github.com/kerl/kerl/archive/2.2.3.tar.gz"
+  sha256 "d3c7d29044f43ddf434d69ab9a0ead866ee01b24ae694df03e398bad777cd6c1"
   license "MIT"
   head "https://github.com/kerl/kerl.git"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 32,912 bytes
- formula fetch time: 0.6 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.