### PR TITLE
mednafen: Explicitly enable Sega Saturn emulation

### DIFF
--- a/Formula/mednafen.rb
+++ b/Formula/mednafen.rb
@@ -4,6 +4,7 @@ class Mednafen < Formula
   url "https://mednafen.github.io/releases/files/mednafen-1.29.0.tar.xz"
   sha256 "da3fbcf02877f9be0f028bfa5d1cb59e953a4049b90fe7e39388a3386d9f362e"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://mednafen.github.io/releases/"
@@ -33,7 +34,7 @@ class Mednafen < Formula
   end
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
+    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking", "--enable-ss"
     system "make", "install"
   end
 


### PR DESCRIPTION
On macOS ARM (not tested on x86 or Linux), Mednafen is not built with the ss (Sega Saturn) module. Enabling the module with the argument in `./configure` works fine. From `./configure`:

```
--enable-ss             build with Sega Saturn emulation [[default=x86_64
                          amd64 aarch64* arm64* ppc64* powerpc64*]]
```
So it looks like this should be enabled by default anyway. It may be an upstream issue but idk ¯\_(ツ)_/¯

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
