### PR TITLE
sonarqube-lts 8.9.6

### DIFF
--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -1,8 +1,8 @@
 class SonarqubeLts < Formula
   desc "Manage code quality"
   homepage "https://www.sonarqube.org/"
-  url "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.9.6.zip"
-  sha256 "9991d4df42c10c181005df6a4aff6b342baf9be2f3ad0e83e52a502f44d2e2d8"
+  url "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-8.9.6.50800.zip"
+  sha256 "b2911b7420e656fbb94880af76ff9cd26ec2f13d26923a6cb4174a2ea9457d3d"
   license "LGPL-3.0-or-later"
 
   # Upstream doesn't distinguish LTS releases in the URL or filename, so this

--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -44,7 +44,8 @@ class SonarqubeLts < Formula
   end
 
   service do
-    run [opt_bin/"sonar", "start"]
+    run [opt_bin/"sonar", "console"]
+    keep_alive true
   end
 
   test do

--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -49,6 +49,6 @@ class SonarqubeLts < Formula
   end
 
   test do
-    assert_match "SonarQube", shell_output("#{bin}/sonar status", 1)
+    assert_match "SonarQube", shell_output("#{bin}/sonar status")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Sonarqube 8.9.6 is now the current LTS.
- The exit status of `sonar status` is now 0.
- The service is now run with `service console` instead of `service start` as for the sonarqube formula.
- `brew audit --strict sonarqube-lts` has the following error (the same as for the current version of sonarqube-lts):
````
sonarqube-lts:
  * Binaries built for a non-native architecture were installed into sonarqube-lts's prefix.
    The offending files are:
      /opt/homebrew/Cellar/sonarqube-lts/8.9.6.50800/libexec/bin/macosx-universal-64/lib/libwrapper.jnilib	(x86_64)
      /opt/homebrew/Cellar/sonarqube-lts/8.9.6.50800/libexec/bin/macosx-universal-64/wrapper	(x86_64)
Error: 1 problem in 1 formula detected
`````
This could be solved by using the Homebrew built java-service-wrapper but for unknown reasons the same replacement as in the sonarqube formula cannot be used. This will be solved in a future PR or when the current sonarqube major version will become LTS.
- `brew services start` and `brew services stop` work as intended.