### PR TITLE
ipv6toolkit: update urls

### DIFF
--- a/Formula/ipv6toolkit.rb
+++ b/Formula/ipv6toolkit.rb
@@ -1,13 +1,13 @@
 class Ipv6toolkit < Formula
   desc "Security assessment and troubleshooting tool for IPv6"
   homepage "https://www.si6networks.com/research/tools/ipv6toolkit/"
-  url "http://pages.cs.wisc.edu/~plonka/ipv6toolkit/ipv6toolkit-v2.0.tar.gz"
+  url "https://pages.cs.wisc.edu/~plonka/ipv6toolkit/ipv6toolkit-v2.0.tar.gz"
   sha256 "16f13d3e7d17940ff53f028ef0090e4aa3a193a224c97728b07ea6e26a19e987"
   license "GPL-3.0-or-later"
   head "https://github.com/fgont/ipv6toolkit.git", branch: "master"
 
   livecheck do
-    url "http://pages.cs.wisc.edu/~plonka/ipv6toolkit/"
+    url "https://pages.cs.wisc.edu/~plonka/ipv6toolkit/"
     regex(/href=.*?ipv6toolkit[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `ipv6toolkit` formula's `stable` and `livecheck` URLs are redirecting to HTTPS, so this updates the URLs to avoid the redirections.