### PR TITLE
imageworsener: add livecheck

### DIFF
--- a/Formula/imageworsener.rb
+++ b/Formula/imageworsener.rb
@@ -14,6 +14,11 @@ class Imageworsener < Formula
     end
   end
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?imageworsener[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "59a3ec8b38b32f1dd73a0e68ed6b04143f5f017c8e2f67104f1c4b04581a9a91"
     sha256 cellar: :any,                 arm64_big_sur:  "0ee5c5f12bf988c164ce3ea06ce3c6a22af96427edaf241fb68f91c3e951d2de"
@@ -25,7 +30,7 @@ class Imageworsener < Formula
   end
 
   head do
-    url "https://github.com/jsummers/imageworsener.git"
+    url "https://github.com/jsummers/imageworsener.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `imageworsener` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

Besides that, this adds `branch: "master"` to the `head` URL to resolve the related audit error.