### PR TITLE
sc-im: default to native clipboard on macOS

### DIFF
--- a/Formula/sc-im.rb
+++ b/Formula/sc-im.rb
@@ -27,7 +27,20 @@ class ScIm < Formula
   uses_from_macos "bison" => :build
 
   def install
+    # Enable plotting with `gnuplot` if available.
+    ENV.append_to_cflags "-DGNUPLOT"
+
     cd "src" do
+      inreplace "Makefile" do |s|
+        # Increase `MAXROWS` to the maximum possible value.
+        # This is the same limit that Microsoft Excel has.
+        s.gsub! "MAXROWS=65536", "MAXROWS=1048576"
+        if OS.mac?
+          # Use `pbcopy` and `pbpaste` as the default clipboard commands.
+          s.gsub!(/^CFLAGS.*(xclip|tmux).*/, "#\\0")
+          s.gsub!(/^#(CFLAGS.*pb(copy|paste).*)$/, "\\1")
+        end
+      end
       system "make", "prefix=#{prefix}"
       system "make", "prefix=#{prefix}", "install"
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The Makefile has the option to use `pbcopy` and `pbpaste` as the default
clipboard commands, but leaves them commented out with the suggestion to
uncomment these lines if you want to use them. Let's do that on macOS
since the alternative clipboard commands (`tmux` and `xclip`) require
additional dependencies.

While we're here, let's also adjust the maximum number of allowed rows
to the largest possible value. The default is set so that this can run
on devices with limited memory, but that's not really an issue for us.

We also define `-DGNUPLOT` to enable use of `gnuplot` for plotting if
available on the user's system.

Other package managers (e.g. Termux, MacPorts) make the same changes to
their build (where applicable).