### PR TITLE
montage: add head, license

### DIFF
--- a/Formula/montage.rb
+++ b/Formula/montage.rb
@@ -3,6 +3,8 @@ class Montage < Formula
   homepage "http://montage.ipac.caltech.edu"
   url "http://montage.ipac.caltech.edu/download/Montage_v4.0.tar.gz"
   sha256 "de143e4d4b65086f04bb75cf482dfa824965a5a402f3431f9bceb395033df5fe"
+  license "BSD-3-Clause"
+  head "https://github.com/Caltech-IPAC/Montage.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:     "304f02cffd94ee9e118026fda40db0f27d4ae25c2d42c74e45b3426d11f1ed3d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

By default, `brew livecheck` gives an `Unable to get versions` error for `montage`. It's possible to add a `livecheck` block to check the [first-party download page](http://montage.ipac.caltech.edu/docs/download2.html) but that page strongly directs users to use the GitHub repository instead of the tarballs on the download page (granted, I'm not sure if this is a temporary or permanent suggestion).

6.0 is the newest version (released on 2018-11-09) and there hasn't been a release since then. The formula isn't using 6.0 because a previous PR (#53118) encountered notable build issues. There have been ~27 commits in the GitHub repository since the 6.0 release (the latest on 2021-08-17) but even building from the `main` branch fails.

That said, it's currently unclear whether the download page will be updated if/when the next version past 6.0 is released or if the GitHub repository is now the canonical source for version information. In light of this ambiguity, I think it's fine to check the Git tags for now and we can adjust the check if/when the situation is clarified in the future.

With this in mind, this PR adds the GitHub repository as a `head` URL. As mentioned, building with `brew install --HEAD montage` fails at the moment but this will at least allow `livecheck` to automatically check the `head` URL using the `Git` strategy by default. I figured this may be better than a livecheck block using `url "https://github.com/Caltech-IPAC/Montage.git"` but we can go that route if we don't want to add a `head` URL if the build doesn't work.