### PR TITLE
udunits: update stable, livecheck

### DIFF
--- a/Formula/udunits.rb
+++ b/Formula/udunits.rb
@@ -1,12 +1,12 @@
 class Udunits < Formula
   desc "Unidata unit conversion library"
   homepage "https://www.unidata.ucar.edu/software/udunits/"
-  url "https://artifacts.unidata.ucar.edu/repository/downloads-udunits/udunits-2.2.28.tar.gz"
+  url "https://artifacts.unidata.ucar.edu/repository/downloads-udunits/2.2.28/udunits-2.2.28.tar.gz"
   sha256 "590baec83161a3fd62c00efa66f6113cec8a7c461e3f61a5182167e0cc5d579e"
 
   livecheck do
-    url "https://artifacts.unidata.ucar.edu/service/rest/repository/browse/downloads-udunits/"
-    regex(%r{href=.*?/udunits[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url "https://artifacts.unidata.ucar.edu/service/rest/repository/browse/downloads-udunits/current/"
+    regex(/href=.*?udunits[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`udunits` tarballs were previously kept in the same [downloads directory](https://artifacts.unidata.ucar.edu/service/rest/repository/browse/downloads-udunits/), as seen in an [archive.org snapshot from 2021-03-18](https://web.archive.org/web/20210318114619/https://artifacts.unidata.ucar.edu/service/rest/repository/browse/downloads-udunits/). Now the tarballs are kept in version subdirectories (e.g., `2.2.28/udunits-2.2.28.tar.gz`), so the existing `stable` URL now gives a 404 and the `livecheck` block is broken.

This PR updates the `stable` URL to the new location for the same tarball (now in a version subdirectory). As expected, the `sha256` remains the same.

This also updates the `livecheck` block to match versions from the tarballs in the `current` subdirectory, which may be better than simply assuming that the highest version directory is the newest release. However, if the `current` subdirectory isn't regularly kept up to date in the future, we can fall back to matching versions from the subdirectory names:

```ruby
url "https://artifacts.unidata.ucar.edu/service/rest/repository/browse/downloads-udunits/"
regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
```

It's also possible to check the version information in the [`release_info.json`](https://artifacts.unidata.ucar.edu/repository/downloads-udunits/release_info.json) file but this would be a bit more involved and potentially more fragile. We have options if we need them in the future, at least.