### PR TITLE
redis: Use jemalloc instead of libc-malloc

### DIFF
--- a/Formula/redis.rb
+++ b/Formula/redis.rb
@@ -24,7 +24,7 @@ class Redis < Formula
   depends_on "openssl@1.1"
 
   def install
-    system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}", "BUILD_TLS=yes"
+    system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}", "BUILD_TLS=yes", "MALLOC=jemalloc"
 
     %w[run db/redis log].each { |p| (var/p).mkpath }
 

--- a/Formula/redis.rb
+++ b/Formula/redis.rb
@@ -4,6 +4,7 @@ class Redis < Formula
   url "https://download.redis.io/releases/redis-6.2.6.tar.gz"
   sha256 "5b2b8b7a50111ef395bf1c1d5be11e6e167ac018125055daa8b5c2317ae131ab"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/redis/redis.git", branch: "unstable"
 
   livecheck do


### PR DESCRIPTION
redis recommends jemalloc over standard malloc, in fact it is
default on Linux. macOS also gains performance by using jemalloc

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

ddfa01c is erased during past update (c8008d9a0b13ebe8f9263e907e24c3ea23dd413d).
This change replaces libc with jemalloc which is recommended by author and proven faster as posted below.

```
% redis-cli info memory | grep mem_allocator
mem_allocator:libc
% redis-benchmark -n 10000000 -t set,get -P 16 -q
SET: 1291322.38 requests per second, p50=0.519 msec
GET: 1305653.50 requests per second, p50=0.463 msec

% redis-benchmark -n 10000000 -t set,get -P 16 -q
SET: 1329964.12 requests per second, p50=0.511 msec
GET: 1413427.62 requests per second, p50=0.479 msec

% brew uninstall redis
Uninstalling /opt/homebrew/Cellar/redis/6.2.6... (14 files, 2MB)

Warning: The following may be redis configuration files and have not been removed!
If desired, remove them manually with `rm -rf`:
  /opt/homebrew/etc/redis-sentinel.conf
  /opt/homebrew/etc/redis.conf

% brew install --build-from-source redis
==> Downloading https://download.redis.io/releases/redis-6.2.6.tar.gz
Already downloaded: /Users/takenaga/Library/Caches/Homebrew/downloads/f3428a23cec52d69af15420afd45cfc857bcd87b9f18e28557bb5816e53cc6c7--redis-6.2.6.tar.gz
==> make install PREFIX=/opt/homebrew/Cellar/redis/6.2.6 CC=clang BUILD_TLS=yes MALLOC=jemalloc
==> Caveats
To restart redis after an upgrade:
  brew services restart redis
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/redis/bin/redis-server /opt/homebrew/etc/redis.conf
==> Summary
🍺  /opt/homebrew/Cellar/redis/6.2.6: 12 files, 2.8MB, built in 25 seconds
==> Running `brew cleanup redis`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

% brew services restart redis
==> Successfully started `redis` (label: homebrew.mxcl.redis)
% redis-cli info memory | grep mem_allocator
mem_allocator:jemalloc-5.1.0
% redis-benchmark -n 10000000 -t set,get -P 16 -q
SET: 1547748.00 requests per second, p50=0.423 msec
GET: 1528818.25 requests per second, p50=0.391 msec

% redis-benchmark -n 10000000 -t set,get -P 16 -q
SET: 1548946.75 requests per second, p50=0.423 msec
GET: 1555935.88 requests per second, p50=0.399 msec

% brew test redis
==> Testing redis
==> /opt/homebrew/Cellar/redis/6.2.6/bin/redis-server --test-memory 2
%