### PR TITLE
xkeyboardconfig: migrate to python@3.10

### DIFF
--- a/Formula/xkeyboardconfig.rb
+++ b/Formula/xkeyboardconfig.rb
@@ -13,7 +13,7 @@ class Xkeyboardconfig < Formula
   depends_on "gettext" => :build
   depends_on "intltool" => :build
   depends_on "pkg-config" => [:build, :test]
-  depends_on "python@3.9" => :build
+  depends_on "python@3.10" => :build
   uses_from_macos "libxslt" => :build
 
   def install


### PR DESCRIPTION
Migrate stand-alone formula `xkeyboardconfig` to Python 3.10. Part of PR #90716.