### PR TITLE
libxmlsec1: explicitly declare dependencies being used

### DIFF
--- a/Formula/libxmlsec1.rb
+++ b/Formula/libxmlsec1.rb
@@ -24,6 +24,7 @@ class Libxmlsec1 < Formula
   depends_on "libgcrypt"
   depends_on "libxml2"
   depends_on "openssl@1.1"
+  uses_from_macos "libxslt"
 
   on_macos do
     depends_on xcode: :build
@@ -43,6 +44,10 @@ class Libxmlsec1 < Formula
             "--prefix=#{prefix}",
             "--disable-crypto-dl",
             "--disable-apps-crypto-dl",
+            "--with-nss=no",
+            "--with-nspr=no",
+            "--enable-mscrypto=no",
+            "--enable-mscng=no",
             "--with-openssl=#{Formula["openssl@1.1"].opt_prefix}"]
 
     system "./configure", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Avoids the build error when `nss` is installed. The formula doesn't explicitly depend on it, so avoid auto searches for it.  
Explicitly added `libxslt` library for Linux, which is being used implicitly on macOS.
Also disabled other dependencies not used explicitly for good measure.  
Resolves the following build error:  
```
bignum.c:22:10: fatal error: 'nss.h' file not found
#include <nss.h>
         ^~~~~~~
1 error generated.
1 error generated.
make[2]: *** [libxmlsec1_nss_la-bignum.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [libxmlsec1_nss_la-crypto.lo] Error 1
1 error generated.
1 error generated.
make[2]: *** [libxmlsec1_nss_la-app.lo] Error 1
make[2]: *** [libxmlsec1_nss_la-ciphers.lo] Error 1
make[1]: *** [install-recursive] Error 1
make: *** [install-recursive] Error 1
```