### PR TITLE
enzyme: Fix build for Linux

### DIFF
--- a/Formula/enzyme.rb
+++ b/Formula/enzyme.rb
@@ -1,7 +1,7 @@
 class Enzyme < Formula
   desc "High-performance automatic differentiation of LLVM"
   homepage "https://enzyme.mit.edu"
-  url "https://github.com/wsmoses/Enzyme/archive/v0.0.26.tar.gz"
+  url "https://github.com/wsmoses/Enzyme/archive/v0.0.26.tar.gz", using: :homebrew_curl
   sha256 "b212bf13a50c3297fb0ca9fa3094cfd16b399f7c57a928b8eb9e293006fa0c32"
   license "Apache-2.0" => { with: "LLVM-exception" }
   head "https://github.com/wsmoses/Enzyme.git", branch: "main"
@@ -16,6 +16,12 @@ class Enzyme < Formula
 
   depends_on "cmake" => :build
   depends_on "llvm"
+
+  on_linux do
+    depends_on "gcc" => :build
+  end
+
+  fails_with gcc: "5"
 
   def llvm
     deps.map(&:to_formula).find { |f| f.name.match? "^llvm" }


### PR DESCRIPTION
Fixes:
```
[  5%] Building CXX object Enzyme/CMakeFiles/ClangEnzyme-13.dir/ActivityAnalysis.cpp.o
cd /tmp/enzyme-20211225-10637-1f81lsz/Enzyme-0.0.26/build/Enzyme && /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/g++-5  -I/home/linuxbrew/.linuxbrew/Cellar/llvm/13.0.0_2/include -I/tmp/enzyme-20211225-10637-1f81lsz/Enzyme-0.0.26/build/include -Wall -fPIC -fno-rtti  -O2 -fPIC   -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -std=gnu++1z -MD -MT Enzyme/CMakeFiles/ClangEnzyme-13.dir/ActivityAnalysis.cpp.o -MF CMakeFiles/ClangEnzyme-13.dir/ActivityAnalysis.cpp.o.d -o CMakeFiles/ClangEnzyme-13.dir/ActivityAnalysis.cpp.o -c /tmp/enzyme-20211225-10637-1f81lsz/Enzyme-0.0.26/enzyme/Enzyme/ActivityAnalysis.cpp
In file included from /home/linuxbrew/.linuxbrew/Cellar/llvm/13.0.0_2/include/llvm/ADT/StringSwitch.h:15:0,
                 from /home/linuxbrew/.linuxbrew/Cellar/llvm/13.0.0_2/include/llvm/ADT/FloatingPointMode.h:16,
                 from /home/linuxbrew/.linuxbrew/Cellar/llvm/13.0.0_2/include/llvm/ADT/APFloat.h:21,
                 from /home/linuxbrew/.linuxbrew/Cellar/llvm/13.0.0_2/include/llvm/IR/Constants.h:23,
                 from /tmp/enzyme-20211225-10637-1f81lsz/Enzyme-0.0.26/enzyme/Enzyme/ActivityAnalysis.cpp:32:
/home/linuxbrew/.linuxbrew/Cellar/llvm/13.0.0_2/include/llvm/ADT/StringRef.h:22:23: fatal error: string_view: No such file or directory
In file included from /home/linuxbrew/.linuxbrew/Cellar/llvm/13.0.0_2/include/llvm/ADT/StringSwitch.h:15:0,
                 from /home/linuxbrew/.linuxbrew/Cellar/llvm/13.0.0_2/include/llvm/ADT/FloatingPointMode.h:16,
                 from /home/linuxbrew/.linuxbrew/Cellar/llvm/13.0.0_2/include/llvm/ADT/APFloat.h:21,
                 from /home/linuxbrew/.linuxbrew/Cellar/llvm/13.0.0_2/include/llvm/IR/Constants.h:23,
                 from /tmp/enzyme-20211225-10637-1f81lsz/Enzyme-0.0.26/enzyme/Enzyme/ActivityAnalysis.cpp:32:
/home/linuxbrew/.linuxbrew/Cellar/llvm/13.0.0_2/include/llvm/ADT/StringRef.h:22:23: fatal error: string_view: No such file or directory
```

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
