### PR TITLE
neovim: add livecheck

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -6,6 +6,11 @@ class Neovim < Formula
   license "Apache-2.0"
   head "https://github.com/neovim/neovim.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 arm64_monterey: "ec4155754605b16da518787995c7ab51e5b163792117f3183ea205cbae5c9e1c"
     sha256 arm64_big_sur:  "4da15cf92d2cf0f113e190c00e431c06c997391be35b5144b81cc218028dc7c2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `neovim` but it's incorrectly giving `1-compiles-and-passes-uf-tests-2-next` as newest (from a `eval-clear-rebase-1-compiles-and-passes-uf-tests-2-next` tag). This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which restricts matching to the version tags we're interested in and correctly gives `0.6.0` as the newest version.