### PR TITLE
libebml: add livecheck

### DIFF
--- a/Formula/libebml.rb
+++ b/Formula/libebml.rb
@@ -15,6 +15,11 @@ class Libebml < Formula
     patch :DATA
   end
 
+  livecheck do
+    url "https://dl.matroska.org/downloads/libebml/"
+    regex(/href=.*?libebml[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "c7ba4bf364135ac436fc50211c4d72557d0c7921d1f0e9af47a530c503354c9f"
     sha256 cellar: :any,                 arm64_big_sur:  "fce6d01b12243501223e4e9294528b8eab1818815b18e4ffe777fd14cec0e525"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `libebml` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The related [libraries page](https://www.matroska.org/downloads/libraries.html) points to the directory listing page as the place to download `libebml` releases.