### PR TITLE
ghcup: disable self-upgrade functionality

### DIFF
--- a/Formula/ghcup.rb
+++ b/Formula/ghcup.rb
@@ -5,6 +5,7 @@ class Ghcup < Formula
   url "https://gitlab.haskell.org/haskell/ghcup-hs/-/archive/v0.1.17.4/ghcup-hs-v0.1.17.4.tar.bz2"
   sha256 "9973a42397bcdecfaf5f5d8251b4513422b80e901b2f2e77b80b0ad28d19f406"
   license "LGPL-3.0-only"
+  revision 1
   head "https://gitlab.haskell.org/haskell/ghcup-hs.git", branch: "master"
 
   livecheck do
@@ -26,9 +27,18 @@ class Ghcup < Formula
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
+  # Disable self-upgrade functionality. Backported from:
+  # https://gitlab.haskell.org/haskell/ghcup-hs/-/commit/b245c11b1d77236c75c29fb094bbb9cfd70eed48
+  # Remove at next release.
+  patch do
+    url "https://gitlab.haskell.org/haskell/ghcup-hs/-/snippets/3838/raw/main/0001-Allow-to-disable-self-upgrade-functionality-wrt-305.patch"
+    sha256 "a20152dead868cf1f35f9c0a3cb2fca30bb4ef09c4543764c1f1dc71a8ba47f7"
+  end
+
   def install
     system "cabal", "v2-update"
-    system "cabal", "v2-install", *std_cabal_v2_args
+    # `+disable-upgrade` disables the self-upgrade feature.
+    system "cabal", "v2-install", *std_cabal_v2_args, "--flags=+disable-upgrade"
 
     bash_completion.install "scripts/shell-completions/bash" => "ghcup"
     fish_completion.install "scripts/shell-completions/fish" => "ghcup.fish"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a requirement of Homebrew's packaging policies.
