### PR TITLE
ncdc: add livecheck

### DIFF
--- a/Formula/ncdc.rb
+++ b/Formula/ncdc.rb
@@ -5,6 +5,11 @@ class Ncdc < Formula
   sha256 "d15fd378aa345f423e59a38691c668f69b516cd4b8afbbcdc446007740c3afad"
   license "MIT"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?ncdc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "3851c0505db606f727353c388b30563b23001ea02e9190216495f7e6df1ce03d"
     sha256 cellar: :any,                 arm64_big_sur:  "7dfeff7bcbd463dd11bcc08b52114a445cacfae8ca7f0f6c8fae65c9e4b19d4a"
@@ -18,7 +23,7 @@ class Ncdc < Formula
   end
 
   head do
-    url "https://g.blicky.net/ncdc.git"
+    url "https://g.blicky.net/ncdc.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ncdc` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.

This also adds `branch: "master"` to the `head` URL, to resolve the related audit error.