### PR TITLE
darkstat 3.0.721

### DIFF
--- a/Formula/darkstat.rb
+++ b/Formula/darkstat.rb
@@ -1,13 +1,10 @@
 class Darkstat < Formula
   desc "Network traffic analyzer"
   homepage "https://unix4lyfe.org/darkstat/"
-  url "https://unix4lyfe.org/darkstat/darkstat-3.0.719.tar.bz2"
-  sha256 "aeaf909585f7f43dc032a75328fdb62114e58405b06a92a13c0d3653236dedd7"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?darkstat[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  url "https://github.com/emikulic/darkstat/archive/3.0.721.tar.gz"
+  sha256 "0b405a6c011240f577559d84db22684a6349b25067c3a800df12439783c25494"
+  license all_of: ["BSD-4-Clause-UC", "GPL-2.0-only", "GPL-3.0-or-later", "X11"]
+  head "https://github.com/emikulic/darkstat.git", branch: "master"
 
   bottle do
     rebuild 1
@@ -22,11 +19,8 @@ class Darkstat < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:     "4e67244fc36d17dbdbe9ae33cc38bd79d2e016eeed0139c164d323e89b15c15e"
   end
 
-  head do
-    url "https://www.unix4lyfe.org/git/darkstat", using: :git
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-  end
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
 
   # Patch reported to upstream on 2017-10-08
   # Work around `redefinition of clockid_t` issue on 10.12 SDK or newer
@@ -36,7 +30,7 @@ class Darkstat < Formula
   end
 
   def install
-    system "autoreconf", "-iv" if build.head?
+    system "autoreconf", "-iv"
     system "./configure", "--disable-debug", "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Sometime after 2021-12-11 (maybe a week ago), the [`darkstat` homepage](https://unix4lyfe.org/darkstat/) was updated to link to the [GitHub project](https://github.com/emikulic/darkstat) for releases. Previously, the homepage linked to a first-party tarball, as seen in the [2021-12-11 snapshot on archive.org](https://web.archive.org/web/20211211202223/https://unix4lyfe.org/darkstat/).

With that in mind, this PR updates `darkstat` to the latest version from GitHub, 3.0.721. The autogenerated tarball from GitHub doesn't contain a `configure` file (like the older first-party tarballs did), so the `head` dependencies and build steps are now necessary for `stable` builds as well.

---

Lastly, this adds `license` information by referencing source files. The `LICENSE` file is a bit ambiguous and simply states:

```
Parts of the darkstat source code are covered by a BSD license (actually
closer to the ISC license template favored by the OpenBSD project).
These are usually the more generalized, reusable parts of the code.

Other parts of the darkstat code are covered by the GPL.  These other
parts are usually not generic code, but are specific to darkstat and its
purpose.

All of the source code is clearly annotated to show which license covers
which parts.

Due to the viral nature of the GPL, once linked, the entire darkstat
binary is infected with the GPL.
```

The GPL 2.0 license comments I saw didn't contain "or...later" language (e.g., [`dns.h`](https://github.com/emikulic/darkstat/blob/master/dns.h)) but the GPL 3.0 comments did (e.g., [`contrib/darkstat_export`](https://github.com/emikulic/darkstat/blob/master/contrib/darkstat_export)). The file that uses a BSD license ([`queue.h`](https://github.com/emikulic/darkstat/blob/master/queue.h)) is closest to `BSD-4-Clause-UC` but the third clause is omitted (whether intentionally or accidentally) and I'm not sure what to make of that. The [`install-sh` file](https://github.com/emikulic/darkstat/blob/master/install-sh) uses the X11 license.