### PR TITLE
chgems: deprecate

### DIFF
--- a/Formula/chgems.rb
+++ b/Formula/chgems.rb
@@ -19,6 +19,8 @@ class Chgems < Formula
     sha256 cellar: :any_skip_relocation, yosemite:       "aac706b654c0e5a617bfa9dab9310334d874d561f2eca10a16778a3b49804545"
   end
 
+  deprecate! date: "2021-12-09", because: :repo_archived
+
   def install
     system "make", "install", "PREFIX=#{prefix}"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [upstream GitHub repository for `chgems`](https://github.com/postmodern/chgems) is archived, so this PR deprecates the formula accordingly.