### PR TITLE
odo, odo-dev: add conflicts_with

### DIFF
--- a/Formula/odo-dev.rb
+++ b/Formula/odo-dev.rb
@@ -17,6 +17,7 @@ class OdoDev < Formula
   end
 
   depends_on "go" => :build
+  conflicts_with "odo", because: "odo also ships 'odo' binary"
 
   def install
     system "make", "bin"

--- a/Formula/odo.rb
+++ b/Formula/odo.rb
@@ -19,6 +19,8 @@ class Odo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "23644efe576abf9c3e3a469cf1baad05b3a3cde749998045b2992c290cf57884"
   end
 
+  conflicts_with "odo-dev", because: "odo-dev also ships 'odo' binary"
+
   def install
     system "make"
     man1.mkpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds conflicts between odo and odo-dev Formulas as they both use the same name for binary.

This is follow up to https://github.com/Homebrew/homebrew-core/pull/93846