### PR TITLE
watchman: build with Homebrew `googletest`

### DIFF
--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -19,6 +19,7 @@ class Watchman < Formula
   pour_bottle? only_if: :default_prefix
 
   depends_on "cmake" => :build
+  depends_on "googletest" => :build
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "boost"
@@ -37,22 +38,10 @@ class Watchman < Formula
 
   fails_with gcc: "5"
 
-  # The `googletest` formula (v1.11+) currently causes build failures.
-  # On macOS: watchman_string.h:114:16: error: no member named 'data' in 'watchman_pending_fs'
-  # On Linux: gtest-printers.h:211:33: error: no match for 'operator<<'
-  # Use https://github.com/facebook/watchman/blob/#{version}/build/fbcode_builder/manifests/googletest
-  resource "googletest" do
-    url "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
-    sha256 "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb"
-  end
-
   def install
-    resource("googletest").stage do
-      cmake_args = std_cmake_args.reject { |s| s["CMAKE_INSTALL_PREFIX"] }
-      system "cmake", ".", *cmake_args, "-DCMAKE_INSTALL_PREFIX=#{buildpath}/googletest"
-      system "make", "install"
-    end
-    ENV["GTest_DIR"] = ENV["GMock_DIR"] = buildpath/"googletest"
+    # Fix build failure on Linux. Borrowed from Fedora:
+    # https://src.fedoraproject.org/rpms/watchman/blob/rawhide/f/watchman.spec#_70
+    inreplace "CMakeLists.txt", /^t_test/, "# t_test" if OS.linux?
 
     system "cmake", "-S", ".", "-B", "build",
                     "-DBUILD_SHARED_LIBS=ON",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

MacPorts are able to build Watchman with GoogleTest 1.11, so we might be
able to start doing so now here too.
