### PR TITLE
dosbox-staging: downgrade to 0.78.0

### DIFF
--- a/Formula/dosbox-staging.rb
+++ b/Formula/dosbox-staging.rb
@@ -1,17 +1,24 @@
 class DosboxStaging < Formula
   desc "Modernized DOSBox soft-fork"
   homepage "https://dosbox-staging.github.io/"
-  url "https://github.com/dosbox-staging/dosbox-staging/archive/v0.78.1.tar.gz"
-  sha256 "9ae322edce853459fff47037fa4f7e3f138325699bf3c33d5335c069282133db"
+  url "https://github.com/dosbox-staging/dosbox-staging/archive/v0.78.0.tar.gz"
+  sha256 "2e6dcfc45d7345b2d89287911718c93f30463f1d58a9bfdc3a353000520cbbf8"
   license "GPL-2.0-or-later"
   head "https://github.com/dosbox-staging/dosbox-staging.git", branch: "main"
 
+  # New releases of dosbox-staging are indicated by a GitHub release (and
+  # an announcement on the homepage), not just a new version tag.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
-    sha256 cellar: :any, arm64_monterey: "f634764b7cefa11e450bcfe29dcecbb82d8125cc2cec86d22a10128a1ff74b19"
-    sha256 cellar: :any, arm64_big_sur:  "6f4dc4d1961d8b03023989407c0f6e87a78e61717bc02dabeb5f5cc3c7c094a0"
-    sha256 cellar: :any, monterey:       "ef7a5a75fe9a3832876bfba92fb436bfc901955e569e1b6834fb220579c6f361"
-    sha256 cellar: :any, big_sur:        "d7f4608edc91ddc0e74dbff45251f6b8e8539fd4994dfa1326f2880c22b4f620"
-    sha256 cellar: :any, catalina:       "8c21190904606a6cc0c6cf0e937cc3ef748298bb4982eb096443d3d1a928ab06"
+    sha256 cellar: :any, arm64_monterey: "1582c58614778487dbd1db8865f4d48da778b8b705d86b4e1a5a0a9b138007ae"
+    sha256 cellar: :any, arm64_big_sur:  "ea91d5a56b9629996f80724521195de779fbcfc1866ec65a0a9bf4aecc0e5126"
+    sha256 cellar: :any, monterey:       "bf526bfb6ff092be2c906fc3639e951fc1c4a38256790e91680ba0f5c789b74a"
+    sha256 cellar: :any, big_sur:        "1bcf72092ca21df66b7f20fdcb21b78120e6e593ca6172012c87dc7e85df9395"
+    sha256 cellar: :any, catalina:       "f4d2f3d4b924d7835efef8edad01c04eb585f2b2a1538e1004909ac8591ee4da"
   end
 
   depends_on "meson" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`dosbox-staging` was updated to 0.78.1 (#92193) because upstream had published a `v0.78.1` tag (since removed). This used the stable tag format but there was no corresponding release on GitHub, no announcement on the homepage, etc.

Upstream confirmed this wasn't a release version and `v0.78.1-rc` would have been a more appropriate tag (dosbox-staging/dosbox-staging#1488). It's unclear when they will release a new version, so this PR downgrades the formula to the latest stable version, `0.78.0`. There aren't many installs (30 days: 90, 90 days: 183, 365 days: 537), so this shouldn't affect many users.

This PR also adds a `livecheck` block using the `GithubLatest` strategy, to align with the upstream release process (i.e., a version tag isn't a sufficient indicator of a new release).