### PR TITLE
criterion 2.4.0 (new formula)

### DIFF
--- a/Formula/criterion.rb
+++ b/Formula/criterion.rb
@@ -1,0 +1,36 @@
+class Criterion < Formula
+  desc "Cross-platform C and C++ unit testing framework for the 21st century"
+  homepage "https://github.com/Snaipe/Criterion"
+  url "https://github.com/Snaipe/Criterion/releases/download/v2.4.0/criterion-2.4.0.tar.xz"
+  sha256 "b13bdb9e007d4d2e87a13446210630e95e3e3d92bb731951bcea4993464b9911"
+  license "MIT"
+  head "https://github.com/Snaipe/Criterion.git", branch: "bleeding"
+
+  depends_on "cmake" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libgit2"
+  depends_on "nanomsg"
+  uses_from_macos "libffi"
+
+  def install
+    system "meson", "setup", *std_meson_args, "--force-fallback-for=boxfort", "build"
+    system "meson", "compile", "-C", "build"
+    system "meson", "install", "--skip-subprojects", "-C", "build"
+  end
+
+  test do
+    (testpath/"test-criterion.c").write <<~EOS
+      #include <criterion/criterion.h>
+
+      Test(suite_name, test_name)
+      {
+        cr_assert(1);
+      }
+    EOS
+
+    system ENV.cc, "test-criterion.c", "-I#{include}", "-L#{lib}", "-lcriterion", "-o", "test-criterion"
+    system "./test-criterion"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
  - [x] `Dependency 'libffi' is provided by macOS; please replace 'depends_on' with 'uses_from_macos'.` <-- I'll have to test this on multiple macOS versions, as I have a feeling that the macOS libffi may not be enough for Criterion.

-----

This PR adds Criterion (a cross-platform C and C++ unit testing framework) to Homebrew.

Also packaged by Debian:
https://packages.debian.org/source/bullseye/criterion