### PR TITLE
spdlog: remove tweakme.h tweak

### DIFF
--- a/Formula/spdlog.rb
+++ b/Formula/spdlog.rb
@@ -22,7 +22,11 @@ class Spdlog < Formula
   def install
     ENV.cxx11
 
-    inreplace "include/spdlog/tweakme.h", "// #define SPDLOG_FMT_EXTERNAL", "#define SPDLOG_FMT_EXTERNAL"
+    inreplace "include/spdlog/tweakme.h", "// #define SPDLOG_FMT_EXTERNAL", <<~EOS
+      #ifndef SPDLOG_FMT_EXTERNAL
+      #define SPDLOG_FMT_EXTERNAL
+      #endif
+    EOS
 
     mkdir "spdlog-build" do
       args = std_cmake_args + %W[


### PR DESCRIPTION
When configuring spdlog with `-DSPDLOG_FMT_EXTERNAL=ON`, the generated spdlog.pc file contains `-DSPDLOG_FMT_EXTERNAL` in its CFlags. This means that when tweakme.h also contains `#define SPDLOG_FMT_EXTERNAL`, it triggers a macro redefinition warning. This commit removes the tweakme.h tweak and keeps the cmake flag.

I asked upstream whether it's most correct to configure with `-DSPDLOG_FMT_EXTERNAL=ON` or to change tweakme.h (https://github.com/gabime/spdlog/issues/2310). They haven't responded yet, but I looked at packages from other systems (Arch and Debian in particular) and they both leave tweakme.h unchanged. It also feels more correct to set the configure-time option. If upstream responds that changing tweakme.h is more correct though, this PR should be revisited.

This fixes https://github.com/Homebrew/homebrew-core/issues/96856.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
