### PR TITLE
ci: Make the 'CI-long-timeout' check fail open on GitHub API errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,18 +106,18 @@ jobs:
                   }
                 }
               }`;
-              const response = await github.graphql(
-                labelCountQuery, {
-                  owner: context.repo.owner,
-                  name: context.repo.repo,
-                  label: 'CI-long-timeout'
-                }
-              )
-              if (response.errors) {
+              try {
+                const response = await github.graphql(
+                  labelCountQuery, {
+                    owner: context.repo.owner,
+                    name: context.repo.repo,
+                    label: 'CI-long-timeout'
+                  }
+                )
+                let long_pr_count = response.data.repository.pullRequests.totalCount
+              } catch (error) {
                 // The GitHub API query errored, so fail open and assume 0 long PRs.
                 let long_pr_count = 0
-              } else {
-                let long_pr_count = response.data.repository.pullRequests.totalCount
               }
               const maximum_long_pr_count = 2
               if (long_pr_count > maximum_long_pr_count) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
               label: 'CI-long-timeout'
             }
             const response = await github.graphql(query, variables)
-            if (response.error) {
+            if (response.errors) {
               // The GitHub API query errored, so fail open and assume 0 PRs.
               core.setOutput('count', 0)
             } else {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,8 +60,13 @@ jobs:
               name: context.repo.repo,
               label: 'CI-long-timeout'
             }
-            const { repository: { pullRequests: { totalCount } } }  = await github.graphql(query, variables)
-            core.setOutput('count', totalCount)
+            const response = await github.graphql(query, variables)
+            if (response.error) {
+              // The GitHub API query errored, so fail open and assume 0 PRs.
+              core.setOutput('count', 0)
+            } else {
+              core.setOutput('count', response.data.repository.pullRequests.totalCount)
+            }
 
   setup_tests:
     if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,33 +41,6 @@ jobs:
         if: github.event_name == 'pull_request'
         id: formulae-detect
 
-      - name: Count pull requests with the `CI-long-timeout` label
-        if: github.event_name == 'pull_request'
-        id: count_long_timeout_prs
-        uses: actions/github-script@v5
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const query = `query($owner:String!, $name:String!, $label:String!) {
-              repository(owner:$owner, name:$name) {
-                pullRequests(last:100, states:OPEN, labels: [$label]) {
-                  totalCount
-                }
-              }
-            }`;
-            const variables = {
-              owner: context.repo.owner,
-              name: context.repo.repo,
-              label: 'CI-long-timeout'
-            }
-            const response = await github.graphql(query, variables)
-            if (response.errors) {
-              // The GitHub API query errored, so fail open and assume 0 PRs.
-              core.setOutput('count', 0)
-            } else {
-              core.setOutput('count', response.data.repository.pullRequests.totalCount)
-            }
-
   setup_tests:
     if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
@@ -126,7 +99,26 @@ jobs:
             }
 
             if (label_names.includes('CI-long-timeout')) {
-              const long_pr_count = ${{ needs.tap_syntax.outputs.long_pr_count }}
+              const labelCountQuery = `query($owner:String!, $name:String!, $label:String!) {
+                repository(owner:$owner, name:$name) {
+                  pullRequests(last: 100, states: OPEN, labels: [$label]) {
+                    totalCount
+                  }
+                }
+              }`;
+              const response = await github.graphql(
+                labelCountQuery, {
+                  owner: context.repo.owner,
+                  name: context.repo.repo,
+                  label: 'CI-long-timeout'
+                }
+              )
+              if (response.errors) {
+                // The GitHub API query errored, so fail open and assume 0 long PRs.
+                let long_pr_count = 0
+              } else {
+                let long_pr_count = response.data.repository.pullRequests.totalCount
+              }
               const maximum_long_pr_count = 2
               if (long_pr_count > maximum_long_pr_count) {
                 core.setFailed(`Too many pull requests (${long_pr_count}) with the long-timeout label!`)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,7 @@ jobs:
                   }
                 }
               }`;
+              var long_pr_count;
               try {
                 const response = await github.graphql(
                   labelCountQuery, {
@@ -114,10 +115,10 @@ jobs:
                     label: 'CI-long-timeout'
                   }
                 )
-                let long_pr_count = response.data.repository.pullRequests.totalCount
+                long_pr_count = response.data.repository.pullRequests.totalCount
               } catch (error) {
                 // The GitHub API query errored, so fail open and assume 0 long PRs.
-                let long_pr_count = 0
+                long_pr_count = 0
               }
               const maximum_long_pr_count = 2
               if (long_pr_count > maximum_long_pr_count) {


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This check hitting timeouts on the GitHub side was failing all tap-syntax CI for normal, non-labelled PRs. :-(
- This unblocks us for now. There's probably a more elegant/risk-averse solution for the future, but I figure that failing open is a good strategy given the vast majority of day-to-day PRs don't have 'CI-long-timeout' labels at all.

/cc @carlocab