### PR TITLE
rssh: deprecate

### DIFF
--- a/Formula/rssh.rb
+++ b/Formula/rssh.rb
@@ -17,6 +17,8 @@ class Rssh < Formula
     sha256 yosemite:       "a63ead463b79c5375e0b919976173db13a236fcea06c4fa038a719375a550ca9"
   end
 
+  deprecate! date: "2021-01-22", because: :unmaintained
+
   # Submitted upstream:
   # https://sourceforge.net/p/rssh/mailman/message/32251335/
   patch do


### PR DESCRIPTION
As mentioned in https://github.com/Homebrew/homebrew-core/issues/92205#issuecomment-1002838437, both upstream and Debian maintainer have given up on maintenance.

NOTE: The author said he announced the deprecation on Jan 28 2020, but I can't find that announcement anywhere, so I'm taking the date of the deprecation mention (Jan 22 2021) as the formula deprecation date.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? _(N/A)_
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? _(N/A)_
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
