### PR TITLE
dungeon: fix formula to run on Apple Silicon and add license

### DIFF
--- a/Formula/dungeon.rb
+++ b/Formula/dungeon.rb
@@ -3,6 +3,7 @@ class Dungeon < Formula
   homepage "https://github.com/GOFAI/dungeon"
   url "https://github.com/GOFAI/dungeon/archive/4.1.tar.gz"
   sha256 "b88c49ef60e908e8611257fbb5a6a41860e1058760df2dfcb7eb141eb34e198b"
+  license "HPND"
   revision 2
 
   bottle do
@@ -23,6 +24,9 @@ class Dungeon < Formula
                                                                      "\n\t2\tACCESS='SEQUENTIAL',ERR=1900)"
         s.gsub! "FILE='dtext',STATUS='OLD',", "FILE='#{opt_pkgshare}/dtext',"
         s.gsub! "1\tFORM='UNFORMATTED',ACCESS='DIRECT',", "1\tSTATUS='OLD',FORM='UNFORMATTED',ACCESS='DIRECT',"
+      end
+      inreplace "Makefile" do |s|
+        s.gsub! "gfortran -g", "gfortran -ffixed-line-length-none -g"
       end
       system "make"
       bin.install "dungeon"


### PR DESCRIPTION
It turns out that on Apple Silicon opt_pkgshare expanded into a pathname so long that it overran the column limits in old-timey Fortran and gfortran flamed out as a result. I've tweaked the formula to pass `-ffixed-line-length-none` to gfortran. Also added HPND license.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
