### PR TITLE
ivtools 2.0.11

### DIFF
--- a/Formula/ivtools.rb
+++ b/Formula/ivtools.rb
@@ -1,0 +1,24 @@
+class Ivtools < Formula
+  desc "X11 vector graphic servers"
+  homepage "https://github.com/vectaport/ivtools"
+  url "https://github.com/vectaport/ivtools/archive/refs/tags/ivtools-2.0.11d.tar.gz"
+  sha256 "8c6fe536dff923f7819b4210a706f0abe721e13db8a844395048ded484fb2437"
+  license "MIT"
+
+  depends_on "ace"
+  depends_on "libx11"
+  depends_on "libxext"
+
+  def install
+    cp "Makefile.orig", "Makefile"
+    ace = Formula["ace"]
+    args = %W[--mandir=#{man} --with-ace=#{ace.opt_include} --with-ace-libs=#{ace.opt_lib}]
+    system "./configure", *std_configure_args, *args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/comterp", "exit(0)"
+  end
+end


### PR DESCRIPTION
ivtools (https://github.com/vectaport/ivtools) is a C++ open-source framework for X11 vector-graphic drawing editors that has been continuously published and supported since 1994 (http://github.com/vectaport/ivtools and http://www.ivtools.org).  It extends the original InterViews from Stanford University last published in 1993 (http://ivtools.sourceforge.net/ivtools/interviews.html), as well as the Unidraw framework created by John Vlissides, one of the authors of the seminal Design Patterns book (http://ivtools.sourceforge.net/ivtools/unidrawinfo.html).  

On top of InterViews and Unidraw, ivtools embeds the comterp scripting language (http://ivtools.sourceforge.net/ivtools/comterp.html) into a variety of drawing editors (http://ivtools.sourceforge.net/ivtools/editors.html).  It also adds networking capability via the ACE package, making these drawing editors into vector graphic servers.  The end result is a self-contained and straightforward environment for a variety of vector and raster graphic applications, useful as a toolkit for commercial and educational activities.

ivtools has been available as a Debian distribution since 1997.  It has also been available in the predecessors to Homebew like "Mac Ports", but finally the need for it to build with homebrew has become paramount.

This PR successfully builds ivtools and `brew test ivtools` and `brew audit --strict ivtools` both pass.  `brew audit --new ivtools` does not see the GitHub metrics it wants for a new package, but I would submit that this is not a "new" package, just a rather mature package that has been long maintained and slowly extended in recent years.  I would greatly appreciate this PR being merged into the homebrew-core repository.

Thanks for your consideration,

Scott Johnston
johnston@vectaport.com
scojohnston@equinix.com
https://github.com/vectaport

p.s. as you will also notice, this PR adds ivtools to audit_exceptions/flat_namespace_allowlist.json.  I hope this exception can be approved, because I desire not to experiment with the long-standing behavior of "make install" that has worked across many Unix'es for many years, and in practice there have been no library name collisions with other open source packages for the entire duration of the project.

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [  ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
