### PR TITLE
easyrpg-player: depend on gcc

### DIFF
--- a/Formula/easyrpg-player.rb
+++ b/Formula/easyrpg-player.rb
@@ -35,6 +35,7 @@ class EasyrpgPlayer < Formula
   on_linux do
     depends_on "pkg-config" => :build
     depends_on "alsa-lib"
+    depends_on "gcc"
   end
 
   fails_with gcc: "5"


### PR DESCRIPTION
Fixes (on Linux):
Undeclared dependencies with linkage:
    gcc

There is alreayd a "fails_with gcc 5" below,
I am just adding the missing dependency

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
