### PR TITLE
mpich: delete args in mpicc/cxx wrapper configs

### DIFF
--- a/Formula/mpich.rb
+++ b/Formula/mpich.rb
@@ -5,6 +5,7 @@ class Mpich < Formula
   mirror "https://fossies.org/linux/misc/mpich-4.0.tar.gz"
   sha256 "df7419c96e2a943959f7ff4dc87e606844e736e30135716971aba58524fbff64"
   license "mpich2"
+  revision 1
 
   livecheck do
     url "https://www.mpich.org/static/downloads/"
@@ -69,8 +70,6 @@ class Mpich < Formula
     # Flag for compatibility with GCC 10
     # https://lists.mpich.org/pipermail/discuss/2020-January/005863.html
     args << "FFLAGS=-fallow-argument-mismatch"
-    args << "CXXFLAGS=-Wno-deprecated"
-    args << "CFLAGS=-fgnu89-inline -Wno-deprecated"
 
     if OS.linux?
       # Use libfabric https://lists.mpich.org/pipermail/discuss/2021-January/006092.html


### PR DESCRIPTION
Remove `-fgnu89-inline` and `-Wno-deprecated` from the configuration of the `mpicc` and `mpicxx` compiler wrappers installed by mpich. Adding these options to the compiler wrappers created a linking issue with C-style inlined functions due to the gnu98 option forcing an older style for C inlined functions. This reverts the compiler wrappers to before where they did not have these options configured during mpich installation.

This would also address previously closed issues in https://github.com/Homebrew/homebrew-core/issues/80465 and in https://github.com/pmodels/mpich/issues/5808.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
