### PR TITLE
rumble 1.17.0 (new formula)

### DIFF
--- a/Formula/rumble.rb
+++ b/Formula/rumble.rb
@@ -1,0 +1,20 @@
+class Rumble < Formula
+  desc "RumbleDB 1.17.0 'Cacao tree' for Apache Spark"
+  homepage "https://rumbledb.org/"
+  url "https://github.com/RumbleDB/rumbledb-brew-zip/releases/download/v1.17.0/rumble-brew.zip"
+  sha256 "21ebe235b3ff0e306eea3ce2d28f5186da0edf5c64236f5feb43e12309538d3d"
+  license "MIT"
+
+  depends_on "apache-spark"
+
+  def install
+    lib.install Dir["*"]
+    bin.install Dir[lib/"bin/*"]
+    bin.env_script_all_files(lib/"bin", SPARK_HOME_BIN: Formula["apache-spark"].bin)
+  end
+
+  test do
+    assert_match "2",
+      pipe_output(bin/"rumbledb -q '1+1'")
+  end
+end


### PR DESCRIPTION
RumbleDB formula installs [RumbleDB 1.17.0](https://rumbledb.org/) and its dependencies (apache-spark). It creates a CLI
`rumbledb` that is a convenience command line tool for "spark-submit
rumble.jar" (approved by the RumbleDB team).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
