### PR TITLE
lv2: put plugins in HOMEBREW_PREFIX/lib/lv2

### DIFF
--- a/Formula/lv2.rb
+++ b/Formula/lv2.rb
@@ -7,7 +7,7 @@ class Lv2 < Formula
   url "https://lv2plug.in/spec/lv2-1.18.2.tar.bz2"
   sha256 "4e891fbc744c05855beb5dfa82e822b14917dd66e98f82b8230dbd1c7ab2e05e"
   license "ISC"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://lv2plug.in/spec/"
@@ -60,15 +60,15 @@ class Lv2 < Formula
 
   def install
     # Python resources and virtualenv are for the lv2specgen.py script that is installed
-    venv = virtualenv_create(libexec, Formula["python@3.9"].opt_bin/"python3")
+    venv = virtualenv_create(libexec, "python3")
     venv.pip_install resources
     rw_info = python_shebang_rewrite_info("#{libexec}/bin/python3")
     rewrite_shebang rw_info, *Dir.glob("lv2specgen/*.py")
 
-    system Formula["python@3.9"].opt_bin/"python3", "./waf", "configure",
-           "--prefix=#{prefix}", "--no-plugins", "--lv2dir=#{lib}"
-    system Formula["python@3.9"].opt_bin/"python3", "./waf", "build"
-    system Formula["python@3.9"].opt_bin/"python3", "./waf", "install"
+    system "python3", "./waf", "configure",
+           "--prefix=#{prefix}", "--no-plugins", "--lv2dir=#{lib}/lv2"
+    system "python3", "./waf", "build"
+    system "python3", "./waf", "install"
 
     (pkgshare/"example").install "plugins/eg-amp.lv2/amp.c"
   end

--- a/Formula/mda-lv2.rb
+++ b/Formula/mda-lv2.rb
@@ -4,6 +4,7 @@ class MdaLv2 < Formula
   url "https://download.drobilla.net/mda-lv2-1.2.6.tar.bz2"
   sha256 "cd66117024ae049cf3aca83f9e904a70277224e23a969f72a9c5d010a49857db"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://download.drobilla.net"
@@ -20,11 +21,21 @@ class MdaLv2 < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "python@3.10" => :build
+  depends_on "sord" => :test
   depends_on "lv2"
 
   def install
-    system "./waf", "configure", "--prefix=#{prefix}"
-    system "./waf"
-    system "./waf", "install", "--destdir=#{prefix}"
+    ENV.cxx11
+    system "python3", "./waf", "configure", "--prefix=#{prefix}", "--lv2dir=#{lib}/lv2"
+    system "python3", "./waf"
+    system "python3", "./waf", "install"
+  end
+
+  test do
+    # Validate mda.lv2 plugin metadata (needs definitions included from lv2)
+    system Formula["sord"].opt_bin/"sord_validate",
+           *Dir[Formula["lv2"].opt_lib/"**/*.ttl"],
+           *Dir[lib/"lv2/mda.lv2/*.ttl"]
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Previously, `lv2` and `mda-lv2` have been putting their LV2 plugins in different places; for `mda-lv2`, they were even in a place that wasn't symlinked out of the Cellar.

This PR moves the location into `HOMEBREW_PREFIX/lib/lv2`, which is a natural extension of the generally accepted guidance of installing LV2 plugins in `/usr/lib/lv2` or `/usr/local/lib/lv2` (assuming a system-level install).

While we're here, use brewed Python to build `mda-lv2` and add a test block.