### PR TITLE
gitg: add license, livecheck

### DIFF
--- a/Formula/gitg.rb
+++ b/Formula/gitg.rb
@@ -3,6 +3,12 @@ class Gitg < Formula
   homepage "https://wiki.gnome.org/Apps/Gitg"
   url "https://download.gnome.org/sources/gitg/41/gitg-41.tar.xz"
   sha256 "7fb61b9fb10fbaa548d23d7065babd72ad63e621de55840c065ce6e3986c4629"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url :stable
+    regex(/gitg[._-]v?(\d+(?:\.\d+)*)\.t/i)
+  end
 
   bottle do
     sha256 arm64_big_sur: "a2bf23c4cb3fdfdcdb05f250b5bf62d33bc60d01072f182f1209a40b604674df"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew livecheck` checks the `stable` URL for `gitg` by default and uses the `Gnome` strategy, which checks the related `cache.json` file for versions in filenames. This is erroneously giving 3.32.1 as newest instead of 41 because the default `Gnome` strategy regex expects that versions will include at least a major and minor version. This has been historically been true but the filename for the newest version is simply `gitg-41.tar.xz`, so the default regex doesn't match this version.

This PR resolves this issue by adding a `livecheck` block that uses the looser `*` form of the standard regex for versions like `1.2.3`/`v1.2.3` (i.e., `v?(\d+(?:\.\d+)*)`), which will also match a version like `41` with no minor/patch versions.

If this becomes a more widespread issue with the newer GNOME version format, we can update the default `Gnome` strategy to use a looser `*` regex. Otherwise, we'll simply handle exceptions on a case-by-case basis (as here).

Lastly, this adds `license "GPL-2.0-or-later"`, as the source files contain GPLv2 license comments that use the "or...later" language. For example:

```
/*
 * gitg-cell-renderer-path.c
 * This file is part of gitg - git repository viewer
 *
 * Copyright (C) 2009 - Jesse van den Kieboom
 *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or
 * (at your option) any later version.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
 *
 * You should have received a copy of the GNU General Public License
 * along with this program; if not, write to the Free Software
 * Foundation, Inc., 59 Temple Place, Suite 330, 
 * Boston, MA 02111-1307, USA.
 */
```