### PR TITLE
verapdf 1.20.3 (new formula)

### DIFF
--- a/Formula/verapdf.rb
+++ b/Formula/verapdf.rb
@@ -1,0 +1,34 @@
+class Verapdf < Formula
+  desc "Open-source industry-supported PDF/A validation"
+  homepage "https://verapdf.org/home/"
+  url "https://github.com/veraPDF/veraPDF-apps/archive/refs/tags/v1.20.3.tar.gz"
+  sha256 "18288947ec21c5267512dc8d53582b7268d3124f5c3eda11e17f361b81b281c2"
+  license any_of: ["GPL-3.0-or-later", "MPL-2.0"]
+  head "https://github.com/veraPDF/veraPDF-apps.git", branch: "integration"
+
+  # Even-numbered minor versions represent stable releases.
+  livecheck do
+    url :stable
+    regex(/^v?(\d+\.\d*[02468](?:\.\d+)*)$/i)
+  end
+
+  depends_on "maven" => :build
+  depends_on "openjdk"
+
+  def install
+    system "mvn", "clean", "install"
+
+    installer_file = Pathname.glob("installer/target/verapdf-izpack-installer-*.jar").first
+    system "java", "-DINSTALL_PATH=#{libexec}", "-jar", installer_file, "-options-system"
+
+    bin.install libexec/"verapdf", libexec/"verapdf-gui"
+    bin.env_script_all_files libexec, Language::Java.overridable_java_home_env
+    prefix.install "tests"
+  end
+
+  test do
+    with_env(VERAPDF: "#{bin}/verapdf", NO_CD: "1") do
+      system prefix/"tests/exit-status.sh"
+    end
+  end
+end


### PR DESCRIPTION
Note that the results of the audit are the following.

```
verapdf-apps:                                                                                       
  * Non-executables were installed to "/opt/homebrew/opt/verapdf-apps/bin".                         
    The offending files are:                                                                        
      /opt/homebrew/opt/verapdf-apps/bin/greenfield-apps-1.21.0-SNAPSHOT.jar                        
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)                    
Error: 2 problems in 1 formula detected                                                             
```

However, the first point should be countered by the fact that the jar file is required by all the binaries in `bin/`, and this is the manner in which the software itself installs it. The second point should be countered by the fact that the veraPDF/veraPDF-library repo easily satisfies the notability constraint, and is the primary repo for all work on veraPDF (veraPDF-apps does *not* have its own issue tracker, for example), and apparently many people interested in veraPDF as a whole have only starred this repo.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for thexsame formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----