### PR TITLE
pam-reattach 1.2 (new formula)

### DIFF
--- a/Formula/pam-reattach.rb
+++ b/Formula/pam-reattach.rb
@@ -1,0 +1,20 @@
+class PamReattach < Formula
+  desc "PAM module for reattaching to the user's GUI (Aqua) session"
+  homepage "https://github.com/fabianishere/pam_reattach"
+  url "https://github.com/fabianishere/pam_reattach/archive/v1.2.tar.gz"
+  sha256 "60133388c400a924ca05ee0e5e6f9cc74c9f619bf97e545afe96f35544b0d011"
+  license "MIT"
+  head "https://github.com/fabianishere/pam_reattach.git", branch: "master"
+
+  depends_on "cmake" => :build
+  depends_on :macos
+
+  def install
+    system "cmake", ".", *std_cmake_args, "-DENABLE_CLI=ON"
+    system "make", "install"
+  end
+
+  test do
+    assert_match("Darwin", shell_output("#{bin}/reattach-to-session-namespace uname"))
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

New formula for https://github.com/fabianishere/pam_reattach.

This enables using Touch ID for PAM in tmux and screen.