### PR TITLE
midgard2: patch incorrect -flat_namespace usage

### DIFF
--- a/Formula/midgard2.rb
+++ b/Formula/midgard2.rb
@@ -1,10 +1,19 @@
 class Midgard2 < Formula
   desc "Generic content repository for web and desktop applications"
   homepage "http://www.midgard-project.org/"
-  url "https://github.com/downloads/midgardproject/midgard-core/midgard2-core-12.09.tar.gz"
-  sha256 "7c1d17e061df8f3b39fd8944ab97ab7220219b470f7874e74471702d2caca2cb"
   license "LGPL-2.0"
   revision 2
+
+  stable do
+    url "https://github.com/downloads/midgardproject/midgard-core/midgard2-core-12.09.tar.gz"
+    sha256 "7c1d17e061df8f3b39fd8944ab97ab7220219b470f7874e74471702d2caca2cb"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
+      sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
+    end
+  end
 
   bottle do
     sha256 arm64_big_sur: "60df7b2c0c5128949c9ad6c8cea8bce50b2abbbf1405da2e2a7681745eea90d0"


### PR DESCRIPTION
This is needed for bottling on Monterey.
