### PR TITLE
solid 3.5.8

### DIFF
--- a/Formula/solid.rb
+++ b/Formula/solid.rb
@@ -1,8 +1,10 @@
 class Solid < Formula
   desc "Collision detection library for geometric objects in 3D space"
-  homepage "http://www.dtecta.com/"
-  url "http://www.dtecta.com/files/solid-3.5.6.tgz"
-  sha256 "4acfa20266f0aa5722732794f8e93d7bb446e467719c947a3ca583f197923af0"
+  homepage "https://github.com/dtecta/solid3/"
+  url "https://github.com/dtecta/solid3/archive/ec3e218616749949487f81165f8b478b16bc7932.tar.gz"
+  version "3.5.8"
+  sha256 "e3a23751ebbad5e35f50e685061f1ab9e1bd3777317efc6912567f55259d0f15"
+  license any_of: ["GPL-2.0-only", "QPL-1.0"]
 
   bottle do
     rebuild 1
@@ -15,39 +17,35 @@ class Solid < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "8cb9ab57cd86c4d1b5da960ea243a776e1b7a695652bf3cbced579bfcf01c312"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  uses_from_macos "texinfo" => :build
+
   # This patch fixes a broken build on clang-600.0.56.
   # Was reported to bugs@dtecta.com (since it also applies to solid-3.5.6)
   patch :DATA
 
   def install
+    # Avoid `required file not found` errors
+    touch ["AUTHORS", "ChangeLog", "NEWS"]
+
+    system "autoreconf", "-fiv"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-debug",
                           "--prefix=#{prefix}",
                           "--infodir=#{info}"
 
-    # exclude the examples from compiling!
-    # the examples do not compile because the include statements
-    # for the GLUT library are not platform independent
-    inreplace "Makefile", " examples ", " "
+    # Don't make examples, as they do not compile because the include
+    # statements for the GLUT library are not platform independent
+    inreplace "Makefile", /^(SUBDIRS *=.*) examples( .+)?/, '\1\2'
 
     system "make", "install"
   end
 end
 
 __END__
-diff --git a/include/MT/Quaternion.h b/include/MT/Quaternion.h
-index 3726b4f..3393697 100644
---- a/include/MT/Quaternion.h
-+++ b/include/MT/Quaternion.h
-@@ -154,7 +154,7 @@ namespace MT {
-
-		Quaternion<Scalar> inverse() const
-		{
--			return conjugate / length2();
-+			return conjugate() / length2();
-		}
-
-		Quaternion<Scalar> slerp(const Quaternion<Scalar>& q, const Scalar& t) const
 diff --git a/src/complex/DT_CBox.h b/src/complex/DT_CBox.h
 index 7fc7c5d..16ce972 100644
 --- a/src/complex/DT_CBox.h


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `solid` to the latest version, 3.5.8.

The first-party website doesn't appear to reference `solid` anymore and this version comes from the related `dtecta/solid3` GitHub repository. This uses a commit archive as `stable` because there aren't any tags, unfortunately. This is the ["Initial github release version 3.5.8"](https://github.com/dtecta/solid3/commit/ec3e218616749949487f81165f8b478b16bc7932) commit from 2016-08-17. There have been commits since then but no releases.

Besides the changes to the build setup, I've removed the part of the existing patch that's already present in 3.5.8. This built fine locally (macOS 12.2, ARM64) with the patch completely removed but I'm not sure if the remaining change is still needed (seven years later) in some obscure context. I can at least say that the remaining change doesn't appear to be present in 3.5.8 or the current `master` branch and doesn't negatively impact the build.

Lastly, this adds ` license any_of: ["GPL-2.0-only", "QPL-1.0"]`, referencing the root `LICENSE_GPL.txt` and `LICENSE_QPL.txt` files and license comments in source files like:

```
/*
 * SOLID - Software Library for Interference Detection
 * 
 * Copyright (C) 2001-2003  Dtecta.  All rights reserved.
 *
 * This library may be distributed under the terms of the Q Public License
 * (QPL) as defined by Trolltech AS of Norway and appearing in the file
 * LICENSE.QPL included in the packaging of this file.
 *
 * This library may be distributed and/or modified under the terms of the
 * GNU General Public License (GPL) version 2 as published by the Free Software
 * Foundation and appearing in the file LICENSE.GPL included in the
 * packaging of this file.
 *
 * This library is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
 * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 *
 * Commercial use or any other use of this library not covered by either 
 * the QPL or the GPL requires an additional license from Dtecta. 
 * Please contact info@dtecta.com for enquiries about the terms of commercial
 * use of this library.
 */
```