### PR TITLE
node@14, code-server: migrate to Python 3.10

### DIFF
--- a/Formula/code-server.rb
+++ b/Formula/code-server.rb
@@ -14,7 +14,7 @@ class CodeServer < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "7ca731bd99f09f23567cbead57850f886bed034036d27ca768b83ec5e889037e"
   end
 
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "yarn" => :build
   depends_on "node@14"
 

--- a/Formula/node@14.rb
+++ b/Formula/node@14.rb
@@ -22,7 +22,7 @@ class NodeAT14 < Formula
   keg_only :versioned_formula
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "brotli"
   depends_on "c-ares"
   depends_on "icu4c"


### PR DESCRIPTION
Migrate `node@14` family to Python 3.10. See https://github.com/Homebrew/homebrew-core/pull/87075#issuecomment-988102123