### PR TITLE
wildfly-as: disable on Linux due to pre-built binary

### DIFF
--- a/Formula/wildfly-as.rb
+++ b/Formula/wildfly-as.rb
@@ -16,6 +16,8 @@ class WildflyAs < Formula
 
   # Installs a pre-built x86_64-only `libwfssl`
   depends_on arch: :x86_64
+  # Installs a pre-built `libartemis-native-64.so` file with linkage to libaio.so.1
+  depends_on :macos
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
