### PR TITLE
nnn: copy quitcd scripts to pkgshare

### DIFF
--- a/Formula/nnn.rb
+++ b/Formula/nnn.rb
@@ -26,6 +26,8 @@ class Nnn < Formula
     bash_completion.install "misc/auto-completion/bash/nnn-completion.bash"
     zsh_completion.install "misc/auto-completion/zsh/_nnn"
     fish_completion.install "misc/auto-completion/fish/nnn.fish"
+
+    pkgshare.install "misc/quitcd"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`nnn` is known for its ["cd on quit" feature](https://github.com/jarun/nnn/wiki/Basic-use-cases#configure-cd-on-quit) and distributes [some relevant scripts](https://github.com/jarun/nnn/tree/master/misc/quitcd).

I've appended the `nnn` formula such that it copies over those scripts to the keg. Users of `nnn` can enable the "cd on quit" feature by importing the relevant script into a shell configuration file, [like so](https://wiki.archlinux.org/title/Nnn#cd_on_quit_(Ctrl-G)):

EDIT: See [@carlocab's reply](https://github.com/Homebrew/homebrew-core/pull/96062#pullrequestreview-897004152).

```
~/.bashrc or ~/.zshrc

-----

#QUITCD="$(brew --cellar nnn)"/$(nnn -V)/share/nnn/quitcd/quitcd.bash_zsh
if [ -f $QUITCD ]; then
    source $QUITCD
fi
```