### PR TITLE
yarn: make `node` a test dependency

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -4,6 +4,7 @@ class Yarn < Formula
   url "https://yarnpkg.com/downloads/1.22.17/yarn-v1.22.17.tar.gz"
   sha256 "267982c61119a055ba2b23d9cf90b02d3d16c202c03cb0c3a53b9633eae37249"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     skip("1.x line is frozen and features/bugfixes only happen on 2.x")
@@ -14,7 +15,7 @@ class Yarn < Formula
     sha256 cellar: :any_skip_relocation, all: "2d9cb60cd75e22835f7d7b840168aa5a5d8999d82f0eea75315cb3193edc8c9e"
   end
 
-  depends_on "node"
+  depends_on "node" => :test
 
   conflicts_with "hadoop", because: "both install `yarn` binaries"
   conflicts_with "corepack", because: "both install `yarn` and `yarnpkg` binaries"
@@ -23,13 +24,20 @@ class Yarn < Formula
     libexec.install buildpath.glob("*")
     (bin/"yarn").write_env_script libexec/"bin/yarn.js",
                                   PREFIX:            HOMEBREW_PREFIX,
-                                  NPM_CONFIG_PYTHON: which("python3")
+                                  NPM_CONFIG_PYTHON: "python3"
     (bin/"yarnpkg").write_env_script libexec/"bin/yarn.js",
                                       PREFIX:            HOMEBREW_PREFIX,
-                                      NPM_CONFIG_PYTHON: which("python3")
+                                      NPM_CONFIG_PYTHON: "python3"
     inreplace libexec/"lib/cli.js", "/usr/local", HOMEBREW_PREFIX
     inreplace libexec/"package.json", '"installationMethod": "tar"',
                                       "\"installationMethod\": \"#{tap.user.downcase}\""
+  end
+
+  def caveats
+    <<~EOS
+      yarn requires a Node installation to function. You can install one with:
+        brew install node
+    EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Yarn can be used with multiple versions of Node, but depending on `node`
specifically breaks that.

This change allows `yarn` to be used as a dependency for
`opensearch-dashboards` (cf. #90403). See also yarnpkg/website#913.

While we're here, let's adjust the `NPM_CONFIG_PYTHON` value, since the
`node` formula doesn't even depend on a Python3 formula at runtime
anymore (and it's not that picky about the Python3 version anyway).