### PR TITLE
mosh: add livecheck

### DIFF
--- a/Formula/mosh.rb
+++ b/Formula/mosh.rb
@@ -35,6 +35,11 @@ class Mosh < Formula
     end
   end
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?mosh[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "e3a5496b74f6d67bc7076816a84ff0c9930eb8ceab3896f87aafeddda2f6929a"
     sha256 cellar: :any,                 arm64_big_sur:  "8e44cdac777141ab536453dd0ad8447e04667f5f430ef3aa488b265467e9e3da"
@@ -45,7 +50,7 @@ class Mosh < Formula
   end
 
   head do
-    url "https://github.com/mobile-shell/mosh.git"
+    url "https://github.com/mobile-shell/mosh.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `mosh` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This also adds `branch: "master"` to the `head` URL, to resolve the related audit error.