### PR TITLE
pango: fix Meson flags

### DIFF
--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -22,6 +22,7 @@ class Pango < Formula
   depends_on "pkg-config" => :build
   depends_on "cairo"
   depends_on "fontconfig"
+  depends_on "freetype"
   depends_on "fribidi"
   depends_on "glib"
   depends_on "harfbuzz"
@@ -31,7 +32,9 @@ class Pango < Formula
       system "meson", *std_meson_args,
                       "-Ddefault_library=both",
                       "-Dintrospection=enabled",
-                      "-Duse_fontconfig=true",
+                      "-Dfontconfig=enabled",
+                      "-Dcairo=enabled",
+                      "-Dfreetype=enabled",
                       ".."
       system "ninja", "-v"
       system "ninja", "install", "-v"


### PR DESCRIPTION
`use_fontconfig` is a non-existent option, so attempting to build this
with the latest version of Meson fails. This has been replaced with the
`feature`-type option `fontconfig`, which can be passed one of `auto`,
`enabled`, or `disabled`.

While we're here, let's make the dependency on `freetype` explicit (this
is a dependency of `fontconfig`, so this adds no new dependencies to
current installations), and make sure that the build doesn't silently
ignore failures in finding dependencies.
