### PR TITLE
nanomsgxx: migrate to python@3.10

### DIFF
--- a/Formula/nanomsgxx.rb
+++ b/Formula/nanomsgxx.rb
@@ -16,7 +16,7 @@ class Nanomsgxx < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "nanomsg"
 
   # Add python3 support


### PR DESCRIPTION
Migrate stand-alone formula `nanomsgxx` to Python 3.10. Part of PR #90716.