### PR TITLE
perkeep: remove go@1.12 reliance

### DIFF
--- a/Formula/perkeep.rb
+++ b/Formula/perkeep.rb
@@ -2,6 +2,7 @@ class Perkeep < Formula
   desc "Lets you permanently keep your stuff, for life"
   homepage "https://perkeep.org/"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/perkeep/perkeep.git", branch: "master"
 
   stable do
@@ -9,10 +10,10 @@ class Perkeep < Formula
         tag:      "0.11",
         revision: "76755286451a1b08e2356f549574be3eea0185e5"
 
-    # gopherjs doesn't tag releases, so just pick the most recent revision for now
+    # Newer gopherjs to support a newer Go version.
     resource "gopherjs" do
-      url "https://github.com/gopherjs/gopherjs/archive/fce0ec30dd00773d3fa974351d04ce2737b5c4d9.tar.gz"
-      sha256 "e5e6ede5f710fde77e48aa1f6a9b75f5afeb1163223949f76c1300ae44263b84"
+      url "https://github.com/gopherjs/gopherjs/archive/refs/tags/1.17.1+go1.17.3.tar.gz"
+      sha256 "8c5275ddf09646fdeb9df701f49425feb2327ec25dddfa49e2d9d323813398af"
     end
   end
 
@@ -34,12 +35,12 @@ class Perkeep < Formula
   def install
     if build.stable?
       ENV["GOPATH"] = buildpath
-      ENV["CAMLI_GOPHERJS_GOROOT"] = Formula["go@1.12"].opt_libexec
+      ENV["CAMLI_GOPHERJS_GOROOT"] = Formula["go"].opt_libexec
 
       (buildpath/"src/perkeep.org").install buildpath.children
 
       # Vendored version of gopherjs requires go 1.10, so use the newest available gopherjs, which
-      # supports up to go 1.12
+      # supports newer Go versions.
       rm_rf buildpath/"src/perkeep.org/vendor/github.com/gopherjs/gopherjs"
       resource("gopherjs").stage buildpath/"src/perkeep.org/vendor/github.com/gopherjs/gopherjs"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
