### PR TITLE
git-utils: disable formula

### DIFF
--- a/Formula/git-utils.rb
+++ b/Formula/git-utils.rb
@@ -9,6 +9,8 @@ class GitUtils < Formula
     sha256 cellar: :any_skip_relocation, all: "7c7e5940ae9e46d0dfacb6b2b8db5dcf98626012d57d563a9ec1ca852bf9f0fb"
   end
 
+  disable! date: "2021-12-07", because: :no_license
+
   conflicts_with "git-extras",
     because: "both install a `git-pull-request` script"
   conflicts_with "willgit",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This software is missing a license. ddollar/git-utils#27 has been opened for over a year, so just deleting the formula instead of adding a `disable!` declaration.