### PR TITLE
flat_namespace_allowlist: add `xmlrpc-c`

### DIFF
--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -16,5 +16,6 @@
   "scalapack",
   "soapysdr",
   "tcl-tk",
+  "xmlrpc-c",
   "xvid"
 ]


### PR DESCRIPTION
The use of the `-flat_namespace` flag does not originate from the
Libtool bug, so appears to be intentional.

This is needed for bottling on Monterey.
