### PR TITLE
msmtp: add back GSSAPI (kerberos) support

### DIFF
--- a/Formula/msmtp.rb
+++ b/Formula/msmtp.rb
@@ -22,10 +22,11 @@ class Msmtp < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "gnutls"
+  depends_on "gsasl"
   depends_on "libidn2"
 
   def install
-    system "./configure", *std_configure_args, "--disable-silent-rules", "--with-macosx-keyring"
+    system "./configure", *std_configure_args, "--disable-silent-rules", "--with-libgsasl", "--with-macosx-keyring"
     system "make", "install"
     (pkgshare/"scripts").install "scripts/msmtpq"
   end


### PR DESCRIPTION
- previous versions of this formula correctly supported gssapi
- libgsasl is required for GSSAPI authentication. Linking with
  the gsasl library correctly uses the native OS X kerberos.
- this change adds the following authentication methods to msmtp:

gssapi digest-md5 scram-sha-1 scram-sha-256

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
