### PR TITLE
grpc-swift 1.6.0

### DIFF
--- a/Formula/grpc-swift.rb
+++ b/Formula/grpc-swift.rb
@@ -1,10 +1,15 @@
 class GrpcSwift < Formula
   desc "Swift language implementation of gRPC"
   homepage "https://github.com/grpc/grpc-swift"
-  url "https://github.com/grpc/grpc-swift/archive/1.5.0.tar.gz"
-  sha256 "f182b5f9b0e809b0a56f1b2089b1c9d6da78ace46871ceeebd28d751ac80a5db"
+  url "https://github.com/grpc/grpc-swift/archive/1.6.0.tar.gz"
+  sha256 "f08729b656dd1e7c1e273f2362a907d3ce6721348a4cd347574cd1ef28a95983"
   license "Apache-2.0"
   head "https://github.com/grpc/grpc-swift.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "3fec127f5e67589e99c1fb4aa146632512676bfc2de3fa82ddca739ac4cb5e40"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates `grpc-swift` to the latest version, 1.6.0. I don't have Xcode installed, so I haven't built/tested this locally.

Besides that, this adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`. This addresses the issue with the default check giving a pre-release version (`1.6.0-async-await.1`) as newest instead of `1.6.0`.