### PR TITLE
gpgme: migrate to python@3.10

### DIFF
--- a/Formula/alot.rb
+++ b/Formula/alot.rb
@@ -6,7 +6,7 @@ class Alot < Formula
   url "https://github.com/pazz/alot/archive/0.9.1.tar.gz"
   sha256 "ee2c1ab1b43d022a8fe2078820ed57d8d72aec260a7d750776dac4ee841d1de4"
   license "GPL-3.0-only"
-  revision 2
+  revision 3
   head "https://github.com/pazz/alot.git", branch: "master"
 
   bottle do
@@ -22,7 +22,7 @@ class Alot < Formula
   depends_on "gpgme"
   depends_on "libmagic"
   depends_on "notmuch"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "wheel" do
     url "https://files.pythonhosted.org/packages/ed/46/e298a50dde405e1c202e316fa6a3015ff9288423661d7ea5e8f22f589071/wheel-0.36.2.tar.gz"

--- a/Formula/gpgme.rb
+++ b/Formula/gpgme.rb
@@ -20,7 +20,7 @@ class Gpgme < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8d96889a4f0d9e5098a59f6c76d1dd42fe4cf5232d7db748754c73576c639c8a"
   end
 
-  depends_on "python@3.9" => [:build, :test]
+  depends_on "python@3.10" => [:build, :test]
   depends_on "swig" => :build
   depends_on "gnupg"
   depends_on "libassuan"
@@ -33,7 +33,9 @@ class Gpgme < Formula
   end
 
   def install
-    ENV["PYTHON"] = Formula["python@3.9"].opt_bin/"python3"
+    python_executable = which("python3")
+    ENV["PYTHON"] = python_executable
+    ENV["PYTHON_VERSION"] = Language::Python.major_minor_version python_executable
 
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
@@ -48,6 +50,6 @@ class Gpgme < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/gpgme-tool --lib-version")
-    system Formula["python@3.9"].opt_bin/"python3", "-c", "import gpg; print(gpg.version.versionstr)"
+    system Formula["python@3.10"].opt_bin/"python3", "-c", "import gpg; print(gpg.version.versionstr)"
   end
 end


### PR DESCRIPTION
Migrate formula `gpgme` to `python@3.10`.