### PR TITLE
swagger2markup-cli: remove superfluous linux bottle

### DIFF
--- a/Formula/swagger2markup-cli.rb
+++ b/Formula/swagger2markup-cli.rb
@@ -8,8 +8,7 @@ class Swagger2markupCli < Formula
 
   bottle do
     rebuild 1
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "021cfe09374afb56b84233fa154091cb7178b45d0c07ed5b4f90c2c8ab1f6ab2"
-    sha256 cellar: :any_skip_relocation, all:          "021cfe09374afb56b84233fa154091cb7178b45d0c07ed5b4f90c2c8ab1f6ab2"
+    sha256 cellar: :any_skip_relocation, all: "021cfe09374afb56b84233fa154091cb7178b45d0c07ed5b4f90c2c8ab1f6ab2"
   end
 
   depends_on "openjdk@11"


### PR DESCRIPTION
The all bottle is all good, the linux bottle was added by mistake

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
