### PR TITLE
aarch64-elf-binutils 2.38 (new formula)

### DIFF
--- a/Formula/aarch64-elf-binutils.rb
+++ b/Formula/aarch64-elf-binutils.rb
@@ -1,0 +1,40 @@
+class Aarch64ElfBinutils < Formula
+  desc "GNU Binutils for aarch64-elf cross development"
+  homepage "https://www.gnu.org/software/binutils/"
+  url "https://ftp.gnu.org/gnu/binutils/binutils-2.38.tar.xz"
+  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.38.tar.xz"
+  sha256 "e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024"
+  license "GPL-3.0-or-later"
+
+  livecheck do
+    formula "binutils"
+  end
+
+  uses_from_macos "texinfo"
+
+  def install
+    target = "aarch64-elf"
+    system "./configure", "--target=#{target}",
+           "--prefix=#{prefix}",
+           "--libdir=#{lib}/#{target}",
+           "--infodir=#{info}/#{target}",
+           "--disable-nls"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test-s.s").write <<~EOS
+      .section .text
+      .globl _start
+      _start:
+          mov x0, #0
+          mov x16, #1
+          svc #0x80
+    EOS
+    system "#{bin}/aarch64-elf-as", "-o", "test-s.o", "test-s.s"
+    assert_match "file format elf64-littleaarch64",
+                 shell_output("#{bin}/aarch64-elf-objdump -a test-s.o")
+    assert_match "f()", shell_output("#{bin}/aarch64-elf-c++filt _Z1fv")
+  end
+end


### PR DESCRIPTION
Add two new formulas for gcc and binutils with support for elf binaries.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Please note that the audit fails due to gcc requiring a patch. This is the same patch as in x86_64-elf-gcc and the hope is that it won't be necessary with future versions of gcc.

-----
