### PR TITLE
mercurial, hg-fast-export: migrate to Python 3.10

### DIFF
--- a/Formula/hg-fast-export.rb
+++ b/Formula/hg-fast-export.rb
@@ -6,15 +6,24 @@ class HgFastExport < Formula
   url "https://github.com/frej/fast-export/archive/v210917.tar.gz"
   sha256 "168f51301f01b4a2572bb00dd9474ee9a50b85f24aa5ed5a7b8abb12896d951a"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "f6532a51ead9d46a0ae6f957ae12f62467d265a741b2cf4be23b0808ed2be1fe"
   end
 
   depends_on "mercurial"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
+    # The Python executable is tested from PATH
+    # Prepend ours Python to the executable candidate list (python2 python python3)
+    # See https://github.com/Homebrew/homebrew-core/pull/90709#issuecomment-988548657
+    %w[hg-fast-export.sh hg-reset.sh].each do |f|
+      inreplace f, "for python_cmd in ",
+                   "for python_cmd in '#{which("python3")}' "
+    end
+
     libexec.install Dir["*"]
 
     %w[hg-fast-export.py hg-fast-export.sh hg-reset.py hg-reset.sh hg2git.py].each do |f|

--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -6,6 +6,7 @@ class Mercurial < Formula
   url "https://www.mercurial-scm.org/release/mercurial-6.0.tar.gz"
   sha256 "53b68b7e592adce3a4e421da3bffaacfc7721f403aac319e6d2c5122574de62f"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.mercurial-scm.org/release/"
@@ -21,17 +22,20 @@ class Mercurial < Formula
     sha256 x86_64_linux:   "3e2f28ff2702e50f54199485a43cb3719593ea462ff0ffc0365fd87c02bac407"
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     ENV["HGPYTHON3"] = "1"
 
-    system "make", "PREFIX=#{prefix}", "PYTHON=python3", "install-bin"
+    system "make", "PREFIX=#{prefix}",
+                   "PYTHON=#{which("python3")}",
+                   "install-bin"
 
     # Install chg (see https://www.mercurial-scm.org/wiki/CHg)
     cd "contrib/chg" do
-      system "make", "PREFIX=#{prefix}", "PYTHON=python3", "HGPATH=#{bin}/hg",
-                     "HG=#{bin}/hg"
+      system "make", "PREFIX=#{prefix}",
+                     "PYTHON=#{which("python3")}",
+                     "HGPATH=#{bin}/hg", "HG=#{bin}/hg"
       bin.install "chg"
     end
 


### PR DESCRIPTION
Migrate `mercurial` family to Python 3.10. See https://github.com/Homebrew/homebrew-core/pull/87075#issuecomment-988102123