### PR TITLE
screen: don't use `--enable-colors256` for master branch

### DIFF
--- a/Formula/screen.rb
+++ b/Formula/screen.rb
@@ -54,11 +54,18 @@ class Screen < Formula
     # https://savannah.gnu.org/bugs/index.php?59465
     ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
 
-    system "./configure", "--prefix=#{prefix}",
-                          "--mandir=#{man}",
-                          "--infodir=#{info}",
-                          "--enable-colors256",
-                          "--enable-pam"
+    # master branch configure script has no
+    # --enable-colors256, so don't use it
+    # when `brew install screen --HEAD`
+    args = [
+      "--prefix=#{prefix}",
+      "--mandir=#{man}",
+      "--infodir=#{info}",
+      "--enable-pam",
+    ]
+    args << "--enable-colors256" unless build.head?
+
+    system "./configure", *args
 
     system "make"
     system "make", "install"


### PR DESCRIPTION
There's no `--enable-colors256` option for the configure script in the master branch.

Currently `brew install screen --HEAD` fails to install because of this

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
