### PR TITLE
twemcache: deprecate

### DIFF
--- a/Formula/twemcache.rb
+++ b/Formula/twemcache.rb
@@ -17,6 +17,8 @@ class Twemcache < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "ebed07a9f27fb7c462c9e313dc51dcfb326804fd7715119a32151ee48b4e815d"
   end
 
+  deprecate! date: "2021-12-11", because: :repo_archived
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libevent"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `twemcache`](https://github.com/twitter/twemcache) was archived sometime between 2021-09-09 and now, so this PR deprecates the formula accordingly.