### PR TITLE
tsduck 3.29-2651 (new formula)

### DIFF
--- a/Formula/tsduck.rb
+++ b/Formula/tsduck.rb
@@ -10,11 +10,14 @@ class Tsduck < Formula
   depends_on "gnu-sed" => :build
   depends_on "grep" => :build
   depends_on "openjdk" => :build
-  depends_on "libedit" if OS.linux?
   depends_on "librist"
-  depends_on "pcsc-lite" if OS.linux?
   depends_on "srt"
   uses_from_macos "curl"
+  on_linux do
+    depends_on "gcc" => :build
+    depends_on "libedit"
+    depends_on "pcsc-lite"
+  end
 
   def install
     ENV["LINUXBREW"] = "true" if OS.linux?

--- a/Formula/tsduck.rb
+++ b/Formula/tsduck.rb
@@ -1,0 +1,40 @@
+class Tsduck < Formula
+  desc "MPEG Transport Stream Toolkit"
+  homepage "https://tsduck.io/"
+  url "https://github.com/tsduck/tsduck/archive/v3.29-2651.tar.gz"
+  sha256 "cab8f5838993aa1abd1a6a4c2ef7f2afba801da02a4001904f3f5ba5c5fe85a0"
+  license "BSD-2-Clause"
+  head "https://github.com/tsduck/tsduck.git", branch: "master"
+
+  depends_on "dos2unix" => :build
+  depends_on "gnu-sed" => :build
+  depends_on "grep" => :build
+  depends_on "openjdk" => :build
+  depends_on "libedit" if OS.linux?
+  depends_on "librist"
+  depends_on "pcsc-lite" if OS.linux?
+  depends_on "srt"
+  uses_from_macos "curl"
+
+  def install
+    ENV["LINUXBREW"] = "true" if OS.linux?
+    system "make", "NOGITHUB=1", "NOTEST=1"
+    system "make", "NOGITHUB=1", "NOTEST=1", "install", "SYSPREFIX=#{prefix}"
+  end
+
+  test do
+    assert_match "TSDuck - The MPEG Transport Stream Toolkit", shell_output("#{bin}/tsp --version 2>&1")
+    input = shell_output("#{bin}/tsp --list=input 2>&1")
+    %w[craft file hls http srt rist].each do |str|
+      assert_match "#{str}:", input
+    end
+    output = shell_output("#{bin}/tsp --list=output 2>&1")
+    %w[ip file hls srt rist].each do |str|
+      assert_match "#{str}:", output
+    end
+    packet = shell_output("#{bin}/tsp --list=packet 2>&1")
+    %w[fork tables analyze sdt timeshift nitscan].each do |str|
+      assert_match "#{str}:", packet
+    end
+  end
+end

--- a/Formula/tsduck.rb
+++ b/Formula/tsduck.rb
@@ -13,11 +13,8 @@ class Tsduck < Formula
   depends_on "librist"
   depends_on "srt"
   uses_from_macos "curl"
-  on_linux do
-    depends_on "gcc" => :build
-    depends_on "libedit"
-    depends_on "pcsc-lite"
-  end
+  uses_from_macos "libedit"
+  uses_from_macos "pcsc-lite"
 
   def install
     ENV["LINUXBREW"] = "true" if OS.linux?


### PR DESCRIPTION
TSDuck is an extensible toolkit for MPEG transport streams. It is used in digital television and video systems for test, monitoring, integration, debug, lab or demo.

Context:
- Home: https://tsduck.io
- Source: https://github.com/tsduck/tsduck
- Project started in 2005
- Open-sourced in 2017 (v3.0)
- One release every three months, approximately
- Linux and Windows: binary packages in GitHub release area
- macOS: hosted in a private Homebrew tap (tsduck/tsduck) since 2017

GitHub statistics:
- 473 stars
- 806 discussion threads
- 125 forks
- 95 pull requests
- 16 contributors
- 2651 commits on master branch
- Average of 3000 binary downloads per release (Windows and Linux packages)

Some notes on the formula:
- Mainly used on macOS Intel
- Not recently tested on macOS ARM (none available), but a contributor provided a few makefile fixes in the previous version which should be still relevant
- Tested once in LinuxBrew environment
- "dos2unix", "gnu-sed", "grep" are only used during the build, from the makefiles, using gXXX names, because of GNU options which cannot be found in the BSD equivalent on macOS (eg. gsed -i).
- "openjdk" is used during the build to compile the Java bindings but Java is not required during execution (if a user needs the Java bindings, he already uses Java anyway)
- On macOS, "libedit" and "pcsc-lite" are native frameworks. On Linux, the LinuxBrew versions are used.
- The "NOGITHUB=1" definition disables the detection of new releases on GitHub, upgrading TSDuck shall come with `brew upgrade`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
