### PR TITLE
spago 0.20.7

### DIFF
--- a/Formula/spago.rb
+++ b/Formula/spago.rb
@@ -1,10 +1,15 @@
 class Spago < Formula
   desc "PureScript package manager and build tool"
   homepage "https://github.com/purescript/spago"
-  url "https://github.com/purescript/spago/archive/refs/tags/0.20.4.tar.gz"
-  sha256 "e2ef8604115556b39ec71301d85a3502502fd5972e40bac82cd556d6a128baff"
+  url "https://github.com/purescript/spago/archive/refs/tags/0.20.7.tar.gz"
+  sha256 "4bb73918813550d9841a8f50b5653f46253da12295d9d8038a63923044d7cf7c"
   license "BSD-3-Clause"
   head "https://github.com/purescript/spago.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "cb44856d548eff894648c7a5b2607776e5e90d3172c246343201e961b570c37c"
@@ -19,6 +24,7 @@ class Spago < Formula
   depends_on "haskell-stack" => :build
   depends_on "purescript"
 
+  # Check the `scripts/fetch-templates` file for appropriate resource versions.
   resource "docs-search-app-0.0.10.js" do
     url "https://github.com/purescript/purescript-docs-search/releases/download/v0.0.10/docs-search-app.js"
     sha256 "45dd227a2139e965bedc33417a895ec7cb267ae4a2c314e6071924d19380aa54"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `spago` to the latest version, 0.20.7.

Besides that, this adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`. By default, livecheck was checking the `stable` URL using the `Git` strategy but it was giving `2` as the latest version, from a `test-travis-deploy-2` tag. The aforementioned regex matches the version tags we're interested in while omitting unrelated tags, so livecheck correctly reports `0.20.7` as the latest version.

I also added a comment before the `resource` blocks to make it clear where the version information can be found, so we stand a better chance of keeping the `resource` blocks up to date in the future (they're fine at the moment).