### PR TITLE
epsilon: regenerate `configure`

### DIFF
--- a/Formula/epsilon.rb
+++ b/Formula/epsilon.rb
@@ -3,7 +3,10 @@ class Epsilon < Formula
   homepage "https://epsilon-project.sourceforge.io"
   url "https://downloads.sourceforge.net/project/epsilon-project/epsilon/0.9.2/epsilon-0.9.2.tar.gz"
   sha256 "5421a15969d4d7af0ac0a11d519ba8d1d2147dc28d8c062bf0c52f3a0d4c54c4"
-  license "GPL-3.0"
+  license all_of: [
+    "BSD-3-Clause",
+    any_of: ["GPL-3.0-or-later", "LGPL-3.0-or-later"],
+  ]
 
   livecheck do
     url :stable
@@ -22,9 +25,14 @@ class Epsilon < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "d74732822ae5b53c57fc5bc613e70de84daca229438e47739c875f6dc50b21b1"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "popt"
 
   def install
+    # None of our patches apply, so regenerate `configure` to fix the `-flat_namespace` bug.
+    system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

None of our `-flat_namespace` patches apply, so let's regenerate
`configure` instead.

Also, I've updated the license based on Debian's copyright file.

This is needed for bottling on Monterey.