### PR TITLE
workflows/tests: increase `HOMEBREW_CURL_RETRIES` if labeled with `CI-no-fail-fast`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -209,6 +209,11 @@ jobs:
           echo 'PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin' >> $GITHUB_ENV
           echo 'GITHUB_ACTIONS_HOMEBREW_MACOS_SELF_HOSTED=1' >> $GITHUB_ENV
 
+      - name: Set HOMEBREW_CURL_RETRIES
+        if: ${{always() && fromJson(needs.setup_tests.outputs.fail-fast) == false}}
+        run: |
+          echo 'HOMEBREW_CURL_RETRIES=10' >> $GITHUB_ENV
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Increase `HOMEBREW_CURL_RETRIES` to 10 (default is 3) if the pull request is labeled with `CI-no-fail-fast`.

Related:

- PR: #90999
- CI test: https://github.com/Homebrew/homebrew-core/runs/4502945658

```
==> FAILED
Full audit otf2 --online --git --skip-style output
  otf2:
    * The homepage URL https://www.vi-hps.org/projects/score-p/ is not reachable
  Error: 1 problem in 1 formula detected
```