### PR TITLE
erlang@21: remove livecheck

### DIFF
--- a/Formula/erlang@21.rb
+++ b/Formula/erlang@21.rb
@@ -7,11 +7,6 @@ class ErlangAT21 < Formula
   license "Apache-2.0"
   revision 2
 
-  livecheck do
-    url :stable
-    regex(/^OTP[._-]v?(21(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 monterey:     "9effd9cdb8786f80257db78e9d1c587e4065313628f6c04c1ffe588afe0d9953"
     sha256 cellar: :any,                 big_sur:      "f05c014c491877da25d19f775a576803a25c36c5d57309548711c253b90711c8"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`deprecate!` was added to `erlang@21` in #96016, with a deprecation date of 2022-03-01. Now that the deprecation is in effect, the `livecheck` block is no longer necessary. This PR removes the `livecheck` block accordingly, so the formula will be automatically skipped as deprecated.