### PR TITLE
uuu: add livecheck

### DIFF
--- a/Formula/uuu.rb
+++ b/Formula/uuu.rb
@@ -6,6 +6,12 @@ class Uuu < Formula
   license "BSD-3-Clause"
   head "https://github.com/NXPmicro/mfgtools.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(%r{href=["']?[^"' >]*?/tag/(?:uuu[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
+  end
+
   bottle do
     sha256 arm64_monterey: "56a412dd091e6e8f16eece2399fe09a6bb60f17f27b3cc9e7ba3a2fa831a1f32"
     sha256 arm64_big_sur:  "3155b7adc7452904671c7da18cbaa59766dfdd567e85a2b242c24cd8dfede40a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `uuu` but it's giving `2.8.0` as the latest version instead of `1.4.165`. This version comes from a `v2.8.0` tag, whereas `uuu` version tags use a `uuu_` prefix. This PR adds a `livecheck` block to address this situation.

Checking the Git tags using a regex like `/^uuu[._-]v?(\d+(?:\.\d+)+)$/i` would give `1.4.174` as newest but this version is currently marked as pre-release on GitHub. As a result, it's necessary to use the `GithubLatest` strategy here along with a modified regex that allows for the `uuu_` tag prefix. All that done, this approach correctly gives `1.4.165` as the newest stable version.