### PR TITLE
libxml++@5: migrate to python@3.10

### DIFF
--- a/Formula/libxml++@5.rb
+++ b/Formula/libxml++@5.rb
@@ -23,7 +23,7 @@ class LibxmlxxAT5 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => [:build, :test]
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   uses_from_macos "libxml2"
 


### PR DESCRIPTION
Migrate stand-alone formula `libxml++@5` to Python 3.10. Part of PR #90716.