### PR TITLE
gauche: update livecheck

### DIFF
--- a/Formula/gauche.rb
+++ b/Formula/gauche.rb
@@ -8,7 +8,7 @@ class Gauche < Formula
   livecheck do
     url :stable
     strategy :github_latest
-    regex(/href=.*?Gauche[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?Gauche[._-]v?(\d+(?:\.\d+)+(?:[._-]p\d+)?)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `regex` used in `gauche`'s `livecheck` block, to handle versions like `0.9.11-p1`, which is the current latest version. Spotted in #92136.

Note: This patch version seems to have fixed a defect in the Windows installer package, and doesn't affect us. I will bump the version in #92136 to replace the revision bump there, and avoid an additional one.