### PR TITLE
htop: remove Python build dependency

### DIFF
--- a/Formula/htop.rb
+++ b/Formula/htop.rb
@@ -24,7 +24,6 @@ class Htop < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
   depends_on "ncurses" # enables mouse scroll
 
   on_linux do


### PR DESCRIPTION
According to htop changelog, Python was removed from their build system in
version 3.0.2: https://github.com/htop-dev/htop/blob/ff4f44b22ae8d6522ee22599174a6cdd41bc0314/ChangeLog#L317-L326

Python was added from https://github.com/Homebrew/homebrew-core/pull/65541, but that pull request doesn't explain why Python was added.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
