### PR TITLE
p11-kit: run `make check`

### DIFF
--- a/Formula/p11-kit.rb
+++ b/Formula/p11-kit.rb
@@ -45,6 +45,8 @@ class P11Kit < Formula
                           "--with-module-config=#{etc}/pkcs11/modules",
                           "--with-trust-paths=#{etc}/ca-certificates/cert.pem"
     system "make"
+    # This formula is used with crypto libraries, so let's run the test suite.
+    system "make", "check"
     system "make", "install"
   end
 

--- a/style_exceptions/make_check_allowlist.json
+++ b/style_exceptions/make_check_allowlist.json
@@ -15,6 +15,7 @@
   "open-mpi",
   "openssl@1.1",
   "openssl@3",
+  "p11-kit",
   "pcre",
   "protobuf",
   "wolfssl",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula is used to interact with various crypto libraries (see the
homepage), so we really should be running `make check` during the build
here.