### PR TITLE
kubecfg: update urls

### DIFF
--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -1,7 +1,7 @@
 class Kubecfg < Formula
   desc "Manage complex enterprise Kubernetes environments as code"
-  homepage "https://github.com/bitnami/kubecfg"
-  url "https://github.com/bitnami/kubecfg/archive/v0.22.0.tar.gz"
+  homepage "https://github.com/kubecfg/kubecfg"
+  url "https://github.com/kubecfg/kubecfg/archive/v0.22.0.tar.gz"
   sha256 "1a27df34f815069c843da18430bca2ae0aa7d3156ea17c5bd4efcfa23014b768"
   license "Apache-2.0"
 
@@ -18,9 +18,9 @@ class Kubecfg < Formula
   depends_on "go" => :build
 
   def install
-    (buildpath/"src/github.com/bitnami/kubecfg").install buildpath.children
+    (buildpath/"src/github.com/kubecfg/kubecfg").install buildpath.children
 
-    cd "src/github.com/bitnami/kubecfg" do
+    cd "src/github.com/kubecfg/kubecfg" do
       system "make", "VERSION=v#{version}"
       bin.install "kubecfg"
       pkgshare.install Dir["examples/*"], "testdata/kubecfg_test.jsonnet"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `kubecfg` formula currently uses the `bitnami/kubecfg` repository on GitHub. However, this redirects to the `vmware-archive/kubecfg` repository, which was archived a few weeks ago and contains the following message at the top of the `README`:

> ## WARNING: kubecfg is no longer actively maintained by VMware.
>VMware has made the difficult decision to stop driving this project and therefore we will no longer actively respond to issues or pull requests. The project will be externally maintained in the following fork: https://github.com/kubecfg/kubecfg

Since the current repository directs users to the `kubecfg/kubecfg` GitHub repository, this PR updates the related references in the formula accordingly. I figured this was more appropriate than simply deprecating the formula as `:repo_archived` but let me know if this should be handled differently.