### PR TITLE
spirv-tools: migrate to python@3.10

### DIFF
--- a/Formula/spirv-tools.rb
+++ b/Formula/spirv-tools.rb
@@ -15,7 +15,7 @@ class SpirvTools < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
 
   resource "re2" do
     # revision number could be found in ./DEPS


### PR DESCRIPTION
Migrate stand-alone formula `spirv-tools` to Python 3.10. Part of PR #90716.