### PR TITLE
Sync rain, aws-console, cfn-format versions

### DIFF
--- a/Formula/aws-console.rb
+++ b/Formula/aws-console.rb
@@ -5,6 +5,10 @@ class AwsConsole < Formula
   sha256 "064bc2b563c9b759d16147f33fe5c64bf0af3640cb4ae543e49615ae17b22e01"
   license "Apache-2.0"
 
+  livecheck do
+    formula "rain"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "43a5d8ececf9b15da91d81d6218a9c137c1a4372d726888025437cf757d2cb18"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "cad10ed651e199a6ca16f3aed1a4ba7b78e29f7924af2e3b7fef9b88a3429ee8"

--- a/Formula/cfn-format.rb
+++ b/Formula/cfn-format.rb
@@ -5,6 +5,10 @@ class CfnFormat < Formula
   sha256 "064bc2b563c9b759d16147f33fe5c64bf0af3640cb4ae543e49615ae17b22e01"
   license "Apache-2.0"
 
+  livecheck do
+    formula "rain"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "746d5b7a5493b01f9263de7ae57d14f7debcc09ae37ed9b88e3ca94e71cccb96"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ae53259389b4dfb638b10beb48257b7edaf84797b2b1873cb18ce915c61cc8ad"

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -2,6 +2,7 @@
   ["advancemame", "advancemenu"],
   ["apache-arrow", "apache-arrow-glib"],
   ["arm-linux-gnueabihf-binutils", "binutils"],
+  ["aws-console", "cfn-format", "rain"],
   ["binutils", "i686-elf-binutils", "x86_64-elf-binutils"],
   ["bundler-completion", "gem-completion", "rails-completion", "ruby-completion"],
   ["cmake", "cmake-docs"],


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `aws-console` and `cfn-format` formulae use the same `stable` URL as the `rain` formula. `rain` is arguably the canonical formula, so this PR adds a `formula "rain"` `livecheck` block to the other two formulae. This ensures that the check for `aws-console` and `cfn-format` will automatically remain in parity with `rain` (e.g., if a `livecheck` block is added to the `rain` formula in the future).

Besides that, this also adds these formulae to the `synced_versions_formulae.json` file, so their versions are kept in sync.