### PR TITLE
formulae(completion): update test for linux build

### DIFF
--- a/Formula/apm-bash-completion.rb
+++ b/Formula/apm-bash-completion.rb
@@ -15,6 +15,6 @@ class ApmBashCompletion < Formula
 
   test do
     assert_match "-F __apm",
-      shell_output("source #{bash_completion}/apm && complete -p apm")
+      shell_output("bash -c 'source #{bash_completion}/apm && complete -p apm'")
   end
 end

--- a/Formula/boom-completion.rb
+++ b/Formula/boom-completion.rb
@@ -17,6 +17,6 @@ class BoomCompletion < Formula
 
   test do
     assert_match "-F _boom_complete",
-      shell_output("source #{bash_completion}/boom && complete -p boom")
+      shell_output("bash -c 'source #{bash_completion}/boom && complete -p boom'")
   end
 end

--- a/Formula/bundler-completion.rb
+++ b/Formula/bundler-completion.rb
@@ -21,6 +21,6 @@ class BundlerCompletion < Formula
 
   test do
     assert_match "-F __bundle",
-      shell_output("source #{bash_completion}/bundler && complete -p bundle")
+      shell_output("bash -c 'source #{bash_completion}/bundler && complete -p bundle'")
   end
 end

--- a/Formula/cap-completion.rb
+++ b/Formula/cap-completion.rb
@@ -14,6 +14,6 @@ class CapCompletion < Formula
 
   test do
     assert_match "-F _cap",
-      shell_output("source #{bash_completion}/cap && complete -p cap")
+      shell_output("bash -c 'source #{bash_completion}/cap && complete -p cap'")
   end
 end

--- a/Formula/fabric-completion.rb
+++ b/Formula/fabric-completion.rb
@@ -29,6 +29,6 @@ class FabricCompletion < Formula
 
   test do
     assert_match "-F __fab_completion",
-      shell_output("source #{bash_completion}/fabric && complete -p fab")
+      shell_output("bash -c 'source #{bash_completion}/fabric && complete -p fab'")
   end
 end

--- a/Formula/gem-completion.rb
+++ b/Formula/gem-completion.rb
@@ -21,6 +21,6 @@ class GemCompletion < Formula
 
   test do
     assert_match "-F __gem",
-      shell_output("source #{bash_completion}/gem && complete -p gem")
+      shell_output("bash -c 'source #{bash_completion}/gem && complete -p gem'")
   end
 end

--- a/Formula/goto.rb
+++ b/Formula/goto.rb
@@ -14,7 +14,7 @@ class Goto < Formula
   end
 
   test do
-    output = shell_output("source #{bash_completion}/goto.sh && complete -p goto")
-    assert_match "-F _complete_goto_bash", output
+    assert_match "-F _complete_goto_bash",
+      shell_output("bash -c 'source #{bash_completion}/goto.sh && complete -p goto'")
   end
 end

--- a/Formula/grunt-completion.rb
+++ b/Formula/grunt-completion.rb
@@ -17,6 +17,6 @@ class GruntCompletion < Formula
 
   test do
     assert_match "-F _grunt_completions",
-      shell_output("source #{bash_completion}/grunt && complete -p grunt")
+      shell_output("bash -c 'source #{bash_completion}/grunt && complete -p grunt'")
   end
 end

--- a/Formula/homesick-completion.rb
+++ b/Formula/homesick-completion.rb
@@ -17,6 +17,6 @@ class HomesickCompletion < Formula
 
   test do
     assert_match "-F _homesick",
-      shell_output("source #{bash_completion}/homesick && complete -p homesick")
+      shell_output("bash -c 'source #{bash_completion}/homesick && complete -p homesick'")
   end
 end

--- a/Formula/kitchen-completion.rb
+++ b/Formula/kitchen-completion.rb
@@ -16,6 +16,6 @@ class KitchenCompletion < Formula
 
   test do
     assert_match "-F __kitchen_options",
-      shell_output("source #{bash_completion}/kitchen && complete -p kitchen")
+      shell_output("bash -c 'source #{bash_completion}/kitchen && complete -p kitchen'")
   end
 end

--- a/Formula/maven-completion.rb
+++ b/Formula/maven-completion.rb
@@ -16,6 +16,6 @@ class MavenCompletion < Formula
 
   test do
     assert_match "-F _mvn",
-      shell_output("source #{bash_completion}/maven && complete -p mvn")
+      shell_output("bash -c 'source #{bash_completion}/maven && complete -p mvn'")
   end
 end

--- a/Formula/mix-completion.rb
+++ b/Formula/mix-completion.rb
@@ -15,6 +15,6 @@ class MixCompletion < Formula
 
   test do
     assert_match "-F _mix",
-      shell_output("source #{bash_completion}/mix && complete -p mix")
+      shell_output("bash -c 'source #{bash_completion}/mix && complete -p mix'")
   end
 end

--- a/Formula/packer-completion.rb
+++ b/Formula/packer-completion.rb
@@ -16,6 +16,6 @@ class PackerCompletion < Formula
 
   test do
     assert_match "-F _packer_completion",
-      shell_output("source #{bash_completion}/packer && complete -p packer")
+      shell_output("bash -c 'source #{bash_completion}/packer && complete -p packer'")
   end
 end

--- a/Formula/pip-completion.rb
+++ b/Formula/pip-completion.rb
@@ -25,6 +25,6 @@ class PipCompletion < Formula
 
   test do
     assert_match "-F _pip",
-      shell_output("source #{bash_completion}/pip && complete -p pip")
+      shell_output("bash -c 'source #{bash_completion}/pip && complete -p pip'")
   end
 end

--- a/Formula/rails-completion.rb
+++ b/Formula/rails-completion.rb
@@ -21,6 +21,6 @@ class RailsCompletion < Formula
 
   test do
     assert_match "-F __rails",
-      shell_output("source #{bash_completion}/rails && complete -p rails")
+      shell_output("bash -c 'source #{bash_completion}/rails && complete -p rails'")
   end
 end

--- a/Formula/rake-completion.rb
+++ b/Formula/rake-completion.rb
@@ -15,6 +15,6 @@ class RakeCompletion < Formula
 
   test do
     assert_match "-F _rakecomplete",
-      shell_output("source #{bash_completion}/rake && complete -p rake")
+      shell_output("bash -c 'source #{bash_completion}/rake && complete -p rake'")
   end
 end

--- a/Formula/ruby-completion.rb
+++ b/Formula/ruby-completion.rb
@@ -21,6 +21,6 @@ class RubyCompletion < Formula
 
   test do
     assert_match "-F __ruby",
-      shell_output("source #{bash_completion}/ruby && complete -p ruby")
+      shell_output("bash -c 'source #{bash_completion}/ruby && complete -p ruby'")
   end
 end

--- a/Formula/rustc-completion.rb
+++ b/Formula/rustc-completion.rb
@@ -25,6 +25,6 @@ class RustcCompletion < Formula
 
   test do
     assert_match "-F _rustc",
-      shell_output("source #{bash_completion}/rustc && complete -p rustc")
+      shell_output("bash -c 'source #{bash_completion}/rustc && complete -p rustc'")
   end
 end

--- a/Formula/sonar-completion.rb
+++ b/Formula/sonar-completion.rb
@@ -16,6 +16,6 @@ class SonarCompletion < Formula
 
   test do
     assert_match "-F _sonar",
-      shell_output("source #{bash_completion}/sonar && complete -p sonar")
+      shell_output("bash -c 'source #{bash_completion}/sonar && complete -p sonar'")
   end
 end

--- a/Formula/spring-completion.rb
+++ b/Formula/spring-completion.rb
@@ -21,6 +21,6 @@ class SpringCompletion < Formula
 
   test do
     assert_match "-F _spring",
-      shell_output("source #{bash_completion}/spring && complete -p spring")
+      shell_output("bash -c 'source #{bash_completion}/spring && complete -p spring'")
   end
 end

--- a/Formula/stormssh-completion.rb
+++ b/Formula/stormssh-completion.rb
@@ -15,6 +15,6 @@ class StormsshCompletion < Formula
 
   test do
     assert_match "-F __stormssh",
-      shell_output("source #{bash_completion}/stormssh && complete -p storm")
+      shell_output("bash -c 'source #{bash_completion}/stormssh && complete -p storm'")
   end
 end

--- a/Formula/t-completion.rb
+++ b/Formula/t-completion.rb
@@ -17,6 +17,6 @@ class TCompletion < Formula
 
   test do
     assert_match "-F _t",
-      shell_output("source #{bash_completion}/t && complete -p t")
+      shell_output("bash -c 'source #{bash_completion}/t && complete -p t'")
   end
 end

--- a/Formula/tmuxinator-completion.rb
+++ b/Formula/tmuxinator-completion.rb
@@ -24,6 +24,6 @@ class TmuxinatorCompletion < Formula
 
   test do
     assert_match "-F _tmuxinator",
-      shell_output("source #{bash_completion}/tmuxinator && complete -p tmuxinator")
+      shell_output("bash -c 'source #{bash_completion}/tmuxinator && complete -p tmuxinator'")
   end
 end

--- a/Formula/vagrant-completion.rb
+++ b/Formula/vagrant-completion.rb
@@ -17,6 +17,6 @@ class VagrantCompletion < Formula
 
   test do
     assert_match "-F _vagrant",
-      shell_output("/bin/bash -c 'source #{bash_completion}/vagrant && complete -p vagrant'")
+      shell_output("bash -c 'source #{bash_completion}/vagrant && complete -p vagrant'")
   end
 end

--- a/Formula/wp-cli-completion.rb
+++ b/Formula/wp-cli-completion.rb
@@ -16,6 +16,6 @@ class WpCliCompletion < Formula
 
   test do
     assert_match "-F _wp_complete",
-      shell_output("source #{bash_completion}/wp && complete -p wp")
+      shell_output("bash -c 'source #{bash_completion}/wp && complete -p wp'")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

If not specifying `bash -c`, then it would have such errors on linux runs:

```
==> source /home/linuxbrew/.linuxbrew/Cellar/rustc-completion/0.12.1/etc/bash_completion.d/rustc && complete -p rustc
/bin/sh: 1: source: not found
Error: rustc-completion: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected: 0
  Actual: 127
```