### PR TITLE
libqalculate and qalculate-gtk 4.0.0

### DIFF
--- a/Formula/libqalculate.rb
+++ b/Formula/libqalculate.rb
@@ -1,8 +1,8 @@
 class Libqalculate < Formula
   desc "Library for Qalculate! program"
   homepage "https://qalculate.github.io/"
-  url "https://github.com/Qalculate/libqalculate/releases/download/v3.22.0/libqalculate-3.22.0.tar.gz"
-  sha256 "533ec2fc3550b44a562e4ff93f2bb21332c802c60d13ae1323bfa54ffe5d57f6"
+  url "https://github.com/Qalculate/libqalculate/releases/download/v4.0.0/libqalculate-4.0.0.tar.gz"
+  sha256 "1bddd1aa5fc5c0915308400845acf376dcb685bcbd8da90360b3d75b87d4c666"
   license "GPL-2.0-or-later"
 
   bottle do

--- a/Formula/qalculate-gtk.rb
+++ b/Formula/qalculate-gtk.rb
@@ -1,8 +1,8 @@
 class QalculateGtk < Formula
   desc "Multi-purpose desktop calculator"
   homepage "https://qalculate.github.io/"
-  url "https://github.com/Qalculate/qalculate-gtk/releases/download/v3.22.0/qalculate-gtk-3.22.0.tar.gz"
-  sha256 "ba6c0238b5f926ac94e234e15a2dfa84215938da5df6fea136db75c5db488556"
+  url "https://github.com/Qalculate/qalculate-gtk/releases/download/v4.0.0/qalculate-gtk-4.0.0.tar.gz"
+  sha256 "51f705737fe6defb6b57058ddd357ca1dd11af57655a90f9e41a40e8dbb9d81c"
   license "GPL-2.0-or-later"
 
   bottle do


### PR DESCRIPTION
Update libqalculate and qalculate-gtk to 4.0.0 in a single PR.