### PR TITLE
notcurses 3.0.0

### DIFF
--- a/Formula/notcurses.rb
+++ b/Formula/notcurses.rb
@@ -1,8 +1,8 @@
 class Notcurses < Formula
   desc "Blingful character graphics/TUI library"
   homepage "https://nick-black.com/dankwiki/index.php/Notcurses"
-  url "https://github.com/dankamongmen/notcurses/archive/refs/tags/v2.4.9.tar.gz"
-  sha256 "a2771ad1633e0158f8273fa8b30b5bce0f12e1205e863045f4ae186b6b52f537"
+  url "https://github.com/dankamongmen/notcurses/archive/refs/tags/v3.0.0.tar.gz"
+  sha256 "b4839108ca8f9aef31d2f537485cbd878356bbcd4ad4f7a4dd19e72201d01cee"
   license "Apache-2.0"
 
   bottle do
@@ -18,9 +18,9 @@ class Notcurses < Formula
   depends_on "pandoc" => :build
   depends_on "pkg-config" => :build
   depends_on "ffmpeg"
+  depends_on "libdeflate"
   depends_on "libunistring"
   depends_on "ncurses"
-  uses_from_macos "zlib"
 
   fails_with gcc: "5"
 


### PR DESCRIPTION
Signed-off-by: nick black <nickblack@linux.com>

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
==> Downloading https://ghcr.io/v2/homebrew/core/glib/manifests/2.70.2
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/glib/blobs/sha256:85ea450b1a990c33a988c12cea63c25ba3a483465eb9ddc762002dbff588642c
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:85ea450b1a990c33a988c12cea63c25ba3a483465eb9ddc
######################################################################## 100.0%
==> Downloading https://github.com/dankamongmen/notcurses/archive/refs/tags/v3.0.0.tar.gz
==> Downloading from https://codeload.github.com/dankamongmen/notcurses/tar.gz/refs/tags/v3.0.0
     # -#O=- #   #                                                            
==> Upgrading notcurses
  2.4.9 -> 3.0.0 

==> Installing dependencies for notcurses: glib
==> Installing notcurses dependency: glib
==> Pouring glib--2.70.2.big_sur.bottle.tar.gz
🍺  /usr/local/Cellar/glib/2.70.2: 444 files, 21.1MB
==> Installing notcurses
==> cmake -S . -B build -DCMAKE_INSTALL_RPATH=@loader_path/../lib
==> cmake --build build
==> cmake --install build
🍺  /usr/local/Cellar/notcurses/3.0.0: 190 files, 9.3MB, built in 17 seconds
==> Running `brew cleanup notcurses`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /usr/local/Cellar/notcurses/2.4.9... (188 files, 8.9MB)
```