### PR TITLE
python@3.10: remove include_dirs, library_dirs from distutils.cfg

### DIFF
--- a/Formula/python@3.10.rb
+++ b/Formula/python@3.10.rb
@@ -331,10 +331,8 @@ class PythonAT310 < Formula
     end
 
     # Help distutils find brewed stuff when building extensions
-    include_dirs = [HOMEBREW_PREFIX/"include",
-                    Formula["sqlite"].opt_include]
-    library_dirs = [HOMEBREW_PREFIX/"lib",
-                    Formula["sqlite"].opt_lib]
+    include_dirs = [HOMEBREW_PREFIX/"include"]
+    library_dirs = [HOMEBREW_PREFIX/"lib"]
 
     cfg = lib_cellar/"distutils/distutils.cfg"
 

--- a/Formula/python@3.10.rb
+++ b/Formula/python@3.10.rb
@@ -331,9 +331,9 @@ class PythonAT310 < Formula
     end
 
     # Help distutils find brewed stuff when building extensions
-    include_dirs = [HOMEBREW_PREFIX/"include", Formula["openssl@1.1"].opt_include,
+    include_dirs = [HOMEBREW_PREFIX/"include",
                     Formula["sqlite"].opt_include]
-    library_dirs = [HOMEBREW_PREFIX/"lib", Formula["openssl@1.1"].opt_lib,
+    library_dirs = [HOMEBREW_PREFIX/"lib",
                     Formula["sqlite"].opt_lib]
 
     cfg = lib_cellar/"distutils/distutils.cfg"

--- a/Formula/python@3.10.rb
+++ b/Formula/python@3.10.rb
@@ -330,18 +330,12 @@ class PythonAT310 < Formula
       (libexec/"bin").install_symlink (bin/versioned_name).realpath => unversioned_name
     end
 
-    # Help distutils find brewed stuff when building extensions
-    include_dirs = [HOMEBREW_PREFIX/"include"]
-    library_dirs = [HOMEBREW_PREFIX/"lib"]
-
+    # Write distutils.cfg
     cfg = lib_cellar/"distutils/distutils.cfg"
 
     cfg.atomic_write <<~EOS
       [install]
       prefix=#{HOMEBREW_PREFIX}
-      [build_ext]
-      include_dirs=#{include_dirs.join ":"}
-      library_dirs=#{library_dirs.join ":"}
     EOS
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Homebrew's python3 installs `distutils.cfg`, which injects include and library paths into the build of every user package. The injected directories appear at the beginning of the paths and hence take precedence over paths configured by the packages' build systems. (We encountered this in the SageMath project in https://trac.sagemath.org/ticket/31335; our workaround is to use `SETUPTOOLS_USE_DISTUTILS=local`, thus disabling homebrew's copy of distutils.) 
In this PR, we remove one item from these paths, with the eventual goal of removing `distutils.cfg` altogether. `distutils.cfg` is an outdated and problematic mechanism, which is moreover set to be ineffective for packages that use `setuptools` when `setuptools` (again) makes `SETUPTOOLS_USE_DISTUTILS=local` the standard behavior (https://github.com/pypa/setuptools/pull/2896). See also #76621.

