### PR TITLE
duckdb: migrate to python@3.10

### DIFF
--- a/Formula/duckdb.rb
+++ b/Formula/duckdb.rb
@@ -16,13 +16,13 @@ class Duckdb < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "utf8proc"
 
   def install
     ENV.deparallelize if OS.linux? # amalgamation builds take GBs of RAM
     mkdir "build/amalgamation"
-    system Formula["python@3.9"].opt_bin/"python3", "scripts/amalgamation.py", "--extended"
+    system Formula["python@3.10"].opt_bin/"python3", "scripts/amalgamation.py", "--extended"
     cd "build/amalgamation" do
       system "cmake", "../..", *std_cmake_args, "-DAMALGAMATION_BUILD=ON"
       system "make"


### PR DESCRIPTION
Migrate stand-alone formula `duckdb` to Python 3.10. Part of PR #90716.