### PR TITLE
lighttpd: update `livecheck` URL

### DIFF
--- a/Formula/lighttpd.rb
+++ b/Formula/lighttpd.rb
@@ -6,7 +6,7 @@ class Lighttpd < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://download.lighttpd.net/lighttpd/releases-1.4.x/"
+    url "https://www.lighttpd.net/download/"
     regex(/href=.*?lighttpd[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `livecheck` URL for `lighttpd`. The current URL contains the major and minor version, so `livecheck` might be unable to retrieve the correct latest version if/when there's a major or minor version bump. By checking the downloads page, we can avoid this problem.