### PR TITLE
nnn: use ncurses from Homebrew

### DIFF
--- a/Formula/nnn.rb
+++ b/Formula/nnn.rb
@@ -4,6 +4,7 @@ class Nnn < Formula
   url "https://github.com/jarun/nnn/archive/v4.4.tar.gz"
   sha256 "e04a3f0f0c2af1e18cb6f005d18267c7703644274d21bb93f03b30e4fd3d1653"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/jarun/nnn.git", branch: "master"
 
   bottle do
@@ -16,9 +17,8 @@ class Nnn < Formula
   end
 
   depends_on "gnu-sed"
+  depends_on "ncurses"
   depends_on "readline"
-
-  uses_from_macos "ncurses"
 
   def install
     system "make", "install", "PREFIX=#{prefix}"


### PR DESCRIPTION
The ncurses that ships with macOS is quite old and does not contain a
terminfo entry for tmux-256color. Even if you manually compile the
tmux-256color terminfo entry from Homebrew, the native ncurses still
won't work because of a [known bug that misinterprets the 'pairs' entry][1].
Instead, use ncurses from Homebrew which ensures nnn works properly
in tmux out of the box.

[1]: https://github.com/tmux/tmux/issues/2262#issuecomment-719985206

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
