### PR TITLE
haskell-language-server: use `ncurses` and `zlib` from macOS

### DIFF
--- a/Formula/haskell-language-server.rb
+++ b/Formula/haskell-language-server.rb
@@ -30,6 +30,9 @@ class HaskellLanguageServer < Formula
     depends_on "ghc@8.8" => [:build, :test]
   end
 
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
   def ghcs
     deps.map(&:to_formula)
         .select { |f| f.name.match? "ghc" }


### PR DESCRIPTION
Fixes a `brew linkage --strict` ~~error~~warning from #90160:

    Undeclared dependencies with linkage:
      ncurses
      zlib
