### PR TITLE
Migrate remaining stand-alone formulae (n-r) to Python 3.10

### DIFF
--- a/Formula/nanomsgxx.rb
+++ b/Formula/nanomsgxx.rb
@@ -16,7 +16,7 @@ class Nanomsgxx < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "nanomsg"
 
   # Add python3 support

--- a/Formula/neovim-remote.rb
+++ b/Formula/neovim-remote.rb
@@ -6,6 +6,7 @@ class NeovimRemote < Formula
   url "https://files.pythonhosted.org/packages/cc/d8/82aec85fc7ad0853afca2c88e73ecc7d3a50c66988c44aa9748ccbc9b689/neovim-remote-2.4.0.tar.gz"
   sha256 "f199ebb61c3decf462feed4e7d467094ed38d8afaf43620736b5983a12fe2427"
   license "MIT"
+  revision 1
   head "https://github.com/mhinz/neovim-remote.git", branch: "master"
 
   bottle do
@@ -19,7 +20,7 @@ class NeovimRemote < Formula
   end
 
   depends_on "neovim"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "greenlet" do
     url "https://files.pythonhosted.org/packages/47/6d/be10df2b141fcb1020c9605f7758881b5af706fb09a05b737e8eb7540387/greenlet-1.1.0.tar.gz"

--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -4,6 +4,7 @@ class Newt < Formula
   url "https://releases.pagure.org/newt/newt-0.52.21.tar.gz"
   sha256 "265eb46b55d7eaeb887fca7a1d51fe115658882dfe148164b6c49fccac5abb31"
   license "LGPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://releases.pagure.org/newt/"
@@ -27,7 +28,7 @@ class Newt < Formula
   depends_on "s-lang"
 
   on_linux do
-    depends_on "python@3.9"
+    depends_on "python@3.10"
   end
 
   def install

--- a/Formula/omniorb.rb
+++ b/Formula/omniorb.rb
@@ -4,7 +4,7 @@ class Omniorb < Formula
   url "https://downloads.sourceforge.net/project/omniorb/omniORB/omniORB-4.2.4/omniORB-4.2.4.tar.bz2"
   sha256 "28c01cd0df76c1e81524ca369dc9e6e75f57dc70f30688c99c67926e4bdc7a6f"
   license "GPL-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -22,7 +22,7 @@ class Omniorb < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "bindings" do
     url "https://downloads.sourceforge.net/project/omniorb/omniORBpy/omniORBpy-4.2.4/omniORBpy-4.2.4.tar.bz2"

--- a/Formula/open-adventure.rb
+++ b/Formula/open-adventure.rb
@@ -23,7 +23,7 @@ class OpenAdventure < Formula
   end
 
   depends_on "asciidoc" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   uses_from_macos "libxml2" => :build
   uses_from_macos "libedit"
@@ -38,7 +38,7 @@ class OpenAdventure < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3.9")
+    venv = virtualenv_create(libexec, "python3.10")
     venv.pip_install resources
     system libexec/"bin/python", "./make_dungeon.py"
     system "make"

--- a/Formula/openmsx.rb
+++ b/Formula/openmsx.rb
@@ -21,7 +21,7 @@ class Openmsx < Formula
     sha256 cellar: :any, mojave:         "57e29bb1e9e2ed95d628b7933c1929eb99da46f9bfc4885bc9b072a94afd6c0e"
   end
 
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "freetype"
   depends_on "glew"
   depends_on "libogg"

--- a/Formula/otf2.rb
+++ b/Formula/otf2.rb
@@ -4,6 +4,7 @@ class Otf2 < Formula
   url "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-2.3/otf2-2.3.tar.gz"
   sha256 "36957428d37c40d35b6b45208f050fb5cfe23c54e874189778a24b0e9219c7e3"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :homepage
@@ -23,7 +24,7 @@ class Otf2 < Formula
   depends_on "sphinx-doc" => :build
   depends_on "gcc" # for gfortran
   depends_on "open-mpi"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "future" do
     url "https://files.pythonhosted.org/packages/45/0b/38b06fd9b92dc2b68d58b75f900e97884c45bedd2ff83203d933cf5851c9/future-0.18.2.tar.gz"
@@ -31,7 +32,7 @@ class Otf2 < Formula
   end
 
   def install
-    python3 = Formula["python@3.9"].opt_bin/"python3"
+    python3 = Formula["python@3.10"].opt_bin/"python3"
     xy = Language::Python.major_minor_version python3
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python#{xy}/site-packages"
 

--- a/Formula/packetbeat.rb
+++ b/Formula/packetbeat.rb
@@ -18,7 +18,7 @@ class Packetbeat < Formula
 
   depends_on "go" => :build
   depends_on "mage" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   uses_from_macos "libpcap"
 

--- a/Formula/protobuf@3.6.rb
+++ b/Formula/protobuf@3.6.rb
@@ -4,7 +4,7 @@ class ProtobufAT36 < Formula
   url "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.tar.gz"
   sha256 "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
 
   bottle do
     sha256 cellar: :any, arm64_monterey: "ceeb84f3074f1ca1d3b7e748212f4ec42a9a8287b952723e6acf992eadc20dfc"
@@ -24,7 +24,7 @@ class ProtobufAT36 < Formula
   depends_on "automake" => :build
   depends_on "cmake" => :build
   depends_on "libtool" => :build
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "six" do
     url "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"
@@ -64,14 +64,14 @@ class ProtobufAT36 < Formula
     ENV.append_to_cflags "-L#{lib}"
 
     resource("six").stage do
-      system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)
+      system Formula["python@3.10"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)
     end
     chdir "python" do
-      system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec),
+      system Formula["python@3.10"].opt_bin/"python3", *Language::Python.setup_install_args(libexec),
                                                       "--cpp_implementation"
     end
 
-    version = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
+    version = Language::Python.major_minor_version Formula["python@3.10"].opt_bin/"python3"
     site_packages = "lib/python#{version}/site-packages"
     pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
     (prefix/site_packages/"homebrew-protobuf.pth").write pth_contents

--- a/Formula/pygitup.rb
+++ b/Formula/pygitup.rb
@@ -6,6 +6,7 @@ class Pygitup < Formula
   url "https://files.pythonhosted.org/packages/89/a3/35f7460cfaf7353ceb23442e5c250fda249cb9b8e26197cf801fa4f63786/git-up-2.1.0.tar.gz"
   sha256 "6e677d91aeb4de37e62bdc166042243313ec873c3caf9938911ac2e7f52a0652"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "c1fc3d05c9426628db3014aad4ca9f54c3ea8ed709187e532c5e0a33ff3cec24"
@@ -18,7 +19,7 @@ class Pygitup < Formula
   end
 
   depends_on "poetry" => :build
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "colorama" do
     url "https://files.pythonhosted.org/packages/1f/bb/5d3246097ab77fa083a61bd8d3d527b7ae063c7d8e8671b1cf8c4ec10cbe/colorama-0.4.4.tar.gz"

--- a/Formula/quex.rb
+++ b/Formula/quex.rb
@@ -4,6 +4,7 @@ class Quex < Formula
   url "https://downloads.sourceforge.net/project/quex/quex-0.71.2.zip"
   sha256 "0453227304a37497e247e11b41a1a8eb04bcd0af06a3f9d627d706b175a8a965"
   license "MIT"
+  revision 1
   head "https://svn.code.sf.net/p/quex/code/trunk"
 
   livecheck do
@@ -16,7 +17,7 @@ class Quex < Formula
     sha256 cellar: :any_skip_relocation, all:           "8e53508d74a86c0ec8decef4bf4233f197a8612168cee8707295e22a7ed05b8b"
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     libexec.install "quex", "quex-exe.py"
@@ -25,7 +26,7 @@ class Quex < Formula
     # Use a shim script to set QUEX_PATH on the user's behalf
     (bin/"quex").write <<~EOS
       #!/bin/bash
-      QUEX_PATH="#{libexec}" "#{Formula["python@3.9"].opt_bin}/python3" "#{libexec}/quex-exe.py" "$@"
+      QUEX_PATH="#{libexec}" "#{Formula["python@3.10"].opt_bin}/python3" "#{libexec}/quex-exe.py" "$@"
     EOS
 
     if build.head?

--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -14,7 +14,7 @@ class Rabbitmq < Formula
     sha256 cellar: :any_skip_relocation, all: "1e5c7b9a5dd11571857d2475a1889b7bdc843a3839f029b4d9a60a35837fcbf1"
   end
 
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "erlang"
 
   def install

--- a/Formula/recode.rb
+++ b/Formula/recode.rb
@@ -16,7 +16,7 @@ class Recode < Formula
   end
 
   depends_on "libtool" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "gettext"
 
   # Fix -flat_namespace being used on Big Sur and later.

--- a/Formula/resty.rb
+++ b/Formula/resty.rb
@@ -6,6 +6,7 @@ class Resty < Formula
   url "https://github.com/micha/resty/archive/v3.0.tar.gz"
   sha256 "9ed8f50dcf70a765b3438840024b557470d7faae2f0c1957a011ebb6c94b9dd1"
   license "MIT"
+  revision 1
   head "https://github.com/micha/resty.git", branch: "master"
 
   bottle do
@@ -24,7 +25,7 @@ class Resty < Formula
   uses_from_macos "perl"
 
   on_linux do
-    depends_on "python@3.9"
+    depends_on "python@3.10"
   end
 
   conflicts_with "nss", because: "both install `pp` binaries"


### PR DESCRIPTION
Part of PR #90716.

- [X] `nanomsgxx`
- [X] `neovim-remote`
- [X] `newt`
- [ ] `node@12` (CI test failed https://github.com/Homebrew/homebrew-core/actions/runs/1558524483)
- [ ] `ns-3` (CI test failed https://github.com/Homebrew/homebrew-core/actions/runs/1558524483)
- [X] `omniorb`
- [ ] `onnxruntime` (CI test failed on Linux https://github.com/Homebrew/homebrew-core/actions/runs/1558524483)
- [X] `open-adventure`
- [ ] `open-babel` (recursively conflict with `python@3.9`)
- [X] `openmsx`
- [X] `opensearch-dashboards` (#90403)
- [X] `otf2`
- [X] `packetbeat`
- [X] `protobuf@3.6`
- [X] `pygitup`
- [X] `quex`
- [X] `rabbitmq`
- [X] `recode`
- [X] `resty`