### PR TITLE
cmake-docs: update livecheck

### DIFF
--- a/Formula/cmake-docs.rb
+++ b/Formula/cmake-docs.rb
@@ -8,11 +8,8 @@ class CmakeDocs < Formula
   license "BSD-3-Clause"
   head "https://gitlab.kitware.com/cmake/cmake.git", branch: "master"
 
-  # The "latest" release on GitHub has been an unstable version before, so we
-  # check the Git tags instead.
   livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    formula "cmake"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`cmake-docs` uses the same URLs and `livecheck` block as the `cmake` formula. Since these formulae use the same `stable` URL and `cmake` is the canonical formula of these two, it's appropriate to update the `cmake-docs` `livecheck` block to use `formula "cmake"`. This will ensure that the `cmake-docs` formula uses the same `livecheck` block as the `cmake` formula without needing to manually keep them in parity.