### PR TITLE
ladspa-sdk: update homepage, livecheck

### DIFF
--- a/Formula/ladspa-sdk.rb
+++ b/Formula/ladspa-sdk.rb
@@ -1,12 +1,12 @@
 class LadspaSdk < Formula
   desc "Linux Audio Developer's Simple Plugin"
-  homepage "https://ladspa.org"
+  homepage "https://www.ladspa.org"
   url "https://www.ladspa.org/download/ladspa_sdk_1.17.tgz"
   sha256 "d9d596171d93f9c226fcdb7e27c6f917422ac487efe2c05e0a18094df4268061"
   license "LGPL-2.1-only"
 
   livecheck do
-    url "https://www.ladspa.org/download/"
+    url "https://www.ladspa.org/download/index.html"
     regex(/href=.*?ladspa[._-]sdk[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `ladspa-sdk` checks the first-party `/download/` page but this now gives a `curl: (18) transfer closed with 9223372036854775807 bytes remaining to read` error. Something may have changed with the server configuration but suffice to say it's necessary to check `/download/index.html` instead.

This also updates the homepage URL to use the `www` subdomain like the other URLs, as it's necessary to avoid an SSL error with the bare domain (i.e., https://ladspa.org).