### PR TITLE
libcap-ng: migrate to python@3.10

### DIFF
--- a/Formula/libcap-ng.rb
+++ b/Formula/libcap-ng.rb
@@ -12,7 +12,7 @@ class LibcapNg < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "swig" => :build
   depends_on :linux
 


### PR DESCRIPTION
Migrate stand-alone formula `libcap-ng` to Python 3.10. Part of PR #90716.