### PR TITLE
molten-vk, ppsspp: migrate to Python 3.10

### DIFF
--- a/Formula/molten-vk.rb
+++ b/Formula/molten-vk.rb
@@ -14,7 +14,7 @@ class MoltenVk < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on xcode: ["11.7", :build]
   # Requires IOSurface/IOSurfaceRef.h.
   depends_on macos: :sierra

--- a/Formula/ppsspp.rb
+++ b/Formula/ppsspp.rb
@@ -20,7 +20,7 @@ class Ppsspp < Formula
   depends_on "cmake" => :build
   depends_on "nasm" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "libpng"
   depends_on "libzip"
   depends_on "sdl2"


### PR DESCRIPTION
Migrate `molten-vk` family to Python 3.10. See https://github.com/Homebrew/homebrew-core/pull/87075#issuecomment-988102123