### PR TITLE
mp4v2: migrate to active revival project

### DIFF
--- a/Formula/mp4v2.rb
+++ b/Formula/mp4v2.rb
@@ -3,6 +3,7 @@ class Mp4v2 < Formula
   homepage "https://mp4v2.org"
   url "https://github.com/enzo1982/mp4v2/releases/download/v2.0.0/mp4v2-2.0.0.tar.bz2"
   sha256 "0319b9a60b667cf10ee0ec7505eb7bdc0a2e21ca7a93db96ec5bd758e3428338"
+  license "MPL-1.1"
 
   bottle do
     rebuild 1

--- a/Formula/mp4v2.rb
+++ b/Formula/mp4v2.rb
@@ -1,7 +1,7 @@
 class Mp4v2 < Formula
   desc "Read, create, and modify MP4 files"
-  homepage "https://code.google.com/archive/p/mp4v2/"
-  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mp4v2/mp4v2-2.0.0.tar.bz2"
+  homepage "https://mp4v2.org"
+  url "https://github.com/enzo1982/mp4v2/releases/download/v2.0.0/mp4v2-2.0.0.tar.bz2"
   sha256 "0319b9a60b667cf10ee0ec7505eb7bdc0a2e21ca7a93db96ec5bd758e3428338"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In January 2022 @enzo1982 launched an effort to revive mp4v2, with a [comprehensive roadmap](http://mp4v2.org/#roadmap) and [active repository](//github.com/enzo1982/mp4v2). Its current latest release is an exact clone of the archived Google Code 2.0.0 release—SHASUMs match.

Seems to me like the best contender for future `mp4v2` releases and the most active community.