### PR TITLE
flatbuffers: add livecheck

### DIFF
--- a/Formula/flatbuffers.rb
+++ b/Formula/flatbuffers.rb
@@ -6,6 +6,11 @@ class Flatbuffers < Formula
   license "Apache-2.0"
   head "https://github.com/google/flatbuffers.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "a127e4a829de86f314a3990b9d85bf14d854bb682e8f8e32272990095b2b654a"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "bd07b2efac10b35609da3ab52c9549d360c6db6b6193d5b916dc5eb98c27267b"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew livecheck` is currently reporting `2.0.5-last-supported-VS2010-12-13` as the latest version of `flatbuffers`, instead of `2.0.5`. Both the `v2.0.5-last-supported-VS2010-12-13` and `v2.0.5` tags reference the same commit, so it makes sense to only match the tags like `v1.2.3`.

This PR adds a `livecheck` block that uses the standard regex for tags like `1.2.3`/`v1.2.3`, which will omit the offending tag and return `2.0.5` as the latest version.

---

For what it's worth, `2.0.0` is the "latest" release on GitHub but it seems like `2.0.5` may be the latest version and upstream simply hasn't created a release for it (these situations are ambiguous and project-specific). Checking repology.org, there are other package managers using `2.0.5`, though some are still using `2.0.0`. [We're still using `2.0.0` in homebrew/core because a version bump PR for `2.0.5` had build failures and was eventually closed as stale.]

If it turns out that `2.0.0` is the correct latest version and we should be tracking the "latest" GitHub release instead, we can always update this later to use the `GithubLatest` strategy instead.