### PR TITLE
thrift: exclude building py3 lib

### DIFF
--- a/Formula/thrift.rb
+++ b/Formula/thrift.rb
@@ -53,6 +53,7 @@ class Thrift < Formula
       --without-php
       --without-php_extension
       --without-python
+      --without-py3
       --without-ruby
       --without-swift
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


motivation:
the original formula came before `py3` lib building argument was introduced. having the current set of args will build py3 lib which isn't needed in this context. excluding it saves people time.