### PR TITLE
vgrep: make test more robust

### DIFF
--- a/Formula/vgrep.rb
+++ b/Formula/vgrep.rb
@@ -32,6 +32,7 @@ class Vgrep < Formula
   test do
     (testpath/"test.txt").write "Hello from Homebrew!\n"
     output = shell_output("#{bin}/vgrep -w Homebrew --no-less .")
-    assert_match "Hello from \e[01;31m\e[KHomebrew\e[m\e[K!\n", output
+    assert_match "Hello from", output
+    assert_match "Homebrew", output
   end
 end


### PR DESCRIPTION
The test currently fails on ARM, no need to check for all these weird characters:

Minitest::Assertion: Expected /Hello\ from\ \x1B\[01;31m\x1B\[KHomebrew\x1B\[m\x1B\[K!\n/ to match "\e[95m\e[4mIndex\e[0m\e[0m \e[94m\e[4mFile      \e[0m\e[0m \e[92m\e[4mLine\e[0m\e[0m \e[4mContent\e[0m\n\e[95m    0\e[0m \e[94m./test.txt\e[0m \e[92m   1\e[0m Hello from \e[0m\e[1m\e[31mHomebrew\e[0m!\n".

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
