### PR TITLE
launch4j: add livecheck

### DIFF
--- a/Formula/launch4j.rb
+++ b/Formula/launch4j.rb
@@ -7,6 +7,14 @@ class Launch4j < Formula
   license all_of: ["BSD-3-Clause", "MIT"]
   revision 1
 
+  livecheck do
+    url :stable
+    regex(/^(?:Release_launch4j[._-])?v?(\d+(?:[._]\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.tr("_", ".") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, monterey: "10fe31dd5081fecb626537d801e678e8921c5f8d655f7daee5e6c8dd2e2ef619"
     sha256 cellar: :any_skip_relocation, big_sur:  "4c6bfb289d9aeca25dbc25ff2f9fe12a49a635bf720fe54b788d4796c25bc108"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `launch4j` but it's currently giving `4j-3_14` as newest instead of `3_14` or `3.14`. This is because the default regex for the `Git` strategy captures everything after the first digit, so`4j-` from the `Release_launch4j-` tag prefix is also included in the version strings.

This PR adds a `livecheck` block using a regex that excludes the full tag prefix from the capture group, so we only capture the numeric version. Additionally, this adds a `strategy` block that replaces `_` in the version string with `.`, converting the `3_14` format found in tags to the formula's `3.14` version format. [The latter is simply for cosmetic reasons, as `3.14` and `3_14` are equal from the standpoint of `Version` comparison (as delimiters aren't compared).]