### PR TITLE
formulae*: deprecate formulae which depend on Python 2

### DIFF
--- a/Formula/appscale-tools.rb
+++ b/Formula/appscale-tools.rb
@@ -14,8 +14,11 @@ class AppscaleTools < Formula
     sha256 cellar: :any, high_sierra: "70e89498336894ae025118e51e418528d8d73da9b1e2786559b6bcbe6055f55b"
   end
 
+  deprecate! date: "2022-03-05", because: "depends on Python 2"
+
   depends_on "libyaml"
   depends_on :macos # Due to Python 2 (Uses SOAPPy, which does not support Python 3)
+  depends_on maximum_macos: :big_sur # Python 2 removed in macOS 12.3
   depends_on "openssl@1.1"
 
   uses_from_macos "libffi"

--- a/Formula/git-remote-hg.rb
+++ b/Formula/git-remote-hg.rb
@@ -15,8 +15,11 @@ class GitRemoteHg < Formula
     sha256 cellar: :any_skip_relocation, high_sierra: "1380e5053a25462f27d9be329840b6dda55b08e01b70ed6c581f3c625c7b332d"
   end
 
+  deprecate! date: "2022-03-05", because: "depends on Python 2"
+
   depends_on "asciidoc" => :build
   depends_on :macos # Due to Python 2
+  depends_on maximum_macos: :big_sur # Python 2 removed in macOS 12.3
 
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"

--- a/Formula/rethinkdb.rb
+++ b/Formula/rethinkdb.rb
@@ -19,7 +19,10 @@ class Rethinkdb < Formula
     sha256 cellar: :any, mojave:   "35771b918dd1e41939aea3a8eec2b3fa8ee38ca4236c1ad0bd2695c3bb598caf"
   end
 
+  deprecate! date: "2022-03-05", because: "depends on Python 2"
+
   depends_on "boost" => :build
+  depends_on maximum_macos: [:big_sur, :build] # Python 2 removed in macOS 12.3
   depends_on :macos # Due to Python 2 (v8 and gyp fail to build)
   # https://github.com/Homebrew/linuxbrew-core/pull/19614
   # https://github.com/rethinkdb/rethinkdb/pull/6401

--- a/Formula/rfcmarkup.rb
+++ b/Formula/rfcmarkup.rb
@@ -19,7 +19,10 @@ class Rfcmarkup < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "993672e2e414a95a06259ac6960d37ac9cf324093766fbf28adf3579fd450678"
   end
 
+  deprecate! date: "2022-03-05", because: "depends on Python 2"
+
   depends_on :macos # Due to Python 2
+  depends_on maximum_macos: :big_sur # Python 2 removed in macOS 12.3
 
   def install
     bin.install "rfcmarkup"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
