### PR TITLE
ncdu: link against Homebrew `ncurses`

### DIFF
--- a/Formula/ncdu.rb
+++ b/Formula/ncdu.rb
@@ -22,7 +22,8 @@ class Ncdu < Formula
 
   depends_on "pkg-config" => :build
   depends_on "zig" => :build
-  uses_from_macos "ncurses"
+  # Without this, `ncdu` is unusable when `TERM=tmux-256color`.
+  depends_on "ncurses"
 
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

macOS ncurses lacks supports for modern terminal features (e.g.
italics).

Linking against system ncurses also makes `ncdu` unusable inside tmux
when `TERM=tmux-256color`, which is a common setting for `TERM`. There
are workarounds (such has hacking together a `tmux-256color` terminfo
database entry that works for macOS ncurses, or wrapping `ncdu` in a
script that sets `TERM=screen-256color` first), but these are really
hacky, and also means that `ncdu` doesn't work out-of-the-box for some
users.

See, for example, https://unix.stackexchange.com/questions/647635/term-tmux-256color-causes-error-opening-terminal
