### PR TITLE
hwloc 2.7.0

### DIFF
--- a/Formula/hwloc.rb
+++ b/Formula/hwloc.rb
@@ -1,9 +1,14 @@
 class Hwloc < Formula
   desc "Portable abstraction of the hierarchical topology of modern architectures"
   homepage "https://www.open-mpi.org/projects/hwloc/"
-  url "https://download.open-mpi.org/release/hwloc/v2.6/hwloc-2.6.0.tar.bz2"
-  sha256 "e1f073e44e28c296ff848dead5e9bd6e2426b77f95ead1792358958e859fa83a"
+  url "https://download.open-mpi.org/release/hwloc/v2.7/hwloc-2.7.0.tar.bz2"
+  sha256 "028cee53ebcfe048283a2b3e87f2fa742c83645fc3ae329134bf5bb8b90384e0"
   license "BSD-3-Clause"
+
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?/software/hwloc/v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "9e4f9091f0ca0fd41860110eae7321f47de9a28e5acf97ecb2b19d07814c9893"
@@ -15,7 +20,7 @@ class Hwloc < Formula
   end
 
   head do
-    url "https://github.com/open-mpi/hwloc.git"
+    url "https://github.com/open-mpi/hwloc.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates `hwloc` to the latest version, 2.7.0. On the homepage, this version is referred to as "new", whereas 2.6.0 is "stable". Looking at past `hwloc` PRs, we appear to be tracking the "new" releases (e.g., 2.6.0 was "new" when the formula was version bumped).

Besides that, this PR adds a `livecheck` block that checks the homepage for version information. The `hwloc` download pages are separated by major/minor version, so it's necessary to identify versions from the sidebar. This currently matches all releases regardless of the "new"/"stable"/etc. designations, so it will return the "new" version. If it turns out we should be tracking "stable" releases instead, I'll update this accordingly.

Lastly, this adds `branch: "master"` to the `head` URL to resolve the related audit.