### PR TITLE
exiv2: update urls

### DIFF
--- a/Formula/exiv2.rb
+++ b/Formula/exiv2.rb
@@ -1,14 +1,14 @@
 class Exiv2 < Formula
   desc "EXIF and IPTC metadata manipulation library and tools"
-  homepage "https://www.exiv2.org/"
-  url "https://www.exiv2.org/builds/exiv2-0.27.5-Source.tar.gz"
+  homepage "https://exiv2.org/"
+  url "https://github.com/Exiv2/exiv2/releases/download/v0.27.5/exiv2-0.27.5-Source.tar.gz"
   sha256 "35a58618ab236a901ca4928b0ad8b31007ebdc0386d904409d825024e45ea6e2"
   license "GPL-2.0-or-later"
   revision 1
   head "https://github.com/Exiv2/exiv2.git", branch: "main"
 
   livecheck do
-    url "https://www.exiv2.org/builds/"
+    url "https://exiv2.org/download.html"
     regex(/href=.*?exiv2[._-]v?(\d+(?:\.\d+)+)-Source\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The homepage for `exiv2` redirects from the `www` subdomain to `exiv2.org`, so this updates the URL to avoid the redirection.

Source tarballs seem to have been migrated to GitHub and the [first-party download page](https://exiv2.org/download.html) links to the same `exiv2-0.27.5-Source.tar.gz` file from the latest GitHub release. This updates the URL, as the existing URL was giving a 404 (not found) response. The `sha256` remains the same, as expected.

Lastly, this updates the `livecheck` block to check the first-party download page, as it links directly to the `stable` archive. If this ends up causing issues in the future (or there's simply a preference), we can always switch to the `GithubLatest` strategy. [Checking the Git tags probably wouldn't be a sufficient alternative in this case, since there may be lag between when a version is tagged and the release with the `Source` tarball is available.]