### PR TITLE
latexml: update urls

### DIFF
--- a/Formula/latexml.rb
+++ b/Formula/latexml.rb
@@ -1,13 +1,13 @@
 class Latexml < Formula
   desc "LaTeX to XML/HTML/MathML Converter"
-  homepage "https://dlmf.nist.gov/LaTeXML/"
-  url "https://dlmf.nist.gov/LaTeXML/releases/LaTeXML-0.8.5.tar.gz"
+  homepage "https://math.nist.gov/~BMiller/LaTeXML/"
+  url "https://math.nist.gov/~BMiller/LaTeXML/releases/LaTeXML-0.8.5.tar.gz"
   sha256 "1de821d0df8c88041ee10820188f33feac77d5618de4c0798a296a425f4e2637"
   license :public_domain
   head "https://github.com/brucemiller/LaTeXML.git", branch: "master"
 
   livecheck do
-    url "https://dlmf.nist.gov/LaTeXML/get.html"
+    url "https://math.nist.gov/~BMiller/LaTeXML/get.html"
     regex(/href=.*?LaTeXML[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `https://dlmf.nist.gov/LaTeXML/` URLs in the `latexml` formula to `https://math.nist.gov/~BMiller/LaTeXML/`, as these URLs redirect from the former to the latter. I didn't label this `CI-syntax-only`, as this technically modifies the `stable` URL.

For what it's worth, the latest version of `latexml` is 0.8.6 but a previous version bump (#86403) didn't work out. If there's any interest in attempting it again, I think it should be handled in a separate PR so these minor changes won't get hung up on potentially-unresolvable issues.