### PR TITLE
synced_versions_formulae: add `fbthrift`

### DIFF
--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -13,7 +13,7 @@
   ["docker", "docker-completion"],
   ["etl", "synfig"],
   ["file-formula", "libmagic"],
-  ["fizz", "folly", "wangle", "watchman"],
+  ["fbthrift", "fizz", "folly", "wangle", "watchman"],
   ["frpc", "frps"],
   ["gcc", "i686-elf-gcc", "libgccjit", "x86_64-elf-gcc"],
   ["ghz", "ghz-web"],


### PR DESCRIPTION
This has the same version scheme as fizz, folly, wangle and watchman.