### PR TITLE
woof 20220202

### DIFF
--- a/Formula/woof.rb
+++ b/Formula/woof.rb
@@ -1,16 +1,21 @@
 class Woof < Formula
+  include Language::Python::Shebang
+
   desc "Ad-hoc single-file webserver"
   homepage "http://www.home.unix-ag.org/simon/woof.html"
-  url "http://www.home.unix-ag.org/simon/woof-2012-05-31.py"
-  version "20120531"
-  sha256 "d84353d07f768321a1921a67193510bf292cf0213295e8c7689176f32e945572"
+  url "https://github.com/simon-budig/woof/archive/woof-20220202.tar.gz"
+  sha256 "cf29214aca196a1778e2f5df1f5cc653da9bee8fc2b19f01439c750c41ae83c1"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "854310e14cd958d44e42c8b6dd5aac3ca360ae2154763a0967cfbe4dee76a512"
   end
 
+  depends_on "python@3.10"
+
   def install
-    bin.install "woof-2012-05-31.py" => "woof"
+    rewrite_shebang detected_python_shebang, "woof"
+    bin.install "woof"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `woof` to the latest commit from 2021-06-09. The last release on the [first-party site](http://www.home.unix-ag.org/simon/woof.html) is from 2012-05-31 and the homepage directs users to the [GitHub repository](https://github.com/simon-budig/woof/) from 2020-06-24 onward.

Unfortunately, the repository has no tags/releases, so this PR is uses a commit archive as `stable`. With this situation, we'll simply have to manually check for new commits periodically and update the formula until/unless upstream starts tagging versions.

I've added `depends_on "python@3.10"`, as the `woof` file is a Python script with a `#!/usr/bin/env python3` hashbang. If this isn't necessary in this context, let me know and I'll remove it.

Past that, this adds `license "GPL-2.0-or-later"`, referencing the license comment in the `woof` file, which reads:

```
#  woof -- an ad-hoc single file webserver
#  Copyright (C) 2004-2009 Simon Budig  <simon@budig.de>
#
#  This program is free software; you can redistribute it and/or modify
#  it under the terms of the GNU General Public License as published by
#  the Free Software Foundation; either version 2 of the License, or
#  (at your option) any later version.
#
#  This program is distributed in the hope that it will be useful,
#  but WITHOUT ANY WARRANTY; without even the implied warranty of
#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
#  GNU General Public License for more details.
#
#  A copy of the GNU General Public License is available at
#  http://www.fsf.org/licenses/gpl.txt, you can also write to the
#  Free Software  Foundation, Inc., 59 Temple Place - Suite 330,
#  Boston, MA 02111-1307, USA.
```