### PR TITLE
aria2: update dependecies

### DIFF
--- a/Formula/aria2.rb
+++ b/Formula/aria2.rb
@@ -4,6 +4,7 @@ class Aria2 < Formula
   url "https://github.com/aria2/aria2/releases/download/release-1.36.0/aria2-1.36.0.tar.xz"
   sha256 "58d1e7608c12404f0229a3d9a4953d0d00c18040504498b483305bcb3de907a5"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_monterey: "74859913b0f8dc82fede202f5b6cb3384202e76887549addc050009e4d277aec"
@@ -16,7 +17,9 @@ class Aria2 < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "gettext"
   depends_on "libssh2"
+  depends_on "sqlite"
 
   uses_from_macos "libxml2"
   uses_from_macos "zlib"


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

According to `otool`, current bottle actually uses `sqlite3` from macOS, but it's main purpose in `aria2`, to load cookies from browsers, is broken with stock `sqlite3`.