### PR TITLE
erofs-utils 1.4 (new formula)

### DIFF
--- a/Formula/erofs-utils.rb
+++ b/Formula/erofs-utils.rb
@@ -1,0 +1,53 @@
+class ErofsUtils < Formula
+  desc "Utilities for Enhanced Read-Only File System"
+  homepage "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git"
+  url "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/snapshot/erofs-utils-1.4.tar.gz"
+  sha256 "67702b1fc5da05719d95ddb7c107e334b04365f5161a9717479d2831fca85a98"
+  license "GPL-2.0-or-later"
+  head "git://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git", branch: "master"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "lz4"
+  depends_on "util-linux" # for libuuid
+
+  on_linux do
+    depends_on "libfuse@2"
+  end
+
+  def install
+    system "./autogen.sh"
+    args = std_configure_args + %w[
+      --disable-silent-rules
+      --enable-lz4
+      --disable-lzma
+      --without-selinux
+    ]
+
+    # Enable erofsfuse only on Linux for now
+    args << if OS.linux?
+      "--enable-fuse"
+    else
+      "--disable-fuse"
+    end
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"in/test1").write "G'day!"
+    (testpath/"in/test2").write "Bonjour!"
+    (testpath/"in/test3").write "Moien!"
+
+    # Test mkfs.erofs can make a valid erofsimg.
+    #   (Also tests that `lz4` support is properly linked.)
+    system "#{bin}/mkfs.erofs", "--quiet", "-zlz4", "test.lz4.erofs", "in"
+    assert_predicate testpath/"test.lz4.erofs", :exist?
+
+    # Unfortunately, fsck.erofs doesn't support extraction for now, and
+    # erofsfuse doesn't officially work on MacOS
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
erofs-utils is the userspace utilities for EROFS file system.

EROFS (Enhanced Read-Only File System) is a lightweight read-only file system with modern designs (e.g. no buffer heads, inline xattrs/data, chunk-based deduplication, multiple devices, etc.) for scenarios which need high-performance read-only solutions, e.g. smartphones with Android OS, LiveCDs and high-density hosts with numerous containers.

It also provides fixed-sized output compression support in order to improve storage density as well as keep relatively higher compression ratios and implements in-place decompression to reuse the file page for compressed data temporarily with proper strategies, which is quite useful to ensure guaranteed end-to-end runtime decompression performance under extremely memory pressure without extra cost.