### PR TITLE
pygitup: migrate to python@3.10

### DIFF
--- a/Formula/pygitup.rb
+++ b/Formula/pygitup.rb
@@ -6,6 +6,7 @@ class Pygitup < Formula
   url "https://files.pythonhosted.org/packages/89/a3/35f7460cfaf7353ceb23442e5c250fda249cb9b8e26197cf801fa4f63786/git-up-2.1.0.tar.gz"
   sha256 "6e677d91aeb4de37e62bdc166042243313ec873c3caf9938911ac2e7f52a0652"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "c1fc3d05c9426628db3014aad4ca9f54c3ea8ed709187e532c5e0a33ff3cec24"
@@ -18,7 +19,7 @@ class Pygitup < Formula
   end
 
   depends_on "poetry" => :build
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "colorama" do
     url "https://files.pythonhosted.org/packages/1f/bb/5d3246097ab77fa083a61bd8d3d527b7ae063c7d8e8671b1cf8c4ec10cbe/colorama-0.4.4.tar.gz"


### PR DESCRIPTION
Migrate stand-alone formula `pygitup` to Python 3.10. Part of PR #90716.