### PR TITLE
citus: fix Linux build

### DIFF
--- a/Formula/citus.rb
+++ b/Formula/citus.rb
@@ -19,12 +19,14 @@ class Citus < Formula
   depends_on "readline"
   depends_on "zstd"
 
+  uses_from_macos "curl"
+
   def install
     ENV["PG_CONFIG"] = Formula["postgresql"].opt_bin/"pg_config"
 
     system "./configure"
 
-    # workaround for https://github.com/Homebrew/homebrew/issues/49948
+    # workaround for https://github.com/Homebrew/legacy-homebrew/issues/49948
     system "make", "libpq=-L#{Formula["postgresql"].opt_lib} -lpq"
 
     # Use stage directory to prevent installing to pg_config-defined dirs,
@@ -32,9 +34,9 @@ class Citus < Formula
     mkdir "stage"
     system "make", "install", "DESTDIR=#{buildpath}/stage"
 
-    bin.install Dir["stage/**/bin/*"]
-    lib.install Dir["stage/**/lib/*"]
-    include.install Dir["stage/**/include/*"]
-    (share/"postgresql/extension").install Dir["stage/**/share/postgresql/extension/*"]
+    path = File.join("stage", HOMEBREW_PREFIX)
+    lib.install (buildpath/path/"lib").children
+    include.install (buildpath/path/"include").children
+    (share/"postgresql/extension").install (buildpath/path/"share/postgresql/extension").children
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Get `citus` to build on Linux. I haven't added a test because this requires a `postgresql` database and a running server, there is no CLI tool I can check instead (hence the removal of `bin.install`). See:
```zsh
➜ brew ls citus
/usr/local/Cellar/citus/10.2.4/include/postgresql/ (116 files)
/usr/local/Cellar/citus/10.2.4/lib/postgresql/citus.so
/usr/local/Cellar/citus/10.2.4/share/postgresql/ (47 files)
```

(Note: this didn't need the `CI-long-timeout` label, was just testing because of an issue with adding it to other PRs.)