### PR TITLE
Migrate remaining stand-alone formulae (s-z) to Python 3.10

### DIFF
--- a/Formula/semgrep.rb
+++ b/Formula/semgrep.rb
@@ -7,6 +7,7 @@ class Semgrep < Formula
       tag:      "v0.76.2",
       revision: "bddf674c52fbc294b11f298704b975dba98f8aa7"
   license "LGPL-2.1-only"
+  revision 1
   head "https://github.com/returntocorp/semgrep.git", branch: "develop"
 
   livecheck do
@@ -31,7 +32,7 @@ class Semgrep < Formula
   depends_on "pipenv" => :build
   depends_on "pkg-config" => :build
   depends_on "pcre"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   depends_on "tree-sitter"
 
   uses_from_macos "rsync" => :build
@@ -179,7 +180,7 @@ class Semgrep < Formula
     ENV["SEMGREP_SKIP_BIN"] = "1"
     python_path = "semgrep"
     cd python_path do
-      venv = virtualenv_create(libexec, Formula["python@3.9"].bin/"python3.9")
+      venv = virtualenv_create(libexec, Formula["python@3.10"].bin/"python3.10")
       venv.pip_install resources.reject { |r| r.name == "ocaml-tree-sitter" }
       venv.pip_install_and_link buildpath/python_path
     end

--- a/Formula/serd.rb
+++ b/Formula/serd.rb
@@ -23,11 +23,11 @@ class Serd < Formula
   depends_on "pkg-config" => :build
 
   on_linux do
-    depends_on "python@3.9" => :build
+    depends_on "python@3.10" => :build
   end
 
   def install
-    ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin" if OS.linux?
+    ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin" if OS.linux?
     system "./waf", "configure", "--prefix=#{prefix}"
     system "./waf"
     system "./waf", "install"

--- a/Formula/spirv-tools.rb
+++ b/Formula/spirv-tools.rb
@@ -15,7 +15,7 @@ class SpirvTools < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   resource "re2" do
     # revision number could be found in ./DEPS

--- a/Formula/stone-soup.rb
+++ b/Formula/stone-soup.rb
@@ -20,7 +20,7 @@ class StoneSoup < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "lua@5.1"
   depends_on "pcre"
   depends_on "sqlite"
@@ -32,7 +32,7 @@ class StoneSoup < Formula
 
   def install
     ENV.cxx11
-    ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin"
+    ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin"
     xy = Language::Python.major_minor_version "python3"
     ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python#{xy}/site-packages"
 

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -36,7 +36,7 @@ class Subversion < Formula
 
   depends_on "openjdk" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "scons" => :build # For Serf
   depends_on "swig" => :build
   depends_on "apr"
@@ -167,7 +167,7 @@ class Subversion < Formula
       --enable-javahl
       --without-jikes
       PERL=#{perl}
-      PYTHON=#{Formula["python@3.9"].opt_bin}/python3
+      PYTHON=#{Formula["python@3.10"].opt_bin}/python3
       RUBY=#{ruby}
     ]
 
@@ -187,7 +187,7 @@ class Subversion < Formula
 
     system "make", "swig-py"
     system "make", "install-swig-py"
-    (lib/"python3.9/site-packages").install_symlink Dir["#{lib}/svn-python/*"]
+    (lib/"python3.10/site-packages").install_symlink Dir["#{lib}/svn-python/*"]
 
     # Java and Perl support don't build correctly in parallel:
     # https://github.com/Homebrew/homebrew/issues/20415

--- a/Formula/thrax.rb
+++ b/Formula/thrax.rb
@@ -6,6 +6,7 @@ class Thrax < Formula
   url "https://www.openfst.org/twiki/pub/GRM/ThraxDownload/thrax-1.3.6.tar.gz"
   sha256 "5f00a2047674753cba6783b010ab273366dd3dffc160bdb356f7236059a793ba"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://www.openfst.org/twiki/bin/view/GRM/ThraxDownload"
@@ -26,7 +27,7 @@ class Thrax < Formula
 
   on_linux do
     depends_on "gcc"
-    depends_on "python@3.9"
+    depends_on "python@3.10"
   end
 
   fails_with gcc: "5"

--- a/Formula/uftrace.rb
+++ b/Formula/uftrace.rb
@@ -4,6 +4,7 @@ class Uftrace < Formula
   url "https://github.com/namhyung/uftrace/archive/v0.11.tar.gz"
   sha256 "101dbb13cb3320ee76525ec26426f2aa1de4e3ee5af74f79cb403ae4d2c6c871"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/namhyung/uftrace.git", branch: "master"
 
   bottle do
@@ -18,7 +19,7 @@ class Uftrace < Formula
   depends_on :linux
   depends_on "luajit-openresty"
   depends_on "ncurses"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     # Obsolete with git master, to be removed when updating to next release

--- a/Formula/unicorn.rb
+++ b/Formula/unicorn.rb
@@ -15,7 +15,7 @@ class Unicorn < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => [:build, :test]
+  depends_on "python@3.10" => [:build, :test]
 
   def install
     ENV["PREFIX"] = prefix
@@ -26,7 +26,7 @@ class Unicorn < Formula
     system "make", "install"
 
     cd "bindings/python" do
-      system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
+      system Formula["python@3.10"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
     end
   end
 
@@ -78,6 +78,6 @@ class Unicorn < Formula
                    "-pthread", "-lpthread", "-lm", "-L#{lib}", "-lunicorn"
     system testpath/"test1"
 
-    system Formula["python@3.9"].opt_bin/"python3", "-c", "import unicorn; print(unicorn.__version__)"
+    system Formula["python@3.10"].opt_bin/"python3", "-c", "import unicorn; print(unicorn.__version__)"
   end
 end

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -5,6 +5,7 @@ class Vim < Formula
   url "https://github.com/vim/vim/archive/v8.2.3750.tar.gz"
   sha256 "fbbb7892d9064a52b58a7c5530faee2e3797cf630094e9015ac4e2ae189bd4d3"
   license "Vim"
+  revision 1
   head "https://github.com/vim/vim.git", branch: "master"
 
   bottle do
@@ -20,7 +21,7 @@ class Vim < Formula
   depends_on "lua"
   depends_on "ncurses"
   depends_on "perl"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   depends_on "ruby"
 
   conflicts_with "ex-vi",
@@ -30,7 +31,7 @@ class Vim < Formula
     because: "vim and macvim both install vi* binaries"
 
   def install
-    ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin"
+    ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin"
 
     # https://github.com/Homebrew/homebrew-core/pull/1046
     ENV.delete("SDKROOT")

--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -4,6 +4,7 @@ class Weechat < Formula
   url "https://weechat.org/files/src/weechat-3.3.tar.xz"
   sha256 "cafeab8af8be4582ccfd3e74fd40e5086a1efa158231f2c26b8b05c3950fcbdf"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/weechat/weechat.git", branch: "master"
 
   bottle do
@@ -26,7 +27,7 @@ class Weechat < Formula
   depends_on "lua"
   depends_on "ncurses"
   depends_on "perl"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   depends_on "ruby"
 
   uses_from_macos "curl"

--- a/Formula/x86_64-elf-gdb.rb
+++ b/Formula/x86_64-elf-gdb.rb
@@ -6,7 +6,7 @@ class X8664ElfGdb < Formula
   mirror "https://ftpmirror.gnu.org/gdb/gdb-10.2.tar.xz"
   sha256 "aaa1223d534c9b700a8bec952d9748ee1977513f178727e1bee520ee000b4f29"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
 
   livecheck do
@@ -23,7 +23,7 @@ class X8664ElfGdb < Formula
   end
 
   depends_on "x86_64-elf-gcc" => :test
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   depends_on "xz"
 
   uses_from_macos "zlib"
@@ -48,7 +48,7 @@ class X8664ElfGdb < Formula
       --disable-debug
       --disable-dependency-tracking
       --with-lzma
-      --with-python=#{Formula["python@3.9"].opt_bin}/python3
+      --with-python=#{Formula["python@3.10"].opt_bin}/python3
       --with-system-zlib
       --disable-binutils
     ]

--- a/Formula/xkeyboardconfig.rb
+++ b/Formula/xkeyboardconfig.rb
@@ -13,7 +13,7 @@ class Xkeyboardconfig < Formula
   depends_on "gettext" => :build
   depends_on "intltool" => :build
   depends_on "pkg-config" => [:build, :test]
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   uses_from_macos "libxslt" => :build
 
   def install

--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -6,6 +6,7 @@ class YoutubeDl < Formula
   url "https://files.pythonhosted.org/packages/c6/75/05979677d9abc76851d13d8db3951e39017ac223545adab6e8576fa0cbe7/youtube_dl-2021.6.6.tar.gz"
   sha256 "cb2d3ee002158ede783e97a82c95f3817594df54367ea6a77ce5ceea4772f0ab"
   license "Unlicense"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "3a010e2e9bef8c7bca72c05aeadb4cbad5fc753f055b073ac249da1b32f1ba4a"
@@ -17,7 +18,7 @@ class YoutubeDl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8cf1a12113ca9116896c792441ac44197a47df59a347eb09685dd6476fdb3ef3"
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -4,6 +4,7 @@ class YoutubeDlc < Formula
   url "https://github.com/blackjack4494/yt-dlc/archive/2020.11.11-3.tar.gz"
   sha256 "649f8ba9a6916ca45db0b81fbcec3485e79895cec0f29fd25ec33520ffffca84"
   license "Unlicense"
+  revision 1
   head "https://github.com/blackjack4494/yt-dlc.git", branch: "master"
 
   livecheck do
@@ -22,7 +23,7 @@ class YoutubeDlc < Formula
   end
 
   depends_on "pandoc" => :build
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   uses_from_macos "zip" => :build
 
   def install


### PR DESCRIPTION
Part of PR #90716.

- [X] `semgrep`
- [X] `serd`
- [ ] `shallow-backup` (CI test failed https://github.com/Homebrew/homebrew-core/actions/runs/1558532572)
- [ ] `simgrid` (recursively conflict with `python@3.9`)
- [ ] `soapysdr` (recursively conflict with `python@3.9`)
- [ ] `spades` (CI test failed https://github.com/Homebrew/homebrew-core/actions/runs/1558532572)
- [X] `spirv-tools`
- [ ] `statik` (CI test failed https://github.com/Homebrew/homebrew-core/actions/runs/1558532572)
- [X] `stone-soup`
- [ ] `subliminal` (CI test failed https://github.com/Homebrew/homebrew-core/actions/runs/1558532572)
- [X] `subversion`
- [ ] `tbb@2020` (recursively conflict with `python@3.9`)
- [X] `thrax`
- [X] `uftrace`
- [X] `unicorn`
- [ ] `uwsgi` (CI test failed https://github.com/Homebrew/homebrew-core/actions/runs/1558532572)
- [X] `vim`
- [X] `weechat`
- [X] `x86_64-elf-gdb`
- [X] `xkeyboardconfig`
- [ ] `yle-dl` (recursively conflict with `python@3.9`)
- [X] `youtube-dl`
- [X] `youtube-dlc`