### PR TITLE
jdtls 1.9.0 (new formula)

### DIFF
--- a/Formula/jdtls.rb
+++ b/Formula/jdtls.rb
@@ -1,0 +1,45 @@
+class Jdtls < Formula
+  desc "Java language specific implementation of the Language Server Protocol"
+  homepage "https://github.com/eclipse/eclipse.jdt.ls"
+  url "https://download.eclipse.org/jdtls/milestones/1.9.0/jdt-language-server-1.9.0-202203031534.tar.gz"
+  sha256 "b8af1925cb3b817fd1061e00a45ffbc6aca76819d8b2f5939626009ebf432fc7"
+  license "EPL-2.0"
+
+  depends_on "openjdk@11"
+  depends_on "python@3.9"
+
+  def install
+    libexec.install "bin"
+    libexec.install "config_mac"
+    libexec.install "config_linux"
+    libexec.install "features"
+    libexec.install "plugins"
+
+    (bin/"jdtls").write_env_script libexec/"bin/jdtls",
+      Language::Java.overridable_java_home_env("11")
+  end
+
+  test do
+    require "open3"
+
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+
+    Open3.popen3("#{bin}/jdtls", "-configuration", "#{testpath}/config", "-data",
+        "#{testpath}/data") do |stdin, stdout, _e, w|
+      stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
+      sleep 3
+      assert_match(/^Content-Length: \d+/i, stdout.readline)
+      Process.kill("KILL", w.pid)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds Eclipse JDT Language Server (jdtls) as a formula.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
