### PR TITLE
zlog: add license

### DIFF
--- a/Formula/zlog.rb
+++ b/Formula/zlog.rb
@@ -3,7 +3,7 @@ class Zlog < Formula
   homepage "https://github.com/HardySimpson/zlog"
   url "https://github.com/HardySimpson/zlog/archive/1.2.15.tar.gz"
   sha256 "00037ab8d52772a95d645f1dcfd2c292b7cea326b54e63e219a5b7fdcb7e6508"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only"
 
   bottle do
     sha256 cellar: :any,                 big_sur:      "07b323ff8ba13c92bf8c720b6fd0a760a776b5e9d6f46356700066ef2b3643a6"
@@ -14,7 +14,7 @@ class Zlog < Formula
   end
 
   def install
-    system "make"
+    system "make", "PREFIX=#{prefix}"
     system "make", "PREFIX=#{prefix}", "install"
   end
 
@@ -51,7 +51,7 @@ class Zlog < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-L#{lib}", "-lzlog", "-lpthread", "-o", "test"
-    system "./test"
+    system ENV.cc, "test.c", "-L#{lib}", "-lzlog", "-pthread", "-o", "test"
+    assert_equal "hello, zlog!\n", shell_output("./test")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As far as I can tell, the project is only licensed under 2.1 specifically. While we're here, check the test output. This should allow for bottling on Monterey and also provide a chance to investigate missing ARM bottles.