### PR TITLE
avrdude: Add hidapi dependency

### DIFF
--- a/Formula/avrdude.rb
+++ b/Formula/avrdude.rb
@@ -2,6 +2,7 @@ class Avrdude < Formula
   desc "Atmel AVR MCU programmer"
   homepage "https://savannah.nongnu.org/projects/avrdude/"
   license "GPL-2.0-or-later"
+  revision 1
 
   stable do
     url "https://download.savannah.gnu.org/releases/avrdude/avrdude-6.4.tar.gz"
@@ -38,6 +39,7 @@ class Avrdude < Formula
   end
 
   depends_on "automake" => :build
+  depends_on "hidapi"
   depends_on "libftdi0"
   depends_on "libhid"
   depends_on "libusb-compat"


### PR DESCRIPTION
This fixes issues with programmers that show up as HID devices
and produce permission denied errors with libusb.

Fixes avrdudes/avrdude#512

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
