### PR TITLE
envconsul-htmltest: clean up std_go_args usage

### DIFF
--- a/Formula/envconsul.rb
+++ b/Formula/envconsul.rb
@@ -19,7 +19,7 @@ class Envconsul < Formula
   depends_on "consul" => :test
 
   def install
-    system "go", "build", "-ldflags", "-s -w", *std_go_args
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do

--- a/Formula/fetch.rb
+++ b/Formula/fetch.rb
@@ -19,7 +19,7 @@ class Fetch < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-X main.VERSION=v#{version}", *std_go_args
+    system "go", "build", *std_go_args(ldflags: "-X main.VERSION=v#{version}")
   end
 
   test do

--- a/Formula/ffuf.rb
+++ b/Formula/ffuf.rb
@@ -18,7 +18,7 @@ class Ffuf < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w"
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do

--- a/Formula/fleet-cli.rb
+++ b/Formula/fleet-cli.rb
@@ -29,7 +29,7 @@ class FleetCli < Formula
       -X github.com/rancher/fleet/pkg/version.Version=#{version}
       -X github.com/rancher/fleet/pkg/version.GitCommit=#{Utils.git_short_head}
     ]
-    system "go", "build", *std_go_args, "-ldflags", ldflags.join(" "), "-o", bin/"fleet"
+    system "go", "build", *std_go_args(output: bin/"fleet", ldflags: ldflags)
   end
 
   test do

--- a/Formula/flint-checker.rb
+++ b/Formula/flint-checker.rb
@@ -26,7 +26,7 @@ class FlintChecker < Formula
     ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/pengwynn").mkpath
     ln_sf buildpath, buildpath/"src/github.com/pengwynn/flint"
-    system "go", "build", *std_go_args, "-o", bin/"flint"
+    system "go", "build", *std_go_args(output: bin/"flint")
   end
 
   test do

--- a/Formula/flux.rb
+++ b/Formula/flux.rb
@@ -40,7 +40,7 @@ class Flux < Formula
     # Set up the influxdata pkg-config wrapper to enable just-in-time compilation & linking
     # of the Rust components in the server.
     resource("pkg-config-wrapper").stage do
-      system "go", "build", *std_go_args, "-o", buildpath/"bootstrap/pkg-config"
+      system "go", "build", *std_go_args(output: buildpath/"bootstrap/pkg-config")
     end
     ENV.prepend_path "PATH", buildpath/"bootstrap"
 

--- a/Formula/fsql.rb
+++ b/Formula/fsql.rb
@@ -18,7 +18,7 @@ class Fsql < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w", "./cmd/fsql"
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/fsql"
   end
 
   test do

--- a/Formula/func-e.rb
+++ b/Formula/func-e.rb
@@ -18,7 +18,7 @@ class FuncE < Formula
       -s -w
       -X main.version=#{version}
     ]
-    system "go", "build", *std_go_args(ldflags: ldflags.join(" "))
+    system "go", "build", *std_go_args(ldflags: ldflags)
   end
 
   test do

--- a/Formula/fzf.rb
+++ b/Formula/fzf.rb
@@ -20,7 +20,7 @@ class Fzf < Formula
   uses_from_macos "ncurses"
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.version=#{version} -X main.revision=brew"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version} -X main.revision=brew")
 
     prefix.install "install", "uninstall"
     (prefix/"shell").install %w[bash zsh fish].map { |s| "shell/key-bindings.#{s}" }

--- a/Formula/gateway-go.rb
+++ b/Formula/gateway-go.rb
@@ -26,7 +26,7 @@ class GatewayGo < Formula
       -X main.commit=#{Utils.git_head}
       -X main.builtBy=homebrew
     ]
-    system "go", "build", "-mod=vendor", "-ldflags", ldflags.join(" "), *std_go_args
+    system "go", "build", "-mod=vendor", *std_go_args(ldflags: ldflags)
     (etc/"gateway-go").install "gateway-go.yaml"
   end
 

--- a/Formula/gdu.rb
+++ b/Formula/gdu.rb
@@ -27,7 +27,7 @@ class Gdu < Formula
       -X "github.com/dundee/gdu/v#{major}/build.Version=v#{version}"
       -X "github.com/dundee/gdu/v#{major}/build.Time=#{time}"
       -X "github.com/dundee/gdu/v#{major}/build.User=#{user}"
-    ].join(" ")
+    ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/gdu"
   end

--- a/Formula/git-hooks-go.rb
+++ b/Formula/git-hooks-go.rb
@@ -21,7 +21,7 @@ class GitHooksGo < Formula
   conflicts_with "git-hooks", because: "both install `git-hooks` binaries"
 
   def install
-    system "go", "build", *std_go_args, "-o", "#{bin}/git-hooks"
+    system "go", "build", *std_go_args(output: bin/"git-hooks")
   end
 
   test do

--- a/Formula/git-hound.rb
+++ b/Formula/git-hound.rb
@@ -19,7 +19,7 @@ class GitHound < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-X main.version=#{version}"
+    system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}")
   end
 
   test do

--- a/Formula/git-town.rb
+++ b/Formula/git-town.rb
@@ -21,7 +21,7 @@ class GitTown < Formula
     ldflags = %W[
       -X github.com/git-town/git-town/src/cmd.version=v#{version}
       -X github.com/git-town/git-town/src/cmd.buildDate=#{time.strftime("%Y/%m/%d")}
-    ].join(" ")
+    ]
     system "go", "build", *std_go_args(ldflags: ldflags)
   end
 

--- a/Formula/github-markdown-toc.rb
+++ b/Formula/github-markdown-toc.rb
@@ -18,7 +18,7 @@ class GithubMarkdownToc < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-o", bin/"gh-md-toc"
+    system "go", "build", *std_go_args(output: bin/"gh-md-toc")
   end
 
   test do

--- a/Formula/gitlab-runner.rb
+++ b/Formula/gitlab-runner.rb
@@ -31,7 +31,7 @@ class GitlabRunner < Formula
       -X #{proj}/common.REVISION=#{Utils.git_short_head(length: 8)}
       -X #{proj}/common.BRANCH=#{version.major}-#{version.minor}-stable
       -X #{proj}/common.BUILT=#{time.strftime("%Y-%m-%dT%H:%M:%S%:z")}
-    ].join(" ")
+    ]
     system "go", "build", *std_go_args(ldflags: ldflags)
   end
 

--- a/Formula/glide.rb
+++ b/Formula/glide.rb
@@ -29,7 +29,7 @@ class Glide < Formula
     glidepath.install buildpath.children
 
     cd glidepath do
-      system "go", "build", *std_go_args, "-ldflags", "-X main.version=#{version}"
+      system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}")
     end
   end
 

--- a/Formula/go-statik.rb
+++ b/Formula/go-statik.rb
@@ -21,8 +21,7 @@ class GoStatik < Formula
   conflicts_with "statik", because: "both install `statik` binaries"
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w"
-    mv bin/"go-statik", bin/"statik"
+    system "go", "build", *std_go_args(output: bin/"statik", ldflags: "-s -w")
   end
 
   test do

--- a/Formula/gojq.rb
+++ b/Formula/gojq.rb
@@ -25,7 +25,7 @@ class Gojq < Formula
       -s -w
       -X github.com/itchyny/gojq/cli.revision=#{revision}
     ]
-    system "go", "build", "-ldflags", ldflags.join(" "), *std_go_args, "./cmd/gojq"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/gojq"
     zsh_completion.install "_gojq"
   end
 

--- a/Formula/golangci-lint.rb
+++ b/Formula/golangci-lint.rb
@@ -24,7 +24,7 @@ class GolangciLint < Formula
       -X main.version=#{version}
       -X main.commit=#{Utils.git_short_head(length: 7)}
       -X main.date=#{time.rfc3339}
-    ].join(" ")
+    ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/golangci-lint"
 

--- a/Formula/gopass-jsonapi.rb
+++ b/Formula/gopass-jsonapi.rb
@@ -18,7 +18,7 @@ class GopassJsonapi < Formula
   depends_on "gopass"
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.version=#{version}"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}")
   end
 
   test do

--- a/Formula/gor.rb
+++ b/Formula/gor.rb
@@ -28,7 +28,7 @@ class Gor < Formula
   uses_from_macos "libpcap"
 
   def install
-    system "go", "build", "-ldflags", "-X main.VERSION=#{version}", *std_go_args
+    system "go", "build", *std_go_args(ldflags: "-X main.VERSION=#{version}")
   end
 
   test do

--- a/Formula/goreleaser.rb
+++ b/Formula/goreleaser.rb
@@ -24,7 +24,7 @@ class Goreleaser < Formula
       -X main.version=#{version}
       -X main.commit=#{Utils.git_head}
       -X main.builtBy=homebrew
-    ].join(" ")
+    ]
 
     system "go", "build", *std_go_args(ldflags: ldflags)
 

--- a/Formula/gosec.rb
+++ b/Formula/gosec.rb
@@ -18,7 +18,7 @@ class Gosec < Formula
   depends_on "go"
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-X main.version=v#{version}", "./cmd/gosec"
+    system "go", "build", *std_go_args(ldflags: "-X main.version=v#{version}"), "./cmd/gosec"
   end
 
   test do

--- a/Formula/gostatic.rb
+++ b/Formula/gostatic.rb
@@ -18,7 +18,7 @@ class Gostatic < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w"
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do

--- a/Formula/gotop.rb
+++ b/Formula/gotop.rb
@@ -18,9 +18,11 @@ class Gotop < Formula
   depends_on "go" => :build
 
   def install
-    time = `date +%Y%m%dT%H%M%S`.chomp
-    system "go", "build", *std_go_args, "-ldflags",
-           "-X main.Version=#{version} -X main.BuildDate=#{time}", "./cmd/gotop"
+    ldflags = %W[
+      -X main.Version=#{version}
+      -X main.BuildDate=#{time.strftime("%Y%m%dT%H%M%S")}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/gotop"
   end
 
   test do

--- a/Formula/gron.rb
+++ b/Formula/gron.rb
@@ -19,7 +19,7 @@ class Gron < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w"
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do

--- a/Formula/grpcui.rb
+++ b/Formula/grpcui.rb
@@ -18,7 +18,7 @@ class Grpcui < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-X main.version=#{version}", "./cmd/grpcui"
+    system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}"), "./cmd/grpcui"
   end
 
   test do

--- a/Formula/grpcurl.rb
+++ b/Formula/grpcurl.rb
@@ -18,7 +18,7 @@ class Grpcurl < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-X main.version=#{version}", "./cmd/grpcurl"
+    system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}"), "./cmd/grpcurl"
   end
 
   test do

--- a/Formula/h2spec.rb
+++ b/Formula/h2spec.rb
@@ -27,7 +27,7 @@ class H2spec < Formula
       -X main.VERSION=#{version}
       -X main.COMMIT=#{commit}
     ]
-    system "go", "build", *std_go_args, "-ldflags", ldflags.join(" "), "./cmd/h2spec"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/h2spec"
   end
 
   test do

--- a/Formula/hcloud.rb
+++ b/Formula/hcloud.rb
@@ -18,7 +18,7 @@ class Hcloud < Formula
 
   def install
     ldflags = "-s -w -X github.com/hetznercloud/cli/internal/version.Version=v#{version}"
-    system "go", "build", *std_go_args, "-ldflags", ldflags, "./cmd/hcloud"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/hcloud"
 
     output = Utils.safe_popen_read("#{bin}/hcloud", "completion", "bash")
     (bash_completion/"hcloud").write output

--- a/Formula/helmsman.rb
+++ b/Formula/helmsman.rb
@@ -21,7 +21,7 @@ class Helmsman < Formula
   depends_on "kubernetes-cli"
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.version=#{version}", "./cmd/helmsman"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./cmd/helmsman"
     pkgshare.install "examples/example.yaml"
   end
 

--- a/Formula/hostess.rb
+++ b/Formula/hostess.rb
@@ -20,7 +20,7 @@ class Hostess < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.version=#{version}"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}")
   end
 
   test do

--- a/Formula/htmltest.rb
+++ b/Formula/htmltest.rb
@@ -21,7 +21,7 @@ class Htmltest < Formula
     ldflags = %W[
       -X main.date=#{time.iso8601}
       -X main.version=#{version}
-    ].join(" ")
+    ]
     system "go", "build", *std_go_args(ldflags: ldflags)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Homebrew 3.3.6 includes https://github.com/Homebrew/brew/pull/12345, so start cleaning up usages of `std_go_args` to leverage these changes where possible. We will also need to check formulae that don't use `std_go_args` (to be addressed in a separate PR).