### PR TITLE
luaver: fix test on Linux

### DIFF
--- a/Formula/luaver.rb
+++ b/Formula/luaver.rb
@@ -26,8 +26,8 @@ class Luaver < Formula
   test do
     lua_versions = %w[5.3.3 5.2.4 5.1.5]
     lua_versions.each do |v|
-      ENV.deparallelize { system ". #{bin}/luaver install #{v} < /dev/null" }
-      system ". #{bin}/luaver use #{v} && lua -v"
+      ENV.deparallelize { system "bash", "-c", ". #{bin}/luaver install #{v} < /dev/null" }
+      system "bash", "-c", ". #{bin}/luaver use #{v} && lua -v"
     end
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Linux failure from #95912
Probably `bash` vs `dash` issue on Ubuntu.

```
==> Testing luaver (again)
  ==> . /home/linuxbrew/.linuxbrew/Cellar/luaver/1.1.0/bin/luaver install 5.3.3 < /dev/null
  Error: luaver: failed
  An exception occurred within a child process:
    BuildError: Failed executing: . /home/linuxbrew/.linuxbrew/Cellar/luaver/1.1.0/bin/luaver install 5.3.3 < /dev/null
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2309:in `block in system'
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2245:in `open'
```