### PR TITLE
link-grammar: migrate to python@3.10

### DIFF
--- a/Formula/link-grammar.rb
+++ b/Formula/link-grammar.rb
@@ -27,7 +27,7 @@ class LinkGrammar < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   uses_from_macos "sqlite"
 


### PR DESCRIPTION
Migrate stand-alone formula `link-grammar` to Python 3.10. Part of PR #90716.