### PR TITLE
textidote 0.8.3 (new formula)

### DIFF
--- a/Formula/textidote.rb
+++ b/Formula/textidote.rb
@@ -12,7 +12,7 @@ class Textidote < Formula
   def install
     # Build the JAR
     system "ant", "download-deps"
-    system "ant", "-Dbuild.targetjdk=17"
+    system "ant", "-Dbuild.targetjdk=#{Formula["openjdk"].version.major"
 
     # Install the JAR + a wrapper script
     libexec.install "textidote.jar"

--- a/Formula/textidote.rb
+++ b/Formula/textidote.rb
@@ -3,7 +3,7 @@ class Textidote < Formula
   homepage "https://sylvainhalle.github.io/textidote"
   url "https://github.com/sylvainhalle/textidote/archive/refs/tags/v0.8.3.tar.gz"
   sha256 "8c55d6f6f35d51fb5b84e7dcc86a4041e06b3f92d6a919023dc332ba2effd584"
-  license "GPL-3.0-only"
+  license "GPL-3.0-or-later"
   head "https://github.com/sylvainhalle/textidote.git", branch: "master"
 
   depends_on "ant" => :build
@@ -12,18 +12,13 @@ class Textidote < Formula
   def install
     # Build the JAR
     system "ant", "download-deps"
-    system "ant", "-Dbuild.targetjdk=1.7"
+    system "ant", "-Dbuild.targetjdk=17"
 
     # Install the JAR + a wrapper script
-    libexec.mkpath
     libexec.install "textidote.jar"
-    bin.mkpath
     bin.write_jar_script libexec/"textidote.jar", "textidote"
 
-    # Install the completions script
-    bash_completion.mkpath
     bash_completion.install "Completions/textidote.bash"
-    zsh_completion.mkpath
     zsh_completion.install "Completions/textidote.zsh" => "_textidote"
   end
 
@@ -38,8 +33,7 @@ class Textidote < Formula
       \\end{document}
     EOF
 
-    # Use `--ci`, otherwise TeXtidote returns the number of warnings as the return code.
-    output = shell_output("#{bin}/textidote --check en --ci #{testpath}/test1.tex")
+    output = shell_output("#{bin}/textidote --check en #{testpath}/test1.tex", 1)
     assert_match "The modal verb 'should' requires the verb's base form..", output
 
     (testpath/"test2.tex").write <<~EOF

--- a/Formula/textidote.rb
+++ b/Formula/textidote.rb
@@ -1,0 +1,55 @@
+class Textidote < Formula
+  desc "Spelling, grammar and style checking on LaTeX documents"
+  homepage "https://sylvainhalle.github.io/textidote"
+  url "https://github.com/sylvainhalle/textidote/archive/refs/tags/v0.8.3.tar.gz"
+  sha256 "8c55d6f6f35d51fb5b84e7dcc86a4041e06b3f92d6a919023dc332ba2effd584"
+  license "GPL-3.0-only"
+  head "https://github.com/sylvainhalle/textidote.git", branch: "master"
+
+  depends_on "ant" => :build
+  depends_on "openjdk"
+
+  def install
+    # Build the JAR
+    system "ant", "download-deps"
+    system "ant", "-Dbuild.targetjdk=1.7"
+
+    # Install the JAR + a wrapper script
+    libexec.mkpath
+    libexec.install "textidote.jar"
+    bin.mkpath
+    bin.write_jar_script libexec/"textidote.jar", "textidote"
+
+    # Install the completions script
+    bash_completion.mkpath
+    bash_completion.install "Completions/textidote.bash"
+    zsh_completion.mkpath
+    zsh_completion.install "Completions/textidote.zsh" => "_textidote"
+  end
+
+  test do
+    output = shell_output("#{bin}/textidote --version")
+    assert_match "TeXtidote", output
+
+    (testpath/"test1.tex").write <<~EOF
+      \\documentclass{article}
+      \\begin{document}
+        This should fails.
+      \\end{document}
+    EOF
+
+    # Use `--ci`, otherwise TeXtidote returns the number of warnings as the return code.
+    output = shell_output("#{bin}/textidote --check en --ci #{testpath}/test1.tex")
+    assert_match "The modal verb 'should' requires the verb's base form..", output
+
+    (testpath/"test2.tex").write <<~EOF
+      \\documentclass{article}
+      \\begin{document}
+        This should work.
+      \\end{document}
+    EOF
+
+    output = shell_output("#{bin}/textidote --check en #{testpath}/test2.tex")
+    assert_match "Everything is OK!", output
+  end
+end

--- a/Formula/textidote.rb
+++ b/Formula/textidote.rb
@@ -12,7 +12,7 @@ class Textidote < Formula
   def install
     # Build the JAR
     system "ant", "download-deps"
-    system "ant", "-Dbuild.targetjdk=#{Formula["openjdk"].version.major"
+    system "ant", "-Dbuild.targetjdk=#{Formula["openjdk"].version.major}"
 
     # Install the JAR + a wrapper script
     libexec.install "textidote.jar"


### PR DESCRIPTION
Added new formula, textidote: a correction tool for LaTeX documents.
The formula includes completions (for both bash and zsh), as well
as a few tests.

Note: when running `brew test textidote`, textidote writes a few lines on stderr.
In one of the tests, these lines include "Found 1 warning(s)": this is perfectly normal (and expected).
It does not pertain to the test itself, but to the document analysed by textidote during this test, which contains a language error.
The line thus shows that textidote correctly detected the error.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
