### PR TITLE
joplin-cli: depend on `cmake`

### DIFF
--- a/Formula/joplin-cli.rb
+++ b/Formula/joplin-cli.rb
@@ -14,6 +14,7 @@ class JoplinCli < Formula
     sha256 catalina:      "248fab15de1b4c16463ec33bf6b2dd9b3f7ecdc64a8e463d38530c3143e64934"
   end
 
+  depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "node"
   depends_on "sqlite"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes
```
  npm ERR! ERR! OMG CMake executable is not found. Please use your system's package manager to install it, or you can get installers from there: http://cmake.org.
```

https://github.com/Homebrew/homebrew-core/runs/4853645201?check_suite_focus=true#step:8:6422