### PR TITLE
htpdate: add license

### DIFF
--- a/Formula/htpdate.rb
+++ b/Formula/htpdate.rb
@@ -3,6 +3,7 @@ class Htpdate < Formula
   homepage "https://www.vervest.org/htp/"
   url "https://www.vervest.org/htp/archive/c/htpdate-1.2.3.tar.xz"
   sha256 "6b4e3fbf93d552a3a20f30a3906bf0caac05d9626bd508220744010fe9dd53f0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://www.vervest.org/htp/?download"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


<details>
<summary>license ref (`htpdate.c`)</summary>

```
/*
	htpdate v1.2.3

	Eddy Vervest <eddy@vervest.org>
	http://www.vervest.org/htp

	Synchronize local workstation with time offered by remote web servers

	This program works with the timestamps return by web servers,
	formatted as specified by HTTP/1.1 (RFC 2616, RFC 1123).

	Example usage:

	Debug mode (shows raw timestamps, round trip time (RTT) and
	time difference):

	~# htpdate -d www.example.com

	Adjust time smoothly:

	~# htpdate -a www.example.com

	...see man page for more details


	This program is free software; you can redistribute it and/or
	modify it under the terms of the GNU General Public License
	as published by the Free Software Foundation; either version 2
	of the License, or (at your option) any later version.
	http://www.gnu.org/copyleft/gpl.html
*/
```


</details>
