### PR TITLE
yt-dlp: fix HEAD build

### DIFF
--- a/Formula/yt-dlp.rb
+++ b/Formula/yt-dlp.rb
@@ -6,7 +6,6 @@ class YtDlp < Formula
   url "https://files.pythonhosted.org/packages/5c/e0/e5bae3e87ee6da0f7507f3b58c5e9ffc1500de0742886ccc72c1a56740f2/yt-dlp-2022.2.4.tar.gz"
   sha256 "81b50ed7cf9cfcc042d8f5a1ad2d1cd7b13c48b36c07faf1880696eac0a7ddb5"
   license "Unlicense"
-  head "https://github.com/yt-dlp/yt-dlp.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "ca50f2157bec68534c4f4188e6398830a7c2a73dbf5ed78e579760f1197d8704"
@@ -15,6 +14,11 @@ class YtDlp < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "d1090c7956a99aaf339272465dc9605855cf0adb0a54daceac0af7e6baab5c40"
     sha256 cellar: :any_skip_relocation, catalina:       "7c87b4e0cf50dc631b8b3460c54a2ff1f22821408b7373c894c7a84846ee827f"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ee0dd20f1e980a2d05a85e586e11be0c62780623caa96670b0b2c16969953f23"
+  end
+
+  head do
+    url "https://github.com/yt-dlp/yt-dlp.git", branch: "master"
+    depends_on "pandoc" => :build
   end
 
   depends_on "python@3.10"
@@ -35,6 +39,7 @@ class YtDlp < Formula
   end
 
   def install
+    system "make", "pypi-files" if build.head?
     virtualenv_install_with_resources
     man1.install_symlink libexec/"share/man/man1/yt-dlp.1"
     bash_completion.install libexec/"share/bash-completion/completions/yt-dlp"


### PR DESCRIPTION
Trying to install HEAD gave the following:
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - /usr/local/Cellar/yt-dlp/HEAD-a312579/libexec/share/bash-completion/completions/yt-dlp

Solved with
make pypi-files
which needs pandoc to be installed.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Note:
The tests pass when run manually, just as they did before the change.
However, there seems to be a problem with the brew test framework, causing strange behavior with the second test.
Using the test framework one out of two tests doesn't pass – just as it didn't before this change.

`brew test yt-dlp`
```
brew test yt-dlp
==> Testing yt-dlp
==> /usr/local/Cellar/yt-dlp/2022.2.4/bin/yt-dlp --simulate https://www.youtube.com/watch?v=pOtd1cbOP7k
==> /usr/local/Cellar/yt-dlp/2022.2.4/bin/yt-dlp --simulate --yes-playlist https://www.youtube.com/watch?list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj
Killing child processes...
Error: yt-dlp: failed
Failure while executing; `/usr/bin/sandbox-exec -f /private/tmp/homebrew20220207-98671-m8why8.sb /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/bin/ruby -W1 -- /usr/local/Homebrew/Library/Homebrew/test.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/yt-dlp.rb` was terminated by uncaught signal TERM.
/usr/local/Homebrew/Library/Homebrew/sandbox.rb:156:in `exec'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/test.rb:102:in `block (2 levels) in test'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:45:in `block (3 levels) in safe_fork'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:37:in `fork'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:37:in `block (2 levels) in safe_fork'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:34:in `open'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:34:in `block in safe_fork'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/lib/ruby/2.6.0/tmpdir.rb:93:in `mktmpdir'
/usr/local/Homebrew/Library/Homebrew/utils/fork.rb:33:in `safe_fork'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/test.rb:90:in `block in test'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/test.rb:45:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/test.rb:45:in `test'
/usr/local/Homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```

Running the test manually works perfectly:
`/usr/local/Cellar/yt-dlp/2022.2.4/bin/yt-dlp --simulate --yes-playlist "https://www.youtube.com/watch?v=pOtd1cbOP7k&list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj"`
```
[youtube:tab] Downloading playlist PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj; add --no-playlist to just download video pOtd1cbOP7k
[youtube:tab] PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj: Downloading webpage
[youtube:tab] PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj: Downloading webpage
[youtube:tab] PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj: Downloading API JSON with unavailable videos
[download] Downloading playlist: homebrew
[youtube:tab] playlist homebrew: Downloading 1 videos
[download] Downloading video 1 of 1
[youtube] pOtd1cbOP7k: Downloading webpage
[youtube] pOtd1cbOP7k: Downloading android player API JSON
[youtube] pOtd1cbOP7k: Downloading MPD manifest
[youtube] pOtd1cbOP7k: Downloading MPD manifest
[info] pOtd1cbOP7k: Downloading 1 format(s): 303+251
[download] Finished downloading playlist: homebrew
```
