### PR TITLE
sonarqube: update livecheck

### DIFF
--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -6,7 +6,7 @@ class Sonarqube < Formula
   license "LGPL-3.0-or-later"
 
   livecheck do
-    url "https://binaries.sonarsource.com/Distribution/sonarqube/"
+    url "https://www.sonarqube.org/success-download-community-edition/"
     regex(/href=.*?sonarqube[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `sonarqube` checks https://binaries.sonarsource.com/Distribution/sonarqube/ but this now gives an XML error response saying the `Distribution/sonarqube/` key doesn't exist. It seems like this only works for individual files now and we can't check this for version information like before. [I can't remember off the top of my head (and archive.org is temporarily down at the moment) but I assume this was a directory listing page.]

This PR updates the `livecheck` block to check the auto-download page for the community edition (i.e., the "Download for free" link on the [first-party Downloads page](https://www.sonarqube.org/downloads/)), which contains a link to the latest `stable` archive file.