### PR TITLE
virgil: depend on x86_64

### DIFF
--- a/Formula/virgil.rb
+++ b/Formula/virgil.rb
@@ -17,6 +17,8 @@ class Virgil < Formula
   end
 
   depends_on "go" => :build
+  # https://github.com/VirgilSecurity/virgil-cli/issues/58
+  depends_on arch: :x86_64
 
   def install
     system "make"


### PR DESCRIPTION
See https://github.com/VirgilSecurity/virgil-cli/issues/58

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
