### PR TITLE
keptn: add livecheck

### DIFF
--- a/Formula/keptn.rb
+++ b/Formula/keptn.rb
@@ -5,6 +5,11 @@ class Keptn < Formula
   sha256 "8420785707859d64d7cabd66bea46e8da7e0ebcd725e3cb311a408058e4cfcce"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "6ea417458a88b18417cdb12db9233338921cfe281bb4cf7e785547ff5a7b7e6f"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "9a462c977cfbce6f0f13aa6bc531ba7ed222109fa02eafff5b30d52b9f178175"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew livecheck` is currently reporting a pre-release version, `0.12.0-next.0`, as newest for `keptn` instead of `0.11.4`. This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which will only match stable versions.

Outside of unstable tags like `0.12.0-next.0`, `0.8.1-alpha`, `0.8.0-rc1`, `0.6.0.beta2`, etc., the only outlier is `0.8.2-hotfix1`. However, this was marked as "Pre-release" on GitHub, so it seems fine to omit those tags for this formula as well.