### PR TITLE
dvm: depends on x86_64

### DIFF
--- a/Formula/dvm.rb
+++ b/Formula/dvm.rb
@@ -16,6 +16,8 @@ class Dvm < Formula
   end
 
   depends_on "go" => :build
+  # Fails to build on ARM
+  depends_on arch: :x86_64
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
Fails to build with:
2022-02-23T07:54:29.0917180Z [34m==>[0m [1mmake VERSION=1.0.2 UPGRADE_DISABLED=true[0m
2022-02-23T07:54:29.0917590Z Last 150 lines from /Users/brew/actions-runner-x86_64/_work/homebrew-core/homebrew-core/bottles/logs/dvm/01.make:
2022-02-23T07:54:29.0917930Z 2022-02-23 07:54:23 +0000
2022-02-23T07:54:29.0918040Z
2022-02-23T07:54:29.0918100Z make
2022-02-23T07:54:29.0918270Z VERSION=1.0.2
2022-02-23T07:54:29.0918440Z UPGRADE_DISABLED=true
2022-02-23T07:54:29.0918550Z
2022-02-23T07:54:29.0918930Z objc[49605]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libamsupport.dylib (0x1fa9cb678) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x1064982c8). One of the two will be used. Which one is undefined.
2022-02-23T07:54:29.0919680Z objc[49605]: Class AMSupportURLSession is implemented in both /usr/lib/libamsupport.dylib (0x1fa9cb6c8) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x106498318). One of the two will be used. Which one is undefined.
2022-02-23T07:54:29.0920180Z fatal: not a git repository (or any of the parent directories): .git
2022-02-23T07:54:29.0920750Z CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -X main.dvmCommit= -X main.dvmVersion=1.0.2 -X main.upgradeDisabled=true' -o dvm-helper/dvm-helper github.com/howtowhale/dvm/dvm-helper
2022-02-23T07:54:29.0921220Z # github.com/howtowhale/dvm/dvm-helper/dockerversion
2022-02-23T07:54:29.0921570Z dvm-helper/dockerversion/dockerversion.go:75:33: undefined: dockerArch
2022-02-23T07:54:29.0921940Z dvm-helper/dockerversion/dockerversion.go:96:35: undefined: dockerArch
2022-02-23T07:54:29.0922280Z dvm-helper/dockerversion/query.go:34:102: undefined: dockerArch
2022-02-23T07:54:29.0922510Z make: *** [local] Error 2

Upstream looks somewhat inactive and we did not get a fix for our last request, see https://github.com/howtowhale/dvm/issues/193

I almost wanted to deprecated dvm, but as the Intel build is still fine, I'm disabling it for ARM

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
