### PR TITLE
workflows/tests: always test dependents unless requested otherwise

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -252,7 +252,7 @@ jobs:
           rm bottles/bottle_output.txt
 
       - name: Run brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
-        if: ${{fromJson(needs.setup_tests.outputs.test-dependents)}}
+        if: ${{always() && fromJson(needs.setup_tests.outputs.test-dependents)}}
         run: |
           cd bottles
           brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}


### PR DESCRIPTION
Skipping testing dependents makes it that much harder to identify
formulae that need revision bumps.

See, for example, #91224, where the need to rebuild `gnuradio` could've
been identified days, if not weeks, earlier if we did not skip dependent
tests when one of the tested formulae fails.

Note that this will still skip the testing of dependents of failed
formulae, because these are passed in the `--skipped-or-failed-formulae`
flag.

Related discussion: #82220
