### PR TITLE
dex2jar: add livecheck

### DIFF
--- a/Formula/dex2jar.rb
+++ b/Formula/dex2jar.rb
@@ -5,6 +5,11 @@ class Dex2jar < Formula
   sha256 "7a9bdf843d43de4d1e94ec2e7b6f55825017b0c4a7ee39ff82660e2493a46f08"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "19befbca4d509e7895c346200eb08faf8fba035a297760bc6e3f60785901add1"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `dex2jar` but it's currently giving a pre-release version (`2.2-SNAPSHOT-2021-10-31`) as newest instead of `2.1`. This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which will restrict matching to stable tags. [This is sufficient for the moment and it's not yet necessary to use the `GithubLatest` strategy for this formula.]