### PR TITLE
libvirt: Don't generate accelerator command line on macOS

### DIFF
--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -4,6 +4,7 @@ class Libvirt < Formula
   url "https://libvirt.org/sources/libvirt-7.10.0.tar.xz"
   sha256 "cb318014af097327928c6e3d72922e3be02a3e6401247b2aa52d9ab8e0b480f9"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
+  revision 1
   head "https://gitlab.com/libvirt/libvirt.git", branch: "master"
 
   livecheck do
@@ -45,6 +46,25 @@ class Libvirt < Formula
 
   on_linux do
     depends_on "libtirpc"
+  end
+
+  # Don't generate accelerator command line on macOS
+  #
+  # This makes it once again possible to use the
+  #
+  #   <qemu:commandline>
+  #     <qemu:arg value='-machine'/>
+  #     <qemu:arg value='q35,accel=hvf'/>
+  #   </qemu:commandline>
+  #
+  # workaround to enable hardware acceleration.
+  #
+  # Drop once proper HVF support is added to libvirt.
+  #
+  # https://gitlab.com/libvirt/libvirt/-/issues/147
+  patch do
+    url "https://gitlab.com/abologna/libvirt/-/commit/da138afc3609a92d473fddcffa54b2020759f986.diff"
+    sha256 "4eb3c9f0ca140a4d8eb5002acde0b6f1234011f82df7d8cc85252be35e8a5cff"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This workaround is necessary to make it possible to run hardware accelerated VMs with libvirt >= 7.10.0. See https://gitlab.com/libvirt/libvirt/-/issues/147 for more details.

I don't currently have access to a macOS machine so I couldn't test any of this. Hopefully it makes things better rather than worse! :)