### PR TITLE
fsh: remove livecheck

### DIFF
--- a/Formula/fsh.rb
+++ b/Formula/fsh.rb
@@ -3,12 +3,7 @@ class Fsh < Formula
   homepage "https://www.lysator.liu.se/fsh/"
   url "https://www.lysator.liu.se/fsh/fsh-1.2.tar.gz"
   sha256 "9600882648966272c264cf3f1c41c11c91e704f473af43d8d4e0ac5850298826"
-  license "GPL-2.0"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?fsh[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "b2814ac8d488659be42929df4fcbdcd3c8755d24fe990034c3125d3b9c61c8ef"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `fsh` formula is deprecated as unsupported, so this PR removes the `livecheck` block.

The latest release is from 2001-12-23 and the bug tracker and mailing lists linked from the homepage are gone. I think it's unlikely we'll see a new release (e.g., supporting Python 3) anytime soon, so there's arguably not much value in checking for new versions.

Past that, this updates the license from `GPL-2.0` to `GPL-2.0-or-later`, referencing the source files which contain license comments using the "or...later" language. For example, from `fsh.py`:

```
#  fsh - fast remote execution
#  Copyright (C) 1999-2001 by Per Cederqvist.
#
#  This program is free software; you can redistribute it and/or modify
#  it under the terms of the GNU General Public License as published by
#  the Free Software Foundation; either version 2 of the License, or
#  (at your option) any later version.
#
#  This program is distributed in the hope that it will be useful,
#  but WITHOUT ANY WARRANTY; without even the implied warranty of
#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
#  GNU General Public License for more details.
#
#  You should have received a copy of the GNU General Public License
#  along with this program; if not, write to the Free Software
#  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
```