### PR TITLE
libetpan: fix Linux build, add pkgconfig file, patch CVE-2020-15953

### DIFF
--- a/Formula/libetpan.rb
+++ b/Formula/libetpan.rb
@@ -4,6 +4,7 @@ class Libetpan < Formula
   url "https://github.com/dinhviethoa/libetpan/archive/1.9.4.tar.gz"
   sha256 "82ec8ea11d239c9967dbd1717cac09c8330a558e025b3e4dc6a7594e80d13bb1"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/dinhviethoa/libetpan.git", branch: "master"
 
   bottle do
@@ -16,27 +17,105 @@ class Libetpan < Formula
     sha256 cellar: :any, high_sierra:    "6a2f29f42a39d9d3eee7bca1974118fdd8d44a745f61af686aa40c449157b733"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
   depends_on xcode: :build
 
+  uses_from_macos "curl"
+  uses_from_macos "cyrus-sasl"
+  uses_from_macos "expat"
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "openssl@1.1"
+  end
+
+  # Fix extra args in pkg-config file.
+  # Remove with the next release.
+  patch do
+    url "https://github.com/dinhvh/libetpan/commit/8e904aa1c92bd0993123dd46d5a10a58f0516721.patch?full_index=1"
+    sha256 "d99cb79037e147bb376effb6ae5cb1eb46201b0dda6397eba49a1beffc22d9b0"
+  end
+
+  # Fix CVE-2020-15953.
+  # Remove with the next release.
+  patch do
+    url "https://github.com/dinhvh/libetpan/commit/1002a0121a8f5a9aee25357769807f2c519fa50b.patch?full_index=1"
+    sha256 "824408a4d4b59b8e395260908b230232d4f764645b014fbe6e9660ad1137251e"
+  end
+  patch do
+    url "https://github.com/dinhvh/libetpan/commit/298460a2adaabd2f28f417a0f106cb3b68d27df9.patch?full_index=1"
+    sha256 "f5e62879eb90d83d06c4b0caada365a7ea53d4426199a650a7cc303cc0f66751"
+  end
+
   def install
-    xcodebuild "-arch", Hardware::CPU.arch,
-               "-project", "build-mac/libetpan.xcodeproj",
-               "-scheme", "static libetpan",
-               "-configuration", "Release",
-               "SYMROOT=build/libetpan",
-               "build"
+    ENV["NOCONFIGURE"] = "1"
+    configure_args = std_configure_args + %w[
+      --without-gnutls
+      --disable-db
+    ]
 
-    xcodebuild "-arch", Hardware::CPU.arch,
-               "-project", "build-mac/libetpan.xcodeproj",
-               "-scheme", "libetpan",
-               "-configuration", "Release",
-               "SYMROOT=build/libetpan",
-               "build"
+    # libetpan has a macOS-specific build script to create a framework.
+    # For backwards compatibility reasons, let's continue to do that.
+    if OS.mac?
+      configure_args << "--without-openssl"
+      inreplace "build-mac/update.sh", %r{\./configure (.*) >}, "./configure #{configure_args.join(" ")} >"
 
-    lib.install "build-mac/build/libetpan/Release/libetpan.a"
-    frameworks.install "build-mac/build/libetpan/Release/libetpan.framework"
-    include.install buildpath.glob("build-mac/build/libetpan/Release/include/**")
-    bin.install "libetpan-config"
+      cd "build-mac" do
+        # Update the anciently generated autoconf result files.
+        system "./update.sh", "prepare"
+      end
+
+      # Extract ABI version.
+      api_current = api_revision = api_compatibility = nil
+      parse_version = lambda do |line, vers_name|
+        line[/^m4_define\(\[#{Regexp.escape(vers_name)}\], \[(\d+)\]\)$/, 1]&.to_i
+      end
+      File.foreach("configure.ac") do |line|
+        api_current ||= parse_version.call(line, "api_current")
+        api_revision ||= parse_version.call(line, "api_revision")
+        api_compatibility ||= parse_version.call(line, "api_compatibility")
+        break if api_current && api_revision && api_compatibility
+      end
+
+      current_version = "#{api_compatibility}.#{api_current - api_compatibility}.#{api_revision}"
+
+      xcodebuild "-arch", Hardware::CPU.arch,
+                 "-project", "build-mac/libetpan.xcodeproj",
+                 "-scheme", "static libetpan",
+                 "-configuration", "Release",
+                 "SYMROOT=build/libetpan",
+                 "FRAMEWORK_VERSION=#{api_compatibility}",
+                 "DYLIB_COMPATIBILITY_VERSION=#{api_compatibility}",
+                 "DYLIB_CURRENT_VERSION=#{current_version}",
+                 "build"
+
+      xcodebuild "-arch", Hardware::CPU.arch,
+                 "-project", "build-mac/libetpan.xcodeproj",
+                 "-scheme", "libetpan",
+                 "-configuration", "Release",
+                 "SYMROOT=build/libetpan",
+                 "FRAMEWORK_VERSION=#{api_compatibility}",
+                 "DYLIB_COMPATIBILITY_VERSION=#{api_compatibility}",
+                 "DYLIB_CURRENT_VERSION=#{current_version}",
+                 "build"
+
+      lib.install "build-mac/build/libetpan/Release/libetpan.a"
+      frameworks.install "build-mac/build/libetpan/Release/libetpan.framework"
+      prefix.install "build-mac/build/libetpan/Release/include"
+      cp include/"libetpan/libetpan.h", include # Compatibility header
+      lib.install_symlink frameworks/"libetpan.framework/Versions/A/libetpan" => "libetpan.dylib"
+      (lib/"pkgconfig").install "libetpan.pc"
+
+      # Backwards ABI compatibility - remove this when api_compatibility is bumped past 20.
+      (frameworks/"libetpan.framework/Versions").install_symlink "20" => "A"
+    else
+      system "./autogen.sh"
+      system "./configure", *configure_args
+      system "make", "install"
+    end
   end
 
   test do
@@ -47,10 +126,17 @@ class Libetpan < Formula
 
       int main(int argc, char ** argv)
       {
-        printf("version is %d.%d",libetpan_get_version_major(), libetpan_get_version_minor());
+        printf("version is %d.%d", libetpan_get_version_major(), libetpan_get_version_minor());
       }
     EOS
-    system ENV.cc, "test.c", "-L#{lib}", "-letpan", "-o", "test"
-    system "./test"
+    expected_output = "version is #{version.major_minor}"
+
+    system ENV.cc, "test.c", "-L#{lib}", "-letpan", "-o", "test-lib"
+    assert_equal expected_output, shell_output("./test-lib")
+
+    return unless OS.mac?
+
+    system ENV.cc, "test.c", "-F#{frameworks}", "-framework", "libetpan", "-o", "test-framework"
+    assert_equal expected_output, shell_output("./test-framework")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also fixes the static library being used by default on macOS.