### PR TITLE
closure-stylesheets: deprecate

### DIFF
--- a/Formula/closure-stylesheets.rb
+++ b/Formula/closure-stylesheets.rb
@@ -10,6 +10,8 @@ class ClosureStylesheets < Formula
     sha256 cellar: :any_skip_relocation, all: "7e1f8c96098f6c2fd2cba714bce4da004aa5687ca5a4a1d745460f53f337b982"
   end
 
+  deprecate! date: "2021-12-09", because: :repo_archived
+
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [upstream GitHub repository for `closure-stylesheets`](https://github.com/google/closure-stylesheets) has been archived, so this PR deprecates the formula accordingly.