### PR TITLE
cosi: disable

### DIFF
--- a/Formula/cosi.rb
+++ b/Formula/cosi.rb
@@ -20,7 +20,8 @@ class Cosi < Formula
 
   # Deprecated in favor of the Cothority `blcosi` package.
   # See: https://github.com/dedis/cothority/tree/master/cosi
-  deprecate! date: "2018-03-01", because: :deprecated_upstream
+  # Original deprecation date: 2018-03-01
+  disable! date: "2022-01-09", because: :deprecated_upstream
 
   depends_on "go" => :build
 


### PR DESCRIPTION
This has been deprecated one year ago in homebrew-core
The project is deprecated since 2018

==> Analytics
install: 0 (30 days), 4 (90 days), 11 (365 days)
install-on-request: 0 (30 days), 4 (90 days), 11 (365 days)
build-error: 0 (30 days)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
