### PR TITLE
juliaup: add julia symlink and remove juliainstaller

### DIFF
--- a/Formula/juliaup.rb
+++ b/Formula/juliaup.rb
@@ -20,7 +20,10 @@ class Juliaup < Formula
   conflicts_with "julia", because: "both install `julia` binaries"
 
   def install
-    system "cargo", "install", *std_cargo_args
+    system "cargo", "install", "--bin", "juliaup", *std_cargo_args
+    system "cargo", "install", "--bin", "julialauncher", *std_cargo_args
+
+    bin.install_symlink "julialauncher" => "julia"
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR does two things:
- It  only compiles two of the three binaries that are part of `juliaup`. The third one, that is now excluded, is a standalone installer binary that should not be distributed when `juliaup` is acquired via a package manager like `brew`.
- It adds a symlink so that the `julia` command starts `julialauncher`. That is needed for the entire system to work properly and something that is done also on all other platforms/package managers where `juliaup` is installed. I also added the required conflict information for that.

I have never done anything with brew, so very possible that there is some mistake in here, please just let me know and I'll try to fix it! I did follow the (excellent) docs on how to do all this.