### PR TITLE
speedtest-cli: depend on python@3.10

### DIFF
--- a/Formula/speedtest-cli.rb
+++ b/Formula/speedtest-cli.rb
@@ -1,4 +1,6 @@
 class SpeedtestCli < Formula
+  include Language::Python::Shebang
+
   desc "Command-line interface for https://speedtest.net bandwidth tests"
   homepage "https://github.com/sivel/speedtest-cli"
   url "https://github.com/sivel/speedtest-cli/archive/v2.1.3.tar.gz"
@@ -11,7 +13,16 @@ class SpeedtestCli < Formula
     sha256 cellar: :any_skip_relocation, all: "ebf51e9de63f99e3fcea09b61015488a25e7769422fd9656fee9c0ecf7ba08b3"
   end
 
+  depends_on "python@3.10"
+
+  # Support Python 3.10, remove on next release
+  patch do
+    url "https://github.com/sivel/speedtest-cli/commit/22210ca35228f0bbcef75a7c14587c4ecb875ab4.patch?full_index=1"
+    sha256 "d0456eb9fded20fb1580dbc6e3bc451a10c3fbcd3441efea66035aa848440c09"
+  end
+
   def install
+    rewrite_shebang detected_python_shebang, "speedtest.py"
     bin.install "speedtest.py" => "speedtest"
     bin.install_symlink "speedtest" => "speedtest-cli"
     man1.install "speedtest-cli.1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

This currently relies on Python 2: https://github.com/sivel/speedtest-cli/blob/22210ca35228f0bbcef75a7c14587c4ecb875ab4/speedtest.py#L1

Part of #93940
