### PR TITLE
neovim: don't clobber default `LUA_PATH` and `LUA_CPATH`

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -67,8 +67,12 @@ class Neovim < Formula
       r.stage(buildpath/"deps-build/build/src"/r.name)
     end
 
-    ENV.prepend_path "LUA_PATH", "#{buildpath}/deps-build/share/lua/5.1/?.lua"
-    ENV.prepend_path "LUA_CPATH", "#{buildpath}/deps-build/lib/lua/5.1/?.so"
+    # The path separator for `LUA_PATH` and `LUA_CPATH` is `;`.
+    ENV.prepend "LUA_PATH", buildpath/"deps-build/share/lua/5.1/?.lua", ";"
+    ENV.prepend "LUA_CPATH", buildpath/"deps-build/lib/lua/5.1/?.so", ";"
+    # Don't clobber the default search path
+    ENV.append "LUA_PATH", ";", ";"
+    ENV.append "LUA_CPATH", ";", ";"
     lua_path = "--lua-dir=#{Formula["luajit-openresty"].opt_prefix}"
 
     cd "deps-build/build/src" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The way we set `LUA_PATH` and `LUA_CPATH` makes it so that the default
search path is completely ignored, which can lead to ~~build failures~~runtime errors
(e.g. neovim/neovim#16688). We fix this by appending `;` to each
variable to make sure that the default paths are searched after the
directories we set.

While we're here, let's make sure we use the right path separator (`;`,
not `:`).

Fixes neovim/neovim#16688. (Actually, that has already been fixed by
neovim/neovim#16714, but the upstream fix has the undesirable consequence
of disabling pre-compilation of LuaJIT bytecode. This change re-enables
pre-compilation.)