### PR TITLE
sdl2_ttf: avoid vendored freetype and harfbuzz

### DIFF
--- a/Formula/sdl2_ttf.rb
+++ b/Formula/sdl2_ttf.rb
@@ -4,6 +4,7 @@ class Sdl2Ttf < Formula
   url "https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.0.18/SDL2_ttf-2.0.18.tar.gz"
   sha256 "7234eb8883514e019e7747c703e4a774575b18d435c22a4a29d068cb768a2251"
   license "Zlib"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "01abc453be483984acdcc80e8e9d3f1ce880a6b06344e8c96295e29935148458"
@@ -24,6 +25,7 @@ class Sdl2Ttf < Formula
 
   depends_on "pkg-config" => :build
   depends_on "freetype"
+  depends_on "harfbuzz"
   depends_on "sdl2"
 
   def install
@@ -31,8 +33,12 @@ class Sdl2Ttf < Formula
 
     system "./autogen.sh" if build.head?
 
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    # `--enable-harfbuzz` is the default, but we pass it
+    # explicitly to generate an error when it isn't found.
+    system "./configure", "--disable-freetype-builtin",
+                          "--disable-harfbuzz-builtin",
+                          "--enable-harfbuzz",
+                          *std_configure_args
     system "make", "install"
   end
 

--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -1,6 +1,7 @@
 [
   "anjuta",
   "coin3d",
+  "freedink",
   "gjs",
   "hive",
   "mpv",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula has a `freetype` dependency, but it's currently unused
since it will use a vendored `freetype` by default. Since we're fixing
this, let's also try to avoid using its vendored `harfbuzz` too.
