### PR TITLE
ipinfo: add livecheck, license

### DIFF
--- a/Formula/ipinfo.rb
+++ b/Formula/ipinfo.rb
@@ -3,6 +3,14 @@ class Ipinfo < Formula
   homepage "https://kyberdigi.cz/projects/ipinfo/"
   url "https://kyberdigi.cz/projects/ipinfo/files/ipinfo-1.2.tar.gz"
   sha256 "19e6659f781a48b56062a5527ff463a29c4dcc37624fab912d1dce037b1ddf2d"
+  license "Beerware"
+
+  # The content of the download page is generated using JavaScript and software
+  # versions are the first string in certain array literals in the page source.
+  livecheck do
+    url :homepage
+    regex(/(?:new Array\(|\[)["']v?(\d+(?:\.\d+)+)["'],/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "e36096abf98dc91542e89ef61e240b9470d7b4203d721f18d9e0021a0bc373e8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, `brew livecheck` is unable to check `ipinfo`. This PR adds a `livecheck` block that identifies version information from JavaScript in the homepage source, as the download "page" is rendered client-side. This method can break in the future but there isn't any alternative (e.g., there isn't a directory listing page for the related tarballs).

This also specifies the `license` as [Beerware](https://spdx.org/licenses/Beerware.html). The `LICENSE` file in the tarball states:

```
"THE BEER-WARE LICENSE" (Revision 42):

<mccohy@kyberdigi.cz> wrote this file. As long as you retain this notice you
can do whatever you want with this stuff. If we meet some day, and you think
this stuff is worth it, you can buy me a beer in return
```

The homepage also contains the following text:

> **Licence Beerware, revize 42:**
> As long as you retain this notice you can do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return.