### PR TITLE
colima: remove service block

### DIFF
--- a/Formula/colima.rb
+++ b/Formula/colima.rb
@@ -37,15 +37,6 @@ class Colima < Formula
     (fish_completion/"colima.fish").write Utils.safe_popen_read(bin/"colima", "completion", "fish")
   end
 
-  service do
-    run [opt_bin/"colima", "start"]
-    keep_alive true
-    environment_variables HOME: ENV["HOME"], PATH: std_service_path_env
-    error_log_path var/"log/colima.log"
-    log_path var/"log/colima.log"
-    working_dir ENV["HOME"]
-  end
-
   test do
     assert_match version.to_s, shell_output("#{bin}/colima version 2>&1")
     assert_match "colima is not running", shell_output("#{bin}/colima status 2>&1", 1)


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#94189

Colima starts up successfully, but then after a period of time is stopped and then immediately restarted regardless of `keep_alive` causing it to restart loop.

Issue: https://github.com/abiosoft/colima/issues/96