### PR TITLE
texlive, lcdf-typetools: add conflict

### DIFF
--- a/Formula/lcdf-typetools.rb
+++ b/Formula/lcdf-typetools.rb
@@ -23,6 +23,8 @@ class LcdfTypetools < Formula
     sha256 x86_64_linux:   "ba34cee40d5450d1deba4434cc43458d5407ef47b9f0563530b04dfac8fadc7a"
   end
 
+  conflicts_with "texlive", because: "both install a `cfftot1` executable"
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -66,6 +66,7 @@ class Texlive < Formula
   end
 
   conflicts_with "cweb", because: "both install `cweb` binaries"
+  conflicts_with "lcdf-typetools", because: "both install a `cfftot1` executable"
 
   fails_with gcc: "5"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- texlive: conflict with `lcdf-typetools`
- lcdf-typetools: conflict with `texlive`

Fixes a CI failure spotted in #93226.
