### PR TITLE
c-ares: fix executable rpath

### DIFF
--- a/Formula/c-ares.rb
+++ b/Formula/c-ares.rb
@@ -7,6 +7,7 @@ class CAres < Formula
   mirror "http://fresh-center.net/linux/misc/dns/legacy/c-ares-1.18.1.tar.gz"
   sha256 "1a7d52a8a84a9fbffb1be9133c0f6e17217d91ea5a6fa61f6b4729cda78ebbcf"
   license "MIT"
+  revision 1
   head "https://github.com/c-ares/c-ares.git", branch: "main"
 
   livecheck do
@@ -26,7 +27,7 @@ class CAres < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end
@@ -45,5 +46,7 @@ class CAres < Formula
     EOS
     system ENV.cc, "test.c", "-L#{lib}", "-lcares", "-o", "test"
     system "./test"
+
+    system "#{bin}/ahost", "127.0.0.1"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Although `libcares.2.5.1.dylib` could be linked and loaded by other executables, it was not being loaded by the formula's own executables `acountry`, `adig`, and `ahost`.
```
caraman@mac ~ [SIGABRT]> adig brew.sh
dyld[79583]: Library not loaded: @rpath/libcares.2.dylib
  Referenced from: /opt/homebrew/Cellar/c-ares/1.18.1/bin/adig
  Reason: tried: '/usr/local/lib/libcares.2.dylib' (no such file), '/usr/lib/libcares.2.dylib' (no such file)
fish: Job 1, 'adig brew.sh' terminated by signal SIGABRT (Abort)
```

I've added a test to ensure `ahost 127.0.0.1` executes, and have passed Homebrew's `rpath` to CMake to resolve the issue.