### PR TITLE
openalpr: deprecate

### DIFF
--- a/Formula/openalpr.rb
+++ b/Formula/openalpr.rb
@@ -15,6 +15,8 @@ class Openalpr < Formula
     sha256 x86_64_linux:   "a37d2f029a47097ea7c81936ed0400451780ae75594cf4aae10cc1647e5bc93e"
   end
 
+  deprecate! date: "2021-12-03", because: :unsupported
+
   depends_on "cmake" => :build
   depends_on "leptonica"
   depends_on "libtiff"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The latest release of `openalpr` was in 2016, the formula already patched (with upstream changes) to support the latest versions of dependencies. 
It started to give us some troubles in `tesseract` (https://github.com/Homebrew/homebrew-core/pull/90220) and `opencv` (https://github.com/Homebrew/homebrew-core/pull/89948) updates.


```
==> Analytics
install: 91 (30 days), 281 (90 days), 906 (365 days)
install-on-request: 91 (30 days), 281 (90 days), 905 (365 days)
build-error: 10 (30 days)
```