### PR TITLE
mold:  remove no-longer-needed xxhash dependency

### DIFF
--- a/Formula/mold.rb
+++ b/Formula/mold.rb
@@ -47,7 +47,6 @@ class Mold < Formula
       LTO=1
       SYSTEM_MIMALLOC=1
       SYSTEM_TBB=1
-      SYSTEM_XXHASH=1
     ]
     args << "STRIP=true" if OS.mac?
     system "make", *args, "install"

--- a/Formula/mold.rb
+++ b/Formula/mold.rb
@@ -16,7 +16,6 @@ class Mold < Formula
   end
 
   depends_on "tbb"
-  depends_on "xxhash"
   uses_from_macos "zlib"
 
   on_macos do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See [the release notes](https://github.com/rui314/mold/releases/tag/v1.1) for evidence.