### PR TITLE
workflows/tests: set longer timeout for self-hosted Linux runner too

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,10 +190,11 @@ jobs:
           - runner: ${{needs.setup_tests.outputs.linux-runner}}
             container: ${{fromJson(needs.setup_tests.outputs.container)}}
             workdir: /github/home
+            timeout: 4320
       fail-fast: ${{fromJson(needs.setup_tests.outputs.fail-fast)}}
     runs-on: ${{matrix.runner}}
     container: ${{matrix.container}}
-    timeout-minutes: ${{ (runner.os == 'Linux' && 4320) || fromJson(needs.setup_tests.outputs.timeout-minutes) }}
+    timeout-minutes: ${{ matrix.timeout || fromJson(needs.setup_tests.outputs.timeout-minutes) }}
     defaults:
       run:
         shell: /bin/bash -e {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -193,7 +193,7 @@ jobs:
       fail-fast: ${{fromJson(needs.setup_tests.outputs.fail-fast)}}
     runs-on: ${{matrix.runner}}
     container: ${{matrix.container}}
-    timeout-minutes: ${{ (matrix.runner == 'ubuntu-latest' && 360) || fromJson(needs.setup_tests.outputs.timeout-minutes) }}
+    timeout-minutes: ${{ (runner.os == 'Linux' && 4320) || fromJson(needs.setup_tests.outputs.timeout-minutes) }}
     defaults:
       run:
         shell: /bin/bash -e {0}


### PR DESCRIPTION
The longer timeout is automatically set when we're using a GitHub runner
on Linux. Let's do the same when using the self-hosted Linux runner.

This is useful for formulae like `util-linux`, which take under an hour
to test on macOS but require the self-hosted Linux runner. See #93704.
