### PR TITLE
docker-machine-completion: deprecate

### DIFF
--- a/Formula/docker-machine-completion.rb
+++ b/Formula/docker-machine-completion.rb
@@ -10,6 +10,8 @@ class DockerMachineCompletion < Formula
     sha256 cellar: :any_skip_relocation, all: "a953e0a6776024c35f839a0f4a23a782e186318fd07fdaa0a8405f41fadbd01a"
   end
 
+  deprecate! date: "2021-09-30", because: :repo_archived
+
   conflicts_with "docker-machine",
     because: "docker-machine already includes completion scripts"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I previously deprecated the `docker-machine` formula in #86218 but, for whatever reason, didn't deprecate `docker-machine-completion` at the time. These formulae use the same archived GitHub repository, so `docker-machine-completion` should be deprecated as well.

This PR adds the `deprecate!` call from `docker-machine` to `docker-machine-completion`, so it will be deprecated accordingly.