### PR TITLE
chmlib: Support Apple Silicon

### DIFF
--- a/Formula/chmlib.rb
+++ b/Formula/chmlib.rb
@@ -29,9 +29,26 @@ class Chmlib < Formula
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
     sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
   end
+  # Add aarch64 to 64-bit integer platform list.
+  patch :DATA
 
   def install
     system "./configure", "--disable-io64", "--enable-examples", "--prefix=#{prefix}"
     system "make", "install"
   end
 end
+
+__END__
+diff --git a/src/chm_lib.c b/src/chm_lib.c
+index 6c6736c..06908c0 100644
+--- a/src/chm_lib.c
++++ b/src/chm_lib.c
+@@ -164,7 +164,7 @@ typedef unsigned long long      UInt64;
+
+ /* x86-64 */
+ /* Note that these may be appropriate for other 64-bit machines. */
+-#elif __x86_64__ || __ia64__
++#elif __x86_64__ || __ia64__ || __aarch64__
+ typedef unsigned char           UChar;
+ typedef short                   Int16;
+ typedef unsigned short          UInt16;

--- a/Formula/chmlib.rb
+++ b/Formula/chmlib.rb
@@ -36,6 +36,18 @@ class Chmlib < Formula
     system "./configure", "--disable-io64", "--enable-examples", "--prefix=#{prefix}"
     system "make", "install"
   end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <chm_lib.h>
+      int main() {
+        struct chmFile* chm = chm_open("file-that-doesnt-exist.chm");
+        return chm != 0; // Fail if non-null.
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lchm", "-o", "test"
+    system "./test"
+  end
 end
 
 __END__

--- a/Formula/chmlib.rb
+++ b/Formula/chmlib.rb
@@ -4,7 +4,7 @@ class Chmlib < Formula
   url "http://www.jedrea.com/chmlib/chmlib-0.40.tar.gz"
   mirror "https://download.tuxfamily.org/slitaz/sources/packages/c/chmlib-0.40.tar.gz"
   sha256 "512148ed1ca86dea051ebcf62e6debbb00edfdd9720cde28f6ed98071d3a9617"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
The audit fails with the following, but I have no idea what to do about the license warning and there doesn't seem to be any text fixtures chm files for me to add new tests with.

```
chmlib:
  * 1: col 1: A `test do` test block should be added
  * Formula chmlib contains deprecated SPDX licenses: ["LGPL-2.1"].
    You may need to add `-only` or `-or-later` for GNU licenses (e.g. `GPL`, `LGPL`, `AGPL`, `GFDL`).
    For a list of valid licenses check: https://spdx.org/licenses/
```

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
