### PR TITLE
duckdb: add parquet, fts, icu and rest server support

### DIFF
--- a/Formula/duckdb.rb
+++ b/Formula/duckdb.rb
@@ -5,6 +5,8 @@ class Duckdb < Formula
       tag:      "v0.3.1",
       revision: "88aa81c6b1b851c538145e6431ea766a6e0ef435"
   license "MIT"
+  revision 1
+  head "https://github.com/duckdb/duckdb.git", branch: "master"
 
   bottle do
     rebuild 1
@@ -18,21 +20,27 @@ class Duckdb < Formula
 
   depends_on "cmake" => :build
   depends_on "python@3.10" => :build
-  depends_on "utf8proc"
 
   def install
-    ENV.deparallelize if OS.linux? # amalgamation builds take GBs of RAM
-    mkdir "build/amalgamation"
+    args = %w[
+      BUILD_ICU=1
+      BUILD_TPCH=1
+      BUILD_FTS=1
+      BUILD_REST=1
+    ]
+
+    # make install includes individual headers, so do it like duckdb does releases
+    system "make", *args
     system Formula["python@3.10"].opt_bin/"python3", "scripts/amalgamation.py", "--extended"
-    cd "build/amalgamation" do
-      system "cmake", "../..", *std_cmake_args, "-DAMALGAMATION_BUILD=ON"
-      system "make"
-      system "make", "install"
-      bin.install "duckdb"
-      # The cli tool was renamed (0.1.8 -> 0.1.9)
-      # Create a symlink to not break compatibility
-      bin.install_symlink bin/"duckdb" => "duckdb_cli"
-    end
+
+    include.install "src/amalgamation/duckdb.hpp"
+    include.install "src/include/duckdb.h"
+    lib.install Dir["build/release/src/libduckdb*.{dylib,so}"]
+    bin.install "build/release/duckdb"
+    bin.install "build/release/tools/rest/duckdb_rest_server"
+    # The cli tool was renamed (0.1.8 -> 0.1.9)
+    # Create a symlink to not break compatibility
+    bin.install_symlink bin/"duckdb" => "duckdb_cli"
   end
 
   test do
@@ -51,6 +59,29 @@ class Duckdb < Formula
       └───────────┘
     EOS
 
-    assert_equal expected_output, shell_output("#{bin}/duckdb_cli < #{path}")
+    assert_equal expected_output, shell_output("#{bin}/duckdb test.duckdb < #{path}")
+
+    port = free_port
+    begin
+      args = %W[
+        --listen=localhost
+        --port=#{port}
+        --read_only
+        --fetch_timeout=2
+        --database=test.duckdb
+      ]
+      pid = fork do
+        exec bin/"duckdb_rest_server", *args
+      end
+      sleep 1
+
+      TCPSocket.open("localhost", port) do |sock|
+        sock.puts("GET /query?q=SELECT+AVG(temp)+FROM+weather HTTP/1.0\r\n\r\n")
+        assert_match "[[45.0]]", sock.read
+        sock.close
+      end
+    ensure
+      Process.kill("TERM", pid)
+    end
   end
 end


### PR DESCRIPTION
Duckdb's own releases include support for reading/writing
parquet files, full text search, icu functions, but they
were left out of the brew package.

This changes how the build is done to mirror duckdb's own github
release actions in order to add them. It also includes the
duckdb rest server, enables --HEAD and removes the
unnecessary utf8proc dependency.

Since it no longer uses amalgamation builds, parallelization was
turned back on for Linux.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
