### PR TITLE
mt32emu 2.5.3 (new formula)

### DIFF
--- a/Formula/mt32emu.rb
+++ b/Formula/mt32emu.rb
@@ -1,0 +1,36 @@
+class Mt32emu < Formula
+  desc "Multi-platform software synthesiser"
+  homepage "https://github.com/munt/munt"
+  url "https://github.com/munt/munt/archive/refs/tags/libmt32emu_2_5_3.tar.gz"
+  sha256 "062d110bbdd7253d01ef291f57e89efc3ee35fd087587458381f054bac49a8f5"
+  license "LGPL-2.1-or-later"
+
+  livecheck do
+    url :stable
+    regex(/^libmt32emu[._-]v?(\d+(?:[._-]\d+)+)$/i)
+  end
+
+  depends_on "cmake" => :build
+  depends_on "libsamplerate"
+  depends_on "libsoxr"
+
+  def install
+    system "cmake", "-S", "mt32emu", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"mt32emu-test.c").write <<~EOS
+      #include "mt32emu.h"
+      #include <stdio.h>
+      int main() {
+        printf("%s", mt32emu_get_library_version_string());
+      }
+    EOS
+
+    ENV.append_to_cflags "-lmt32emu"
+    system "make", "mt32emu-test"
+    assert_match version.to_s, shell_output("./mt32emu-test")
+  end
+end

--- a/Formula/mt32emu.rb
+++ b/Formula/mt32emu.rb
@@ -29,8 +29,7 @@ class Mt32emu < Formula
       }
     EOS
 
-    ENV.append_to_cflags "-lmt32emu"
-    system "make", "mt32emu-test"
+    system ENV.cc, "mt32emu-test.c", "-I#{include}", "-L#{lib}", "-lmt32emu", "-o", "mt32emu-test"
     assert_match version.to_s, shell_output("./mt32emu-test")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is needed to enable MT32 emulation in dosbox-staging. See
dosbox-staging/dosbox-staging#1270.