### PR TITLE
libmatroska: add livecheck

### DIFF
--- a/Formula/libmatroska.rb
+++ b/Formula/libmatroska.rb
@@ -6,6 +6,11 @@ class Libmatroska < Formula
   license "LGPL-2.1"
   head "https://github.com/Matroska-Org/libmatroska.git", branch: "master"
 
+  livecheck do
+    url "https://dl.matroska.org/downloads/libmatroska/"
+    regex(/href=.*?libmatroska[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "8547a058752a4a107227a379565968ca1240846464ebcc85478ea986f3a14caf"
     sha256 cellar: :any,                 arm64_big_sur:  "80b085f93f8bd5a189b65ef9f9792d1070a3e2743d5b0d80fea37320a05f7821"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `libmatroska` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. The related [libraries page](https://www.matroska.org/downloads/libraries.html) points to the directory listing page as the place to download `libmatroska` releases.