### PR TITLE
gdb: mark as Intel-only

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -14,6 +14,7 @@ class Gdb < Formula
     sha256 x86_64_linux: "271013a91e3dbc94654df18414018c4a66af56ef3976ae37263fada80e76a070"
   end
 
+  depends_on arch: :x86_64 # gdb is not supported on macOS ARM
   depends_on "gmp"
   depends_on "python@3.10"
   depends_on "xz" # required for lzma support


### PR DESCRIPTION
Addresses every ARM64 GDB-related issue and discussion to date, including https://github.com/Homebrew/homebrew-core/issues/95532.

`CI-syntax-only`, no rebuild needed.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
