### PR TITLE
proj@7: undeprecate

### DIFF
--- a/Formula/proj@7.rb
+++ b/Formula/proj@7.rb
@@ -17,8 +17,6 @@ class ProjAT7 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-03-01", because: :unsupported
-
   depends_on "pkg-config" => :build
   depends_on "libtiff"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This deprecation causes problems for users that they struggle a lot to do something about. See #94789.

This also aligns the formula with our policy on (not) deprecating formulae with dependents. See https://docs.brew.sh/Deprecating-Disabling-and-Removing-Formulae#deprecation.