### PR TITLE
xapian omega 1.4.19

### DIFF
--- a/Formula/omega.rb
+++ b/Formula/omega.rb
@@ -1,8 +1,8 @@
 class Omega < Formula
   desc "Packaged search engine for websites, built on top of Xapian"
   homepage "https://xapian.org/"
-  url "https://oligarchy.co.uk/xapian/1.4.18/xapian-omega-1.4.18.tar.xz"
-  sha256 "14bec53234bea5eb36aa4b91940842e62c7968f4fd68c959db396c15069acbaf"
+  url "https://oligarchy.co.uk/xapian/1.4.19/xapian-omega-1.4.19.tar.xz"
+  sha256 "e4b2ef287e55df6754a1cb13b7677231bfda6df22567d28944046f6994d5cd8c"
   license "GPL-2.0-or-later"
 
   livecheck do

--- a/Formula/xapian.rb
+++ b/Formula/xapian.rb
@@ -1,8 +1,8 @@
 class Xapian < Formula
   desc "C++ search engine library"
   homepage "https://xapian.org/"
-  url "https://oligarchy.co.uk/xapian/1.4.18/xapian-core-1.4.18.tar.xz"
-  sha256 "196ddbb4ad10450100f0991a599e4ed944cbad92e4a6fe813be6dce160244b77"
+  url "https://oligarchy.co.uk/xapian/1.4.19/xapian-core-1.4.19.tar.xz"
+  sha256 "1fca48fca6cc3526cc4ba93dd194fe9c1326857b78edcfb37e68d086d714a9c3"
   license "GPL-2.0-or-later"
   version_scheme 1
 
@@ -19,8 +19,8 @@ class Xapian < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "e77c1412ab0f38e3acd480edbbf5a41a082ce3aad4db12ebc5cd287beccd0bc8"
   end
 
+  depends_on "python@3.10" => [:build, :test]
   depends_on "sphinx-doc" => :build
-  depends_on "python@3.9"
 
   uses_from_macos "zlib"
 
@@ -31,14 +31,19 @@ class Xapian < Formula
   skip_clean :la
 
   resource "bindings" do
-    url "https://oligarchy.co.uk/xapian/1.4.18/xapian-bindings-1.4.18.tar.xz"
-    sha256 "fe52064e90d202f7819130ae3ad013c8b2b9cb517ad9fd607cf41d0110c5f18f"
+    url "https://oligarchy.co.uk/xapian/1.4.19/xapian-bindings-1.4.19.tar.xz"
+    sha256 "91c385a48951aa7cdf665effd25533f7477fc22781ca712e50b5496459a2883d"
+  end
+
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
   end
 
   def install
-    python = Formula["python@3.9"].opt_bin/"python3"
+    python = Formula["python@3.10"].opt_bin/"python3"
     ENV["PYTHON"] = python
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
@@ -53,10 +58,6 @@ class Xapian < Formula
       ENV.append_path "PYTHONPATH", Formula["sphinx-doc"].opt_libexec/"lib/python#{xy}/site-packages"
       ENV.append_path "PYTHONPATH", Formula["sphinx-doc"].opt_libexec/"vendor/lib/python#{xy}/site-packages"
 
-      # Fix build on Big Sur (darwin20)
-      # https://github.com/xapian/xapian/pull/319
-      inreplace "configure", "*-darwin[91]*", "*-darwin[912]*"
-
       system "./configure", "--disable-dependency-tracking",
                             "--prefix=#{prefix}",
                             "--with-python3"
@@ -67,6 +68,6 @@ class Xapian < Formula
 
   test do
     system bin/"xapian-config", "--libs"
-    system Formula["python@3.9"].opt_bin/"python3", "-c", "import xapian"
+    system Formula["python@3.10"].opt_bin/"python3", "-c", "import xapian"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As far as I can tell, the only Python dependency in `xapian` is for bindings. Moreover, it requires the `sphinx` Python module from `sphinx-doc` formula. Since `sphinx-doc` formula is now using `python@3.10`:
- Move `xapian` from `python@3.9` to `python@3.10`
- Change dependency to `[:build, :test]` since it's really optional at runtime

Upstream also seems to have addressed https://github.com/xapian/xapian/pull/319, but looks like a flat namespace patch is also needed (the issue in the linked PR affects the _bindings_, but the flat namespace issue was found in the dylib itself - so the removal of the `inreplace` is unrelated to the flat namespace issue).

Bump `omega` too; `xapian` and `omega` should be bumped together it seems (or, at least it seems each `omega` release requires the corresponding `xapian` release to be present/merged).