### PR TITLE
rhino: bump revision for Linux

### DIFF
--- a/Formula/rhino.rb
+++ b/Formula/rhino.rb
@@ -1,9 +1,10 @@
 class Rhino < Formula
   desc "JavaScript engine"
-  homepage "https://www.mozilla.org/rhino/"
+  homepage "https://github.com/mozilla/rhino"
   url "https://github.com/mozilla/rhino/releases/download/Rhino1_7_13_Release/rhino-1.7.13.zip"
   sha256 "8531e0e0229140c80d743ece77ffda155d4eb3fa56cca4f36fbfba1088478b3e"
   license "MPL-2.0"
+  revision 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
Fixes:
==> Testing rhino
==> /home/linuxbrew/.linuxbrew/Cellar/rhino/1.7.13/bin/rhino -e "print(6*7)"
/home/linuxbrew/.linuxbrew/Cellar/rhino/1.7.13/bin/rhino: line 3: /home/linuxbrew/.linuxbrew/opt/openjdk@11/libexec/openjdk.jdk/Contents/Home/bin/java: No such file or directory
Error: rhino: failed

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
