### PR TITLE
omniorb: use only python3 for bindings

### DIFF
--- a/Formula/omniorb.rb
+++ b/Formula/omniorb.rb
@@ -29,17 +29,20 @@ class Omniorb < Formula
   end
 
   def install
+    ENV["PYTHON"] = which("python3")
     system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make", "install"
 
     resource("bindings").stage do
-      system "./configure", "--prefix=#{prefix}", "PYTHON=python3"
+      system "./configure", "--prefix=#{prefix}"
       system "make", "install"
     end
   end
 
   test do
     system "#{bin}/omniidl", "-h"
+    system "#{bin}/omniidl", "-bcxx", "-u"
+    system "#{bin}/omniidl", "-bpython", "-u"
   end
 end


### PR DESCRIPTION
omniidl should not longer use python2.7 (i.e. on OSX)

- [y] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [y] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [y] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [y] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [y] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [y] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
