### PR TITLE
node-sass@4 4.14.1 (new formula)

### DIFF
--- a/Formula/node-sass@4.rb
+++ b/Formula/node-sass@4.rb
@@ -1,0 +1,33 @@
+require "language/node"
+
+class NodeSassAT4 < Formula
+  desc "Node.js bindings to libsass"
+  homepage "https://github.com/sass/node-sass"
+  url "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz"
+  sha256 "7e372a40c5fc2b5bcbccdc712190dc80df7deebd029ce15395fee3694f2e1ea0"
+  license "MIT"
+
+  keg_only :versioned_formula
+
+  depends_on "node@14"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    node = Formula["node@14"].opt_bin/"node"
+
+    (testpath/"test.scss").write <<~EOS
+      div {
+        img {
+          border: 0px;
+        }
+      }
+    EOS
+
+    output = shell_output("#{node} #{bin}/node-sass --output-style=compressed test.scss").strip
+    assert_equal "div img{border:0px}", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

After https://github.com/Homebrew/homebrew-core/pull/90839, we started to get build failures dependent on `node@14` formulae for Apple Silicon.

If a formula requires `node-sass` as a node dependency (from package.json) — it fails to build it from source on Apple Silicon by node/npm scripts. But it seems it's works well if we wrap `node-sass@4` it into a separate formula and then symlink to `buildpath` of affected formula (like `ln_s Formula["node-sass@4"].libexec/"lib/node_modules/node-sass", buildpath/"webui/node_modules/node-sass"`). 
To not build `node-sass@4` for all `node@14` dependant formulae, I propose putting it into a separate versioned formula.

Affected formulae are:
- https://github.com/Homebrew/homebrew-core/pull/91164
- https://github.com/Homebrew/homebrew-core/pull/91181
- (potentially all dependent on `node@14` formulae)