### PR TITLE
vim: Add support for X11

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -17,6 +17,7 @@ class Vim < Formula
   end
 
   depends_on "gettext"
+  depends_on "libx11"
   depends_on "lua"
   depends_on "ncurses"
   depends_on "perl"
@@ -55,7 +56,6 @@ class Vim < Formula
                           "--enable-rubyinterp",
                           "--enable-python3interp",
                           "--enable-gui=no",
-                          "--without-x",
                           "--enable-luainterp",
                           "--with-lua-prefix=#{Formula["lua"].opt_prefix}"
     system "make"


### PR DESCRIPTION
Building Vim with X11 available (and without the --without-x option)
makes the 'unnamedplus' register available so one can yank directly to
the system clipboard.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
I find this functionality of Vim/X11 quite useful, so I was surprised when Homebrew didn't compile Vim with X11 support. If there's no particular reasons why this was excluded, I'd be happy if we could change that.

N.B. Running `brew tests` as advised in [the guide for pull requests](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#create-your-pull-request-from-a-new-branch) leads to a single test failure on my system. But that seems unrelated to this change, as the test also fails without this change.