### PR TITLE
ooniprobe.rb: update to v3.14.0 and add tor dependency

### DIFF
--- a/Formula/ooniprobe.rb
+++ b/Formula/ooniprobe.rb
@@ -1,8 +1,8 @@
 class Ooniprobe < Formula
   desc "Network interference detection tool"
   homepage "https://ooni.org/"
-  url "https://github.com/ooni/probe-cli/archive/v3.13.0.tar.gz"
-  sha256 "a055aed8c2d0d898b7cdb843cf247cf3b593c8ac7045103c08b3088b7d4d1737"
+  url "https://github.com/ooni/probe-cli/archive/v3.14.0.tar.gz"
+  sha256 "30ada9f266ab62ab4044c17e9523edfb7a751169d114890506dfc4e3101af8a6"
   license "GPL-3.0-or-later"
 
   livecheck do
@@ -20,6 +20,7 @@ class Ooniprobe < Formula
   end
 
   depends_on "go" => :build
+  depends_on "tor"
 
   def install
     system "go", "run", "./internal/cmd/getresources"


### PR DESCRIPTION
This commit upgrades ooniprobe to v3.14.0 and adds tor as a dependency.

The new tor dependency is required because in v3.14.0 ooniprobe introduces new
network experiments that assume tor is installed.

Reference (OONI) issue for this work: https://github.com/ooni/probe/issues/2022

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
