### PR TITLE
Drop depends_on arch: :x86_64 in Formula/imageoptim-cli.rb

### DIFF
--- a/Formula/imageoptim-cli.rb
+++ b/Formula/imageoptim-cli.rb
@@ -20,7 +20,6 @@ class ImageoptimCli < Formula
 
   depends_on "node" => :build
   depends_on "yarn" => :build
-  depends_on arch: :x86_64 # Installs pre-built x86-64 binaries
   depends_on :macos
 
   def install


### PR DESCRIPTION
This line prevents `imageoptim-cli` from being installed on `arm64` Macs where [user reports indicate it runs fine through Rosetta](https://github.com/JamieMason/ImageOptim-CLI/issues/191#issuecomment-1059933252).

https://github.com/Homebrew/homebrew-core/blob/01c0f33ce751a621e1560b6dbb6f3de9d1a269ae/Formula/imageoptim-cli.rb#L23