### PR TITLE
nss: update livecheck

### DIFF
--- a/Formula/nss.rb
+++ b/Formula/nss.rb
@@ -8,6 +8,9 @@ class Nss < Formula
   livecheck do
     url "https://ftp.mozilla.org/pub/security/nss/releases/"
     regex(%r{href=.*?NSS[._-]v?(\d+(?:[._]\d+)+)[._-]RTM/?["' >]}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match.first.tr("_", ".") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `nss` is functional but the versions use a `1_2_3` format instead of `1.2.3`. This doesn't matter from the standpoint of `Version` comparison, as delimiters are ignored (i.e., `1_2_3` == `1.2.3`). However, the filename/formula version uses dots as a delimiter, so it would be good to follow suit.

This resolves the issue by adding a `strategy` block to the `livecheck` block that replaces `_` in the livecheck versions with `.`.