### PR TITLE
iso-codes: migrate to python@3.10

### DIFF
--- a/Formula/iso-codes.rb
+++ b/Formula/iso-codes.rb
@@ -11,7 +11,7 @@ class IsoCodes < Formula
   end
 
   depends_on "gettext" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
Migrate stand-alone formula `iso-codes` to Python 3.10. Part of PR #90716.