### PR TITLE
xmlsh: remove livecheck

### DIFF
--- a/Formula/xmlsh.rb
+++ b/Formula/xmlsh.rb
@@ -4,11 +4,6 @@ class Xmlsh < Formula
   url "https://downloads.sourceforge.net/project/xmlsh/xmlsh/1.2.5/xmlsh_1_2_5.zip"
   sha256 "489df45f19a6bb586fdb5abd1f8ba9397048597895cb25def747b0118b02b1c8"
 
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/v?(\d+(?:\.\d+)+)/xmlsh}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "e9a08dc3cd955e21c5e170cb205584b19cf67d10f062a597bc6284ffca9dbc70"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`xmlsh` has been disabled for various reasons (#90662), primarily the lack of a license. This PR removes the `livecheck` block, so the formula will be automatically skipped as disabled.