### PR TITLE
serialosc: Add service definition

### DIFF
--- a/Formula/serialosc.rb
+++ b/Formula/serialosc.rb
@@ -5,7 +5,7 @@ class Serialosc < Formula
       tag:      "v1.4.3",
       revision: "12fa410a14b2759617c6df2ff9088bc79b3ee8de"
   license "ISC"
-  head "https://github.com/monome/serialosc.git", branch: "master"
+  head "https://github.com/monome/serialosc.git", branch: "main"
 
   bottle do
     sha256 cellar: :any, arm64_monterey: "307d8cd2d6a4a8cedbb5728dcc4f68175b5428c2d54b289b8dea2c08b6a8e488"

--- a/Formula/serialosc.rb
+++ b/Formula/serialosc.rb
@@ -26,6 +26,13 @@ class Serialosc < Formula
     system "./waf", "install"
   end
 
+  service do
+    run [opt_bin/"serialoscd"]
+    keep_alive true
+    log_path var/"log/serialoscd.log"
+    error_log_path var/"log/serialoscd.log"
+  end
+
   test do
     assert_match version.to_s, shell_output("#{bin}/serialoscd -v")
   end


### PR DESCRIPTION
Historically packaged installers provided by monome included and installed service plist which ran serialoscd automatically. This change brings functional parity to homebrew installs.

This PR includes a separate commit to change head to use the `main` branch in order to address issues reported by `brew audit`.

Thanks!

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?