### PR TITLE
ncdu: add livecheck

### DIFF
--- a/Formula/ncdu.rb
+++ b/Formula/ncdu.rb
@@ -6,6 +6,11 @@ class Ncdu < Formula
   license "MIT"
   head "https://g.blicky.net/ncdu.git", branch: "zig"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?ncdu[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "c64a0d0632324546644eeea92b3602c575f03d78deb2683322ee717a3c26d7dc"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f3701146877931592e1ee5da09419d9b8c1468690c8299e24e00aa1eb6ef11b1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ncdu` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.