### PR TITLE
cwb3 3.4.33 (new formula)

### DIFF
--- a/Formula/cwb3.rb
+++ b/Formula/cwb3.rb
@@ -23,13 +23,17 @@ class Cwb3 < Formula
   uses_from_macos "ncurses"
 
   def install
-    system("make", "all",
-      "PLATFORM=homebrew-formula", "SITE=homebrew-formula", "FULL_MESSAGES=1",
-      "PREFIX=#{prefix}", "HOMEBREW_ROOT=#{HOMEBREW_PREFIX}")
+    args = %W[
+      PLATFORM=homebrew-formula
+      SITE=homebrew-formula
+      FULL_MESSAGES=1
+      PREFIX=#{prefix}
+      HOMEBREW_ROOT=#{HOMEBREW_PREFIX}
+    ]
+
+    system "make", "all", *args
     ENV.deparallelize
-    system("make", "install",
-      "PLATFORM=homebrew-formula", "SITE=homebrew-formula", "FULL_MESSAGES=1",
-      "PREFIX=#{prefix}", "HOMEBREW_ROOT=#{HOMEBREW_PREFIX}")
+    system "make", "install", *args
   end
 
   def post_install

--- a/Formula/cwb3.rb
+++ b/Formula/cwb3.rb
@@ -2,7 +2,7 @@ class Cwb3 < Formula
   desc "Tools for managing and querying large text corpora with linguistic annotations"
   homepage "https://cwb.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/cwb/cwb/cwb-3.5-RC/cwb-3.4.33-src.tar.gz"
-  sha256 "947d5f6d710fd8f818c2dc027e991b898308d581cb9b89c4ce6db054fbb20948"
+  sha256 "856b72785522d42f13f4a0528d2b80c2bf422c10411234a8e4b61df111af77dd"
   license "GPL-2.0-or-later"
   head "svn://svn.code.sf.net/p/cwb/code/cwb/trunk"
 
@@ -15,6 +15,11 @@ class Cwb3 < Formula
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
   uses_from_macos "ncurses"
+
+  resource("tutorial_data") do
+    url "https://cwb.sourceforge.io/files/encoding_tutorial_data.zip"
+    sha256 "bbd37514fdbdfd25133808afec6a11037fb28253e63446a9e548fb437cbdc6f0"
+  end
 
   def install
     args = %W[
@@ -38,16 +43,11 @@ class Cwb3 < Formula
   def caveats
     default_registry = HOMEBREW_PREFIX/"share/cwb/registry"
     <<~STOP
-      CWB registry directory: #{default_registry}
+      CWB default registry directory: #{default_registry}
     STOP
   end
 
   test do
-    resource("tutorial_data") do
-      url "https://cwb.sourceforge.io/files/encoding_tutorial_data.zip"
-      sha256 "bbd37514fdbdfd25133808afec6a11037fb28253e63446a9e548fb437cbdc6f0"
-    end
-
     resource("tutorial_data").stage do
       Pathname("registry").mkdir
       Pathname("data").mkdir

--- a/Formula/cwb3.rb
+++ b/Formula/cwb3.rb
@@ -1,16 +1,10 @@
 class Cwb3 < Formula
   desc "Tools for managing and querying large text corpora with linguistic annotations"
   homepage "https://cwb.sourceforge.io/"
+  url "https://downloads.sourceforge.net/project/cwb/cwb/cwb-3.5-RC/cwb-3.4.33-src.tar.gz"
+  sha256 "947d5f6d710fd8f818c2dc027e991b898308d581cb9b89c4ce6db054fbb20948"
   license "GPL-2.0-or-later"
-
-  stable do
-    url "https://downloads.sourceforge.net/project/cwb/cwb/cwb-3.5-RC/cwb-3.4.33-src.tar.gz"
-    sha256 "947d5f6d710fd8f818c2dc027e991b898308d581cb9b89c4ce6db054fbb20948"
-  end
-
-  head do
-    url "svn://svn.code.sf.net/p/cwb/code/cwb/trunk"
-  end
+  head "svn://svn.code.sf.net/p/cwb/code/cwb/trunk"
 
   depends_on "pkg-config" => :build
   depends_on "gettext"

--- a/Formula/cwb3.rb
+++ b/Formula/cwb3.rb
@@ -1,0 +1,102 @@
+class Cwb3 < Formula
+  desc "Tools for managing and querying large text corpora with linguistic annotations"
+  homepage "https://cwb.sourceforge.io/"
+  license "GPL-2.0-or-later"
+
+  stable do
+    url "https://downloads.sourceforge.net/project/cwb/cwb/cwb-3.5-RC/cwb-3.4.33-src.tar.gz"
+    sha256 "947d5f6d710fd8f818c2dc027e991b898308d581cb9b89c4ce6db054fbb20948"
+  end
+
+  head do
+    url "svn://svn.code.sf.net/p/cwb/code/cwb/trunk"
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "pcre"
+  depends_on "readline"
+
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "ncurses"
+
+  def install
+    system("make", "all",
+      "PLATFORM=homebrew-formula", "SITE=homebrew-formula", "FULL_MESSAGES=1",
+      "PREFIX=#{prefix}", "HOMEBREW_ROOT=#{HOMEBREW_PREFIX}")
+    ENV.deparallelize
+    system("make", "install",
+      "PLATFORM=homebrew-formula", "SITE=homebrew-formula", "FULL_MESSAGES=1",
+      "PREFIX=#{prefix}", "HOMEBREW_ROOT=#{HOMEBREW_PREFIX}")
+  end
+
+  def post_install
+    default_registry = HOMEBREW_PREFIX/"share/cwb/registry"
+    default_registry.mkpath # make sure default registry exists
+  end
+
+  def caveats
+    default_registry = HOMEBREW_PREFIX/"share/cwb/registry"
+    <<~STOP
+      CWB default registry directory for this build: #{default_registry}
+    STOP
+  end
+
+  test do
+    resource("tutorial_data") do
+      url "https://cwb.sourceforge.io/files/encoding_tutorial_data.zip"
+      sha256 "bbd37514fdbdfd25133808afec6a11037fb28253e63446a9e548fb437cbdc6f0"
+    end
+
+    resource("tutorial_data").stage do
+      Pathname("registry").mkdir
+      Pathname("data").mkdir
+
+      system(bin/"cwb-encode", "-c", "ascii",
+        "-d", "data", "-R", "registry/ex", "-f", "example.vrt",
+        "-P", "pos", "-P", "lemma", "-S", "s:0")
+      assert_predicate(Pathname("registry")/"ex", :exist?,
+        "registry file has been created")
+      assert_predicate(Pathname("data")/"lemma.lexicon", :exist?,
+        "lexicon file for p-attribute lemma has been created")
+
+      system(bin/"cwb-makeall", "-r", "registry", "EX")
+      assert_predicate(Pathname("data")/"lemma.corpus.rev", :exist?,
+        "reverse index file for p-attribute lemma has been created")
+
+      assert_equal("Tokens:\t5\nTypes:\t5\n",
+        shell_output("#{bin}/cwb-lexdecode -r registry -S EX"),
+        "correct token & type count for p-attribute")
+      assert_equal("0\t4\n",
+        shell_output("#{bin}/cwb-s-decode -r registry EX -S s"),
+        "correct span for s-attribute")
+
+      assert_equal("3\n",
+        shell_output("#{bin}/cqpcl -r registry -D EX 'A=[pos = \"\\w{2}\"]; size A;'"),
+        "CQP query works correctly")
+
+      Pathname("test.c").write <<~STOP
+        #include <stdlib.h>
+        #include <cwb/cl.h>
+
+        int main(int argc, char *argv[]) {
+          int *id, n_id, n_token;
+          Corpus *C = cl_new_corpus("registry", "ex");
+          Attribute *word = cl_new_attribute(C, "word", ATT_POS);
+          id = cl_regex2id(word, "\\\\p{Ll}+", 0, &n_id);
+          if (n_id > 0)
+            n_token = cl_idlist2freq(word, id, n_id);
+          else
+            n_token = 0;
+          printf("%d\\n", n_token);
+          return 0;
+        }
+      STOP
+      system("#{ENV.cc} -o test `#{bin}/cwb-config -I` test.c `#{bin}/cwb-config -L`")
+      assert_equal("3\n", shell_output("./test"),
+        "compiled test program works")
+    end
+  end
+end

--- a/Formula/cwb3.rb
+++ b/Formula/cwb3.rb
@@ -38,7 +38,7 @@ class Cwb3 < Formula
   def caveats
     default_registry = HOMEBREW_PREFIX/"share/cwb/registry"
     <<~STOP
-      CWB default registry directory for this build: #{default_registry}
+      CWB registry directory: #{default_registry}
     STOP
   end
 

--- a/Formula/cwb3.rb
+++ b/Formula/cwb3.rb
@@ -31,8 +31,8 @@ class Cwb3 < Formula
   end
 
   def post_install
-    default_registry = HOMEBREW_PREFIX/"share/cwb/registry"
-    default_registry.mkpath # make sure default registry exists
+    # make sure default registry exists
+    (HOMEBREW_PREFIX/"share/cwb/registry").mkpath
   end
 
   def caveats

--- a/Formula/cwb3.rb
+++ b/Formula/cwb3.rb
@@ -92,7 +92,9 @@ class Cwb3 < Formula
           return 0;
         }
       STOP
-      system("#{ENV.cc} -o test `#{bin}/cwb-config -I` test.c `#{bin}/cwb-config -L`")
+      cppflags = Utils.safe_popen_read("#{bin}/cwb-config", "-I").strip.split
+      ldflags = Utils.safe_popen_read("#{bin}/cwb-config", "-L").strip.split
+      system ENV.cc, "-o", "test", *cppflags, "test.c", *ldflags
       assert_equal("3\n", shell_output("./test"),
         "compiled test program works")
     end

--- a/Formula/cwb3.rb
+++ b/Formula/cwb3.rb
@@ -35,13 +35,16 @@ class Cwb3 < Formula
     system "make", "install", *args
   end
 
+  def default_registry
+    HOMEBREW_PREFIX/"share/cwb/registry"
+  end
+
   def post_install
     # make sure default registry exists
-    (HOMEBREW_PREFIX/"share/cwb/registry").mkpath
+    default_registry.mkpath
   end
 
   def caveats
-    default_registry = HOMEBREW_PREFIX/"share/cwb/registry"
     <<~STOP
       CWB default registry directory: #{default_registry}
     STOP


### PR DESCRIPTION
IMS Open Corpus Workbench (CWB) is a set of tools for indexing and querying large text corpora with linguistic annotations, which is widely used in corpus linguistics, computational lexicography and related fields, e.g. via various CQPweb servers across the world. 

This new HomeBrew formula provides the preferred way of installing CWB on MacOS.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
