### PR TITLE
ghostscript: fix sha256sum for patch

### DIFF
--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -4,6 +4,7 @@ class Ghostscript < Formula
   url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9550/ghostpdl-9.55.0.tar.gz"
   sha256 "b73cdfcb7b1c2a305748d23b00a765bcba48310564940b1eff1457f19f898172"
   license "AGPL-3.0-or-later"
+  revision 1
 
   # We check the tags from the `head` repository because the GitHub tags are
   # formatted ambiguously, like `gs9533` (corresponding to version 9.53.3).
@@ -59,7 +60,7 @@ class Ghostscript < Formula
 
   patch do
     url "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=830afae5454dea3bff903869d82022306890a96c"
-    sha256 "b0b7a042e50f3eb5f7de8f8e833397953f8730030c71572ae372f44f7144c9bb"
+    sha256 "9c282e3f732b5c182ab761e187850d9f4c29d938a93e3785d9cb6ced13111d6c"
   end
 
   def install

--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -4,7 +4,6 @@ class Ghostscript < Formula
   url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9550/ghostpdl-9.55.0.tar.gz"
   sha256 "b73cdfcb7b1c2a305748d23b00a765bcba48310564940b1eff1457f19f898172"
   license "AGPL-3.0-or-later"
-  revision 1
 
   # We check the tags from the `head` repository because the GitHub tags are
   # formatted ambiguously, like `gs9533` (corresponding to version 9.53.3).


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

the current version of the ghostscript formula has a sha256sum mismatch for a patch file linked within the formula. this PR should update the formula with the correct sha256sum, and add / bump a revision block to `revision 1` within the formula file.

as of right now, the current formula will fail to build with `brew install ghostscript -s -v` due to the sha256sum mismatch.