### PR TITLE
tomcat@9: update to support an overridable $JAVA_HOME

### DIFF
--- a/Formula/tomcat@9.rb
+++ b/Formula/tomcat@9.rb
@@ -5,6 +5,7 @@ class TomcatAT9 < Formula
   mirror "https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.56/bin/apache-tomcat-9.0.56.tar.gz"
   sha256 "960ce89fa93099a412f7d1b828d6d97465d5e11500247e9c58a637fded523e0d"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -30,7 +31,7 @@ class TomcatAT9 < Formula
     libexec.install_symlink pkgetc => "conf"
 
     libexec.install Dir["*"]
-    (bin/"catalina").write_env_script "#{libexec}/bin/catalina.sh", JAVA_HOME: Formula["openjdk"].opt_prefix
+    (bin/"catalina").write_env_script "#{libexec}/bin/catalina.sh", Language::Java.overridable_java_home_env
   end
 
   def caveats


### PR DESCRIPTION
Closes #90661.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [NO] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Audit fails for some reason:

```
brew audit --strict 'Formula/tomcat@9.rb'
Error: Failed to load cask: Formula/tomcat@9.rb
Cask 'tomcat@9' is unreadable: wrong constant name #<Class:0x000000011e11bd58>
Warning: Treating Formula/tomcat@9.rb as a formula.
Error: undefined method `path' for nil:NilClass
Did you mean?  paths
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/opt/homebrew/Library/Homebrew/formula_auditor.rb:124:in `audit_synced_versions_formulae'
/opt/homebrew/Library/Homebrew/formula_auditor.rb:823:in `block in audit'
/opt/homebrew/Library/Homebrew/formula_auditor.rb:818:in `each'
/opt/homebrew/Library/Homebrew/formula_auditor.rb:818:in `audit'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:185:in `block in audit'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:169:in `map'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:169:in `audit'
/opt/homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```
-----
