### PR TITLE
gradle-completion no depends_on bash-completion

### DIFF
--- a/Formula/gradle-completion.rb
+++ b/Formula/gradle-completion.rb
@@ -10,8 +10,6 @@ class GradleCompletion < Formula
     sha256 cellar: :any_skip_relocation, all: "6889d645ade2d3296031a3bdebaec9c2622bf26755fae51024e1692f6872ccb3"
   end
 
-  depends_on "bash-completion"
-
   def install
     bash_completion.install "gradle-completion.bash" => "gradle"
     zsh_completion.install "_gradle" => "_gradle"


### PR DESCRIPTION
A formula that `depends_on "bash-completion"` cannot be installed on a
system that has `bash-completion@2` installed without errors, unless
using `--ignore-dependencies` which is not ideal when automating via
e.g. ansible.

For reference, neither [maven-completion][1] nor [rustc-completion][2]
have `depends_on "bash-completion"` in their formulae.

[1]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/maven-completion.rb
[2]: https://github.com/Homebrew/homebrew-core/blob/master/Formula/rustc-completion.rb

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
