### PR TITLE
nebula: build with support for -service flag

### DIFF
--- a/Formula/nebula.rb
+++ b/Formula/nebula.rb
@@ -4,6 +4,7 @@ class Nebula < Formula
   url "https://github.com/slackhq/nebula/archive/v1.5.2.tar.gz"
   sha256 "391ac38161561690a65c0fa5ad65a2efb2d187323cc8ee84caa95fa24cb6c36a"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "ba9506da111fa6b894cb7644a881937ee33f5916db6c4318a2042b3ec8fa6bb9"
@@ -18,7 +19,7 @@ class Nebula < Formula
 
   def install
     ENV["BUILD_NUMBER"] = version
-    system "make", "bin"
+    system "make", "service"
     bin.install "./nebula"
     bin.install "./nebula-cert"
     prefix.install_metafiles


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Addresses https://github.com/Homebrew/discussions/discussions/2731. Based on [upstream CI configuration](https://github.com/slackhq/nebula/blob/master/.github/workflows/release.yml#L87-L88), looks like the `make service` command (instead of `make bin`) enables the missing flag (the `nebula-cert` program gets built either way - looks like the `service` target just sets a flag and then delegates to run any other targets listed; `bin` is presumably the default target).