### PR TITLE
podman: make formula relocatable

### DIFF
--- a/Formula/podman.rb
+++ b/Formula/podman.rb
@@ -38,6 +38,10 @@ class Podman < Formula
     ENV["CGO_ENABLED"] = "1"
     os = OS.kernel_name.downcase
 
+    inreplace "vendor/github.com/containers/common/pkg/config/config_#{os}.go",
+              "/usr/local/libexec/podman",
+              libexec
+
     system "make", "podman-remote-#{os}"
     if OS.mac?
       bin.install "bin/#{os}/podman" => "podman-remote"


### PR DESCRIPTION
Applies the patch suggested in https://github.com/Homebrew/homebrew-core/pull/90379#issuecomment-986968635.

Refs: https://github.com/Homebrew/homebrew-core/pull/90379

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
