### PR TITLE
ginac: migrate to python@3.10

### DIFF
--- a/Formula/ginac.rb
+++ b/Formula/ginac.rb
@@ -4,6 +4,7 @@ class Ginac < Formula
   url "https://www.ginac.de/ginac-1.8.1.tar.bz2"
   sha256 "f1695dbd6b187061ef3fba507648c9d6dba438f733b058c16f9278cbdcf5e1ab"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.ginac.de/Download.html"
@@ -20,7 +21,7 @@ class Ginac < Formula
 
   depends_on "pkg-config" => :build
   depends_on "cln"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
   depends_on "readline"
 
   # Fix -flat_namespace being used on Big Sur and later.


### PR DESCRIPTION
Migrate stand-alone formula `ginac` to Python 3.10. Part of PR #90716.