### PR TITLE
mftrace: add livecheck, update license

### DIFF
--- a/Formula/mftrace.rb
+++ b/Formula/mftrace.rb
@@ -3,8 +3,13 @@ class Mftrace < Formula
   homepage "https://lilypond.org/mftrace/"
   url "https://lilypond.org/downloads/sources/mftrace/mftrace-1.2.20.tar.gz"
   sha256 "626b7a9945a768c086195ba392632a68d6af5ea24ef525dcd0a4a8b199ea5f6f"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   revision 1
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?mftrace[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "9c6697dda8331a25dfebad452baa00d2b896246dd2e793be153f4d3dffcd523b"
@@ -17,7 +22,7 @@ class Mftrace < Formula
   end
 
   head do
-    url "https://github.com/hanwen/mftrace.git"
+    url "https://github.com/hanwen/mftrace.git", branch: "master"
     depends_on "autoconf" => :build
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `mftrace` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This also updates the `license` from `GPL-2.0` to `GPL-2.0-only`, as the source files don't use the "or...later" language in license comments. For example, from `mftrace.py`:

```
# This program is free software; you can redistribute it and/or modify
# it under the terms of the GNU General Public License version 2
# as published by the Free Software Foundation
#
# This program is distributed in the hope that it will be useful,
# but WITHOUT ANY WARRANTY; without even the implied warranty of
# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
# GNU Library General Public License for more details.
#
# You should have received a copy of the GNU General Public License
# along with this program; if not, write to the Free Software
# Foundation, Inc., 
# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA 
```

Lastly, this updates the `head` URL to use `branch: "master"`, to resolve the related audit error.