### PR TITLE
cwb3: don't reference Cellar paths to dependencies

### DIFF
--- a/Formula/cwb3.rb
+++ b/Formula/cwb3.rb
@@ -4,7 +4,7 @@ class Cwb3 < Formula
   url "https://downloads.sourceforge.net/project/cwb/cwb/cwb-3.5-RC/cwb-3.4.33-src.tar.gz"
   sha256 "856b72785522d42f13f4a0528d2b80c2bf422c10411234a8e4b61df111af77dd"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
   head "svn://svn.code.sf.net/p/cwb/code/cwb/trunk"
 
   livecheck do
@@ -48,6 +48,12 @@ class Cwb3 < Formula
     system "make", "all", *args
     ENV.deparallelize
     system "make", "install", *args
+
+    # Avoid rebuilds when dependencies are bumped.
+    inreplace bin/"cwb-config" do |s|
+      s.gsub! Formula["glib"].prefix.realpath, Formula["glib"].opt_prefix
+      s.gsub! Formula["pcre"].prefix.realpath, Formula["pcre"].opt_prefix
+    end
   end
 
   def default_registry


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This was rev bumped in #93848 because `cwb-config` recorded the (now
stale) Cellar path to `glib`. Let's fix that by making sure we reference
stable paths instead.
