### PR TITLE
deno: depend on gcc for Linux

### DIFF
--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -27,7 +27,7 @@ class Deno < Formula
 
   on_linux do
     depends_on "pkg-config" => :build
-    depends_on "gcc" => :test # CompilerSelectionError: deno cannot be built with any available compilers.
+    depends_on "gcc"
     depends_on "glib"
   end
 


### PR DESCRIPTION
Fixes:
Undeclared dependencies with linkage:
    gcc

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
