### PR TITLE
iproute2: add livecheck

### DIFF
--- a/Formula/iproute2.rb
+++ b/Formula/iproute2.rb
@@ -6,6 +6,11 @@ class Iproute2 < Formula
   license "GPL-2.0-only"
   head "https://git.kernel.org/pub/scm/network/iproute2/iproute2.git", branch: "main"
 
+  livecheck do
+    url "https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/"
+    regex(/href=.*?iproute2[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 x86_64_linux: "1101f8a608be6e4c999c0d2abe3cc980466faca68f7f5b04696b67fadba84c28"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `iproute2` but it incorrectly reports `060323` as the newest version (from an `ss-060323` tag) instead of `5.15.0`.

This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The homepage links to this page as the location where the current version is found, so it acts as the download page. Besides returning the correct latest version, this approach also aligns the check with the `stable` source, which we prefer when possible.