### PR TITLE
libzzip: migrate to python@3.10

### DIFF
--- a/Formula/libzzip.rb
+++ b/Formula/libzzip.rb
@@ -19,7 +19,7 @@ class Libzzip < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   uses_from_macos "zip" => :test
   uses_from_macos "zlib"


### PR DESCRIPTION
Migrate stand-alone formula `libzzip` to Python 3.10. Part of PR #90716.