### PR TITLE
git-hooks-go: remove conflict, git-hooks has been deleted

### DIFF
--- a/Formula/git-hooks-go.rb
+++ b/Formula/git-hooks-go.rb
@@ -18,8 +18,6 @@ class GitHooksGo < Formula
 
   depends_on "go" => :build
 
-  conflicts_with "git-hooks", because: "both install `git-hooks` binaries"
-
   def install
     system "go", "build", *std_go_args(output: bin/"git-hooks")
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
