### PR TITLE
juju-wait: migrate to python@3.10

### DIFF
--- a/Formula/juju-wait.rb
+++ b/Formula/juju-wait.rb
@@ -6,7 +6,7 @@ class JujuWait < Formula
   url "https://files.pythonhosted.org/packages/0c/2b/f4bd0138f941e4ba321298663de3f1c8d9368b75671b17aa1b8d41a154dc/juju-wait-2.8.4.tar.gz"
   sha256 "9e84739056e371ab41ee59086313bf357684bc97aae8308716c8fe3f19df99be"
   license "GPL-3.0-only"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "c91fa90978e376e52e9bcadc23a86103d4ac976f372917095d22bed638ae6d14"
@@ -21,7 +21,7 @@ class JujuWait < Formula
 
   depends_on "juju"
   depends_on "libyaml"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "PyYAML" do
     url "https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz"


### PR DESCRIPTION
Migrate stand-alone formula `juju-wait` to Python 3.10. Part of PR #90716.