### PR TITLE
sonarqube-lts: update livecheck

### DIFF
--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -5,13 +5,9 @@ class SonarqubeLts < Formula
   sha256 "9991d4df42c10c181005df6a4aff6b342baf9be2f3ad0e83e52a502f44d2e2d8"
   license "LGPL-3.0-or-later"
 
-  # Upstream doesn't distinguish LTS releases in the URL or filename, so this
-  # only matches versions for the formula's current major/minor version. This
-  # won't identify a new LTS version with a different major/minor but updating
-  # the `stable` URL with the new LTS will fix the check until the next time.
   livecheck do
-    url "https://binaries.sonarsource.com/Distribution/sonarqube/"
-    regex(/href=.*?sonarqube[._-]v?(#{Regexp.escape(version.major_minor)}(?:\.\d+)*)\.zip/i)
+    url "https://www.sonarqube.org/downloads/"
+    regex(/SonarQube\s+v?\d+(?:\.\d+)+\s+LTS.*?href=.*?sonarqube[._-]v?(\d+(?:\.\d+)+)\.(?:zip|t)/im)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates the `sonarqube-lts` `livecheck` block to return to checking LTS versions from the first-party download page, using an approach that isn't too dissimilar to what we were doing prior to #76848.

In the past, we were previously able to identify LTS versions from text that was adjacent to download URLs in the page source. We lost that approach when the download page was revamped, so I fell back to checking the directory listing page where the `stable` archive is found, albeit with shortcomings (as described in the above PR).

So long as the download page retains the current format, it seems like we can successfully match the version from LTS archive files. It's not the prettiest regex but it gets the job done for now, without the shortcomings of the existing approach (i.e., not being able to automatically identify new major LTS versions).