### PR TITLE
php: switch compiler

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -37,6 +37,7 @@ class Php < Formula
   depends_on "autoconf"
   depends_on "curl"
   depends_on "freetds"
+  depends_on "gcc"
   depends_on "gd"
   depends_on "gettext"
   depends_on "gmp"
@@ -66,6 +67,10 @@ class Php < Formula
     # see https://github.com/php/php-src/pull/3472
     patch :DATA
   end
+
+  # Default xcode compiler builds fail 1/4 times
+  # See https://bugs.php.net/bug.php?id=81666
+  fails_with :clang
 
   def install
     if OS.mac? && (MacOS.version == :el_capitan || MacOS.version == :sierra)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


Turns out that the default xcode compiler produces flaky results.

Locally, I get failure 1/4 of the time.

By changing it to gcc it compiles without issue.

See https://bugs.php.net/bug.php?id=81666

https://github.com/Homebrew/homebrew-core/pull/89973#issuecomment-981074572