### PR TITLE
Make mumps dependency explicit in Ipopt.rb

### DIFF
--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -19,8 +19,8 @@ class Ipopt < Formula
   depends_on "pkg-config" => [:build, :test]
   depends_on "ampl-mp"
   depends_on "gcc" # for gfortran
-  depends_on "openblas"
   depends_on "mumps-seq"
+  depends_on "openblas"
 
   resource "test" do
     url "https://github.com/coin-or/Ipopt/archive/releases/3.14.5.tar.gz"

--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -41,7 +41,7 @@ class Ipopt < Formula
       "--prefix=#{prefix}",
       "--with-blas=-L#{Formula["openblas"].opt_lib} -lopenblas",
       "--with-mumps-cflags=-I#{mumps_formula.opt_libexec}/include",
-      "--with-mumps-lflags=-L#{mumps_formula.opt_lib} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord -lm",
+      "--with-mumps-lflags=-L#{mumps_formula.opt_lib} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord",
       "--with-asl-cflags=-I#{Formula["ampl-mp"].opt_include}/asl",
       "--with-asl-lflags=-L#{Formula["ampl-mp"].opt_lib} -lasl",
     ]

--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -39,8 +39,8 @@ class Ipopt < Formula
       "--enable-shared",
       "--prefix=#{prefix}",
       "--with-blas=-L#{Formula["openblas"].opt_lib} -lopenblas",
-      "--with-mumps-cflags=-I#{Formula["mumps-seq"].opt_include}/",
-      "--with-mumps-lflags=-L#{Formula["mumps-seq"].opt_lib} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord",
+      "--with-mumps-cflags=-I#{Formula["coin-or-tools/coinor/mumps-seq"].opt_libexec}/include",
+      "--with-mumps-lflags=-L#{Formula["coin-or-tools/coinor/mumps-seq"].opt_lib} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord",
       "--with-asl-cflags=-I#{Formula["ampl-mp"].opt_include}/asl",
       "--with-asl-lflags=-L#{Formula["ampl-mp"].opt_lib} -lasl",
     ]

--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -32,6 +32,7 @@ class Ipopt < Formula
     ENV.delete("MPICXX")
     ENV.delete("MPIFC")
 
+    mumps_formula = Formula["coin-or-tools/coinor/mumps-seq"]
     args = [
       "--disable-debug",
       "--disable-dependency-tracking",
@@ -39,8 +40,8 @@ class Ipopt < Formula
       "--enable-shared",
       "--prefix=#{prefix}",
       "--with-blas=-L#{Formula["openblas"].opt_lib} -lopenblas",
-      "--with-mumps-cflags=-I#{Formula["coin-or-tools/coinor/mumps-seq"].opt_libexec}/include",
-      "--with-mumps-lflags=-L#{Formula["coin-or-tools/coinor/mumps-seq"].opt_lib} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord",
+      "--with-mumps-cflags=-I#{mumps_formula.opt_libexec}/include",
+      "--with-mumps-lflags=-L#{mumps_formula.opt_lib} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord",
       "--with-asl-cflags=-I#{Formula["ampl-mp"].opt_include}/asl",
       "--with-asl-lflags=-L#{Formula["ampl-mp"].opt_lib} -lasl",
     ]

--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -41,7 +41,7 @@ class Ipopt < Formula
       "--prefix=#{prefix}",
       "--with-blas=-L#{Formula["openblas"].opt_lib} -lopenblas",
       "--with-mumps-cflags=-I#{mumps_formula.opt_libexec}/include",
-      "--with-mumps-lflags=-L#{mumps_formula.opt_lib} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord",
+      "--with-mumps-lflags=-L#{mumps_formula.opt_lib} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord -lm",
       "--with-asl-cflags=-I#{Formula["ampl-mp"].opt_include}/asl",
       "--with-asl-lflags=-L#{Formula["ampl-mp"].opt_lib} -lasl",
     ]

--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -18,8 +18,8 @@ class Ipopt < Formula
   depends_on "openjdk" => :build
   depends_on "pkg-config" => [:build, :test]
   depends_on "ampl-mp"
+  depends_on "coin-or-tools/coinor/mumps-seq"
   depends_on "gcc" # for gfortran
-  depends_on "mumps-seq"
   depends_on "openblas"
 
   resource "test" do

--- a/Formula/ipopt.rb
+++ b/Formula/ipopt.rb
@@ -20,24 +20,7 @@ class Ipopt < Formula
   depends_on "ampl-mp"
   depends_on "gcc" # for gfortran
   depends_on "openblas"
-
-  resource "mumps" do
-    url "http://mumps.enseeiht.fr/MUMPS_5.4.0.tar.gz"
-    sha256 "c613414683e462da7c152c131cebf34f937e79b30571424060dd673368bbf627"
-
-    patch do
-      # MUMPS does not provide a Makefile.inc customized for macOS.
-      on_macos do
-        url "https://raw.githubusercontent.com/Homebrew/formula-patches/ab96a8b8e510a8a022808a9be77174179ac79e85/ipopt/mumps-makefile-inc-generic-seq.patch"
-        sha256 "0c570ee41299073ec2232ad089d8ee10a2010e6dfc9edc28f66912dae6999d75"
-      end
-
-      on_linux do
-        url "https://gist.githubusercontent.com/dawidd6/09f831daf608eb6e07cc80286b483030/raw/b5ab689dea5772e9b6a8b6d88676e8d76224c0cc/mumps-homebrew-linux.patch"
-        sha256 "13125be766a22aec395166bf015973f5e4d82cd3329c87895646f0aefda9e78e"
-      end
-    end
-  end
+  depends_on "mumps-seq"
 
   resource "test" do
     url "https://github.com/coin-or/Ipopt/archive/releases/3.14.5.tar.gz"
@@ -49,24 +32,6 @@ class Ipopt < Formula
     ENV.delete("MPICXX")
     ENV.delete("MPIFC")
 
-    resource("mumps").stage do
-      cp "Make.inc/Makefile.inc.generic.SEQ", "Makefile.inc"
-      inreplace "Makefile.inc", "@rpath/", "#{opt_lib}/" if OS.mac?
-
-      # Fix for GCC 10
-      inreplace "Makefile.inc", "OPTF    = -fPIC",
-                "OPTF    = -fPIC -fallow-argument-mismatch"
-
-      ENV.deparallelize { system "make", "d" }
-
-      (buildpath/"mumps_include").install Dir["include/*.h", "libseq/mpi.h"]
-      lib.install Dir[
-        "lib/#{shared_library("*")}",
-        "libseq/#{shared_library("*")}",
-        "PORD/lib/#{shared_library("*")}"
-      ]
-    end
-
     args = [
       "--disable-debug",
       "--disable-dependency-tracking",
@@ -74,8 +39,8 @@ class Ipopt < Formula
       "--enable-shared",
       "--prefix=#{prefix}",
       "--with-blas=-L#{Formula["openblas"].opt_lib} -lopenblas",
-      "--with-mumps-cflags=-I#{buildpath}/mumps_include",
-      "--with-mumps-lflags=-L#{lib} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord",
+      "--with-mumps-cflags=-I#{Formula["mumps-seq"].opt_include}/",
+      "--with-mumps-lflags=-L#{Formula["mumps-seq"].opt_lib} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord",
       "--with-asl-cflags=-I#{Formula["ampl-mp"].opt_include}/asl",
       "--with-asl-lflags=-L#{Formula["ampl-mp"].opt_lib} -lasl",
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

## Description
Avoids hidden dependency of Ipopt into Mumps, and instead use the `depends_on` syntax.

@tkralphs I am keen to hear your thoughts on this, on how this fits to the dependency logic of `homebrew-coinor`.

## What was the reason I opened this?
This hidden dependency was causing segfaults in an application of mine that was using `Ipopt` from this formula, in conjuction with Cbc from `coin-or-tools/coinor/cbc`, as both of them were reliant on Mumps but were build with different versions of it.