### PR TITLE
mpg123: Build both static and dynamic libraries

### DIFF
--- a/Formula/mpg123.rb
+++ b/Formula/mpg123.rb
@@ -26,6 +26,7 @@ class Mpg123 < Formula
       --disable-dependency-tracking
       --prefix=#{prefix}
       --with-module-suffix=.so
+      --enable-static
     ]
 
     args << "--with-default-audio=coreaudio" if OS.mac?


### PR DESCRIPTION
Add flag to also generate static libraries. Tested locally to confirm both `libmpg123.0.dylib` and `libmpg123.a` are present.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
