### PR TITLE
gdb, gdbgui: migrate to Python 3.10

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -5,6 +5,7 @@ class Gdb < Formula
   mirror "https://ftpmirror.gnu.org/gdb/gdb-11.1.tar.xz"
   sha256 "cccfcc407b20d343fb320d4a9a2110776dd3165118ffd41f4b1b162340333f94"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
 
   bottle do
@@ -16,7 +17,7 @@ class Gdb < Formula
   end
 
   depends_on "gmp"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   depends_on "xz" # required for lzma support
 
   uses_from_macos "texinfo" => :build
@@ -46,7 +47,7 @@ class Gdb < Formula
       --disable-debug
       --disable-dependency-tracking
       --with-lzma
-      --with-python=#{Formula["python@3.9"].opt_bin}/python3
+      --with-python=#{Formula["python@3.10"].opt_bin}/python3
       --disable-binutils
     ]
 

--- a/Formula/gdbgui.rb
+++ b/Formula/gdbgui.rb
@@ -6,6 +6,7 @@ class Gdbgui < Formula
   url "https://files.pythonhosted.org/packages/4b/67/63e55e2fde8628603326e5a9f1882bf831f49b2feaa966aee602fced77ae/gdbgui-0.15.0.1.tar.gz"
   sha256 "6f0ae578b9f7181c783227b692e8ed694a3e5c200b33e8512f2488644465060d"
   license "GPL-3.0-only"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, monterey:     "66ab0fe289baa0e06dca98ce2c3fbb6179093da983faab5119967ca33554e372"
@@ -16,7 +17,7 @@ class Gdbgui < Formula
   end
 
   depends_on "gdb"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "bidict" do
     url "https://files.pythonhosted.org/packages/bd/7c/83fbbc8568be511bc48704b97ef58f67ff2ab85ec4fcd1dad12cd2323c32/bidict-0.21.2.tar.gz"


### PR DESCRIPTION
Migrate `gdb` family to Python 3.10. See https://github.com/Homebrew/homebrew-core/pull/87075#issuecomment-988102123