### PR TITLE
exiv2 0.27.5_1 with support of bmff files enabled by default

### DIFF
--- a/Formula/exiv2.rb
+++ b/Formula/exiv2.rb
@@ -4,6 +4,7 @@ class Exiv2 < Formula
   url "https://www.exiv2.org/builds/exiv2-0.27.5-Source.tar.gz"
   sha256 "35a58618ab236a901ca4928b0ad8b31007ebdc0386d904409d825024e45ea6e2"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/Exiv2/exiv2.git", branch: "main"
 
   livecheck do
@@ -41,6 +42,7 @@ class Exiv2 < Formula
       -DEXIV2_ENABLE_WEBREADY=ON
       -DEXIV2_ENABLE_CURL=ON
       -DEXIV2_ENABLE_SSH=ON
+      -DEXIV2_ENABLE_BMFF=ON
       -DEXIV2_BUILD_SAMPLES=OFF
       -DSSH_LIBRARY=#{Formula["libssh"].opt_lib}/#{shared_library("libssh")}
       -DSSH_INCLUDE_DIR=#{Formula["libssh"].opt_include}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Activating support for bmff files (CR3, HEIF, HEIC, and AVIF) by default.

See https://github.com/Exiv2/exiv2/issues/1229 and https://github.com/Exiv2/exiv2#2-19 for more details. Note that according to the original authors "Attention is drawn to the possibility that bmff support may be the subject of patent rights."