### PR TITLE
libmonome: needs Python, add test, build on Linux

### DIFF
--- a/Formula/libmonome.rb
+++ b/Formula/libmonome.rb
@@ -1,9 +1,12 @@
 class Libmonome < Formula
-  desc "Interact with monome devices via C, Python, or FFI"
+  include Language::Python::Shebang
+
+  desc "Library for easy interaction with monome devices"
   homepage "https://monome.org/"
   url "https://github.com/monome/libmonome/archive/v1.4.4.tar.gz"
   sha256 "466acc432b023e6c0bfa8dfb46d79abb1fb8c870f16279ffca7cf5286a63a823"
   license "ISC"
+  revision 1
   head "https://github.com/monome/libmonome.git", branch: "main"
 
   bottle do
@@ -15,6 +18,7 @@ class Libmonome < Formula
     sha256 cellar: :any, mojave:         "a75784a9297378f3c477ee251f9e729f3e98230113908af03078a92cd4c7d076"
   end
 
+  depends_on "python@3.10" => :build
   depends_on "liblo"
 
   def install
@@ -23,8 +27,16 @@ class Libmonome < Formula
     inreplace "wscript", /conf.env.append_unique.*-mmacosx-version-min=10.5.*/,
                          "pass"
 
+    rewrite_shebang detected_python_shebang, *Dir.glob("**/{waf,wscript}")
+
     system "./waf", "configure", "--prefix=#{prefix}"
     system "./waf", "build"
     system "./waf", "install"
+
+    pkgshare.install Dir["examples/*.c"]
+  end
+
+  test do
+    assert_match "failed to open", shell_output("#{bin}/monomeserial", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This was erroring out on Linux with `/usr/bin/env: ‘python’: No such file or directory`. I've added a test and bumped the revision here due to adding the Python dependency.