### PR TITLE
libvoikko: migrate to python@3.10

### DIFF
--- a/Formula/libvoikko.rb
+++ b/Formula/libvoikko.rb
@@ -22,7 +22,7 @@ class Libvoikko < Formula
 
   depends_on "foma" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "hfstospell"
 
   resource "voikko-fi" do


### PR DESCRIPTION
Migrate stand-alone formula `libvoikko` to Python 3.10. Part of PR #90716.