### PR TITLE
xmlsectool: Tweak test, `--listBlacklist` is deprecated

### DIFF
--- a/Formula/xmlsectool.rb
+++ b/Formula/xmlsectool.rb
@@ -24,6 +24,6 @@ class Xmlsectool < Formula
   end
 
   test do
-    system "#{bin}/xmlsectool", "--listBlacklist"
+    system "#{bin}/xmlsectool", "--listAlgorithms"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```shell
❯ xmlsectool --listBlacklist
WARN  DEPRECATED - command-line option '--listBlacklist': This will be removed in the next major version of this software; replacement is --listAlgorithms
[...]

❯ xmlsectool --listAlgorithms
Disallowed digest algorithms:
   http://www.w3.org/2000/09/xmldsig#sha1
   http://www.w3.org/2001/04/xmldsig-more#md5

Disallowed signature algorithms:
   http://www.w3.org/2000/09/xmldsig#rsa-sha1
   http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1
   http://www.w3.org/2001/04/xmldsig-more#rsa-md5
```

Once this is merged we can get rid of https://github.com/Homebrew/brew/blob/283c0e51051c50aa7f09cb639032c2c53adc159f/Library/.rubocop.yml#L99-L100