### PR TITLE
snap7: remove python call from test

### DIFF
--- a/Formula/snap7.rb
+++ b/Formula/snap7.rb
@@ -24,6 +24,16 @@ class Snap7 < Formula
   end
 
   test do
-    system "python", "-c", "import ctypes.util,sys;ctypes.util.find_library('snap7') or sys.exit(1)"
+    (testpath/"test.c").write <<~EOS
+      #include "snap7.h"
+      int main()
+      {
+        S7Object Client = Cli_Create();
+        Cli_Destroy(&Client);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-o", "test", "test.c", "-L#{lib}", "-lsnap7"
+    system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Related to https://github.com/Homebrew/homebrew-core/issues/93940