### PR TITLE
workflows/tests: error when `long build` is set without `CI-long-timeout`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,7 @@ jobs:
               core.setOutput('test-dependents', 'true')
             }
 
+            const maximum_long_pr_count = 2
             if (label_names.includes('CI-long-timeout')) {
               const labelCountQuery = `query($owner:String!, $name:String!, $label:String!) {
                 repository(owner:$owner, name:$name) {
@@ -119,7 +120,6 @@ jobs:
                 long_pr_count = 0
                 core.warning('CI-long-timeout label count query failed. Assuming no long PRs.')
               }
-              const maximum_long_pr_count = 2
               if (long_pr_count > maximum_long_pr_count) {
                 core.setFailed(`Too many pull requests (${long_pr_count}) with the long-timeout label!`)
                 core.error(`Only ${maximum_long_pr_count} pull requests at a time can use this label.`)
@@ -130,6 +130,13 @@ jobs:
             } else {
               console.log('No CI-long-timeout label found. Setting short GitHub Actions timeout.')
               core.setOutput('timeout-minutes', '60')
+
+              if (label_names.includes('long build')) {
+                core.setFailed('PR requires the CI-long-timeout label but it is not set!')
+                core.error('If the longer timeout is not required, remove the "long build" label.')
+                core.error('Otherwise, add the "CI-long-timeout" label.')
+                core.error(`No more than ${maximum_long_pr_count} PRs at a time may use "CI-long-timeout".`)
+              }
             }
 
             const container = {}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -134,8 +134,8 @@ jobs:
               path: Formula/.+
               content: system "swift", "build"
 
-            - label: CI-long-timeout
-              path: Formula/(boost|qt).rb
+            - label: long build
+              path: Formula/(agda|arangodb|boost|deno|gcc|ghc|llvm|node|ponyc|rust|swift|texlive|qt)(@[0-9]+)?.rb
               keep_if_no_match: true
 
             - label: CI-build-dependents-from-source


### PR DESCRIPTION
We now use a `long build` label to identify PRs that need the
`CI-long-timeout` label but don't have it because other PRs are
currently using it.

Let's save some CI time by failing CI whenever a PR has the `long build`
label but not the `CI-long-timeout` label.

I've also updated `triage.yml` to add the `long build` label where
appropriate. The criterion I used here was whether a CI run that skips
dependent testing will still exceed the short timeout of 60 minutes.

This leaves out formulae that regularly take a long time only due to
having a large number of dependents (e.g. `python@3.*`, `go`). I think
this is the correct thing to do to avoid having to manually remove the
`long build` label every time the `triage` workflow is run in cases
where the CI run will not actually need `CI-long-timeout` (e.g. when we
use `CI-skip-dependents`).

This is based on the suggestion from #94792.
