### PR TITLE
vice: fix build against jpeg

### DIFF
--- a/Formula/vice.rb
+++ b/Formula/vice.rb
@@ -39,6 +39,11 @@ class Vice < Formula
   depends_on "librsvg"
   depends_on "libvorbis"
 
+  # Fix build against jpeg.
+  # https://sourceforge.net/p/vice-emu/code/40001/
+  # Remove with next release.
+  patch :DATA
+
   def install
     configure_flags = %W[
       --prefix=#{prefix}
@@ -67,3 +72,16 @@ class Vice < Formula
     assert_match "cycle limit reached", shell_output("#{bin}/x64sc -console -limitcycles 1000000 -logfile -", 1)
   end
 end
+
+__END__
+--- a/configure.ac
++++ b/configure.ac
+@@ -3186,7 +3186,7 @@
+ dnl check for jpeg support
+ if test x"$with_jpeg" = "xyes" ; then
+   dnl Check for the JPEG library.
+-  AC_CHECK_HEADER(jpeglib.h,,)
++  AC_CHECK_HEADER(jpeglib.h,,,-)
+ 
+   if test x"$ac_cv_header_jpeglib_h" = "xyes" ; then
+     AC_CHECK_LIB(jpeg, jpeg_CreateCompress, [


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

arm64 support will come in version 3.6. There's a few changes involved so I won't be backporting that.