### PR TITLE
orientdb 3.2.5

### DIFF
--- a/Formula/orientdb.rb
+++ b/Formula/orientdb.rb
@@ -1,13 +1,13 @@
 class Orientdb < Formula
   desc "Graph database"
   homepage "https://orientdb.org/"
-  url "https://s3.us-east-2.amazonaws.com/orientdb3/releases/3.2.4/orientdb-3.2.4.zip"
-  sha256 "7da015f7e86be37bbeb8fdc02b284ed7589a05afc44114105c0ffe3ea5f37f47"
+  url "https://search.maven.org/remotecontent?filepath=com/orientechnologies/orientdb-community/3.2.5/orientdb-community-3.2.5.zip"
+  sha256 "4391ec4a538a365775549a4ca425de060c2f34777d69e958f1cb5e06c8b389ad"
   license "Apache-2.0"
 
   livecheck do
     url "https://orientdb.org/download"
-    regex(/href=.*?orientdb[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+    regex(/href=.*?orientdb(?:-community)?[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `orientdb` to the latest version, 3.2.5. The [first-party download page](https://orientdb.org/download) links to files on Maven nowadays instead of the previous AWS links (e.g., in this [2021-05-14 snapshot](https://web.archive.org/web/20210514035705/https://orientdb.org/download)). To be clear, updating the existing URL to use `3.2.5` gives a 404, so it's fair to say Maven is the canonical source for the `stable` archive now.

The existing `livecheck` block for `orientdb` was unable to identify the latest version and was erroneously giving 3.1.15 as newest. This is because the filename for the `stable` zip file now uses an `orientdb-community-1.2.3.zip` format instead of the previous `orientdb-1.2.3.zip` format. This updates the regex to match either format, so it correctly reports 3.2.5 as newest.