### PR TITLE
libgit2: actually enable ssh support

### DIFF
--- a/Formula/libgit2.rb
+++ b/Formula/libgit2.rb
@@ -4,6 +4,7 @@ class Libgit2 < Formula
   url "https://github.com/libgit2/libgit2/archive/v1.4.2.tar.gz"
   sha256 "901c2b4492976b86477569502a41c31b274b69adc177149c02099ea88404ef19"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/libgit2/libgit2.git", branch: "main"
 
   livecheck do
@@ -28,6 +29,7 @@ class Libgit2 < Formula
     args = std_cmake_args
     args << "-DBUILD_EXAMPLES=YES"
     args << "-DBUILD_CLAR=NO" # Don't build tests.
+    args << "-DUSE_SSH=YES"
 
     mkdir "build" do
       system "cmake", "..", *args
@@ -45,9 +47,11 @@ class Libgit2 < Formula
   test do
     (testpath/"test.c").write <<~EOS
       #include <git2.h>
+      #include <assert.h>
 
       int main(int argc, char *argv[]) {
         int options = git_libgit2_features();
+        assert(options & GIT_FEATURE_SSH);
         return 0;
       }
     EOS


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We have `depends_on "libssh2"` but currently SSH support is not working because ustream libgit2 1.4.0 silently switched the default to `USE_SSH=OFF` (not sure if this was intentional, it wasn't mentioned in the changelog).