### PR TITLE
bib-tool: Fix deprecated license for bib-tool

### DIFF
--- a/Formula/bib-tool.rb
+++ b/Formula/bib-tool.rb
@@ -3,7 +3,7 @@ class BibTool < Formula
   homepage "http://www.gerd-neugebauer.de/software/TeX/BibTool/en/"
   url "https://github.com/ge-ne/bibtool/releases/download/BibTool_2_68/BibTool-2.68.tar.gz"
   sha256 "e1964d199b0726f431f9a1dc4ff7257bb3dba879b9fa221803e0aa7840dee0e0"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256                               arm64_monterey: "d9e9e76159ba4398731428fd7ab2523d9066c325b28efc7b6012b5e9784bfd95"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

This PR fixes a warning on ``brew audit --strict `` warning about deprecated license for bib-tool
-----
