### PR TITLE
podman: new 4.0.2 release

### DIFF
--- a/Formula/podman.rb
+++ b/Formula/podman.rb
@@ -4,9 +4,15 @@ class Podman < Formula
   license "Apache-2.0"
 
   stable do
-    url "https://github.com/containers/podman/archive/v3.4.4.tar.gz"
-    sha256 "718c9e1e734c2d374fcf3c59e4cc7c1755acb954fc7565093e1d636c04b72e3a"
-
+    url "https://github.com/containers/podman/archive/v4.0.2.tar.gz"
+    sha256 "cac4328b0a5e618f4f6567944e255d15fad3e1f7901df55603f1efdd7aaeda95"
+    # This patch is needed to allow proper booting of the machine as well
+    # as volume mounting with 9p on darwin. It is already merged upstream
+    # and can be removed at Podman 4.1.
+    patch do
+      url "https://github.com/containers/podman/commit/cdb6deb148f72cad9794dec176e4df1b81d31d08.patch?full_index=1"
+      sha256 "10d1383f4179fd4af947f554677c301dc64c53c13d2f0f59aa7b4d370de49fcf"
+    end
     resource "gvproxy" do
       url "https://github.com/containers/gvisor-tap-vsock/archive/v0.3.0.tar.gz"
       sha256 "6ca454ae73fce3574fa2b615e6c923ee526064d0dc2bcf8dab3cca57e9678035"
@@ -56,12 +62,7 @@ class Podman < Formula
       libexec.install "bin/gvproxy"
     end
 
-    if build.head?
-      system "make", "podman-remote-#{os}-docs"
-    else
-      system "make", "install-podman-remote-#{os}-docs"
-    end
-
+    system "make", "podman-remote-#{os}-docs"
     man1.install Dir["docs/build/remote/#{os}/*.1"]
 
     bash_completion.install "completions/bash/podman"


### PR DESCRIPTION
Update to 4.0.2 release for podman.

Replaces #95318

Signed-off-by: Brent Baude <bbaude@redhat.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
