### PR TITLE
clang-format 5.0.2 (new formula)

### DIFF
--- a/Formula/clang-format@5.rb
+++ b/Formula/clang-format@5.rb
@@ -1,0 +1,44 @@
+class ClangFormatAT5 < Formula
+  desc "Formatting tools for C, C++, Obj-C, Java, JavaScript, TypeScript"
+  homepage "https://clang.llvm.org/docs/ClangFormat.html"
+  url "https://releases.llvm.org/5.0.2/llvm-5.0.2.src.tar.xz"
+  sha256 "d522eda97835a9c75f0b88ddc81437e5edbb87dc2740686cb8647763855c2b3c"
+  license "Apache-2.0"
+  revision 1
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
+  resource "clang" do
+    url "https://releases.llvm.org/5.0.2/cfe-5.0.2.src.tar.xz"
+    sha256 "fa9ce9724abdb68f166deea0af1f71ca0dfa9af8f7e1261f2cae63c280282800"
+  end
+
+  def install
+    (buildpath/"tools/clang").install resource("clang")
+
+    mkdir buildpath/"build" do
+      args = std_cmake_args
+      args << ".."
+      system "cmake", "-G", "Ninja", *args
+      system "ninja", "clang-format"
+    end
+
+    bin.install buildpath/"build/bin/clang-format" => "clang-format-5"
+    bin.install buildpath/"tools/clang/tools/clang-format/git-clang-format" => "git-clang-format-5"
+  end
+
+  test do
+    # NB: below C code is messily formatted on purpose.
+    (testpath/"test.c").write <<~EOS
+      int         main(char *args) { \n   \t printf("hello"); }
+    EOS
+
+    assert_equal "int main(char *args) { printf(\"hello\"); }\n",
+        shell_output("#{bin}/clang-format-5 -style=Google test.c")
+  end
+end

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -3,6 +3,7 @@
   "autoconf@2.13",
   "bash-completion@2",
   "cairomm@1.14",
+  "clang-format@5",
   "clang-format@8",
   "clang-format@11",
   "gcc@4.9",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

This PR introduced clang-format 5.0.2, some old projects still use clang-format-5 to check style, if we can support it, the will be great.