### PR TITLE
apache-ctakes: fix url, deprecate

### DIFF
--- a/Formula/apache-ctakes.rb
+++ b/Formula/apache-ctakes.rb
@@ -1,8 +1,9 @@
 class ApacheCtakes < Formula
   desc "NLP system for extraction of information from EMR clinical text"
   homepage "https://ctakes.apache.org"
-  url "https://apache.claz.org/ctakes/ctakes-4.0.0.1/apache-ctakes-4.0.0.1-bin.tar.gz"
+  url "https://dlcdn.apache.org//ctakes/ctakes-4.0.0.1/apache-ctakes-4.0.0.1-bin.tar.gz"
   sha256 "f741016e3755054876f3bb27f916a8008af27175ef33785638a6292d300c972e"
+  license "Apache-2.0"
 
   livecheck do
     url "https://ctakes.apache.org/downloads.cgi"
@@ -12,6 +13,8 @@ class ApacheCtakes < Formula
   bottle do
     sha256 cellar: :any_skip_relocation, all: "99b42543678adc7a3d3ae931e52130a48fda2f46df7b5de143f7efb708de31ef"
   end
+
+  deprecate! date: "2021-12-21", because: "installs binaries and does not build from source"
 
   depends_on "openjdk"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
