### PR TITLE
libunwind: add fpic to cflags

### DIFF
--- a/Formula/libunwind.rb
+++ b/Formula/libunwind.rb
@@ -22,6 +22,7 @@ class Libunwind < Formula
   uses_from_macos "zlib"
 
   def install
+    ENV.append_to_cflags '-fPIC'
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make"
     system "make", "install"

--- a/Formula/libunwind.rb
+++ b/Formula/libunwind.rb
@@ -22,7 +22,7 @@ class Libunwind < Formula
   uses_from_macos "zlib"
 
   def install
-    ENV.append_to_cflags '-fPIC'
+    ENV.append_to_cflags "-fPIC"
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add `'-fPIC'` to cflags, for building shared library that depend on libunwind.a.
For more details see https://github.com/Homebrew/homebrew-core/issues/92125.
