### PR TITLE
Adds to peru a dependency on git

### DIFF
--- a/Formula/peru.rb
+++ b/Formula/peru.rb
@@ -18,9 +18,9 @@ class Peru < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "edf871502a89345ab82d466d2d99d1e727618273af9c23713da1f2c5eb4a925a"
   end
 
+  depends_on "git"
   depends_on "libyaml"
   depends_on "python@3.10"
-  depends_on "git"
 
   resource "docopt" do
     url "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz"

--- a/Formula/peru.rb
+++ b/Formula/peru.rb
@@ -20,6 +20,7 @@ class Peru < Formula
 
   depends_on "libyaml"
   depends_on "python@3.10"
+  depends_on "git"
 
   resource "docopt" do
     url "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz"


### PR DESCRIPTION
Peru [uses git internally][1] in a subprocess even when not retrieving a git module.

[1]: https://github.com/buildinspace/peru/blob/dac923d2cb43af4533161196459703a86c0490b9/peru/cache.py#L54-L70

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Commit made in GitHub, so it's untested.
