### PR TITLE
libprelude: migrate to python@3.10

### DIFF
--- a/Formula/dovecot.rb
+++ b/Formula/dovecot.rb
@@ -4,6 +4,7 @@ class Dovecot < Formula
   url "https://dovecot.org/releases/2.3/dovecot-2.3.17.tar.gz"
   sha256 "224412cd77a23a3ffb857da294da200883d956082cff7257942eff2789bd2df9"
   license all_of: ["BSD-3-Clause", "LGPL-2.1-or-later", "MIT", "Unicode-DFS-2016", :public_domain]
+  revision 1
 
   livecheck do
     url "https://www.dovecot.org/download/"
@@ -26,6 +27,7 @@ class Dovecot < Formula
 
   on_linux do
     depends_on "linux-pam"
+    depends_on "zstd"
   end
 
   resource "pigeonhole" do

--- a/Formula/libprelude.rb
+++ b/Formula/libprelude.rb
@@ -4,7 +4,7 @@ class Libprelude < Formula
   url "https://www.prelude-siem.org/attachments/download/1395/libprelude-5.2.0.tar.gz"
   sha256 "187e025a5d51219810123575b32aa0b40037709a073a775bc3e5a65aa6d6a66e"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://www.prelude-siem.org/projects/prelude/files"
@@ -25,7 +25,7 @@ class Libprelude < Formula
   depends_on "pkg-config" => :build
   depends_on "gnutls"
   depends_on "libgpg-error"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     ENV["HAVE_CXX"] = "yes"
@@ -38,7 +38,7 @@ class Libprelude < Formula
       --without-perl
       --without-swig
       --without-python2
-      --with-python3=python#{Formula["python@3.9"].version.major_minor}
+      --with-python3=python#{Language::Python.major_minor_version("python3")}
       --with-libgnutls-prefix=#{Formula["gnutls"].opt_prefix}
     ]
 


### PR DESCRIPTION
Migrate stand-alone formula `libprelude` to Python 3.10. Part of PR #90716.