### PR TITLE
recode: migrate to python@3.10

### DIFF
--- a/Formula/recode.rb
+++ b/Formula/recode.rb
@@ -16,7 +16,7 @@ class Recode < Formula
   end
 
   depends_on "libtool" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "gettext"
 
   # Fix -flat_namespace being used on Big Sur and later.


### PR DESCRIPTION
Migrate stand-alone formula `recode` to Python 3.10. Part of PR #90716.