### PR TITLE
sha3sum: bump revision for libkeccak dependency

### DIFF
--- a/Formula/sha3sum.rb
+++ b/Formula/sha3sum.rb
@@ -4,6 +4,7 @@ class Sha3sum < Formula
   url "https://github.com/maandree/sha3sum/archive/1.2.1.tar.gz"
   sha256 "3ab7cecf3fbbf096ce43573f48dab9969866e8f8662beefb2777a6713891a4d9"
   license "ISC"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "2612ba6b36a58c1b56c779c1049d9e36b6ae4a74c2564c3729d8dd6f16a63df4"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since it's a bugfix, bottles should be rebuilt.