### PR TITLE
czmq: remove macOS dependency

### DIFF
--- a/Formula/czmq.rb
+++ b/Formula/czmq.rb
@@ -31,7 +31,7 @@ class Czmq < Formula
   end
 
   head do
-    url "https://github.com/zeromq/czmq.git"
+    url "https://github.com/zeromq/czmq.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -41,7 +41,6 @@ class Czmq < Formula
   depends_on "asciidoc" => :build
   depends_on "pkg-config" => :build
   depends_on "xmlto" => :build
-  depends_on :macos # Due to Python 2
   depends_on "zeromq"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This removes `depends_on :macos` from `czmq`, as this formula may not require Python in its current configuration.

The Python bindings aren't being installed by the formula and the build artifacts are the same on macOS and Linux with `depends_on :macos` present, with it removed, or with it replaced by `depends_on "python@3.10"`. The test predictably passes in each scenario as well.

It would be good for someone familiar with `czmq` to check my work, as I may have overlooked some other requirement outside of building/testing.

Relates to #93940.