### PR TITLE
languagetool: add service to run languagetool-server

### DIFF
--- a/Formula/languagetool.rb
+++ b/Formula/languagetool.rb
@@ -43,34 +43,11 @@ class Languagetool < Formula
     EOS
   end
 
-  plist_options manual: "#{HOMEBREW_PREFIX}/bin/languagetool-server --port 8081 --allow-origin"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{HOMEBREW_PREFIX}/bin/languagetool-server</string>
-          <string>--port</string>
-          <string>8081</string>
-          <string>--allow-origin</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>KeepAlive</key>
-        <true/>
-        <key>StandardOutPath</key>
-        <string>#{var}/log/languagetool/languagetool-server.log</string>
-        <key>StandardErrorPath</key>
-        <string>#{var}/log/languagetool/languagetool-server.log</string>
-      </dict>
-      </plist>
-    EOS
+  service do
+    run [bin/"languagetool-server", "--port", "8081", "--allow-origin"]
+    keep_alive true
+    log_path var/"log/languagetool/languagetool-server.log"
+    error_log_path var/"log/languagetool/languagetool-server.log"
   end
 
   test do

--- a/Formula/languagetool.rb
+++ b/Formula/languagetool.rb
@@ -43,6 +43,36 @@ class Languagetool < Formula
     EOS
   end
 
+  plist_options manual: "#{HOMEBREW_PREFIX}/bin/languagetool-server --port 8081 --allow-origin"
+
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{HOMEBREW_PREFIX}/bin/languagetool-server</string>
+          <string>--port</string>
+          <string>8081</string>
+          <string>--allow-origin</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <true/>
+        <key>StandardOutPath</key>
+        <string>#{var}/log/languagetool/languagetool-server.log</string>
+        <key>StandardErrorPath</key>
+        <string>#{var}/log/languagetool/languagetool-server.log</string>
+      </dict>
+      </plist>
+    EOS
+  end
+
   test do
     (testpath/"test.txt").write <<~EOS
       Homebrew, this is an test


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds a service block to the formula to run the languagetool-server.
@languagetool-org