### PR TITLE
crystal: compile with interpreter

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -82,6 +82,7 @@ class Crystal < Formula
     # Build crystal
     crystal_build_opts = []
     crystal_build_opts << "release=true"
+    crystal_build_opts << "interpreter=1"
     crystal_build_opts << "FLAGS=--no-debug"
     crystal_build_opts << "CRYSTAL_CONFIG_LIBRARY_PATH="
     crystal_build_opts << "CRYSTAL_CONFIG_BUILD_COMMIT=#{Utils.git_short_head}" if build.head?


### PR DESCRIPTION
Crystal 1.3 added an experimental interpreter. But it requires the `interpreter=1` build option: https://crystal-lang.org/2022/01/06/1.3.0-released.html#interpreter

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
