### PR TITLE
nut: add livecheck

### DIFF
--- a/Formula/nut.rb
+++ b/Formula/nut.rb
@@ -16,6 +16,11 @@ class Nut < Formula
     end
   end
 
+  livecheck do
+    url "https://networkupstools.org/download.html"
+    regex(/href=.*?nut[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 arm64_monterey: "de8faf2fdb4127d92e1e0df5289d485b7936da149055fefb136f23978da49c4b"
@@ -28,7 +33,7 @@ class Nut < Formula
   end
 
   head do
-    url "https://github.com/networkupstools/nut.git"
+    url "https://github.com/networkupstools/nut.git", branch: "master"
     depends_on "asciidoc" => :build
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `nut` (from the `head` URL) and successfully identifies the latest version at the moment. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.