### PR TITLE
gst-plugins-rs 0.8.1 (new formula)

### DIFF
--- a/Formula/gst-plugins-rs.rb
+++ b/Formula/gst-plugins-rs.rb
@@ -1,0 +1,40 @@
+class GstPluginsRs < Formula
+  desc "GStreamer plugins written in Rust"
+  homepage "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs"
+  url "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/archive/0.8.1/gst-plugins-rs-0.8.1.tar.bz2"
+  sha256 "ab5f33b119257d3e663b7f3733e182433bfd2c7e919aba497aebe3aa5f7ac857"
+  license "MIT"
+
+  depends_on "cargo-c" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "rust" => :build
+  depends_on "dav1d"
+  depends_on "gst-plugins-base"
+  depends_on "gstreamer"
+  depends_on "gtk4"
+  depends_on "pango" # for closedcaption
+
+  def install
+    mkdir "build" do
+      # csound is disabled as the dependency detection seems to fail
+      # the sodium crate fails while building native code as well
+      args = std_meson_args + %w[
+        -Dclosedcaption=enabled
+        -Ddav1d=enabled
+        -Dsodium=disabled
+        -Dcsound=disabled
+        -Dgtk4=enabled
+      ]
+      system "meson", *args, ".."
+      system "ninja", "-v"
+      system "ninja", "install", "-v"
+    end
+  end
+
+  test do
+    gst = Formula["gstreamer"].opt_bin/"gst-inspect-1.0"
+    output = shell_output("#{gst} --plugin rsfile")
+    assert_match version.to_s, output
+  end
+end


### PR DESCRIPTION
Add GStreamer plugins set written in Rust. A couple of plugins that were
problematic to build on macOS Monterey are disabled with comments.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
