### PR TITLE
zstd: compile with legacy format support

### DIFF
--- a/Formula/zstd.rb
+++ b/Formula/zstd.rb
@@ -22,14 +22,16 @@ class Zstd < Formula
   uses_from_macos "zlib"
 
   def install
-    cd "build/cmake" do
-      system "cmake", "-S", ".", "-B", "builddir",
-                      "-DZSTD_BUILD_CONTRIB=ON",
-                      "-DCMAKE_INSTALL_RPATH=#{rpath}",
-                      *std_cmake_args
-      system "cmake", "--build", "builddir"
-      system "cmake", "--install", "builddir"
-    end
+    # Legacy support is the default after
+    # https://github.com/facebook/zstd/commit/db104f6e839cbef94df4df8268b5fecb58471274
+    # Set it to `ON` to be explicit about the configuration.
+    system "cmake", "-S", "build/cmake", "-B", "builddir",
+                    "-DZSTD_BUILD_CONTRIB=ON",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    "-DZSTD_LEGACY_SUPPORT=ON",
+                    *std_cmake_args
+    system "cmake", "--build", "builddir"
+    system "cmake", "--install", "builddir"
   end
 
   test do


### PR DESCRIPTION
ZSTD is capable of decoding legacy format but it is not enabled by default.
This is compile-time option, see https://github.com/facebook/zstd/blob/dev/programs/README.md



- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
