### PR TITLE
squirrel 3.2

### DIFF
--- a/Formula/squirrel.rb
+++ b/Formula/squirrel.rb
@@ -1,14 +1,17 @@
 class Squirrel < Formula
   desc "High level, imperative, object-oriented programming language"
   homepage "http://www.squirrel-lang.org"
-  url "https://downloads.sourceforge.net/project/squirrel/squirrel3/squirrel%203.1%20stable/squirrel_3_1_stable.tar.gz"
-  version "3.1.0"
-  sha256 "4845a7fb82e4740bde01b0854112e3bb92a0816ad959c5758236e73f4409d0cb"
+  url "https://downloads.sourceforge.net/project/squirrel/squirrel3/squirrel%203.2%20stable/squirrel_3_2_stable.tar.gz"
+  sha256 "211f1452f00b24b94f60ba44b50abe327fd2735600a7bacabc5b774b327c81db"
   license "MIT"
+  head "https://github.com/albertodemichelis/squirrel.git", branch: "master"
 
   livecheck do
     url :stable
     regex(%r{url=.*?/squirrel[._-]v?(\d+(?:[_-]\d+)+)[._-]stable\.t}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map { |match| match.first.tr("_", ".") }
+    end
   end
 
   bottle do
@@ -25,14 +28,16 @@ class Squirrel < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ef0fb28b06ae9677d7f573189e5e2c8b012f1eb52d42b8d23d385117a826c2e5"
   end
 
-  # Upstream patch to fix compilation with Xcode 9
-  # https://github.com/albertodemichelis/squirrel/commit/a3a78eec
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/dcaba40/squirrel/xcode9.patch"
-    sha256 "7821b25b11c477341553c29dce5fb3fca2541e829276be2b2e3cd0c5b5a225d2"
-  end
-
   def install
+    # The tarball files are in a subdirectory, unlike the upstream repository.
+    # Moving tarball files out of the subdirectory allows us to use the same
+    # build steps for stable and HEAD builds.
+    squirrel_subdir = "squirrel#{version.major}"
+    if Dir.exist?(squirrel_subdir)
+      mv Dir["squirrel#{version.major}/*"], "."
+      rmdir squirrel_subdir
+    end
+
     system "make"
     prefix.install %w[bin include lib]
     doc.install Dir["doc/*.pdf"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `squirrel` to the latest version, 3.2. This is the first new release since 2016-03-27.

* The changes in the existing patch have already been integrated upstream, so it's no longer necessary.
* I've removed `version`, as the parsed version from the `stable` URL is `3.2`, which is how this version is referenced on the homepage, upstream repository, etc.
* This adds a `strategy` block to the `livecheck` block, to convert versions from filenames (e.g., `3_2`) to the expected version format with dots (e.g., `3.2`).
* The 3.2 tarball keeps the files in a `squirrel3` subdirectory, whereas the GitHub repository simply keeps the files in the root directory. I added some additional logic to the`install` block to move the tarball files into the root directory, so we can use the same build steps for both `stable` and `head` builds.
* I added the GitHub repository as the `head` URL and it seems to build fine with this setup.

I'm not sure if the `pc_file` is still necessary at this point but I don't use Squirrel, so I figured it may be better to leave it alone unless/until someone more knowledgeable says otherwise.