### PR TITLE
elasticsearch@6, kibana@6: deprecate

### DIFF
--- a/Formula/elasticsearch@6.rb
+++ b/Formula/elasticsearch@6.rb
@@ -16,6 +16,8 @@ class ElasticsearchAT6 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2022-02-10", because: :unsupported
+
   depends_on "openjdk"
 
   def cluster_name

--- a/Formula/kibana@6.rb
+++ b/Formula/kibana@6.rb
@@ -14,6 +14,8 @@ class KibanaAT6 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2022-02-10", because: :unsupported
+
   depends_on "yarn" => :build
   depends_on :macos # Due to Python 2
   depends_on "node@10"


### PR DESCRIPTION
These are now EOL after the release of 8.0.