### PR TITLE
scotch: build without -DSCOTCH_PTHREAD_MPI

### DIFF
--- a/Formula/scotch.rb
+++ b/Formula/scotch.rb
@@ -38,6 +38,7 @@ class Scotch < Formula
         s.change_make_var! "CCS", ENV.cc
         s.change_make_var! "CCP", "mpicc"
         s.change_make_var! "CCD", "mpicc"
+        s.gsub! "-DSCOTCH_PTHREAD_MPI", ""
       end
 
       system "make", "libscotch", "libptscotch"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Compilation of `scotch` with `-DSCOTCH_PTHREAD` causes issues with some projects (specifically, OpenFOAM). Dropping the `-DSCOTCH_PTHREAD` flag within Homebrew has been proposed and discussed in the past (#88387), including mentions of other package distributions that do so; but the final decision was to keep it unless there were more complaints.

As of `scotch 7.0.1` (current version), [a new flag `-DSCOTCH_PTHREAD_MPI` was added](https://www.mail-archive.com/debian-devel-changes@lists.debian.org/msg733635.html). Dropping only the `-DSCOTCH_PTHREAD_MPI` seems to solve the issues with OpenFOAM while allowing to keep the more general `-DSCOTCH_PTHREAD` flag enabled as default.
