### PR TITLE
workflows: recreate macOS runners on a schedule

### DIFF
--- a/.github/workflows/recreate-macos-runners.yml
+++ b/.github/workflows/recreate-macos-runners.yml
@@ -1,0 +1,137 @@
+name: Recreate macOS self-hosted runners on schedule
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Once each 24 hours, at 1 during the night
+    - cron: "0 1 * * *"
+
+concurrency:
+  group: recreate-macos-runners
+  cancel-in-progress: true
+
+jobs:
+  recreate:
+    if: github.repository == 'Homebrew/homebrew-core'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - runner_name: monterey-1
+            label: 12
+            vm_name: monterey
+            node: macpro-4
+            port: 8822
+          - runner_name: monterey-2
+            label: 12
+            vm_name: monterey
+            node: macpro-4
+            port: 8823
+          - runner_name: monterey-3
+            label: 12
+            vm_name: monterey
+            node: macpro-4
+            port: 8824
+          - runner_name: monterey-4
+            label: 12
+            vm_name: monterey
+            node: macpro-4
+            port: 8825
+          - runner_name: bigsur-1
+            label: 11
+            vm_name: bigsur
+            node: macpro-5
+            port: 8822
+          - runner_name: bigsur-2
+            label: 11
+            vm_name: bigsur
+            node: macpro-5
+            port: 8823
+          - runner_name: bigsur-3
+            label: 11
+            vm_name: bigsur
+            node: macpro-5
+            port: 8824
+          - runner_name: bigsur-4
+            label: 11
+            vm_name: bigsur
+            node: macpro-5
+            port: 8825
+          - runner_name: catalina-1
+            label: 10.15
+            vm_name: catalina
+            node: macpro-6
+            port: 8822
+          - runner_name: catalina-2
+            label: 10.15
+            vm_name: catalina
+            node: macpro-6
+            port: 8823
+          - runner_name: catalina-3
+            label: 10.15
+            vm_name: catalina
+            node: macpro-6
+            port: 8824
+          - runner_name: catalina-4
+            label: 10.15
+            vm_name: catalina
+            node: macpro-6
+            port: 8825
+    steps:
+      - name: Install openconnect
+        run: brew install openconnect
+
+      - name: Checkout Orka API Client gem
+        uses: actions/checkout@v2
+        with:
+          repository: Homebrew/orka_api_client
+          path: orka_api_client
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+          working-directory: orka_api_client
+
+      - name: Install Orka API Client gem
+        working-directory: orka_api_client
+        run: |
+          bundle exec rake
+          gem install pkg/orka_api_client-*.gem
+
+      - name: Wait for idle runner
+        id: killable
+        uses: Homebrew/actions/wait-for-idle-runner@master
+        with:
+          runner_name: ${{ matrix.runner_name }}
+          github_token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+
+      - name: Connect to Orka VPN
+        if: ${{ steps.killable.outputs.runner-found == 'true' && steps.killable.outputs.runner-idle == 'true' }}
+        run: echo "${{ secrets.ORKA_VPN_PASSWORD }}" | openconnect "${{ secrets.ORKA_VPN_IP }}" --user="${{ secrets.ORKA_VPN_USER }}" --background --setuid=$(whoami) --servercert pin-sha256:vbaO8lPevDx8SUVMUy43VtttA+hL2RxYSjgXHd0Qey8=
+
+      - name: Kill runner and create a new one
+        if: ${{ steps.killable.outputs.runner-found == 'true' && steps.killable.outputs.runner-idle == 'true' }}
+        run: |
+          ruby -rorka_api_client -e '
+            client = OrkaAPI::Client.new("${{ secrets.ORKA_API_URL }}", token: "${{ secrets.ORKA_API_TOKEN }}")
+            resource = client.vm_resource("${{ matrix.vm_name }}")
+            instance = resource.instances.find do |instance|
+              instance.node.name == "${{ matrix.node }}" && instance.ssh_port == ${{ matrix.port }}
+            end
+
+            raise "Cannot find VM for ${{ matrix.runner_name }}!" if instance.nil?
+
+            instance.delete
+            resource.deploy(node: instance.node, vm_metadata: {
+              "registration_token" => "",
+              "runner_name" => "${{ matrix.runner_name }}",
+              "label" => "${{ matrix.label }}",
+            })
+          '
+
+      - name: Disonnect from Orka VPN
+        if: ${{ always() && steps.killable.outputs.runner-found == 'true' && steps.killable.outputs.runner-idle == 'true' }}
+        run: killall -SIGINT openconnect


### PR DESCRIPTION
This is a workflow that does the same thing as what the existing Linux runner recreation does.

This requires some changes to our VMs to make it work. I'll try get this done in the maintenance window on Monday. (These changes are also required in a fully ephemeral system.)

Note however it does have notable limitations:

* The mapping to runner names to VMs is hardcoded in this workflow. It is not possible to attach labels to Orka VMs to my knowledge so this mapping needs to be externally managed, like in this workflow (or alternatively, SSH into each VM and figure out from that but that's slow and more error prone). When we do full ephemeral, an external orchestrator to manage that would remember the mappings itself.
* There is no "locking". Race conditions can occur if a PR picks up a runner between `wait-for-idle-runner` returning and the VM being destroyed. We are not actually using GitHub's ephemeral feature at all here, because we're not destroying after every PR so we lose a lot of guarantees there.
* This _will_ bottleneck CI usage of `ubuntu-latest` runners since we busy wait here.
* Error handling is very much uncharted territory.
* It requires a significant number of dangerous secrets. In a full ephemeral system, I'm hoping to be able to do things like GitHub app tokens with majorly reduced permissions.

With that said, I'm not actually that far from demonstrating what a fully ephemeral system might look like. I'm also aiming for Monday for that (it's coincidence how that happens to align with the Orka maintenance window) so it's possible this will never need to be merged. It is however a good presentation of how things are coming together and is something to also fall back to should we face problems further down the line.