### PR TITLE
php-cs-fixer: PHP_CS_FIXER_IGNORE_ENV for tests

### DIFF
--- a/Formula/php-cs-fixer.rb
+++ b/Formula/php-cs-fixer.rb
@@ -25,6 +25,7 @@ class PhpCsFixer < Formula
       $this->foo('homebrew rox');
     EOS
 
+    ENV["PHP_CS_FIXER_IGNORE_ENV"] = "1"
     system "#{bin}/php-cs-fixer", "fix", "test.php"
     assert compare_file("test.php", "correct_test.php")
   end

--- a/Formula/php-cs-fixer@2.rb
+++ b/Formula/php-cs-fixer@2.rb
@@ -24,6 +24,7 @@ class PhpCsFixerAT2 < Formula
       <?php $this->foo('homebrew rox');
     EOS
 
+    ENV["PHP_CS_FIXER_IGNORE_ENV"] = "1"
     system "#{bin}/php-cs-fixer", "fix", "test.php"
     assert compare_file("test.php", "correct_test.php")
   end


### PR DESCRIPTION
This makes it possible to run PHP CS Fixer on versions that it does not yet support. It's needed to be able to merge PHP 8.1 support while PHP CS Fixer doesn't officially supports it yet.

See https://github.com/Homebrew/homebrew-core/pull/89973

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
