### PR TITLE
misc: prevent rewrite_shebang from erroring

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -52,7 +52,7 @@ class Glib < Formula
       system "meson", *args, ".."
       system "ninja", "-v"
       system "ninja", "install", "-v"
-      bin.find { |f| rewrite_shebang detected_python_shebang, f }
+      rewrite_shebang detected_python_shebang, *bin.children
     end
 
     # ensure giomoduledir contains prefix, as this pkgconfig variable will be

--- a/Formula/gobject-introspection.rb
+++ b/Formula/gobject-introspection.rb
@@ -104,7 +104,7 @@ class GobjectIntrospection < Formula
         ".."
       system "ninja", "-v"
       system "ninja", "install", "-v"
-      bin.find { |f| rewrite_shebang detected_python_shebang, f }
+      rewrite_shebang detected_python_shebang, *bin.children
     end
   end
 

--- a/Formula/gupnp.rb
+++ b/Formula/gupnp.rb
@@ -40,7 +40,7 @@ class Gupnp < Formula
       system "meson", *std_meson_args, ".."
       system "ninja"
       system "ninja", "install"
-      bin.find { |f| rewrite_shebang detected_python_shebang, f }
+      rewrite_shebang detected_python_shebang, *bin.children
     end
   end
 

--- a/Formula/lcov.rb
+++ b/Formula/lcov.rb
@@ -58,7 +58,7 @@ class Lcov < Formula
     # Disable dynamic selection of perl which may cause segfault when an
     # incompatible perl is picked up.
     # https://github.com/Homebrew/homebrew-core/issues/4936
-    bin.find { |f| rewrite_shebang detected_perl_shebang, f }
+    rewrite_shebang detected_perl_shebang, *bin.children
 
     bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
   end

--- a/Formula/percona-toolkit.rb
+++ b/Formula/percona-toolkit.rb
@@ -73,7 +73,7 @@ class PerconaToolkit < Formula
     # Disable dynamic selection of perl which may cause segfault when an
     # incompatible perl is picked up.
     # https://github.com/Homebrew/homebrew-core/issues/4936
-    bin.find { |f| rewrite_shebang detected_perl_shebang, f }
+    rewrite_shebang detected_perl_shebang, *bin.children
 
     bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
   end

--- a/Formula/simgrid.rb
+++ b/Formula/simgrid.rb
@@ -45,7 +45,7 @@ class Simgrid < Formula
                     *std_cmake_args
     system "make", "install"
 
-    bin.find { |f| rewrite_shebang detected_python_shebang, f }
+    rewrite_shebang detected_python_shebang, *bin.children
   end
 
   test do

--- a/Formula/spades.rb
+++ b/Formula/spades.rb
@@ -42,7 +42,7 @@ class Spades < Formula
       system "cmake", "..", *std_cmake_args
       system "make", "install"
     end
-    bin.find { |f| rewrite_shebang detected_python_shebang, f }
+    rewrite_shebang detected_python_shebang, *bin.children
   end
 
   test do

--- a/Formula/sql-translator.rb
+++ b/Formula/sql-translator.rb
@@ -110,7 +110,7 @@ class SqlTranslator < Formula
     # Disable dynamic selection of perl which may cause segfault when an
     # incompatible perl is picked up.
     # https://github.com/Homebrew/homebrew-core/issues/4936
-    bin.find { |f| rewrite_shebang detected_perl_shebang, f }
+    rewrite_shebang detected_perl_shebang, *bin.children
 
     bin.env_script_all_files libexec/"bin", PERL5LIB: ENV["PERL5LIB"]
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Since https://github.com/Homebrew/brew/pull/12820, `rewrite_shebang` will error if none of the files given were rewritten. This was causing failures for some formula that called `rewrite_shebang` once per file. Instead, call it with all `bin` files.
