### PR TITLE
imap-backup solargraph: fix pre-Catalina builds

### DIFF
--- a/Formula/imap-backup.rb
+++ b/Formula/imap-backup.rb
@@ -15,7 +15,7 @@ class ImapBackup < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "356b64f9b6611dacf9ad9323b075f04687dcfee8f71277ad3cb6894e67926027"
   end
 
-  uses_from_macos "ruby"
+  uses_from_macos "ruby", since: :catalina
 
   def install
     ENV["GEM_HOME"] = libexec

--- a/Formula/solargraph.rb
+++ b/Formula/solargraph.rb
@@ -16,7 +16,7 @@ class Solargraph < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9ea302b96d25305df9675aa39f2ab7270cfdf81c13f977a69dcc45abe5cca860"
   end
 
-  uses_from_macos "ruby"
+  uses_from_macos "ruby", since: :catalina
 
   def install
     ENV["GEM_HOME"] = libexec


### PR DESCRIPTION
Both formulae require Ruby >= 2.5, so only Catalina and above can use system Ruby.

This should NOT require rebuilding, since Catalina is now "minimum supported". Nevertheless, I've built and tested against my personal Mojave setup.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?