### PR TITLE
p11-kit: fix tls issues and missing head branch

### DIFF
--- a/Formula/p11-kit.rb
+++ b/Formula/p11-kit.rb
@@ -4,7 +4,7 @@ class P11Kit < Formula
   url "https://github.com/p11-glue/p11-kit/releases/download/0.24.0/p11-kit-0.24.0.tar.xz"
   sha256 "81e6140584f635e4e956a1b93a32239acf3811ff5b2d3a5c6094e94e99d2c685"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
 
   bottle do
     sha256 arm64_monterey: "5709b9c664f0e70a5b8ab1ae42d55c91f1e32cad67e2d0098e5cb4ba9b2915b1"
@@ -17,7 +17,7 @@ class P11Kit < Formula
   end
 
   head do
-    url "https://github.com/p11-glue/p11-kit.git"
+    url "https://github.com/p11-glue/p11-kit.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -26,7 +26,9 @@ class P11Kit < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "ca-certificates"
   depends_on "libffi"
+  depends_on "libtasn1"
 
   def install
     # https://bugs.freedesktop.org/show_bug.cgi?id=91602#c1
@@ -39,11 +41,10 @@ class P11Kit < Formula
 
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
-                          "--disable-trust-module",
                           "--prefix=#{prefix}",
                           "--sysconfdir=#{etc}",
                           "--with-module-config=#{etc}/pkcs11/modules",
-                          "--without-libtasn1"
+                          "--with-trust-paths=#{etc}/ca-certificates/cert.pem"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
Some applications need the p11-kit to be able to validate tls connexions
through p11-kit using ca-certificates. In particualar, many flatpak
packages will take homebrew’s version of p11-kit and won’t be able to
connect to the internet without the trust-module. Closes [#12677](https://github.com/Homebrew/brew/issues/12677). Also see https://github.com/p11-glue/p11-kit/issues/404 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
