### PR TITLE
coreutils: fix cp filling destination files with 0x00 bytes

### DIFF
--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -5,6 +5,7 @@ class Coreutils < Formula
   mirror "https://ftpmirror.gnu.org/coreutils/coreutils-9.0.tar.xz"
   sha256 "ce30acdf4a41bc5bb30dd955e9eaa75fa216b4e3deb08889ed32433c7b3b97ce"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_monterey: "9a72c1fef593eef2757398be776c656885def021d5e276be11ab26174bfe5d91"
@@ -28,6 +29,10 @@ class Coreutils < Formula
     depends_on "xz" => :build
   end
 
+  # autoconf, automake are required for patch :DATA. remove when dropping patch
+  # https://github.com/Homebrew/homebrew-core/pull/94432
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "gmp"
   uses_from_macos "gperf" => :build
 
@@ -50,6 +55,10 @@ class Coreutils < Formula
     %w[dir dircolors vdir]
   end
 
+  # patch to fix cp 0x00 bytes bug, probably can be removed after 9.0 release
+  # https://github.com/Homebrew/homebrew-core/pull/94432
+  patch :DATA
+
   def install
     system "./bootstrap" if build.head?
 
@@ -60,6 +69,9 @@ class Coreutils < Formula
       --without-selinux
     ]
 
+    # aclocal is required for patch :DATA. remove when dropping patch
+    # https://github.com/Homebrew/homebrew-core/pull/94432
+    system "aclocal", "-Im4"
     system "./configure", *args
     system "make", "install"
 
@@ -123,3 +135,134 @@ class Coreutils < Formula
     system bin/"gln", "-f", "test", "test.sha1"
   end
 end
+
+__END__
+coreutils: fix cp filling destination files with 0x00 bytes:
+- https://github.com/Homebrew/homebrew-core/pull/94432
+- https://github.com/Homebrew/homebrew-core/issues/94405
+
+Upstream bug:
+- https://debbugs.gnu.org/cgi/bugreport.cgi?bug=51857
+
+This patch cherry picks following commits from gnulib:
+- 4db8db34112b86ddf8bac48f16b5acff732b5fa9
+- 1a268176fbb184e393c98575e61fe692264c7d91
+
+These patches will be very likely included next coreutils version followed by 9.0
+
+--
+Elan Ruusamäe <glen@pld-linux.org>
+
+From 4db8db34112b86ddf8bac48f16b5acff732b5fa9 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Mon, 15 Nov 2021 15:08:25 -0800
+Subject: [PATCH] lseek: port around macOS SEEK_DATA glitch
+
+Problem reported by Sudhip Nashi (Bug#51857).
+* doc/posix-functions/lseek.texi (lseek): Mention macOS SEEK_DATA
+issue.
+* lib/lseek.c (rpl_lseek): Work around macOS portability glitch.
+* m4/lseek.m4 (gl_FUNC_LSEEK): Replace lseek on Darwin.
+* modules/lseek (Depends-on): Depend on msvc-nothrow
+and fstat only if needed.
+---
+ ChangeLog                      | 11 +++++++++++
+ doc/posix-functions/lseek.texi |  4 ++++
+ lib/lseek.c                    | 16 ++++++++++++++++
+ m4/lseek.m4                    | 10 ++++++++--
+ modules/lseek                  |  4 ++--
+ 5 files changed, 41 insertions(+), 4 deletions(-)
+
+diff --git a/lib/lseek.c b/lib/lseek.c
+index 0042546a8..7dcd6c9da 100644
+--- a/lib/lseek.c
++++ b/lib/lseek.c
+@@ -52,6 +52,22 @@ rpl_lseek (int fd, off_t offset, int whence)
+       errno = ESPIPE;
+       return -1;
+     }
++#elif defined __APPLE__ && defined __MACH__ && defined SEEK_DATA
++  if (whence == SEEK_DATA)
++    {
++      /* If OFFSET points to data, macOS lseek+SEEK_DATA returns the
++         start S of the first data region that begins *after* OFFSET,
++         where the region from OFFSET to S consists of possibly-empty
++         data followed by a possibly-empty hole.  To work around this
++         portability glitch, check whether OFFSET is within data by
++         using lseek+SEEK_HOLE, and if so return to OFFSET by using
++         lseek+SEEK_SET.  */
++      off_t next_hole = lseek (fd, offset, SEEK_HOLE);
++      if (next_hole < 0)
++        return next_hole;
++      if (next_hole != offset)
++        whence = SEEK_SET;
++    }
+ #else
+   /* BeOS lseek mistakenly succeeds on pipes...  */
+   struct stat statbuf;
+diff --git a/m4/lseek.m4 b/m4/lseek.m4
+index 0af63780a..faab09b73 100644
+--- a/m4/lseek.m4
++++ b/m4/lseek.m4
+@@ -1,4 +1,4 @@
+-# lseek.m4 serial 11
++# lseek.m4 serial 12
+ dnl Copyright (C) 2007, 2009-2021 Free Software Foundation, Inc.
+ dnl This file is free software; the Free Software Foundation
+ dnl gives unlimited permission to copy and/or distribute it,
+@@ -59,7 +59,7 @@ AC_DEFUN([gl_FUNC_LSEEK],
+          ;;
+      esac
+     ])
+-  if test $gl_cv_func_lseek_pipe = no; then
++  if test "$gl_cv_func_lseek_pipe" = no; then
+     REPLACE_LSEEK=1
+     AC_DEFINE([LSEEK_PIPE_BROKEN], [1],
+       [Define to 1 if lseek does not detect pipes.])
+@@ -69,4 +69,10 @@ AC_DEFUN([gl_FUNC_LSEEK],
+   if test $WINDOWS_64_BIT_OFF_T = 1; then
+     REPLACE_LSEEK=1
+   fi
++
++  dnl macOS SEEK_DATA is incompatible with other platforms.
++  case $host_os in
++    darwin*)
++      REPLACE_LSEEK=1;;
++  esac
+ ])
+From 1a268176fbb184e393c98575e61fe692264c7d91 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Mon, 15 Nov 2021 22:17:44 -0800
+Subject: [PATCH] lseek: port around macOS SEEK_HOLE glitch
+
+Problem reported by Sudhip Nashi (Bug#51857#47).
+* lib/lseek.c (rpl_lseek): Work around macOS lseek+SEEK_HOLE
+returning -1 with ENXIO if there are no holes before EOF,
+contrary to the macOS documentation.
+---
+ ChangeLog   | 6 ++++++
+ lib/lseek.c | 6 ++++--
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/lib/lseek.c b/lib/lseek.c
+index 7dcd6c9da..e9a96ad20 100644
+--- a/lib/lseek.c
++++ b/lib/lseek.c
+@@ -61,10 +61,12 @@ rpl_lseek (int fd, off_t offset, int whence)
+          data followed by a possibly-empty hole.  To work around this
+          portability glitch, check whether OFFSET is within data by
+          using lseek+SEEK_HOLE, and if so return to OFFSET by using
+-         lseek+SEEK_SET.  */
++         lseek+SEEK_SET.  Also, contrary to the macOS documentation,
++         lseek+SEEK_HOLE can fail with ENXIO if there are no holes on
++         or after OFFSET.  What a mess!  */
+       off_t next_hole = lseek (fd, offset, SEEK_HOLE);
+       if (next_hole < 0)
+-        return next_hole;
++        return errno == ENXIO ? offset : next_hole;
+       if (next_hole != offset)
+         whence = SEEK_SET;
+     }
+-- 
+2.35.1
+


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/issues/94405

Problem happens:
- macOS 12.x
- `cp` files from mounted partitions of different devices

Test:

```sh
/usr/local/opt/coreutils/libexec/gnubin/cp /etc/passwd /tmp
md5 /etc/passwd /tmp/passwd # must print same hashes
```

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

