### PR TITLE
mutanus 0.1.x (new formula)

### DIFF
--- a/Formula/mutanus.rb
+++ b/Formula/mutanus.rb
@@ -1,15 +1,12 @@
 class Mutanus < Formula
   desc "Performs mutation testing of you Swift project"
   homepage "https://github.com/SoriUR/mutanus/"
-  url "https://github.com/SoriUR/mutanus/archive/refs/tags/v0.1.0.tar.gz"
-  sha256 "73204fe4b1788c2427d2d12f8a5d2579469cd8910ecfa777974d431118d83155"
+  url "https://github.com/SoriUR/mutanus/archive/refs/tags/v0.1.1.tar.gz"
+  sha256 "a534071a0f6f234cd3dc412afab6e825d54181fd8de0a8cc2a3478f1ba2189a8"
   license "MIT"
 
   depends_on xcode: [">= 12.5", :build]
-  depends_on macos: [
-    :catalina,
-    :big_sur,
-  ]
+  depends_on macos: :catalina
 
   def install
     system "swift", "build", "--disable-sandbox", "-c", "release"

--- a/Formula/mutanus.rb
+++ b/Formula/mutanus.rb
@@ -1,11 +1,12 @@
 class Mutanus < Formula
   desc "Performs mutation testing of you Swift project"
   homepage "https://github.com/SoriUR/mutanus/"
-  url "https://github.com/SoriUR/mutanus/archive/refs/tags/v0.1.2.tar.gz"
-  sha256 "ec5f663a76166c18ee3a76e3fd69bfd1b29526dc567c3994e9a119624b992e34"
+  url "https://github.com/SoriUR/mutanus/archive/refs/tags/v0.1.3.tar.gz"
+  sha256 "f235804fa48e4150bdadf9276ba6380fa224aad1233e273c9dc5e61391803efc"
   license "MIT"
 
   depends_on xcode: ["12.5", :build]
+  depends_on :macos
   depends_on macos: :catalina
 
   def install

--- a/Formula/mutanus.rb
+++ b/Formula/mutanus.rb
@@ -1,0 +1,22 @@
+class Mutanus < Formula
+  desc "Performs mutation testing of you Swift project"
+  homepage "https://github.com/SoriUR/mutanus/"
+  url "https://github.com/SoriUR/mutanus/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "73204fe4b1788c2427d2d12f8a5d2579469cd8910ecfa777974d431118d83155"
+  license "MIT"
+
+  depends_on xcode: [">= 12.5", :build]
+  depends_on macos: [
+    :catalina,
+    :big_sur,
+  ]
+
+  def install
+    system "swift", "build", "--disable-sandbox", "-c", "release"
+    bin.install ".build/release/mutanus"
+  end
+
+  test do
+    system "#{bin}/mutanus", "--help"
+  end
+end

--- a/Formula/mutanus.rb
+++ b/Formula/mutanus.rb
@@ -1,11 +1,11 @@
 class Mutanus < Formula
   desc "Performs mutation testing of you Swift project"
   homepage "https://github.com/SoriUR/mutanus/"
-  url "https://github.com/SoriUR/mutanus/archive/refs/tags/v0.1.1.tar.gz"
-  sha256 "a534071a0f6f234cd3dc412afab6e825d54181fd8de0a8cc2a3478f1ba2189a8"
+  url "https://github.com/SoriUR/mutanus/archive/refs/tags/v0.1.2.tar.gz"
+  sha256 "ec5f663a76166c18ee3a76e3fd69bfd1b29526dc567c3994e9a119624b992e34"
   license "MIT"
 
-  depends_on xcode: [">= 12.5", :build]
+  depends_on xcode: ["12.5", :build]
   depends_on macos: :catalina
 
   def install
@@ -14,6 +14,7 @@ class Mutanus < Formula
   end
 
   test do
-    system "#{bin}/mutanus", "--help"
+    system "#{bin}/mutanus", "config"
+    assert_predicate testpath/"MutanusConfig.json", :exist?
   end
 end


### PR DESCRIPTION
Mutanus is a command line tool written in Swift dedicated to perform mutation testing of Swift projects. 


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
