### PR TITLE
[apache-pulsar formula] Remove workaround for a now-fixed upstream bug

### DIFF
--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -24,9 +24,6 @@ class ApachePulsar < Formula
   depends_on "openjdk@11"
 
   def install
-    # Missing executable permission reported upstream: https://github.com/apache/pulsar/issues/11833
-    chmod "+x", "src/rename-netty-native-libs.sh"
-
     with_env("TMPDIR" => buildpath, **Language::Java.java_home_env("11")) do
       system "mvn", "-X", "clean", "package", "-DskipTests", "-Pcore-modules"
     end


### PR DESCRIPTION
The `chmod` in this build was needed because of https://github.com/apache/pulsar/issues/11833, which has since been fixed. That code can now be removed.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [waiting for brew CI] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [waiting for brew CI] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
