### PR TITLE
duck: codesign in `post_install` on ARM

### DIFF
--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -143,11 +143,17 @@ class Duck < Formula
       libexec.install Dir["cli/osx/target/duck.bundle/*"]
       rm_rf libdir/"JavaNativeFoundation.framework"
       libdir.install buildpath/"JavaNativeFoundation.framework"
-      # Replace runtime with already installed dependency
-      rm_r "#{libexec}/Contents/PlugIns/Runtime.jre"
-      ln_s Formula["openjdk"].libexec/"openjdk.jdk", "#{libexec}/Contents/PlugIns/Runtime.jre"
       rm libdir/shared_library("librococoa")
       libdir.install buildpath/shared_library("librococoa")
+
+      # Replace runtime with already installed dependency
+      rm_r libexec/"Contents/PlugIns/Runtime.jre"
+      if Hardware::CPU.intel?
+        ln_s Formula["openjdk"].libexec/"openjdk.jdk", libexec/"Contents/PlugIns/Runtime.jre"
+      else
+        # We need to `codesign` this on ARM, so let's copy it over.
+        cp_r Formula["openjdk"].libexec/"openjdk.jdk", libexec/"Contents/PlugIns/Runtime.jre"
+      end
     else
       libexec.install Dir["cli/linux/target/release/duck/*"]
     end
@@ -155,6 +161,14 @@ class Duck < Formula
     rm libdir/shared_library("libjnidispatch")
     libdir.install buildpath/shared_library("libjnidispatch")
     bin.install_symlink "#{bindir}/duck" => "duck"
+  end
+
+  # FIXME: Bottling seems to break the ad-hoc signature.
+  # https://github.com/Homebrew/homebrew-core/issues/92180
+  def post_install
+    return if !OS.mac? || !Hardware::CPU.arm?
+
+    quiet_system "codesign", "--force", "--deep", "--sign", "-", libexec
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Bottling seems to break the ad-hoc signature, so let's fix that in
`post_install`.

There's probably a better solution for this, but I'm not really sure what it would be.

Fixes #92180.