### PR TITLE
yarn: do not set NPM_CONFIG_PYTHON

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -4,7 +4,7 @@ class Yarn < Formula
   url "https://yarnpkg.com/downloads/1.22.17/yarn-v1.22.17.tar.gz"
   sha256 "267982c61119a055ba2b23d9cf90b02d3d16c202c03cb0c3a53b9633eae37249"
   license "BSD-2-Clause"
-  revision 1
+  revision 2
 
   livecheck do
     skip("1.x line is frozen and features/bugfixes only happen on 2.x")
@@ -21,12 +21,8 @@ class Yarn < Formula
 
   def install
     libexec.install buildpath.glob("*")
-    (bin/"yarn").write_env_script libexec/"bin/yarn.js",
-                                  PREFIX:            HOMEBREW_PREFIX,
-                                  NPM_CONFIG_PYTHON: "python3"
-    (bin/"yarnpkg").write_env_script libexec/"bin/yarn.js",
-                                      PREFIX:            HOMEBREW_PREFIX,
-                                      NPM_CONFIG_PYTHON: "python3"
+    (bin/"yarn").write_env_script libexec/"bin/yarn.js", PREFIX: HOMEBREW_PREFIX
+    (bin/"yarnpkg").write_env_script libexec/"bin/yarn.js", PREFIX: HOMEBREW_PREFIX
     inreplace libexec/"lib/cli.js", "/usr/local", HOMEBREW_PREFIX
     inreplace libexec/"package.json", '"installationMethod": "tar"',
                                       "\"installationMethod\": \"#{tap.user.downcase}\""


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Do not `NPM_CONFIG_PYTHON` env var to allow `yarn` (and node scripts which run under it) to find python 2 when it's needed (for example, for node-sass for `node@14`) 