### PR TITLE
pilosa: deprecate

### DIFF
--- a/Formula/pilosa.rb
+++ b/Formula/pilosa.rb
@@ -12,6 +12,9 @@ class Pilosa < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "776da185052f34aa5c973e92bfefb27304168a7d24f5cbb1dd1a951e1330cd5e"
   end
 
+  # https://github.com/pilosa/pilosa/issues/2149#issuecomment-993029527
+  deprecate! date: "2021-12-14", because: :unmaintained
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
See https://github.com/pilosa/pilosa/issues/2149#issuecomment-993029527

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
