### PR TITLE
helix 0.5.0 (new formula)

### DIFF
--- a/Formula/helix.rb
+++ b/Formula/helix.rb
@@ -12,6 +12,8 @@ class Helix < Formula
 
   def install
     system "cargo", "install", *std_cargo_args(path: "helix-term")
+    prefix.install "runtime"
+    (bin/"hx").write_env_script(bin/"hx", HELIX_RUNTIME: prefix/"runtime")
   end
 
   test do

--- a/Formula/helix.rb
+++ b/Formula/helix.rb
@@ -1,0 +1,20 @@
+class Helix < Formula
+  desc "Post-modern modal text editor"
+  homepage "https://helix-editor.com"
+  # pull from git tag to get submodules
+  url "https://github.com/helix-editor/helix.git",
+      tag:      "v0.5.0",
+      revision: "a1b7f003a6ea61b2a77056ce8865a779b3452975"
+  license "MPL-2.0"
+  head "https://github.com/helix-editor/helix.git", branch: "master"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "helix-term")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/hx --version 0>&1")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Requesting also approval from the main maintainer of Helix, @archseer.

Helix was already available through this tap: https://github.com/helix-editor/homebrew-helix, this PR follows the previous implementation with small adjustments to follow the linting and test requirements of Homebrew.

Adding this formula was mentioned in this PR: https://github.com/helix-editor/helix/pull/1371 in helix.