### PR TITLE
orgalorg: fix checksum

### DIFF
--- a/Formula/orgalorg.rb
+++ b/Formula/orgalorg.rb
@@ -3,7 +3,7 @@ class Orgalorg < Formula
   homepage "https://github.com/reconquest/orgalorg"
   url "https://github.com/reconquest/orgalorg.git",
       tag:      "1.2.0",
-      revision: "6608ee908273ac16fa881d37ef7b55051a31073d"
+      revision: "5024122fb3efaad577fa509e2d17aab1f12217de"
   license "MIT"
   head "https://github.com/reconquest/orgalorg.git", branch: "master"
 


### PR DESCRIPTION
Looks like the only change was a version bump to fix CI on their side:
https://github.com/reconquest/orgalorg/commit/5024122fb3efaad577fa509e2d17aab1f12217de

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
