### PR TITLE
workflows/tests: remove `bottles` directory on Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -222,6 +222,7 @@ jobs:
       - name: Run brew test-bot ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
         id: brew-test-bot-formulae
         run: |
+          rm -rf bottles
           mkdir bottles
           cd bottles
           brew test-bot ${{ needs.setup_tests.outputs.test-bot-formulae-args }}


### PR DESCRIPTION
Creating this directory produces a `File exists` error on the
self-hosted Linux runner (cf. #90611).

There ought to be a better solution, but I have no idea what it is, so
let's unblock PRs that need the self-hosted runner for now.