### PR TITLE
luarocks: add livecheck

### DIFF
--- a/Formula/luarocks.rb
+++ b/Formula/luarocks.rb
@@ -6,6 +6,11 @@ class Luarocks < Formula
   license "MIT"
   head "https://github.com/luarocks/luarocks.git", branch: "master"
 
+  livecheck do
+    url :homepage
+    regex(%r{/luarocks[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "3c1d3b809e453e3754e920e6b915ebe9ad2562e7de23bcea9dff62e253681882"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "3c1d3b809e453e3754e920e6b915ebe9ad2562e7de23bcea9dff62e253681882"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `luarocks` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which references the `stable` archive URL in the install instructions (albeit, as text rather than a link).

Alternatively, it's possible to check the ["Download" wiki page on GitHub](https://github.com/luarocks/luarocks/wiki/Download), which links to the `stable` archive. Since both pages reference the latest tarball, I simply opted to use the one that's on the same server as the `stable` archive (i.e., the `homepage`). If the homepage ends up being unreliable over time for identifying the latest version, we can always switch to the "Download" wiki page on GitHub in the future.