### PR TITLE
musepack: Fix build for Linux

### DIFF
--- a/Formula/musepack.rb
+++ b/Formula/musepack.rb
@@ -31,7 +31,8 @@ class Musepack < Formula
   end
 
   def install
-    ENV.append "LDFLAGS", "-lm" if OS.linux?
+    # Fix missing linkage to libm on Linux
+    (buildpath/"libmpcdec/CMakeLists.txt").append_lines "target_link_libraries(mpcdec m)\n" if OS.linux?
 
     system "cmake", ".", *std_cmake_args
     system "make", "install"

--- a/Formula/musepack.rb
+++ b/Formula/musepack.rb
@@ -31,9 +31,11 @@ class Musepack < Formula
   end
 
   def install
+    ENV.append "LDFLAGS", "-lm" if OS.linux?
+
     system "cmake", ".", *std_cmake_args
     system "make", "install"
-    lib.install "libmpcdec/libmpcdec.dylib"
+    lib.install "libmpcdec/#{shared_library("libmpcdec")}"
   end
 
   test do


### PR DESCRIPTION
Fixes:
./libmpcdec/libmpcdec.so: undefined reference to `pow'

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
