### PR TITLE
libadwaita 1.0.1 (new formula)

### DIFF
--- a/Formula/libadwaita.rb
+++ b/Formula/libadwaita.rb
@@ -1,0 +1,45 @@
+class Libadwaita < Formula
+  desc "Building blocks for modern adaptive GNOME applications"
+  homepage "https://gnome.pages.gitlab.gnome.org/libadwaita/"
+  url "https://download.gnome.org/sources/libadwaita/1.0/libadwaita-1.0.1.tar.xz"
+  sha256 "bb49cf5a09d2e8bc144946c2c3272aecd611667fd027f3808b95d7101ed473d6"
+  license "LGPL-2.1-or-later"
+
+  depends_on "gobject-introspection" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "sassc" => :build
+  depends_on "vala" => :build
+  depends_on "gtk4"
+
+  def install
+    args = std_meson_args + %w[
+      -Dtests=false
+    ]
+
+    mkdir "build" do
+      system "meson", *args, ".."
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <adwaita.h>
+
+      int main(int argc, char *argv[]) {
+        g_autoptr (AdwApplication) app = NULL;
+        app = adw_application_new ("org.example.Hello", G_APPLICATION_FLAGS_NONE);
+        return g_application_run (G_APPLICATION (app), argc, argv);
+      }
+    EOS
+    flags = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs libadwaita-1").strip.split
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test", "--help"
+
+    # include a version check for the pkg-config files
+    assert_match version.to_s, (lib/"pkgconfig/libadwaita-1.pc").read
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Thanks to @Cogitri for his (closed) PR #80282 for an alpha version which I used as a reference in creating this one. I talked to him privately and we agreed that I would open this PR, now that both libadwaita had its 1.0 release and GTK 4.6 have been released, as he's no longer actively using macOS. (libadwaita requires GTK >= 4.5, so 4.6 is the first stable release which satisfies its requirements.)

On the matter of naming the formula, I think it should be called `libadwaita-1` (rather than simply `libadwaita`) as in the future multiple incompatible major versions of libadwaita might need to coexist, similarly to how there's now a `gtk4` formula which needs to be able to coexist with `gtk+3`. `libadwaita-1` is also the name of the `pkg-config` package which the upstream installs, presumably for the same reason.