### PR TITLE
envoy: add livecheck

### DIFF
--- a/Formula/envoy.rb
+++ b/Formula/envoy.rb
@@ -9,6 +9,11 @@ class Envoy < Formula
   license "Apache-2.0"
   head "https://github.com/envoyproxy/envoy.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "bf22e01df08c56e453469d1b9057bc4735bbbcb15edb6e81a557a10e103897a0"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "82a538bffdfe021e54774e9713351c8555bbb7b2766c6f9b96998918fdcaaa11"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `envoy` using the `Git` strategy but it's erroneously giving `36ab5ad2cc9d420137c9` as the latest version (instead of 1.21.1), which comes from a one-off `untagged-36ab5ad2cc9d420137c9` tag. This PR resolves the issue by adding a `livecheck` block that uses the standard regex for tags like 1.2.3/v1.2.3, which will omit the aforementioned tag.

A newer version is available (1.21.1) but the build process may be a bit involved, so I figured it would be easier to handle the livecheck issue separately.