### PR TITLE
plotutils: fix erroneous use of the `-flat_namespace` flag

### DIFF
--- a/Formula/plotutils.rb
+++ b/Formula/plotutils.rb
@@ -30,6 +30,9 @@ class Plotutils < Formula
     # Fix usage of libpng to be 1.5 compatible
     inreplace "libplot/z_write.c", "png_ptr->jmpbuf", "png_jmpbuf (png_ptr)"
 
+    # Avoid `-flat_namespace` flag.
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s
+
     args = %W[
       --disable-debug
       --disable-dependency-tracking
@@ -37,6 +40,8 @@ class Plotutils < Formula
       --prefix=#{prefix}
       --enable-libplotter
     ]
+    # Prevent opportunistic linkage to X11
+    args << "--without-x" if OS.mac?
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

None of our usual patches apply to their `configure` script, but,
conveniently, we don't need one if we set `MACOSX_DEPLOYMENT_TARGET`
appropriately.

Let's also pass `--without-x` on macOS to avoid opportunistic linkage
with X11 libraries.

This is needed for bottling on Monterey. See #94212.
