### PR TITLE
luvit: remove unneeded `inreplace`

### DIFF
--- a/Formula/luvit.rb
+++ b/Formula/luvit.rb
@@ -41,13 +41,11 @@ class Luvit < Formula
     luajit = Formula["luajit-openresty"]
 
     resource("luvi").stage do
-      # Build scripts set LUA_PATH before invoking LuaJIT, but that causes errors.
-      # Reported at https://github.com/luvit/luvi/issues/242
-      inreplace "cmake/Modules/LuaJITAddExecutable.cmake",
-                "COMMAND \"LUA_PATH=${LUA_PATH}\" luajit", "COMMAND luajit"
+      # The build scripts require `LUA_PATH` to be set in the environment.
+      ENV["LUA_PATH"] = "';;'"
 
       # Build scripts double the prefix of this directory, so we set it manually.
-      # Reported in the issue linked above.
+      # Reported at https://github.com/luvit/luvi/issues/242
       ENV["LPEGLIB_DIR"] = "deps/lpeg"
 
       # CMake flags adapted from


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This shouldn't be necessary if we set `LUA_PATH` to search the default
one.