### PR TITLE
wasmer: Install "distribution" Package

### DIFF
--- a/Formula/wasmer.rb
+++ b/Formula/wasmer.rb
@@ -20,9 +20,24 @@ class Wasmer < Formula
   depends_on "wabt" => :build
 
   def install
+    # wasmer CLI
     chdir "lib/cli" do
       system "cargo", "install", "--features", "cranelift", *std_cargo_args
     end
+
+    # Build C API
+    chdir "lib/c-api" do
+      system "cargo", "build",
+        "--features", "wat,universal,dylib,staticlib,wasi,middlewares,cranelift",
+        "--no-default-features",
+        "--release"
+    end
+
+    # Install C API
+    lib.install OS.mac? ? "target/release/libwasmer.dylib" : "target/release/libwasmer.so"
+    lib.install "target/release/libwasmer.a"
+    include.install "lib/c-api/wasmer.h"
+    include.install "lib/c-api/tests/wasm-c-api/include/wasm.h"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

## The Problem

Currently, the [`wasmer` formula](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/wasmer.rb) only installs the [`wasmer` CLI](https://github.com/wasmerio/wasmer/tree/master/lib/cli), but not the [C API](https://github.com/wasmerio/wasmer/tree/master/lib/c-api). 

This causes problems when, for example, you’re following the [C API tutorial](https://github.com/wasmerio/wasmer/tree/master/lib/c-api#readme), because it claims that “Once you  [install Wasmer in your system](https://github.com/wasmerio/wasmer-install) , the _shared object files_ and the _headers_ are available **inside the Wasmer installed path**“. 

In the Readme of “install Wasmer in your system”, only the Bash and PowerShell scripts, and [`scoop`](https://scoop.sh) ([`wasmer` package file](https://github.com/ScoopInstaller/Main/blob/master/bucket/wasmer.json)) install the object files and the headers. 
The `cargo` and `homebrew` installation options only installs the `wasmer` CLI. 

## The Solution

The formula is modified to:
* `make` the C API and `wamser` CLI
* `make distribution` (copy `wasmer` into the `dist` directory and arrange the C API libs and headers in that directory)

These changes shouldn’t have any negative impact on users, because the `wasmer` CLI is still installed in the `bin` directory.
