### PR TITLE
teku: fix build

### DIFF
--- a/Formula/teku.rb
+++ b/Formula/teku.rb
@@ -1,9 +1,11 @@
 class Teku < Formula
   desc "Java Implementation of the Ethereum 2.0 Beacon Chain"
   homepage "https://docs.teku.consensys.net/"
-  url "https://github.com/ConsenSys/teku/archive/refs/tags/21.12.2.tar.gz"
-  sha256 "fdd2e23ee8228b0bcb883f3bdfb4c24b82b21346a0444309e933ff019d5c3f39"
+  url "https://github.com/ConsenSys/teku.git",
+        tag:      "21.12.2",
+        revision: "a443c80dd686092e535b1e37c26b8ba50234b223"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "4bdb86599a5102ce0bbd8ee05a098b79984ed3b5e0282ca1e19c96362dae98ad"

--- a/Formula/teku.rb
+++ b/Formula/teku.rb
@@ -34,7 +34,7 @@ class Teku < Formula
     fork do
       exec bin/"teku", "--rest-api-enabled", "--rest-api-port=#{rest_port}", "--p2p-enabled=false"
     end
-    sleep 10
+    sleep 15
 
     output = shell_output("curl -sS -XGET http://127.0.0.1:#{rest_port}/eth/v1/node/syncing")
     assert_match "is_syncing", output


### PR DESCRIPTION
The Teku build process determines the version using git tags, but the Formula was building from a downloaded source tarball which does not include tag information. As a result, `teku --version` would report `UNKNOWN` as the version rather than the actual version built.

Additionally, the Teku build does not support arbitrary versions of gradle, and should always be built with the `./gradlew` wrapper script to ensure the correct version of gradle is used.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
