### PR TITLE
Allow go 1.18 unstable builds

### DIFF
--- a/audit_exceptions/unstable_allowlist.json
+++ b/audit_exceptions/unstable_allowlist.json
@@ -3,6 +3,7 @@
   "automysqlbackup": "3.0-rc",
   "aview": "1.3.0rc",
   "ftgl": "2.1.3-rc",
+  "go": "1.18.",
   "libcaca": "0.99b",
   "librasterlite2": "1.1.0-beta",
   "premake": "4.4-beta",


### PR DESCRIPTION
As advised by @SMillerDev in #91369 to allow building go 1.18 rc