### PR TITLE
tests: show linkage and bottle output earlier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -231,6 +231,18 @@ jobs:
           cat bottles/steps_output.txt
           rm bottles/steps_output.txt
 
+      - name: Output brew linkage result
+        if: always()
+        run: |
+          cat bottles/linkage_output.txt
+          rm bottles/linkage_output.txt
+
+      - name: Output brew bottle result
+        if: always()
+        run: |
+          cat bottles/bottle_output.txt
+          rm bottles/bottle_output.txt
+
       - name: Run brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
         if: ${{fromJson(needs.setup_tests.outputs.test-dependents)}}
         run: |
@@ -243,18 +255,6 @@ jobs:
           touch bottles/steps_output.txt
           cat bottles/steps_output.txt
           rm bottles/steps_output.txt
-
-      - name: Output brew linkage result
-        if: always()
-        run: |
-          cat bottles/linkage_output.txt
-          rm bottles/linkage_output.txt
-
-      - name: Output brew bottle result
-        if: always()
-        run: |
-          cat bottles/bottle_output.txt
-          rm bottles/bottle_output.txt
 
       - name: Upload logs
         if: always()


### PR DESCRIPTION
These don't need the outcome of the dependent tests, so let's show them
earlier. It'll also make the formulae step easier to distinguish from
the dependents step in the CI log.
