### PR TITLE
stdman: change description to strip C++ version

### DIFF
--- a/Formula/stdman.rb
+++ b/Formula/stdman.rb
@@ -1,5 +1,5 @@
 class Stdman < Formula
-  desc "Formatted C++ language & standard library man pages from cppreference.com"
+  desc "Formatted C++ stdlib man pages from cppreference.com"
   homepage "https://github.com/jeaye/stdman"
   url "https://github.com/jeaye/stdman/archive/2021.12.21.tar.gz"
   sha256 "5cfea407f0cd6da0c66396814cafc57504e90df518b7c9fa3748edd5cfdd08e3"

--- a/Formula/stdman.rb
+++ b/Formula/stdman.rb
@@ -1,5 +1,5 @@
 class Stdman < Formula
-  desc "Formatted C++11/14/17 stdlib man pages from cppreference.com"
+  desc "Formatted C++ language & standard library man pages from cppreference.com"
   homepage "https://github.com/jeaye/stdman"
   url "https://github.com/jeaye/stdman/archive/2021.12.21.tar.gz"
   sha256 "5cfea407f0cd6da0c66396814cafc57504e90df518b7c9fa3748edd5cfdd08e3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`stdman` is a package providing C++ man pages from cppreference.com. It is not restricted to C++11/14/17 since C++20 and 23 documentations had already appeared, and probably we shouldn't depend on specific C++ versions in the description.

An alternative approach is to adopt the [repo](https://github.com/jeaye/stdman)'s description, `Formatted C++20 stdlib man pages (cppreference)`. But I do not really think that is a good description due to depending on version names either. If we promise to update the description every new release then probably that will be worth it. I can change to this if the Homebrew maintainers wish to follow the official repo description.
