### PR TITLE
terminalimageviewer: requires Catalina minimum

### DIFF
--- a/Formula/terminalimageviewer.rb
+++ b/Formula/terminalimageviewer.rb
@@ -16,6 +16,7 @@ class Terminalimageviewer < Formula
   end
 
   depends_on "imagemagick"
+  depends_on macos: :catalina
 
   on_linux do
     depends_on "gcc"


### PR DESCRIPTION
Building on Mojave results in many errors like:
```
tiv.cpp:580:28: error: 'is_directory' is unavailable: introduced in macOS 10.15
```
This should be `CI-syntax-only`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
