### PR TITLE
ec2-ami-tools: depends on ruby

### DIFF
--- a/Formula/ec2-ami-tools.rb
+++ b/Formula/ec2-ami-tools.rb
@@ -11,6 +11,8 @@ class Ec2AmiTools < Formula
 
   depends_on "openjdk"
 
+  uses_from_macos "ruby"
+
   def install
     env = { JAVA_HOME: Formula["openjdk"].opt_prefix, EC2_AMITOOL_HOME: libexec }
     rm Dir["bin/*.cmd"] # Remove Windows versions


### PR DESCRIPTION
Fixes:
Error: ==> Testing ec2-ami-tools
  ==> /home/linuxbrew/.linuxbrew/Cellar/ec2-ami-tools/1.5.7_2/bin/ec2-ami-tools-version
  /home/linuxbrew/.linuxbrew/Cellar/ec2-ami-tools/1.5.7_2/libexec/bin/ec2-ami-tools-version: line 6: ruby: command not found

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
