### PR TITLE
scrcpy: fix build on Linux

### DIFF
--- a/Formula/scrcpy.rb
+++ b/Formula/scrcpy.rb
@@ -19,6 +19,13 @@ class Scrcpy < Formula
   depends_on "ffmpeg"
   depends_on "sdl2"
 
+  on_linux do
+    depends_on "gcc" => :build
+    depends_on "libusb"
+  end
+
+  fails_with gcc: "5"
+
   resource "prebuilt-server" do
     url "https://github.com/Genymobile/scrcpy/releases/download/v1.21/scrcpy-server-v1.21"
     sha256 "dbcccab523ee26796e55ea33652649e4b7af498edae9aa75e4d4d7869c0ab848"
@@ -76,7 +83,7 @@ class Scrcpy < Formula
 
     # It's expected to fail after adb reverse step because fakeadb exits
     # with code 42
-    out = shell_output("#{bin}/scrcpy -p 1337 2>&1", 1)
+    out = shell_output("#{bin}/scrcpy --no-display --record=file.mp4 -p 1337 2>&1", 1)
     assert_match(/ 42/, out)
 
     log_content = File.read(testpath/"fakeadb.log")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I've left `gcc` as only a build-time dependency for now, as it appears there is no linkage:
```
$ brew linkage scrcpy
System libraries:
  /lib/x86_64-linux-gnu/libc.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/lib/libavcodec.so.58 (ffmpeg)
  /home/linuxbrew/.linuxbrew/lib/libavdevice.so.58 (ffmpeg)
  /home/linuxbrew/.linuxbrew/lib/libavformat.so.58 (ffmpeg)
  /home/linuxbrew/.linuxbrew/lib/libavutil.so.56 (ffmpeg)
  /home/linuxbrew/.linuxbrew/lib/libusb-1.0.so.0 (libusb)
  /home/linuxbrew/.linuxbrew/lib/libSDL2-2.0.so.0 (sdl2)
```