### PR TITLE
mbedtls@2: migrate to python@3.10

### DIFF
--- a/Formula/mbedtls@2.rb
+++ b/Formula/mbedtls@2.rb
@@ -24,7 +24,7 @@ class MbedtlsAT2 < Formula
   keg_only :versioned_formula
 
   depends_on "cmake" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   def install
     inreplace "include/mbedtls/config.h" do |s|
@@ -36,7 +36,7 @@ class MbedtlsAT2 < Formula
 
     system "cmake", "-S", ".", "-B", "build",
                     "-DUSE_SHARED_MBEDTLS_LIBRARY=On",
-                    "-DPython3_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3",
+                    "-DPython3_EXECUTABLE=#{Formula["python@3.10"].opt_bin}/python3",
                     *std_cmake_args
     system "cmake", "--build", "build"
     # We run CTest because this is a crypto library. Running tests in parallel causes failures.


### PR DESCRIPTION
Migrate stand-alone formula `mbedtls@2` to Python 3.10. Part of PR #90716.