### PR TITLE
v8 9.6.180.21

### DIFF
--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -4,9 +4,10 @@ class V8 < Formula
   # Track V8 version from Chrome stable: https://omahaproxy.appspot.com
   # revert back to GitHub mirror tar.gz archives once it's synced again
   url "https://chromium.googlesource.com/v8/v8.git",
-      tag:      "9.7.106.18",
-      revision: "96e2674d6126c2ae64d44024aaa7968c853ac4a2"
+      tag:      "9.6.180.21",
+      revision: "f7fbc9b2fdaef29e377c9cb2fbcdd2cc092974a4"
   license "BSD-3-Clause"
+  version_scheme 1
 
   livecheck do
     url "https://omahaproxy.appspot.com/all.json?os=mac&channel=stable"
@@ -23,7 +24,9 @@ class V8 < Formula
   end
 
   depends_on "ninja" => :build
-  depends_on "python@3.10" => :build
+  # Does not support Python 3.10
+  # https://github.com/Homebrew/homebrew-core/pull/91497
+  depends_on "python@3.9" => :build
 
   on_macos do
     depends_on "llvm" => :build
@@ -39,36 +42,36 @@ class V8 < Formula
   fails_with gcc: "5"
 
   # Look up the correct resource revisions in the DEP file of the specific releases tag
-  # e.g. for CIPD dependency gn: https://chromium.googlesource.com/v8/v8.git/+/refs/tags/9.7.106.18/DEPS#43
+  # e.g. for CIPD dependency gn: https://chromium.googlesource.com/v8/v8.git/+/refs/tags/9.6.180.21/DEPS#52
   resource "gn" do
     url "https://gn.googlesource.com/gn.git",
-        revision: "8926696a4186279489cc2b8d768533e61bba73d7"
+        revision: "0153d369bbccc908f4da4993b1ba82728055926a"
   end
 
-  # e.g.: https://chromium.googlesource.com/v8/v8.git/+/refs/tags/9.7.106.18/DEPS#84
+  # e.g.: https://chromium.googlesource.com/v8/v8.git/+/refs/tags/9.6.180.21/DEPS#93
   resource "v8/base/trace_event/common" do
     url "https://chromium.googlesource.com/chromium/src/base/trace_event/common.git",
-        revision: "7f36dbc19d31e2aad895c60261ca8f726442bfbb"
+        revision: "68d816952258c9d817bba656ee2664b35507f01b"
   end
 
   resource "v8/build" do
     url "https://chromium.googlesource.com/chromium/src/build.git",
-        revision: "cf325916d58a194a935c26a56fcf6b525d1e2bf4"
+        revision: "ebad8533842661f66b9b905e0ee9890a32f628d5"
   end
 
   resource "v8/third_party/googletest/src" do
     url "https://chromium.googlesource.com/external/github.com/google/googletest.git",
-        revision: "16f637fbf4ffc3f7a01fa4eceb7906634565242f"
+        revision: "3b49be074d5c1340eeb447e6a8e78427051e675a"
   end
 
   resource "v8/third_party/icu" do
     url "https://chromium.googlesource.com/chromium/deps/icu.git",
-        revision: "eedbaf76e49d28465d9119b10c30b82906e606ff"
+        revision: "3f443830bd52d3aa5fab3c1aa2b6d0848bb5039d"
   end
 
   resource "v8/third_party/jinja2" do
     url "https://chromium.googlesource.com/chromium/src/third_party/jinja2.git",
-        revision: "ee69aa00ee8536f61db6a451f3858745cf587de6"
+        revision: "6db8da1615a13fdfab925688bc4bf2eb394a73af"
   end
 
   resource "v8/third_party/markupsafe" do
@@ -78,7 +81,7 @@ class V8 < Formula
 
   resource "v8/third_party/zlib" do
     url "https://chromium.googlesource.com/chromium/src/third_party/zlib.git",
-        revision: "6da1d53b97c89b07e47714d88cab61f1ce003c68"
+        revision: "dfa96e81458fb3b39676e45f7e9e000dff789b05"
   end
 
   def install


### PR DESCRIPTION
Go back to old version as we shipped a beta version by mistake
See https://github.com/Homebrew/homebrew-core/pull/91497

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
