### PR TITLE
libxkbcommon: add livecheck

### DIFF
--- a/Formula/libxkbcommon.rb
+++ b/Formula/libxkbcommon.rb
@@ -6,6 +6,11 @@ class Libxkbcommon < Formula
   license "MIT"
   head "https://github.com/xkbcommon/libxkbcommon.git", branch: "master"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?libxkbcommon[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_monterey: "a0e6a5b584a7f3fc1d50a73fe23219fece03acfccde7aefc64eb02b387ada6bd"
     sha256 arm64_big_sur:  "1eb1269f05403fc56cde1b2ba18316db80c3d7bc06343c744856df94a35fca05"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `libxkbcommon` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.