### PR TITLE
jruby: fix brew link issue on Linux

### DIFF
--- a/Formula/jruby.rb
+++ b/Formula/jruby.rb
@@ -27,7 +27,7 @@ class Jruby < Formula
 
     cd "bin" do
       # Prefix a 'j' on some commands to avoid clashing with other rubies
-      %w[ast rake rdoc ri racc].each { |f| mv f, "j#{f}" }
+      %w[ast bundle bundler rake rdoc ri racc].each { |f| mv f, "j#{f}" }
       # Delete some unnecessary commands
       rm "gem" # gem is a wrapper script for jgem
       rm "irb" # irb is an identical copy of jirb


### PR DESCRIPTION
No need for a rev bump, a new set of bottles is fine.

Fixes
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /home/linuxbrew/.linuxbrew
Could not symlink bin/bundle
Target /home/linuxbrew/.linuxbrew/bin/bundle
is a symlink belonging to ruby. You can unlink it:
  brew unlink ruby

To force the link and overwrite all conflicting files:
  brew link --overwrite jruby

To list all files that would be deleted:
  brew link --overwrite --dry-run jruby

Possible conflicting files are:
/home/linuxbrew/.linuxbrew/bin/bundle -> /home/linuxbrew/.linuxbrew/Cellar/ruby/3.0.3/bin/bundle

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
