### PR TITLE
ffmpeg: enable neon

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -120,6 +120,7 @@ class Ffmpeg < Formula
 
     # Needs corefoundation, coremedia, corevideo
     args << "--enable-videotoolbox" if OS.mac?
+    args << "--enable-neon" if Hardware::CPU.arm?
 
     # Replace hardcoded default VMAF model path
     unless build.head?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


some story from https://github.com/Homebrew/homebrew-core/pull/91840 , now the `x265` fixes the issue on `HEAD`.

In order to have the benefit of neon patch on Apple M1, the step is 
1. Apply this patch
2. `brew install ffmpeg`  which will install bottled version of `ffmpeg` and `x265`, which does not have the neon patch yet
3. `brew uninstall –ignore-dependencies x265`, which will uninstall the `x265` first 
4. `brew install x265 --HEAD`, install `x265` from the source code `HEAD`, which will have the neon patch
5. Homebrew will reinstall `ffmpeg` automatically, since the dependency changes. And since we have `1`, now you can use `ffmpeg` on Apple Silicon with neon patch  