### PR TITLE
duck 8.1.1

### DIFF
--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -24,7 +24,7 @@ class Duck < Formula
   depends_on xcode: :build
 
   depends_on "libffi"
-  depends_on "openjdk@17"
+  depends_on "openjdk"
 
   uses_from_macos "zlib"
 
@@ -130,7 +130,7 @@ class Duck < Formula
       libdir.install buildpath/"JavaNativeFoundation.framework"
       # Replace runtime with already installed dependency
       rm_r "#{libexec}/Contents/PlugIns/Runtime.jre"
-      ln_s Formula["openjdk@17"].libexec/"openjdk.jdk", "#{libexec}/Contents/PlugIns/Runtime.jre"
+      ln_s Formula["openjdk"].libexec/"openjdk.jdk", "#{libexec}/Contents/PlugIns/Runtime.jre"
     else
       libexec.install Dir["cli/linux/target/release/duck/*"]
     end

--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -24,7 +24,7 @@ class Duck < Formula
   depends_on xcode: :build
 
   depends_on "libffi"
-  depends_on "openjdk"
+  depends_on "openjdk@17"
 
   uses_from_macos "zlib"
 
@@ -128,6 +128,9 @@ class Duck < Formula
       libexec.install Dir["cli/osx/target/duck.bundle/*"]
       rm_rf libdir/"JavaNativeFoundation.framework"
       libdir.install buildpath/"JavaNativeFoundation.framework"
+      # Replace runtime with already installed dependency
+      rm_r "#{libexec}/Contents/PlugIns/Runtime.jre"
+      ln_s Formula["openjdk@17"].libexec/"openjdk.jdk", "#{libexec}/Contents/PlugIns/Runtime.jre"
     else
       libexec.install Dir["cli/linux/target/release/duck/*"]
     end

--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -106,6 +106,7 @@ class Duck < Formula
       xcconfig = buildpath/"Overrides.xcconfig"
       xcconfig.write <<~EOS
         OTHER_LDFLAGS = -headerpad_max_install_names
+        VALID_ARCHS=#{Hardware::CPU.arch}
       EOS
       ENV["XCODE_XCCONFIG_FILE"] = xcconfig
 

--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -45,6 +45,11 @@ class Duck < Formula
     sha256 "97680b8ddb5c0f01e50f63d04680d0823a5cb2d9b585287094de38278d2e6625"
   end
 
+  resource "rococoa" do
+    url "https://github.com/iterate-ch/rococoa/archive/refs/tags/0.9.1.tar.gz"
+    sha256 "62c3c36331846384aeadd6014c33a30ad0aaff7d121b775204dc65cb3f00f97b"
+  end
+
   resource "JavaNativeFoundation" do
     url "https://github.com/apple/openjdk/archive/refs/tags/iTunesOpenJDK-1014.0.2.12.1.tar.gz"
     sha256 "e8556a73ea36c75953078dfc1bafc9960e64593bc01e733bc772d2e6b519fd4a"
@@ -102,6 +107,15 @@ class Duck < Formula
       end
     end
 
+    resource("rococoa").stage do
+      next unless OS.mac?
+
+      cd "rococoa/rococoa-core" do
+        xcodebuild "VALID_ARCHS=#{Hardware::CPU.arch}", "-project", "rococoa.xcodeproj"
+        buildpath.install shared_library("build/Release/librococoa")
+      end
+    end
+
     os = if OS.mac?
       xcconfig = buildpath/"Overrides.xcconfig"
       xcconfig.write <<~EOS
@@ -132,6 +146,8 @@ class Duck < Formula
       # Replace runtime with already installed dependency
       rm_r "#{libexec}/Contents/PlugIns/Runtime.jre"
       ln_s Formula["openjdk"].libexec/"openjdk.jdk", "#{libexec}/Contents/PlugIns/Runtime.jre"
+      rm libdir/shared_library("librococoa")
+      libdir.install buildpath/shared_library("librococoa")
     else
       libexec.install Dir["cli/linux/target/release/duck/*"]
     end

--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -1,8 +1,8 @@
 class Duck < Formula
   desc "Command-line interface for Cyberduck (a multi-protocol file transfer tool)"
   homepage "https://duck.sh/"
-  url "https://dist.duck.sh/duck-src-8.1.0.36410.tar.gz"
-  sha256 "4ebb31052302fcfe3e7b73d756bd30079d36080221222a674496a0d635e35d84"
+  url "https://dist.duck.sh/duck-src-8.1.1.36550.tar.gz"
+  sha256 "0496edc6273ab0d6e5161cc1dcb4d3554c0e93b42cc2bcebc23a01b58858cf81"
   license "GPL-3.0-only"
   head "https://github.com/iterate-ch/cyberduck.git"
 

--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -23,7 +23,6 @@ class Duck < Formula
   depends_on "pkg-config" => :build
   depends_on xcode: :build
 
-  depends_on arch: :x86_64
   depends_on "libffi"
   depends_on "openjdk"
 

--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -1,8 +1,8 @@
 class Duck < Formula
   desc "Command-line interface for Cyberduck (a multi-protocol file transfer tool)"
   homepage "https://duck.sh/"
-  url "https://dist.duck.sh/duck-src-8.0.0.36226.tar.gz"
-  sha256 "11c5aac7a8175490e8f503f846b33f861ba58a0e9ffdcf095572fbc637253f0d"
+  url "https://dist.duck.sh/duck-src-8.1.0.36410.tar.gz"
+  sha256 "4ebb31052302fcfe3e7b73d756bd30079d36080221222a674496a0d635e35d84"
   license "GPL-3.0-only"
   head "https://svn.cyberduck.io/trunk/"
 

--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -4,7 +4,7 @@ class Duck < Formula
   url "https://dist.duck.sh/duck-src-8.1.0.36410.tar.gz"
   sha256 "4ebb31052302fcfe3e7b73d756bd30079d36080221222a674496a0d635e35d84"
   license "GPL-3.0-only"
-  head "https://svn.cyberduck.io/trunk/"
+  head "https://github.com/iterate-ch/cyberduck.git"
 
   livecheck do
     url "https://dist.duck.sh/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The built artifact fails to launch with a stacktrace 

```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	       0x18bb259b8 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x18bb5915c pthread_kill + 288
2   libsystem_c.dylib             	       0x18ba96314 abort + 164
3   libjvm.dylib                  	       0x106ed002c os::abort(bool, void*, void const*) + 56
4   libjvm.dylib                  	       0x10710e168 VMError::report_and_die(int, char const*, char const*, char*, Thread*, unsigned char*, void*, void*, char const*, int, unsigned long) + 2684
5   libjvm.dylib                  	       0x10710d6e0 VMError::report_and_die(Thread*, unsigned int, unsigned char*, void*, void*, char const*, ...) + 72
6   libjvm.dylib                  	       0x10710e2b0 VMError::report_and_die(Thread*, unsigned int, unsigned char*, void*, void*) + 36
7   libjvm.dylib                  	       0x106febbe0 JVM_handle_bsd_signal + 420
8   libsystem_platform.dylib      	       0x18bb704e4 _sigtramp + 56
9   libjimage.dylib               	       0x104395c14 ZipDecompressor::decompress_resource(unsigned char*, unsigned char*, ResourceHeader*, ImageStrings const*) + 40
10  libjimage.dylib               	       0x104395b9c ImageDecompressor::decompress_resource(unsigned char*, unsigned char*, unsigned long long, ImageStrings const*, Endian*) + 292
11  libjimage.dylib               	       0x1043967dc ImageFileReader::get_resource(ImageLocation&, unsigned char*) const + 256
12  libjimage.dylib               	       0x10439763c ImageFileReader::get_resource(unsigned int, unsigned char*) const + 132
13  libjimage.dylib               	       0x1043977f4 JIMAGE_GetResource + 20
14  libjvm.dylib                  	       0x106960e9c ClassPathImageEntry::open_stream_for_loader(JavaThread*, char const*, ClassLoaderData*) + 276
15  libjvm.dylib                  	       0x106963de8 ClassLoader::load_class(Symbol*, bool, JavaThread*) + 284
16  libjvm.dylib                  	       0x10706f6f0 SystemDictionary::load_instance_class_impl(Symbol*, Handle, JavaThread*) + 720
17  libjvm.dylib                  	       0x10706dfdc SystemDictionary::load_instance_class(unsigned int, Symbol*, Handle, JavaThread*) + 48
18  libjvm.dylib                  	       0x10706d6e8 SystemDictionary::resolve_instance_class_or_null(Symbol*, Handle, Handle, JavaThread*) + 1244
19  libjvm.dylib                  	       0x10706ccd4 SystemDictionary::resolve_or_fail(Symbol*, Handle, Handle, bool, JavaThread*) + 128
20  libjvm.dylib                  	       0x10710a5b8 vmClasses::resolve_all(JavaThread*) + 344
21  libjvm.dylib                  	       0x1070703a0 SystemDictionary::initialize(JavaThread*) + 204
22  libjvm.dylib                  	       0x1070ca1d8 Universe::genesis(JavaThread*) + 168
23  libjvm.dylib                  	       0x1070ccddc universe2_init() + 36
24  libjvm.dylib                  	       0x106b53484 init_globals() + 88
25  libjvm.dylib                  	       0x1070a3760 Threads::create_vm(JavaVMInitArgs*, bool*) + 940
26  libjvm.dylib                  	       0x106bee888 JNI_CreateJavaVM + 120
27  libjli.dylib                  	       0x1043acaa8 JavaMain + 260
28  libjli.dylib                  	       0x1043af958 __JVMInit_block_invoke + 80
29  Foundation                    	       0x18cadc600 __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ + 24
30  Foundation                    	       0x18cadc4a8 -[NSBlockOperation main] + 104
31  Foundation                    	       0x18cadc438 __NSOPERATION_IS_INVOKING_MAIN__ + 24
32  Foundation                    	       0x18cadb67c -[NSOperation start] + 804
33  Foundation                    	       0x18cb1caa4 __NSThreadPerformPerform + 212
34  CoreFoundation                	       0x18bc24bbc __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
35  CoreFoundation                	       0x18bc24b08 __CFRunLoopDoSource0 + 208
36  CoreFoundation                	       0x18bc247f4 __CFRunLoopDoSources0 + 268
37  CoreFoundation                	       0x18bc23168 __CFRunLoopRun + 820
38  CoreFoundation                	       0x18bc22694 CFRunLoopRunSpecific + 600
39  libjli.dylib                  	       0x1043aefec CreateExecutionEnvironment + 400
40  libjli.dylib                  	       0x1043ab1fc JLI_Launch + 1184
41  duck                          	       0x104187940 launch + 2284
42  duck                          	       0x104186f9c main + 68
43  dyld                          	       0x1044410f4 start + 520
```

I suspect a code signing issue. The crash is inside the runtime environment we are bundling which has been updated to a build of OpenJDK 17. 

*Note*: Running `duck` from the build output prior installing with Homebrew does not crash. I tested this by removing the `libexec.install` phase and keeping the built source using `--keep-tmp`.

```
 /private/tmp/duck-20211128-99304-1gschx9/cli/osx/target/duck.bundle/Contents/MacOS/duck 
Missing required option: [--upload Upload file or folder recursively, -d Download file or folder. Denote a folder with a trailing '/', --copy Copy between servers, -l List files in remote folder, -L Long list format with modification date and permission mask, -D Delete, -c Make directory, --synchronize Synchronize folders, --edit Edit file in external editor, --purge Invalidate file in CDN, -V Show version number and quit., -h Print this help]
Try 'duck --help' for more options.
```

Any educated guesses what might be wrong are welcome. Replacing the ad-hoc code signature on the installed bundle did not seem to make a difference.