### PR TITLE
mrbayes: revision bump for Linux

### DIFF
--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -4,6 +4,7 @@ class Mrbayes < Formula
   url "https://github.com/NBISweden/MrBayes/archive/v3.2.7a.tar.gz"
   sha256 "3eed2e3b1d9e46f265b6067a502a89732b6f430585d258b886e008e846ecc5c6"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/NBISweden/MrBayes.git", branch: "develop"
 
   livecheck do


### PR DESCRIPTION
Fixes:
Thread 1 "mb" received signal SIGILL, Illegal instruction.
0x00000000004a869b in SetUpMoveTypes ()

(gdb)  bt full
#0  0x00000000004a869b in SetUpMoveTypes ()
No symbol table info available.
#1  0x00000000004046cf in InitializeMrBayes ()
No symbol table info available.
#2  0x000000000040376d in main ()
No symbol table info available.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
