### PR TITLE
srtp: Compile with --enable-openssl

### DIFF
--- a/Formula/srtp.rb
+++ b/Formula/srtp.rb
@@ -4,6 +4,7 @@ class Srtp < Formula
   url "https://github.com/cisco/libsrtp/archive/v2.4.2.tar.gz"
   sha256 "3b1bcb14ebda572b04b9bdf07574a449c84cb924905414e4d94e62837d22b628"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/cisco/libsrtp.git", branch: "master"
 
   livecheck do
@@ -22,9 +23,10 @@ class Srtp < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "openssl@1.1"
 
   def install
-    system "./configure", "--disable-debug", "--prefix=#{prefix}"
+    system "./configure", "--disable-debug", "--prefix=#{prefix}", "--enable-openssl"
     system "make", "test"
     system "make", "shared_library"
     system "make", "install" # Can't go in parallel of building the dylib


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

When I run `brew audit --strict srtp` there is an existing error "Formula ... should not run build-time checks". I have not fixed that error, but do not see any new errors introduced by these changes.