### PR TITLE
dbmate: build with makefile

### DIFF
--- a/Formula/dbmate.rb
+++ b/Formula/dbmate.rb
@@ -18,7 +18,8 @@ class Dbmate < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s", "-o", bin/"dbmate", "."
+    system "make", "build"
+    bin.install "dist/dbmate"
   end
 
   test do

--- a/Formula/dbmate.rb
+++ b/Formula/dbmate.rb
@@ -18,8 +18,7 @@ class Dbmate < Formula
   depends_on "go" => :build
 
   def install
-    system "make", "build"
-    bin.install "dist/dbmate"
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "-tags", "sqlite_omit_load_extension,sqlite_json"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Per https://github.com/amacneil/dbmate/issues/247: dbmate in homebrew was not using the default build flags, due to not using the official makefile.

This PR updates the formula to use `make build`, then copy the resulting single binary to the `bin` directory.