### PR TITLE
jmeter: switch to openjdk@11

### DIFF
--- a/Formula/jmeter.rb
+++ b/Formula/jmeter.rb
@@ -10,7 +10,7 @@ class Jmeter < Formula
     sha256 cellar: :any_skip_relocation, all: "71af8d00cd769598a7a1291565a1d15d97f9ef78ea4dc23d0025b8d4d503e76a"
   end
 
-  depends_on "openjdk"
+  depends_on "openjdk@11"
 
   resource "jmeter-plugins-manager" do
     url "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/1.7/jmeter-plugins-manager-1.7.jar"


### PR DESCRIPTION
JMeter only works with JDK 8 or 11, but the `openjdk` formula is on 17

This commit downgrades OpenJDK to 11, which is the last supported version


### questions for reviewer:
- Any JDK distro will do.  Is there a way to say that this formula requires **one of** OpenJDK, AdoptOpenJDK, etc.?
- imo since people install Java many different ways, I think it's a mistake depending on Java at all.  Instead, we should remove
```rb
    (bin/"jmeter").write_env_script libexec/"bin/jmeter", JAVA_HOME: Formula["openjdk"].opt_prefix
```
and just use whichever JDK users have installed
  - *maybe* we check for the `JAVA_HOME` env variable and only install Java if it's not found (but even this will have false positives)


I'm holding off on completing the checklist until I get some guidance for my questions
### Checklist
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
