### PR TITLE
luarocks: test with luajit-openresty

### DIFF
--- a/Formula/luarocks.rb
+++ b/Formula/luarocks.rb
@@ -22,7 +22,7 @@ class Luarocks < Formula
 
   depends_on "lua@5.1" => :test
   depends_on "lua@5.3" => :test
-  depends_on "luajit" => :test unless Hardware::CPU.arm?
+  depends_on "luajit-openresty" => :test
   depends_on "lua"
 
   uses_from_macos "unzip"
@@ -76,12 +76,10 @@ class Luarocks < Formula
           "Luafilesystem failed to create the expected directory"
 
         # LuaJIT is compatible with lua5.1, so we can also test it here
-        unless Hardware::CPU.arm?
-          rmdir testpath/"blank_space"
-          system "#{Formula["luajit"].bin}/luajit", "lfs_#{luaversion}test.lua"
-          assert_predicate testpath/"blank_space", :directory?,
-            "Luafilesystem failed to create the expected directory"
-        end
+        rmdir testpath/"blank_space"
+        system "#{Formula["luajit-openresty"].bin}/luajit", "lfs_#{luaversion}test.lua"
+        assert_predicate testpath/"blank_space", :directory?,
+          "Luafilesystem failed to create the expected directory"
       else
         (testpath/"lfs_#{luaversion}test.lua").write <<~EOS
           require("lfs")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Just changing test dependency to remove all references of older `luajit` (making it easier to deprecate if wanted - #68013)

Once this and #95846 are merged, there should be 0 usage of `luajit` as build/test/runtime dependency inside `homebrew-core`