### PR TITLE
lc0: migrate to python@3.10

### DIFF
--- a/Formula/lc0.rb
+++ b/Formula/lc0.rb
@@ -20,7 +20,7 @@ class Lc0 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build # required to compile .pb files
+  depends_on "python@3.10" => :build # required to compile .pb files
   depends_on "eigen"
 
   uses_from_macos "zlib"


### PR DESCRIPTION
Migrate stand-alone formula `lc0` to Python 3.10. Part of PR #90716.