### PR TITLE
phpunit 9.5.16

### DIFF
--- a/Formula/phpunit.rb
+++ b/Formula/phpunit.rb
@@ -1,8 +1,8 @@
 class Phpunit < Formula
   desc "Programmer-oriented testing framework for PHP"
   homepage "https://phpunit.de"
-  url "https://phar.phpunit.de/phpunit-9.5.15.phar"
-  sha256 "fb9afa97a4100fc9cf0be2bd7afa11a9df2154acfe929e474d8727f1210a94fd"
+  url "https://phar.phpunit.de/phpunit-9.5.16.phar"
+  sha256 "342166d3067cb86a4d9620d0a49b9ae4b4bbe25d5d751a0ecfd3ed4e96409b0a"
   license "BSD-3-Clause"
 
   livecheck do


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 4,513,114 bytes
- formula fetch time: 4.5 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.