### PR TITLE
lilv: use brewed python

### DIFF
--- a/Formula/lilv.rb
+++ b/Formula/lilv.rb
@@ -4,6 +4,7 @@ class Lilv < Formula
   url "https://download.drobilla.net/lilv-0.24.12.tar.bz2"
   sha256 "26a37790890c9c1f838203b47f5b2320334fe92c02a4d26ebbe2669dbd769061"
   license "ISC"
+  revision 1
 
   livecheck do
     url "https://download.drobilla.net/"
@@ -20,14 +21,30 @@ class Lilv < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "python@3.10" => [:build, :test]
   depends_on "lv2"
   depends_on "serd"
   depends_on "sord"
   depends_on "sratom"
 
   def install
-    system "./waf", "configure", "--prefix=#{prefix}"
-    system "./waf"
-    system "./waf", "install"
+    system "python3", "./waf", "configure", "--prefix=#{prefix}"
+    system "python3", "./waf"
+    system "python3", "./waf", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <lilv/lilv.h>
+
+      int main(void) {
+        LilvWorld* const world = lilv_world_new();
+        lilv_world_free(world);
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}/lilv-0", "-L#{lib}", "-llilv-0", "-o", "test"
+    system "./test"
+
+    system Formula["python@3.10"].opt_bin/"python3", "-c", "import lilv"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Revision bump since this change affects the version of the Python bindings that are getting built. We can omit the revision bump if that difference feels negligible enough.

I've kept the Python dependency as build-time (to run Waf/build Python bindings) and test-time (to test the Python bindings). Otherwise, at runtime, it's an optional dependency.