### PR TITLE
ffmpeg2theora: add livecheck

### DIFF
--- a/Formula/ffmpeg2theora.rb
+++ b/Formula/ffmpeg2theora.rb
@@ -6,6 +6,11 @@ class Ffmpeg2theora < Formula
   revision 9
   head "https://gitlab.xiph.org/xiph/ffmpeg2theora.git"
 
+  livecheck do
+    url "http://v2v.cc/~j/ffmpeg2theora/download.html"
+    regex(/href=.*?ffmpeg2theora[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_monterey: "90738560daa49a15f7aabf51be18dd1ce4f4c748c35c669b279e394853200a89"
     sha256 cellar: :any, arm64_big_sur:  "114e5f48ead0a1375f4dab1217723fe5f6850529ee5fc3f5fe4042295adf327a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ffmpeg2theora ` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.