### PR TITLE
elixir-ls 0.9.0 (new formula)

### DIFF
--- a/Formula/elixir-ls.rb
+++ b/Formula/elixir-ls.rb
@@ -16,11 +16,19 @@ class ElixirLs < Formula
     system "mix", "compile"
     system "mix", "elixir_ls.release", "-o", libexec
 
-    bin.install_symlink libexec/"language_server.sh" => "language_server.sh"
+    bin.install_symlink libexec/"language_server.sh" => "elixir-ls"
   end
 
   test do
-    assert_predicate bin/"language_server.sh", :exist?
-    assert_match "", pipe_output("#{bin}/language_server.sh", "")
+    assert_predicate bin/"elixir-ls", :exist?
+    input =
+      "Content-Length: 152\r\n" \
+      "\r\n" \
+      "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"" \
+      "processId\":88075,\"rootUri\":null,\"capabilities\":{},\"trace\":\"ver" \
+      "bose\",\"workspaceFolders\":null}}\r\n"
+
+    output = pipe_output("#{bin}/elixir-ls", input, 0)
+    assert_match "Content-Length", output
   end
 end

--- a/Formula/elixir-ls.rb
+++ b/Formula/elixir-ls.rb
@@ -1,0 +1,26 @@
+class ElixirLs < Formula
+  desc "Language Server and Debugger for Elixir"
+  homepage "https://elixir-lsp.github.io/elixir-ls"
+  url "https://github.com/elixir-lsp/elixir-ls/archive/refs/tags/v0.9.0.tar.gz"
+  sha256 "eaa2f5fd4ab9e497889e25419e4409cfaf808daca06259718668a71de8616e3f"
+  license "Apache-2.0"
+
+  depends_on "elixir"
+
+  def install
+    ENV["MIX_ENV"] = "prod"
+
+    system "mix", "local.hex", "--force"
+    system "mix", "local.rebar", "--force"
+    system "mix", "deps.get"
+    system "mix", "compile"
+    system "mix", "elixir_ls.release", "-o", libexec
+
+    bin.install_symlink libexec/"language_server.sh" => "language_server.sh"
+  end
+
+  test do
+    assert_predicate bin/"language_server.sh", :exist?
+    assert_match "", pipe_output("#{bin}/language_server.sh", "")
+  end
+end


### PR DESCRIPTION
Adding a new formula for the Elixir Language Server. It is a code
intelligence server and debugger implementing the LSP and DAP.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
