### PR TITLE
tfenv: add caveats to specify the download

### DIFF
--- a/Formula/tfenv.rb
+++ b/Formula/tfenv.rb
@@ -23,6 +23,13 @@ class Tfenv < Formula
     prefix.install %w[bin lib libexec share]
   end
 
+  def caveats
+    <<~EOS
+      Add the following line to your ~/.bash_profile:
+        export TFENV_ARCH=`uname -m`
+    EOS
+  end
+
   test do
     assert_match "0.10.0", shell_output("#{bin}/tfenv list-remote")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
$ export TFENV_ARCH=`uname -m`
$ tfenv install 1.1.0
Installing Terraform v1.1.0
Downloading release tarball from https://releases.hashicorp.com/terraform/1.1.0/terraform_1.1.0_darwin_arm64.zip
```

relates to https://github.com/tfutils/tfenv/blob/master/README.md#tfenv_arch