### PR TITLE
zsh-navigation-tools: deprecate

### DIFF
--- a/Formula/zsh-navigation-tools.rb
+++ b/Formula/zsh-navigation-tools.rb
@@ -19,6 +19,8 @@ class ZshNavigationTools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8b5a0cee362c74dd8466a9551c20bdcdcef893f0c7a461ba7ac6b69f7e2b1b9f"
   end
 
+  deprecate! date: "2021-12-11", because: :repo_removed
+
   uses_from_macos "zsh"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The psprint/zsh-navigation-tools repository on GitHub was removed around a month ago and related URLs in the formula (`homepage`, `stable`) are currently failing. The author seems to have removed nearly all of their GitHub repositories, so this PR deprecates the formula as `:repo_removed`.

The [zdharma-continuum](https://github.com/zdharma-continuum) GitHub organization contains unofficial forks of related projects (including `zsh-navigation-tools`) along with an accompanying [explanation](https://github.com/zdharma-continuum/I_WANT_TO_HELP). However, this was simply created by a user who was left out in the cold by the developer deleting the repositories, so it's an unofficial alternative.

That said, it may be best for us to simply deprecate this formula for now and see how the situation plays out before updating any URLs. It's possible to use archive.org URLs for `homepage` and `stable` but the `sha256` for the tarball is different for whatever reason, so I skipped that for now. If there's any interest in that approach, I can update those URLs accordingly.