### PR TITLE
rarian: regenerate `configure`

### DIFF
--- a/Formula/rarian.rb
+++ b/Formula/rarian.rb
@@ -3,6 +3,7 @@ class Rarian < Formula
   homepage "https://rarian.freedesktop.org/"
   url "https://rarian.freedesktop.org/Releases/rarian-0.8.1.tar.bz2"
   sha256 "aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://rarian.freedesktop.org/Releases/"
@@ -21,12 +22,27 @@ class Rarian < Formula
     sha256 x86_64_linux:  "13a02a92eb31d5071c87d10e227c419a6a2506f1407f6bb6a08b7ca2581a9645"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
   conflicts_with "scrollkeeper",
     because: "rarian and scrollkeeper install the same binaries"
 
   def install
+    # Regenerate `configure` to fix `-flat_namespace` bug.
+    system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  test do
+    seriesid1 = shell_output(bin/"rarian-sk-gen-uuid").strip
+    sleep 5
+    seriesid2 = shell_output(bin/"rarian-sk-gen-uuid").strip
+    assert_match(/^\h+(?:-\h+)+$/, seriesid1)
+    assert_match(/^\h+(?:-\h+)+$/, seriesid2)
+    refute_equal seriesid1, seriesid2
   end
 end


### PR DESCRIPTION
This is affected by the `-flat_namespace` bug from Libtool, but none of
our patches apply. Let's regenerate the `configure` script instead.

This is needed for bottling on Monterey.

While we're here, let's add a `test` block and specify the `license`.
