### PR TITLE
dnsprobe: fix typo

### DIFF
--- a/Formula/dnsprobe.rb
+++ b/Formula/dnsprobe.rb
@@ -17,7 +17,7 @@ class Dnsprobe < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "badafaac8f8da8392fc966e9339ef5989e851bef8901655705de1cdd4e45e740"
   end
 
-  # repo derecated in favor of `projectdiscovery/dnsx`
+  # repo deprecated in favor of `projectdiscovery/dnsx`
   deprecate! date: "2020-11-13", because: :repo_archived
 
   depends_on "go" => :build


### PR DESCRIPTION
derecated -> deprecated

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
