### PR TITLE
Add inso{,mnia} to Autobump

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -359,6 +359,8 @@ env:
     influxdb-cli
     influxdb@1
     inlets
+    inso
+    insomnia
     ioctl
     ipinfo-cli
     ipmiutil


### PR DESCRIPTION
With these merged in, the `inso` and `insomnia` casks should be okay to add to autobump:
- https://github.com/Homebrew/homebrew-cask/pull/119280
- https://github.com/Homebrew/homebrew-cask/pull/119281

That would save me from having to manage bumps to these 2 casks in [github actions elsewhere](https://github.com/Kong/insomnia/runs/5209051939?check_suite_focus=true#step:6:6):