### PR TITLE
litani 1.20.0 (new formula)

### DIFF
--- a/Formula/litani.rb
+++ b/Formula/litani.rb
@@ -1,0 +1,61 @@
+class Litani < Formula
+  include Language::Python::Virtualenv
+
+  desc "Metabuild system"
+  homepage "https://awslabs.github.io/aws-build-accumulator/"
+  url "https://github.com/awslabs/aws-build-accumulator.git",
+      tag:      "1.20.0",
+      revision: "e95f1e601ab62def0f3350906355978741b63830"
+  license "Apache-2.0"
+
+  depends_on "coreutils" => :build
+  depends_on "mandoc" => :build
+  depends_on "scdoc" => :build
+  depends_on "gnuplot"
+  depends_on "graphviz"
+  depends_on "ninja"
+  depends_on "python@3.9"
+
+  resource "Jinja2" do
+    url "https://files.pythonhosted.org/packages/39/11/8076571afd97303dfeb6e466f27187ca4970918d4b36d5326725514d3ed3/Jinja2-3.0.1.tar.gz"
+    sha256 "703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
+  end
+
+  resource "MarkupSafe" do
+    url "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz"
+    sha256 "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"
+  end
+
+  resource "PyYAML" do
+    url "https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz"
+    sha256 "607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"
+  end
+
+  def install
+    ENV.prepend_path "PATH", libexec/"vendor/bin"
+    venv = virtualenv_create(libexec/"vendor", "python3")
+    venv.pip_install resources
+
+    libexec.install Dir["*"] - ["test", "examples"]
+    (bin/"litani").write_env_script libexec/"litani", PATH: "\"#{libexec}/vendor/bin:${PATH}\""
+
+    cd libexec/"doc" do
+      system libexec/"vendor/bin/python3", "configure"
+      system "ninja", "--verbose"
+    end
+    man1.install libexec.glob("doc/out/man/*.1")
+    man5.install libexec.glob("doc/out/man/*.5")
+    man7.install libexec.glob("doc/out/man/*.7")
+    doc.install libexec/"doc/out/html/index.html"
+    rm_rf libexec/"doc"
+  end
+
+  test do
+    system bin/"litani", "init", "--project-name", "test-installation"
+    system bin/"litani", "add-job",
+           "--command", "/usr/bin/true",
+           "--pipeline-name", "test-installation",
+           "--ci-stage", "test"
+    system bin/"litani", "run-build"
+  end
+end


### PR DESCRIPTION
AWS Build Accumulator collects build jobs from multiple sources before
executing them concurrently. It provides platform-independent job
control (timeouts, return code control) and an output format that is
easy to render into reports. AWS Build Accumulator shines where your
project uses multiple different build systems or requires an unified
interface describing heterogeneous build jobs.
https://github.com/awslabs/aws-build-accumulator

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
