### PR TITLE
Iodine 0.7.5 (new formula)

### DIFF
--- a/Formula/iodine.rb
+++ b/Formula/iodine.rb
@@ -6,6 +6,8 @@ class Iodine < Formula
   license "ISC"
   head "https://github.com/yarrick/iodine.git", branch: "master"
   depends_on "cmake" => :build
+  
+  uses_from_macos "libzip"
 
   def install
     system "make"

--- a/Formula/iodine.rb
+++ b/Formula/iodine.rb
@@ -1,0 +1,21 @@
+class Iodine < Formula
+  desc "Tunnel IPv4 traffic through a DNS server"
+  homepage "https://code.kryo.se/iodine"
+  url "https://github.com/yarrick/iodine/archive/refs/tags/v0.7.0.tar.gz"
+  sha256 "7281e2301804e48029877bab27134f7c0eb04567da4d21a6fcbaa7265cb5849e"
+  license "ISC"
+  head "https://github.com/yarrick/iodine.git", branch: "master"
+  depends_on "cmake" => :build
+
+  def install
+    system "make"
+    bin.install "bin/iodine"
+    bin.install "bin/iodined"
+    man8.install "man/iodine.8"
+  end
+
+  test do
+    system "#{bin}/iodine", "-h"
+    system "#{bin}/iodined", "-h"
+  end
+end

--- a/Formula/iodine.rb
+++ b/Formula/iodine.rb
@@ -1,4 +1,3 @@
-class Iodine < Formula
   desc "Tunnel IPv4 traffic through a DNS server"
   homepage "https://code.kryo.se/iodine"
   url "https://github.com/yarrick/iodine/archive/refs/tags/v0.7.0.tar.gz"
@@ -6,18 +5,18 @@ class Iodine < Formula
   license "ISC"
   head "https://github.com/yarrick/iodine.git", branch: "master"
   depends_on "cmake" => :build
-  
-  uses_from_macos "libzip"
+
+  uses_from_macos "zlib"
 
   def install
     system "make"
-    bin.install "bin/iodine"
-    bin.install "bin/iodined"
-    man8.install "man/iodine.8"
+    system "make", "prefix=#{prefix}", "install"
   end
 
   test do
-    system "#{bin}/iodine", "-h"
-    system "#{bin}/iodined", "-h"
+    # iodine and iodined require being run as root. Match on the non-root error text, which is printed to
+    # stderr, as a successful test
+    assert_match("iodine: Run as root and you'll be happy.", pipe_output("#{sbin}/iodine google.com 2>&1"))
+    assert_match("iodined: Run as root and you'll be happy.", pipe_output("#{sbin}/iodined google.com 2>&1"))
   end
 end

--- a/Formula/iodine.rb
+++ b/Formula/iodine.rb
@@ -5,6 +5,7 @@ class Iodine < Formula
   sha256 "7281e2301804e48029877bab27134f7c0eb04567da4d21a6fcbaa7265cb5849e"
   license "ISC"
   head "https://github.com/yarrick/iodine.git", branch: "master"
+
   depends_on "cmake" => :build
 
   uses_from_macos "zlib"

--- a/Formula/iodine.rb
+++ b/Formula/iodine.rb
@@ -1,3 +1,4 @@
+class Iodine < Formula
   desc "Tunnel IPv4 traffic through a DNS server"
   homepage "https://code.kryo.se/iodine"
   url "https://github.com/yarrick/iodine/archive/refs/tags/v0.7.0.tar.gz"

--- a/Formula/iodine.rb
+++ b/Formula/iodine.rb
@@ -11,7 +11,6 @@ class Iodine < Formula
   uses_from_macos "zlib"
 
   def install
-    system "make"
     system "make", "prefix=#{prefix}", "install"
   end
 


### PR DESCRIPTION
Iodine DNS tunnel allows tunneling IPv4 packets over a DNS server

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
