### PR TITLE
zsh-fast-syntax-highlighting 1.55 (new formula)

### DIFF
--- a/Formula/zsh-fast-syntax-highlighting.rb
+++ b/Formula/zsh-fast-syntax-highlighting.rb
@@ -1,0 +1,31 @@
+class ZshFastSyntaxHighlighting < Formula
+  desc "Feature-rich syntax highlighting for Zsh"
+  homepage "https://github.com/zdharma-continuum/fast-syntax-highlighting"
+  url "https://github.com/zdharma-continuum/fast-syntax-highlighting/archive/refs/tags/v1.55.tar.gz"
+  sha256 "d06cea9c047ce46ad09ffd01a8489a849fc65b8b6310bd08f8bcec9d6f81a898"
+  license "BSD-3-Clause"
+  head "https://github.com/zdharma-continuum/fast-syntax-highlighting.git", branch: "master"
+
+  uses_from_macos "zsh" => [:build, :test]
+
+  def install
+    pkgshare.install Dir["*"]
+  end
+
+  def caveats
+    <<~EOS
+      To activate the syntax highlighting, add the following at the end of your .zshrc:
+        source #{opt_pkgshare}/fast-syntax-highlighting.plugin.zsh
+    EOS
+  end
+
+  test do
+    test_script = testpath/"script.zsh"
+    test_script.write <<~ZSH
+      #!/usr/bin/env zsh
+      source #{pkgshare}/fast-syntax-highlighting.plugin.zsh
+      printf '%s' ${FAST_HIGHLIGHT_STYLES+yes}
+    ZSH
+    assert_match "yes", shell_output("zsh #{test_script}")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Continued from https://github.com/Homebrew/homebrew-core/pull/89070

NOTE: This test probably isn't quite right. What kinds of inputs does `shell_output` accept? Is it a string that is run as a shell script? Can I use [`Open3.capture3`](https://ruby-doc.org/stdlib-3.0.3/libdoc/open3/rdoc/Open3.html#method-c-capture3) instead, as per https://stackoverflow.com/a/20001569/2954547?

```ruby
  test do
    test_script = testpath/"script.zsh"
    test_script.write <<~ZSH
      #!/usr/bin/env zsh
      source #{pkgshare}/fast-syntax-highlighting.plugin.zsh
      printf '%s' ${FAST_HIGHLIGHT_STYLES+yes}
    ZSH
    test_out, test_err, test_ret = Open3.capture3('zsh', test_script)
    assert_equal 0, test_ret
    assert_match "yes", test_out
  end
```