### PR TITLE
javarepl: deprecate as unmaintained

### DIFF
--- a/Formula/javarepl.rb
+++ b/Formula/javarepl.rb
@@ -11,6 +11,10 @@ class Javarepl < Formula
     sha256 cellar: :any_skip_relocation, all: "fb7f0cc6ad4aa7b39635b74969d7eafd2e665085d0b4bb58f63598806b050a8f"
   end
 
+  # The GitHub README.md says: NOT MAINTAINED: Since Java is now
+  # released with REPL this project will no longer be maintained.
+  deprecate! date: "2022-03-08", because: :unmaintained
+
   depends_on "openjdk@8"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This deprecates `javarepl` based on upstream status.

There is also a Linux issue seen in #95575. It is possible to partially fix by adding `java` to `PATH`, but there is some behavior issue when shutting down (https://github.com/albertlatacz/java-repl/issues/117) and test will need to be rewritten.

If someone wants to fix, they can, but for now just adding to `deprecate --> disable --> remove` workflow