### PR TITLE
lean 3.38.0

### DIFF
--- a/Formula/lean.rb
+++ b/Formula/lean.rb
@@ -1,16 +1,22 @@
 class Lean < Formula
   desc "Theorem prover"
   homepage "https://leanprover-community.github.io/"
-  url "https://github.com/leanprover-community/lean/archive/v3.35.1.tar.gz"
-  sha256 "501170db2958a9302e075c6f1c849c42e12c2623fb3e7c527f3a5da3483eea93"
+  url "https://github.com/leanprover-community/lean/archive/v3.38.0.tar.gz"
+  sha256 "3b6fdfc2847a5553511943c88e166b3c14cafb78fecab33eb5acc89b9c2952a1"
   license "Apache-2.0"
   head "https://github.com/leanprover-community/lean.git", branch: "master"
 
-  # The Lean 3 repository (https://github.com/leanprover/lean/) is archived
-  # and there won't be any new releases. Lean 4 is being developed but is still
-  # a work in progress: https://github.com/leanprover/lean4
   livecheck do
-    skip "Lean 3 is archived; add a new check once Lean 4 is stable"
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.map do |tag|
+        version = tag[regex, 1]
+        next if version == "9.9.9" # Omit a problematic version tag
+
+        version
+      end
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `lean` to the latest community version, 3.38.0.

Besides that, this updates the `livecheck` block to use the standard regex for Git tags like `1.2.3`/`v1.2.3` and a `strategy` block that omits the problematic `v9.9.9` tag (which is always treated as newest). The formula was switched from the archived leanprover/lean repository to leanprover-community/lean sometime in the past but the `livecheck` block hadn't been updated accordingly, so this formula was still being skipped.