### PR TITLE
wartremover: use latest openjdk

### DIFF
--- a/Formula/wartremover.rb
+++ b/Formula/wartremover.rb
@@ -4,6 +4,7 @@ class Wartremover < Formula
   url "https://github.com/wartremover/wartremover/archive/v2.4.18.tar.gz"
   sha256 "7bfa3ee9ebfef06e880ac1890831255e3f4ba8a20dfab9940d02ce70841e47bd"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/wartremover/wartremover.git", branch: "master"
 
   bottle do
@@ -11,13 +12,12 @@ class Wartremover < Formula
   end
 
   depends_on "sbt" => :build
-  depends_on "openjdk@8"
+  depends_on "openjdk"
 
   def install
-    system "sbt", "-sbt-jar", Formula["sbt"].opt_libexec/"bin/sbt-launch.jar",
-                    "core/assembly"
+    system "sbt", "-sbt-jar", Formula["sbt"].opt_libexec/"bin/sbt-launch.jar", "core/assembly"
     libexec.install "wartremover-assembly.jar"
-    bin.write_jar_script libexec/"wartremover-assembly.jar", "wartremover", java_version: "1.8"
+    bin.write_jar_script libexec/"wartremover-assembly.jar", "wartremover"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Try updating `openjdk@8` dependency.

Upstream does run CI test for 8, 11, and 17 (since v2.4.17): https://github.com/wartremover/wartremover/blob/master/.github/workflows/ci.yml#L26