### PR TITLE
sourcedocs: update min Xcode

### DIFF
--- a/Formula/sourcedocs.rb
+++ b/Formula/sourcedocs.rb
@@ -13,7 +13,7 @@ class Sourcedocs < Formula
     sha256 cellar: :any_skip_relocation, catalina:       "71442a1bb13f262c5aad88da184352ae817f15b18f65f17abf2dabc39d85ca40"
   end
 
-  depends_on xcode: ["10.3", :build, :test]
+  depends_on xcode: ["12.0", :build, :test]
 
   def install
     system "swift", "build", "--disable-sandbox", "-c", "release"


### PR DESCRIPTION
Building on Mojave errors out with:
```
error: package at <build_dir> is using Swift tools version 5.3.0 but the installed version is 5.1.0
```
Swift 5.3.0 corresponds to Xcode 12.0.

No rebuild needed, `CI-syntax-only`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
