### PR TITLE
abi-compliance-checker: build an `:all` bottle

### DIFF
--- a/Formula/abi-compliance-checker.rb
+++ b/Formula/abi-compliance-checker.rb
@@ -29,6 +29,9 @@ class AbiComplianceChecker < Formula
   def install
     system "perl", "Makefile.pl", "-install", "-prefix", prefix
     (bin/"abi-compliance-checker.cmd").unlink if OS.mac?
+
+    # Make bottles uniform
+    inreplace pkgshare/"modules/Internals/SysFiles.pm", "/usr/local", HOMEBREW_PREFIX
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `inreplace` changes where this looks for headers, so we actually
probably also want this path fixed whenever we don't install in
`/usr/local`.