### PR TITLE
formulae(rust): update licenses

### DIFF
--- a/Formula/bat.rb
+++ b/Formula/bat.rb
@@ -3,7 +3,7 @@ class Bat < Formula
   homepage "https://github.com/sharkdp/bat"
   url "https://github.com/sharkdp/bat/archive/v0.19.0.tar.gz"
   sha256 "6a920cad1e7ae069eb9393f5b6883e0a7f2c957186b1075976331daaa5e0468a"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "aa858e2e27ed299915da9127e2ae6e66a49278a36296568df7c3454f6432df2f"

--- a/Formula/cmdshelf.rb
+++ b/Formula/cmdshelf.rb
@@ -3,7 +3,7 @@ class Cmdshelf < Formula
   homepage "https://github.com/toshi0383/cmdshelf"
   url "https://github.com/toshi0383/cmdshelf/archive/2.0.2.tar.gz"
   sha256 "dea2ea567cfa67196664629ceda5bc775040b472c25e96944c19c74892d69539"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
 
   bottle do
     rebuild 2

--- a/Formula/diesel.rb
+++ b/Formula/diesel.rb
@@ -3,7 +3,7 @@ class Diesel < Formula
   homepage "https://diesel.rs"
   url "https://github.com/diesel-rs/diesel/archive/v1.4.8.tar.gz"
   sha256 "229b40ba777c2728430112c6e89d591a62198851890b2d0a5cab3472effba240"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/diesel-rs/diesel.git", branch: "master"
 
   bottle do

--- a/Formula/diskus.rb
+++ b/Formula/diskus.rb
@@ -3,7 +3,7 @@ class Diskus < Formula
   homepage "https://github.com/sharkdp/diskus"
   url "https://github.com/sharkdp/diskus/archive/v0.7.0.tar.gz"
   sha256 "64b1b2e397ef4de81ea20274f98ec418b0fe19b025860e33beaba5494d3b8bd1"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "81ccae56cd463196bfd65dcc54a3ffc2825fa873f38fd50e01580237ae010ce5"

--- a/Formula/elan-init.rb
+++ b/Formula/elan-init.rb
@@ -3,7 +3,7 @@ class ElanInit < Formula
   homepage "https://github.com/leanprover/elan"
   url "https://github.com/leanprover/elan/archive/v1.3.1.tar.gz"
   sha256 "8e1380a1cb20cec54f07e30519ad7bc0179d9e3d68d33c02d0476248322b5015"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/leanprover/elan.git", branch: "master"
 
   bottle do

--- a/Formula/fd.rb
+++ b/Formula/fd.rb
@@ -3,7 +3,7 @@ class Fd < Formula
   homepage "https://github.com/sharkdp/fd"
   url "https://github.com/sharkdp/fd/archive/v8.3.1.tar.gz"
   sha256 "834a90fbb4e1deee2ca7f3aa84575c9187869d8af00f72e431ecab4776ae1f62"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/sharkdp/fd.git", branch: "master"
 
   bottle do

--- a/Formula/fselect.rb
+++ b/Formula/fselect.rb
@@ -3,7 +3,7 @@ class Fselect < Formula
   homepage "https://github.com/jhspetersson/fselect"
   url "https://github.com/jhspetersson/fselect/archive/0.7.9.tar.gz"
   sha256 "b1cb4108d1d35c8e2d2630cdb78a42e1e10ff36ea00ce2e76577e1723905d4a2"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "de48331a0819e96a03a39749439eda8a425ca8bc779fdc8f6a66cf8c0b265993"

--- a/Formula/hexyl.rb
+++ b/Formula/hexyl.rb
@@ -3,7 +3,7 @@ class Hexyl < Formula
   homepage "https://github.com/sharkdp/hexyl"
   url "https://github.com/sharkdp/hexyl/archive/v0.9.0.tar.gz"
   sha256 "73f0dc1be1eaa1a34e3280bc1eeb4f86f34b024205fc7bf3c87d5a0bc4021a6a"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "94627ec8776e6140328d0270d877dcd8476da32d253c0ee77d9154f31fd72f8e"

--- a/Formula/hyperfine.rb
+++ b/Formula/hyperfine.rb
@@ -3,7 +3,7 @@ class Hyperfine < Formula
   homepage "https://github.com/sharkdp/hyperfine"
   url "https://github.com/sharkdp/hyperfine/archive/v1.12.0.tar.gz"
   sha256 "2120870a97e68fa3426eac5646a071c9646e96d2309220e3c258bf588e496454"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "08143e785ff6982bc64c1299aac9f16f0230850ea4e8fcb9b9728176e6c7c20a"

--- a/Formula/pastel.rb
+++ b/Formula/pastel.rb
@@ -3,7 +3,7 @@ class Pastel < Formula
   homepage "https://github.com/sharkdp/pastel"
   url "https://github.com/sharkdp/pastel/archive/v0.8.1.tar.gz"
   sha256 "e1afcd8035a4c1da7f6d0fc8d5fc703dee72baa77bd0588a67d3b606e70146cb"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/sharkdp/pastel.git", branch: "master"
 
   bottle do

--- a/Formula/rust-analyzer.rb
+++ b/Formula/rust-analyzer.rb
@@ -5,7 +5,7 @@ class RustAnalyzer < Formula
        tag:      "2022-01-10",
        revision: "0f8c96c92689af8378dbe9f466c6bf15a3a27458"
   version "2022-01-10"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "9fe0507d3902db1e52dbe3961ce6afe1bb956079c6c6e0126cbcd73e2b33c854"

--- a/Formula/rustup-init.rb
+++ b/Formula/rustup-init.rb
@@ -3,7 +3,7 @@ class RustupInit < Formula
   homepage "https://github.com/rust-lang/rustup"
   url "https://github.com/rust-lang/rustup/archive/1.24.3.tar.gz"
   sha256 "24a8cede4ccbbf45ab7b8de141d92f47d1881bb546b3b9180d5a51dc0622d0f6"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "f3e0c708bf0bc403fb5591b9f6991d709c68800ee230793cd587286c76c3711a"

--- a/Formula/tealdeer.rb
+++ b/Formula/tealdeer.rb
@@ -3,7 +3,7 @@ class Tealdeer < Formula
   homepage "https://github.com/dbrgn/tealdeer"
   url "https://github.com/dbrgn/tealdeer/archive/v1.5.0.tar.gz"
   sha256 "00902a50373ab75fedec4578c6c2c02523fad435486918ad9a86ed01f804358a"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "0d1d7ba657937c479ae47d27942e66d1ff15cc3f957596d223e28b26361d9021"

--- a/Formula/tokei.rb
+++ b/Formula/tokei.rb
@@ -3,7 +3,7 @@ class Tokei < Formula
   homepage "https://github.com/XAMPPRocky/tokei"
   url "https://github.com/XAMPPRocky/tokei/archive/v12.1.2.tar.gz"
   sha256 "81ef14ab8eaa70a68249a299f26f26eba22f342fb8e22fca463b08080f436e50"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
 
   livecheck do
     url :stable

--- a/Formula/vsts-cli.rb
+++ b/Formula/vsts-cli.rb
@@ -5,6 +5,7 @@ class VstsCli < Formula
   homepage "https://docs.microsoft.com/en-us/cli/vsts"
   url "https://files.pythonhosted.org/packages/f9/c2/3ed698480ab30d2807fc961eef152099589aeaec3f1407945a4e07275de5/vsts-cli-0.1.4.tar.gz"
   sha256 "27defe1d8aaa1fcbc3517274c0fdbd42b5ebe2c1c40edfc133d98fe4bb7114de"
+  license "MIT"
   revision 5
 
   bottle do

--- a/Formula/wagyu.rb
+++ b/Formula/wagyu.rb
@@ -3,6 +3,7 @@ class Wagyu < Formula
   homepage "https://github.com/AleoHQ/wagyu"
   url "https://github.com/AleoHQ/wagyu/archive/v0.6.1.tar.gz"
   sha256 "2458b3d49653acd5df5f3161205301646527eca9f6ee3d84c7871afa275bad9f"
+  license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/AleoHQ/wagyu.git", branch: "master"
 
   bottle do

--- a/Formula/wasm-pack.rb
+++ b/Formula/wasm-pack.rb
@@ -3,7 +3,7 @@ class WasmPack < Formula
   homepage "https://rustwasm.github.io/wasm-pack/"
   url "https://github.com/rustwasm/wasm-pack/archive/v0.10.2.tar.gz"
   sha256 "533b7f63c04411e5d771d406b1c56134e3045b48fb1673985ad8fed1bc937517"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/rustwasm/wasm-pack.git", branch: "master"
 
   bottle do

--- a/Formula/wasmtime.rb
+++ b/Formula/wasmtime.rb
@@ -4,7 +4,7 @@ class Wasmtime < Formula
   url "https://github.com/bytecodealliance/wasmtime.git",
       tag:      "v0.33.0",
       revision: "8043c1f919a77905255eded33e4e51a6fbfd1de1"
-  license "Apache-2.0"
+  license "Apache-2.0" => { with: "LLVM-exception" }
   head "https://github.com/bytecodealliance/wasmtime.git", branch: "main"
 
   livecheck do

--- a/Formula/xsv.rb
+++ b/Formula/xsv.rb
@@ -3,6 +3,7 @@ class Xsv < Formula
   homepage "https://github.com/BurntSushi/xsv"
   url "https://github.com/BurntSushi/xsv/archive/0.13.0.tar.gz"
   sha256 "2b75309b764c9f2f3fdc1dd31eeea5a74498f7da21ae757b3ffd6fd537ec5345"
+  license any_of: ["MIT", "Unlicense"]
   head "https://github.com/BurntSushi/xsv.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The updates in here are for Rust formulae, most of them are dual licensed under MIT/Apache-2.0, but Github cannot display dual licenses, which results in the Apache-2.0 for license data return. 

For example, here is the license identifier info for `cmdshelf` shelf formula.
https://github.com/toshi0383/cmdshelf/blob/master/Cargo.toml#L17

- Also relates to the issue report I made, https://github.com/dear-github/dear-github/issues/400