### PR TITLE
gnupg: fix linkage with `libusb` on ARM and Linux

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -37,6 +37,9 @@ class Gnupg < Formula
   end
 
   def install
+    libusb = Formula["libusb"]
+    ENV.append "CPPFLAGS", "-I#{libusb.opt_include}/libusb-#{libusb.version.major_minor}"
+
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`gnupg` does not link to `libusb` on ARM and Linux because the
`configure` script is not able to find the `libusb.h` header after
checking only `/usr` and `/usr/local`.

Let's fix that by adding the correct include path to `CPPFLAGS`.

I've omitted the revision bump for now since there have been no
complaints about it so far. (Removing the dependency will get
complaints, though.)