### PR TITLE
gitlab-runner: Run process with higher priority

### DIFF
--- a/Formula/gitlab-runner.rb
+++ b/Formula/gitlab-runner.rb
@@ -41,6 +41,7 @@ class GitlabRunner < Formula
     working_dir ENV["HOME"]
     keep_alive true
     macos_legacy_timers true
+    process_type :interactive
   end
 
   test do


### PR DESCRIPTION
It seems setting process type to interactive has been lost on the refactoring of brew services (initially introduced in #76073).

As mentioned in the previous pull-request, LegayTimers seems to have no effect without also changing the ProcessType.

> This key may have no effect if the job's ProcessType is not set to Interactive.

https://www.unix.com/man-page/mojave/5/launchd.plist/

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
