### PR TITLE
opencascade: fix missing fontconfig dependency

### DIFF
--- a/Formula/opencascade.rb
+++ b/Formula/opencascade.rb
@@ -30,10 +30,15 @@ class Opencascade < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "rapidjson" => :build
+  depends_on "fontconfig"
   depends_on "freeimage"
   depends_on "freetype"
   depends_on "tbb@2020"
   depends_on "tcl-tk"
+
+  on_linux do
+    depends_on "mesa" # For OpenGL
+  end
 
   def install
     tcltk = Formula["tcl-tk"]
@@ -66,7 +71,9 @@ class Opencascade < Formula
   end
 
   test do
-    output = shell_output("#{bin}/DRAWEXE -c \"pload ALL\"")
-    assert_equal "1", output.chomp
+    output = shell_output("#{bin}/DRAWEXE -b -c \"pload ALL\"")
+
+    # Discard the first line ("DRAW is running in batch mode"), and check that the second line is "1"
+    assert_equal "1", output.split(/\n/, 2)[1].chomp
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
