### PR TITLE
Remove autobump formulae with Repology issues

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -37,7 +37,6 @@ env:
     apidoc
     apktool
     arb
-    archiver
     argo
     argocd
     argocd-autopilot
@@ -71,7 +70,6 @@ env:
     bbtools
     bcoin
     bear
-    bee
     benthos
     berglas
     bettercap
@@ -155,21 +153,18 @@ env:
     cortex
     cosign
     couchdb
-    crane
     croc
     cromwell
     crowdin
     crun
     css-crush
     csvtk
-    ctop
     cubejs-cli
     cweb
     cypher-shell
     dafny
     darkstat
     datree
-    davmail
     dbdeployer
     ddrescue
     deark
@@ -210,7 +205,6 @@ env:
     drone-cli
     druid
     dstask
-    dtm
     dua-cli
     duckscript
     dune
@@ -252,7 +246,6 @@ env:
     flow-cli
     fluent-bit
     flume
-    flux
     fluxctl
     flyway
     fmt
@@ -268,7 +261,6 @@ env:
     futhark
     gatsby-cli
     gau
-    gauge
     gdu
     geeqie
     geph4
@@ -300,7 +292,6 @@ env:
     gnuplot
     go-md2man
     go@1.16
-    gofish
     gofumpt
     gojq
     golang-migrate
@@ -347,7 +338,6 @@ env:
     htmltest
     htpdate
     httpx
-    hugo
     hyperfine
     iamy
     igv
@@ -373,7 +363,6 @@ env:
     jenkins-job-builder
     jenkins-lts
     jetty
-    jetty-runner
     jfrog-cli
     jhipster
     jmeter
@@ -500,7 +489,6 @@ env:
     nats-server
     nats-streaming-server
     navi
-    ncc
     ncspot
     neo4j
     neofetch
@@ -558,10 +546,8 @@ env:
     phpstan
     pianod
     picard-tools
-    pickle
     pig
     pillow
-    pkg-config-wrapper
     plantuml
     plow
     pmd
@@ -683,7 +669,6 @@ env:
     teleport
     tendermint
     tengo
-    termius
     termshark
     terracognita
     terraform-inventory
@@ -704,7 +689,6 @@ env:
     tomcat-native
     tomcat@8
     tomcat@9
-    tomee-plume
     tomee-plus
     tomee-webprofile
     topgrade


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `bump-formulae` action was recently updated to use `brew bump` internally (Homebrew/actions#250). `bump` uses the newest version from livecheck and Repology when creating version bump PRs, which can be a problem when Repology is reporting a newer version than livecheck but the Repology version is incorrect or inappropriate with respect to the Homebrew context. The Repology version for the affected formulae in this PR is inappropriate, so we have to remove these formulae from the `autobump` list until we can tell `brew bump` to only open a PR for a new version from livecheck.

The issues are listed below:

* archiver: Repology's 4.0.0 version is for the cask
* bee: Repology's 3.1.5 version is for the cask
* crane: Repology's 3.6.1 version is for different software (https://github.com/michaelsauter/crane)
* ctop: Repology's 1.0.0 version is for different software (https://github.com/yadutaf/ctop, now archived)
* davmail: Some package managers include the number after the hyphen (e.g., 6.0.1-3390) in their version, which is always treated as newer since the formula omits it (e.g., 6.0.1)
* dtm: Repology's 2.36 version is for different software
* flux: Repology's 41.5 version is for the cask. There are all sorts of different flux versions above the formula's 0.149.0 version besides that, so Repology's data isn't useful with respect to the `flux` formula.
* gauge: Repology's 2.1.7 version is for different software (http://tzclock.org/)
* gofish: Repology's 1.2 version is for different software (http://gofish.sourceforge.net/)
* hugo (hugo-sitegen): Repology's 0.92.0.20220112 version appends a date after the version, so it will always be newer than the formula's 0.92.0 version
* jetty-runner: Repology's 9.4.44.20210927 version omits `v` before the date, so it will always be newer than the formula/livecheck version (9.4.44.v20210927)
* ncc: Repology's 2.8 version is for different software (http://students.ceid.upatras.gr/~sxanth/ncc/)
* pickle: Repology's 5.01 version is for different software (https://wiki.kewl.org/dokuwiki/projects:pickle)
* pkg-config-wrapper: Repology's 0.29.2 version appears to be for different software (in nixpkgs)
* termius: Repology's 7.32.0 version is for the cask
* tomee-plume (tomee): Repology's 9.0.0_M7 version is a milestone release (from AUR), whereas the formula and livecheck correctly give 8.0.9 as the latest stable version

---

We discussed a couple options of how to address this in `brew bump` in the near term (https://github.com/Homebrew/homebrew-core/pull/94087#issuecomment-1025920512, https://github.com/Homebrew/homebrew-core/pull/94087#issuecomment-1025956669) but we still need to decide on an approach before implementing it.

Outside of a short-term fix, I have some ideas for how we could better handle this long-term but that's probably better left to a separate Homebrew/brew issue.