### PR TITLE
openapi-generator: add livecheck

### DIFF
--- a/Formula/openapi-generator.rb
+++ b/Formula/openapi-generator.rb
@@ -5,12 +5,17 @@ class OpenapiGenerator < Formula
   sha256 "81dc1b3fb1102b43becd2f46098cfd861e9c4e84fbebb534ad67d7c6b0eeff77"
   license "Apache-2.0"
 
+  livecheck do
+    url "https://search.maven.org/remotecontent?filepath=org/openapitools/openapi-generator-cli/maven-metadata.xml"
+    regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "ead0082bf72df72f7349393f1733daaeff4f52a1d1910384fbfe2004fff4add3"
   end
 
   head do
-    url "https://github.com/OpenAPITools/openapi-generator.git"
+    url "https://github.com/OpenAPITools/openapi-generator.git", branch: "master"
 
     depends_on "maven" => :build
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `openapi-generator` (from the `head` URL) and successfully identifies the latest version. However, we prefer to align the livecheck source with the `stable` source, when possible. This PR adds a `livecheck` block that checks the Maven metadata file, which contains version information.