### PR TITLE
workflows/tests: limit use of `CI-long-timeout` label

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Count pull requests with the `CI-long-timeout` label
-        id: count_long_timeout_prs
+        if: contains(github.event.pull_request.labels.*.name, 'CI-long-timeout')
         uses: actions/github-script@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -65,14 +65,9 @@ jobs:
             const { repository: { pullRequests: { totalCount } } }  = await github.graphql(query, variables)
             core.setOutput('count', totalCount)
 
-      - name: Remove `CI-long-timeout` label if applicable
-        if: fromJson(steps.count_long_timeout_prs.outputs.count) >= 2
-        uses: Homebrew/actions/label-pull-requests@master
-        with:
-          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          def: |
-            - label: CI-long-timeout
-              path: nonexistent/path/hack
+            if (totalCount > 2) {
+              core.setFailed(`Too many pull requests (${totalCount}) with the long-timeout label!`)
+            }
 
   setup_tests:
     if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,15 +40,13 @@ jobs:
         if: github.event_name == 'pull_request'
         id: formulae-detect
 
-  count_timeout_labels:
+  timeout_labels:
     if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
-    outputs:
-      long-pr-count: ${{ steps.count.outputs.count }}
     steps:
       - name: Count pull requests with the `CI-long-timeout` label
-        id: count
-        uses: actions/github-script@v3
+        id: count_long_timeout_prs
+        uses: actions/github-script@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -67,12 +65,8 @@ jobs:
             const { repository: { pullRequests: { totalCount } } }  = await github.graphql(query, variables)
             core.setOutput('count', totalCount)
 
-  remove_timeout_labels:
-    if: ${{ (github.event_name == 'pull_request') && (github.repository == 'Homebrew/homebrew-core') && (fromJson(needs.count_timeout_labels.outputs.long-pr-count) >= 2) }}
-    needs: count_timeout_labels
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove `CI-long-timeout` label
+      - name: Remove `CI-long-timeout` label if applicable
+        if: fromJson(steps.count_long_timeout_prs.outputs.count) >= 2
         uses: Homebrew/actions/label-pull-requests@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
@@ -83,7 +77,7 @@ jobs:
   setup_tests:
     if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
-    needs: [tap_syntax, remove_timeout_labels]
+    needs: [tap_syntax, timeout_labels]
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
       linux-runner: ${{ steps.check-labels.outputs.linux-runner }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,50 @@ jobs:
         if: github.event_name == 'pull_request'
         id: formulae-detect
 
+  count_timeout_labels:
+    if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'
+    runs-on: ubuntu-latest
+    outputs:
+      long-pr-count: ${{ steps.count.outputs.count }}
+    steps:
+      - name: Count pull requests with the `CI-long-timeout` label
+        id: count
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const query = `query($owner:String!, $name:String!, $label:String!) {
+              repository(owner:$owner, name:$name) {
+                pullRequests(last:100, states:OPEN, labels: [$label]) {
+                  totalCount
+                }
+              }
+            }`;
+            const variables = {
+              owner: context.repo.owner,
+              name: context.repo.repo,
+              label: 'CI-long-timeout'
+            }
+            const { repository: { pullRequests: { totalCount } } }  = await github.graphql(query, variables)
+            core.setOutput('count', totalCount)
+
+  remove_timeout_labels:
+    if: ${{ (github.event_name == 'pull_request') && (github.repository == 'Homebrew/homebrew-core') && (fromJson(needs.count_timeout_labels.outputs.long-pr-count) >= 2) }}
+    needs: count_timeout_labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove `CI-long-timeout` label
+        uses: Homebrew/actions/label-pull-requests@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          def: |
+            - label: CI-long-timeout
+              path: nonexistent/path/hack
+
   setup_tests:
     if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
-    needs: tap_syntax
+    needs: [tap_syntax, remove_timeout_labels]
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
       linux-runner: ${{ steps.check-labels.outputs.linux-runner }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,8 +122,11 @@ jobs:
 
             if (label_names.includes('CI-long-timeout')) {
               const long_pr_count = ${{ needs.tap_syntax.outputs.long_pr_count }}
-              if (long_pr_count > 2) {
+              const maximum_long_pr_count = 2
+              if (long_pr_count > maximum_long_pr_count) {
                 core.setFailed(`Too many pull requests (${long_pr_count}) with the long-timeout label!`)
+                core.error(`Only ${maximum_long_pr_count} pull requests at a time can use this label.`)
+                core.error('Remove the long-timeout label from this or other PRs (once their CI has completed).')
               }
               console.log('CI-long-timeout label found. Setting long GitHub Actions timeout.')
               core.setOutput('timeout-minutes', '4320')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
       testing_formulae: ${{ steps.formulae-detect.outputs.testing_formulae }}
       added_formulae: ${{ steps.formulae-detect.outputs.added_formulae }}
       deleted_formulae: ${{ steps.formulae-detect.outputs.deleted_formulae }}
+      long_pr_count: ${{ steps.count_long_timeout_prs.outputs.count }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -40,12 +41,9 @@ jobs:
         if: github.event_name == 'pull_request'
         id: formulae-detect
 
-  timeout_labels:
-    if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'
-    runs-on: ubuntu-latest
-    steps:
       - name: Count pull requests with the `CI-long-timeout` label
-        if: contains(github.event.pull_request.labels.*.name, 'CI-long-timeout')
+        if: github.event_name == 'pull_request'
+        id: count_long_timeout_prs
         uses: actions/github-script@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -65,14 +63,10 @@ jobs:
             const { repository: { pullRequests: { totalCount } } }  = await github.graphql(query, variables)
             core.setOutput('count', totalCount)
 
-            if (totalCount > 2) {
-              core.setFailed(`Too many pull requests (${totalCount}) with the long-timeout label!`)
-            }
-
   setup_tests:
     if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
-    needs: [tap_syntax, timeout_labels]
+    needs: tap_syntax
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
       linux-runner: ${{ steps.check-labels.outputs.linux-runner }}
@@ -127,6 +121,10 @@ jobs:
             }
 
             if (label_names.includes('CI-long-timeout')) {
+              const long_pr_count = ${{ needs.tap_syntax.outputs.long_pr_count }}
+              if (long_pr_count > 2) {
+                core.setFailed(`Too many pull requests (${long_pr_count}) with the long-timeout label!`)
+              }
               console.log('CI-long-timeout label found. Setting long GitHub Actions timeout.')
               core.setOutput('timeout-minutes', '4320')
             } else {


### PR DESCRIPTION
The `CI-long-timeout` label is currently overused: it is almost always
added (immediately) to every PR that takes longer than an hour to run, and we suffer
from long CI queues as a consequence. This defeats the purpose of having
the label in the first place.

Let's try to mitigate this by automatically removing the
`CI-long-timeout` label whenever there are at least two open PRs that
already have the label applied.

I employ a little hack to be able to use our `label-pull-requests`
action, since trying to do this with `actions/github-script` is a little
involved. An alternative to this is to use an external action such as
`andymckay/labeler`. [1] I can also look at adapting our action
properly, but this might take a while since I don't know JavaScript.

[1] https://github.com/andymckay/labeler