### PR TITLE
jless: update homepage

### DIFF
--- a/Formula/jless.rb
+++ b/Formula/jless.rb
@@ -1,6 +1,6 @@
 class Jless < Formula
   desc "Command-line pager for JSON data"
-  homepage "https://pauljuliusmartinez.github.io/"
+  homepage "https://jless.io/"
   url "https://github.com/PaulJuliusMartinez/jless/archive/refs/tags/v0.7.2.tar.gz"
   sha256 "5d776cb6488743ccdaeeffb4bfc54d84862028170cee852a8bb5c156526ed263"
   license "MIT"


### PR DESCRIPTION
My project [jless](https://github.com/PaulJuliusMartinez/jless) was recently added to Homebrew (https://github.com/Homebrew/homebrew-core/pull/95013), and I've since moved the homepage to its own domain ([jless.io](https://jless.io)) instead of GitHub Pages.


Separately, this is the first project that I've released publicly. Someone else initially added it to Homebrew, and I saw that there was [another PR](https://github.com/Homebrew/homebrew-core/pull/95534) made last night when I released a new version. Does this happen automatically (if so, how?), or is someone (@alebcay?) watching the repository? Do I need to make updating Homebrew part of my release process?