### PR TITLE
autobump: track more php formulae

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -25,6 +25,7 @@ env:
     b3sum
     bcoin
     bottom
+    brew-php-switcher
     broot
     buildkit
     bundletool
@@ -63,6 +64,7 @@ env:
     double-conversion
     dprint
     dvc
+    easyengine
     envconsul
     esbuild
     eslint
@@ -144,11 +146,17 @@ env:
     okteto
     opensearch
     oxipng
+    phoronix-test-suite
+    php-code-sniffer
+    php-cs-fixer
+    phpmd
+    phpstan
     pickle
     pnpm
     pocsuite3
     procs
     protoc-gen-go-grpc
+    psalm
     rbw
     rollup
     s2n


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Ref PRs, https://github.com/Homebrew/homebrew-core/issues?page=1&q=label%3Abump-formula-pr+label%3Aphp+is%3Aclosed
