### PR TITLE
envoy: bump to 1.20.1

### DIFF
--- a/Formula/envoy.rb
+++ b/Formula/envoy.rb
@@ -4,8 +4,8 @@ class Envoy < Formula
   # Switch to a tarball when the following issue is resolved:
   # https://github.com/envoyproxy/envoy/issues/2181
   url "https://github.com/envoyproxy/envoy.git",
-      tag:      "v1.20.0",
-      revision: "96701cb24611b0f3aac1cc0dd8bf8589fbdf8e9e"
+      tag:      "v1.20.1",
+      revision: "ea23f47b27464794980c05ab290a3b73d801405e"
   license "Apache-2.0"
 
   # Apple M1/arm64 is pending envoyproxy/envoy#16482


### PR DESCRIPTION
Note: This is supposed to fix macOS 12/Monterey, but does not fix arm64.

See #87708
See https://github.com/envoyproxy/envoy/blob/ea23f47b27464794980c05ab290a3b73d801405e/docs/root/version_history/current.rst

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
