### PR TITLE
ecl: avoid -flat_namespace usage

### DIFF
--- a/Formula/ecl.rb
+++ b/Formula/ecl.rb
@@ -28,6 +28,9 @@ class Ecl < Formula
   def install
     ENV.deparallelize
 
+    # Avoid -flat_namespace usage on macOS
+    inreplace "src/configure", "-flat_namespace -undefined suppress ", "" if OS.mac?
+
     system "./configure", "--prefix=#{prefix}",
                           "--enable-threads=yes",
                           "--enable-boehm=system",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Unlike the usual relevant `configure` snippet, looks like the one in `ecl` is hand-crafted and just covers all macOS versions:
```shell
darwin*)
                thehost='darwin'
                shared='yes'
                SHAREDEXT='dylib'
                PICFLAG='-fPIC -fno-common'
                SHARED_LDFLAGS="-dynamiclib -flat_namespace -undefined suppress ${LDFLAGS}"
...
```