### PR TITLE
solana: additional binaries

### DIFF
--- a/Formula/solana.rb
+++ b/Formula/solana.rb
@@ -21,10 +21,12 @@ class Solana < Formula
 
   depends_on "protobuf" => :build
   depends_on "rust" => :build
+  depends_on "rustfmt" => :build
 
   uses_from_macos "zlib"
 
   on_linux do
+    depends_on "llvm" => :build
     depends_on "pkg-config" => :build
 
     depends_on "openssl@1.1"
@@ -33,20 +35,33 @@ class Solana < Formula
 
   def install
     %w[
+      accounts-bench
+      accounts-cluster-bench
       cli
       bench-streamer
+      bench-tps
+      dos
       faucet
+      genesis
+      gossip
       keygen
+      ledger-tool
       log-analyzer
+      merkle-root-bench
       net-shaper
+      net-utils
+      poh-bench
+      rbpf-cli
+      replica-node
       stake-accounts
       sys-tuner
       tokens
+      transaction-dos
+      upload-perf
+      validator
       watchtower
     ].each do |bin|
-      cd bin do
-        system "cargo", "install", "--no-default-features", *std_cargo_args
-      end
+      system "cargo", "install", *std_cargo_args(path: "./#{bin}")
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Now that `rustfmt` is in the tree, additional binaries can be compiled, most notably the Solana validator. 