### PR TITLE
notcurses: patch for linuxbrew build

### DIFF
--- a/Formula/notcurses.rb
+++ b/Formula/notcurses.rb
@@ -24,6 +24,11 @@ class Notcurses < Formula
 
   fails_with gcc: "5"
 
+  patch do
+    url "https://nick-black.com/strndup-mingw-only.patch"
+    sha256 "8ea4a3be2181e1091e44868646830ea37f2efcfcde984a57e5d8dd48d6bb43e0"
+  end
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", "--build", "build"


### PR DESCRIPTION
Taking a swing at resolving the Linuxbrew build failure discussed most recently in #90536. The actual build failure is kinda mystifying; this declaration is only necessary on Windows, so let's see if eliding it resolves things. Maybe it does, maybe it doesn't. https://github.com/dankamongmen/notcurses/issues/2428

Signed-off-by: nick black <nickblack@linux.com>

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
