### PR TITLE
cyrus-sasl: build with krb5 for gs2

### DIFF
--- a/Formula/cyrus-sasl.rb
+++ b/Formula/cyrus-sasl.rb
@@ -4,6 +4,7 @@ class CyrusSasl < Formula
   url "https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.27/cyrus-sasl-2.1.27.tar.gz"
   sha256 "26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5"
   license "BSD-3-Clause-Attribution"
+  revision 1
 
   bottle do
     sha256 arm64_monterey: "be512b38bef60c94dfbdfc7724db969547641f0fe1e40440e2d035b22c790852"
@@ -17,6 +18,7 @@ class CyrusSasl < Formula
 
   keg_only :provided_by_macos
 
+  depends_on "krb5"
   depends_on "openssl@1.1"
 
   def install


### PR DESCRIPTION
This builds libgs2.so in cyrus-sasl/lib/sasl2
This is needed for percona-server

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
