### PR TITLE
ghc@8.6: migrate to python@3.10

### DIFF
--- a/Formula/ghc@8.6.rb
+++ b/Formula/ghc@8.6.rb
@@ -21,7 +21,7 @@ class GhcAT86 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on arch: :x86_64
 
   uses_from_macos "m4" => :build
@@ -60,7 +60,7 @@ class GhcAT86 < Formula
   def install
     ENV["CC"] = ENV.cc
     ENV["LD"] = "ld"
-    ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
+    ENV["PYTHON"] = Formula["python@3.10"].opt_bin/"python3"
 
     args = %w[--enable-numa=no]
     if OS.mac?


### PR DESCRIPTION
Part of PR #90769, split for CI timeout.