### PR TITLE
liquibase: fix JAVA_HOME

### DIFF
--- a/Formula/liquibase.rb
+++ b/Formula/liquibase.rb
@@ -4,6 +4,7 @@ class Liquibase < Formula
   url "https://github.com/liquibase/liquibase/releases/download/v4.8.0/liquibase-4.8.0.tar.gz"
   sha256 "7462b6e92f7077e1858865c403d52f0dce1bd66d03b1fae907815c10825feb33"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "834f5d7086283d639aba0b0df361dc65f84863adcbeef0be4519e440d264ca17"
@@ -16,7 +17,7 @@ class Liquibase < Formula
     chmod 0755, "liquibase"
     prefix.install_metafiles
     libexec.install Dir["*"]
-    (bin/"liquibase").write_env_script libexec/"liquibase", JAVA_HOME: Formula["openjdk"].opt_prefix
+    (bin/"liquibase").write_env_script libexec/"liquibase", Language::Java.overridable_java_home_env
     (libexec/"lib").install_symlink Dir["#{libexec}/sdk/lib-sdk/slf4j*"]
   end
 


### PR DESCRIPTION
Liquibase is created to look for the system JAVA_HOME and this is expected behavior. The formulae has had a hard-coded JAVA_HOME since 4.2.1 creating an non-standard liquibase experience. This PR fixes this by replacing `JAVA_HOME: Formula["openjdk"].opt_prefix` with `Language::Java.overridable_java_home_env`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
