### PR TITLE
rure 1.5.4 (new formula)

### DIFF
--- a/Formula/rure.rb
+++ b/Formula/rure.rb
@@ -2,7 +2,7 @@ class Rure < Formula
   desc "C API for RUst's REgex engine"
   homepage "https://github.com/rust-lang/regex/tree/master/regex-capi"
   url "https://github.com/rust-lang/regex/archive/1.5.4.tar.gz"
-  version "0.2.1"
+  version "1.5.4"
   sha256 "a91d5b3e1644a1b298ca4ac8e458d693ae268df7fd3307c6d5d12915b5bc3870"
   license all_of: [
     "Unicode-TOU",

--- a/Formula/rure.rb
+++ b/Formula/rure.rb
@@ -14,7 +14,7 @@ class Rure < Formula
   def install
     system "cargo", "build", "--manifest-path", "regex-capi/Cargo.toml", "--release"
     include.install "regex-capi/include/rure.h"
-    lib.install Dir["target/release/librure.{a,dylib}"]
+    lib.install Pathname.glob("target/release/librure.*") - [Pathname.new("target/release/librure.d")]
   end
 
   test do

--- a/Formula/rure.rb
+++ b/Formula/rure.rb
@@ -14,8 +14,8 @@ class Rure < Formula
   def install
     system "cargo", "build", "--lib", "--manifest-path", "regex-capi/Cargo.toml", "--release"
     include.install "regex-capi/include/rure.h"
-    lib.install Pathname.glob("target/release/#{shared_library("librure")}")
-    lib.install Pathname.glob("target/release/librure.a")
+    lib.install "target/release/#{shared_library("librure")}"
+    lib.install "target/release/librure.a"
   end
 
   test do

--- a/Formula/rure.rb
+++ b/Formula/rure.rb
@@ -1,0 +1,31 @@
+class Rure < Formula
+  desc "C API for RUst's REgex engine"
+  homepage "https://github.com/rust-lang/regex/tree/master/regex-capi"
+  url "https://github.com/rust-lang/regex/archive/1.5.4.tar.gz"
+  version "0.2.1"
+  sha256 "a91d5b3e1644a1b298ca4ac8e458d693ae268df7fd3307c6d5d12915b5bc3870"
+  license all_of: [
+    "Unicode-TOU",
+    any_of: ["Apache-2.0", "MIT"],
+  ]
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "build", "--manifest-path", "regex-capi/Cargo.toml", "--release"
+    include.install "regex-capi/include/rure.h"
+    lib.install Dir["target/release/librure.{a,dylib}"]
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <rure.h>
+      int main(int argc, char **argv) {
+        rure *re = rure_compile_must("a");
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lrure", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/rure.rb
+++ b/Formula/rure.rb
@@ -2,7 +2,6 @@ class Rure < Formula
   desc "C API for RUst's REgex engine"
   homepage "https://github.com/rust-lang/regex/tree/HEAD/regex-capi"
   url "https://github.com/rust-lang/regex/archive/1.5.4.tar.gz"
-  version "1.5.4"
   sha256 "a91d5b3e1644a1b298ca4ac8e458d693ae268df7fd3307c6d5d12915b5bc3870"
   license all_of: [
     "Unicode-TOU",

--- a/Formula/rure.rb
+++ b/Formula/rure.rb
@@ -12,7 +12,7 @@ class Rure < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "build", "--manifest-path", "regex-capi/Cargo.toml", "--release"
+    system "cargo", "build", "--lib", "--manifest-path", "regex-capi/Cargo.toml", "--release"
     include.install "regex-capi/include/rure.h"
     lib.install Pathname.glob("target/release/#{shared_library("librure")}")
     lib.install Pathname.glob("target/release/librure.a")

--- a/Formula/rure.rb
+++ b/Formula/rure.rb
@@ -1,6 +1,6 @@
 class Rure < Formula
   desc "C API for RUst's REgex engine"
-  homepage "https://github.com/rust-lang/regex/tree/master/regex-capi"
+  homepage "https://github.com/rust-lang/regex/tree/HEAD/regex-capi"
   url "https://github.com/rust-lang/regex/archive/1.5.4.tar.gz"
   version "1.5.4"
   sha256 "a91d5b3e1644a1b298ca4ac8e458d693ae268df7fd3307c6d5d12915b5bc3870"

--- a/Formula/rure.rb
+++ b/Formula/rure.rb
@@ -14,7 +14,8 @@ class Rure < Formula
   def install
     system "cargo", "build", "--manifest-path", "regex-capi/Cargo.toml", "--release"
     include.install "regex-capi/include/rure.h"
-    lib.install Pathname.glob("target/release/librure.*") - [Pathname.new("target/release/librure.d")]
+    lib.install Pathname.glob("target/release/#{shared_library("librure")}")
+    lib.install Pathname.glob("target/release/librure.a")
   end
 
   test do

--- a/Formula/rure.rb
+++ b/Formula/rure.rb
@@ -16,6 +16,7 @@ class Rure < Formula
     include.install "regex-capi/include/rure.h"
     lib.install "target/release/#{shared_library("librure")}"
     lib.install "target/release/librure.a"
+    prefix.install "regex-capi/README.md" => "README-capi.md"
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? _See discussion below_

-----

This commit adds a formula for [`rure`](https://github.com/rust-lang/regex/tree/master/regex-capi#c-api-for-rusts-regex-engine), the C library version of the Rust regex engine. The formula includes a test that links against the library.

Everything works, but `brew audit --new rure` produces the following error, which is inappropriate for this formula:
```
  * 15: col 5: use "cargo", "install", *std_cargo_args
Error: 1 problem in 1 formula detected
```
Because this Rust library of the `cdylib` type does not produce any executables, `cargo install` does not work. The compiled libraries, `librure.dylib` and `librure.a`, must be installed into `lib` explicitly. I searched Cargo documentation but couldn't find a way to get cargo to automatically install libraries to a `lib` prefix and headers to an `include` prefix so I think this has to be done manually with `lib.install` / `include.install`.