### PR TITLE
soapysdr: remove flat_namespace and fix gnuradio

### DIFF
--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -6,7 +6,7 @@ class Gnuradio < Formula
   url "https://github.com/gnuradio/gnuradio/archive/refs/tags/v3.9.3.0.tar.gz"
   sha256 "4073ac72524f95fed4bda7dd553cb946f66d2e00bd07c4ae7758f1b787d507e0"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/gnuradio/gnuradio.git", branch: "master"
 
   livecheck do

--- a/Formula/soapyrtlsdr.rb
+++ b/Formula/soapyrtlsdr.rb
@@ -4,6 +4,7 @@ class Soapyrtlsdr < Formula
   url "https://github.com/pothosware/SoapyRTLSDR/archive/soapy-rtl-sdr-0.3.2.tar.gz"
   sha256 "d0335684179d5b0357213cc786a78d7b6dc5728de7af9dcbf6364b17e62cef02"
   license "MIT"
+  revision 1
   head "https://github.com/pothosware/SoapyRTLSDR.git", branch: "master"
 
   bottle do

--- a/Formula/soapysdr.rb
+++ b/Formula/soapysdr.rb
@@ -4,6 +4,7 @@ class Soapysdr < Formula
   url "https://github.com/pothosware/SoapySDR/archive/soapy-sdr-0.8.1.tar.gz"
   sha256 "a508083875ed75d1090c24f88abef9895ad65f0f1b54e96d74094478f0c400e6"
   license "BSL-1.0"
+  revision 1
   head "https://github.com/pothosware/SoapySDR.git", branch: "master"
 
   bottle do
@@ -19,6 +20,9 @@ class Soapysdr < Formula
   depends_on "cmake" => :build
   depends_on "swig" => :build
   depends_on "python@3.9"
+
+  # Remove -flat_namespace flag
+  patch :DATA
 
   def install
     args = std_cmake_args + %W[
@@ -39,3 +43,19 @@ class Soapysdr < Formula
     assert_match "Loading modules... done", shell_output("#{bin}/SoapySDRUtil --check=null")
   end
 end
+
+__END__
+--- a/lib/CMakeLists.txt	2022-01-07 23:53:21.000000000 +0100
++++ b/lib/CMakeLists.txt	2022-01-07 23:53:25.000000000 +0100
+@@ -99,11 +99,6 @@
+     target_compile_definitions(SoapySDR PUBLIC -DNOMINMAX) #enables std::min and std::max
+ endif ()
+
+-if(APPLE)
+-    #fixes issue with duplicate module registry when using application bundle
+-    target_link_libraries(SoapySDR PUBLIC "-flat_namespace")
+-endif()
+-
+ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+     target_compile_options(SoapySDR PUBLIC -stdlib=libc++)
+ endif()


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
