### PR TITLE
haskell-stack: revision bump

### DIFF
--- a/Formula/haskell-stack.rb
+++ b/Formula/haskell-stack.rb
@@ -2,6 +2,7 @@ class HaskellStack < Formula
   desc "Cross-platform program for developing Haskell projects"
   homepage "https://haskellstack.org/"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/commercialhaskell/stack.git", branch: "master"
 
   stable do


### PR DESCRIPTION
With existing arm64_big_sur bottle,

```bash
brew install haskell-stack
cd any-stack-project # navigate into any stack project
stack setup
```

Will fail with following error message:

```
I don't know how to install GHC for (OSX,AArch64), please install manually..
```

This issue was fixed by Homebrew/homebrew-core#95032 but the revision was not bumped. I hereby bump the revision to rebuild arm64_big_sur bottle.

###### References:
- https://github.com/Homebrew/homebrew-core/pull/95032#issuecomment-1046350415

###### Checklists:
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?