### PR TITLE
rdkit: Fix build

### DIFF
--- a/Formula/rdkit.rb
+++ b/Formula/rdkit.rb
@@ -34,6 +34,12 @@ class Rdkit < Formula
   depends_on "py3cairo"
   depends_on "python@3.9"
 
+  # Fix for Comic Neue md5 checksum change, remove with next release
+  patch do
+    url "https://github.com/rdkit/rdkit/commit/d05501c5db6f30b72b5d751e7100be165549ebdc.patch?full_index=true"
+    sha256 "06eb6f9f8479c9cc227948654c42e71892c4ae19878291cf3e108feb7a8edc7d"
+  end
+
   def install
     ENV.cxx11
     ENV.libcxx


### PR DESCRIPTION
CMake Error at Code/cmake/Modules/RDKitUtils.cmake:235 (MESSAGE):
    The md5 checksum for
    /tmp/rdkit-20220115-98273-ovxwat/rdkit-Release_2021_09_4/Code/GraphMol/MolDraw2D/Comic_Neue.zip
    is incorrect; expected: 23ed3f833c1ae0adb141a26b4a30d73e, found:
    850b0df852f1cda4970887b540f8f333

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
