### PR TITLE
libusb 1.0.24 versioned

### DIFF
--- a/Formula/libusb@1.0.24.rb
+++ b/Formula/libusb@1.0.24.rb
@@ -1,0 +1,36 @@
+class LibusbAT1024 < Formula
+  desc "Library for USB device access"
+  homepage "https://libusb.info/"
+  url "https://github.com/libusb/libusb/releases/download/v1.0.24/libusb-1.0.24.tar.bz2"
+  sha256 "7efd2685f7b327326dcfb85cee426d9b871fd70e22caa15bb68d595ce2a2b12a"
+  license "LGPL-2.1-or-later"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  keg_only :versioned_formula
+
+  on_linux do
+    depends_on "systemd"
+  end
+
+  def install
+    args = %W[--disable-dependency-tracking --prefix=#{prefix}]
+
+    system "./autogen.sh" if build.head?
+    system "./configure", *args
+    system "make", "install"
+    (pkgshare/"examples").install Dir["examples/*"] - Dir["examples/Makefile*"]
+  end
+
+  test do
+    cp_r (pkgshare/"examples"), testpath
+    cd "examples" do
+      system ENV.cc, "listdevs.c", "-L#{lib}", "-I#{include}/libusb-1.0",
+             "-lusb-1.0", "-o", "test"
+      system "./test"
+    end
+  end
+end


### PR DESCRIPTION
libusb version 1.0.25 contains some new and not well tested code that fails with some software. This provides a "rewind" option for a keg-only version of the 1.0.24 for compiling problematic code.
