### PR TITLE
libewf: fix the branch name

### DIFF
--- a/Formula/libewf.rb
+++ b/Formula/libewf.rb
@@ -17,7 +17,7 @@ class Libewf < Formula
   end
 
   head do
-    url "https://github.com/libyal/libewf.git"
+    url "https://github.com/libyal/libewf.git", branch: "main"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "gettext" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
