### PR TITLE
aws-apigateway-importer: disable

### DIFF
--- a/Formula/aws-apigateway-importer.rb
+++ b/Formula/aws-apigateway-importer.rb
@@ -15,7 +15,8 @@ class AwsApigatewayImporter < Formula
     sha256 cellar: :any_skip_relocation, yosemite:    "bbe12dac66d033674840eace741bcf5c3549e7317ab9ca6fa9f349418a6c9861"
   end
 
-  deprecate! date: "2020-11-12", because: :repo_archived
+  # Original deprecation date: 2020-11-12
+  disable! date: "2022-01-22", because: :repo_archived
 
   depends_on "maven" => :build
   depends_on "openjdk@8"


### PR DESCRIPTION
This is deprecated since 2 years now
Download counts are low:
==> Analytics
install: 16 (30 days), 48 (90 days), 225 (365 days)
install-on-request: 16 (30 days), 48 (90 days), 225 (365 days)
build-error: 0 (30 days)

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
