### PR TITLE
gd: add avif support

### DIFF
--- a/Formula/gd.rb
+++ b/Formula/gd.rb
@@ -27,6 +27,7 @@ class Gd < Formula
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "jpeg"
+  depends_on "libavif"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "webp"


### PR DESCRIPTION
Avif support is used by PHP 8.1 --with-external-gd
