### PR TITLE
llvm: remove symlinks causing build issues

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -5,6 +5,7 @@ class Llvm < Formula
   sha256 "326335a830f2e32d06d0a36393b5455d17dc73e0bd1211065227ee014f92cbf8"
   # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
   license "Apache-2.0" => { with: "LLVM-exception" }
+  revision 1
   head "https://github.com/llvm/llvm-project.git", branch: "main"
 
   livecheck do
@@ -133,10 +134,6 @@ class Llvm < Formula
       args << "-DLLVM_ENABLE_LIBCXX=ON"
       args << "-DRUNTIMES_CMAKE_ARGS=-DCMAKE_INSTALL_RPATH=#{rpath}"
       args << "-DDEFAULT_SYSROOT=#{macos_sdk}" if macos_sdk
-
-      # Apple does this for the components of LLVM they ship
-      args << "-DLLVM_INSTALL_BINUTILS_SYMLINKS=ON"
-      args << "-DLLVM_INSTALL_CCTOOLS_SYMLINKS=ON"
 
       # Skip the PGO build on HEAD installs or non-bottle source builds
       build.stable? && build.bottle?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Specifically, we are hitting issues with LLVM's `install_tool_name`, which I think is created due to `LLVM_INSTALL_CCTOOLS_SYMLINKS`

Previously seen issues:
- #95319
- #95683

Locally seen issue when building `julia`:
```
install_name_tool -id @rpath/libblastrampoline.dylib /private/tmp/julia-20220301-27089-1cfkv7u/julia-1.7.1/usr/lib/libblastrampoline.dylib
mv /private/tmp/julia-20220301-27089-1cfkv7u/julia-1.7.1/usr-staging/dsfmt-2.2.4.tgz.tmp /private/tmp/julia-20220301-27089-1cfkv7u/julia-1.7.1/usr-staging/dsfmt-2.2.4.tgz
[ ! -e /private/tmp/julia-20220301-27089-1cfkv7u/julia-1.7.1/usr/manifest/dsfmt ] || /Applications/Xcode.app/Contents/Developer/usr/bin/make uninstall-dsfmt
/usr/bin/tar -xmUzf /private/tmp/julia-20220301-27089-1cfkv7u/julia-1.7.1/usr-staging/dsfmt-2.2.4.tgz -C /private/tmp/julia-20220301-27089-1cfkv7u/julia-1.7.1/usr
install_name_tool -id @rpath/libdSFMT.dylib /private/tmp/julia-20220301-27089-1cfkv7u/julia-1.7.1/usr/lib/libdSFMT.dylib
install_name_tool: error: unsupported load command (cmd=0x80000034)
make[2]: *** [/private/tmp/julia-20220301-27089-1cfkv7u/julia-1.7.1/usr/manifest/dsfmt] Error 1
make[2]: *** Waiting for unfinished jobs....
install_name_tool: error: unsupported load command (cmd=0x80000034)
```