### PR TITLE
parallel: add caveat for --csv option

### DIFF
--- a/Formula/parallel.rb
+++ b/Formula/parallel.rb
@@ -33,6 +33,14 @@ class Parallel < Formula
     inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
   end
 
+  def caveats
+    <<~EOS
+      To use the --csv option, the Perl Text::CSV module has to be installed.
+      You can install it via:
+        perl -MCPAN -e'install Text::CSV'
+    EOS
+  end
+
   test do
     assert_equal "test\ntest\n",
                  shell_output("#{bin}/parallel --will-cite echo ::: test test")


### PR DESCRIPTION
Explain that the Text::CSV module has to be installed in order for the --csv option to work.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
