### PR TITLE
pcre: update stable, livecheck

### DIFF
--- a/Formula/pcre.rb
+++ b/Formula/pcre.rb
@@ -4,7 +4,7 @@ class Pcre < Formula
   license "BSD-3-Clause"
 
   stable do
-    url "https://ftp.pcre.org/pub/pcre/pcre-8.45.tar.bz2"
+    url "https://downloads.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.tar.bz2"
     mirror "https://www.mirrorservice.org/sites/ftp.exim.org/pub/pcre/pcre-8.45.tar.bz2"
     sha256 "4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8"
 
@@ -15,9 +15,14 @@ class Pcre < Formula
     end
   end
 
+  # From the PCRE homepage:
+  # "The older, but still widely deployed PCRE library, originally released in
+  # 1997, is at version 8.45. This version of PCRE is now at end of life, and
+  # is no longer being actively maintained. Version 8.45 is expected to be the
+  # final release of the older PCRE library, and new projects should use PCRE2
+  # instead."
   livecheck do
-    url "https://ftp.pcre.org/pub/pcre/"
-    regex(/href=.*?pcre[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    skip "PCRE was declared end of life in 2021-06"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The PCRE homepage was updated between 2021-06-17 and 2021-06-22 to state:

> The older, but still widely deployed PCRE library, originally released in 1997, is at version 8.45. This version of PCRE is now at end of life, and is no longer being actively maintained. Version 8.45 is expected to be the final release of the older PCRE library, and new projects should use PCRE2 instead.

Additionally, the formula's current `stable` URL uses ftp.pcre.org but this source is no longer available:

> Note that the former ftp.pcre.org FTP site is no longer available. You will need to update any scripts that download PCRE source code to download via HTTPS, Git, or Subversion from the new home on GitHub instead.

The GitHub repository is only for PCRE2, so this PR switches to the 8.45 tarball from the unofficial SourceForge mirror referenced on the homepage. As expected, the SHA256 remains the same. If we would prefer to use a different mirror, just let me know and I'll update the URL.

Past that, this updates the `livecheck` block to skip, as PCRE is EOL and there there will seemingly be no new releases in the future (i.e., with ftp.pcre.org decommissioned and only mirrors remaining). Alternatively, we can deprecate the formula but it's a dependency for 80+ formula, so I figured this was the better route for now.