### PR TITLE
odo-dev 2.5.0 (new formula)

### DIFF
--- a/Formula/odo-dev.rb
+++ b/Formula/odo-dev.rb
@@ -1,0 +1,34 @@
+class OdoDev < Formula
+  desc "Developer-focused CLI for Kubernetes and OpenShift"
+  homepage "https://odo.dev"
+
+  url "https://github.com/redhat-developer/odo.git",
+    tag:      "v2.5.0",
+    revision: "724f16e689545dd4a81671da3e116a33df4832d3"
+
+  license "Apache-2.0"
+  head "https://github.com/redhat-developer/odo.git", branch: "main"
+
+  depends_on "go" => :build
+  conflicts_with "odo", because: "odo also ships 'odo' binary"
+
+  def install
+    system "make", "bin"
+    bin.install "odo"
+  end
+
+  test do
+    # try set preference
+    ENV["GLOBALODOCONFIG"] = "#{testpath}/preference.yaml"
+    shell_output("#{bin}/odo preference set ConsentTelemetry false")
+    assert_predicate testpath/"preference.yaml", :exist?
+
+    # test version
+    version_output = shell_output("#{bin}/odo version --client 2>&1").strip
+    tag = stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:tag]
+    short_rev = stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:revision].slice(0, 9)
+    assert_match "odo #{tag} (#{short_rev})", version_output
+
+    # almost all other odo commands require connection to OpenShift cluster
+  end
+end

--- a/Formula/odo-dev.rb
+++ b/Formula/odo-dev.rb
@@ -1,11 +1,9 @@
 class OdoDev < Formula
   desc "Developer-focused CLI for Kubernetes and OpenShift"
   homepage "https://odo.dev"
-
   url "https://github.com/redhat-developer/odo.git",
-    tag:      "v2.5.0",
-    revision: "724f16e689545dd4a81671da3e116a33df4832d3"
-
+      tag:      "v2.5.0",
+      revision: "724f16e689545dd4a81671da3e116a33df4832d3"
   license "Apache-2.0"
   head "https://github.com/redhat-developer/odo.git", branch: "main"
 

--- a/Formula/odo-dev.rb
+++ b/Formula/odo-dev.rb
@@ -25,9 +25,7 @@ class OdoDev < Formula
 
     # test version
     version_output = shell_output("#{bin}/odo version --client 2>&1").strip
-    tag = stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:tag]
-    short_rev = stable.instance_variable_get(:@resource).instance_variable_get(:@specs)[:revision].slice(0, 9)
-    assert_match "odo #{tag} (#{short_rev})", version_output
+    assert_match "odo #{version} (#{Utils.git_head})", version_output
 
     # almost all other odo commands require connection to OpenShift cluster
   end

--- a/Formula/odo-dev.rb
+++ b/Formula/odo-dev.rb
@@ -18,7 +18,7 @@ class OdoDev < Formula
   test do
     # try set preference
     ENV["GLOBALODOCONFIG"] = "#{testpath}/preference.yaml"
-    shell_output("#{bin}/odo preference set ConsentTelemetry false")
+    system bin/"odo", "preference", "set", "ConsentTelemetry", "false"
     assert_predicate testpath/"preference.yaml", :exist?
 
     # test version

--- a/Formula/odo-dev.rb
+++ b/Formula/odo-dev.rb
@@ -8,7 +8,6 @@ class OdoDev < Formula
   head "https://github.com/redhat-developer/odo.git", branch: "main"
 
   depends_on "go" => :build
-  conflicts_with "odo", because: "odo also ships 'odo' binary"
 
   def install
     system "make", "bin"
@@ -23,8 +22,13 @@ class OdoDev < Formula
 
     # test version
     version_output = shell_output("#{bin}/odo version --client 2>&1").strip
-    assert_match "odo #{version} (#{Utils.git_head})", version_output
+    assert_match(/odo v#{version} \([a-f0-9]{9}\)/, version_output)
 
-    # almost all other odo commands require connection to OpenShift cluster
+    # try to creation new component
+    system bin/"odo", "create", "nodejs"
+    assert_predicate testpath/"devfile.yaml", :exist?
+
+    push_output = shell_output("#{bin}/odo push 2>&1", 1).strip
+    assert_match("invalid configuration", push_output)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The proper name for this Formula would be "odo", but there already is [odo](https://github.com/Homebrew/homebrew-core/blob/master/Formula/odo.rb) Formula, so I named this "odo-dev" because odo.dev is a homepage for this project.





