### PR TITLE
bosh-cli: fix checksum

### DIFF
--- a/Formula/bosh-cli.rb
+++ b/Formula/bosh-cli.rb
@@ -2,8 +2,9 @@ class BoshCli < Formula
   desc "Cloud Foundry BOSH CLI v2"
   homepage "https://bosh.io/docs/cli-v2/"
   url "https://github.com/cloudfoundry/bosh-cli/archive/v6.4.8.tar.gz"
-  sha256 "fd45680cff13b2f6a9955d10125ec56fc2a0419c2f224842c528286ff253dd81"
+  sha256 "0525115cdb07915321f478ff61ec6ba28971b0fbac2e8ffb0b6a5fcea12ea322"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/cloudfoundry/bosh-cli.git", branch: "main"
 
   bottle do


### PR DESCRIPTION
See:
https://github.com/cloudfoundry/bosh-cli/issues/578

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
