### PR TITLE
pmccabe 2.8

### DIFF
--- a/Formula/pmccabe.rb
+++ b/Formula/pmccabe.rb
@@ -1,8 +1,17 @@
 class Pmccabe < Formula
   desc "Calculate McCabe-style cyclomatic complexity for C/C++ code"
-  homepage "https://packages.debian.org/sid/pmccabe"
-  url "https://deb.debian.org/debian/pool/main/p/pmccabe/pmccabe_2.6.tar.gz"
-  sha256 "e490fe7c9368fec3613326265dd44563dc47182d142f579a40eca0e5d20a7028"
+  homepage "https://gitlab.com/pmccabe/pmccabe"
+  url "https://gitlab.com/pmccabe/pmccabe/-/archive/v2.8/pmccabe-v2.8.tar.bz2"
+  sha256 "d37cafadfb64507c32d75297193f99f1afcf12289b7fcc1ddde4a852f0f2ac8a"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:[._]\d+)+[a-z]?)$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.tr("_", ".") }
+    end
+  end
 
   bottle do
     rebuild 1
@@ -22,7 +31,7 @@ class Pmccabe < Formula
   def install
     ENV.append_to_cflags "-D__unix"
 
-    system "make"
+    system "make", "CFLAGS=#{ENV.cflags}"
     bin.install "pmccabe", "codechanges", "decomment", "vifn"
     man1.install Dir["*.1"]
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `pmccabe` to the latest version, 2.8.

The [Debian package](https://packages.debian.org/sid/pmccabe) information points to the [pmccabe/pmccabe](https://gitlab.com/pmccabe/pmccabe) GitLab project as the authoritative source, so this updates the `homepage` and `stable` URL accordingly. For what it's worth, the `pmccabe-v2.8.tar.gz` tarball from the [2.8 release on GitLab](https://gitlab.com/pmccabe/pmccabe/-/releases/v2.8) is the same as Debian's `pmccabe_2.8.orig.tar.gz` tarball.

When building this locally (macOS 12.2, ARM64), I encountered errors from `decomment.c` due to `unistd.h` not being included (e.g., `error: use of undeclared identifier 'optarg'`, `error: use of undeclared identifier 'optind'`). The related `#include` is behind an `#ifdef` that doesn't appear to be true on macOS:

```cpp
#ifdef __unix
#include <unistd.h>
#endif
```

The existing `ENV.append_to_cflags "-D__unix"` line in the formula's `install` block is intended to address this but it doesn't seem to be sufficient at this point. I tried `ENV.append "CFLAGS", "-D__unix"` (as well as `#prepend`) but that didn't change anything. The only way I found to resolve it (without doing an `inreplace`) was to add `"CFLAGS=#{ENV.cflags}"` to the `system "make"` line. There may be a better way to address this (I'm open to ideas) but this builds now, at least.

Modifying the related `#ifdef __unix` to something like `#if defined(__unix) || defined (__APPLE__)` would seemingly fix the issue without requiring us to modify `CFLAGS` in the formula but upstream doesn't seem very responsive to merge requests (none merged and the open ones are months old).

---

Past that, this adds a `livecheck` block with a version of the standard regex for Git tags like `1.2.3`/`v1.2.3`, modified to also match older tags (`V2_7`) and tags with a trailing letter (`v2.7b`) while omitting unstable tags like `V2_7_pre`. This also uses a `strategy` block to convert tag versions like `2_7` to `2.7`, simply for the sake of consistency/aesthetics (as delimiters don't matter from the perspective of `Version` comparison).

Lastly, this adds `license "GPL-2.0-or-later"`, as the `COPYING` file is GPL 2 and the source files contain comments that use the "or...later" language. For example:

```
Copyright (c) 2002 Hewlett-Packard under GPL version 2 or later
```

```
/* Declarations for getopt.
   Copyright (C) 1989, 1990, 1991, 1992, 1993 Free Software Foundation, Inc.

   This program is free software; you can redistribute it and/or modify it
   under the terms of the GNU General Public License as published by the
   Free Software Foundation; either version 2, or (at your option) any
   later version.

   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

   You should have received a copy of the GNU General Public License
   along with this program; if not, write to the Free Software
   Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
```