### PR TITLE
quex: migrate to python@3.10

### DIFF
--- a/Formula/quex.rb
+++ b/Formula/quex.rb
@@ -4,6 +4,7 @@ class Quex < Formula
   url "https://downloads.sourceforge.net/project/quex/quex-0.71.2.zip"
   sha256 "0453227304a37497e247e11b41a1a8eb04bcd0af06a3f9d627d706b175a8a965"
   license "MIT"
+  revision 1
   head "https://svn.code.sf.net/p/quex/code/trunk"
 
   livecheck do
@@ -16,7 +17,7 @@ class Quex < Formula
     sha256 cellar: :any_skip_relocation, all:           "8e53508d74a86c0ec8decef4bf4233f197a8612168cee8707295e22a7ed05b8b"
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     libexec.install "quex", "quex-exe.py"
@@ -25,7 +26,7 @@ class Quex < Formula
     # Use a shim script to set QUEX_PATH on the user's behalf
     (bin/"quex").write <<~EOS
       #!/bin/bash
-      QUEX_PATH="#{libexec}" "#{Formula["python@3.9"].opt_bin}/python3" "#{libexec}/quex-exe.py" "$@"
+      QUEX_PATH="#{libexec}" "#{Formula["python@3.10"].opt_bin}/python3" "#{libexec}/quex-exe.py" "$@"
     EOS
 
     if build.head?


### PR DESCRIPTION
Migrate stand-alone formula `quex` to Python 3.10. Part of PR #90716.