### PR TITLE
libaacs: add livecheck

### DIFF
--- a/Formula/libaacs.rb
+++ b/Formula/libaacs.rb
@@ -5,6 +5,11 @@ class Libaacs < Formula
   sha256 "6d884381fbb659e2a565eba91e72499778635975e4b3d6fd94ab364a25965387"
   license "LGPL-2.1-or-later"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?libaacs[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "628a46b83ed82425221046952f86bd52c06d7fadc93307dfef15164b16ab821e"
     sha256 cellar: :any,                 arm64_big_sur:  "dcbccde309919c3349987341fda3259e218549d5ec5c34c38c628ff6ada98bce"
@@ -17,7 +22,7 @@ class Libaacs < Formula
   end
 
   head do
-    url "https://code.videolan.org/videolan/libaacs.git"
+    url "https://code.videolan.org/videolan/libaacs.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `libaacs` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

Besides that, this adds `branch: "master"` to the `head` URL, to resolve the related audit error.