### PR TITLE
multitail: undeprecate

### DIFF
--- a/Formula/multitail.rb
+++ b/Formula/multitail.rb
@@ -1,10 +1,10 @@
 class Multitail < Formula
   desc "Tail multiple files in one terminal simultaneously"
   homepage "https://vanheusden.com/multitail/"
-  url "https://vanheusden.com/multitail/multitail-6.5.0.tgz"
+  url "https://fossies.org/linux/privat/multitail-6.5.0.tgz"
   sha256 "b29d5e77dfc663c7500f78da67de5d82d35d9417a4741a89a18ce9ee7bdba9ed"
   license "GPL-2.0"
-  head "https://github.com/flok99/multitail.git"
+  head "https://github.com/halturin/multitail.git"
 
   bottle do
     sha256 cellar: :any, arm64_big_sur: "931b37ad30df49390ef2e7c2d191821a735202d38b9fbb85f5ab9b00ed248eea"

--- a/Formula/multitail.rb
+++ b/Formula/multitail.rb
@@ -14,8 +14,6 @@ class Multitail < Formula
     sha256 cellar: :any, high_sierra:   "57526de43035b0d5d2520d54b252d29c20a4efb146c019ac044ad5067be5351a"
   end
 
-  deprecate! date: "2021-05-20", because: "Upstream website has disappeared"
-
   depends_on "pkg-config" => :build
   depends_on "ncurses"
 


### PR DESCRIPTION
Multitail upstream website reappeared https://www.vanheusden.com/multitail/

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
