### PR TITLE
qsoas: fix build, use mruby 2

### DIFF
--- a/Formula/qsoas.rb
+++ b/Formula/qsoas.rb
@@ -4,6 +4,7 @@ class Qsoas < Formula
   url "https://bip.cnrs.fr/wp-content/uploads/qsoas/qsoas-3.0.tar.gz"
   sha256 "54b54f54363f69a9845b3e9aa4da7dae9ceb7bb0f3ed59ba92ffa3b408163850"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url "https://github.com/fourmond/QSoas.git"
@@ -16,17 +17,35 @@ class Qsoas < Formula
     sha256 cellar: :any, mojave:   "fc0e4157d6dd55ba6563e56c11af2da9106c88daadd2e94e809f4300fec5ad66"
   end
 
+  depends_on "bison" => :build
   depends_on "gsl"
-  depends_on "mruby"
   depends_on "qt@5"
 
+  uses_from_macos "ruby"
+
+  # Needs mruby 2, see https://github.com/fourmond/QSoas/issues/2
+  resource "mruby2" do
+    url "https://github.com/mruby/mruby/archive/2.1.2.tar.gz"
+    sha256 "4dc0017e36d15e81dc85953afb2a643ba2571574748db0d8ede002cefbba053b"
+  end
+
   def install
+    resource("mruby2").stage do
+      inreplace "build_config.rb", /default/, "full-core"
+      system "make"
+
+      cd "build/host/" do
+        libexec.install %w[bin lib mrbgems mrblib]
+      end
+
+      libexec.install "include"
+    end
+
     gsl = Formula["gsl"].opt_prefix
-    mruby = Formula["mruby"].opt_prefix
     qt5 = Formula["qt@5"].opt_prefix
 
-    system "#{qt5}/bin/qmake", "MRUBY_DIR=#{mruby}", "GSL_DIR=#{gsl}/include",
-                    "QMAKE_LFLAGS=-L#{mruby}/lib -L#{gsl}/lib"
+    system "#{qt5}/bin/qmake", "MRUBY_DIR=#{libexec}", "GSL_DIR=#{gsl}/include",
+                    "QMAKE_LFLAGS=-L#{libexec}/lib -L#{gsl}/lib"
     system "make"
 
     prefix.install "QSoas.app"


### PR DESCRIPTION
See https://github.com/fourmond/QSoas/issues/2
Fixes:
Undefined symbols for architecture x86_64:
"MRuby::detectParameters(QByteArray const&)", referenced from:
Expression::variablesNeeded(QString const&, QStringList const&) in expression.o
mRubyArgs(QString const&, QString, QHash<QString, ArgumentMarshaller*> const&) in mruby.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [QSoas.app/Contents/MacOS/QSoas] Error 1

Upstream says that only mruby is supported for the time being

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
