### PR TITLE
duplicity: reflect move to GitLab

### DIFF
--- a/Formula/duplicity.rb
+++ b/Formula/duplicity.rb
@@ -2,7 +2,7 @@ class Duplicity < Formula
   include Language::Python::Virtualenv
 
   desc "Bandwidth-efficient encrypted backup"
-  homepage "https://launchpad.net/duplicity"
+  homepage "https://gitlab.com/duplicity/duplicity"
   url "https://files.pythonhosted.org/packages/84/65/5ca97dade5527b6a93757e88455c53b0d7002322f9d47d848c35902ef431/duplicity-0.8.20.tar.gz"
   sha256 "488af2ecadb059214074f2b3ac51bf9d7de55a800e37ccc2f1075cd0a74940e3"
   license "GPL-2.0-or-later"


### PR DESCRIPTION
Note their "Duplicity has moved…" message on https://launchpad.net/duplicity

- [-] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [-] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [-] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [-] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [-] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since this is just a homepage update, I didn't follow the code-related guidelines.