### PR TITLE
Migrate remaining stand-alone formulae (g-k) to Python 3.10

### DIFF
--- a/Formula/ginac.rb
+++ b/Formula/ginac.rb
@@ -4,6 +4,7 @@ class Ginac < Formula
   url "https://www.ginac.de/ginac-1.8.1.tar.bz2"
   sha256 "f1695dbd6b187061ef3fba507648c9d6dba438f733b058c16f9278cbdcf5e1ab"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.ginac.de/Download.html"
@@ -20,7 +21,7 @@ class Ginac < Formula
 
   depends_on "pkg-config" => :build
   depends_on "cln"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   depends_on "readline"
 
   # Fix -flat_namespace being used on Big Sur and later.

--- a/Formula/gitfs.rb
+++ b/Formula/gitfs.rb
@@ -6,7 +6,7 @@ class Gitfs < Formula
   url "https://github.com/presslabs/gitfs/archive/0.5.2.tar.gz"
   sha256 "921e24311e3b8ea3a5448d698a11a747618ee8dd62d5d43a85801de0b111cbf3"
   license "Apache-2.0"
-  revision 8
+  revision 9
   head "https://github.com/presslabs/gitfs.git"
 
   bottle do
@@ -14,7 +14,7 @@ class Gitfs < Formula
   end
 
   depends_on "libgit2"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   uses_from_macos "libffi"
 
@@ -97,7 +97,7 @@ class Gitfs < Formula
   end
 
   test do
-    xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
+    xy = Language::Python.major_minor_version Formula["python@3.10"].opt_bin/"python3"
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{xy}/site-packages"
 
     (testpath/"test.py").write <<~EOS
@@ -106,7 +106,7 @@ class Gitfs < Formula
       pygit2.init_repository('testing/.git', True)
     EOS
 
-    system Formula["python@3.9"].opt_bin/"python3", "test.py"
+    system Formula["python@3.10"].opt_bin/"python3", "test.py"
     assert_predicate testpath/"testing/.git/config", :exist?
     cd "testing" do
       system "git", "remote", "add", "homebrew", "https://github.com/Homebrew/homebrew-core.git"

--- a/Formula/hsd.rb
+++ b/Formula/hsd.rb
@@ -18,7 +18,7 @@ class Hsd < Formula
     sha256 catalina: "32607b1d4de029dfe5be50508b30aca83ee087a5e43fad5e275c4b753ba28c57"
   end
 
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "node@10"
   depends_on "unbound"
 

--- a/Formula/i386-elf-gdb.rb
+++ b/Formula/i386-elf-gdb.rb
@@ -6,7 +6,7 @@ class I386ElfGdb < Formula
   mirror "https://ftpmirror.gnu.org/gdb/gdb-10.2.tar.xz"
   sha256 "aaa1223d534c9b700a8bec952d9748ee1977513f178727e1bee520ee000b4f29"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
 
   livecheck do
@@ -24,7 +24,7 @@ class I386ElfGdb < Formula
   end
 
   depends_on "i686-elf-gcc" => :test
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   depends_on "xz" # required for lzma support
 
   uses_from_macos "texinfo" => :build
@@ -50,7 +50,7 @@ class I386ElfGdb < Formula
       --disable-debug
       --disable-dependency-tracking
       --with-lzma
-      --with-python=#{Formula["python@3.9"].opt_bin}/python3
+      --with-python=#{Formula["python@3.10"].opt_bin}/python3
       --with-system-zlib
       --disable-binutils
     ]

--- a/Formula/infer.rb
+++ b/Formula/infer.rb
@@ -44,7 +44,7 @@ class Infer < Formula
   depends_on "opam" => :build
   depends_on "openjdk@11" => [:build, :test]
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "gmp"
   depends_on "mpfr"
   depends_on "sqlite"

--- a/Formula/iso-codes.rb
+++ b/Formula/iso-codes.rb
@@ -11,7 +11,7 @@ class IsoCodes < Formula
   end
 
   depends_on "gettext" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/juju-wait.rb
+++ b/Formula/juju-wait.rb
@@ -6,7 +6,7 @@ class JujuWait < Formula
   url "https://files.pythonhosted.org/packages/0c/2b/f4bd0138f941e4ba321298663de3f1c8d9368b75671b17aa1b8d41a154dc/juju-wait-2.8.4.tar.gz"
   sha256 "9e84739056e371ab41ee59086313bf357684bc97aae8308716c8fe3f19df99be"
   license "GPL-3.0-only"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "c91fa90978e376e52e9bcadc23a86103d4ac976f372917095d22bed638ae6d14"
@@ -21,7 +21,7 @@ class JujuWait < Formula
 
   depends_on "juju"
   depends_on "libyaml"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "PyYAML" do
     url "https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz"

--- a/Formula/kibana.rb
+++ b/Formula/kibana.rb
@@ -19,7 +19,7 @@ class Kibana < Formula
   # https://www.elastic.co/blog/licensing-change
   deprecate! date: "2021-01-14", because: "is switching to an incompatible license"
 
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "yarn" => :build
   depends_on "node@10"
 

--- a/Formula/ktoblzcheck.rb
+++ b/Formula/ktoblzcheck.rb
@@ -4,7 +4,7 @@ class Ktoblzcheck < Formula
   url "https://downloads.sourceforge.net/project/ktoblzcheck/ktoblzcheck-1.53.tar.gz"
   sha256 "18b9118556fe83240f468f770641d2578f4ff613cdcf0a209fb73079ccb70c55"
   license "LGPL-2.1-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -23,7 +23,7 @@ class Ktoblzcheck < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     system "cmake", ".", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{opt_lib}"


### PR DESCRIPTION
Part of PR #90716.

- [ ] `genometools` (recursively conflict with `python@3.9`)
- [X] `ghc@8.6` (CI timeout #90787)
- [X] `ghc@8.8` (CI timeout #90786)
- [X] `ghc@9` (CI timeout #90784)
- [X] `ginac`
- [X] `gitfs`
- [X] `glslang` (#90836)
- [ ] `gprof2dot` (recursively conflict with `python@3.9`)
- [X] `gpsd` (#90848)
- [X] `handbrake` (#90767)
- [ ] `hatari` (CI test failed https://github.com/Homebrew/homebrew-core/actions/runs/1558507355)
- [X] `hsd`
- [X] `htop` (#90696)
- [ ] `hy` (CI test failed https://github.com/Homebrew/homebrew-core/actions/runs/1558507355)
- [X] `i386-elf-gdb`
- [X] `infer`
- [X] `iso-codes`
- [X] `juju-wait`
- [X] `kibana`
- [X] `ktoblzcheck`