### PR TITLE
synced_versions_formulae: add `fb303`

### DIFF
--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -13,7 +13,7 @@
   ["docker", "docker-completion"],
   ["etl", "synfig"],
   ["file-formula", "libmagic"],
-  ["fbthrift", "fizz", "folly", "wangle", "watchman"],
+  ["fb303", "fbthrift", "fizz", "folly", "wangle", "watchman"],
   ["frpc", "frps"],
   ["gcc", "i686-elf-gcc", "libgccjit", "x86_64-elf-gcc"],
   ["ghz", "ghz-web"],


### PR DESCRIPTION
This has the same version scheme as the other Facebook formulae.
