### PR TITLE
qpid-proton: set `CMAKE_INSTALL_RPATH`

### DIFF
--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -20,14 +20,14 @@ class QpidProton < Formula
   depends_on "openssl@1.1"
 
   def install
-    mkdir "build" do
-      system "cmake", "..", "-DBUILD_BINDINGS=",
-                         "-DLIB_INSTALL_DIR=#{lib}",
-                         "-DBUILD_TESTING=OFF",
-                         "-Dproactor=libuv",
-                         *std_cmake_args
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DBUILD_BINDINGS=",
+                    "-DLIB_INSTALL_DIR=#{lib}",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    "-Dproactor=libuv",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do

--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -16,6 +16,8 @@ class QpidProton < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "python@3.10" => :build
   depends_on "libuv"
   depends_on "openssl@1.1"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes an rpath audit warning seen in #96616.
