### PR TITLE
wagyu: fix url due to conflict in tag and branch

### DIFF
--- a/Formula/wagyu.rb
+++ b/Formula/wagyu.rb
@@ -1,7 +1,7 @@
 class Wagyu < Formula
   desc "Rust library for generating cryptocurrency wallets"
   homepage "https://github.com/AleoHQ/wagyu"
-  url "https://github.com/AleoHQ/wagyu/archive/v0.6.1.tar.gz"
+  url "https://github.com/AleoHQ/wagyu/archive/refs/tags/v0.6.1.tar.gz"
   sha256 "2458b3d49653acd5df5f3161205301646527eca9f6ee3d84c7871afa275bad9f"
   license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/AleoHQ/wagyu.git", branch: "master"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in #95807

```console
❯ curl "https://github.com/AleoHQ/wagyu/archive/v0.6.1.tar.gz" -L
the given path has multiple possibilities: #<Git::Ref:0x00007f55927bb7b0>, #<Git::Ref:0x00007f55927bb1e8>%
```