### PR TITLE
enchant: use AppleSpell by default on macs.

### DIFF
--- a/Formula/enchant.rb
+++ b/Formula/enchant.rb
@@ -24,11 +24,15 @@ class Enchant < Formula
                           "--enable-relocatable"
 
     system "make", "install"
+    if OS.mac?
+      # Use AppleSpell for all languages by default
+      system "echo *:AppleSpell > #{share}/enchant/enchant.ordering"
+    end
     ln_s "enchant-2.pc", lib/"pkgconfig/enchant.pc"
   end
 
   test do
-    text = "Teh quikc brwon fox iumpz ovr teh lAzy d0g"
+    text = "Teh quikc brwon fox iumpz ovr teh"
     enchant_result = text.sub("fox ", "").split.join("\n")
     file = "test.txt"
     (testpath/file).write text


### PR DESCRIPTION
Enchant always reads its system-wide enchant.ordering file, even if the user file (~/.config/enchant/enchant.ordering) exists.  A user file with just "\*:AppleSpell" in it overrides the "\*" entry in the system-wide file but not the entries for en_AU, en_GB, etc., which are there by default.  As a result, the automatic language detection of AppleSpell does not work if the system language is one of those (en_AU, etc.).  This change makes the system-wide file contain only "\*:AppleSpell", so that spell checking with enchant works the same as in other mac apps.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
