### PR TITLE
dosbox-staging: enable mt32 emulation support

### DIFF
--- a/Formula/dosbox-staging.rb
+++ b/Formula/dosbox-staging.rb
@@ -4,6 +4,7 @@ class DosboxStaging < Formula
   url "https://github.com/dosbox-staging/dosbox-staging/archive/v0.77.1.tar.gz"
   sha256 "85359efb7cd5c5c0336d88bdf023b7b462a8233490e00274fef0b85cca2f5f3c"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/dosbox-staging/dosbox-staging.git"
 
   bottle do
@@ -20,13 +21,14 @@ class DosboxStaging < Formula
   depends_on "pkg-config" => :build
   depends_on "fluid-synth"
   depends_on "libpng"
+  depends_on "mt32emu"
   depends_on "opusfile"
   depends_on "sdl2"
   depends_on "sdl2_net"
 
   def install
     mkdir "build" do
-      system "meson", *std_meson_args, "-Duse_mt32emu=false", ".."
+      system "meson", *std_meson_args, "-Db_lto=true", ".."
       system "ninja", "-v"
       system "ninja", "install", "-v"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

MT32 emulation was disabled in ce048c52d717f1b554d6ee09f2fd5dbc40de9641
because it required a dependency not available in Homebrew/core.

`mt32emu` is now available as of aa12751ff3da3a43962fdb6d99a702272feac040
so we no longer need to disable it. This feature is enabled by default.

While we're here, let's enable LTO as recommended by upstream.

Fixes dosbox-staging/dosbox-staging#1270.