### PR TITLE
lynis 3.0.7

### DIFF
--- a/Formula/lynis.rb
+++ b/Formula/lynis.rb
@@ -1,14 +1,9 @@
 class Lynis < Formula
   desc "Security and system auditing tool to harden systems"
   homepage "https://cisofy.com/lynis/"
-  url "https://github.com/CISOfy/lynis/archive/3.0.6.tar.gz"
-  sha256 "584ed6f6fa9dedeea1b473d888a4fe92fa9716400284fe41c92aed09cf10ec3e"
+  url "https://github.com/CISOfy/lynis/archive/3.0.7.tar.gz"
+  sha256 "13cedb14b17f0fff6c0ae7cdcc0550a887975bb3da4db96b47b2caf41c1c143b"
   license "GPL-3.0-only"
-
-  livecheck do
-    url "https://cisofy.com/downloads/lynis/"
-    regex(%r{href=.*?/lynis[._-]v?(\d+(?:\.\d+)+)\.t}i)
-  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "fc0a9524b52fc385fe438af0ec82772adffd8eb80fe8e54207130cb2945b1102"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `lynis` to the latest version, 3.0.7.

This also removes the `livecheck` block, which was created at a time when we were using tarballs from the first-party website (before the PR for version 3.0.1). The check is currently broken because the tarball link on the [first-party download page](https://cisofy.com/downloads/lynis/) is missing the `.tar.gz` extension (i.e., https://downloads.cisofy.com/lynis/lynis-3.0.7 404s but https://downloads.cisofy.com/lynis/lynis-3.0.7.tar.gz exists).

Updating the regex to `/href=.*?lynis[._-]v?(\d+(?:\.\d+)+)(?:\.t)?/i` would fix the check but removing the `livecheck` block is more appropriate in this context. Without the `livecheck` block, livecheck will check Git tags from the `stable` URL by default, aligning the check with the `stable` source (which is preferred).