### PR TITLE
Migrate remaining stand-alone formulae (l-m) to Python 3.10

### DIFF
--- a/Formula/lc0.rb
+++ b/Formula/lc0.rb
@@ -20,7 +20,7 @@ class Lc0 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build # required to compile .pb files
+  depends_on "python@3.10" => :build # required to compile .pb files
   depends_on "eigen"
 
   uses_from_macos "zlib"

--- a/Formula/libbtbb.rb
+++ b/Formula/libbtbb.rb
@@ -7,6 +7,7 @@ class Libbtbb < Formula
   version "2020-12-R1"
   sha256 "9478bb51a38222921b5b1d7accce86acd98ed37dbccb068b38d60efa64c5231f"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/greatscottgadgets/libbtbb.git"
 
   bottle do
@@ -20,7 +21,7 @@ class Libbtbb < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     mkdir "build" do

--- a/Formula/libcap-ng.rb
+++ b/Formula/libcap-ng.rb
@@ -12,7 +12,7 @@ class LibcapNg < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "swig" => :build
   depends_on :linux
 

--- a/Formula/libpqxx@6.rb
+++ b/Formula/libpqxx@6.rb
@@ -22,12 +22,12 @@ class LibpqxxAT6 < Formula
   deprecate! date: "2020-06-23", because: :versioned_formula
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "xmlto" => :build
   depends_on "libpq"
 
   def install
-    ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin"
+    ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin"
     ENV["PG_CONFIG"] = Formula["libpq"].opt_bin/"pg_config"
 
     system "./configure", "--prefix=#{prefix}", "--enable-shared"

--- a/Formula/libprelude.rb
+++ b/Formula/libprelude.rb
@@ -4,7 +4,7 @@ class Libprelude < Formula
   url "https://www.prelude-siem.org/attachments/download/1395/libprelude-5.2.0.tar.gz"
   sha256 "187e025a5d51219810123575b32aa0b40037709a073a775bc3e5a65aa6d6a66e"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://www.prelude-siem.org/projects/prelude/files"
@@ -25,7 +25,7 @@ class Libprelude < Formula
   depends_on "pkg-config" => :build
   depends_on "gnutls"
   depends_on "libgpg-error"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     ENV["HAVE_CXX"] = "yes"
@@ -38,7 +38,7 @@ class Libprelude < Formula
       --without-perl
       --without-swig
       --without-python2
-      --with-python3=python#{Formula["python@3.9"].version.major_minor}
+      --with-python3=python#{Formula["python@3.10"].version.major_minor}
       --with-libgnutls-prefix=#{Formula["gnutls"].opt_prefix}
     ]
 

--- a/Formula/libpsl.rb
+++ b/Formula/libpsl.rb
@@ -19,7 +19,7 @@ class Libpsl < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "icu4c"
 
   def install

--- a/Formula/librdkafka.rb
+++ b/Formula/librdkafka.rb
@@ -22,7 +22,7 @@ class Librdkafka < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "lz4"
   depends_on "lzlib"
   depends_on "openssl@1.1"

--- a/Formula/libtcod.rb
+++ b/Formula/libtcod.rb
@@ -17,7 +17,7 @@ class Libtcod < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "sdl2"
 
   conflicts_with "libzip", "minizip-ng", because: "libtcod, libzip and minizip-ng install a `zip.h` header"

--- a/Formula/libtensorflow@1.rb
+++ b/Formula/libtensorflow@1.rb
@@ -18,10 +18,10 @@ class LibtensorflowAT1 < Formula
   deprecate! date: "2021-01-06", because: :versioned_formula
 
   depends_on "bazel" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   def install
-    ENV["PYTHON_BIN_PATH"] = Formula["python@3.9"].opt_bin/"python3"
+    ENV["PYTHON_BIN_PATH"] = Formula["python@3.10"].opt_bin/"python3"
     ENV["CC_OPT_FLAGS"] = "-march=native"
     ENV["TF_IGNORE_MAX_BAZEL_VERSION"] = "1"
     ENV["TF_NEED_JEMALLOC"] = "1"

--- a/Formula/libvoikko.rb
+++ b/Formula/libvoikko.rb
@@ -22,7 +22,7 @@ class Libvoikko < Formula
 
   depends_on "foma" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "hfstospell"
 
   resource "voikko-fi" do

--- a/Formula/libxml++@5.rb
+++ b/Formula/libxml++@5.rb
@@ -23,7 +23,7 @@ class LibxmlxxAT5 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => [:build, :test]
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   uses_from_macos "libxml2"
 

--- a/Formula/libzzip.rb
+++ b/Formula/libzzip.rb
@@ -19,7 +19,7 @@ class Libzzip < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   uses_from_macos "zip" => :test
   uses_from_macos "zlib"

--- a/Formula/link-grammar.rb
+++ b/Formula/link-grammar.rb
@@ -27,7 +27,7 @@ class LinkGrammar < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   uses_from_macos "sqlite"
 

--- a/Formula/mbedtls.rb
+++ b/Formula/mbedtls.rb
@@ -23,7 +23,7 @@ class Mbedtls < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   def install
     inreplace "include/mbedtls/mbedtls_config.h" do |s|
@@ -35,7 +35,7 @@ class Mbedtls < Formula
 
     system "cmake", "-S", ".", "-B", "build",
                     "-DUSE_SHARED_MBEDTLS_LIBRARY=On",
-                    "-DPython3_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3",
+                    "-DPython3_EXECUTABLE=#{Formula["python@3.10"].opt_bin}/python3",
                     "-DCMAKE_INSTALL_RPATH=#{rpath}",
                     *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/mbedtls@2.rb
+++ b/Formula/mbedtls@2.rb
@@ -24,7 +24,7 @@ class MbedtlsAT2 < Formula
   keg_only :versioned_formula
 
   depends_on "cmake" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   def install
     inreplace "include/mbedtls/config.h" do |s|
@@ -36,7 +36,7 @@ class MbedtlsAT2 < Formula
 
     system "cmake", "-S", ".", "-B", "build",
                     "-DUSE_SHARED_MBEDTLS_LIBRARY=On",
-                    "-DPython3_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3",
+                    "-DPython3_EXECUTABLE=#{Formula["python@3.10"].opt_bin}/python3",
                     *std_cmake_args
     system "cmake", "--build", "build"
     # We run CTest because this is a crypto library. Running tests in parallel causes failures.

--- a/Formula/metricbeat.rb
+++ b/Formula/metricbeat.rb
@@ -18,7 +18,7 @@ class Metricbeat < Formula
 
   depends_on "go" => :build
   depends_on "mage" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   def install
     # remove non open source files

--- a/Formula/mm-common.rb
+++ b/Formula/mm-common.rb
@@ -4,6 +4,7 @@ class MmCommon < Formula
   url "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.3.tar.xz"
   sha256 "e81596625899aacf1d0bf27ccc2fcc7f373405ec48735ca1c7273c0fbcdc1ef5"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "f40a6de3865dbb9c453f82b2eae422bb54ae0e422ee287ad41cea24f4b084937"
@@ -16,7 +17,7 @@ class MmCommon < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     mkdir "build" do

--- a/Formula/monetdb.rb
+++ b/Formula/monetdb.rb
@@ -24,7 +24,7 @@ class Monetdb < Formula
   depends_on "bison" => :build # macOS bison is too old
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "lz4"
   depends_on "openssl@1.1"
   depends_on "pcre"

--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -4,6 +4,7 @@ class Mono < Formula
   url "https://download.mono-project.com/sources/mono/mono-6.12.0.122.tar.xz"
   sha256 "29c277660fc5e7513107aee1cbf8c5057c9370a4cdfeda2fc781be6986d89d23"
   license "MIT"
+  revision 1
 
   livecheck do
     url "https://www.mono-project.com/download/stable/"
@@ -19,7 +20,7 @@ class Mono < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   uses_from_macos "unzip" => :build
 

--- a/Formula/mps-youtube.rb
+++ b/Formula/mps-youtube.rb
@@ -6,7 +6,7 @@ class MpsYoutube < Formula
   url "https://files.pythonhosted.org/packages/b1/8e/5156416119545e3f5ba16ec0fdbb2c7d0b57fad9e19ee8554856cd4a41ad/mps-youtube-0.2.8.tar.gz"
   sha256 "59ce3944626fbd1a041e1e1b15714bbd138ebc71ceb89e32ea9470d8152af083"
   license "GPL-3.0-or-later"
-  revision 11
+  revision 12
 
   bottle do
     rebuild 2
@@ -18,7 +18,7 @@ class MpsYoutube < Formula
   end
 
   depends_on "mplayer"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "pafy" do
     url "https://files.pythonhosted.org/packages/7e/02/b70f4d2ad64bbc7d2a00018c6545d9b9039208553358534e73e6dd5bbaf6/pafy-0.5.5.tar.gz"

--- a/Formula/mx.rb
+++ b/Formula/mx.rb
@@ -4,6 +4,7 @@ class Mx < Formula
   url "https://github.com/graalvm/mx/archive/refs/tags/5.296.0.tar.gz"
   sha256 "d6867cdfa80575c70a3e64ada62e8cb22a226e2df6dc4c4bf6db5964bd9a8fde"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url :stable
@@ -16,7 +17,7 @@ class Mx < Formula
 
   depends_on "openjdk" => :test
   depends_on arch: :x86_64
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource("testdata") do
     url "https://github.com/oracle/graal/archive/refs/tags/vm-21.0.0.2.tar.gz"
@@ -25,7 +26,7 @@ class Mx < Formula
 
   def install
     libexec.install Dir["*"]
-    (bin/"mx").write_env_script libexec/"mx", MX_PYTHON: "#{Formula["python@3.9"].opt_bin}/python3"
+    (bin/"mx").write_env_script libexec/"mx", MX_PYTHON: "#{Formula["python@3.10"].opt_bin}/python3"
     bash_completion.install libexec/"bash_completion/mx" => "mx"
   end
 


### PR DESCRIPTION
Part of PR #90716.

- [X] `lc0`
- [ ] `ldns` (recursively conflict with `python@3.9`)
- [X] `libbtbb`
- [X] `libcap-ng`
- [ ] `libpqxx` (CI test failed https://github.com/Homebrew/homebrew-core/runs/4469872212)
- [X] `libpqxx@6`
- [X] `libprelude`
- [X] `libpsl`
- [X] `librdkafka`
- [ ] `libstfl`(CI test failed https://github.com/Homebrew/homebrew-core/runs/4469872212)
- [X] `libtcod`
- [X] `libtensorflow@1`
- [X] `libvoikko`
- [X] `libxml++@5`
- [X] `libzzip`
- [X] `link-grammar`
- [ ] `macvim` (CI test failed https://github.com/Homebrew/homebrew-core/runs/4469872212)
- [X] `mbedtls`
- [X] `mbedtls@2`
- [X] `metricbeat`
- [ ] `mkvtomp4` (recursively conflict with `python@3.9`)
- [X] `mm-common`
- [X] `monetdb`
- [X] `mono`
- [X] `mps-youtube`
- [X] `mx`