### PR TITLE
ivtools: fix conflict with dialog

### DIFF
--- a/Formula/ivtools.rb
+++ b/Formula/ivtools.rb
@@ -4,6 +4,7 @@ class Ivtools < Formula
   url "https://github.com/vectaport/ivtools/archive/refs/tags/ivtools-2.0.11d.tar.gz"
   sha256 "8c6fe536dff923f7819b4210a706f0abe721e13db8a844395048ded484fb2437"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 big_sur:  "a349834ee1394a4dbf95392aebfe1e89a29fb0f28892296a43b0585c55a15703"
@@ -21,6 +22,9 @@ class Ivtools < Formula
     system "./configure", *std_configure_args, *args
     system "make"
     system "make", "install"
+
+    # Conflicts with dialog
+    mv man3/"Dialog.3", man3/"Dialog_ivtools.3"
   end
 
   test do


### PR DESCRIPTION
Fixes:
  Error: The `brew link` step did not complete successfully
  Could not symlink share/man/man3/Dialog.3
  Target /usr/local/share/man/man3/Dialog.3
  is a symlink belonging to dialog. You can unlink it:
    brew unlink dialog

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
