### PR TITLE
redpen: use openjdk@11 java rather than java on PATH

### DIFF
--- a/Formula/redpen.rb
+++ b/Formula/redpen.rb
@@ -4,7 +4,7 @@ class Redpen < Formula
   url "https://github.com/redpen-cc/redpen/releases/download/redpen-1.10.4/redpen-1.10.4.tar.gz"
   sha256 "6c3dc4a6a45828f9cc833ca7253fdb036179036631248288251cb9ac4520c39d"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -24,7 +24,9 @@ class Redpen < Formula
     libexec.install %w[conf lib sample-doc js]
 
     prefix.install "bin"
-    bin.env_script_all_files libexec/"bin", JAVA_HOME: Formula["openjdk@11"].opt_prefix
+    env = Language::Java.java_home_env("11")
+    env["PATH"] = "$JAVA_HOME/bin:$PATH"
+    bin.env_script_all_files libexec/"bin", env
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Test failure seen in #95675. I think it happens when `openjdk` is installed at same time and gets picked up by `redpen` (which checks `java` command before `JAVA_HOME`).
```sh
JAVA_CMD=java
JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=$REDPEN_HOME/conf/logback.xml -Dfile.encoding=UTF-8"

which $JAVA_CMD >/dev/null
if [ $? != 0 ]; then
  if [ -z "$JAVA_HOME" ]; then
```
