### PR TITLE
googler: deprecate

### DIFF
--- a/Formula/googler.rb
+++ b/Formula/googler.rb
@@ -6,14 +6,23 @@ class Googler < Formula
   url "https://github.com/jarun/googler/archive/v4.3.2.tar.gz"
   sha256 "bd59af407e9a45c8a6fcbeb720790cb9eccff21dc7e184716a60e29f14c68d54"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/jarun/googler.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "18cddbd924b8544fa84dce44221443c08053e1939f4b638538e0da04a696df03"
   end
 
+  deprecate! date: "2022-01-24", because: :repo_archived
+
   depends_on "python@3.10"
+
+  # Upstream PROTOCOL_TLS patch, review for removal on next release (if any)
+  # https://github.com/jarun/googler/pull/426
+  patch do
+    url "https://github.com/jarun/googler/commit/52e2da672911cd9186bd3497fcdf81149071e72b.patch?full_index=1"
+    sha256 "d8d8a813b6c0645990b8b1849718b0fc406f4201068ca483f27498599fd86cbf"
+  end
 
   def install
     rewrite_shebang detected_python_shebang, "googler"


### PR DESCRIPTION
Upstream author (Arun) confirmed via private email that the project repo was archived because he's no longer maintaining it.

Also apply upstream PROTOCOL_TLS patch that has been merged but not released (addresses https://github.com/Homebrew/discussions/discussions/2825).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
