### PR TITLE
graphicsmagick: add livecheck

### DIFF
--- a/Formula/graphicsmagick.rb
+++ b/Formula/graphicsmagick.rb
@@ -6,6 +6,10 @@ class Graphicsmagick < Formula
   license "MIT"
   head "http://hg.code.sf.net/p/graphicsmagick/code", using: :hg
 
+  livecheck do
+    url "https://sourceforge.net/projects/graphicsmagick/rss?path=/graphicsmagick"
+  end
+
   bottle do
     sha256 arm64_monterey: "423213e0b36e1c6cef66354fe96f3c1c13f0836a4c5bb8ef299fc5ae90740ace"
     sha256 arm64_big_sur:  "05f9bae927f523a7caf3361fa586f50de4e0eb55ae2a7a0f10d53f595955399f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, `brew livecheck` checks the `stable` URL for `graphicsmagick` using the `Sourceforge` strategy. This checks the main RSS feed for `graphicsmagick` files but this includes more than just stable versions.

At the moment, `brew livecheck` is reporting `1.4.020220226` as newest, which comes from the `graphicsmagick-snapshots` subdirectory. Stable versions are found in the `graphicsmagick` subdirectory, where the latest stable version is `1.3.37` (the current formula version).

This PR resolves the issue by adding a `livecheck` block that checks the SourceForge RSS feed for the `graphicsmagick` subdirectory, so livecheck will only identify stable versions. This will still use the `Sourceforge` strategy and the default strategy regex works fine, so there's no need to supply a regex here.