### PR TITLE
bug.yml: fix missing `label` property

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: New issue for Reproducible Bug
 description: "If you're sure it's reproducible and not just your machine: submit an issue so we can investigate."
-labels: bug
+labels: [bug]
 body:
   - type: markdown
     attributes:
@@ -13,6 +13,7 @@ body:
       required: true
   - type: checkboxes
     attributes:
+      label: Verification
       description: Please verify that you've followed these steps.
       options:
         - label: I ran `brew update` and am still able to reproduce my issue.


### PR DESCRIPTION
Submitting bug reports hasn't worked for a while because of the missing
`label`.

My editor complained about `labels` needing to be an array, so I've made
that one too. It was also complaining about the missing label property
for the checkboxes, so I guess it knows what it's talking about here.

See https://github.com/Homebrew/discussions/discussions/2526#discussioncomment-1731168
