### PR TITLE
binutils: Build using glibc@2.13 on Linux

### DIFF
--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -5,6 +5,7 @@ class Binutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.38.tar.xz"
   sha256 "e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024"
   license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.0-or-later", "LGPL-3.0-only"]
+  revision 1
 
   bottle do
     sha256                               arm64_monterey: "688777b47a3ccd4bf77ba9fa46c0ed66dd0c8a662dbd9c0021e574df5c87a783"
@@ -19,32 +20,45 @@ class Binutils < Formula
 
   uses_from_macos "zlib"
 
+  on_linux do
+    depends_on "glibc@2.13" => :build
+  end
+
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--enable-deterministic-archives",
-                          "--prefix=#{prefix}",
-                          "--infodir=#{info}",
-                          "--mandir=#{man}",
-                          "--disable-werror",
-                          "--enable-interwork",
-                          "--enable-multilib",
-                          "--enable-64-bit-bfd",
-                          "--enable-gold",
-                          "--enable-plugins",
-                          "--enable-targets=all",
-                          "--with-system-zlib",
-                          "--disable-nls"
-    system "make"
-    system "make", "install"
-    bin.install_symlink "ld.gold" => "gold"
+    # Fix error: 'LONG_MIN' undeclared
+    ENV.append "CFLAGS", "-DHAVE_LIMITS_H -DHAVE_FCNTL_H" unless OS.mac?
+
+    args = [
+      "--disable-debug",
+      "--disable-dependency-tracking",
+      "--enable-deterministic-archives",
+      "--prefix=#{prefix}",
+      "--infodir=#{info}",
+      "--mandir=#{man}",
+      "--disable-werror",
+      "--enable-interwork",
+      "--enable-multilib",
+      "--enable-64-bit-bfd",
+      "--enable-plugins",
+      "--enable-targets=all",
+      "--with-system-zlib",
+      "--disable-nls",
+      "--disable-gold",
+    ]
+    system "./configure", *args
+    # Pass MAKEINFO=true to disable generation of HTML documentation.
+    # This avoids a build time dependency on texinfo.
+    make_args = OS.mac? ? [] : ["MAKEINFO=true"]
+    system "make", *make_args
+    system "make", "install", *make_args
+
     if OS.mac?
       Dir["#{bin}/*"].each do |f|
         bin.install_symlink f => "g" + File.basename(f)
       end
     else
       # Reduce the size of the bottle.
-      system "strip", *Dir[bin/"*", lib/"*.a"]
+      system "strip", *bin.children, *lib.glob("*.a")
     end
   end
 

--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -8,12 +8,12 @@ class Binutils < Formula
   revision 1
 
   bottle do
-    sha256                               arm64_monterey: "688777b47a3ccd4bf77ba9fa46c0ed66dd0c8a662dbd9c0021e574df5c87a783"
-    sha256                               arm64_big_sur:  "794eab8c0705e58f4578480ac49225a96bdb8d25ae9642a9e9161730f354e83a"
-    sha256                               monterey:       "6e8ef1eab4c0ca426453a36584a6791fe16619a3641646feb1932423c5e0e27d"
-    sha256                               big_sur:        "0bdf6d0186c29f175d4493118a4086f0c24056088359fe0c333123e1b9e03759"
-    sha256                               catalina:       "f32ac82487eff8fb84bd6d6780213f9c152dc2403e67d6adda50f9c91d5a889e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7c260a27d2cec70f223f75b8f56e158db62c2f5bc9f25f39d7332a02c2ff03ac"
+    sha256                               arm64_monterey: "a4e8c248c8ca839855bebec3e0a0414f6cbb2b6f25c4556af87691f0e5b5f19a"
+    sha256                               arm64_big_sur:  "5c7e1a88496e77d129216c995c1a42bfc806c01677e830ee578125fd632eb57b"
+    sha256                               monterey:       "8ae9223fa1f08d34e36d1d6444af57fc4264c97045d8095acb7ab7b5e6113bc2"
+    sha256                               big_sur:        "2a2bf7d856f86ea3b01eab9d267167f85b3c90457336e58908d7d53135dacfc1"
+    sha256                               catalina:       "840ebed8d7204e8392aff0f830baff3e6a749207d70cc7b44b2d29f4f1444eba"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9a90a33ab3678b5a325d8f5f16470f17a04700717ae936d7d71a81c37354d605"
   end
 
   keg_only :shadowed_by_macos, "Apple's CLT provides the same tools"

--- a/Formula/gold.rb
+++ b/Formula/gold.rb
@@ -6,6 +6,10 @@ class Gold < Formula
   sha256 "e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024"
   license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.0-or-later", "LGPL-3.0-only"]
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "f603d71e281e77548939b9742b9a309718b5c436a907b6aea687a63c8e855a9e"
+  end
+
   depends_on :linux
 
   uses_from_macos "zlib"

--- a/Formula/gold.rb
+++ b/Formula/gold.rb
@@ -1,0 +1,43 @@
+class Gold < Formula
+  desc "GNU gold linker"
+  homepage "https://www.gnu.org/software/binutils/binutils.html"
+  url "https://ftp.gnu.org/gnu/binutils/binutils-2.38.tar.xz"
+  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.38.tar.xz"
+  sha256 "e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024"
+  license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.0-or-later", "LGPL-3.0-only"]
+
+  depends_on :linux
+
+  uses_from_macos "zlib"
+
+  def install
+    args = [
+      "--disable-debug",
+      "--disable-dependency-tracking",
+      "--enable-deterministic-archives",
+      "--prefix=#{prefix}",
+      "--infodir=#{info}",
+      "--mandir=#{man}",
+      "--disable-werror",
+      "--enable-gold",
+      "--enable-interwork",
+      "--enable-multilib",
+      "--enable-plugins",
+      "--enable-targets=all",
+      "--with-system-zlib",
+      "--disable-nls",
+    ]
+
+    system "./configure", *args
+    # Pass MAKEINFO=true to disable generation of HTML documentation.
+    # This avoids a build time dependency on texinfo.
+    system "make", "all-gold", "MAKEINFO=true"
+    system "make", "install-gold", "MAKEINFO=true"
+    bin.install_symlink "ld.gold" => "gold"
+    system "strip", *bin.children, *lib.glob("*.a")
+  end
+
+  test do
+    assert_match "fatal error: no input files", shell_output("#{bin}/gold 2>&1", 1)
+  end
+end

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -4,6 +4,7 @@
   ["apache-pulsar", "libpulsar"],
   ["avro-c", "avro-cpp", "avro-tools"],
   ["aws-console", "cfn-format", "rain"],
+  ["binutils", "gold"],
   ["boost", "boost-bcp", "boost-mpi", "boost-python3"],
   ["bundler-completion", "gem-completion", "rails-completion", "ruby-completion"],
   ["buildifier", "buildozer"],


### PR DESCRIPTION
glibc@2.13 2.13 (new formula)
binutils: Build using glibc@2.13 on Linux

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Build the `binutils` bottle using brewed `glibc@2.13`
- Use an older version of Glibc so that the `binutils` bottle can be used to build brewed `glibc` from source, since the `glibc` bottle is not `cellar :any`
- Using a brewed `glibc@2.13` to build the `binutils` bottle allows us to drop the Debian 7 (Wheezy) Docker image `homebrew/debian7`
- Likely also need to build the `zlib` bottle using `glibc@2.13` (not yet done in this PR)