### PR TITLE
grafana-agent 0.21.2 (new formula)

### DIFF
--- a/Formula/grafana-agent.rb
+++ b/Formula/grafana-agent.rb
@@ -1,0 +1,48 @@
+class GrafanaAgent < Formula
+  desc "Exporter for Prometheus Metrics, Loki Logs, and Tempo Traces"
+  homepage "https://grafana.com/docs/agent/"
+  url "https://github.com/grafana/agent/archive/refs/tags/v0.21.2.tar.gz"
+  sha256 "a9deceaf1c09f19e5f44204e7d7c755dc24a5dd5a532c76c0524e762a695b590"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  on_linux do
+    depends_on "systemd" => :build
+  end
+
+  def install
+    ldflags = %W[
+      -X github.com/grafana/agent/pkg/build.Branch=HEAD
+      -X github.com/grafana/agent/pkg/build.Version=v#{version}
+      -X github.com/grafana/agent/pkg/build.BuildUser=#{tap.user}
+      -X github.com/grafana/agent/pkg/build.BuildDate=#{time.rfc3339}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "./cmd/agent"
+    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "-o", bin/"grafana-agentctl", "./cmd/agentctl"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/grafana-agent --version")
+    assert_match version.to_s, shell_output("#{bin}/grafana-agentctl --version")
+
+    port = free_port
+
+    (testpath/"grafana-agent.yaml").write <<~EOS
+      server:
+        log_level: info
+        http_listen_port: #{port}
+        grpc_listen_port: #{free_port}
+    EOS
+
+    system "#{bin}/grafana-agentctl", "config-check", "#{testpath}/grafana-agent.yaml"
+
+    fork do
+      exec bin/"grafana-agent", "-config.file=#{testpath}/grafana-agent.yaml"
+    end
+    sleep 3
+
+    output = shell_output("curl -s 127.0.0.1:#{port}/metrics")
+    assert_match "agent_build_info", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
  - There is an [older](https://github.com/Homebrew/homebrew-core/pull/66723) attempt, but it didn't seem to qualify
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds a formula for [Grafana Agent](https://github.com/grafana/agent), a tool which collects Prometheus metrics, logs and traces, and exports via the network to Prometheus Remote Write, Grafana Loki and Grafana Tempo (most commonly to Grafana Cloud, a SaaS product by the author)