### PR TITLE
certigo: add livecheck

### DIFF
--- a/Formula/certigo.rb
+++ b/Formula/certigo.rb
@@ -6,6 +6,11 @@ class Certigo < Formula
   license "Apache-2.0"
   head "https://github.com/square/certigo.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "8d58d141ec797642a5328639290a50e8af1aab185a38c36be13d4a5e8c7aa0a6"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "cbb97e3b924fe9c0074b14c885682c3eec696ded881a65db17af607bfeb85c97"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `certigo` but it's giving an unstable version as newest (`1.13.0-test.2`, from a `v1.13.0-test.2` tag), instead of the latest stable version (`1.13.0`). This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which restricts matching to stable version tags and correctly reports `1.13.0` as newest.