### PR TITLE
publish-commit-bottles: pass `--autosquash`

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -8,7 +8,7 @@ on:
         required: true
       args:
         description: "Extra arguments to `brew pr-pull`"
-        default: ""
+        default: "--autosquash"
 
 env:
   HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1


### PR DESCRIPTION
This makes triggering this workflow in the GitHub UI match the behaviour
when triggered via the command-line with `brew pr-publish`.

See discussion at #94403.
