### PR TITLE
svgcleaner: deprecate

### DIFF
--- a/Formula/svgcleaner.rb
+++ b/Formula/svgcleaner.rb
@@ -18,6 +18,8 @@ class Svgcleaner < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "faae5c691c1bbb241aa001e912458be50a1aaf6eea241591b6a34148d3d93228"
   end
 
+  deprecate! date: "2021-12-11", because: :repo_archived
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `svgcleaner`](https://github.com/RazrFalcon/svgcleaner) was archived sometime between 2021-10-10 and 2021-12-03, so this PR deprecates the formula accordingly.