### PR TITLE
kubernetes-cli@1.22 1.22.4 (new formula)

### DIFF
--- a/Aliases/kubectl@1.22
+++ b/Aliases/kubectl@1.22
@@ -1,0 +1,1 @@
+../Formula/kubernetes-cli@1.22.rb

--- a/Aliases/kubectl@1.23
+++ b/Aliases/kubectl@1.23
@@ -1,0 +1,1 @@
+../Formula/kubernetes-cli.rb

--- a/Aliases/kubernetes-cli@1.23
+++ b/Aliases/kubernetes-cli@1.23
@@ -1,0 +1,1 @@
+../Formula/kubernetes-cli.rb

--- a/Formula/kubernetes-cli@1.22.rb
+++ b/Formula/kubernetes-cli@1.22.rb
@@ -1,0 +1,64 @@
+class KubernetesCliAT122 < Formula
+  desc "Kubernetes command-line interface"
+  homepage "https://kubernetes.io/"
+  url "https://github.com/kubernetes/kubernetes.git",
+      tag:      "v1.22.4",
+      revision: "b695d79d4f967c403a96986f1750a35eb75e75f1"
+  license "Apache-2.0"
+
+  livecheck do
+    url :stable
+    regex(/^v?(1\.22(?:\.\d+)+)$/i)
+  end
+
+  keg_only :versioned_formula
+
+  # https://kubernetes.io/releases/patch-releases/#1-22
+  deprecate! date: "2022-08-28", because: :deprecated_upstream
+  # disable! date: "2022-10-28", because: :deprecated_upstream
+
+  depends_on "bash" => :build
+  depends_on "coreutils" => :build
+  depends_on "go@1.16" => :build
+
+  uses_from_macos "rsync" => :build
+
+  def install
+    # Don't dirty the git tree
+    rm_rf ".brew_home"
+
+    # Make binary
+    # Deparallelize to avoid race conditions in creating symlinks, creating an error like:
+    #   ln: failed to create symbolic link: File exists
+    # See https://github.com/kubernetes/kubernetes/issues/106165
+    ENV.deparallelize
+    ENV.prepend_path "PATH", Formula["coreutils"].libexec/"gnubin" # needs GNU date
+    system "make", "WHAT=cmd/kubectl"
+    bin.install "_output/bin/kubectl"
+
+    # Install bash completion
+    output = Utils.safe_popen_read(bin/"kubectl", "completion", "bash")
+    (bash_completion/"kubectl").write output
+
+    # Install zsh completion
+    output = Utils.safe_popen_read(bin/"kubectl", "completion", "zsh")
+    (zsh_completion/"_kubectl").write output
+
+    # Install man pages
+    # Leave this step for the end as this dirties the git tree
+    system "hack/update-generated-docs.sh"
+    man1.install Dir["docs/man/man1/*.1"]
+  end
+
+  test do
+    run_output = shell_output("#{bin}/kubectl 2>&1")
+    assert_match "kubectl controls the Kubernetes cluster manager.", run_output
+
+    version_output = shell_output("#{bin}/kubectl version --client 2>&1")
+    assert_match "GitTreeState:\"clean\"", version_output
+    if build.stable?
+      revision = stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:revision]
+      assert_match revision.to_s, version_output
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Per [Kubernetes's Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/#kubectl):

> `kubectl` is supported within one minor version (older or newer) of `kube-apiserver`.

IOW, `kubernetes-cli@1.21` is the most recent version that can manage Kubernetes v1.20, which is [still supported upstream](https://kubernetes.io/releases/patch-releases/#1-20).