### PR TITLE
protobuf@3.6: migrate to python@3.10

### DIFF
--- a/Formula/protobuf@3.6.rb
+++ b/Formula/protobuf@3.6.rb
@@ -4,7 +4,7 @@ class ProtobufAT36 < Formula
   url "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.tar.gz"
   sha256 "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
 
   bottle do
     sha256 cellar: :any, arm64_monterey: "ceeb84f3074f1ca1d3b7e748212f4ec42a9a8287b952723e6acf992eadc20dfc"
@@ -24,7 +24,7 @@ class ProtobufAT36 < Formula
   depends_on "automake" => :build
   depends_on "cmake" => :build
   depends_on "libtool" => :build
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "six" do
     url "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"
@@ -64,14 +64,14 @@ class ProtobufAT36 < Formula
     ENV.append_to_cflags "-L#{lib}"
 
     resource("six").stage do
-      system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)
+      system Formula["python@3.10"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)
     end
     chdir "python" do
-      system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec),
+      system Formula["python@3.10"].opt_bin/"python3", *Language::Python.setup_install_args(libexec),
                                                       "--cpp_implementation"
     end
 
-    version = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
+    version = Language::Python.major_minor_version Formula["python@3.10"].opt_bin/"python3"
     site_packages = "lib/python#{version}/site-packages"
     pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
     (prefix/site_packages/"homebrew-protobuf.pth").write pth_contents


### PR DESCRIPTION
Migrate stand-alone formula `protobuf@3.6` to Python 3.10. Part of PR #90716.