### PR TITLE
wiggle: remove livecheck

### DIFF
--- a/Formula/wiggle.rb
+++ b/Formula/wiggle.rb
@@ -5,11 +5,6 @@ class Wiggle < Formula
   sha256 "ff92cf0133c1f4dce33563e263cb30e7ddb6f4abdf86d427b1ec1490bec25afa"
   license "GPL-2.0-or-later"
 
-  livecheck do
-    url "https://neil.brown.name/wiggle/"
-    regex(/href=.*?wiggle[._-](\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "2340430acf70ad6cff33fb034eda572c80f359b3847b90ebcce1c732cc2bb792"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f585911f982b406255e79f0c3b6a4a71b7e438b0d102f1d9c39d1fdb806fe40e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `wiggle` formula was updated to 1.3 in #95291 and the `stable` source was switched to GitHub in the process. The existing `livecheck` block still checks the old website but it doesn't provide tarballs for versions beyond 1.2, so `brew livecheck` erroneously reports version 1.2 as newest.

This PR resolves the issue by removing the `livecheck` block, so `brew livecheck` will check the `stable` URL using the `Git` strategy. The repository currently only contains tags using a `v1.3` format, which the default `Git` strategy regex handles, so we can simply omit a `livecheck` block for now.