### PR TITLE
jfrog-cli: build jf, symlink jfrog to jf

### DIFF
--- a/Formula/jfrog-cli.rb
+++ b/Formula/jfrog-cli.rb
@@ -4,6 +4,7 @@ class JfrogCli < Formula
   url "https://github.com/jfrog/jfrog-cli/archive/v2.12.0.tar.gz"
   sha256 "4a524dd36165ffe992b80cb81c9a80ab027158319fba1b828e2a0e3ea53a77d8"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "b51c6aeac710e8dc3e5e929a359f660bb1a30f409bd69cc1c77abc7cd234ba3e"
@@ -17,14 +18,19 @@ class JfrogCli < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w -extldflags '-static'", "-trimpath", "-o", bin/"jfrog"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w -extldflags '-static'", output: bin/"jf")
+    bin.install_symlink "jf" => "jfrog"
+
     system "go", "generate", "./completion/shells/..."
     bash_completion.install "completion/shells/bash/jfrog"
-    zsh_completion.install "completion/shells/zsh/jfrog" => "_jfrog"
+    zsh_completion.install "completion/shells/zsh/jfrog" => "_jf"
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/jf -v")
     assert_match version.to_s, shell_output("#{bin}/jfrog -v")
+    with_env(JFROG_CLI_REPORT_USAGE: "false", CI: "true") do
+      assert_match "\"version\": \"#{version}\"", shell_output("#{bin}/jf rt bp --dry-run --url=http://127.0.0.1")
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Recently the `jfrog` executable was changed to `jf` (see https://www.jfrog.com/confluence/display/CLI/JFrog+CLI#JFrogCLI-General).
This Pull Request changes `jfrog` to `jf`. To add also backward compatibility, a symlink from jfrog to jf was added.