### PR TITLE
dieharder: deprecate

### DIFF
--- a/Formula/dieharder.rb
+++ b/Formula/dieharder.rb
@@ -21,6 +21,13 @@ class Dieharder < Formula
     sha256 cellar: :any, sierra:         "8a40fb61aef5230ad77b3b851a6e8b6d575ff2adaa747c3b73a75cd203197945"
   end
 
+  # At the time of writing (2022-01-17), the webhome.phy.duke.edu server has
+  # an incomplete SSL certificate chain, which causes an error on Linux
+  # and with brewed curl on macOS (`curl: (60) SSL certificate problem: unable
+  # to get local issuer certificate`). We may be able to revert this deprecation
+  # if this issue is fixed on the upstream server in the future.
+  deprecate! date: "2022-01-17", because: "uses an upstream server with an incomplete SSL certificate chain"
+
   depends_on "gsl"
 
   on_linux do


### PR DESCRIPTION
Fixes:
curl: (60) server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
