### PR TITLE
ncmpcpp: add livecheck

### DIFF
--- a/Formula/ncmpcpp.rb
+++ b/Formula/ncmpcpp.rb
@@ -6,6 +6,11 @@ class Ncmpcpp < Formula
   license "GPL-2.0-or-later"
   revision 3
 
+  livecheck do
+    url "https://rybczak.net/ncmpcpp/installation/"
+    regex(/href=.*?ncmpcpp[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "94960d768fe4de3022c3d9f5a58086bc2cdf3212eb3c3735f1c62989f2337ddc"
     sha256 cellar: :any,                 arm64_big_sur:  "589a36dfb83da7b7093605e58cdf6a9ae6f58e8bc915fc84a937742b17aafad6"
@@ -17,7 +22,7 @@ class Ncmpcpp < Formula
   end
 
   head do
-    url "https://github.com/ncmpcpp/ncmpcpp.git"
+    url "https://github.com/ncmpcpp/ncmpcpp.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ncmpcpp` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the first-party installation page, which links to the `stable` archive.

Additionally, this adds `branch: "master"` to the `head` URL to resolve the related audit error.