### PR TITLE
ccls: use llvm opt_prefix for resource dir

### DIFF
--- a/Formula/ccls.rb
+++ b/Formula/ccls.rb
@@ -4,7 +4,7 @@ class Ccls < Formula
   url "https://github.com/MaskRay/ccls/archive/0.20210330.tar.gz"
   sha256 "28c228f49dfc0f23cb5d581b7de35792648f32c39f4ca35f68ff8c9cb5ce56c2"
   license "Apache-2.0"
-  revision 2
+  revision 3
   head "https://github.com/MaskRay/ccls.git", branch: "master"
 
   bottle do
@@ -29,11 +29,16 @@ class Ccls < Formula
   fails_with gcc: "5"
 
   def install
-    system "cmake", *std_cmake_args
+    resource_dir = Utils.safe_popen_read(Formula["llvm"].bin/"clang", "-print-resource-dir").chomp
+    resource_dir.gsub! Formula["llvm"].prefix.realpath, Formula["llvm"].opt_prefix
+    system "cmake", *std_cmake_args, "-DCLANG_RESOURCE_DIR=#{resource_dir}"
     system "make", "install"
   end
 
   test do
-    system bin/"ccls", "-index=#{testpath}"
+    output = shell_output("#{bin}/ccls -index=#{testpath} 2>&1")
+
+    resource_dir = output.match(/resource-dir=(\S+)/)[1]
+    assert_path_exists "#{resource_dir}/include"
   end
 end


### PR DESCRIPTION
Building `ccls` automatically runs `clang -print-resource-dir` to find the Clang resource dir, but that returns a Cellar ref like `/usr/local/Cellar/llvm/13.0.0_2/lib/clang/13.0.0`, which breaks unnecessarily on revision bumps.

This PR configures it with the more stable `opt_prefix` ref instead (`/usr/local/opt/llvm/lib/clang/13.0.0`).

Also added a test to catch mismatched `resource-dir` with LLVM dependency, so `llvm` _version_ bumps will force (required) `ccls` rebuilds.

Addresses https://github.com/Homebrew/discussions/discussions/2656 and https://github.com/MaskRay/ccls/issues/853#issuecomment-997448145

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
