### PR TITLE
mrbayes: bump revision for Linux

### DIFF
--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -4,7 +4,7 @@ class Mrbayes < Formula
   url "https://github.com/NBISweden/MrBayes/archive/v3.2.7a.tar.gz"
   sha256 "3eed2e3b1d9e46f265b6067a502a89732b6f430585d258b886e008e846ecc5c6"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/NBISweden/MrBayes.git", branch: "develop"
 
   livecheck do


### PR DESCRIPTION
Fixes test that fails with "illegal instruction"
Not sure what is going on but we probably missed a revision bump somewhere

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
