### PR TITLE
rpm: fix build on Apple Silicon

### DIFF
--- a/Formula/rpm.rb
+++ b/Formula/rpm.rb
@@ -19,6 +19,10 @@ class Rpm < Formula
     sha256 x86_64_linux: "1147c07948c53779fdf751623b349d6da6d6b4753103ce2c898da2cc68a0a041"
   end
 
+  # We need autotools for the Lua patch below. Remove when the patch is no longer needed.
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "berkeley-db"
   depends_on "gettext"
   depends_on "libarchive"
@@ -32,10 +36,21 @@ class Rpm < Formula
   depends_on "xz"
   depends_on "zstd"
 
-  # Fix -flat_namespace being used on Big Sur and later.
+  # Fix `fstat64` detection for Apple Silicon.
+  # https://github.com/rpm-software-management/rpm/pull/1775
+  # https://github.com/rpm-software-management/rpm/pull/1897
+  if Hardware::CPU.arm?
+    patch do
+      url "https://github.com/rpm-software-management/rpm/commit/ad87ced3990c7e14b6b593fa411505e99412e248.patch?full_index=1"
+      sha256 "a129345c6ba026b337fe647763874bedfcaf853e1994cf65b1b761bc2c7531ad"
+    end
+  end
+
+  # Remove defunct Lua rex extension, which causes linking errors with Homebrew's Lua.
+  # https://github.com/rpm-software-management/rpm/pull/1797/files
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
-    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    url "https://github.com/rpm-software-management/rpm/commit/83d781c442158ce61286ac68cc350d10c2d3837e.patch?full_index=1"
+    sha256 "5dc9fb093ad46657575e5782d257d9b47d3c8119914283794464a84a7aef50b0"
   end
 
   def install
@@ -49,6 +64,9 @@ class Rpm < Formula
     inreplace "scripts/pkgconfigdeps.sh",
               "/usr/bin/pkg-config", Formula["pkg-config"].opt_bin/"pkg-config"
 
+    # Regenerate the `configure` script, since the lua patch touches luaext/Makefile.am.
+    # This also fixes the "-flat-namespace" bug. Remove `autoreconf` when the Lua patch is no longer needed.
+    system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
@@ -65,7 +83,10 @@ class Rpm < Formula
                           # Don't allow superenv shims to be saved into lib/rpm/macros
                           "__MAKE=/usr/bin/make",
                           "__GIT=/usr/bin/git",
-                          "__LD=/usr/bin/ld"
+                          "__LD=/usr/bin/ld",
+                          # GPG is not a strict dependency, so set stored GPG location to a decent default
+                          "__GPG=#{Formula["gpg"].opt_bin}/gpg"
+
     system "make", "install"
 
     # NOTE: We need the trailing `/` to avoid leaving it behind.
@@ -74,11 +95,6 @@ class Rpm < Formula
 
   def post_install
     (var/"lib/rpm").mkpath
-
-    if OS.mac?
-      # Attempt to fix expected location of GPG to a sane default.
-      inreplace lib/"rpm/macros", "/usr/bin/gpg2", HOMEBREW_PREFIX/"bin/gpg"
-    end
   end
 
   def test_spec


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Add two upstream patches to the RPM formula. The [first](https://github.com/rpm-software-management/rpm/pull/1775) addresses the usage of *64 stat symbols, which have been removed on the Apple Silicon toolchain. The [second](https://github.com/rpm-software-management/rpm/pull/1797) patch removes a broken Lua regular expression extension. This extension has been broken for fifteen years and references a symbol that has been removed in recent versions of Lua.

This PR also removes the generic libtools configure script patch (introduced in #87993) for fixing the flat namespace bug. This is not necessary anymore, as we regenerate the entire configure script due to the Lua patch touching a `Makefile.am` file.

I am a first-time contributor, so please let me know if there's anything I can do to improve this PR!