### PR TITLE
php-code-sniffer: New hashes due to repackaging

### DIFF
--- a/Formula/php-code-sniffer.rb
+++ b/Formula/php-code-sniffer.rb
@@ -2,8 +2,9 @@ class PhpCodeSniffer < Formula
   desc "Check coding standards in PHP, JavaScript and CSS"
   homepage "https://github.com/squizlabs/PHP_CodeSniffer/"
   url "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/3.6.2/phpcs.phar"
-  sha256 "a022fbc98c5a3603c02bcd3e9c15ac36517fa192d7b3d54a2feb9561cc0d12e9"
+  sha256 "c0832cdce3e419c337011640ddebd08b7daac32344250ac7cfbc799309506f77"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "d5c7160d3dd8754f61d68efcf3635ee9fee6144afb0f560f9ee8aa76df344daf"
@@ -13,7 +14,7 @@ class PhpCodeSniffer < Formula
 
   resource "phpcbf.phar" do
     url "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/3.6.2/phpcbf.phar"
-    sha256 "e69d6ddb94aff39658bd38079848e9340a6fee897fda38b746b5bb11a9922076"
+    sha256 "28d74aaaa7ad251c4ed23481e7fa18b755450ee57872d22be0ecb8fe21f50dc8"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The PHAR distribution of PHP CodeSniffer has been repackaged as announced by the maintainer on Twitter: https://twitter.com/gregsherwood/status/1471635840702955520

This PR updates the hashes accordingly. Since this change was made to address compatibility issues with PHP 8.1 which is Homebrew's default PHP version at the moment, I decided to bump the revision number.