### PR TITLE
clang-format 9.0.1

### DIFF
--- a/Formula/clang-format@9.rb
+++ b/Formula/clang-format@9.rb
@@ -1,0 +1,37 @@
+class ClangFormatAT9 < Formula
+  desc "Formatting tools for C, C++, Obj-C, Java, JavaScript, TypeScript"
+  homepage "https://clang.llvm.org/docs/ClangFormat.html"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/llvm-9.0.1.src.tar.xz"
+  sha256 "00a1ee1f389f81e9979f3a640a01c431b3021de0d42278f6508391a2f0b81c9a"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
+  resource "clang" do
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/clang-9.0.1.src.tar.xz"
+    sha256 "5778512b2e065c204010f88777d44b95250671103e434f9dc7363ab2e3804253"
+  end
+
+  def install
+    (buildpath/"tools/clang").install resource("clang")
+
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build", "--target", "clang-format"
+
+    bin.install buildpath/"build/bin/clang-format" => "clang-format-9"
+    bin.install buildpath/"tools/clang/tools/clang-format/git-clang-format" => "git-clang-format-9"
+  end
+
+  test do
+    # NB: below C code is messily formatted on purpose.
+    (testpath/"test.c").write <<~EOS
+      int         main(char *args) { \n   \t printf("hello"); }
+    EOS
+
+    assert_equal "int main(char *args) { printf(\"hello\"); }\n",
+        shell_output("#{bin}/clang-format-9 -style=Google test.c")
+  end
+end


### PR DESCRIPTION
Provide clang-format-9.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Kindly include this version of clang-format in addition to the existing ones to allow developers of projects relying on v9 of clang-format to install clang-format easily especially on macOS. The main reason for choosing v9 is that it is the most widely supported fixed-version clang package under Ubuntu, [being available in all versions from Bionic 18.04LTS onwards](https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=clang-format).

`brew audit` suggest to add `keg_only :versioned_formula`, but I believe that similar to the other clang-format@NN formulas, that this would not be the right choice here.

This PR is based on the clang-format@11 formula.