### PR TITLE
composer 2.2.5

### DIFF
--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -1,8 +1,8 @@
 class Composer < Formula
   desc "Dependency Manager for PHP"
   homepage "https://getcomposer.org/"
-  url "https://getcomposer.org/download/2.2.4/composer.phar"
-  sha256 "ba04e246960d193237d5ed6542bd78456898e7787fafb586f500c6807af7458d"
+  url "https://getcomposer.org/download/2.2.5/composer.phar"
+  sha256 "81ef304a70c957d6f05a7659f03b00eb50df6155195f51118459b2e49c96c3f3"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 2,358,836 bytes
- formula fetch time: 1.7 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.