### PR TITLE
beansdb: disable

### DIFF
--- a/Formula/beansdb.rb
+++ b/Formula/beansdb.rb
@@ -19,7 +19,8 @@ class Beansdb < Formula
 
   # Deprecated upstream in favor of `gobeansdb`:
   # https://github.com/douban/gobeansdb
-  deprecate! date: "2018-06-11", because: :repo_archived
+  # Original deprecation date: 2018-06-11
+  disable! date: "2022-01-09", because: :repo_archived
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build


### PR DESCRIPTION
This has been deprecated one year ago in homebrew
THe project is deprecated since 2018

==> Analytics
install: 1 (30 days), 2 (90 days), 16 (365 days)
install-on-request: 1 (30 days), 2 (90 days), 16 (365 days)
build-error: 0 (30 days)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
