### PR TITLE
open-mesh: add livecheck, license

### DIFF
--- a/Formula/open-mesh.rb
+++ b/Formula/open-mesh.rb
@@ -3,6 +3,7 @@ class OpenMesh < Formula
   homepage "https://openmesh.org/"
   url "https://www.openmesh.org/media/Releases/8.1/OpenMesh-8.1.tar.bz2"
   sha256 "9bc43a3201ba27ed63de66c4c09e23746272882c37a3451e71f0cf956f9be076"
+  license "BSD-3-Clause"
   head "https://www.graphics.rwth-aachen.de:9000/OpenMesh/OpenMesh.git", branch: "master"
 
   livecheck do

--- a/Formula/open-mesh.rb
+++ b/Formula/open-mesh.rb
@@ -3,7 +3,12 @@ class OpenMesh < Formula
   homepage "https://openmesh.org/"
   url "https://www.openmesh.org/media/Releases/8.1/OpenMesh-8.1.tar.bz2"
   sha256 "9bc43a3201ba27ed63de66c4c09e23746272882c37a3451e71f0cf956f9be076"
-  head "https://www.graphics.rwth-aachen.de:9000/OpenMesh/OpenMesh.git"
+  head "https://www.graphics.rwth-aachen.de:9000/OpenMesh/OpenMesh.git", branch: "master"
+
+  livecheck do
+    url "https://www.openmesh.org/download/"
+    regex(/href=.*?OpenMesh[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "e066cb3914efa547fa06a4dfdbb4f5d4ecaf54c4eeaeecd4d41d4a0f3d16d23a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `open-mesh` (from the `head` URL) and successfully identifies the latest version at the moment. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the first-party download page, which links to the `stable` archive.

One thing to note is that www.openmesh.org URLs redirect to www.graphics.rwth-aachen.de/software/openmesh/ (with any existing path appended). I've simply aligned the `livecheck` block URL with the existing `homepage`/`stable` URLs for the moment. That said, do we want to update these URLs to avoid the redirection (aligning with the `head` URL) or is it preferable to continue using www.openmesh.org?