### PR TITLE
mujs: build shared libs as dylib on macOS

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -4,6 +4,7 @@ class Mpv < Formula
   url "https://github.com/mpv-player/mpv/archive/v0.34.0.tar.gz"
   sha256 "f654fb6275e5178f57e055d20918d7d34e19949bc98ebbf4a7371902e88ce309"
   license :cannot_represent
+  revision 1
   head "https://github.com/mpv-player/mpv.git"
 
   bottle do

--- a/Formula/mujs.rb
+++ b/Formula/mujs.rb
@@ -22,6 +22,11 @@ class Mujs < Formula
     depends_on "readline"
   end
 
+  patch do
+    url "https://github.com/ccxvii/mujs/commit/f1434ee155d17db41c7e03c699472a963e2b5000.patch?full_index=1"
+    sha256 "b7797962a17a2894c5d191443221a95a80dfddff7c30b4f5c5054873f3873c59"
+  end
+
   def install
     system "make", "release"
     system "make", "prefix=#{prefix}", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It seems that mujs doesn't care about macOS much, and specifies the extension of shared libs `.so` explicitly. This PR tries to address this issue by patching the make file