### PR TITLE
buildpulse-test-reporter: add livecheck

### DIFF
--- a/Formula/buildpulse-test-reporter.rb
+++ b/Formula/buildpulse-test-reporter.rb
@@ -6,6 +6,11 @@ class BuildpulseTestReporter < Formula
   license "MIT"
   head "https://github.com/buildpulse/test-reporter.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "8058fc7befab1fca308927f42c006f5a07422d223db3bb61cb7dc963c6a6196f"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "5e2f8443094f637f0248dab74dd5b35028588c5fb0b303116d1ef22dde5478d6"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add `livecheck` with standard regex for tags to avoid pre-releases (e.g. #95685).