### PR TITLE
libdivecomputer: add livecheck

### DIFF
--- a/Formula/libdivecomputer.rb
+++ b/Formula/libdivecomputer.rb
@@ -6,6 +6,11 @@ class Libdivecomputer < Formula
   license "LGPL-2.1-or-later"
   head "https://github.com/libdivecomputer/libdivecomputer.git", branch: "master"
 
+  livecheck do
+    url "https://www.libdivecomputer.org/releases/"
+    regex(/href=.*?libdivecomputer[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_big_sur: "c5f918bf0cf0716949639440453e31eb929a918d5328fb1d4dd50ad6f6a497a5"
     sha256 cellar: :any,                 big_sur:       "80a648490411d90cee0ae9bbafbc91e48e6ee1d4b449bfad5795cd375b5337d0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `libdivecomputer ` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible.

This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. [The [first-party download page](https://www.libdivecomputer.org/download.html) doesn't link to the `stable` archive and instead points to the `/releases/` page as the place to download stable versions.]