### PR TITLE
gnuradio: use brewed cppzmq

### DIFF
--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -6,7 +6,7 @@ class Gnuradio < Formula
   url "https://github.com/gnuradio/gnuradio/archive/refs/tags/v3.9.3.0.tar.gz"
   sha256 "4073ac72524f95fed4bda7dd553cb946f66d2e00bd07c4ae7758f1b787d507e0"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/gnuradio/gnuradio.git", branch: "master"
 
   livecheck do
@@ -26,6 +26,7 @@ class Gnuradio < Formula
   depends_on "pybind11" => :build
   depends_on "adwaita-icon-theme"
   depends_on "boost"
+  depends_on "cppzmq"
   depends_on "fftw"
   depends_on "gmp"
   depends_on "gsl"
@@ -70,11 +71,6 @@ class Gnuradio < Formula
     sha256 "607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"
   end
 
-  resource "cppzmq" do
-    url "https://raw.githubusercontent.com/zeromq/cppzmq/46fc0572c5e9f09a32a23d6f22fd79b841f77e00/zmq.hpp"
-    sha256 "964031c0944f913933f55ad1610938105a6657a69d1ac5a6dd50e16a679104d5"
-  end
-
   # patch to build with qt6
   # PR ref, https://github.com/gnuradio/gnuradio/pull/5034
   patch do
@@ -101,8 +97,6 @@ class Gnuradio < Formula
       s.gsub! "${CMAKE_C_COMPILER}", ENV.cc
       s.gsub! "${CMAKE_CXX_COMPILER}", ENV.cxx
     end
-
-    resource("cppzmq").stage include.to_s
 
     args = std_cmake_args + %W[
       -DGR_PKG_CONF_DIR=#{etc}/gnuradio/conf.d


### PR DESCRIPTION
When the formula was created in 001c1eabbc9d, there was probably no cppzmq formula
Vendoring into the include foler can create a conflict when trying to install cppzmq.

Fixes:
Error: The `brew link` step did not complete successfully
  Could not symlink include/zmq.hpp
  Target /usr/local/include/zmq.hpp
  is a symlink belonging to gnuradio. You can unlink it:
    brew unlink gnuradio

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
