### PR TITLE
ldc: switch back to LLVM 12 on macOS

### DIFF
--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -4,6 +4,7 @@ class Ldc < Formula
   url "https://github.com/ldc-developers/ldc/releases/download/v1.28.1/ldc-1.28.1-src.tar.gz"
   sha256 "654958bca5378cd97819f2ef61d3f220aa652a9d2b5ff41d6f2109302ae6eb94"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/ldc-developers/ldc.git", branch: "master"
 
   livecheck do
@@ -23,20 +24,11 @@ class Ldc < Formula
   depends_on "cmake" => :build
   depends_on "libconfig" => :build
   depends_on "pkg-config" => :build
+  depends_on "llvm@12"
 
   uses_from_macos "libxml2" => :build
   # CompilerSelectionError: ldc cannot be built with any available compilers.
   uses_from_macos "llvm" => [:build, :test]
-
-  on_macos do
-    depends_on "llvm"
-  end
-
-  on_linux do
-    # When built with LLVM, errors with:
-    # undefined reference to `std::__throw_bad_array_new_length()'
-    depends_on "llvm@12"
-  end
 
   fails_with :gcc
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

1. Their release notes state that they support only up to LLVM 12
2. This already uses LLVM 12 on Linux, because it fails to build with
   LLVM
3. There appear to be random segfaults from using the latest LLVM. See
   #94339.

Fixes a CI failure in #94339.
