### PR TITLE
qemu: Enable gtk gui when running on linux

### DIFF
--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -36,6 +36,7 @@ class Qemu < Formula
 
   on_linux do
     depends_on "gcc"
+    depends_on "gtk+3"
   end
 
   fails_with gcc: "5"
@@ -61,7 +62,6 @@ class Qemu < Formula
       --enable-vde
       --extra-cflags=-DNCURSES_WIDECHAR=1
       --disable-sdl
-      --disable-gtk
     ]
     # Sharing Samba directories in QEMU requires the samba.org smbd which is
     # incompatible with the macOS-provided version. This will lead to
@@ -70,7 +70,9 @@ class Qemu < Formula
     # Samba installations from external taps.
     args << "--smbd=#{HOMEBREW_PREFIX}/sbin/samba-dot-org-smbd"
 
+    args << "--disable-gtk" if OS.mac?
     args << "--enable-cocoa" if OS.mac?
+    args << "--enable-gtk" if OS.linux?
 
     system "./configure", *args
     system "make", "V=1", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There was no GUI enabled for the Linux build, only for the Mac build.