### PR TITLE
edge-impulse-cli 1.14.2 (new formula)

### DIFF
--- a/Formula/edge-impulse-cli.rb
+++ b/Formula/edge-impulse-cli.rb
@@ -1,0 +1,23 @@
+require "language/node"
+
+class EdgeImpulseCli < Formula
+  desc "Command-line interface tools for Edge Impulse"
+  homepage "https://github.com/edgeimpulse/edge-impulse-cli"
+  url "https://registry.npmjs.org/edge-impulse-cli/-/edge-impulse-cli-1.14.2.tgz"
+  sha256 "ecbd5eb1b5acad313db98cf326349bab6a13f663146f3726bce0f497c30991b8"
+  license "Apache-2.0"
+
+  depends_on "python@3.9" => :build
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match "Invalid API key", shell_output(
+      "edge-impulse-uploader --api-key notarealkey --category training path/to/file.wav 2>&1", 1
+    )
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Edge Impulse is the leading open source development platform for machine learning on edge devices.

For more information check https://edgeimpulse.com/