### PR TITLE
neo4j@3 3.5.18 (new formula)

### DIFF
--- a/Formula/neo4j@3.rb
+++ b/Formula/neo4j@3.rb
@@ -11,7 +11,6 @@ class Neo4jAT3 < Formula
           |href=.*?release=v?(\d+(?:\.\d+)+)[^"' >]+edition=community/ix)
   end
 
-  bottle :unneeded
   keg_only :versioned_formula
 
   depends_on "openjdk@8"

--- a/Formula/neo4j@3.rb
+++ b/Formula/neo4j@3.rb
@@ -1,0 +1,86 @@
+class Neo4jAT3 < Formula
+  desc "Robust (fully ACID) transactional property graph database"
+  homepage "https://neo4j.com/"
+  url "https://neo4j.com/artifact.php?name=neo4j-community-3.5.18-unix.tar.gz"
+  sha256 "ed6c2c52faf048919cea6da8f214071b57e3cdcfae4527957d25948a35c6c75a"
+  license "GPL-3.0-or-later"
+
+  livecheck do
+    url "https://neo4j.com/download-center/"
+    regex(/href=.*?edition=community[^"' >]+release=v?(\d+(?:\.\d+)+)[&"' >]
+          |href=.*?release=v?(\d+(?:\.\d+)+)[^"' >]+edition=community/ix)
+  end
+
+  bottle :unneeded
+  keg_only :versioned_formula
+
+  depends_on "openjdk@8"
+
+  def install
+    env = {
+      JAVA_HOME:  Formula["openjdk@8"].opt_prefix,
+      NEO4J_HOME: libexec,
+    }
+    # Remove windows files
+    rm_f Dir["bin/*.bat"]
+
+    # Install jars in libexec to avoid conflicts
+    libexec.install Dir["*"]
+
+    # Symlink binaries
+    bin.install Dir["#{libexec}/bin/neo4j{,-shell,-import,-shared.sh,-admin}", "#{libexec}/bin/cypher-shell"]
+    bin.env_script_all_files(libexec/"bin", env)
+
+    # Adjust UDC props
+    # Suppress the empty, focus-stealing java gui.
+    (libexec/"conf/neo4j.conf").append_lines <<~EOS
+      wrapper.java.additional=-Djava.awt.headless=true
+      wrapper.java.additional.4=-Dneo4j.ext.udc.source=homebrew
+      dbms.directories.data=#{var}/neo4j/data
+      dbms.directories.logs=#{var}/log/neo4j
+    EOS
+  end
+
+  def post_install
+    (var/"log/neo4j").mkpath
+    (var/"neo4j").mkpath
+  end
+
+  plist_options manual: "neo4j start"
+
+  def plist
+    <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>KeepAlive</key>
+          <false/>
+          <key>Label</key>
+          <string>#{plist_name}</string>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{opt_bin}/neo4j</string>
+            <string>console</string>
+          </array>
+          <key>RunAtLoad</key>
+          <true/>
+          <key>WorkingDirectory</key>
+          <string>#{var}</string>
+          <key>StandardErrorPath</key>
+          <string>#{var}/log/neo4j.log</string>
+          <key>StandardOutPath</key>
+          <string>#{var}/log/neo4j.log</string>
+        </dict>
+      </plist>
+    EOS
+  end
+
+  test do
+    ENV["NEO4J_HOME"] = libexec
+    ENV["NEO4J_LOG"] = testpath/"libexec/data/log/neo4j.log"
+    ENV["NEO4J_PIDFILE"] = testpath/"libexec/data/neo4j-service.pid"
+    mkpath testpath/"libexec/data/log"
+    assert_match(/Neo4j .*is not running/i, shell_output("#{bin}/neo4j status", 3))
+  end
+end

--- a/Formula/neo4j@3.rb
+++ b/Formula/neo4j@3.rb
@@ -8,10 +8,11 @@ class Neo4jAT3 < Formula
   livecheck do
     url "https://neo4j.com/download-center/"
     regex(/href=.*?edition=community[^"' >]+release=v?(\d+(?:\.\d+)+)[&"' >]
-          |href=.*?release=v?(\d+(?:\.\d+)+)[^"' >]+edition=community/ix)
+    |href=.*?release=v?(\d+(?:\.\d+)+)[^"' >]+edition=community/ix)
   end
 
   keg_only :versioned_formula
+  deprecate! date: "2022-05-27", because: "Neo4j 3.5 EOL https://support.neo4j.com/hc/en-us/articles/4407792164755-Neo4j-3-5-EOL-End-of-Life-Extension"
 
   depends_on "openjdk@8"
 


### PR DESCRIPTION
Adding a 3.x version of neo4j. The reason for a 3.x version of neo4j is that the 4.x
versions are not 100% compatible with queries written for the 3.x versions. It is
convenient to be able to use homebrew to get one of the previous major versions.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
