### PR TITLE
fish: Remove ncurses dep, loosen Sphinx for --head, add caveat

### DIFF
--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -70,6 +70,6 @@ class Fish < Formula
   end
 
   test do
-    system "#{bin}/fish", "-c", "math 5 + 5"
+    assert_equal "10\n", shell_output("#{bin}/fish -c \"math 5 + 5\"")
   end
 end

--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -54,18 +54,8 @@ class Fish < Formula
 
   def caveats
     <<~EOS
-      #{Tty.bold}fish#{Tty.reset} has been installed to #{Tty.underline}#{HOMEBREW_PREFIX}/bin/fish#{Tty.reset}
-
-      To set fish as your default login shell:
-
-      #{Tty.bold}chsh -s #{HOMEBREW_PREFIX}/bin/fish#{Tty.reset}
-
-      If you get a "non-standard shell" error:
-
-      All shells must be listed in /etc/shells to permit use as a login shell.
-      So append the install list of paths as sudo:
-
-      #{Tty.bold}echo #{HOMEBREW_PREFIX}/bin/fish | sudo tee -a /etc/shells#{Tty.reset}
+      fish has been installed to:
+        #{opt_bin}/bin/fish
     EOS
   end
 

--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -4,6 +4,7 @@ class Fish < Formula
   url "https://github.com/fish-shell/fish-shell/releases/download/3.3.1/fish-3.3.1.tar.xz"
   sha256 "b5b4ee1a5269762cbbe993a4bd6507e675e4100ce9bbe84214a5eeb2b19fae89"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,16 +22,18 @@ class Fish < Formula
   end
 
   head do
-    url "https://github.com/fish-shell/fish-shell.git"
+    url "https://github.com/fish-shell/fish-shell.git", branch: "master"
 
-    depends_on "sphinx-doc" => :build
+    # The source tarballs come with prebuilt documentation.
+    # It's only needed for git checkouts, and even then it's optional,
+    # as fish will fall back to using documentation hosted in a versioned
+    # path at fish-shell.com/docs/. This can actually be safely skipped.
+    depends_on "sphinx-doc" => :reccomended
   end
 
   depends_on "cmake" => :build
-  # Apple ncurses (5.4) is 15+ years old and
-  # has poor support for modern terminals
-  depends_on "ncurses"
   depends_on "pcre2"
+  uses_from_macos "ncurses"
 
   def install
     args = %W[
@@ -49,7 +52,24 @@ class Fish < Formula
     (pkgshare/"vendor_conf.d").mkpath
   end
 
+  def caveats
+    <<~EOS
+      #{Tty.bold}fish#{Tty.reset} has been installed to #{Tty.underline}#{HOMEBREW_PREFIX}/bin/fish#{Tty.reset}
+
+      To set fish as your default login shell:
+
+      #{Tty.bold}chsh -s #{HOMEBREW_PREFIX}/bin/fish#{Tty.reset}
+
+      If you get a "non-standard shell" error:
+
+      All shells must be listed in /etc/shells to permit use as a login shell.
+      So append the install list of paths as sudo:
+
+      #{Tty.bold}echo #{HOMEBREW_PREFIX}/bin/fish | sudo tee -a /etc/shells#{Tty.reset}
+    EOS
+  end
+
   test do
-    system "#{bin}/fish", "-c", "echo"
+    system "#{bin}/fish", "-c", "math 5 + 5"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hi there, I'm a core developer of the fish shell. #76868 frankly erred in adding the keg ncurses dependency here. Especially on macOS of all platforms. Something to know is that fish hardly uses curses itself at all. We mostly just access the terminfo database. On macOS we actually fill in known missing fields like `sitm`, `ritm`, `dim` we expect to be missing from the system terminfo. There are not really other strings we need to access that are unavailable. We just don't need `ncurses` specifically, or modern ncurses. Just the system curses.

Some assertions from that PR, #76868, are just wrong:

> - this lets fish benefit from fixes to terminal handling (such as character widths)

curses plays zero role in character width calculations. They're all based on our heuristics, [widecharwidth](https://github.com/ridiculousfish/widecharwidth), and system wcstring. If you managed to hack in a wild 15 year-old NetBSD curses implementation on OS X instead of ncurses, stlll, nothing would care as far as character width calculation goes.

> as well as letting it use the Homebrew-provided terminfo database (for terminal types like tmux-256color and alacritty-direct).

Not really. Homebrew does not replace the system terminfo databases or ncurses library: therefore you cannot export such a TERM value for a shell session without some pain, you are going to experience… many utilities linked to the system curses experience problems.

fish does not benefit from this extra dependency, and it actually only complicates the terminfo situation.

See https://gpanders.com/blog/the-definitive-guide-to-using-tmux-256color-on-macos/.

