### PR TITLE
stone-soup: migrate to python@3.10

### DIFF
--- a/Formula/stone-soup.rb
+++ b/Formula/stone-soup.rb
@@ -20,7 +20,7 @@ class StoneSoup < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   depends_on "lua@5.1"
   depends_on "pcre"
   depends_on "sqlite"
@@ -32,7 +32,7 @@ class StoneSoup < Formula
 
   def install
     ENV.cxx11
-    ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin"
+    ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin"
     xy = Language::Python.major_minor_version "python3"
     ENV.prepend_create_path "PYTHONPATH", buildpath/"vendor/lib/python#{xy}/site-packages"
 


### PR DESCRIPTION
Migrate stand-alone formula `stone-soup` to Python 3.10. Part of PR #90716.