### PR TITLE
vermin 1.3.3 (new formula)

### DIFF
--- a/Formula/vermin.rb
+++ b/Formula/vermin.rb
@@ -1,0 +1,21 @@
+class Vermin < Formula
+  include Language::Python::Virtualenv
+
+  desc "Concurrently detect the minimum Python versions needed to run code"
+  homepage "https://github.com/netromdk/vermin"
+  url "https://github.com/netromdk/vermin/archive/v1.3.3.tar.gz"
+  sha256 "35cd8bc3f54f651dbb162a7b35b4b091409154ce6d565df043f7f04bf9401d7d"
+  license "MIT"
+  head "https://github.com/netromdk/vermin.git", branch: "master"
+
+  depends_on "python@3.10"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    path = libexec/"lib/python3.10/site-packages/vermin"
+    assert_match "Minimum required versions: 2.7, 3.0", shell_output("#{bin}/vermin -q #{path}")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I'm adding Vermin as formula. Vermin concurrently detects the minimum Python versions needed to run code.

The project has been around for about 4 years at this point and exists on other package repositories already:
- [PyPi](https://pypi.python.org/pypi/vermin/)
- [Spack](https://spack.io/) ([package](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/py-vermin/package.py)) - Vermin is also used internally to check Python packages in Spack
- [Arch Linux (AUR)](https://aur.archlinux.org/packages/python-vermin/)

It is currently [used in 44 repositories](https://github.com/netromdk/vermin/network/dependents?package_id=UGFja2FnZS01MjY4NjU4Nw%3D%3D) here on GitHub.