### PR TITLE
glib: migrate to python@3.10

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -6,6 +6,7 @@ class Glib < Formula
   url "https://download.gnome.org/sources/glib/2.70/glib-2.70.3.tar.xz"
   sha256 "233fa4841c1e19e396db7607d58f6b75ba3313c50bf0fce07b2e3532d5eb7d46"
   license "LGPL-2.1-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_monterey: "2b4d9f0366e234076bd740aeb41030976f89bec8f56d1e5d3d1915d0af661697"
@@ -22,7 +23,7 @@ class Glib < Formula
   depends_on "gettext"
   depends_on "libffi"
   depends_on "pcre"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   on_linux do
     depends_on "util-linux"


### PR DESCRIPTION
Migrate formula `glib` to `python@3.10`.