### PR TITLE
gobject-introspection: fix PyInstaller compatibility on Monterey

### DIFF
--- a/Formula/gobject-introspection.rb
+++ b/Formula/gobject-introspection.rb
@@ -6,7 +6,7 @@ class GobjectIntrospection < Formula
   url "https://download.gnome.org/sources/gobject-introspection/1.70/gobject-introspection-1.70.0.tar.xz"
   sha256 "902b4906e3102d17aa2fcb6dad1c19971c70f2a82a159ddc4a94df73a3cafc4a"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.0-or-later", "MIT"]
-  revision 1
+  revision 2
 
   bottle do
     sha256 arm64_monterey: "b3415581141e6a2dd35baf1065aef21bfa07cacd582c8f18a728606750904a0c"
@@ -40,6 +40,14 @@ class GobjectIntrospection < Formula
   patch do
     url "https://gitlab.gnome.org/tschoonj/gobject-introspection/-/commit/a7be304478b25271166cd92d110f251a8742d16b.diff"
     sha256 "740c9fba499b1491689b0b1216f9e693e5cb35c9a8565df4314341122ce12f81"
+  end
+
+  # Fix compatibility with PyInstaller on Monterey.
+  # See: https://github.com/pyinstaller/pyinstaller/issues/6354
+  #      https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/303
+  patch do
+    url "https://gitlab.gnome.org/rokm/gobject-introspection/-/commit/56df7b0f007fe260b2bd26ef9cc331ad73022700.diff"
+    sha256 "56312cd45b2b3a7fd74eaae89843a49b9a06d1423785fb57416a8a61b1cb811f"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Patch the shared library finder in the typelib loader to treat `@`-prefixed shared library names as absolute. This prevents
attempts to merge the `@`-prefixed paths with configured library search paths, which produces mangled paths, such as
`/usr/local/lib/@loader_path/libgobject-2.0.0.dylib`.

On Big Sur and earlier, `dlopen` failed to resolve such mangled paths, which led to subsequent successful attempt to load the
original `@loader_path`-relative library path. However, on Monterey, the  `dlopen` falls back to known library paths, which include `/usr/local/lib`. Therefore, if a PyInstaller-frozen application that uses `Gtk` via `PyGObject` is launched on a Monterey system that has `Gtk` installed via homebrew, it ends up with two copies of shared libraries being loaded (one from the application bundle, and the one from homebrew installation that was pulled in due to the fallback triggered by the mangled path) and crashes.

Original PyInstaller issue: https://github.com/pyinstaller/pyinstaller/issues/6354
Upstream merge request: https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/303