### PR TITLE
audacious: fix build

### DIFF
--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -68,13 +68,12 @@ class Audacious < Formula
 
   def install
     args = std_meson_args + %w[
-      -Ddbus=false
       -Dgtk=false
       -Dqt=true
     ]
 
     mkdir "build" do
-      system "meson", *args, ".."
+      system "meson", *args, "-Ddbus=false", ".."
       system "ninja", "-v"
       system "ninja", "install", "-v"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Fix `../meson.build:1:0: ERROR: Unknown options: "dbus"` from #90103
