### PR TITLE
geogram 1.7.8

### DIFF
--- a/Formula/geogram.rb
+++ b/Formula/geogram.rb
@@ -1,10 +1,8 @@
 class Geogram < Formula
   desc "Programming library of geometric algorithms"
   homepage "http://alice.loria.fr/software/geogram/doc/html/index.html"
-  # Homepage links to gforge.inria.fr for downloads, which gives a 403 response.
-  # We're using a GitHub tarball unless/until upstream finds a new home.
-  url "https://github.com/alicevision/geogram/archive/v1.7.7.tar.gz"
-  sha256 "7323d9f6a38fbaff3e07c47955e0c8f310906871d38171536ec8bc0758e816aa"
+  url "https://members.loria.fr/BLevy/PACKAGES/geogram_1.7.8.tar.gz"
+  sha256 "28e70b353705faec555700d8a7b7b9d703687702f46866bad09e033f86a96faf"
   license all_of: ["BSD-3-Clause", :public_domain, "LGPL-3.0-or-later", "MIT"]
 
   bottle do


### PR DESCRIPTION
This also updates the repo URL to use:

https://members.loria.fr/BLevy/PACKAGES/

As announced on the geogram-users mailing list.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Note: this version still fails to install on M1 Macs, but should succeed on x86 Macs. This is an upstream issue.