### PR TITLE
samba: apply `[PATCH] smbd: Safeguards for getpwuid`

### DIFF
--- a/Formula/samba.rb
+++ b/Formula/samba.rb
@@ -7,6 +7,7 @@ class Samba < Formula
   url "https://download.samba.org/pub/samba/stable/samba-4.15.5.tar.gz"
   sha256 "69115e33831937ba5151be0247943147765aece658ba743f44741672ad68d17f"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.samba.org/samba/download/"
@@ -33,6 +34,14 @@ class Samba < Formula
   resource "Parse::Yapp" do
     url "https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz"
     sha256 "3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5"
+  end
+
+  # [PATCH] smbd: Safeguards for getpwuid
+  # Fix `Regression: Samba 4.15.2 on macOS segfaults intermittently during strcpy in tdbsam_getsampwnam`
+  # https://bugzilla.samba.org/show_bug.cgi?id=14900
+  patch do
+    url "https://attachments.samba.org/attachment.cgi?id=17147"
+    sha256 "ca414d668d4c669e9d1886ccfc81bf5215f002ae7a2ca9491ac99548dd88bf9b"
   end
 
   def install


### PR DESCRIPTION
Fix `Regression: Samba 4.15.2 on macOS segfaults intermittently during strcpy in tdbsam_getsampwnam`

https://bugzilla.samba.org/show_bug.cgi?id=14900

Tested 30 times locally (macOS 12 Intel).
I predict that the patch will be merged into the next version of Samba (Samba v4.14.6), but I suggest cherry-picking the patch right now, to avoid segfaults.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
