### PR TITLE
*formulae: Fix some `HEAD` branch names

### DIFF
--- a/Formula/amp.rb
+++ b/Formula/amp.rb
@@ -5,7 +5,7 @@ class Amp < Formula
   sha256 "9279efcecdb743b8987fbedf281f569d84eaf42a0eee556c3447f3dc9c9dfe3b"
   license "GPL-3.0-or-later"
   revision 1
-  head "https://github.com/jmacdonald/amp.git", branch: "master"
+  head "https://github.com/jmacdonald/amp.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "a16ac20a15f1ff7716824be467f4980b0e3ab1f99326539d9a8b086eece946bb"

--- a/Formula/auditbeat.rb
+++ b/Formula/auditbeat.rb
@@ -5,7 +5,7 @@ class Auditbeat < Formula
       tag:      "v8.0.0",
       revision: "2ab3a7334016f570e0bfc7e9a577a35a22e02df5"
   license "Apache-2.0"
-  head "https://github.com/elastic/beats.git", branch: "master"
+  head "https://github.com/elastic/beats.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "23d0e93cfd2858fcf1ead2665e70442f3cbdbdf3ca4305ab542699b94279896c"

--- a/Formula/bandit.rb
+++ b/Formula/bandit.rb
@@ -6,7 +6,7 @@ class Bandit < Formula
   url "https://files.pythonhosted.org/packages/67/f3/99409392d1eb5e3d65efacf2d30e94b2d2c4e24e0849fab2e84f35748a3b/bandit-1.7.2.tar.gz"
   sha256 "6d11adea0214a43813887bfe71a377b5a9955e4c826c8ffd341b494e3ab25260"
   license "Apache-2.0"
-  head "https://github.com/PyCQA/bandit.git", branch: "master"
+  head "https://github.com/PyCQA/bandit.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "3d1a5802305f29b27b9a403e54a32c4c0316b79d0b79e1a415b3cce8cae1e910"

--- a/Formula/bench.rb
+++ b/Formula/bench.rb
@@ -3,7 +3,7 @@ class Bench < Formula
   homepage "https://github.com/Gabriel439/bench"
   license "BSD-3-Clause"
   revision 1
-  head "https://github.com/Gabriel439/bench.git", branch: "master"
+  head "https://github.com/Gabriel439/bench.git", branch: "main"
 
   stable do
     url "https://hackage.haskell.org/package/bench-1.0.12/bench-1.0.12.tar.gz"

--- a/Formula/box2d.rb
+++ b/Formula/box2d.rb
@@ -4,7 +4,7 @@ class Box2d < Formula
   url "https://github.com/erincatto/box2d/archive/v2.4.1.tar.gz"
   sha256 "d6b4650ff897ee1ead27cf77a5933ea197cbeef6705638dd181adc2e816b23c2"
   license "MIT"
-  head "https://github.com/erincatto/Box2D.git", branch: "master"
+  head "https://github.com/erincatto/Box2D.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, monterey:    "ce38e11785a57c7cd416fd4cb6a9cd2567363e1f1bc4938d010b13e0b2eefc34"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- The last three checklist items don't matter, these are `--HEAD` installs. Users who want to use the software can fix any install failures themselves. 😇
- CI doesn't test `--HEAD` install blocks, hence the syntax-only label.
- Yes, I periodically run a script to install `--HEAD` formulae and notice which ones don't clone because of the remote branch not being found. Here's five of the broken ones - I got bored of watching my script and it's late. This PR can be "Rebase and merge"d when it's passing CI.