### PR TITLE
lemon: add comment to re-sync version with sqlite

### DIFF
--- a/Formula/lemon.rb
+++ b/Formula/lemon.rb
@@ -1,6 +1,8 @@
 class Lemon < Formula
   desc "LALR(1) parser generator like yacc or bison"
   homepage "https://www.hwaci.com/sw/lemon/"
+  # FIXME: Add this back to `synced_versions_formula.json` when
+  #        this is updated to 3.37.0.
   url "https://www.sqlite.org/2021/sqlite-src-3360000.zip"
   version "3.36.0"
   sha256 "25a3b9d08066b3a9003f06a96b2a8d1348994c29cc912535401154501d875324"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The test is failing for 3.37.0, and it's not very clear how to fix it.
I've dropped the version bump from #90059, but let's add it back to the
synced versions list when this is fixed.