### PR TITLE
spidermonkey@78 (new formula), spidermonkey 91.6.0, gjs 1.70.1

### DIFF
--- a/Aliases/spidermonkey@91
+++ b/Aliases/spidermonkey@91
@@ -1,0 +1,1 @@
+../Formula/spidermonkey.rb

--- a/Formula/spidermonkey.rb
+++ b/Formula/spidermonkey.rb
@@ -1,11 +1,10 @@
 class Spidermonkey < Formula
   desc "JavaScript-C Engine"
   homepage "https://spidermonkey.dev"
-  url "https://archive.mozilla.org/pub/mozilla.org/js/js185-1.0.0.tar.gz"
-  version "1.8.5"
-  sha256 "5d12f7e1f5b4a99436685d97b9b7b75f094d33580227aa998c406bbae6f2a687"
-  license "MPL-1.1"
-  revision 4
+  url "https://archive.mozilla.org/pub/firefox/releases/91.6.0esr/source/firefox-91.6.0esr.source.tar.xz"
+  version "91.6.0"
+  sha256 "7e802832152c39588b9a5c8392e90c1b00036bf948fa4a97a7af0d1435ba09a1"
+  license "MPL-2.0"
   head "https://hg.mozilla.org/mozilla-central", using: :hg
 
   # Spidermonkey versions use the same versions as Firefox, so we simply check
@@ -22,49 +21,72 @@ class Spidermonkey < Formula
     sha256 cellar: :any, mojave:   "8c0b46bc04a7e95f99262969b22cc311ee1f7d83413af05865318743ccd96944"
   end
 
-  depends_on :macos # Due to Python 2
+  depends_on "autoconf@2.13" => :build
+  depends_on "pkg-config" => :build
+  depends_on "python@3.9" => :build
+  depends_on "rust" => :build
+  depends_on "icu4c"
   depends_on "nspr"
   depends_on "readline"
 
+  uses_from_macos "llvm" => :build # for llvm-objdump
+  uses_from_macos "m4" => :build
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
+
   conflicts_with "narwhal", because: "both install a js binary"
 
+  # From python/mozbuild/mozbuild/test/configure/test_toolchain_configure.py
+  fails_with :gcc do
+    version "6"
+    cause "Only GCC 7.1 or newer is supported"
+  end
+
   def install
-    cd "js/src" do
-      # Remove the broken *(for anyone but FF) install_name
-      inreplace "config/rules.mk",
-        "-install_name @executable_path/$(SHARED_LIBRARY) ",
-        "-install_name #{lib}/$(SHARED_LIBRARY) "
+    # Remove the broken *(for anyone but FF) install_name
+    # _LOADER_PATH := @executable_path
+    inreplace "config/rules.mk",
+              "-install_name $(_LOADER_PATH)/$(SHARED_LIBRARY) ",
+              "-install_name #{lib}/$(SHARED_LIBRARY) "
 
-      # The ./configure script assumes that it can find readline
-      # just as "-lreadline", but we want it to look in opt/readline/lib
-      inreplace "configure", "-lreadline", "-L#{Formula["readline"].opt_lib} -lreadline"
-    end
+    inreplace "old-configure", "-Wl,-executable_path,${DIST}/bin", ""
 
-    # The ./configure script that comes with spidermonkey 1.8.5 makes some mistakes
-    # with Xcode 12's default setting of -Werror,implicit-function-declaration
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
-
+    cd "js/src"
+    system "autoconf213"
     mkdir "brew-build" do
-      system "../js/src/configure", "--prefix=#{prefix}",
-                                    "--enable-readline",
-                                    "--enable-threadsafe",
-                                    "--with-system-nspr",
-                                    "--with-nspr-prefix=#{Formula["nspr"].opt_prefix}",
-                                    "--enable-macos-target=#{MacOS.version}"
-
-      inreplace "js-config", /JS_CONFIG_LIBS=.*?$/, "JS_CONFIG_LIBS=''"
-      # These need to be in separate steps.
+      system "../configure", "--prefix=#{prefix}",
+                             "--enable-optimize",
+                             "--enable-readline",
+                             "--enable-release",
+                             "--enable-shared-js",
+                             "--disable-bootstrap",
+                             "--disable-jemalloc",
+                             "--with-intl-api",
+                             "--with-system-icu",
+                             "--with-system-nspr",
+                             "--with-system-zlib"
       system "make"
       system "make", "install"
-
-      # Also install js REPL.
-      bin.install "shell/js"
     end
+
+    (lib/"libjs_static.ajs").unlink
+
+    # Add an unversioned `js` to be used by dependents like `jsawk` & `plowshare`
+    ln_s bin/"js#{version.major}", bin/"js"
+
+    # Avoid writing nspr's versioned Cellar path in js*-config
+    inreplace bin/"js#{version.major}-config",
+              Formula["nspr"].prefix.realpath,
+              Formula["nspr"].opt_prefix
   end
 
   test do
     path = testpath/"test.js"
     path.write "print('hello');"
+    assert_equal "hello", shell_output("#{bin}/js#{version.major} #{path}").strip
     assert_equal "hello", shell_output("#{bin}/js #{path}").strip
   end
 end

--- a/Formula/spidermonkey@78.rb
+++ b/Formula/spidermonkey@78.rb
@@ -1,0 +1,72 @@
+class SpidermonkeyAT78 < Formula
+  desc "JavaScript-C Engine"
+  homepage "https://spidermonkey.dev"
+  url "https://archive.mozilla.org/pub/firefox/releases/78.15.0esr/source/firefox-78.15.0esr.source.tar.xz"
+  version "78.15.0"
+  sha256 "a4438d84d95171a6d4fea9c9f02c2edbf0475a9c614d968ebe2eedc25a672151"
+  license "MPL-2.0"
+
+  depends_on "autoconf@2.13" => :build
+  depends_on "pkg-config" => :build
+  depends_on "python@3.9" => :build
+  depends_on "rust" => :build
+  depends_on arch: :x86_64 # ld: unknown/unsupported architecture name for: -arch armv4t
+  depends_on "icu4c"
+  depends_on "nspr"
+  depends_on "readline"
+
+  uses_from_macos "llvm" => :build # for llvm-objdump
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
+
+  # From python/mozbuild/mozbuild/test/configure/test_toolchain_configure.py
+  fails_with :gcc do
+    version "6"
+    cause "Only GCC 7.1 or newer is supported"
+  end
+
+  def install
+    inreplace "build/moz.configure/toolchain.configure",
+              "sdk_max_version = Version('10.15.4')",
+              "sdk_max_version = Version('99.99')"
+
+    # Remove the broken *(for anyone but FF) install_name
+    # _LOADER_PATH := @executable_path
+    inreplace "config/rules.mk",
+              "-install_name $(_LOADER_PATH)/$(SHARED_LIBRARY) ",
+              "-install_name #{lib}/$(SHARED_LIBRARY) "
+
+    inreplace "old-configure", "-Wl,-executable_path,${DIST}/bin", ""
+
+    mkdir "brew-build" do
+      system "../js/src/configure", "--prefix=#{prefix}",
+                                    "--enable-optimize",
+                                    "--enable-readline",
+                                    "--enable-release",
+                                    "--enable-shared-js",
+                                    "--disable-jemalloc",
+                                    "--with-intl-api",
+                                    "--with-system-icu",
+                                    "--with-system-nspr",
+                                    "--with-system-zlib"
+      system "make"
+      system "make", "install"
+    end
+
+    (lib/"libjs_static.ajs").unlink
+
+    # Avoid writing nspr's versioned Cellar path in js*-config
+    inreplace bin/"js#{version.major}-config",
+              Formula["nspr"].prefix.realpath,
+              Formula["nspr"].opt_prefix
+  end
+
+  test do
+    path = testpath/"test.js"
+    path.write "print('hello');"
+    assert_equal "hello", shell_output("#{bin}/js#{version.major} #{path}").strip
+  end
+end

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -26,5 +26,6 @@
   "pyqt@5",
   "python@3.9",
   "python-tk@3.9",
+  "spidermonkey@78",
   "wxwidgets@3.0"
 ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Testing out some dependency refactoring. Essentially something closer to Arch's packages, e.g.
- https://archlinux.org/packages/extra/x86_64/js78/
- https://archlinux.org/packages/extra/x86_64/js91/
- https://archlinux.org/packages/extra/x86_64/gjs/

Notes:
- First taking `spidermonkey@78` (previous ESR) logic out of `gjs` into separate formula
- Plan to use v78 formula as dependency for `couchdb`, which has restricted `spidermonkey` versions. So, both `gjs` and `couchdb` cannot use unversioned `spidermonkey`.
- Some logic from #78997 in attempt to later bump `spidermonkey` formula.
- Added `spidermonkey@91` (next ESR) since `gjs` and `couchdb` both support this in HEAD. Essentially, should deprecate/disable `spidermonkey@78` when both dependents are released.
- Should figure out how to handle unversioned `spidermonkey` Formula later.

Need to still try building Linux.
ARM support only exists in v91. Doesn't seem worth checking for backport.