### PR TITLE
tarsnap: update livecheck

### DIFF
--- a/Formula/tarsnap.rb
+++ b/Formula/tarsnap.rb
@@ -7,8 +7,8 @@ class Tarsnap < Formula
   revision 1
 
   livecheck do
-    url "https://www.tarsnap.com/download/"
-    regex(/href=.*?tarsnap-autoconf[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://www.tarsnap.com/download.html"
+    regex(/href=.*?tarsnap-autoconf[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
   end
 
   bottle do
@@ -24,7 +24,7 @@ class Tarsnap < Formula
   end
 
   head do
-    url "https://github.com/Tarsnap/tarsnap.git"
+    url "https://github.com/Tarsnap/tarsnap.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew livecheck tarsnap` is currently reporting an unstable version as newest (1.0.39.99) instead of the latest stable version (1.0.39). This PR resolves the issue by updating the `livecheck` block to check the first-party download page instead of the directory listing page where the `stable` archive is found. This also updates the regex to be able to match versions with a trailing letter (1.0.36c), as the directory listing makes it clear that this could be an eventuality.

Besides that, this adds `branch: "master"` to the `head` URL, to resolve the related audit error.