### PR TITLE
musepack: enable installation on linux

### DIFF
--- a/Formula/musepack.rb
+++ b/Formula/musepack.rb
@@ -33,7 +33,11 @@ class Musepack < Formula
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"
-    lib.install "libmpcdec/libmpcdec.dylib"
+    if OS.mac?
+      lib.install "libmpcdec/libmpcdec.dylib"
+    else
+      lib.install "libmpcdec/libmpcdec.so"
+    end
   end
 
   test do


### PR DESCRIPTION
Signed-off-by: KOSHIKAWA Kenichi <reishoku.misc ~@~ pm.me>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
