### PR TITLE
ndpi: needs `libpcap`, bottle on Linux

### DIFF
--- a/Formula/ndpi.rb
+++ b/Formula/ndpi.rb
@@ -20,6 +20,8 @@ class Ndpi < Formula
   depends_on "pkg-config" => :build
   depends_on "json-c"
 
+  uses_from_macos "libpcap"
+
   def install
     system "./autogen.sh"
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds `uses_from_macos "libpcap"` to bottle `ndpi` on Linux.