### PR TITLE
r: build manuals

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -21,7 +21,7 @@ class R < Formula
 
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build
-  depends_on "texlive" => :build
+  depends_on "texlive" => :build if OS.mac?
   depends_on "cairo"
   depends_on "gcc" # for gfortran
   depends_on "gettext"

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -20,6 +20,7 @@ class R < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "texinfo" => :build
   depends_on "cairo"
   depends_on "gcc" # for gfortran
   depends_on "gettext"
@@ -65,6 +66,7 @@ class R < Formula
     if OS.mac?
       args << "--without-x"
       args << "--with-aqua"
+      ENV.prepend_path "PATH", "/Library/TeX/texbin" if File.exist? "/Library/TeX/texbin/tex"
     else
       args << "--libdir=#{lib}" # avoid using lib64 on CentOS
 

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -21,9 +21,6 @@ class R < Formula
 
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build
-  on_macos do
-    depends_on "texlive" => :build
-  end
   depends_on "cairo"
   depends_on "gcc" # for gfortran
   depends_on "gettext"
@@ -38,6 +35,10 @@ class R < Formula
 
   uses_from_macos "curl"
   uses_from_macos "icu4c"
+
+  on_macos do
+    depends_on "texlive" => :build
+  end
 
   on_linux do
     depends_on "pango"

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -21,6 +21,7 @@ class R < Formula
 
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build
+  depends_on "texlive" => :build
   depends_on "cairo"
   depends_on "gcc" # for gfortran
   depends_on "gettext"
@@ -66,7 +67,6 @@ class R < Formula
     if OS.mac?
       args << "--without-x"
       args << "--with-aqua"
-      ENV.prepend_path "PATH", "/Library/TeX/texbin" if File.exist? "/Library/TeX/texbin/tex"
     else
       args << "--libdir=#{lib}" # avoid using lib64 on CentOS
 

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -21,7 +21,9 @@ class R < Formula
 
   depends_on "pkg-config" => :build
   depends_on "texinfo" => :build
-  depends_on "texlive" => :build if OS.mac?
+  on_macos do
+    depends_on "texlive" => :build
+  end
   depends_on "cairo"
   depends_on "gcc" # for gfortran
   depends_on "gettext"


### PR DESCRIPTION
The current r formula does not build the manuals, so the links in the *Manuals* section of the RStudio help pane don't work.  This change makes the formula build the manuals for macos.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
