### PR TITLE
teku 21.12.2 (new formula)

### DIFF
--- a/Formula/teku.rb
+++ b/Formula/teku.rb
@@ -1,0 +1,31 @@
+class Teku < Formula
+  desc "Java Implementation of the Ethereum 2.0 Beacon Chain"
+  homepage "https://docs.teku.consensys.net/"
+  url "https://github.com/ConsenSys/teku/archive/refs/tags/21.12.2.tar.gz"
+  sha256 "fdd2e23ee8228b0bcb883f3bdfb4c24b82b21346a0444309e933ff019d5c3f39"
+  license "Apache-2.0"
+
+  depends_on "gradle" => :build
+  depends_on "openjdk"
+
+  def install
+    system "gradle", "installDist"
+
+    libexec.install Dir["build/install/teku/*"]
+
+    (bin/"teku").write_env_script libexec/"bin/teku", Language::Java.overridable_java_home_env
+  end
+
+  test do
+    assert_match "teku/", shell_output("#{bin}/teku --version")
+
+    rest_port = free_port
+    fork do
+      exec bin/"teku", "--rest-api-enabled", "--rest-api-port=#{rest_port}", "--p2p-enabled=false"
+    end
+    sleep 10
+
+    output = shell_output("curl -sS -XGET http://127.0.0.1:#{rest_port}/eth/v1/node/syncing")
+    assert_match "is_syncing", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Teku is an implementation of the Eth2 beacon chain in Java. Eth2 is a series of ongoing upgrades to the Ethereum cryptocurrency to fix the high energy usage of the network.

This PR is part of a series of new formulas. There exist a few implementations of Eth2, most notably Prysm (Go), Nimbus-Eth2 (Nim) #91969, Lighthouse (Rust) #91984 and Teku (Java). All of these clients are well maintained, implement the same protocol and have mostly the same ergonomics. I aim to enroll all of them in Homebrew.