### PR TITLE
pcre: Enable JIT on Linux

### DIFF
--- a/Formula/pcre.rb
+++ b/Formula/pcre.rb
@@ -55,7 +55,7 @@ class Pcre < Formula
     ]
 
     # JIT not currently supported for Apple Silicon or OS older than sierra
-    args << "--enable-jit" if MacOS.version >= :sierra && !Hardware::CPU.arm?
+    args << "--enable-jit" if OS.linux? || (MacOS.version >= :sierra && !Hardware::CPU.arm?)
 
     system "./autogen.sh" if build.head?
     system "./configure", *args


### PR DESCRIPTION
The condition didn't account for Linux support. PCRE JIT should work on all supported Linux platforms.
