### PR TITLE
nimbus-eth2 1.5.5 (new formula)

### DIFF
--- a/Formula/nimbus-eth2.rb
+++ b/Formula/nimbus-eth2.rb
@@ -1,0 +1,49 @@
+class NimbusEth2 < Formula
+  desc "Nim implementation of the Ethereum 2.0 blockchain"
+  homepage "https://nimbus.guide/"
+  # pull from git tag to get submodules
+  url "https://github.com/status-im/nimbus-eth2.git",
+      tag:      "v1.5.5",
+      revision: "f0f9735955070d297b33fbec466537cb7029e0cc"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "make"
+
+    %w[
+      nimbus_beacon_node
+      deposit_contract
+      ncli
+      ncli_db
+      nimbus_validator_client
+      nimbus_signing_node
+    ].each do |program|
+      bin.install "build/#{program}"
+    end
+  end
+
+  test do
+    assert_match "Nimbus beacon node", shell_output("#{bin}/nimbus_beacon_node --version")
+    assert_match "deposit_contract", shell_output("#{bin}/deposit_contract --help")
+    assert_match "ncli", shell_output("#{bin}/ncli --help")
+    assert_match "ncli_db", shell_output("#{bin}/ncli_db --help")
+    assert_match "Nimbus validator client", shell_output("#{bin}/nimbus_validator_client --version")
+    assert_match "Nimbus signing node", shell_output("#{bin}/nimbus_signing_node --version")
+
+    rest_port = free_port
+    fork do
+      exec bin/"nimbus_beacon_node",
+           "--rest",
+           "--rest-port=#{rest_port}",
+           "--non-interactive",
+           "--tcp-port=#{free_port}",
+           "--udp-port=#{free_port}"
+    end
+    sleep 10
+
+    output = shell_output("curl -sS -XGET http://127.0.0.1:#{rest_port}/eth/v1/node/syncing")
+    assert_match "is_syncing", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

[nimbus-eth2](https://github.com/status-im/nimbus-eth2) is an implementation of the [Eth2](https://ethereum.org/en/eth2/) beacon chain in [Nim](https://nim-lang.org). Eth2 is a series of ongoing upgrades to the Ethereum cryptocurrency to fix the high energy usage of the network.

This PR is part of a series of new formulas. There exist a few implementations of Eth2, most notably Prysm (Go), Nimbus-Eth2 (Nim), Lighthouse (Rust) #91984 and Teku (Java) #91986. All of these clients are well maintained, implement the same protocol and have mostly the same ergonomics. I aim to enroll all of them in Homebrew.