### PR TITLE
kryptor 3.1.0 (new formula)

### DIFF
--- a/Formula/kryptor.rb
+++ b/Formula/kryptor.rb
@@ -6,6 +6,7 @@ class Kryptor < Formula
   license "GPL-3.0-or-later"
 
   depends_on "dotnet"
+  depends_on "libsodium"
 
   def install
     os = OS.mac? ? "osx" : OS.kernel_name.downcase

--- a/Formula/kryptor.rb
+++ b/Formula/kryptor.rb
@@ -1,0 +1,24 @@
+class Kryptor < Formula
+  desc "Simple, modern, and secure file encryption and signing"
+  homepage "https://www.kryptor.co.uk/"
+  url "https://github.com/samuel-lucas6/Kryptor/archive/v3.1.0.tar.gz"
+  sha256 "e7372ac4ccc4676fa6079bcc7be257c3677003b8ec33df486a4d43ba8bd1f3af"
+  license "GPL-3.0-or-later"
+
+  depends_on "dotnet"
+
+  def install
+    os = OS.mac? ? "osx" : OS.kernel_name.downcase
+
+    system "dotnet", "publish", "src/KryptorCLI/KryptorCLI.csproj",
+           "-c", "Release",
+           "-r", "#{os}-x64",
+           "-p:PublishTrimmed=true",
+           "-p:IncludeNativeLibrariesForSelfExtract=true",
+           "-p:PublishSingleFile=true",
+           "--self-contained", "true"
+
+    env = { DOTNET_ROOT: "${DOTNET_ROOT:-#{Formula["dotnet"].opt_libexec}}" }
+    (bin/"kryptor").write_env_script libexec/"kryptor", env
+  end
+end

--- a/Formula/kryptor.rb
+++ b/Formula/kryptor.rb
@@ -24,7 +24,7 @@ class Kryptor < Formula
   end
 
   test do
-    pipe_output("#{bin}/kryptor -e -p:'Jet-Visa-Famine-Antivirus' test")
+    system bin/"kryptor", "-e", "-p:'Jet-Visa-Famine-Antivirus'", "test"
     assert_equal "test", shell_output("#{bin}/kryptor -d -p:'Jet-Visa-Famine-Antivirus' test.kryptor")
   end
 end

--- a/Formula/kryptor.rb
+++ b/Formula/kryptor.rb
@@ -22,4 +22,9 @@ class Kryptor < Formula
     env = { DOTNET_ROOT: "${DOTNET_ROOT:-#{Formula["dotnet"].opt_libexec}}" }
     (bin/"kryptor").write_env_script libexec/"kryptor", env
   end
+
+  test do
+    pipe_output("#{bin}/kryptor -e -p:'Jet-Visa-Famine-Antivirus' test")
+    assert_equal "test", shell_output("#{bin}/kryptor -d -p:'Jet-Visa-Famine-Antivirus' test.kryptor")
+  end
 end

--- a/Formula/kryptor.rb
+++ b/Formula/kryptor.rb
@@ -14,6 +14,7 @@ class Kryptor < Formula
     system "dotnet", "publish", "src/KryptorCLI/KryptorCLI.csproj",
            "-c", "Release",
            "-r", "#{os}-#{arch}",
+           "--output", libexec,
            "-p:PublishTrimmed=true",
            "-p:IncludeNativeLibrariesForSelfExtract=true",
            "-p:PublishSingleFile=true",

--- a/Formula/kryptor.rb
+++ b/Formula/kryptor.rb
@@ -9,10 +9,11 @@ class Kryptor < Formula
 
   def install
     os = OS.mac? ? "osx" : OS.kernel_name.downcase
+    arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
 
     system "dotnet", "publish", "src/KryptorCLI/KryptorCLI.csproj",
            "-c", "Release",
-           "-r", "#{os}-x64",
+           "-r", "#{os}-#{arch}",
            "-p:PublishTrimmed=true",
            "-p:IncludeNativeLibrariesForSelfExtract=true",
            "-p:PublishSingleFile=true",

--- a/kryptor.rb
+++ b/kryptor.rb
@@ -1,0 +1,28 @@
+class Kryptor < Formula
+  desc "Simple, modern, and secure file encryption and signing"
+  homepage "https://www.kryptor.co.uk/"
+  url "https://github.com/samuel-lucas6/Kryptor/archive/v3.1.0.tar.gz"
+  sha256 "e7372ac4ccc4676fa6079bcc7be257c3677003b8ec33df486a4d43ba8bd1f3af"
+  license "GPL-3.0-or-later"
+
+  depends_on "dotnet"
+  depends_on "libsodium"
+
+  def install
+    os = OS.mac? ? "osx" : OS.kernel_name.downcase
+    arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
+
+    system "dotnet", "publish", "src/KryptorCLI/KryptorCLI.csproj",
+           "-c", "Release",
+           "-r", "#{os}-#{arch}",
+           "--output", libexec
+
+    env = { DOTNET_ROOT: "${DOTNET_ROOT:-#{Formula["dotnet"].opt_libexec}}" }
+    (bin/"kryptor").write_env_script libexec/"kryptor", env
+  end
+
+  test do
+    system bin/"kryptor", "-e", "-p:'Jet-Visa-Famine-Antivirus'", "test"
+    assert_equal "test", shell_output("#{bin}/kryptor -d -p:'Jet-Visa-Famine-Antivirus' test.kryptor")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----
My desktop is running Windows, so I can't run these commands. I've also embarrassingly spent hours trying to figure this out. I know there should be a test, but I'm not sure how to implement one. 

I came up with a Cask that likely works better and would support M1 Macs, but I read and was told that it would probably be rejected since my program is open source and a CLI application. It also doesn't support Linux, whereas hopefully this Formula will. Here's the Cask:

```rb
cask "kryptor" do
  version "3.1.0"
  sha256 "dd3745f1b4925777af3e8d35b4187b16198ebbc0b3aa693e8f529c584c5de072"

  url "https://github.com/samuel-lucas6/Kryptor/releases/download/v#{version}/kryptor-macos.zip",
      verified: "github.com/samuel-lucas6/Kryptor/"
  name "Kryptor"
  desc "A simple, modern, and secure encryption and signing tool."
  homepage "https://www.kryptor.co.uk/"

  app "Kryptor.app"
end
```