### PR TITLE
openal-soft: add livecheck

### DIFF
--- a/Formula/openal-soft.rb
+++ b/Formula/openal-soft.rb
@@ -6,6 +6,11 @@ class OpenalSoft < Formula
   license "LGPL-2.0-or-later"
   head "https://github.com/kcat/openal-soft.git", branch: "master"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?openal-soft[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "92e045739dcb27b75019946bb931011495b64a1cdebef9413401f476d6480cd0"
     sha256 cellar: :any,                 arm64_big_sur:  "7e15f3c0087f0bce3c5bcad1efd612ffb83327b3cd25702ffc474f6513307d73"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `openal-soft` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` archive.