### PR TITLE
libswiften: disable

### DIFF
--- a/Formula/libswiften.rb
+++ b/Formula/libswiften.rb
@@ -17,6 +17,10 @@ class Libswiften < Formula
     sha256 cellar: :any, sierra:      "07e2d9467520a4c814e15b5328bec8b989449284161c66e120b036f09eed8d14"
   end
 
+  # All the scons scripts are Python 2 only
+  # Upstream does not look active with no release in the last 4 years
+  disable! date: "2022-01-17", because: :does_not_build
+
   depends_on "scons" => :build
   depends_on "boost"
   depends_on "libidn"


### PR DESCRIPTION
This does not build:
File "/tmp/libswiften-20220117-7737-1w85t90/swift-4.0.2/BuildTools/SCons/Version.py", line 166
      windowsVersionMapping = list(map(lambda (x,y): (x, convertToWindowsVersion(x)), versionStringsWithOldVersions))
                                              ^
  SyntaxError: invalid syntax

No release in the last 4 years
I checked and there are some more places where the scons scripts are Python only
Last bottle was built for Cataline

Download counts are low:
install: 3 (30 days), 10 (90 days), 25 (365 days)
install-on-request: 3 (30 days), 10 (90 days), 25 (365 days)
build-error: 2 (30 days)

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
