### PR TITLE
ipsumdump: add livecheck

### DIFF
--- a/Formula/ipsumdump.rb
+++ b/Formula/ipsumdump.rb
@@ -6,6 +6,11 @@ class Ipsumdump < Formula
   license "MIT"
   head "https://github.com/kohler/ipsumdump.git"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?ipsumdump[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_monterey: "1494705fff0bb7937d74557efd7484896a8c87133dad9a4e40ee2ee5b5da67eb"
     sha256 arm64_big_sur:  "6348649ec33f562a3622f97fb7b253d39ed8b3f919a9aa2af8fa84b8d67d765a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ipsumdump` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.