### PR TITLE
wiggle: fixes for Linux

### DIFF
--- a/Formula/wiggle.rb
+++ b/Formula/wiggle.rb
@@ -3,7 +3,7 @@ class Wiggle < Formula
   homepage "https://github.com/neilbrown/wiggle"
   url "https://github.com/neilbrown/wiggle/archive/refs/tags/v1.3.tar.gz"
   sha256 "ff92cf0133c1f4dce33563e263cb30e7ddb6f4abdf86d427b1ec1490bec25afa"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://neil.brown.name/wiggle/"
@@ -17,6 +17,9 @@ class Wiggle < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "233a538ebdde21f7038aafd73fb4a20afb0dbb6715f54f4fc305ad7ca4966672"
     sha256 cellar: :any_skip_relocation, catalina:       "e50353191b0368db9dd898d730b74ea3612c1cff728717fc8b5904a6d44e2015"
   end
+
+  uses_from_macos "groff" => :build
+  uses_from_macos "ncurses"
 
   def install
     system "make", "OptDbg=#{ENV.cflags}", "wiggle", "wiggle.man", "test"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds `uses_from_macos "groff" => :build` and `uses_from_macos "ncurses"` to bottle `wiggle` for Linux. The license is also updated based on this text:
```
==> /usr/local/Cellar/wiggle/1.3/bin/wiggle --version
wiggle 1.3 2020-10-03 GPL-2+ http://neil.brown.name/wiggle/
```