### PR TITLE
libmonome 1.4.6

### DIFF
--- a/Formula/libmonome.rb
+++ b/Formula/libmonome.rb
@@ -3,8 +3,8 @@ class Libmonome < Formula
 
   desc "Library for easy interaction with monome devices"
   homepage "https://monome.org/"
-  url "https://github.com/monome/libmonome/archive/v1.4.5.tar.gz"
-  sha256 "c7109014f47f451f7b86340c40a1a05ea5c48e8c97493b1d4c0102b9ee375cd4"
+  url "https://github.com/monome/libmonome/archive/v1.4.6.tar.gz"
+  sha256 "dbb886eacb465ea893465beb7b5ed8340ae77c25b24098ab36abcb69976ef748"
   license "ISC"
   head "https://github.com/monome/libmonome.git", branch: "main"
 
@@ -21,11 +21,6 @@ class Libmonome < Formula
   depends_on "liblo"
 
   def install
-    # Fix build on Mojave
-    # https://github.com/monome/libmonome/issues/62
-    inreplace "wscript", /conf.env.append_unique.*-mmacosx-version-min=10.5.*/,
-                         "pass"
-
     rewrite_shebang detected_python_shebang, *Dir.glob("**/{waf,wscript}")
 
     system "./waf", "configure", "--prefix=#{prefix}"


### PR DESCRIPTION
Bumps library version to 1.4.6 and removes the patch to wscript
to prevent it from setting -mmacosx-version-min because the
up related upstream ticket has been closed.
https://github.com/monome/libmonome/issues/62

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
