### PR TITLE
jrsonnet: add livecheck

### DIFF
--- a/Formula/jrsonnet.rb
+++ b/Formula/jrsonnet.rb
@@ -6,6 +6,11 @@ class Jrsonnet < Formula
   license "MIT"
   head "https://github.com/CertainLach/jrsonnet.git"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "fcb5b5d99df55c43c70b475ea291ee1d614b76e705be867d688f17bb22ac9842"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "583e666fb6a076a89b1d447ad9220d30409cc62e931c1f4c9dd99cfee9291252"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `jrsonnet` but it's giving a pre-release version as newest (`0.5.0-gcmodule-test`) instead of `0.4.2`. This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which omits unstable tags with suffixes that livecheck doesn't automatically exclude (e.g., `-pre1-gc`, `-gcmodule-test`) and correctly reports `0.4.2` as the newest stable version.