### PR TITLE
loudmouth: add livecheck, update license

### DIFF
--- a/Formula/loudmouth.rb
+++ b/Formula/loudmouth.rb
@@ -1,7 +1,7 @@
 class Loudmouth < Formula
   desc "Lightweight C library for the Jabber protocol"
   homepage "https://mcabber.com"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   stable do
     url "https://mcabber.com/files/loudmouth/loudmouth-1.5.4.tar.bz2"
@@ -12,6 +12,11 @@ class Loudmouth < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
       sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
     end
+  end
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?loudmouth[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do
@@ -25,7 +30,7 @@ class Loudmouth < Formula
   end
 
   head do
-    url "https://github.com/mcabber/loudmouth.git"
+    url "https://github.com/mcabber/loudmouth.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `loudmouth` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This also updates the `license` from `LGPL-2.1` to `LGPL-2.1-or-later`, as the source files contain a license comment using the "or...later" language. For example, from `loudmouth/lm-asyncns-resolver.c`:

```
/*
 * Copyright (C) 2008 Imendio AB
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU Lesser General Public License as
 * published by the Free Software Foundation; either version 2 of the
 * License, or (at your option) any later version.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 * Lesser General Public License for more details.
 *
 * You should have received a copy of the GNU Lesser General Public
 * License along with this program; if not, see <https://www.gnu.org/licenses>
 */
```

Lastly, this modifies the `head` URL to use `branch: "master"`, to resolve the related audit error.