### PR TITLE
libhid: fix incorrect `-flat_namespace` usage on Big Sur

### DIFF
--- a/Formula/libhid.rb
+++ b/Formula/libhid.rb
@@ -23,6 +23,9 @@ class Libhid < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "fb334329832a5847225997b9b7bb0f54a0e26c69636f34cd3b1af77475eef922"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "libusb"
   depends_on "libusb-compat"
 
@@ -33,6 +36,7 @@ class Libhid < Formula
   end
 
   def install
+    system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-swig"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

None of our usual patches apply, but we can fix the use of the
`-flat_namespace` flag by regenerating `configure` with our Autotools
stack.

This is needed for bottling on Monterey.