### PR TITLE
libtensorflow@1: migrate to python@3.10

### DIFF
--- a/Formula/libtensorflow@1.rb
+++ b/Formula/libtensorflow@1.rb
@@ -18,10 +18,10 @@ class LibtensorflowAT1 < Formula
   deprecate! date: "2021-01-06", because: :versioned_formula
 
   depends_on "bazel" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   def install
-    ENV["PYTHON_BIN_PATH"] = Formula["python@3.9"].opt_bin/"python3"
+    ENV["PYTHON_BIN_PATH"] = Formula["python@3.10"].opt_bin/"python3"
     ENV["CC_OPT_FLAGS"] = "-march=native"
     ENV["TF_IGNORE_MAX_BAZEL_VERSION"] = "1"
     ENV["TF_NEED_JEMALLOC"] = "1"
@@ -46,6 +46,7 @@ class LibtensorflowAT1 < Formula
 
     bazel_compatibility_flags = %w[
       --noincompatible_remove_legacy_whole_archive
+      --incompatible_restrict_string_escapes=false
     ]
     system "bazel", "build", "--jobs", ENV.make_jobs, "--compilation_mode=opt",
                     "--copt=-march=native", *bazel_compatibility_flags, "tensorflow:libtensorflow.so"


### PR DESCRIPTION
Migrate stand-alone formula `libtensorflow@1` to Python 3.10. Part of PR #90716.