### PR TITLE
go 1.18

### DIFF
--- a/Formula/go-critic.rb
+++ b/Formula/go-critic.rb
@@ -4,6 +4,7 @@ class GoCritic < Formula
   url "https://github.com/go-critic/go-critic/archive/refs/tags/v0.6.2.tar.gz"
   sha256 "75248d8a909e8655040b3af778d92b27beca271dcc210e546607abecc9589d09"
   license "MIT"
+  revision 1
   head "https://github.com/go-critic/go-critic.git", branch: "master"
 
   livecheck do

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -1,9 +1,9 @@
 class Go < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.17.8.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.17.8.src.tar.gz"
-  sha256 "2effcd898140da79a061f3784ca4f8d8b13d811fb2abe9dad2404442dabbdf7a"
+  url "https://go.dev/dl/go1.18.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.18.src.tar.gz"
+  sha256 "38f423db4cc834883f2b52344282fa7a39fbb93650dc62a11fdf0be6409bdad6"
   license "BSD-3-Clause"
   head "https://go.googlesource.com/go.git", branch: "master"
 

--- a/Formula/golangci-lint.rb
+++ b/Formula/golangci-lint.rb
@@ -5,6 +5,7 @@ class GolangciLint < Formula
       tag:      "v1.45.0",
       revision: "1f4c1ed9f9fad6f04796748cd1e6641dbdee2126"
   license "GPL-3.0-only"
+  revision 1
   head "https://github.com/golangci/golangci-lint.git", branch: "master"
 
   bottle do

--- a/Formula/gosec.rb
+++ b/Formula/gosec.rb
@@ -4,6 +4,7 @@ class Gosec < Formula
   url "https://github.com/securego/gosec/archive/v2.10.0.tar.gz"
   sha256 "a2cfd36884745693f7e6737922a6e3a9d60aeafe5dd24fcc398250ffa201ceda"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/securego/gosec.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
Final release build of the Go 1.18.

See
- Release notes: https://go.dev/doc/go1.18
- Blog post https://go.dev/blog/go1.18
- Download page: https://go.dev/dl/

Earlier pre-releases were result of a discussion https://github.com/Homebrew/discussions/discussions/2618 after #90350
