### PR TITLE
Stop service if it is present on system (it may be spinning)

### DIFF
--- a/cmd/postgresql-upgrade-database.rb
+++ b/cmd/postgresql-upgrade-database.rb
@@ -68,8 +68,8 @@ module Homebrew
       ohai "Upgrading #{name} data from #{pg_version_data} to #{pg_version_installed}..."
       services_json_output = Utils.popen_read("brew", "services", "info", "--all", "--json")
       services_json = JSON.parse(services_json_output, object_class: OpenStruct)
-      running_service_names = services_json.select(&:running).map(&:name)
-      if running_service_names.include?(name)
+      service_names = services_json.map(&:name)
+      if service_names.include?(name)
         system "brew", "services", "stop", name
         service_stopped = true
       elsif quiet_system "#{bin}/pg_ctl", "-D", datadir, "status"
@@ -78,7 +78,7 @@ module Homebrew
       end
 
       # Shut down old server if it is up via brew services
-      if sys_services.any? { |svc| svc['name'] == old_pg_name }
+      if service_names.include?(old_pg_name)
         system "brew", "services", "stop", old_pg_name
       end
 

--- a/cmd/postgresql-upgrade-database.rb
+++ b/cmd/postgresql-upgrade-database.rb
@@ -66,8 +66,8 @@ module Homebrew
       # Following instructions from:
       # https://www.postgresql.org/docs/10/static/pgupgrade.html
       ohai "Upgrading #{name} data from #{pg_version_data} to #{pg_version_installed}..."
-
-      if /^#{name}\s+/.match?(Utils.popen_read("brew", "services", "list"))
+      sys_services = JSON.parse(Utils.popen_read("brew", "services", "info", "--all", "--json"))
+      if sys_services.any? { |svc| svc['name'] == name }
         system "brew", "services", "stop", name
         service_stopped = true
       elsif quiet_system "#{bin}/pg_ctl", "-D", datadir, "status"
@@ -76,7 +76,7 @@ module Homebrew
       end
 
       # Shut down old server if it is up via brew services
-      if /^#{old_pg_name}\s+/.match?(Utils.popen_read("brew", "services", "list"))
+      if sys_services.any? { |svc| svc['name'] == old_pg_name }
         system "brew", "services", "stop", old_pg_name
       end
 

--- a/cmd/postgresql-upgrade-database.rb
+++ b/cmd/postgresql-upgrade-database.rb
@@ -69,8 +69,8 @@ module Homebrew
       ohai "Upgrading #{name} data from #{pg_version_data} to #{pg_version_installed}..."
       services_json_output = Utils.popen_read("brew", "services", "info", "--all", "--json")
       services_json = JSON.parse(services_json_output, object_class: OpenStruct)
-      service_names = services_json.map(&:name)
-      if service_names.include?(name)
+      loaded_service_names = services_json.select(&:loaded).map(&:name)
+      if loaded_service_names.include?(name)
         system "brew", "services", "stop", name
         service_stopped = true
       elsif quiet_system "#{bin}/pg_ctl", "-D", datadir, "status"
@@ -79,7 +79,7 @@ module Homebrew
       end
 
       # Shut down old server if it is up via brew services
-      system "brew", "services", "stop", old_pg_name if service_names.include?(old_pg_name)
+      system "brew", "services", "stop", old_pg_name if loaded_service_names.include?(old_pg_name)
 
       # get 'lc_collate' from old DB"
       unless quiet_system "#{old_bin}/pg_ctl", "-w", "-D", datadir, "status"

--- a/cmd/postgresql-upgrade-database.rb
+++ b/cmd/postgresql-upgrade-database.rb
@@ -67,7 +67,7 @@ module Homebrew
       # https://www.postgresql.org/docs/10/static/pgupgrade.html
       ohai "Upgrading #{name} data from #{pg_version_data} to #{pg_version_installed}..."
 
-      if /#{name}\s+started/.match?(Utils.popen_read("brew", "services", "list"))
+      if /#{name}\s+/.match?(Utils.popen_read("brew", "services", "list"))
         system "brew", "services", "stop", name
         service_stopped = true
       elsif quiet_system "#{bin}/pg_ctl", "-D", datadir, "status"
@@ -76,7 +76,7 @@ module Homebrew
       end
 
       # Shut down old server if it is up via brew services
-      if /#{old_pg_name}\s+started/.match?(Utils.popen_read("brew", "services", "list"))
+      if /#{old_pg_name}\s+/.match?(Utils.popen_read("brew", "services", "list"))
         system "brew", "services", "stop", old_pg_name
       end
 

--- a/cmd/postgresql-upgrade-database.rb
+++ b/cmd/postgresql-upgrade-database.rb
@@ -66,8 +66,10 @@ module Homebrew
       # Following instructions from:
       # https://www.postgresql.org/docs/10/static/pgupgrade.html
       ohai "Upgrading #{name} data from #{pg_version_data} to #{pg_version_installed}..."
-      sys_services = JSON.parse(Utils.popen_read("brew", "services", "info", "--all", "--json"))
-      if sys_services.any? { |svc| svc['name'] == name }
+      services_json_output = Utils.popen_read("brew", "services", "info", "--all", "--json")
+      services_json = JSON.parse(services_json_output, object_class: OpenStruct)
+      running_service_names = services_json.select(&:running).map(&:name)
+      if running_service_names.include?(name)
         system "brew", "services", "stop", name
         service_stopped = true
       elsif quiet_system "#{bin}/pg_ctl", "-D", datadir, "status"

--- a/cmd/postgresql-upgrade-database.rb
+++ b/cmd/postgresql-upgrade-database.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cli/parser"
@@ -78,9 +79,7 @@ module Homebrew
       end
 
       # Shut down old server if it is up via brew services
-      if service_names.include?(old_pg_name)
-        system "brew", "services", "stop", old_pg_name
-      end
+      system "brew", "services", "stop", old_pg_name if service_names.include?(old_pg_name)
 
       # get 'lc_collate' from old DB"
       unless quiet_system "#{old_bin}/pg_ctl", "-w", "-D", datadir, "status"

--- a/cmd/postgresql-upgrade-database.rb
+++ b/cmd/postgresql-upgrade-database.rb
@@ -67,7 +67,7 @@ module Homebrew
       # https://www.postgresql.org/docs/10/static/pgupgrade.html
       ohai "Upgrading #{name} data from #{pg_version_data} to #{pg_version_installed}..."
 
-      if /#{name}\s+/.match?(Utils.popen_read("brew", "services", "list"))
+      if /^#{name}\s+/.match?(Utils.popen_read("brew", "services", "list"))
         system "brew", "services", "stop", name
         service_stopped = true
       elsif quiet_system "#{bin}/pg_ctl", "-D", datadir, "status"
@@ -76,7 +76,7 @@ module Homebrew
       end
 
       # Shut down old server if it is up via brew services
-      if /#{old_pg_name}\s+/.match?(Utils.popen_read("brew", "services", "list"))
+      if /^#{old_pg_name}\s+/.match?(Utils.popen_read("brew", "services", "list"))
         system "brew", "services", "stop", old_pg_name
       end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hi, this change is simply to run brew services stop on the name if the service is installed on the system. 

At present it will only be stopped if the service's status is started. 

However, if pg is spinning (because the data directory has not been migrated), the service will not be in the started state, but pg will continue to try to start. This will manifest as errors in the upgrade process referring to an existing postmaster.pid file (which only exists for an instant). Running services stop will stop the pg attempts to start and allow the upgrade script to proceed. There are a number of users who face this issue, e.g. on stackoverflow:

- https://stackoverflow.com/questions/63749141/initb-fails-for-brew-postgresql-upgrade-database?rq=1
- https://stackoverflow.com/questions/17822974/postgres-fatal-database-files-are-incompatible-with-server