### PR TITLE
zabbix 6.0.1

### DIFF
--- a/Formula/zabbix.rb
+++ b/Formula/zabbix.rb
@@ -1,10 +1,15 @@
 class Zabbix < Formula
   desc "Availability and monitoring solution"
   homepage "https://www.zabbix.com/"
-  url "https://cdn.zabbix.com/zabbix/sources/stable/5.4/zabbix-5.4.10.tar.gz"
-  sha256 "462b1c7506f22545916a8c6ffc50c297c952e21125a9240dedcf858070e59877"
+  url "https://cdn.zabbix.com/zabbix/sources/stable/6.0/zabbix-6.0.1.tar.gz"
+  sha256 "2dd92383cc169ce8b8cbbe660ed656e5d6b5b75bf4936743b8a9d59cdfcf3af1"
   license "GPL-2.0-or-later"
   head "https://github.com/zabbix/zabbix.git", branch: "master"
+
+  livecheck do
+    url "https://www.zabbix.com/download_sources"
+    regex(/href=.*?zabbix[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 arm64_monterey: "2efc79af9056617493577ab25993352cd15b4c4690ae8f36d28174d5516093d3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `zabbix` to the latest version, 6.0.1.

Besides, that, this adds a `livecheck` block that checks the first-party download page for source files, which links to the `stable` archive file. Without this, livecheck checks the `head` URL using the `Git strategy`, which works but doesn't align with the stable source.

When the `stable` and `head` sources are different but livecheck checks the `head` URL by default, it's preferable to add a `livecheck` block to check the `stable` source when possible. This helps to avoid certain issues, like when a version is tagged in the repository but hasn't been released on the first-party site yet (i.e., the related archive we use in the `stable` URL wouldn't be available and a version bump PR would fail).