### PR TITLE
goproxy: avoid subshells

### DIFF
--- a/Formula/goproxy.rb
+++ b/Formula/goproxy.rb
@@ -25,17 +25,15 @@ class Goproxy < Formula
   test do
     bind_address = "127.0.0.1:#{free_port}"
     begin
-      server = IO.popen(
-        ["#{bin}/goproxy", "-proxy=https://goproxy.io", "-listen=#{bind_address}"],
-        err: [:child, :out],
-      )
-      sleep 10
+      server = IO.popen("#{bin}/goproxy -proxy=https://goproxy.io -listen=#{bind_address}", err: [:child, :out])
+      sleep 1
       ENV["GOPROXY"] = "http://#{bind_address}"
       test_module = "github.com/spf13/cobra"
       system "go", "get", test_module
     ensure
-      Process.kill("SIGINT", server.pid)
-      Process.wait(server.pid)
+      nil
+      # Process.kill("SIGINT", server.pid)
+      # Process.wait(server.pid)
     end
     assert_match test_module, server.read
   end

--- a/Formula/goproxy.rb
+++ b/Formula/goproxy.rb
@@ -25,8 +25,11 @@ class Goproxy < Formula
   test do
     bind_address = "127.0.0.1:#{free_port}"
     begin
-      server = IO.popen("#{bin}/goproxy -proxy=https://goproxy.io -listen=#{bind_address}", err: [:child, :out])
-      sleep 1
+      server = IO.popen(
+        ["#{bin}/goproxy", "-proxy=https://goproxy.io", "-listen=#{bind_address}"],
+        err: [:child, :out],
+      )
+      sleep 10
       ENV["GOPROXY"] = "http://#{bind_address}"
       test_module = "github.com/spf13/cobra"
       system "go", "get", test_module


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Subshells seem to make the test hang indefinitely (e.g. #90350). Let's also
sleep for longer since short `sleep`s tend to cause trouble in CI.