### PR TITLE
flatbuffers, osrm-backend: add conflict

### DIFF
--- a/Formula/flatbuffers.rb
+++ b/Formula/flatbuffers.rb
@@ -23,6 +23,8 @@ class Flatbuffers < Formula
   depends_on "cmake" => :build
   depends_on "python@3.10" => :build
 
+  conflicts_with "osrm-backend", because: "both install flatbuffers headers"
+
   def install
     system "cmake", "-G", "Unix Makefiles", *std_cmake_args
     system "make", "install"

--- a/Formula/osrm-backend.rb
+++ b/Formula/osrm-backend.rb
@@ -28,6 +28,8 @@ class OsrmBackend < Formula
   depends_on "lua"
   depends_on "tbb@2020"
 
+  conflicts_with "flatbuffers", because: "both install flatbuffers headers"
+
   def install
     lua = Formula["lua"]
     luaversion = lua.version.major_minor


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Both formulae install `flatbuffers` headers. There doesn't appear to be a way to fix `osrm-backend` to use Homebrew `flatbuffers` instead, and I don't see a simple way to get `osrm-backend` to install the `flatbuffers` headers into a private directory.

Fixes a CI error in #91224.
