### PR TITLE
qemu: backport M1 HVF patches to support recent Linux guests

### DIFF
--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -4,6 +4,7 @@ class Qemu < Formula
   url "https://download.qemu.org/qemu-6.2.0.tar.xz"
   sha256 "68e15d8e45ac56326e0b9a4afa8b49a3dfe8aba3488221d098c84698bca65b45"
   license "GPL-2.0-only"
+  revision 1
   head "https://git.qemu.org/git/qemu.git", branch: "master"
 
   bottle do
@@ -46,6 +47,25 @@ class Qemu < Formula
   resource "homebrew-test-image" do
     url "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/official/FD12FLOPPY.zip"
     sha256 "81237c7b42dc0ffc8b32a2f5734e3480a3f9a470c50c14a9c4576a2561a35807"
+  end
+
+  # Backport the following commits from QEMU master (QEMU 7):
+  # - ad99f64f hvf: arm: Use macros for sysreg shift/masking
+  # - 7f6c295c hvf: arm: Handle unknown ID registers as RES0
+  #
+  # These patches are required for running the following guests:
+  # - Linux 5.17
+  # - Ubuntu 21.10, kernel 5.13.0-35.40  (March 2022)
+  # - Ubuntu 20.04, kernel 5.4.0-103.117 (March 2022)
+  #
+  # See https://gitlab.com/qemu-project/qemu/-/issues/899
+  patch do
+    url "https://gitlab.com/qemu-project/qemu/-/commit/ad99f64f1cfff7c5e7af0e697523d9b7e45423b6.diff"
+    sha256 "004e1b7b7c422628b3d6a95827bfca8a19ec36c0d2a0e6ee1f1046d0a2a101ad"
+  end
+  patch do
+    url "https://gitlab.com/qemu-project/qemu/-/commit/7f6c295cdfeaa229c360cac9a36e4e595aa902ae.diff"
+    sha256 "a8d02dcad74da3c3cb18c113a195477dcb76d1128761e48e6827f04d235ed3ce"
   end
 
   def install


### PR DESCRIPTION
**Update** (Mar 14, 2022): The content of this PR was merged into QEMU 6.2.0_1: https://github.com/Homebrew/homebrew-core/commit/0301a2b3a8781d2fa4d3d46bec29644d69cf13db

- - -
Backport the following commits from QEMU master (QEMU 7):
- qemu/qemu@ad99f64f hvf: arm: Use macros for sysreg shift/masking
- qemu/qemu@7f6c295c hvf: arm: Handle unknown ID registers as RES0

These patches are required for running the following guests:
- Linux 5.17 https://github.com/torvalds/linux/commit/9e45365f1469ef2b934f9d035975dbc9ad352116
- Ubuntu 21.10, kernel 5.13.0-35.40  (March 2022) https://kernel.ubuntu.com/git/ubuntu/ubuntu-impish.git/commit/?id=7936f2a576f1d7c3e1a80f8a07a217cdfa2b7338
- Ubuntu 20.04, kernel 5.4.0-103.117 (March 2022) https://kernel.ubuntu.com/git/ubuntu/ubuntu-focal.git/commit/?id=0d9955120cd5b59c6082668fd235cdf77a33a880

See https://gitlab.com/qemu-project/qemu/-/issues/899

Thanks to @fuzmish for testing: https://github.com/lima-vm/lima/issues/712#issuecomment-1065828766

> |`images.location`|default qemu|patched qemu|
> |-|-|-|
> |[impish/20220309](https://cloud-images.ubuntu.com/impish/20220309/)\*1|:x:|:white_check_mark:|
> |[impish/20220204](https://cloud-images.ubuntu.com/impish/20220204/)|:white_check_mark:|:white_check_mark:|
> |[impish/20220201](https://cloud-images.ubuntu.com/impish/20220201/)|:white_check_mark:|:white_check_mark:|
> |[focal/20220308](https://cloud-images.ubuntu.com/focal/20220308/)|:x:|:white_check_mark:|
> |[focal/20220307](https://cloud-images.ubuntu.com/focal/20220307/)|:white_check_mark:|:white_check_mark:|
> |[focal/20220302](https://cloud-images.ubuntu.com/focal/20220302/)|:white_check_mark:|:white_check_mark:|


- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
