### PR TITLE
libarchive: update livecheck

### DIFF
--- a/Formula/libarchive.rb
+++ b/Formula/libarchive.rb
@@ -6,7 +6,7 @@ class Libarchive < Formula
   license "BSD-2-Clause"
 
   livecheck do
-    url "https://libarchive.org/downloads/"
+    url :homepage
     regex(/href=.*?libarchive[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `libarchive` checks the libarchive.org downloads file listing but it's reporting 3.5.2 as newest instead of 3.6.0. This has seemingly worked fine in the past but the aforementioned page is referred to as "legacy releases" on the homepage and it doesn't link to any files for 3.6.0. Instead, the links to the 3.6.0 files are only on the homepage.

With this in mind, it seems like we'll have to check the homepage to identify the latest version instead, so this PR updates the `livecheck` block to use `url :homepage` (no need to modify the regex).