### PR TITLE
iamy-nfpm: clean up std_go_args usage

### DIFF
--- a/Formula/hasura-cli.rb
+++ b/Formula/hasura-cli.rb
@@ -25,7 +25,7 @@ class HasuraCli < Formula
       -s -w
       -X github.com/hasura/graphql-engine/cli/v2/version.BuildVersion=#{version}
       -X github.com/hasura/graphql-engine/cli/v2/plugins.IndexBranchRef=master
-    ].join(" ")
+    ]
 
     # Based on `make build-cli-ext`, but only build a single host-specific binary
     cd "cli-ext" do
@@ -39,7 +39,7 @@ class HasuraCli < Formula
       os = OS.kernel_name.downcase
 
       cp "../cli-ext/bin/cli-ext-hasura", "./internal/cliext/static-bin/#{os}/#{arch}/cli-ext"
-      system "go", "build", *std_go_args(ldflags: ldflags), "-o", bin/"hasura", "./cmd/hasura/"
+      system "go", "build", *std_go_args(output: bin/"hasura", ldflags: ldflags), "./cmd/hasura/"
 
       output = Utils.safe_popen_read("#{bin}/hasura", "completion", "bash")
       (bash_completion/"hasura").write output

--- a/Formula/iamy.rb
+++ b/Formula/iamy.rb
@@ -20,8 +20,7 @@ class Iamy < Formula
   depends_on "awscli"
 
   def install
-    system "go", "build", *std_go_args, "-ldflags",
-            "-s -w -X main.Version=v#{version}"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.Version=v#{version}")
   end
 
   test do

--- a/Formula/influxdb-cli.rb
+++ b/Formula/influxdb-cli.rb
@@ -30,10 +30,9 @@ class InfluxdbCli < Formula
       -X main.version=#{version}
       -X main.commit=#{Utils.git_short_head(length: 10)}
       -X main.date=#{time.iso8601}
-    ].join(" ")
+    ]
 
-    system "go", "build", *std_go_args(ldflags: ldflags),
-           "-o", bin/"influx", "./cmd/influx"
+    system "go", "build", *std_go_args(output: bin/"influx", ldflags: ldflags), "./cmd/influx"
 
     bash_complete = buildpath/"bash-completion"
     bash_complete.write Utils.safe_popen_read(bin/"influx", "completion", "bash")

--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -46,7 +46,7 @@ class Influxdb < Formula
     # Set up the influxdata pkg-config wrapper to enable just-in-time compilation & linking
     # of the Rust components in the server.
     resource("pkg-config-wrapper").stage do
-      system "go", "build", *std_go_args, "-o", buildpath/"bootstrap/pkg-config"
+      system "go", "build", *std_go_args(output: buildpath/"bootstrap/pkg-config")
     end
     ENV.prepend_path "PATH", buildpath/"bootstrap"
 
@@ -63,10 +63,10 @@ class Influxdb < Formula
       -X main.version=#{version}
       -X main.commit=#{Utils.git_short_head(length: 10)}
       -X main.date=#{time.iso8601}
-    ].join(" ")
+    ]
 
-    system "go", "build", *std_go_args(ldflags: ldflags),
-           "-tags", "assets,sqlite_foreign_keys,sqlite_json", "-o", bin/"influxd", "./cmd/influxd"
+    system "go", "build", *std_go_args(output: bin/"influxd", ldflags: ldflags),
+           "-tags", "assets,sqlite_foreign_keys,sqlite_json", "./cmd/influxd"
 
     data = var/"lib/influxdb2"
     data.mkpath

--- a/Formula/influxdb@1.rb
+++ b/Formula/influxdb@1.rb
@@ -27,7 +27,7 @@ class InfluxdbAT1 < Formula
     ldflags = "-s -w -X main.version=#{version}"
 
     %w[influxd influx influx_stress influx_inspect].each do |f|
-      system "go", "build", "-ldflags", ldflags, *std_go_args, "-o", bin/f, "./cmd/#{f}"
+      system "go", "build", *std_go_args(output: bin/f, ldflags: ldflags), "./cmd/#{f}"
     end
 
     etc.install "etc/config.sample.toml" => "influxdb.conf"

--- a/Formula/infracost.rb
+++ b/Formula/infracost.rb
@@ -21,7 +21,7 @@ class Infracost < Formula
   def install
     ENV["CGO_ENABLED"] = "0"
     ldflags = "-X github.com/infracost/infracost/internal/version.Version=v#{version}"
-    system "go", "build", *std_go_args, "-ldflags", ldflags, "./cmd/infracost"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/infracost"
   end
 
   test do

--- a/Formula/jd.rb
+++ b/Formula/jd.rb
@@ -18,7 +18,7 @@ class Jd < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w"
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do

--- a/Formula/juju.rb
+++ b/Formula/juju.rb
@@ -30,13 +30,8 @@ class Juju < Formula
       -X version.GitCommit=#{Utils.git_head}
       -X version.GitTreeState=clean
     ]
-    system "go", "build", *std_go_args,
-                 "-ldflags", ld_flags.join(" "),
-                 "./cmd/juju"
-    system "go", "build", *std_go_args,
-                 "-ldflags", ld_flags.join(" "),
-                 "-o", bin/"juju-metadata",
-                 "./cmd/plugins/juju-metadata"
+    system "go", "build", *std_go_args(ldflags: ld_flags), "./cmd/juju"
+    system "go", "build", *std_go_args(output: bin/"juju-metadata", ldflags: ld_flags), "./cmd/plugins/juju-metadata"
     bash_completion.install "etc/bash_completion.d/juju"
   end
 

--- a/Formula/k3d.rb
+++ b/Formula/k3d.rb
@@ -37,7 +37,7 @@ class K3d < Formula
 
     system "go", "build",
            "-mod", "vendor",
-           *std_go_args(ldflags: ldflags.join(" "))
+           *std_go_args(ldflags: ldflags)
 
     # Install bash completion
     output = Utils.safe_popen_read(bin/"k3d", "completion", "bash")

--- a/Formula/k3sup.rb
+++ b/Formula/k3sup.rb
@@ -30,7 +30,7 @@ class K3sup < Formula
       -X github.com/alexellis/k3sup/cmd.Version=#{version}
       -X github.com/alexellis/k3sup/cmd.GitCommit=#{Utils.git_short_head}
     ]
-    system "go", "build", "-ldflags", ldflags.join(" "), *std_go_args
+    system "go", "build", *std_go_args(ldflags: ldflags)
   end
 
   test do

--- a/Formula/k9s.rb
+++ b/Formula/k9s.rb
@@ -19,10 +19,12 @@ class K9s < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags",
-             "-s -w -X github.com/derailed/k9s/cmd.version=#{version}
-             -X github.com/derailed/k9s/cmd.commit=#{Utils.git_head}",
-             *std_go_args
+    ldflags = %W[
+      -s -w
+      -X github.com/derailed/k9s/cmd.version=#{version}
+      -X github.com/derailed/k9s/cmd.commit=#{Utils.git_head}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags)
 
     bash_output = Utils.safe_popen_read(bin/"k9s", "completion", "bash")
     (bash_completion/"k9s").write bash_output

--- a/Formula/karn.rb
+++ b/Formula/karn.rb
@@ -18,7 +18,7 @@ class Karn < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w", "./cmd/karn/karn.go"
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/karn/karn.go"
   end
 
   test do

--- a/Formula/keptn.rb
+++ b/Formula/keptn.rb
@@ -22,7 +22,7 @@ class Keptn < Formula
       -s -w
       -X main.Version=#{version}
       -X main.KubeServerVersionConstraints=""
-    ].join(" ")
+    ]
 
     cd buildpath/"cli" do
       system "go", "build", *std_go_args(ldflags: ldflags)

--- a/Formula/kertish-dfs.rb
+++ b/Formula/kertish-dfs.rb
@@ -19,10 +19,10 @@ class KertishDfs < Formula
 
   def install
     cd "fs-tool" do
-      system "go", "build", *std_go_args, "-ldflags", "-X main.version=#{version}", "-o", "#{bin}/krtfs"
+      system "go", "build", *std_go_args(output: bin/"krtfs", ldflags: "-X main.version=#{version}")
     end
     cd "admin-tool" do
-      system "go", "build", *std_go_args, "-ldflags", "-X main.version=#{version}", "-o", "#{bin}/krtadm"
+      system "go", "build", *std_go_args(output: bin/"krtadm", ldflags: "-X main.version=#{version}")
     end
   end
 

--- a/Formula/kn.rb
+++ b/Formula/kn.rb
@@ -25,7 +25,7 @@ class Kn < Formula
       -X knative.dev/client/pkg/kn/commands/version.Version=v#{version}
       -X knative.dev/client/pkg/kn/commands/version.GitRevision=#{Utils.git_head(length: 8)}
       -X knative.dev/client/pkg/kn/commands/version.BuildDate=#{time.iso8601}
-    ].join(" ")
+    ]
 
     system "go", "build", "-mod=vendor", *std_go_args(ldflags: ldflags), "./cmd/..."
   end

--- a/Formula/ko.rb
+++ b/Formula/ko.rb
@@ -18,8 +18,7 @@ class Ko < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags",
-      "-s -w -X github.com/google/ko/pkg/commands.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/google/ko/pkg/commands.Version=#{version}")
 
     bash_output = Utils.safe_popen_read(bin/"ko", "completion")
     (bash_completion/"ko").write bash_output

--- a/Formula/ksync.rb
+++ b/Formula/ksync.rb
@@ -34,7 +34,7 @@ class Ksync < Formula
       -X #{project}/pkg/ksync.BuildDate=#{time.rfc3339(9)}
       -X #{project}/pkg/ksync.VersionString=#{tap.user}
       -X #{project}/pkg/ksync.GoVersion=go#{Formula["go"].version}
-    ].join(" ")
+    ]
     system "go", "build", *std_go_args(ldflags: ldflags), "#{project}/cmd/ksync"
   end
 

--- a/Formula/kube-score.rb
+++ b/Formula/kube-score.rb
@@ -24,7 +24,7 @@ class KubeScore < Formula
       -X main.version=#{version}
       -X main.commit=#{Utils.git_head}
       -X main.date=#{time.iso8601}
-    ].join(" ")
+    ]
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/kube-score"
   end
 

--- a/Formula/kubeaudit.rb
+++ b/Formula/kubeaudit.rb
@@ -24,7 +24,7 @@ class Kubeaudit < Formula
       -X github.com/Shopify/kubeaudit/cmd.BuildDate=#{time.strftime("%F")}
     ]
 
-    system "go", "build", "-ldflags", ldflags.join(" "), *std_go_args, "./cmd"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd"
   end
 
   test do

--- a/Formula/kubebuilder.rb
+++ b/Formula/kubebuilder.rb
@@ -29,7 +29,7 @@ class Kubebuilder < Formula
       -X main.gitCommit=#{Utils.git_head}
       -X main.buildDate=#{time.iso8601}
     ]
-    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "./cmd"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd"
 
     output = Utils.safe_popen_read(bin/"kubebuilder", "completion", "bash")
     (bash_completion/"kubebuilder").write output

--- a/Formula/kubecm.rb
+++ b/Formula/kubecm.rb
@@ -17,9 +17,7 @@ class Kubecm < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build",
-           "-ldflags", "-X github.com/sunny0826/kubecm/cmd.kubecmVersion=#{version}",
-           *std_go_args
+    system "go", "build", *std_go_args(ldflags: "-X github.com/sunny0826/kubecm/cmd.kubecmVersion=#{version}")
 
     # Install bash completion
     output = Utils.safe_popen_read("#{bin}/kubecm", "completion", "bash")

--- a/Formula/kubeprod.rb
+++ b/Formula/kubeprod.rb
@@ -19,7 +19,7 @@ class Kubeprod < Formula
 
   def install
     cd "kubeprod" do
-      system "go", "build", *std_go_args, "-ldflags", "-X main.version=v#{version}", "-mod=vendor"
+      system "go", "build", *std_go_args(ldflags: "-X main.version=v#{version}"), "-mod=vendor"
     end
   end
 

--- a/Formula/kubespy.rb
+++ b/Formula/kubespy.rb
@@ -19,8 +19,7 @@ class Kubespy < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args,
-              "-ldflags", "-X github.com/pulumi/kubespy/version.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags: "-X github.com/pulumi/kubespy/version.Version=#{version}")
   end
 
   test do

--- a/Formula/kubeval.rb
+++ b/Formula/kubeval.rb
@@ -24,7 +24,7 @@ class Kubeval < Formula
       -X main.version=#{version}
       -X main.commit=#{Utils.git_head}
       -X main.date=#{time.iso8601}
-    ].join(" ")
+    ]
     system "go", "build", *std_go_args(ldflags: ldflags)
 
     pkgshare.install "fixtures"

--- a/Formula/kumactl.rb
+++ b/Formula/kumactl.rb
@@ -27,7 +27,7 @@ class Kumactl < Formula
       -X github.com/kumahq/kuma/pkg/version.version=#{version}
       -X github.com/kumahq/kuma/pkg/version.gitTag=#{version}
       -X github.com/kumahq/kuma/pkg/version.buildDate=#{time.strftime("%F")}
-    ].join(" ")
+    ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./app/kumactl"
 

--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -32,7 +32,7 @@ class Kustomize < Formula
         -X sigs.k8s.io/kustomize/api/provenance.version=#{name}/v#{version}
         -X sigs.k8s.io/kustomize/api/provenance.gitCommit=#{commit}
         -X sigs.k8s.io/kustomize/api/provenance.buildDate=#{time.iso8601}
-      ].join(" ")
+      ]
 
       system "go", "build", *std_go_args(ldflags: ldflags)
     end

--- a/Formula/kyma-cli.rb
+++ b/Formula/kyma-cli.rb
@@ -24,9 +24,9 @@ class KymaCli < Formula
       -X github.com/kyma-project/cli/cmd/kyma/version.Version=#{version}
       -X github.com/kyma-project/cli/cmd/kyma/install.DefaultKymaVersion=#{version}
       -X github.com/kyma-project/cli/cmd/kyma/upgrade.DefaultKymaVersion=#{version}
-    ].join(" ")
+    ]
 
-    system "go", "build", *std_go_args, "-o", bin/"kyma", "-ldflags", ldflags, "./cmd"
+    system "go", "build", *std_go_args(output: bin/"kyma", ldflags: ldflags), "./cmd"
   end
 
   test do

--- a/Formula/lab.rb
+++ b/Formula/lab.rb
@@ -20,7 +20,7 @@ class Lab < Formula
 
   def install
     ldflags = "-X main.version=#{version} -s -w"
-    system "go", "build", *std_go_args, "-ldflags=#{ldflags}"
+    system "go", "build", *std_go_args(ldflags: ldflags)
     output = Utils.safe_popen_read("#{bin}/lab", "completion", "bash")
     (bash_completion/"lab").write output
     output = Utils.safe_popen_read("#{bin}/lab", "completion", "zsh")

--- a/Formula/lean-cli.rb
+++ b/Formula/lean-cli.rb
@@ -19,11 +19,7 @@ class LeanCli < Formula
 
   def install
     build_from = build.head? ? "homebrew-head" : "homebrew"
-    system "go", "build",
-            "-ldflags", "-s -w -X main.pkgType=#{build_from}",
-            *std_go_args,
-            "-o", bin/"lean",
-            "./lean"
+    system "go", "build", *std_go_args(output: bin/"lean", ldflags: "-s -w -X main.pkgType=#{build_from}"), "./lean"
 
     bash_completion.install "misc/lean-bash-completion" => "lean"
     zsh_completion.install "misc/lean-zsh-completion" => "_lean"

--- a/Formula/leaps.rb
+++ b/Formula/leaps.rb
@@ -18,7 +18,7 @@ class Leaps < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w", "./cmd/leaps"
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/leaps"
   end
 
   test do

--- a/Formula/lego.rb
+++ b/Formula/lego.rb
@@ -18,7 +18,7 @@ class Lego < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.version=#{version}", "./cmd/lego"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./cmd/lego"
   end
 
   test do

--- a/Formula/lf.rb
+++ b/Formula/lf.rb
@@ -17,7 +17,7 @@ class Lf < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.gVersion=#{version}"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.gVersion=#{version}")
     man1.install "lf.1"
     zsh_completion.install "etc/lf.zsh" => "_lf"
     fish_completion.install "etc/lf.fish"

--- a/Formula/liqoctl.rb
+++ b/Formula/liqoctl.rb
@@ -22,7 +22,7 @@ class Liqoctl < Formula
     ldflags = %W[
       -s -w
       -X github.com/liqotech/liqo/pkg/liqoctl/version.liqoctlVersion=v#{version}
-    ].join(" ")
+    ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/liqoctl"
 

--- a/Formula/mage.rb
+++ b/Formula/mage.rb
@@ -27,7 +27,7 @@ class Mage < Formula
       -X github.com/magefile/mage/mage.commitHash=#{Utils.git_short_head}
       -X github.com/magefile/mage/mage.gitTag=#{version}
     ]
-    system "go", "build", *std_go_args, "-ldflags", ldflags.join(" ")
+    system "go", "build", *std_go_args(ldflags: ldflags)
   end
 
   test do

--- a/Formula/megacmd.rb
+++ b/Formula/megacmd.rb
@@ -20,7 +20,7 @@ class Megacmd < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w"
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do

--- a/Formula/microplane.rb
+++ b/Formula/microplane.rb
@@ -19,7 +19,7 @@ class Microplane < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.version=#{version}", "-o", bin/"mp"
+    system "go", "build", *std_go_args(output: bin/"mp", ldflags: "-s -w -X main.version=#{version}")
   end
 
   test do

--- a/Formula/minio.rb
+++ b/Formula/minio.rb
@@ -41,7 +41,7 @@ class Minio < Formula
         -X github.com/minio/minio/cmd.CommitID=#{Utils.git_head}
       ]
 
-      system "go", "build", *std_go_args(ldflags: ldflags.join(" "))
+      system "go", "build", *std_go_args(ldflags: ldflags)
     end
   end
 

--- a/Formula/mkcert.rb
+++ b/Formula/mkcert.rb
@@ -19,7 +19,7 @@ class Mkcert < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w -X main.Version=v#{version}"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.Version=v#{version}")
   end
 
   test do

--- a/Formula/nats-server.rb
+++ b/Formula/nats-server.rb
@@ -18,7 +18,7 @@ class NatsServer < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w", *std_go_args
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   service do

--- a/Formula/nfpm.rb
+++ b/Formula/nfpm.rb
@@ -18,7 +18,7 @@ class Nfpm < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-X main.version=v#{version}", *std_go_args, "./cmd/nfpm"
+    system "go", "build", *std_go_args(ldflags: "-X main.version=v#{version}"), "./cmd/nfpm"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Homebrew 3.3.6 includes https://github.com/Homebrew/brew/pull/12345, so start cleaning up usages of `std_go_args` to leverage these changes where possible. We will also need to check formulae that don't use `std_go_args` (to be addressed in a separate PR).