### PR TITLE
dhall: install man page

### DIFF
--- a/Formula/dhall.rb
+++ b/Formula/dhall.rb
@@ -23,6 +23,7 @@ class Dhall < Formula
   def install
     system "cabal", "v2-update"
     system "cabal", "v2-install", *std_cabal_v2_args
+    man1.install "man/dhall.1"
   end
 
   test do


### PR DESCRIPTION
This adds man page for dhall(1).

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Dhall has several other packages such as `dhall-json`, but only `dhall` and `dhall-docs` seem to have man pages and `homebrew-core` does not have a formula for `dhall-docs` now, so we don't need to take care of other packages.