### PR TITLE
sratoolkit: add livecheck

### DIFF
--- a/Formula/sratoolkit.rb
+++ b/Formula/sratoolkit.rb
@@ -22,6 +22,11 @@ class Sratoolkit < Formula
     end
   end
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any, monterey:     "7288ce0e3eca352589f120ae8a24f60009bd5ee7ad7b5fcd3ef68960ee0cb144"
     sha256 cellar: :any, big_sur:      "3ed43023475647f878bc0876f69ed16e46dee7eea3d6ebcbd5fa1e5e8849f4ce"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the `stable` URL for `sratoolkit` using the `Git` strategy but it's erroneously giving 4760-2.9.7 as newest (instead of 3.0.0), from a one-off `VDB-4760-2.9.7` tag. This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like 1.2.3/v1.2.3, which will omit the aforementioned tag.

A new version is available (3.0.0) but it will require notable changes to the formula, so I figured it would be better to address the livecheck issue separately for now.