### PR TITLE
apktool: Allow newer and relocatable Java versions

### DIFF
--- a/Formula/apktool.rb
+++ b/Formula/apktool.rb
@@ -4,6 +4,7 @@ class Apktool < Formula
   url "https://github.com/iBotPeaches/Apktool/releases/download/v2.6.0/apktool_2.6.0.jar"
   sha256 "f750a3cd2c1f942f27f5f7fd5d17eada3bdaff0a6643f49db847e842579fdda5"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     rebuild 1

--- a/Formula/apktool.rb
+++ b/Formula/apktool.rb
@@ -10,7 +10,7 @@ class Apktool < Formula
     sha256 cellar: :any_skip_relocation, all: "2b7f71c67cdaf038871d235a22fdf80f3ee5ffb353424bcb5f0d17503560bb11"
   end
 
-  depends_on "openjdk@8"
+  depends_on "openjdk"
 
   resource "sample.apk" do
     url "https://github.com/downloads/stephanenicolas/RoboDemo/robodemo-sample-1.0.1.apk"
@@ -19,9 +19,7 @@ class Apktool < Formula
 
   def install
     libexec.install "apktool_#{version}.jar"
-    (libexec/"bin").write_jar_script libexec/"apktool_#{version}.jar", "apktool"
-    (libexec/"bin/apktool").chmod 0755
-    (bin/"apktool").write_env_script libexec/"bin/apktool", Language::Java.java_home_env("1.8")
+    bin.write_jar_script libexec/"apktool_#{version}.jar", "apktool"
   end
 
   test do


### PR DESCRIPTION
Removed the ancient dependency on Java 8.

Removed a redundant level of indirection; using just the `write_jar_script` function lets us use either the dependent JDK, or another set via `$JAVA_HOME`.

---
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
$ brew uninstall --force apktool

$ brew install --build-from-source apktool
…
==> Installing dependencies for apktool: openjdk
==> Installing apktool dependency: openjdk
==> Pouring openjdk--17.0.1_1.arm64_monterey.bottle.tar.gz
🍺  /opt/homebrew/Cellar/openjdk/17.0.1_1: 640 files, 306.2MB
==> Installing apktool
🍺  /opt/homebrew/Cellar/apktool/2.6.0: 4 files, 19MB, built in 1 second

$ brew test apktool
==> Testing apktool
==> /opt/homebrew/Cellar/apktool/2.6.0/bin/apktool d robodemo-sample-1.0.1.apk
==> /opt/homebrew/Cellar/apktool/2.6.0/bin/apktool b robodemo-sample-1.0.1

$ brew audit --strict apktool

$ brew style apktool

1 file inspected, no offenses detected

$ which apktool
/opt/homebrew/bin/apktool

$ apktool | head -n2
Apktool v2.6.0 - a tool for reengineering Android apk files
with smali v2.5.2 and baksmali v2.5.2
```