### PR TITLE
typedb 2.6.0

### DIFF
--- a/Formula/typedb.rb
+++ b/Formula/typedb.rb
@@ -1,8 +1,8 @@
 class Typedb < Formula
   desc "Distributed hyper-relational database for knowledge engineering"
   homepage "https://vaticle.com/"
-  url "https://github.com/vaticle/typedb/releases/download/2.5.0/typedb-all-mac-2.5.0.zip"
-  sha256 "881e5a50ed0a961d1c091da1d669285135738431b5e6bd72da6dfad9765d3eea"
+  url "https://github.com/vaticle/typedb/releases/download/2.6.0/typedb-all-mac-2.6.0.zip"
+  sha256 "770ec5c4f543873c8db92fa923902e30d24cd1d991f6ba44eead889361d549a7"
   license "AGPL-3.0-or-later"
 
   bottle do
@@ -13,7 +13,10 @@ class Typedb < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "899d7b2dbbfba0279aed9df963356dae18c0624490a1232062e603fc3efbe435"
   end
 
+  depends_on arch: :x86_64
   depends_on "openjdk@11"
+
+  uses_from_macos "netcat" => :test
 
   def install
     libexec.install Dir["*"]
@@ -22,6 +25,15 @@ class Typedb < Formula
   end
 
   test do
-    assert_match "A STRONGLY-TYPED DATABASE", shell_output("#{bin}/typedb server status")
+    port = free_port
+    mkdir "data"
+    mkdir "logs"
+    fork do
+      exec bin/"typedb", "server", "--server.address=localhost:#{port}",
+           "--storage.data=#{testpath}/data", "--log.output.file.directory=#{testpath}/logs"
+    end
+    sleep 10
+
+    system "nc", "-z", "localhost", port
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Following up from #91916, looks like TypeDB ships a JNI library that is only available for x86_64 architecture. The existing `arm64_big_sur` bottle is defective (and probably has never worked) - the new test found that.

Also of note, we're shipping what appears to be a macOS-specific distribution of TypeDB on both macOS and Linux, but it _seems_ to work on Linux too (probably because any JARs containing JNI dependencies have both ELF/Mach-O versions of the compiled pieces). I'm going to leave that as-is for now since I've been having trouble getting TypeDB to build via Bazel on Linux.

I also spent a day trying to fix the JNI library issue for Apple Silicon, but got stuck on the Bazel build issue on Linux. That attempt is kept in the [`typedb-build-from-source`](https://github.com/alebcay/homebrew-core/tree/typedb-build-from-source) branch on my fork, for anyone who wants to pick it up/have a try at fixing it.