### PR TITLE
autobump: track more java formulae

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -14,21 +14,40 @@ env:
   HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
   FORMULAE: |
     ack
+    activemq
+    alda
+    allure
+    alluxio
+    ammonite-repl
     angular-cli
+    ant
     apache-archiva
+    apache-flink
+    apache-opennlp
     apidoc
+    apktool
     argo
     artifactory
+    asciidoctorj
     atuin
     autorest
     aws-cdk
     b3sum
+    ballerina
+    bazel
+    bazelisk
+    bbtools
     bcoin
+    bee
+    bnd
     bottom
     brew-php-switcher
     broot
+    buildifier
     buildkit
+    buildozer
     bundletool
+    byteman
     cadence
     calicoctl
     cargo-audit
@@ -39,22 +58,38 @@ env:
     cargo-llvm-lines
     cargo-outdated
     cargo-watch
+    carrot2
+    cassandra
+    cassandra-reaper
     cdk8s
+    cfr-decompiler
+    checkstyle
     chezmoi
     chromaprint
     circleci
     clair
     cliclick
+    clojurescript
+    closure-compiler
     cloudflare-wrangler
     composer
     consul
     consul-template
+    cromwell
+    crowdin
     crun
     cubejs-cli
+    cypher-shell
+    dafny
+    davmail
     deno
+    dependency-check
     detekt
     detox
     devspace
+    dex2jar
+    digdag
+    djl-serving
     dnscrypt-proxy
     docker
     docker-compose
@@ -63,67 +98,108 @@ env:
     docuum
     double-conversion
     dprint
+    druid
     dvc
     easyengine
+    elasticsearch@6
+    emscripten
     envconsul
     esbuild
     eslint
     etcd
     ethereum
     exploitdb
+    fabric-installer
+    fantom
     fennel
     firebase-cli
+    flank
     flarectl
     flux
+    flyway
     fuse-overlayfs
+    fuseki
     futhark
     gatsby-cli
     git-cliff
     git-delta
+    gitbucket
     gitleaks
+    glassfish
     gleam
     glooctl
     gofish
     golang-migrate
+    google-java-format
     goreleaser
     gosec
     gostatic
     gpg-tui
+    gradle
+    gradle-completion
+    gradle-profiler
+    grails
+    groovy
+    groovysdk
+    hapi-fhir-cli
     hcloud
     helm
     helmfile
     htmldoc
     hugo
+    igv
     imagemagick
     imagemagick@6
     imap-backup
+    ipopt
     ircd-hybrid
+    jadx
+    java-service-wrapper
+    jena
     jenkins
+    jenkins-lts
+    jetty
+    jetty-runner
     jfrog-cli
+    jhipster
+    jmeter
     jql
+    jruby
     jsonnet
     just
     k3d
     k9s
+    kafka
     keptn
     keydb
+    ki
+    kotlin
+    ktlint
     kubeaudit
     kubecfg
     kumactl
     kustomize
+    languagetool
     lazydocker
+    leiningen
     lexbor
     liboqs
+    librdkafka
+    liquibase
     localstack
     lout
     macchina
     marked
     marp-cli
+    maven
+    maxwell
     mdbook
     mdcat
     meson
     metabase
     micro
+    micronaut
+    mill
     minikube
     mmctl
     moto
@@ -132,8 +208,10 @@ env:
     nativefier
     navi
     ncc
+    neo4j
     neofetch
     netlify-cli
+    nexus
     nfpm
     nng
     node-sass
@@ -143,41 +221,74 @@ env:
     oauth2_proxy
     oci-cli
     octant
+    octave
     okteto
     opensearch
+    orc-tools
+    orientdb
     oxipng
+    payara
+    pdftk-java
     phoronix-test-suite
     php-code-sniffer
     php-cs-fixer
     phpmd
     phpstan
+    picard-tools
     pickle
+    plantuml
+    pmd
     pnpm
     pocsuite3
+    presto
     procs
     protoc-gen-go-grpc
     psalm
+    questdb
     rbw
+    riemann
     rollup
+    rubberband
     s2n
+    sbt
+    scala
     selene
+    selenium-server
     serverless
+    sjk
     skaffold
     skopeo
+    sleuthkit
     solana
+    solr
+    sonarqube
+    sonarqube-lts
     sponge
+    spotbugs
+    stanford-corenlp
     starship
     stdman
+    storm
     stress-ng
+    structurizr-cli
     svgo
     svtplay-dl
+    swagger-codegen
+    swagger-codegen@2
     syncthing
     teleport
     termshark
     terraform-ls
+    tika
     toast
+    tomcat
+    tomcat-native
+    tomcat@8
+    tomcat@9
     topgrade
     traefik
+    trino
+    typedb
     vale
     vault-cli
     vercel-cli
@@ -190,7 +301,10 @@ env:
     webpack
     webtorrent-cli
     whistle
+    wildfly-as
+    wiremock-standalone
     xcbeautify
+    xgboost
     xplr
     yaegi
     zellij

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -21,9 +21,13 @@ env:
     ammonite-repl
     angular-cli
     ant
+    ant@1.9
     apache-archiva
+    apache-drill
     apache-flink
+    apache-geode
     apache-opennlp
+    apache-spark
     apidoc
     apktool
     argo
@@ -34,6 +38,7 @@ env:
     aws-cdk
     b3sum
     ballerina
+    batik
     bazel
     bazelisk
     bbtools
@@ -75,6 +80,7 @@ env:
     composer
     consul
     consul-template
+    couchdb
     cromwell
     crowdin
     crun
@@ -84,6 +90,7 @@ env:
     davmail
     deno
     dependency-check
+    derby
     detekt
     detox
     devspace
@@ -115,8 +122,10 @@ env:
     firebase-cli
     flank
     flarectl
+    flume
     flux
     flyway
+    fop
     fuse-overlayfs
     fuseki
     futhark
@@ -141,10 +150,12 @@ env:
     grails
     groovy
     groovysdk
+    hadoop
     hapi-fhir-cli
     hcloud
     helm
     helmfile
+    hive
     htmldoc
     hugo
     igv
@@ -153,6 +164,7 @@ env:
     imap-backup
     ipopt
     ircd-hybrid
+    ivy
     jadx
     java-service-wrapper
     jena
@@ -166,6 +178,7 @@ env:
     jql
     jruby
     jsonnet
+    jsvc
     just
     k3d
     k9s
@@ -187,6 +200,7 @@ env:
     librdkafka
     liquibase
     localstack
+    log4cxx
     lout
     macchina
     marked
@@ -236,6 +250,7 @@ env:
     phpstan
     picard-tools
     pickle
+    pig
     plantuml
     pmd
     pnpm
@@ -244,6 +259,7 @@ env:
     procs
     protoc-gen-go-grpc
     psalm
+    qpid-proton
     questdb
     rbw
     riemann
@@ -261,6 +277,7 @@ env:
     sleuthkit
     solana
     solr
+    solr@7.7
     sonarqube
     sonarqube-lts
     sponge
@@ -271,6 +288,7 @@ env:
     storm
     stress-ng
     structurizr-cli
+    subversion
     svgo
     svtplay-dl
     swagger-codegen
@@ -279,14 +297,19 @@ env:
     teleport
     termshark
     terraform-ls
+    thrift
     tika
     toast
     tomcat
     tomcat-native
     tomcat@8
     tomcat@9
+    tomee-plume
+    tomee-plus
+    tomee-webprofile
     topgrade
     traefik
+    trafficserver
     trino
     typedb
     vale
@@ -303,11 +326,14 @@ env:
     whistle
     wildfly-as
     wiremock-standalone
+    xalan-c
     xcbeautify
+    xerces-c
     xgboost
     xplr
     yaegi
     zellij
+    zookeeper
 
 jobs:
   autobump:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

ref PRs: https://github.com/Homebrew/homebrew-core/pulls?page=21&q=is%3Apr+label%3Abump-formula-pr+label%3Ajava+is%3Aclosed