### PR TITLE
netmask 2.4.4 (new formula)

### DIFF
--- a/Formula/netmask.rb
+++ b/Formula/netmask.rb
@@ -1,0 +1,22 @@
+class Netmask < Formula
+  desc "IP address netmask generation utility"
+  homepage "https://github.com/tlby/netmask/blob/master/README"
+  url "https://github.com/tlby/netmask/archive/refs/tags/v2.4.4.tar.gz"
+  sha256 "7e4801029a1db868cfb98661bcfdf2152e49d436d41f8748f124d1f4a3409d83"
+  license "GPL-2.0-only"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  uses_from_macos "texinfo" => :build
+
+  def install
+    system "./autogen"
+    system "./configure"
+    system "make"
+    bin.install "netmask"
+  end
+
+  test do
+    assert_equal "100.64.0.0/10", shell_output("#{bin}/netmask -c 100.64.0.0:100.127.255.255").strip
+  end
+end


### PR DESCRIPTION
This tool is very popular for network engineers and pentesters.

Please-See: https://www.kali.org/tools/netmask/

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For context. This was submitted before and determined to not be notable. It might not be well-trafficked on GitHub but it is a default package in some distros particularly Kali Linux: https://www.kali.org/tools/netmask/. It is also referenced as a package in the Debian repos in forums and blogs.

Sources:

* https://www.youtube.com/watch?v=THY0_dNywF4
* https://chousensha.github.io/blog/2017/07/07/netmask-kali-linux-tools/
