### PR TITLE
vcpkg 2022.02.01

### DIFF
--- a/Formula/vcpkg.rb
+++ b/Formula/vcpkg.rb
@@ -7,6 +7,14 @@ class Vcpkg < Formula
   license "MIT"
   head "https://github.com/microsoft/vcpkg-tool.git", branch: "main"
 
+  # The source repository has pre-release tags with the same
+  # format as the stable tags.
+  livecheck do
+    url :stable
+    strategy :github_latest
+    regex(/href=.*?\/tag\/v?(\d{4}(?:[._-]\d{2}){2})["' >]/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "8116bce6059d312ab0532fc41b37d7a1e96b3676aab2e36b1d700cdb4b777807"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "e58d2e3fbf843883563579ec544828788ca051c9b5bd46edc0e5df71c35b90dc"

--- a/Formula/vcpkg.rb
+++ b/Formula/vcpkg.rb
@@ -27,6 +27,7 @@ class Vcpkg < Formula
 
   depends_on "cmake" => :build
   depends_on "fmt"
+  depends_on "ninja" # This will install its own copy at runtime if one isn't found.
 
   on_linux do
     depends_on "gcc" # for C++17

--- a/Formula/vcpkg.rb
+++ b/Formula/vcpkg.rb
@@ -48,7 +48,7 @@ class Vcpkg < Formula
   # This is specific to the way we install only the `vcpkg` tool.
   def caveats
     <<~EOS
-      To use vcpkg:
+      This formula provieds only the `vcpkg` executable. To use vcpkg:
         git clone https://github.com/microsoft/vcpkg "$HOME/vcpkg"
         export VCPKG_ROOT="$HOME/vcpkg"
     EOS

--- a/Formula/vcpkg.rb
+++ b/Formula/vcpkg.rb
@@ -1,8 +1,8 @@
 class Vcpkg < Formula
   desc "C++ Library Manager"
   homepage "https://github.com/microsoft/vcpkg"
-  url "https://github.com/microsoft/vcpkg/archive/2021.05.12.tar.gz"
-  sha256 "907f26a5357c30e255fda9427f1388a39804f607a11fa4c083cc740cb268f5dc"
+  url "https://github.com/microsoft/vcpkg/archive/2022.02.02.tar.gz"
+  sha256 "c32c8e98ba705d054dced56003dd7a9b7e367d0908b0b57730be54dc4024abf4"
   license "MIT"
   head "https://github.com/microsoft/vcpkg.git", branch: "master"
 

--- a/Formula/vcpkg.rb
+++ b/Formula/vcpkg.rb
@@ -35,6 +35,10 @@ class Vcpkg < Formula
   fails_with gcc: "5"
 
   def install
+    # Improve error message when user fails to set `VCPKG_ROOT`.
+    inreplace ["src/vcpkg/vcpkgpaths.cpp", "locales/messages.json"],
+              "If you are trying to use a copy of vcpkg that you've built, y", "Y"
+
     system "cmake", "-S", ".", "-B", "build",
                     "-DVCPKG_DEVELOPMENT_WARNINGS=OFF",
                     "-DVCPKG_BASE_VERSION=#{version.to_s.tr(".", "-")}",
@@ -55,6 +59,7 @@ class Vcpkg < Formula
   end
 
   test do
-    assert_match "Error", shell_output("#{bin}/vcpkg search sqlite", 1)
+    message = "Error: Could not detect vcpkg-root. You must define the VCPKG_ROOT environment variable"
+    assert_match message, shell_output("#{bin}/vcpkg search sqlite", 1)
   end
 end

--- a/Formula/vcpkg.rb
+++ b/Formula/vcpkg.rb
@@ -3,7 +3,7 @@ class Vcpkg < Formula
   homepage "https://github.com/microsoft/vcpkg"
   url "https://github.com/microsoft/vcpkg-tool/archive/2022-02-01.tar.gz"
   version "2022.02.01"
-  sha256 "c32c8e98ba705d054dced56003dd7a9b7e367d0908b0b57730be54dc4024abf4"
+  sha256 "cbbefd729f5ba60f3ab0c9db64f271ac931a432781baae333939f4bd57db949c"
   license "MIT"
   head "https://github.com/microsoft/vcpkg-tool.git", branch: "main"
 

--- a/Formula/vcpkg.rb
+++ b/Formula/vcpkg.rb
@@ -12,7 +12,7 @@ class Vcpkg < Formula
   livecheck do
     url :stable
     strategy :github_latest
-    regex(/href=.*?\/tag\/v?(\d{4}(?:[._-]\d{2}){2})["' >]/i)
+    regex(%r{href=.*?/tag/v?(\d{4}(?:[._-]\d{2}){2})["' >]}i)
   end
 
   bottle do
@@ -35,9 +35,9 @@ class Vcpkg < Formula
   fails_with gcc: "5"
 
   def install
-    system "cmake", "-S", ".","-B", "build",
+    system "cmake", "-S", ".", "-B", "build",
                     "-DVCPKG_DEVELOPMENT_WARNINGS=OFF",
-                    "-DVCPKG_BASE_VERSION=#{version.to_s.gsub(".", "-")}",
+                    "-DVCPKG_BASE_VERSION=#{version.to_s.tr(".", "-")}",
                     "-DVCPKG_VERSION=#{version}",
                     "-DVCPKG_DEPENDENCY_EXTERNAL_FMT=ON",
                     *std_cmake_args


### PR DESCRIPTION
Hello, I'm new to the process of Homebrew formula update submission. I have an issue with vcpkg on the latest macOS 12.2, so trying to find out how to solve it.

My issue: https://github.com/microsoft/vcpkg/discussions/22926
Similar issue: https://github.com/Homebrew/homebrew-core/issues/74905

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
