### PR TITLE
mergepbx: deprecate

### DIFF
--- a/Formula/mergepbx.rb
+++ b/Formula/mergepbx.rb
@@ -17,6 +17,10 @@ class Mergepbx < Formula
     sha256 cellar: :any_skip_relocation, all:           "8ecddaec0eaeb4d63ccc9935e66c8f0b5bf7a5a07fbb313909270e47088bf590"
   end
 
+  # Requires Python2.
+  # https://github.com/Homebrew/homebrew-core/issues/93940
+  deprecate! date: "2022-03-09", because: :unsupported
+
   resource "dummy_base" do
     url "https://raw.githubusercontent.com/simonwagner/mergepbx/a9bd9d8f4a732eff989ea03fbc0d78f6f6fb594f/test/fixtures/merge/dummy/dummy1/project.pbxproj.base"
     sha256 "d2cf3fdec1b37489e9bc219c82a7ee945c3dfc4672c8b4e89bc08ae0087d6477"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----

This PR deprecates mergepbx. This addresses one of the tasks in #93940 