### PR TITLE
lensfun 0.3.3

### DIFF
--- a/Formula/lensfun.rb
+++ b/Formula/lensfun.rb
@@ -3,15 +3,16 @@ class Lensfun < Formula
 
   desc "Remove defects from digital images"
   homepage "https://lensfun.github.io/"
-  url "https://downloads.sourceforge.net/project/lensfun/0.3.95/lensfun-0.3.95.tar.gz"
-  sha256 "82c29c833c1604c48ca3ab8a35e86b7189b8effac1b1476095c0529afb702808"
+  url "https://github.com/lensfun/lensfun/archive/refs/tags/v0.3.3.tar.gz"
+  sha256 "57ba5a0377f24948972339e18be946af12eda22b7c707eb0ddd26586370f6765"
   license all_of: [
     "LGPL-3.0-only",
     "GPL-3.0-only",
     "CC-BY-3.0",
     :public_domain,
   ]
-  revision 4
+  version_scheme 1
+  head "https://github.com/lensfun/lensfun.git", branch: "master"
 
   bottle do
     sha256 arm64_monterey: "530ebafb7cb54daaa3095f543ba8f05e331fd8a36265fbb2cfbe482e5822a223"
@@ -30,13 +31,9 @@ class Lensfun < Formula
   depends_on "libpng"
   depends_on "python@3.9"
 
-  # This patch can be removed when new Lensfun release (v0.3.96) is available.
-  patch do
-    url "https://github.com/lensfun/lensfun/commit/de954c952929316ea2ad0f6f1e336d9d8164ace0.patch?full_index=1"
-    sha256 "67f0d2f33160bb1ab2b4d1e0465ad5967dbd8f8e3ba1d231b5534ec641014e3b"
-  end
-
   def install
+    # setuptools>=60 prefers its own bundled distutils, which breaks the installation
+    ENV["SETUPTOOLS_USE_DISTUTILS"] = "stdlib"
     system "cmake", ".", *std_cmake_args
     system "make", "install"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Homebrew currently provides an "alpha" (in contrast to stable) version of lensfun: _"2018-06-29 Alpha release 0.3.95: This is an alpha release and snapshot of the current development."_, see https://lensfun.github.io (its original homepage) for details.

The major issue about lensfun 0.3.95 is that it breaks backward compatibility (see https://github.com/lensfun/lensfun/issues/945) to previous stable releases. The effect is that in case you edited your photos with a previous version, those edits will be broken and you can simply start from scratch with all of your work.

Consumers of lensfun like [darktable.org](https://www.darktable.org/) have also reported about this issue, see https://github.com/darktable-org/darktable/issues/2813. Due to that they are still making use of the last stable release of lensfun which is 0.3.2 (dating back to 2015). macports also has an issue about this aspect: https://trac.macports.org/ticket/64024.

Happily lensfun just released a stable successor of 0.3.2 in form of https://github.com/lensfun/lensfun/releases/tag/v0.3.3 (as fresh as 2022) . So this one is build on top of 0.3.2 and incorporates all the new lenses and cameras but not the changes that broke backward compatibility in alpha 0.3.95.

To all what I found out the current lensfun formula is not a dependency to any other package.

I suggest to change the default `lensfun` formula to provide the latest stable release v0.3.3. In addition the current formula was renamed to `lensfun@0.3.95`, in case it is (still) of any use to someone.

I was not able to build from source on my machine, see https://github.com/Homebrew/homebrew-core/issues/96662. It was immediately closed. After briefly talking to @SMillerDev (see  https://github.com/Homebrew/discussions/discussions/3070) I am still sending in a PR to outline and discuss my proposed changes.

Thanks a lot for considering it. Any help and feedback is highly appreciated!