### PR TITLE
kubescape: add "v' to version. (v2.0.149 instead of 2.0.149)

### DIFF
--- a/Formula/kubescape.rb
+++ b/Formula/kubescape.rb
@@ -4,6 +4,7 @@ class Kubescape < Formula
   url "https://github.com/armosec/kubescape/archive/v2.0.149.tar.gz"
   sha256 "6a97eab6d41ea65216fa399c676337434783465bedf06ce8827ae1be939fccee"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/armosec/kubescape.git", branch: "master"
 
   bottle do

--- a/Formula/kubescape.rb
+++ b/Formula/kubescape.rb
@@ -20,7 +20,7 @@ class Kubescape < Formula
   def install
     ldflags = %W[
       -s -w
-      -X github.com/armosec/kubescape/cautils.BuildNumber="v"#{version}
+      -X github.com/armosec/kubescape/cautils.BuildNumber=v#{version}
     ]
     system "go", "build", *std_go_args(ldflags: ldflags)
 

--- a/Formula/kubescape.rb
+++ b/Formula/kubescape.rb
@@ -20,7 +20,7 @@ class Kubescape < Formula
   def install
     ldflags = %W[
       -s -w
-      -X github.com/armosec/kubescape/cautils.BuildNumber=#{version}
+      -X github.com/armosec/kubescape/cautils.BuildNumber="v"#{version}
     ]
     system "go", "build", *std_go_args(ldflags: ldflags)
 


### PR DESCRIPTION
if there is some other proper way doing that- ill be happy to hear

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
