### PR TITLE
xmlsh: disable

### DIFF
--- a/Formula/xmlsh.rb
+++ b/Formula/xmlsh.rb
@@ -13,6 +13,13 @@ class Xmlsh < Formula
     sha256 cellar: :any_skip_relocation, all: "e9a08dc3cd955e21c5e170cb205584b19cf67d10f062a597bc6284ffca9dbc70"
   end
 
+  # Disabled as xmlsh has no license.
+  # It also does not build anymore (1.2.5 sources are gone)
+  # and there are no build instructions to build 1.3.x
+  # https://github.com/xmlsh/xmlsh1_3
+  # https://github.com/xmlsh/xmlsh/
+  disable! date: "2021-12-07", because: :no_license
+
   depends_on "openjdk@11"
 
   def install


### PR DESCRIPTION
Disabled as xmlsh has no license.
It also does not build anymore (1.2.5 sources are gone)
and there are no build instructions to build 1.3.x
There are some pre-compiled binaries but we do not want to use these

https://github.com/xmlsh/xmlsh1_3
https://github.com/xmlsh/xmlsh/

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
