### PR TITLE
mbedtls: migrate to python@3.10

### DIFF
--- a/Formula/mbedtls.rb
+++ b/Formula/mbedtls.rb
@@ -23,7 +23,7 @@ class Mbedtls < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   def install
     inreplace "include/mbedtls/mbedtls_config.h" do |s|
@@ -35,7 +35,7 @@ class Mbedtls < Formula
 
     system "cmake", "-S", ".", "-B", "build",
                     "-DUSE_SHARED_MBEDTLS_LIBRARY=On",
-                    "-DPython3_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3",
+                    "-DPython3_EXECUTABLE=#{which("python3")}",
                     "-DCMAKE_INSTALL_RPATH=#{rpath}",
                     *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
Migrate stand-alone formula `mbedtls` to Python 3.10. Part of PR #90716.