### PR TITLE
aerc: Set SHAREDIR to symlink rather than {prefix}

### DIFF
--- a/Formula/aerc.rb
+++ b/Formula/aerc.rb
@@ -4,6 +4,7 @@ class Aerc < Formula
   url "https://git.sr.ht/~rjarry/aerc/archive/0.7.1.tar.gz"
   sha256 "e149236623c103c8526b1f872b4e630e67f15be98ac604c0ea0186054dbef0cc"
   license "MIT"
+  revision 1
 
   bottle do
     sha256                               arm64_monterey: "57d6954219e420d87ac3eb38d66c832c5b4ddb3b16aabfd49924627fbf749007"
@@ -18,7 +19,7 @@ class Aerc < Formula
   depends_on "scdoc" => :build
 
   def install
-    system "make", "PREFIX=#{prefix}"
+    system "make", "SHAREDIR=#{opt_pkgshare}", "PREFIX=#{prefix}"
     system "make", "install", "PREFIX=#{prefix}"
   end
 


### PR DESCRIPTION
This commit changes the way aerc is built from source to enable seamless upgrades on the same machine.

When aerc is run for the first time, a preferences file is written to `~/Library/Preferences/aerc.conf` that includes references to the Cellar directory that Homebrew maintains. This breaks after an update because the directory is versioned and still references the old version.

This commit instead makes aerc use the symlink at `/usr/local/share` which is also maintained by Homebrew and always points at the current version installed by the user.

Fixes: #93407

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?