### PR TITLE
gobject-introspection: fix doctemplates error

### DIFF
--- a/Formula/gobject-introspection.rb
+++ b/Formula/gobject-introspection.rb
@@ -82,6 +82,14 @@ class GobjectIntrospection < Formula
     sha256 "56312cd45b2b3a7fd74eaae89843a49b9a06d1423785fb57416a8a61b1cb811f"
   end
 
+  # Upstream patch for doctemplates error
+  # Review for removal at version bump
+  # See: https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/414
+  patch do
+    url "https://gitlab.gnome.org/GNOME/gobject-introspection/-/commit/effb1e09dee263cdac4ec593e8caf316e6f01fe2.diff"
+    sha256 "e0f4932f230a26563c0948b83d3ec347b7ecd195503a6d4f1519a276a8022b95"
+  end
+
   def install
     ENV["GI_SCANNER_DISABLE_CACHE"] = "true"
     inreplace "giscanner/transformer.py", "/usr/share", "#{HOMEBREW_PREFIX}/share"


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/issues/92992 and https://github.com/Homebrew/homebrew-core/issues/93211.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
