### PR TITLE
phpunit 9.5.11

### DIFF
--- a/Formula/phpunit.rb
+++ b/Formula/phpunit.rb
@@ -1,8 +1,8 @@
 class Phpunit < Formula
   desc "Programmer-oriented testing framework for PHP"
   homepage "https://phpunit.de"
-  url "https://phar.phpunit.de/phpunit-9.5.10.phar"
-  sha256 "a34b9db21de3e75ba2e609e68a4da94633f4a99cad8413fd3731a2cd9aa08ca8"
+  url "https://phar.phpunit.de/phpunit-9.5.11.phar"
+  sha256 "e74ea97cf904f72e537de2778fa70ad94651580879bdc04386fd2ae62d7e03a5"
   license "BSD-3-Clause"
 
   livecheck do


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 4,497,267 bytes
- formula fetch time: 4.5 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.