### PR TITLE
ffmpeg, chromaprint: cleanup

### DIFF
--- a/Formula/chromaprint.rb
+++ b/Formula/chromaprint.rb
@@ -18,8 +18,6 @@ class Chromaprint < Formula
   depends_on "cmake" => :build
   depends_on "ffmpeg@4"
 
-  conflicts_with "ffmpeg", because: "build reasons"
-
   fails_with gcc: "5" # ffmpeg is compiled with GCC
 
   def install

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -67,8 +67,6 @@ class Ffmpeg < Formula
     depends_on "gcc" # because rubbernand is compiled with gcc
   end
 
-  conflicts_with "chromaprint", because: "build reasons"
-
   fails_with gcc: "5"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A conflict was added in #93167 to avoid `chromaprint` from trying to link with `ffmpeg` when it should be linking with `ffmpeg@4` instead. That conflict no longer applies, so let's remove it.

It would be good to fix `test-bot` to handle this better.
