### PR TITLE
ocrmypdf: drop unneeded packages

### DIFF
--- a/Formula/ocrmypdf.rb
+++ b/Formula/ocrmypdf.rb
@@ -20,7 +20,6 @@ class Ocrmypdf < Formula
   depends_on "rust" => :build
   depends_on "ghostscript"
   depends_on "jbig2enc"
-  depends_on "leptonica"
   depends_on "libffi"
   depends_on "libpng"
   depends_on "pillow"


### PR DESCRIPTION
Upstream (i.e. me) recently removed dependencies on:
-leptonica
-cffi
-libffi

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

