### PR TITLE
jdtls 1.7.0 (new formula)

### DIFF
--- a/Formula/jdtls.rb
+++ b/Formula/jdtls.rb
@@ -1,0 +1,52 @@
+class Jdtls < Formula
+  desc "Java language specific implementation of the Language Server Protocol"
+  homepage "https://github.com/eclipse/eclipse.jdt.ls"
+  url "https://download.eclipse.org/jdtls/milestones/1.7.0/jdt-language-server-1.7.0-202112161541.tar.gz"
+  sha256 "2f0c28dfec317a268ec44904420657181b43a7ba2a32f0bf788ea388dacb8552"
+  license "EPL-2.0"
+
+  depends_on "openjdk@11"
+
+  def install
+    etc.install "config_mac" => "jdtls"
+    libexec.install "features"
+    libexec.install "plugins"
+
+    bin.write_jar_script \
+      libexec/"plugins/org.eclipse.equinox.launcher_1.6.400.v20210924-0641.jar", \
+         "jdtls", \
+         "-Declipse.application=org.eclipse.jdt.ls.core.id1 \
+          -Dosgi.bundles.defaultStartLevel=4 \
+          -Dosgi.checkConfiguration=true \
+          -Dosgi.sharedConfiguration.area=#{etc}/jdtls \
+          -Dosgi.sharedConfiguration.area.readOnly=true \
+          -Dosgi.configuration.cascaded=true \
+          -Declipse.product=org.eclipse.jdt.ls.core.product", \
+         java_version: "11"
+  end
+
+  test do
+    require "open3"
+
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+
+    Open3.popen3("#{bin}/jdtls", "-configuration", "#{testpath}/config", "-data",
+        "#{testpath}/data") do |stdin, stdout, _e, w|
+      stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
+      sleep 3
+      stdin.close
+      assert_match(/^Content-Length: \d+/i, stdout.readline)
+      Process.kill("KILL", w.pid)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds Eclipse JDT Language Server (jdtls) as a formula.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
