### PR TITLE
libpsl: migrate to python@3.10

### DIFF
--- a/Formula/libpsl.rb
+++ b/Formula/libpsl.rb
@@ -19,7 +19,7 @@ class Libpsl < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "icu4c"
 
   def install


### PR DESCRIPTION
Migrate stand-alone formula `libpsl` to Python 3.10. Part of PR #90716.