### PR TITLE
molten-vk: mark as macOS-only

### DIFF
--- a/Formula/molten-vk.rb
+++ b/Formula/molten-vk.rb
@@ -18,6 +18,7 @@ class MoltenVk < Formula
   depends_on xcode: ["11.7", :build]
   # Requires IOSurface/IOSurfaceRef.h.
   depends_on macos: :sierra
+  depends_on :macos # Linux does not have a Metal implementation. Not implied by the line above.
 
   # MoltenVK depends on very specific revisions of its dependencies.
   # For each resource the path to the file describing the expected


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Confusingly, we still need `depends_on :macos` despite the `depends_on
macos: :sierra` to indicate that this is macOS-only.

See discussion at #94640.
