### PR TITLE
libtcod: migrate to python@3.10

### DIFF
--- a/Formula/libtcod.rb
+++ b/Formula/libtcod.rb
@@ -17,7 +17,7 @@ class Libtcod < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "sdl2"
 
   conflicts_with "libzip", "minizip-ng", because: "libtcod, libzip and minizip-ng install a `zip.h` header"


### PR DESCRIPTION
Migrate stand-alone formula `libtcod` to Python 3.10. Part of PR #90716.