### PR TITLE
mongosh 1.1.8

### DIFF
--- a/Formula/mongosh.rb
+++ b/Formula/mongosh.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Mongosh < Formula
   desc "MongoDB Shell to connect, configure, query, and work with your MongoDB database"
   homepage "https://github.com/mongodb-js/mongosh#readme"
-  url "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-1.1.7.tgz"
-  sha256 "0715886b8ad7d4df364e88a0406c2c724eb4e8330ce7a21b95d3e15971c39094"
+  url "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-1.1.8.tgz"
+  sha256 "eca227ea81100db325623bba44b5b9ab6e9f567aad1c2050822d5135fe585efa"
   license "Apache-2.0"
 
   bottle do


### PR DESCRIPTION
This PR was created automatically and bumps `mongosh` to the latest published version `1.1.8`.

For additional details see https://github.com/mongodb-js/mongosh/releases/tag/v1.1.8.
