### PR TITLE
doxygen: fix source checksum

### DIFF
--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -3,8 +3,9 @@ class Doxygen < Formula
   homepage "https://www.doxygen.org/"
   url "https://doxygen.nl/files/doxygen-1.9.3.src.tar.gz"
   mirror "https://downloads.sourceforge.net/project/doxygen/rel-1.9.3/doxygen-1.9.3.src.tar.gz"
-  sha256 "1a413e7122a0f9bb519697613ba05247afad1adc5699390b6e6ee387d42c0b2d"
+  sha256 "f352dbc3221af7012b7b00935f2dfdc9fb67a97d43287d2f6c81c50449d254e0"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/doxygen/doxygen.git", branch: "master"
 
   livecheck do


### PR DESCRIPTION
Upstream confirmed that they'd done a re-release to incorporate a missing one-line fix for https://github.com/doxygen/doxygen/issues/8355.  I've suggested cutting a new release in future, even for small changes.

Addresses https://github.com/Homebrew/discussions/discussions/2726.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
