### PR TITLE
ecl: update urls

### DIFF
--- a/Formula/ecl.rb
+++ b/Formula/ecl.rb
@@ -1,14 +1,14 @@
 class Ecl < Formula
   desc "Embeddable Common Lisp"
-  homepage "https://common-lisp.net/project/ecl/"
-  url "https://common-lisp.net/project/ecl/static/files/release/ecl-21.2.1.tgz"
+  homepage "https://ecl.common-lisp.dev"
+  url "https://ecl.common-lisp.dev/static/files/release/ecl-21.2.1.tgz"
   sha256 "b15a75dcf84b8f62e68720ccab1393f9611c078fcd3afdd639a1086cad010900"
   license "LGPL-2.1-or-later"
   revision 1
   head "https://gitlab.com/embeddable-common-lisp/ecl.git", branch: "develop"
 
   livecheck do
-    url "https://common-lisp.net/project/ecl/static/files/release/"
+    url "https://ecl.common-lisp.dev/static/files/release/"
     regex(/href=.*?ecl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`common-lisp.net/project/ecl/` URLs in the `ecl` formula are redirecting to `ecl.common-lisp.dev`. This PR updates these URLs to avoid the redirection.