### PR TITLE
workflows/dispatch-build-bottle: always upload logs

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -141,7 +141,7 @@ jobs:
           rm bottles/bottle_output.txt
 
       - name: Upload logs
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@main
         with:
           name: logs


### PR DESCRIPTION
This is the same change as in #94067.

In particular, I need this in order to diagnose a bottling failure for
`libxslt` which I can't reproduce locally.
