### PR TITLE
charmcraft: use craft-cli commit since tag was modified

### DIFF
--- a/Formula/charmcraft.rb
+++ b/Formula/charmcraft.rb
@@ -241,8 +241,8 @@ class Charmcraft < Formula
   # Fixes unspecified dependency: https://github.com/canonical/charmcraft/issues/617
   # Remove this and `extra_packages` from `pypi_formula_mappings.json` when fixed
   resource "craft-cli" do
-    url "https://github.com/canonical/craft-cli/archive/0.1.tar.gz"
-    sha256 "6b4fcff2cd43c86632d305882451aa3832d68ae09f70d3aa952e613e8a2b9eaf"
+    url "https://github.com/canonical/craft-cli/archive/4af19f9c0da733321dc754be1180aea28f3feeb1.tar.gz"
+    sha256 "c568748b7e6b114af7d4ecfc90a1705dc40ee665fc059f0997c2cb3138053177"
   end
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The commit is the actual version used by `charmcraft` for 1.4.0: https://github.com/canonical/charmcraft/blob/1.4.0/requirements.txt#L48
```
git+git://github.com/canonical/craft-cli.git@4af19f9c0da733321dc754be1180aea28f3feeb1
```

In previous PR #92919, tag `0.1` was picked as close to commit hash with only documentation diff.

Since then, upstream has modified original `0.1` tag.

The commit itself still exists, so just use that and replace with PyPI resource in next (1.5) release.