### PR TITLE
evince: fix build with newer Meson

### DIFF
--- a/Formula/evince.rb
+++ b/Formula/evince.rb
@@ -30,6 +30,13 @@ class Evince < Formula
   depends_on "poppler"
   depends_on "python@3.9"
 
+  # Fix compilation failure due to incorrect args for `i18n.merge_file`
+  # https://gitlab.gnome.org/GNOME/evince/-/issues/1732
+  patch do
+    url "https://gitlab.gnome.org/GNOME/evince/-/commit/1060b24d051607f14220f148d2f7723b29897a54.diff"
+    sha256 "5e9690beee8a472148a7c6fda78793a3499d5d0c38e08f61e1589598fab68f1a"
+  end
+
   def install
     ENV["DESTDIR"] = "/"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The calls to `i18n.merge_file` in their build scripts have always been
wrong, but now Meson 0.60+ fails instead of ignoring the invalid
positional arguments. This patch hopefully fixes that.
