### PR TITLE
winetricks: add livecheck

### DIFF
--- a/Formula/winetricks.rb
+++ b/Formula/winetricks.rb
@@ -6,6 +6,11 @@ class Winetricks < Formula
   license "LGPL-2.1-or-later"
   head "https://github.com/Winetricks/winetricks.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d{6,8})$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "322c2e6e1dd72073bfb03a230820eb039592c016103d0c442739e9f6c9f3470b"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew livecheck` is currently giving an unstable version, `20211230-test`, as latest for `winetricks` instead of `20210825`. This PR adds a `livecheck` block with a regex that will only match stable tags like `20210825` (no prefix other than an optional `v`, no suffix), not unstable tags like `20211230-test`.