### PR TITLE
tree: fix manpage install

### DIFF
--- a/Formula/tree.rb
+++ b/Formula/tree.rb
@@ -4,6 +4,7 @@ class Tree < Formula
   url "http://mama.indstate.edu/users/ice/tree/src/tree-2.0.0.tgz"
   sha256 "782cd73179f65cfca7f29326f1511306e49e9b11d5b861daa57e13fd7262889f"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "http://mama.indstate.edu/users/ice/tree/src/"
@@ -24,7 +25,7 @@ class Tree < Formula
     objs = "tree.o list.o hash.o color.o file.o filter.o info.o unix.o xml.o json.o html.o strverscmp.o"
 
     system "make", "prefix=#{prefix}",
-                   "MANDIR=#{man1}",
+                   "MANDIR=#{man}",
                    "CC=#{ENV.cc}",
                    "CFLAGS=#{ENV.cflags}",
                    "LDFLAGS=#{ENV.ldflags}",


### PR DESCRIPTION
Original formula installed into `.../man/man1/man1/tree.1`

Fixes https://github.com/Homebrew/homebrew-core/issues/91918

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?