### PR TITLE
webp-pixbuf-loader 0.0.4 (new formula)

### DIFF
--- a/Formula/webp-pixbuf-loader.rb
+++ b/Formula/webp-pixbuf-loader.rb
@@ -1,0 +1,69 @@
+class WebpPixbufLoader < Formula
+  desc "WebP Image format GdkPixbuf loader"
+  homepage "https://github.com/aruiz/webp-pixbuf-loader"
+  url "https://github.com/aruiz/webp-pixbuf-loader/archive/0.0.4.tar.gz"
+  sha256 "cd6e4ec44755e8df3e298688c0aeb72b9467bbdd03009989c0d94b219b30fb51"
+  license "LGPL-2.0-or-later"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => [:build, :test]
+  depends_on "gdk-pixbuf"
+  depends_on "webp"
+
+  # Constants for gdk-pixbuf's multiple version numbers.
+  def gdk_so_ver
+    "2.0"
+  end
+
+  def gdk_module_ver
+    "2.10.0"
+  end
+
+  # Subfolder that pixbuf loaders are installed into.
+  def module_subdir
+    "lib/gdk-pixbuf-#{gdk_so_ver}/#{gdk_module_ver}/loaders"
+  end
+
+  def install
+    mkdir "build" do
+      system "meson", *std_meson_args, "-Dgdk_pixbuf_moduledir=#{prefix}/#{module_subdir}", ".."
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+    end
+  end
+
+  # After the loader is linked in, update the global cache of pixbuf loaders
+  def post_install
+    ENV["GDK_PIXBUF_MODULEDIR"] = "#{HOMEBREW_PREFIX}/#{module_subdir}"
+    system "#{HOMEBREW_PREFIX}/bin/gdk-pixbuf-query-loaders", "--update-cache"
+  end
+
+  test do
+    # Generate a .webp file to test with.
+    system "#{HOMEBREW_PREFIX}/bin/cwebp", test_fixtures("test.png"), "-o", "test.webp"
+
+    # Sample program to load a .webp file via gdk-pixbuf.
+    (testpath/"test.c").write <<~EOS
+      #include <gdk-pixbuf/gdk-pixbuf.h>
+
+      gint main (gint argc, gchar **argv)  {
+        GError *error = NULL;
+        GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file (argv[1], &error);
+        if (error) {
+          g_error("%s", error->message);
+          return 1;
+        };
+
+        g_assert(gdk_pixbuf_get_width(pixbuf) == 8);
+        g_assert(gdk_pixbuf_get_height(pixbuf) == 8);
+        g_object_unref(pixbuf);
+        return 0;
+      }
+    EOS
+
+    flags = shell_output("pkg-config --cflags --libs gdk-pixbuf-#{gdk_so_ver}").chomp.split
+    system ENV.cc, "test.c", "-o", "test_loader", *flags
+    system "./test_loader", "test.webp"
+  end
+end

--- a/Formula/webp-pixbuf-loader.rb
+++ b/Formula/webp-pixbuf-loader.rb
@@ -11,13 +11,14 @@ class WebpPixbufLoader < Formula
   depends_on "gdk-pixbuf"
   depends_on "webp"
 
-  # Constants for gdk-pixbuf's multiple version numbers.
+  # Constants for gdk-pixbuf's multiple version numbers, which are the same as
+  # the constants in the gdk-pixbuf formula.
   def gdk_so_ver
-    "2.0"
+    Formula["gdk-pixbuf"].gdk_so_ver
   end
 
   def gdk_module_ver
-    "2.10.0"
+    Formula["gdk-pixbuf"].gdk_module_ver
   end
 
   # Subfolder that pixbuf loaders are installed into.

--- a/Formula/webp-pixbuf-loader.rb
+++ b/Formula/webp-pixbuf-loader.rb
@@ -36,12 +36,12 @@ class WebpPixbufLoader < Formula
   # After the loader is linked in, update the global cache of pixbuf loaders
   def post_install
     ENV["GDK_PIXBUF_MODULEDIR"] = "#{HOMEBREW_PREFIX}/#{module_subdir}"
-    system "#{HOMEBREW_PREFIX}/bin/gdk-pixbuf-query-loaders", "--update-cache"
+    system "#{Formula["gdk-pixbuf"].opt_bin}/gdk-pixbuf-query-loaders", "--update-cache"
   end
 
   test do
     # Generate a .webp file to test with.
-    system "#{HOMEBREW_PREFIX}/bin/cwebp", test_fixtures("test.png"), "-o", "test.webp"
+    system "#{Formula["webp"].opt_bin}/cwebp", test_fixtures("test.png"), "-o", "test.webp"
 
     # Sample program to load a .webp file via gdk-pixbuf.
     (testpath/"test.c").write <<~EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This is a module that provides support for loading `webp` images via the [GdkPixbuf](https://docs.gtk.org/gdk-pixbuf/)  library, and is already packaged in several Linux distros (e.g. Fedora and Arch)