### PR TITLE
openjdk@11: Enable Shenandoah GC

### DIFF
--- a/Formula/openjdk@11.rb
+++ b/Formula/openjdk@11.rb
@@ -78,6 +78,7 @@ class OpenjdkAT11 < Formula
       --with-boot-jdk=#{boot_jdk}
       --with-debug-level=release
       --with-conf-name=release
+      --with-jvm-features=shenandoahgc
       --with-jvm-variants=server
       --with-native-debug-symbols=none
       --with-vendor-bug-url=#{tap.issues_url}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR enables using `-XX:+UseShenandoahGC` with OpenJDK 11, which requires a build time opt-in. [Shenandoah GC](https://wiki.openjdk.java.net/display/shenandoah/Main) is also available in Adopt OpenJDK and Zulu 11.