### PR TITLE
q: deprecate

### DIFF
--- a/Formula/q.rb
+++ b/Formula/q.rb
@@ -17,7 +17,7 @@ class Q < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "bed14a331133ff96b85fa37e0729ca695bd273f78ee82e792185d137edf9917a"
   end
 
-  deprecate! date: "2021-11-30", because: "q has moved to its own tap. Use `brew install harelba/q/q` to install"
+  deprecate! date: "2021-11-30", because: "Installation changed. Please take a look at https://harelba.github.io/q/"
 
   depends_on "ronn" => :build
   depends_on "python@3.9"

--- a/Formula/q.rb
+++ b/Formula/q.rb
@@ -17,7 +17,7 @@ class Q < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "bed14a331133ff96b85fa37e0729ca695bd273f78ee82e792185d137edf9917a"
   end
 
-  deprecate! date: "2021-11-30", because: "q has moved from homebrew-core to its own tap. Use `brew install harelba/q/q`"
+  deprecate! date: "2021-11-30", because: "q has moved to its own tap. Use `brew install harelba/q/q` to install"
 
   depends_on "ronn" => :build
   depends_on "python@3.9"

--- a/Formula/q.rb
+++ b/Formula/q.rb
@@ -17,7 +17,7 @@ class Q < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "bed14a331133ff96b85fa37e0729ca695bd273f78ee82e792185d137edf9917a"
   end
 
-  deprecate! date: "2021-11-30", because: "Installation changed. Please take a look at https://harelba.github.io/q/"
+  deprecate! date: "2021-11-30", because: "requires PyOxidizer, which is a disallowed dependency in homebrew/core"
 
   depends_on "ronn" => :build
   depends_on "python@3.9"
@@ -29,6 +29,12 @@ class Q < Formula
     virtualenv_install_with_resources
     system "ronn", "--roff", "--section=1", "doc/USAGE.markdown"
     man1.install "doc/USAGE.1" => "q.1"
+  end
+
+  def caveats
+    <<~EOS
+      q is moving out of homebrew-core. See the web site for details.
+    EOS
   end
 
   test do

--- a/Formula/q.rb
+++ b/Formula/q.rb
@@ -17,7 +17,7 @@ class Q < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "bed14a331133ff96b85fa37e0729ca695bd273f78ee82e792185d137edf9917a"
   end
 
-  deprecate! date: "2021-11-30", because: "requires PyOxidizer, which is a disallowed dependency in homebrew/core"
+  deprecate! date: "2021-11-30", because: "q has moved from homebrew-core to its own tap. Use `brew install harelba/q/q`"
 
   depends_on "ronn" => :build
   depends_on "python@3.9"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Updating q deprecation warning to point to the new tap, so people can easily find it if they upgrade/install.