### PR TITLE
getdns: set `CMAKE_INSTALL_RPATH`

### DIFF
--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -34,11 +34,12 @@ class Getdns < Formula
   depends_on "unbound"
 
   def install
-    system "cmake", ".", *std_cmake_args,
-                         "-DBUILD_TESTING=OFF",
-                         "-DPATH_TRUST_ANCHOR_FILE=#{etc}/getdns-root.key"
-    system "make"
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    "-DPATH_TRUST_ANCHOR_FILE=#{etc}/getdns-root.key",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes the missing RPATH audit warning seen in #96616.
