### PR TITLE
lua-language-server 2.5.2 (new formula)

### DIFF
--- a/Formula/lua-language-server.rb
+++ b/Formula/lua-language-server.rb
@@ -1,0 +1,51 @@
+class LuaLanguageServer < Formula
+  desc "Language Server for the Lua language"
+  homepage "https://github.com/sumneko/lua-language-server"
+  # pull from git tag to get submodules
+  url "https://github.com/sumneko/lua-language-server.git",
+      tag:      "2.5.2",
+      revision: "cb2042160865589b5534a6bf0b6c366ae4ab1d99"
+  license "MIT"
+  head "https://github.com/sumneko/lua-language-server.git", branch: "master"
+
+  depends_on "ninja" => :build
+
+  on_linux do
+    depends_on "gcc" # For C++17
+  end
+
+  fails_with gcc: 5
+
+  def install
+    ENV.cxx11
+
+    # Disable `filesystem.test_appdata_path`.
+    # This test expects to find user cache directories under ${HOME},
+    # which is not compatible with homebrew's build environment.
+    # See https://github.com/actboy168/bee.lua/issues/21
+    inreplace buildpath.glob("**/3rd/bee.lua/test/test_filesystem.lua"),
+              "test_fs:test_appdata_path()",
+              "\\0 do return end"
+
+    chdir "3rd/luamake" do
+      system "compile/install.sh"
+    end
+    system "3rd/luamake/luamake", "rebuild"
+
+    bindir = if OS.mac?
+      "bin/macOS"
+    else
+      "bin/Linux"
+    end
+    (libexec/bindir).install "#{bindir}/lua-language-server", "#{bindir}/main.lua"
+    libexec.install "main.lua", "debugger.lua", "locale", "meta", "script"
+    bin.write_exec_script libexec/bindir/"lua-language-server"
+    (libexec/"log").mkpath
+  end
+
+  test do
+    output = /Content-Length: \d+\r\n\r\n/
+
+    assert_match output, pipe_output("#{bin}/lua-language-server", 0)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a bit of a tricky one due to the non-standard build system and hard-coded (relative) install layout.

The patch is necessary to skip a (mandatory!) test in the build scripts for a function that returns (on macOS) the user's default `Library/Caches` directory, which it expects to find under `$HOME`. This obviously fails in the build environment; see https://github.com/macports/macports-ports/tree/master/lua/lua-language-server and the linked issue for background. (I'd be happy to acknowledge the work by Macports more visibly.) Of course, the patch can be moved into the appropriate repo, but it's easier for now to iterate here. (And, since I expect that it needs to be adapted for most version bumps, even in the long run?)