### PR TITLE
gforth: update stable url

### DIFF
--- a/Formula/gforth.rb
+++ b/Formula/gforth.rb
@@ -1,7 +1,7 @@
 class Gforth < Formula
   desc "Implementation of the ANS Forth language"
   homepage "https://www.gnu.org/software/gforth/"
-  url "https://www.complang.tuwien.ac.at/forth/gforth/gforth-0.7.3.tar.gz"
+  url "https://ftp.gnu.org/gnu/gforth/gforth-0.7.3.tar.gz"
   sha256 "2f62f2233bf022c23d01c920b1556aa13eab168e3236b13352ac5e9f18542bb0"
   revision 3
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `gforth` formula originally linked to [http://www.jwdt.com/~paysan/gforth.html](https://web.archive.org/web/20110723170018/http://www.jwdt.com/~paysan/gforth.html) as the homepage, which linked to a tarball from http://www.complang.tuwien.ac.at/forth/gforth/. This homepage started redirecting to [http://bernd-paysan.de/gforth.html](https://web.archive.org/web/20111016184713/http://bernd-paysan.de/gforth.html) around 2011-08 and the formula's homepage was updated around 2012-11.

The latter homepage started linking to a tarball from http://ftp.gnu.org/gnu/gforth/ around 2015-04 but the `stable` URL in the formula was never updated, likely because the version at the time was 0.7.3 and there hasn't been a new release after this. The formula homepage was updated 2014-07 to point to http://www.gnu.org/software/gforth/.

This PR updates the `stable` URL to use the GNU tarball, as this corresponds with the link on the homepage and also aligns the `homepage` and `stable` URLs.