### PR TITLE
workflows/tests: always upload logs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -257,7 +257,7 @@ jobs:
           rm bottles/bottle_output.txt
 
       - name: Upload logs
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@main
         with:
           name: logs-${{ matrix.runner }}


### PR DESCRIPTION
I think the logs of successful runs are often still interesting (e.g.
for comparison of a successful run on one runner vs a failed run on
another). Moreover, given that we no longer fail CI when a formula
doesn't have a bottle, not all successful CI runs are successful builds,
so the logs may still be of interest even when CI is successful.
