### PR TITLE
q: deprecate

### DIFF
--- a/Formula/q.rb
+++ b/Formula/q.rb
@@ -17,6 +17,8 @@ class Q < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "bed14a331133ff96b85fa37e0729ca695bd273f78ee82e792185d137edf9917a"
   end
 
+  deprecate! date: "2021-11-30", because: "requires PyOxidizer, which is a disallowed dependency in homebrew/core"
+
   depends_on "ronn" => :build
   depends_on "python@3.9"
   depends_on "six"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula now requires `pyoxidizer` to build, which will embed its
own (non-Homebrew) version of Python into the resulting binaries.

We can un-deprecate this if there is a way to build this without
`pyoxidizer` in the future.

See:
- Homebrew/homebrew-core#90025
- Homebrew/brew#12493

Closes #90025.