### PR TITLE
little-cms2: update livecheck

### DIFF
--- a/Formula/little-cms2.rb
+++ b/Formula/little-cms2.rb
@@ -14,7 +14,7 @@ class LittleCms2 < Formula
   # that the post URLs, headings, etc. maintain a consistent format.
   livecheck do
     url "https://www.littlecms.com/categories/releases/"
-    regex(%r{href=.*lcms2[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
+    regex(/Little\s*CMS\s+v?(\d+(?:\.\d+)+)\s+released/im)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `little-cms2` checks the releases blog posts and identifies versions in links. However, the check is currently giving 2.13 as the newest version instead of 2.13.1. This is because the URL path for the 2.13.1 release post is `/blog/2022/01/28/lcms2-2.13/`, so it doesn't include the full version.

To address this issue, this PR updates the regex to match version information in blog post titles. This regex is pretty loose but this may be fine for this unusual situation. We can always restrict it in the future (e.g., anchoring the start/end with `>\s*`/`\s*<` to match within the `a` element's inner text) if it ends up matching something undesirable.