### PR TITLE
dockutil: add livecheck

### DIFF
--- a/Formula/dockutil.rb
+++ b/Formula/dockutil.rb
@@ -5,6 +5,11 @@ class Dockutil < Formula
   sha256 "6dbbc1467caaab977bf4c9f2d106ceadfedd954b6a4848c54c925aff81159a65"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "f5f87d9e286c2b294bb157ac9f87baa2720fff044c7a92c0b80b9cb82db8a87e"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the `stable` URL using the `Git` strategy but this is currently reporting an unstable version as newest (3.0.0b3). livecheck catches some unstable version formats and filters them out by default (when a `livecheck` block isn't present) but it doesn't handle a format like 3.0.0b3 (something like 3.0.0-beta3 would be filtered out by default).

This PR adds a `livecheck` block that uses the standard regex for Git tags like 1.2.3/v1.2.3, which omits unstable versions and correctly identifies 3.0.0 as the latest stable version.

---

For what it's worth, 3.0.0 is a rewrite in Swift (the previous 2.0.5 version was released on 2016-09-14) and the formula will need to be reworked, so that's better left to a separate PR. I tried my hand at it but I couldn't get past the sandbox issue when fetching the https://github.com/apple/swift-argument-parser.git dependency. Looking at older PRs and similar formulae, this may be something that only upstream can resolve but I don't have enough experience with Swift formulae to know for sure.