### PR TITLE
brigade-cli 2.0.0 (new formula)

### DIFF
--- a/Formula/brigade-cli.rb
+++ b/Formula/brigade-cli.rb
@@ -1,0 +1,35 @@
+class BrigadeCli < Formula
+  desc "Brigade command-line interface"
+  homepage "https://brigade.sh"
+  url "https://github.com/brigadecore/brigade.git",
+      tag:      "v2.0.0",
+      revision: "b2f0aa11555f785894059d35f2646ccc05ab52f0"
+  license "Apache-2.0"
+  head "https://github.com/brigadecore/brigade.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["SKIP_DOCKER"] = "true"
+    ENV["VERSION"] = "v#{version}"
+
+    system "make", "hack-build-cli"
+
+    os = Utils.safe_popen_read("go", "env", "GOOS").strip
+    arch = Utils.safe_popen_read("go", "env", "GOARCH").strip
+    bin.install "bin/brig-#{os}-#{arch}" => "brig"
+  end
+
+  test do
+    system bin/"brig", "init", "--id", "foo"
+    assert_predicate testpath/".brigade", :directory?
+
+    version_output = shell_output(bin/"brig version 2>&1")
+    assert_match "Brigade client:", version_output
+
+    return unless build.stable?
+
+    commit = stable.specs[:revision][0..6]
+    assert_match "Brigade client: version v#{version} -- commit #{commit}", version_output
+  end
+end


### PR DESCRIPTION
Installs the CLI component of Brigade (brig).
Server side components are installed separately using Helm.

Signed-off-by: Kent Rancourt <kent.rancourt@microsoft.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
