### PR TITLE
semgrep: fix linkage to gcc on Linux

### DIFF
--- a/Formula/semgrep.rb
+++ b/Formula/semgrep.rb
@@ -7,6 +7,7 @@ class Semgrep < Formula
       tag:      "v0.75.0",
       revision: "d786313c7bfdaac0c53e07cffc6fcb91a1b5c0ee"
   license "LGPL-2.1-only"
+  revision 1
   head "https://github.com/returntocorp/semgrep.git", branch: "develop"
 
   livecheck do
@@ -36,7 +37,7 @@ class Semgrep < Formula
   uses_from_macos "rsync" => :build
 
   on_linux do
-    depends_on "gcc" => [:build, :test]
+    depends_on "gcc"
   end
 
   fails_with gcc: "5"


### PR DESCRIPTION
The current bottle ships a semgrep that links against gcc,
which went unnoticed before.
This change makes the linkage explicit.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
