### PR TITLE
percona-server: equal sign is required for datadir

### DIFF
--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -186,7 +186,7 @@ class PerconaServer < Formula
   end
 
   service do
-    run [opt_bin/"mysqld_safe", "--datadir", var/"mysql"]
+    run [opt_bin/"mysqld_safe", "--datadir=#{var}/mysql"]
     keep_alive true
     working_dir var/"mysql"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I have noticed that persona-server won't start using `brew services start persona-server`

```
Name           Status  User File
percona-server error  256 root ~/Library/LaunchAgents/homebrew.mxcl.percona-server.plist
```

Checking `homebrew.mxcl.percona-server.plist` :

```xml
<key>ProgramArguments</key>
<array>
    <string>/usr/local/opt/percona-server/bin/mysqld_safe</string>
    <string>--datadir</string>
    <string>/usr/local/var/mysql</string>
</array>
```

running `/usr/local/opt/percona-server/bin/mysqld_safe --datadir /usr/local/var/mysql` doesn't work : 
```
$ /usr/local/opt/percona-server/bin/mysqld_safe --datadir /usr/local/var/mysql
sed: 1: "s/^/usr/local/var/mysql ...": bad flag in substitute command: 'l'
2022-01-11T06:55:24.6NZ mysqld_safe Logging to '/usr/local/var/mysql/mbp.local.err'.
2022-01-11T06:55:24.6NZ mysqld_safe Starting mysqld daemon with databases from /usr/local/var/mysql
2022-01-11T06:55:24.6NZ mysqld_safe mysqld from pid file /usr/local/var/mysql/mbp.local.pid ended with return value of 1
```

Add an `=` after `--datadir` fixed it.
