### PR TITLE
jsmin 2019-10-30

### DIFF
--- a/Formula/jsmin.rb
+++ b/Formula/jsmin.rb
@@ -1,9 +1,17 @@
 class Jsmin < Formula
   desc "Minify JavaScript code"
   homepage "https://www.crockford.com/javascript/jsmin.html"
-  url "https://github.com/douglascrockford/JSMin/archive/1bf6ce5f74a9f8752ac7f5d115b8d7ccb31cfe1b.tar.gz"
-  version "2013-03-29"
-  sha256 "aae127bf7291a7b2592f36599e5ed6c6423eac7abe0cd5992f82d6d46fe9ed2d"
+  url "https://github.com/douglascrockford/JSMin/archive/430bfe68dc0823d8c0f92c08d426e517cbc8de5e.tar.gz"
+  version "2019-10-30"
+  sha256 "24e3ad04979ace5d734e38b843f62f0dc832f94f5ba48642da31b4a33ccec9ac"
+  license "JSON"
+
+  # The GitHub repository doesn't contain any tags, so we have to check the
+  # date in the comment at the top of the `jsmin.c` file.
+  livecheck do
+    url "https://raw.githubusercontent.com/douglascrockford/JSMin/master/jsmin.c"
+    regex(/jsmin\.c\s*(\d{4}-\d{1,2}-\d{1,2})/im)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "e471be3d192ef30727fd5f4091216cc04409092d9db4d0ecc89854a668c06afd"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `jsmin` to the latest version, 2019-10-30. This date comes from the starting comment in the `jsmin.c` file but the commit I'm using here is really from 2019-10-31. The date change in the `jsmin.c` file was introduced on 2019-10-30 but then a few follow-up commits were made with fixes (but no date change) and I figured it made sense to include those.

This also adds a `livecheck` block that checks the date in the comment at the top of the `jsmin.c` file. Between the homepage and GitHub repository, this is the only available version information to check (i.e., there's no version information on the homepage, no tags in the repository, etc.). I'm not fond of this approach but I don't see a better alternative.

Lastly, this specifies the license as [JSON](https://spdx.org/licenses/JSON.html), referencing the comment at the top of the [`jsmin.c` file](https://github.com/douglascrockford/JSMin/blob/master/jsmin.c):

```
Copyright (C) 2002 Douglas Crockford  (www.crockford.com)

Permission is hereby granted, free of charge, to any person obtaining a copy of
this software and associated documentation files (the "Software"), to deal in
the Software without restriction, including without limitation the rights to
use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
of the Software, and to permit persons to whom the Software is furnished to do
so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

The Software shall be used for Good, not Evil.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.
```