### PR TITLE
aliddns-driftctl: clean up std_go_args usage

### DIFF
--- a/Formula/aliddns.rb
+++ b/Formula/aliddns.rb
@@ -26,7 +26,7 @@ class Aliddns < Formula
       -X main.commit=#{Utils.git_head}
       -X main.builtBy=homebrew
     ]
-    system "go", "build", "-mod=vendor", "-ldflags", ldflags.join(" "), *std_go_args
+    system "go", "build", "-mod=vendor", *std_go_args(ldflags: ldflags)
     pkgetc.install "aliddns.yaml"
   end
 

--- a/Formula/amfora.rb
+++ b/Formula/amfora.rb
@@ -29,7 +29,7 @@ class Amfora < Formula
       -X main.commit=#{Utils.git_head}
       -X main.builtBy=homebrew
     ]
-    system "go", "build", *std_go_args(ldflags: ldflags.join(" "))
+    system "go", "build", *std_go_args(ldflags: ldflags)
     pkgshare.install "contrib/themes"
   end
 

--- a/Formula/anycable-go.rb
+++ b/Formula/anycable-go.rb
@@ -32,7 +32,7 @@ class AnycableGo < Formula
       "-X github.com/anycable/anycable-go/utils.version=#{version}"
     end
 
-    system "go", "build", "-mod=vendor", "-ldflags", ldflags.join(" "), *std_go_args,
+    system "go", "build", "-mod=vendor", *std_go_args(ldflags: ldflags),
                           "-v", "github.com/anycable/anycable-go/cmd/anycable-go"
   end
 

--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -44,7 +44,7 @@ class Arangodb < Formula
         -X main.projectVersion=#{resource("starter").version}
         -X main.projectBuild=#{Utils.git_head}
       ]
-      system "go", "build", *std_go_args, "-ldflags", ldflags.join(" "), "github.com/arangodb-helper/arangodb"
+      system "go", "build", *std_go_args(ldflags: ldflags), "github.com/arangodb-helper/arangodb"
     end
 
     mkdir "build" do

--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -29,7 +29,7 @@ class ArduinoCli < Formula
       -X github.com/arduino/arduino-cli/version.versionString=#{version}
       -X github.com/arduino/arduino-cli/version.commit=#{Utils.git_head(length: 8)}
       -X github.com/arduino/arduino-cli/version.date=#{time.iso8601}
-    ].join(" ")
+    ]
     system "go", "build", *std_go_args(ldflags: ldflags)
 
     output = Utils.safe_popen_read(bin/"arduino-cli", "completion", "bash")

--- a/Formula/argocd-vault-plugin.rb
+++ b/Formula/argocd-vault-plugin.rb
@@ -25,7 +25,7 @@ class ArgocdVaultPlugin < Formula
       -X github.com/IBM/argocd-vault-plugin/version.Version=#{version}
       -X github.com/IBM/argocd-vault-plugin/version.BuildDate=#{time.iso8601}
       -X github.com/IBM/argocd-vault-plugin/version.CommitSHA=#{Utils.git_head}
-    ].join(" ")
+    ]
 
     system "go", "build", *std_go_args(ldflags: ldflags)
   end

--- a/Formula/armor.rb
+++ b/Formula/armor.rb
@@ -21,7 +21,7 @@ class Armor < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w", "cmd/armor/main.go"
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "cmd/armor/main.go"
     prefix.install_metafiles
   end
 

--- a/Formula/assh.rb
+++ b/Formula/assh.rb
@@ -19,7 +19,7 @@ class Assh < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w"
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do

--- a/Formula/aws-iam-authenticator.rb
+++ b/Formula/aws-iam-authenticator.rb
@@ -24,7 +24,7 @@ class AwsIamAuthenticator < Formula
                "-X sigs.k8s.io/aws-iam-authenticator/pkg.Version=#{version}",
                "-X sigs.k8s.io/aws-iam-authenticator/pkg.CommitID=#{Utils.git_head}",
                "-buildid=''"]
-    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "./cmd/aws-iam-authenticator"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/aws-iam-authenticator"
     prefix.install_metafiles
   end
 

--- a/Formula/aws-okta.rb
+++ b/Formula/aws-okta.rb
@@ -26,7 +26,7 @@ class AwsOkta < Formula
   end
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.Version=#{version}")
   end
 
   test do

--- a/Formula/awsweeper.rb
+++ b/Formula/awsweeper.rb
@@ -23,7 +23,7 @@ class Awsweeper < Formula
       -X github.com/jckuester/awsweeper/internal.date=#{time.strftime("%F")}
     ]
 
-    system "go", "build", *std_go_args, "-ldflags", ldflags.join(" ")
+    system "go", "build", *std_go_args(ldflags: ldflags)
   end
 
   test do

--- a/Formula/bit-git.rb
+++ b/Formula/bit-git.rb
@@ -20,7 +20,7 @@ class BitGit < Formula
   conflicts_with "bit", because: "both install `bit` binaries"
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-X main.version=v#{version}"
+    system "go", "build", *std_go_args(ldflags: "-X main.version=v#{version}")
     bin.install_symlink "bit-git" => "bit"
   end
 

--- a/Formula/brook.rb
+++ b/Formula/brook.rb
@@ -18,9 +18,8 @@ class Brook < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-s -w"
     cd "cli/brook" do
-      system "go", "build", *std_go_args, "-ldflags", ldflags
+      system "go", "build", *std_go_args(ldflags: "-s -w")
     end
   end
 

--- a/Formula/buildpulse-test-reporter.rb
+++ b/Formula/buildpulse-test-reporter.rb
@@ -22,7 +22,7 @@ class BuildpulseTestReporter < Formula
       -s -w
       -X main.Version=#{version}
       -X main.Commit=#{tap.user}
-    ].join(" ")
+    ]
     system "go", "build", *std_go_args(ldflags: goldflags), "./cmd/test-reporter"
   end
 

--- a/Formula/cassowary.rb
+++ b/Formula/cassowary.rb
@@ -19,7 +19,7 @@ class Cassowary < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w -X main.version=#{version}", *std_go_args, "./cmd/cassowary"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./cmd/cassowary"
   end
 
   test do

--- a/Formula/cfssl.rb
+++ b/Formula/cfssl.rb
@@ -22,8 +22,8 @@ class Cfssl < Formula
   def install
     ldflags = "-s -w -X github.com/cloudflare/cfssl/cli/version.version=#{version}"
 
-    system "go", "build", *std_go_args(ldflags: ldflags), "-o", "#{bin}/cfssl", "cmd/cfssl/cfssl.go"
-    system "go", "build", *std_go_args(ldflags: ldflags), "-o", "#{bin}/cfssljson", "cmd/cfssljson/cfssljson.go"
+    system "go", "build", *std_go_args(output: bin/"cfssl", ldflags: ldflags), "cmd/cfssl/cfssl.go"
+    system "go", "build", *std_go_args(output: bin/"cfssljson", ldflags: ldflags), "cmd/cfssljson/cfssljson.go"
     system "go", "build", "-o", "#{bin}/cfsslmkbundle", "cmd/mkbundle/mkbundle.go"
   end
 

--- a/Formula/chart-testing.rb
+++ b/Formula/chart-testing.rb
@@ -29,8 +29,8 @@ class ChartTesting < Formula
       -X github.com/helm/chart-testing/v#{version.major}/ct/cmd.Version=#{version}
       -X github.com/helm/chart-testing/v#{version.major}/ct/cmd.GitCommit=#{Utils.git_head}
       -X github.com/helm/chart-testing/v#{version.major}/ct/cmd.BuildDate=#{time.strftime("%F")}
-    ].join(" ")
-    system "go", "build", *std_go_args, "-ldflags", ldflags, "-o", bin/"ct", "./ct/main.go"
+    ]
+    system "go", "build", *std_go_args(output: bin/"ct", ldflags: ldflags), "./ct/main.go"
     etc.install "etc" => "ct"
   end
 

--- a/Formula/chezmoi.rb
+++ b/Formula/chezmoi.rb
@@ -25,7 +25,7 @@ class Chezmoi < Formula
       -X main.commit=#{Utils.git_head}
       -X main.date=#{time.rfc3339}
       -X main.builtBy=#{tap.user}
-    ].join(" ")
+    ]
     system "go", "build", *std_go_args(ldflags: ldflags)
 
     bash_completion.install "completions/chezmoi-completion.bash"

--- a/Formula/cilium-cli.rb
+++ b/Formula/cilium-cli.rb
@@ -18,7 +18,7 @@ class CiliumCli < Formula
 
   def install
     ldflags = "-s -w -X github.com/cilium/cilium-cli/internal/cli/cmd.Version=#{version}"
-    system "go", "build", *std_go_args(ldflags: ldflags), "-o", "#{bin}/cilium", "./cmd/cilium"
+    system "go", "build", *std_go_args(output: bin/"cilium", ldflags: ldflags), "./cmd/cilium"
 
     bash_output = Utils.safe_popen_read(bin/"cilium", "completion", "bash")
     (bash_completion/"cilium").write bash_output

--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -29,7 +29,7 @@ class Circleci < Formula
       -X github.com/CircleCI-Public/circleci-cli/version.Version=#{version}
       -X github.com/CircleCI-Public/circleci-cli/version.Commit=#{Utils.git_short_head}
     ]
-    system "go", "build", *std_go_args(ldflags: ldflags.join(" "))
+    system "go", "build", *std_go_args(ldflags: ldflags)
 
     output = Utils.safe_popen_read("#{bin}/circleci", "--skip-update-check", "completion", "bash")
     (bash_completion/"circleck").write output

--- a/Formula/clair.rb
+++ b/Formula/clair.rb
@@ -24,9 +24,9 @@ class Clair < Formula
     ldflags = %W[
       -s -w
       -X main.Version=#{version}
-    ].join(" ")
+    ]
 
-    system "go", "build", *std_go_args, "-ldflags", ldflags, "./cmd/clair"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/clair"
     (etc/"clair").install "config.yaml.sample"
   end
 

--- a/Formula/cli53.rb
+++ b/Formula/cli53.rb
@@ -18,7 +18,7 @@ class Cli53 < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w", "./cmd/cli53"
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/cli53"
   end
 
   test do

--- a/Formula/cloud-nuke.rb
+++ b/Formula/cloud-nuke.rb
@@ -18,7 +18,7 @@ class CloudNuke < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w -X main.VERSION=v#{version}", *std_go_args
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.VERSION=v#{version}")
   end
 
   test do

--- a/Formula/cointop.rb
+++ b/Formula/cointop.rb
@@ -17,7 +17,7 @@ class Cointop < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-X github.com/cointop-sh/cointop/cointop.version=#{version}"
+    system "go", "build", *std_go_args(ldflags: "-X github.com/cointop-sh/cointop/cointop.version=#{version}")
   end
 
   test do

--- a/Formula/colfer.rb
+++ b/Formula/colfer.rb
@@ -19,7 +19,7 @@ class Colfer < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-o", bin/"colf", "./cmd/colf"
+    system "go", "build", *std_go_args(output: bin/"colf"), "./cmd/colf"
   end
 
   test do

--- a/Formula/colima.rb
+++ b/Formula/colima.rb
@@ -26,7 +26,7 @@ class Colima < Formula
       -X #{project}/config.appVersion=#{version}
       -X #{project}/config.revision=#{Utils.git_head}
     ]
-    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "./cmd/colima"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/colima"
 
     (bash_completion/"colima").write Utils.safe_popen_read(bin/"colima", "completion", "bash")
     (zsh_completion/"_colima").write Utils.safe_popen_read(bin/"colima", "completion", "zsh")

--- a/Formula/collector-sidecar.rb
+++ b/Formula/collector-sidecar.rb
@@ -27,7 +27,7 @@ class CollectorSidecar < Formula
       -X github.com/Graylog2/collector-sidecar/common.CollectorVersion=#{version}
     ]
 
-    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "-o", bin/"graylog-sidecar"
+    system "go", "build", *std_go_args(output: bin/"graylog-sidecar", ldflags: ldflags)
     (etc/"graylog/sidecar/sidecar.yml").install "sidecar-example.yml"
   end
 

--- a/Formula/consul-backinator.rb
+++ b/Formula/consul-backinator.rb
@@ -19,7 +19,7 @@ class ConsulBackinator < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.appVersion=#{version}"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.appVersion=#{version}")
   end
 
   test do

--- a/Formula/consul-template.rb
+++ b/Formula/consul-template.rb
@@ -25,7 +25,7 @@ class ConsulTemplate < Formula
       -X #{project}/version.Name=consul-template
       -X #{project}/version.GitCommit=#{Utils.git_short_head}
     ]
-    system "go", "build", "-ldflags", ldflags.join(" "), *std_go_args
+    system "go", "build", *std_go_args(ldflags: ldflags)
     prefix.install_metafiles
   end
 

--- a/Formula/container-diff.rb
+++ b/Formula/container-diff.rb
@@ -19,7 +19,7 @@ class ContainerDiff < Formula
 
   def install
     pkg = "github.com/GoogleContainerTools/container-diff/version"
-    system "go", "build", *std_go_args, "-ldflags", "-s -w -X #{pkg}.version=#{version}"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X #{pkg}.version=#{version}")
   end
 
   test do

--- a/Formula/convox.rb
+++ b/Formula/convox.rb
@@ -33,7 +33,7 @@ class Convox < Formula
     ldflags = %W[
       -s -w
       -X main.version=#{version}
-    ].join(" ")
+    ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/convox"
   end

--- a/Formula/cosign.rb
+++ b/Formula/cosign.rb
@@ -26,7 +26,7 @@ class Cosign < Formula
       -X #{pkg}.gitCommit=#{Utils.git_head}
       -X #{pkg}.gitTreeState="clean"
       -X #{pkg}.buildDate=#{time.iso8601}
-    ].join(" ")
+    ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/cosign"
   end

--- a/Formula/cql.rb
+++ b/Formula/cql.rb
@@ -33,7 +33,7 @@ class Cql < Formula
       -X main.version=v#{version}
       -X github.com/CovenantSQL/CovenantSQL/conf.RoleTag=C
       -X github.com/CovenantSQL/CovenantSQL/utils/log.SimpleLog=Y
-    ].join(" ")
+    ]
     system "go", "build", *std_go_args(ldflags: ldflags), "-tags", "sqlite_omit_load_extension", "./cmd/cql"
 
     bash_completion.install "bin/completion/cql-completion.bash"

--- a/Formula/crane.rb
+++ b/Formula/crane.rb
@@ -17,9 +17,12 @@ class Crane < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags",
-      "-s -w -X github.com/google/go-containerregistry/cmd/crane/cmd.Version=#{version}",
-      "./cmd/crane"
+    ldflags = %W[
+      -s -w
+      -X github.com/google/go-containerregistry/cmd/crane/cmd.Version=#{version}
+    ]
+
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/crane"
   end
 
   test do

--- a/Formula/cwlogs.rb
+++ b/Formula/cwlogs.rb
@@ -32,7 +32,7 @@ class Cwlogs < Formula
 
     cd "src/github.com/segmentio/cwlogs" do
       system "govendor", "sync"
-      system "go", "build", *std_go_args, "-ldflags", "-X main.Version=#{version}"
+      system "go", "build", *std_go_args(ldflags: "-X main.Version=#{version}")
     end
   end
 

--- a/Formula/darksky-weather.rb
+++ b/Formula/darksky-weather.rb
@@ -22,7 +22,7 @@ class DarkskyWeather < Formula
     ldflags = ["-s -w",
                "-X #{project}/version.GITCOMMIT=#{tap.user.downcase}",
                "-X #{project}/version.VERSION=v#{version}"]
-    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "-o", bin/"weather"
+    system "go", "build", *std_go_args(output: bin/"weather", ldflags: ldflags)
   end
 
   test do

--- a/Formula/dasel.rb
+++ b/Formula/dasel.rb
@@ -19,7 +19,7 @@ class Dasel < Formula
 
   def install
     ldflags = "-X 'github.com/tomwright/dasel/internal.Version=#{version}'"
-    system "go", "build", *std_go_args, "-ldflags", ldflags, "./cmd/dasel"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/dasel"
   end
 
   test do

--- a/Formula/delve.rb
+++ b/Formula/delve.rb
@@ -17,7 +17,7 @@ class Delve < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-o", bin/"dlv", "./cmd/dlv"
+    system "go", "build", *std_go_args(output: bin/"dlv"), "./cmd/dlv"
   end
 
   test do

--- a/Formula/devspace.rb
+++ b/Formula/devspace.rb
@@ -30,7 +30,7 @@ class Devspace < Formula
       -X main.commitHash=#{Utils.git_head}
       -X main.version=#{version}
     ]
-    system "go", "build", "-ldflags", ldflags.join(" "), *std_go_args
+    system "go", "build", *std_go_args(ldflags: ldflags)
   end
 
   test do

--- a/Formula/docker-compose.rb
+++ b/Formula/docker-compose.rb
@@ -22,7 +22,7 @@ class DockerCompose < Formula
     ldflags = %W[
       -s -w
       -X github.com/docker/compose/v2/internal.Version=#{version}
-    ].join(" ")
+    ]
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd"
   end
 

--- a/Formula/docker.rb
+++ b/Formula/docker.rb
@@ -35,7 +35,7 @@ class Docker < Formula
       ldflags = ["-X \"github.com/docker/cli/cli/version.BuildTime=#{time.iso8601}\"",
                  "-X github.com/docker/cli/cli/version.GitCommit=#{Utils.git_short_head}",
                  "-X github.com/docker/cli/cli/version.Version=#{version}",
-                 "-X \"github.com/docker/cli/cli/version.PlatformName=Docker Engine - Community\""].join(" ")
+                 "-X \"github.com/docker/cli/cli/version.PlatformName=Docker Engine - Community\""]
       system "go", "build", *std_go_args(ldflags: ldflags), "github.com/docker/cli/cmd/docker"
 
       Pathname.glob("man/*.[1-8].md") do |md|

--- a/Formula/doctl.rb
+++ b/Formula/doctl.rb
@@ -24,7 +24,7 @@ class Doctl < Formula
       #{base_flag}.Minor=#{version.minor}
       #{base_flag}.Patch=#{version.patch}
       #{base_flag}.Label=release
-    ].join(" ")
+    ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/doctl"
 

--- a/Formula/docui.rb
+++ b/Formula/docui.rb
@@ -19,7 +19,7 @@ class Docui < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w"
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do

--- a/Formula/dolt.rb
+++ b/Formula/dolt.rb
@@ -24,8 +24,8 @@ class Dolt < Formula
   def install
     chdir "go" do
       system "go", "build", *std_go_args, "./cmd/dolt"
-      system "go", "build", *std_go_args, "-o", bin/"git-dolt", "./cmd/git-dolt"
-      system "go", "build", *std_go_args, "-o", bin/"git-dolt-smudge", "./cmd/git-dolt-smudge"
+      system "go", "build", *std_go_args(output: bin/"git-dolt"), "./cmd/git-dolt"
+      system "go", "build", *std_go_args(output: bin/"git-dolt-smudge"), "./cmd/git-dolt-smudge"
     end
   end
 

--- a/Formula/driftctl.rb
+++ b/Formula/driftctl.rb
@@ -23,7 +23,7 @@ class Driftctl < Formula
       -s -w
       -X github.com/cloudskiff/driftctl/build.env=release
       -X github.com/cloudskiff/driftctl/pkg/version.version=v#{version}
-    ].join(" ")
+    ]
 
     system "go", "build", *std_go_args(ldflags: ldflags)
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Homebrew 3.3.6 includes https://github.com/Homebrew/brew/pull/12345, so start cleaning up usages of `std_go_args` to leverage these changes where possible. We will also need to check formulae that don't use `std_go_args` (to b e addressed in a separate PR).