### PR TITLE
cbmc-viewer 2.11 (new formula)

### DIFF
--- a/Formula/cbmc-viewer.rb
+++ b/Formula/cbmc-viewer.rb
@@ -1,0 +1,57 @@
+class CbmcViewer < Formula
+  include Language::Python::Virtualenv
+  desc "Scans the output of CBMC and produces a browsable summary of the results"
+  homepage "https://github.com/awslabs/aws-viewer-for-cbmc"
+  url "https://github.com/awslabs/aws-viewer-for-cbmc.git",
+      tag:      "viewer-2.11",
+      revision: "33bdc901dcada996fdcf47e2258d4db4c27c6ee5"
+  license "Apache-2.0"
+
+  depends_on "cbmc" => :test
+  depends_on "python@3.9"
+  depends_on "universal-ctags"
+
+  resource "Jinja2" do
+    url "https://files.pythonhosted.org/packages/91/a5/429efc6246119e1e3fbf562c00187d04e83e54619249eb732bb423efa6c6/Jinja2-3.0.3.tar.gz"
+    sha256 "611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"
+  end
+
+  resource "MarkupSafe" do
+    url "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz"
+    sha256 "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"
+  end
+
+  resource "voluptuous" do
+    url "https://files.pythonhosted.org/packages/c0/2c/ccbeb25364e3e0c5e4522f13d66e2fc639bb4d4ecdf73be0959552cbecb4/voluptuous-0.12.2.tar.gz"
+    sha256 "4db1ac5079db9249820d49c891cb4660a6f8cae350491210abce741fabf56513"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    (testpath/"main.c").write <<~EOS
+      #include <stdlib.h>
+
+      static int global;
+
+      int main() {
+        int *ptr = malloc(sizeof(int));
+        assert(global > 0);
+        return 0;
+      }
+    EOS
+
+    system "goto-cc", "-o", "main.goto", testpath/"main.c"
+    (testpath/"cbmc.xml").write shell_output("cbmc main.goto --trace --xml-ui", 10)
+    (testpath/"coverage.xml").write shell_output("cbmc main.goto --cover location --xml-ui")
+    (testpath/"property.xml").write shell_output("cbmc main.goto --show-properties --xml-ui")
+    system bin/"cbmc-viewer", "--goto", "main.goto",
+                              "--result", "cbmc.xml",
+                              "--coverage", "coverage.xml",
+                              "--property", "property.xml",
+                              "--srcdir", "."
+    assert_predicate testpath/"result/html/index.html", :exist?
+  end
+end


### PR DESCRIPTION
CBMC Viewer scans the output of CBMC and produces a summary that can
be opened in any web browser to understand and debug CBMC findings.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
