### PR TITLE
libsmi: regenerate `configure`

### DIFF
--- a/Formula/libsmi.rb
+++ b/Formula/libsmi.rb
@@ -4,6 +4,7 @@ class Libsmi < Formula
   url "https://www.ibr.cs.tu-bs.de/projects/libsmi/download/libsmi-0.5.0.tar.gz"
   mirror "https://www.mirrorservice.org/sites/distfiles.macports.org/libsmi/libsmi-0.5.0.tar.gz"
   sha256 "f21accdadb1bb328ea3f8a13fc34d715baac6e2db66065898346322c725754d3"
+  license all_of: ["TCL", "BSD-3-Clause", "Beerware"]
 
   livecheck do
     url "https://www.ibr.cs.tu-bs.de/projects/libsmi/download/"
@@ -20,7 +21,14 @@ class Libsmi < Formula
     sha256               x86_64_linux:  "7c1d475b1062dec302c4022771cbed447f00923a404a1ea131b79796f44d07f5"
   end
 
+  # Regenerate `configure` to avoid `-flat_namespace` bug.
+  # None of our usual patches apply.
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
   def install
+    system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We need this to get rid of the bad `-flat_namespace` flag. None of our
usual patches apply.

This is needed for bottling on Monterey. See #94212.
