### PR TITLE
x265: enable neon from HEAD

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -6,7 +6,7 @@ class Ffmpeg < Formula
   # None of these parts are used by default, you have to explicitly pass `--enable-gpl`
   # to configure to activate them. In this case, FFmpeg's license changes to GPL v2+.
   license "GPL-2.0-or-later"
-  revision 3
+  revision 4
   head "https://github.com/FFmpeg/FFmpeg.git", branch: "master"
 
   livecheck do
@@ -120,8 +120,11 @@ class Ffmpeg < Formula
     # Remove in the next release
     args << "--enable-avresample" unless build.head?
 
-    # Needs corefoundation, coremedia, corevideo
-    args << "--enable-videotoolbox" if OS.mac?
+    if OS.mac?
+      # Needs corefoundation, coremedia, corevideo
+      args << "--enable-videotoolbox"
+      args << "--enable-neon" if Hardware::CPU.arm?
+    end
 
     # Replace hardcoded default VMAF model path
     %w[doc/filters.texi libavfilter/vf_libvmaf.c].each do |f|

--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -20,6 +20,8 @@ class X265 < Formula
   depends_on "cmake" => :build
   depends_on "nasm" => :build if Hardware::CPU.intel?
 
+  patch :DATA if build.head?
+
   def install
     # Build based off the script at ./build/linux/multilib.sh
     args = std_cmake_args + %W[
@@ -74,3 +76,23 @@ class X265 < Formula
     assert_equal header.unpack("m"), [x265_path.read(10)]
   end
 end
+
+__END__
+diff --git a/source/common/aarch64/asm-primitives.cpp b/source/common/aarch64/asm-primitives.cpp
+index c41bb4c31..25cc44c98 100644
+--- a/source/common/aarch64/asm-primitives.cpp
++++ b/source/common/aarch64/asm-primitives.cpp
+@@ -109,10 +109,10 @@ void setupAssemblyPrimitives(EncoderPrimitives &p, int cpuMask)
+ {
+     if (cpuMask & X265_CPU_NEON)
+     {
++#if !HIGH_BIT_DEPTH
+     	  // quant
+         p.quant = PFX(quant_neon);
+-        
+-#if !HIGH_BIT_DEPTH
++
+         p.pu[LUMA_4x8].satd   = PFX(pixel_satd_4x8_neon);
+         p.pu[LUMA_4x16].satd  = PFX(pixel_satd_4x16_neon);
+ 
+


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


Apple provided a [patch](https://github.com/HandBrake/HandBrake/commit/67a490a171764eafe8eb8afb72fa1dff763a3275) to `x265`'s downstream `handshake`, `x265` [merged](https://bitbucket.org/multicoreware/x265_git/commits/4bf31dc15fb6d1f93d12ecf21fad5e695f0db5c0) it back to its `master` branch, however, it is broken as [x265_git#608](https://bitbucket.org/multicoreware/x265_git/issues/608/).

This PR borrows the patch from [x265_git#608](https://bitbucket.org/multicoreware/x265_git/issues/608/) and try to enable neon patch for Apple Silicon users.

In order to take the benefit of the neon patch, we need to do:
1. merge/apply this PR
2. `brew reinstall x265 --HEAD`, reinstall `x265` by building from the `HEAD` with the patch 
3. homebrew will trigger a rebuild of `ffmpeg`, which will used to x265 library we just rebuild. 
4. enjoy ffmpeg with the neon patch 

Ideally, when `x265` accept the patch and make a new release, we don't need to patch in `x265.rb` any more, but I make this change in advanced and hope `x265` can merge the original patch in the future