### PR TITLE
yafc: add libbsd on linux

### DIFF
--- a/Formula/yafc.rb
+++ b/Formula/yafc.rb
@@ -19,6 +19,10 @@ class Yafc < Formula
   depends_on "libssh"
   depends_on "readline"
 
+  on_linux do
+    depends_on "libbsd"
+  end
+
   def install
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
YAFC or "Yet Another FTP Client" requires libbsd to install on
non-BSD-based operating systems.

See https://github.com/sebastinas/yafc/blob/master/INSTALL

This fixes issue #91530

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
