### PR TITLE
workflows/tests: warn when label count query fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,6 +119,7 @@ jobs:
               } catch (error) {
                 // The GitHub API query errored, so fail open and assume 0 long PRs.
                 long_pr_count = 0
+                core.warning('CI-long-timeout label count query failed. Assuming no long PRs.')
               }
               const maximum_long_pr_count = 2
               if (long_pr_count > maximum_long_pr_count) {


### PR DESCRIPTION
I suspect this query is failing all the time these days, but can't
confirm because the query fails silently. Let's at least set a warning
when it fails so what we can check whether it did or didn't.
