### PR TITLE
kubernetes-cli: head uses go@1.17

### DIFF
--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -1,11 +1,14 @@
 class KubernetesCli < Formula
   desc "Kubernetes command-line interface"
   homepage "https://kubernetes.io/"
-  url "https://github.com/kubernetes/kubernetes.git",
-      tag:      "v1.22.4",
-      revision: "b695d79d4f967c403a96986f1750a35eb75e75f1"
   license "Apache-2.0"
-  head "https://github.com/kubernetes/kubernetes.git"
+
+  stable do
+    url "https://github.com/kubernetes/kubernetes.git",
+        tag:      "v1.22.4",
+        revision: "b695d79d4f967c403a96986f1750a35eb75e75f1"
+    depends_on "go@1.16" => :build
+  end
 
   livecheck do
     url :stable
@@ -21,9 +24,14 @@ class KubernetesCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "31dcccdfcba0ee62d713610c1302130f4cc1fb4fe581730f8766aaeddf152e7a"
   end
 
+  # HEAD builds with Go 1.17. Consolidate once v1.23 is released
+  head do
+    url "https://github.com/kubernetes/kubernetes.git"
+    depends_on "go" => :build
+  end
+
   depends_on "bash" => :build
   depends_on "coreutils" => :build
-  depends_on "go@1.16" => :build
 
   uses_from_macos "rsync" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Following kubernetes/kubernetes#103692, this PR changes `kubernetes-cli` to build using Go 1.17 when building from HEAD. This will also be needed when the next minor release (v1.23) is released.