### PR TITLE
infer: migrate to python@3.10

### DIFF
--- a/Formula/infer.rb
+++ b/Formula/infer.rb
@@ -44,7 +44,7 @@ class Infer < Formula
   depends_on "opam" => :build
   depends_on "openjdk@11" => [:build, :test]
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "gmp"
   depends_on "mpfr"
   depends_on "sqlite"


### PR DESCRIPTION
Migrate stand-alone formula `infer` to Python 3.10. Part of PR #90716.