### PR TITLE
varnish: fix build for Linux

### DIFF
--- a/Formula/varnish.rb
+++ b/Formula/varnish.rb
@@ -26,6 +26,9 @@ class Varnish < Formula
   depends_on "sphinx-doc" => :build
   depends_on "pcre2"
 
+  uses_from_macos "libedit"
+  uses_from_macos "ncurses"
+
   # Fix -flat_namespace being used on Big Sur and later.
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
@@ -33,7 +36,7 @@ class Varnish < Formula
   end
 
   def install
-    ENV["PYTHON"] = which("python3")
+    ENV["PYTHON"] = Formula["python@3.10"].opt_bin/"python3"
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
@@ -44,6 +47,9 @@ class Varnish < Formula
     # can install VMODs and VCL.
     ENV.append_to_cflags "-DVARNISH_VMOD_DIR='\"#{HOMEBREW_PREFIX}/lib/varnish/vmods\"'"
     ENV.append_to_cflags "-DVARNISH_VCL_DIR='\"#{pkgetc}:#{HOMEBREW_PREFIX}/share/varnish/vcl\"'"
+
+    # Fix missing pthread symbols on Linux
+    ENV.append_to_cflags "-pthread" if OS.linux?
 
     system "make", "install", "CFLAGS=#{ENV.cflags}"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `ENV["PYTHON"]` change is just a style change; I'm pretty sure it already uses `python@3.10`'s Python at build, but the precedent with our other formulae is to be explicit in situations where we need to specify things like this.