### PR TITLE
urdfdom: set CMAKE_INSTALL_RPATH

### DIFF
--- a/Formula/urdfdom.rb
+++ b/Formula/urdfdom.rb
@@ -27,8 +27,9 @@ class Urdfdom < Formula
 
   def install
     ENV.cxx11
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do
@@ -48,5 +49,44 @@ class Urdfdom < Formula
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lurdfdom_world", "-std=c++11",
                     "-o", "test"
     system "./test"
+
+    (testpath/"test.xml").write <<~EOS
+      <robot name="test">
+        <joint name="j1" type="fixed">
+          <parent link="l1"/>
+          <child link="l2"/>
+        </joint>
+        <joint name="j2" type="fixed">
+          <parent link="l1"/>
+          <child link="l2"/>
+        </joint>
+        <link name="l1">
+          <visual>
+            <geometry>
+              <sphere radius="1.349"/>
+            </geometry>
+            <material name="">
+              <color rgba="1.0 0.65 0.0 0.01" />
+            </material>
+          </visual>
+          <inertial>
+            <mass value="8.4396"/>
+            <inertia ixx="0.087" ixy="0.14" ixz="0.912" iyy="0.763" iyz="0.0012" izz="0.908"/>
+          </inertial>
+        </link>
+        <link name="l2">
+          <visual>
+            <geometry>
+              <cylinder radius="3.349" length="7.5490"/>
+            </geometry>
+            <material name="red ish">
+              <color rgba="1 0.0001 0.0 1" />
+            </material>
+          </visual>
+        </link>
+      </robot>
+    EOS
+
+    system "#{bin}/check_urdf", testpath/"test.xml"
   end
 end


### PR DESCRIPTION
This fixes crashes on Arm due to rpath not found.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
