### PR TITLE
monetdb: update livecheck

### DIFF
--- a/Formula/monetdb.rb
+++ b/Formula/monetdb.rb
@@ -7,7 +7,7 @@ class Monetdb < Formula
   head "https://dev.monetdb.org/hg/MonetDB", using: :hg
 
   livecheck do
-    url "https://www.monetdb.org/downloads/sources/Latest/"
+    url "https://www.monetdb.org/downloads/sources/archive/"
     regex(/href=.*?MonetDB[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `monetdb` uses a `/downloads/sources/Latest/` URL, which is supposed to redirect to the newest version of MonetDB. Unfortunately, this redirection hasn't been kept up to date and it points to an old version, so `brew livecheck` is reporting 11.41.15 as newest instead of 11.43.9.

This PR modifies the `livecheck` URL to simply check the directory listing page for the macOS source archive files (`/downloads/sources/archive/`) and identify the newest version from the available tarballs. Looking at recent `monetdb` version bump PRs, this seems like an appropriate approach.