### PR TITLE
blink1: fixes for Linux

### DIFF
--- a/Formula/blink1.rb
+++ b/Formula/blink1.rb
@@ -15,11 +15,17 @@ class Blink1 < Formula
     sha256 cellar: :any, catalina:       "52a3d5efa444acbd4fe4a76ba38152513bdbfa7138d66e799401aeb0ac87af78"
   end
 
+  on_linux do
+    depends_on "pkg-config" => :build
+    depends_on "systemd"
+  end
+
   def install
     system "make"
     bin.install "blink1-tool"
-    lib.install "libBlink1.dylib"
     include.install "blink1-lib.h"
+    library = OS.mac? ? "libBlink1.dylib" : "libblink1.so"
+    lib.install library
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The previous bump PR (#93897) logs indicated that this wasn't building due to the absence of `libudev.h`, which is a part of `systemd`.

Also, I've done this instead of using `shared_library` because I wasn't sure whether case-sensitivity would be an issue:

```ruby
  library = OS.mac? ? "libBlink1.dylib" : "libblink1.so"
```