### PR TITLE
fbthrift: enable on Mojave

### DIFF
--- a/Formula/fbthrift.rb
+++ b/Formula/fbthrift.rb
@@ -30,14 +30,27 @@ class Fbthrift < Formula
   uses_from_macos "flex" => :build
   uses_from_macos "zlib"
 
+  on_macos do
+    depends_on "llvm" if DevelopmentTools.clang_build_version <= 1100
+  end
+
   on_linux do
     depends_on "gcc@10"
+  end
+
+  fails_with :clang do
+    build 1100
+    cause <<~EOS
+      error: 'asm goto' constructs are not supported yet
+    EOS
   end
 
   fails_with gcc: "5" # C++ 17
   fails_with gcc: "11" # https://github.com/facebook/folly#ubuntu-lts-centos-stream-fedora
 
   def install
+    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
+
     # The static libraries are a bit annoying to build. If modifying this formula
     # to include them, make sure `bin/thrift1` links with the dynamic libraries
     # instead of the static ones (e.g. `libcompiler_base`, `libcompiler_lib`, etc.)


### PR DESCRIPTION
`fbthrift` requires LLVM on Mojave and earlier, to support `asm goto`.

Does not affect supported platforms, so no revision bump. Tested on Catalina to verify that LLVM is not used.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
