### PR TITLE
libcaca: update livecheck

### DIFF
--- a/Formula/libcaca.rb
+++ b/Formula/libcaca.rb
@@ -9,6 +9,9 @@ class Libcaca < Formula
 
   livecheck do
     url :stable
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.gsub(/\.?beta/, "b") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream `libcaca` tags use a format like `v0.99.beta20` but the formula uses `0.99b20` for the same version. This PR adds a `strategy` block to the existing `livecheck` block that converts the versions from the tags to the format used in the formula's `version`.