### PR TITLE
proj: update build to cmake (8.2.1, HEAD)

### DIFF
--- a/Formula/proj.rb
+++ b/Formula/proj.rb
@@ -4,6 +4,7 @@ class Proj < Formula
   url "https://github.com/OSGeo/PROJ/releases/download/8.2.1/proj-8.2.1.tar.gz"
   sha256 "76ed3d0c3a348a6693dfae535e5658bbfd47f71cb7ff7eb96d9f12f7e068b1cf"
   license "MIT"
+  head "https://github.com/OSGeo/proj.git", branch: "master"
 
   bottle do
     sha256 arm64_monterey: "62cb9712728f6564c3a16dbc0ff0039018190140006a116d859f33d74b25ae97"
@@ -14,13 +15,8 @@ class Proj < Formula
     sha256 x86_64_linux:   "402f0a4d03f0fc03f8ee6faa81dd13bf7e207d3df58de2790c9e51e950ac1725"
   end
 
-  head do
-    url "https://github.com/OSGeo/proj.git"
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
-
+  depends_on "cmake" => :build
+  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "libtiff"
 
@@ -39,10 +35,9 @@ class Proj < Formula
 
   def install
     (buildpath/"nad").install resource("datumgrid")
-    system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This represents preparatory tweaks needed to build `proj` version `9.0` when released as the autotools method of building is set to be depreciated, according to the upcoming installation docs (quoted below). It has the benefit of facilitating the current current (8.2) `HEAD` (which was my current need, and hence this early WIP).

It will need further tweaks, in particular:
- How to deal with versions earlier than 9.0? (8.2 should also build with cmake, but not clear to me how far back this goes, if targetting proj@7 etc. Any advice on how to deal with this appreciated.
- The current code tests for HEAD and then uses cmake. This should be changed to remove test for HEAD once 9.0 released (probably 1st March), (and possibly test for earlier versions?).

Happy for edits to be made directly by maintainers etc.

```
Note

    Support for Autotools was maintained until PROJ 8.2 (see [:ref:`RFC7`](https://github.com/OSGeo/PROJ/blob/master/docs/source/install.rst#id11)). PROJ 9.0 and later releases only support builds using CMake.
```
(https://github.com/OSGeo/PROJ/blob/master/docs/source/install.rst)