### PR TITLE
coursier 2.1.0-M5

### DIFF
--- a/Formula/coursier.rb
+++ b/Formula/coursier.rb
@@ -1,9 +1,15 @@
 class Coursier < Formula
   desc "Pure Scala Artifact Fetching"
   homepage "https://get-coursier.io/"
-  url "https://github.com/coursier/coursier/releases/download/v2.1.0-M2/coursier.jar"
-  sha256 "fda87fc2d52b96a338b38c3b1c69a33fb0a0dd57fb2ab5d7880164c0ea9234f2"
+  url "https://github.com/coursier/coursier/releases/download/v2.1.0-M5/coursier.jar"
+  version "2.1.0-M5"
+  sha256 "4e9041524151a4213e71a6d76daae41307b5aeaed643257188618f1d99e8486d"
   license "Apache-2.0"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+(?:-M\d+)?)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "5096cf898c56949605292c2054a673746622ff424cd6baaac4b52c52791d93bd"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `coursier` to the latest version on GitHub that isn't marked as pre-release, 2.1.0-M5. Only the first part of the version is automatically parsed from the `stable` URL (i.e., `2.1.0`), so it's necessary to specify the full version as `2.1.0-M5` for version comparison to properly work in livecheck.

This also adds a `livecheck` block that restricts matching to versions like `1.2.3` or `1.2.3-M4` while omitting a variety of unstable tags (e.g., `v1.0.0-M12-1`, `v2.0.0-RC1`, `v2.0.0-RC2-1`, `v2.0.16+69-g69cab05e6`, `v2.0.16-156-g18556160e`, `v2.1.0-M2-19-g5a34ba7c1`, etc.). In the long-run, it may be necessary to switch to the `GithubLatest` strategy with a permissive regex (e.g., `%r{href=["']?[^"' >]*?/tag/v?([^"' >]+)["' >]}i`) but checking the Git tags seems to be sufficient for now.