### PR TITLE
fbthrift 2022.01.10.00 (new formula)

### DIFF
--- a/Formula/fbthrift.rb
+++ b/Formula/fbthrift.rb
@@ -1,0 +1,59 @@
+class Fbthrift < Formula
+  desc "Facebook's branch of Apache Thrift, including a new C++ server"
+  homepage "https://github.com/facebook/fbthrift"
+  url "https://github.com/facebook/fbthrift/archive/v2022.01.10.00.tar.gz"
+  sha256 "ad0efb16fa2a269e50248391532317da5982cfaf95f79d190c4103a9bdbf7fc9"
+  license "Apache-2.0"
+  head "https://github.com/facebook/fbthrift.git", branch: "main"
+
+  depends_on "bison" => :build # Needs Bison 3.1+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "fizz"
+  depends_on "fmt"
+  depends_on "folly"
+  depends_on "gflags"
+  depends_on "glog"
+  depends_on "openssl@1.1"
+  depends_on "wangle"
+  depends_on "zstd"
+
+  uses_from_macos "flex" => :build
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc@10"
+  end
+
+  fails_with gcc: "5" # C++ 17
+  fails_with gcc: "11" # https://github.com/facebook/folly#ubuntu-lts-centos-stream-fedora
+
+  def install
+    # The static libraries are a bit annoying to build. If modifying this formula
+    # to include them, make sure `bin/thrift1` links with the dynamic libraries
+    # instead of the static ones (e.g. `libcompiler_base`, `libcompiler_lib`, etc.)
+    shared_args = ["-DBUILD_SHARED_LIBS=ON", "-DCMAKE_INSTALL_RPATH=#{rpath}"]
+    shared_args << "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-undefined,dynamic_lookup" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build/shared", *std_cmake_args, *shared_args
+    system "cmake", "--build", "build/shared"
+    system "cmake", "--install", "build/shared"
+
+    elisp.install "thrift/contrib/thrift.el"
+    (share/"vim/vimfiles/syntax").install "thrift/contrib/thrift.vim"
+  end
+
+  test do
+    (testpath/"example.thrift").write <<~EOS
+      namespace cpp tamvm
+
+      service ExampleService {
+        i32 get_number(1:i32 number);
+      }
+    EOS
+
+    system bin/"thrift1", "--gen", "mstch_cpp2", "example.thrift"
+    assert_predicate testpath/"gen-cpp2", :exist?
+    assert_predicate testpath/"gen-cpp2", :directory?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The audit fails because of the `bison` dependency, but this does not work with macOS-provided `bison`.