### PR TITLE
polipo: disable

### DIFF
--- a/Formula/polipo.rb
+++ b/Formula/polipo.rb
@@ -20,7 +20,8 @@ class Polipo < Formula
   end
 
   # https://github.com/jech/polipo/commit/4d42ca1b5849518762d110f34b6ce2e03d6df9ec
-  deprecate! date: "2016-11-06", because: :unsupported
+  # Original deprecation date: 2016-11-06
+  disable! date: "2022-01-03", because: :unsupported
 
   uses_from_macos "texinfo"
 


### PR DESCRIPTION
This formula was deprecated on 2020-07-05, and the repo is archived since 2016

==> Analytics
install: 86 (30 days), 307 (90 days), 1,391 (365 days)
install-on-request: 84 (30 days), 300 (90 days), 1,353 (365 days)
build-error: 0 (30 days)

Disabling gives the formula one more year before deletion.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
