### PR TITLE
rabbitmq: migrate to python@3.10

### DIFF
--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -14,7 +14,7 @@ class Rabbitmq < Formula
     sha256 cellar: :any_skip_relocation, all: "1e5c7b9a5dd11571857d2475a1889b7bdc843a3839f029b4d9a60a35837fcbf1"
   end
 
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "erlang"
 
   def install


### PR DESCRIPTION
Migrate stand-alone formula `rabbitmq` to Python 3.10. Part of PR #90716.