### PR TITLE
git-flow: Proper autocomplete installation for ZSH

### DIFF
--- a/Formula/git-flow.rb
+++ b/Formula/git-flow.rb
@@ -2,6 +2,7 @@ class GitFlow < Formula
   desc "Extensions to follow Vincent Driessen's branching model"
   homepage "https://github.com/nvie/gitflow"
   license "BSD-2-Clause"
+  revision 1
 
   stable do
     # Use the tag instead of the tarball to get submodules
@@ -42,11 +43,18 @@ class GitFlow < Formula
   def install
     system "make", "prefix=#{libexec}", "install"
     bin.write_exec_script libexec/"bin/git-flow"
-
     resource("completion").stage do
+      # Fix a comment referencing `/usr/local` that causes deviations between bottles.
+      inreplace "git-flow-completion.bash", "/usr/local", HOMEBREW_PREFIX
       bash_completion.install "git-flow-completion.bash"
-      zsh_completion.install "git-flow-completion.zsh"
     end
+  end
+
+  def caveats
+    <<~EOS
+      To install Zsh completions:
+        brew install zsh-completions
+    EOS
   end
 
   test do


### PR DESCRIPTION
Autocomplete doesn't work out of the box and it lacks a caveat telling you what to do. 
That being said, the caveat, as mentioned at the top of `git-flow-completion.zsh` is outdated, as it wouldn't be optimal. 

In the end, we decided to remove the ZSH completion all together and rely on 
```ruby
  def caveats
     <<~EOS
       To install Zsh completions:
         brew install zsh-completions
     EOS
   end
```

If you're using a plugin manager, like say `zinit` this also works
```sh
zinit ice lucid blockf wait depth"1" as"completion"
zinit snippet https://github.com/zsh-users/zsh-completions/blob/master/src/_git-flow
```

~~Renaming  `git-flow-completion.zsh` as `_git-flow` and replaces `"#!zsh` with  `"#compdef git-flow"`.
This breaks backwards compatibility, for existing users that source it, but they should change anyway.
Fixes the review comments:~~ 
https://github.com/Homebrew/homebrew-core/pull/93187#pullrequestreview-853563740
https://github.com/Homebrew/homebrew-core/pull/93187#pullrequestreview-853576361

~~So on post install it copies `git-flow-completion.zsh` as `_git-flow` and prepends `"#compdef git-flow"` to it before symlinking to `HOMEBREW_PREFIX/"share/zsh/site-functions"`.
That should make autocomplete work out of the box as long as `/usr/local/share/zsh/site-functions` is in `fpath`.
Also following other standards like `_brew` or `_aws`.~~


~~Maintaining backwards compatibility by keeping `git-flow-completion.zsh` symlinked and intact.~~

Also, I wonder, does this formula really need bottles as it's just a shell script?

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? I

-----
