### PR TITLE
terminalimageviewer 1.1.1 (new formula)

### DIFF
--- a/Aliases/tiv
+++ b/Aliases/tiv
@@ -1,0 +1,1 @@
+../Formula/terminalimageviewer.rb

--- a/Formula/terminalimageviewer.rb
+++ b/Formula/terminalimageviewer.rb
@@ -1,0 +1,28 @@
+class Terminalimageviewer < Formula
+  desc "Display images in a terminal using block graphic characters"
+  homepage "https://github.com/stefanhaustein/TerminalImageViewer"
+  url "https://github.com/stefanhaustein/TerminalImageViewer/archive/refs/tags/v1.1.1.tar.gz"
+  sha256 "9a5f5c8688ef8db0e88dfcea6a1ae30da32268a7ab7972ff0de71955a75af0db"
+  license "Apache-2.0"
+  head "https://github.com/stefanhaustein/TerminalImageViewer.git", branch: "master"
+
+  depends_on "imagemagick"
+
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5"
+
+  def install
+    cd "src/main/cpp" do
+      system "make"
+      bin.install "tiv"
+    end
+  end
+
+  test do
+    assert_equal "\e[48;2;0;0;255m\e[38;2;0;0;255m  \e[0m",
+                 shell_output("#{bin}/tiv #{test_fixtures("test.png")}").strip
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
From [stefanhaustein/TerminalImageViewer](https://github.com/stefanhaustein/TerminalImageViewer).
A bit unsure whether I should name this "tiv" or "terminalImageViewer".
There was a previous request on it that failed due to mac not supporting `<filesystem>` at the time. Starting with Catalina, `< filesystem>` is supported.