### PR TITLE
mist 1.6.1 (new formula)

### DIFF
--- a/Formula/mist.rb
+++ b/Formula/mist.rb
@@ -4,7 +4,6 @@ class Mist < Formula
   url "https://github.com/ninxsoft/Mist/archive/refs/tags/v1.6.1.tar.gz"
   sha256 "0b1ec7fed7bbafb3221656376bf69407fe602ad4cdb938089d8cf7c585112394"
   license "MIT"
-
   head "https://github.com/ninxsoft/Mist.git", branch: "main"
 
   # Mist requires Swift 5.5

--- a/Formula/mist.rb
+++ b/Formula/mist.rb
@@ -8,6 +8,7 @@ class Mist < Formula
 
   # Mist requires Swift 5.5
   depends_on xcode: ["13.1", :build]
+  uses_from_macos "swift"
 
   def install
     system "swift", "build", "--disable-sandbox", "--configuration", "release"

--- a/Formula/mist.rb
+++ b/Formula/mist.rb
@@ -1,0 +1,31 @@
+class Mist < Formula
+  desc "Mac command-line tool that automatically downloads macOS Installers / Firmwares"
+  homepage "https://github.com/ninxsoft/Mist"
+  url "https://github.com/ninxsoft/Mist/archive/refs/tags/v1.6.1.tar.gz"
+  sha256 "0b1ec7fed7bbafb3221656376bf69407fe602ad4cdb938089d8cf7c585112394"
+  license "MIT"
+
+  head "https://github.com/ninxsoft/Mist.git", branch: "main"
+
+  # Mist requires Swift 5.5
+  depends_on xcode: ["13.1", :build]
+
+  def install
+    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    bin.install ".build/release/mist"
+  end
+
+  test do
+    # basic usage output
+    assert_match "-h, --help", shell_output("#{bin}/mist").strip
+
+    # check we can export the output list
+    out = testpath/"out.json"
+    shell_output("#{bin}/mist list --quiet --export #{out} --output-type json").strip
+    assert_predicate out, :exist?
+
+    # check that it's parseable JSON in the format we expect
+    parsed = JSON.parse(File.read(out))
+    assert_kind_of Array, parsed
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should improve on the tests for this new formula since I asked earlier today in https://github.com/Homebrew/discussions/discussions/2604

I specified `depends_on xcode: ["13.1", :build]` because it requires Swift 5.5 to build. Although the deployment target for this goes back to 10.10. Is there anything I should specify differently so that this could still build bottles for older OS versions?
