### PR TITLE
cassandra@2.1, cassandra@2.2: deprecrate

### DIFF
--- a/Formula/cassandra@2.1.rb
+++ b/Formula/cassandra@2.1.rb
@@ -15,6 +15,8 @@ class CassandraAT21 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2022-03-01", because: :unsupported
+
   depends_on :macos # Due to Python 2 (does not support Python 3)
 
   # Only Yosemite has new enough setuptools for successful compile of the below deps.

--- a/Formula/cassandra@2.2.rb
+++ b/Formula/cassandra@2.2.rb
@@ -14,6 +14,8 @@ class CassandraAT22 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2022-03-01", because: :unsupported
+
   depends_on "cython" => :build
   depends_on arch: :x86_64 # openjdk@8 is not supported on ARM
   depends_on :macos # Due to Python 2 (does not support Python 3)


### PR DESCRIPTION
These are no longer supported.

They also require Python 2.