### PR TITLE
go@1.17 1.17.8 (new formula)

### DIFF
--- a/Aliases/go@1.17
+++ b/Aliases/go@1.17
@@ -1,1 +1,0 @@
-../Formula/go.rb

--- a/Formula/go@1.17.rb
+++ b/Formula/go@1.17.rb
@@ -1,0 +1,58 @@
+class GoAT117 < Formula
+  desc "Go programming environment (1.17)"
+  homepage "https://golang.org"
+  url "https://go.dev/dl/go1.17.8.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.17.8.src.tar.gz"
+  sha256 "2effcd898140da79a061f3784ca4f8d8b13d811fb2abe9dad2404442dabbdf7a"
+  license "BSD-3-Clause"
+
+  livecheck do
+    url "https://golang.org/dl/"
+    regex(/href=.*?go[._-]?v?(1\.17(?:\.\d+)*)[._-]src\.t/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOROOT_BOOTSTRAP"] = Formula["go"].opt_libexec
+
+    cd "src" do
+      ENV["GOROOT_FINAL"] = libexec
+      system "./make.bash", "--no-clean"
+    end
+
+    (buildpath/"pkg/obj").rmtree
+    libexec.install Dir["*"]
+    bin.install_symlink Dir[libexec/"bin/go*"]
+
+    system bin/"go", "install", "-race", "std"
+
+    # Remove useless files.
+    # Breaks patchelf because folder contains weird debug/test files
+    (libexec/"src/debug/elf/testdata").rmtree
+    # Binaries built for an incompatible architecture
+    (libexec/"src/runtime/pprof/testdata").rmtree
+  end
+
+  test do
+    (testpath/"hello.go").write <<~EOS
+      package main
+
+      import "fmt"
+
+      func main() {
+        fmt.Println("Hello World")
+      }
+    EOS
+    # Run go fmt check for no errors then run the program.
+    # This is a a bare minimum of go working as it uses fmt, build, and run.
+    system bin/"go", "fmt", "hello.go"
+    assert_equal "Hello World\n", shell_output("#{bin}/go run hello.go")
+
+    ENV["GOOS"] = "freebsd"
+    ENV["GOARCH"] = Hardware::CPU.intel? ? "amd64" : Hardware::CPU.arch.to_s
+    system bin/"go", "build", "hello.go"
+  end
+end


### PR DESCRIPTION
For #91369, instead of adding the versioned formula afterwards, I actually propose an alternative this time round: introduce it first. There _are_ dependents which are not compatible with Go 1.18 yet and I feel we can get that merged quicker by allowing them to depend on 1.17 until they are updated. Notably, some dependents I've found are already deprecated upstream and will never be updated so this will be required anyway unless we want to do custom patches.

The preferred approach will however continue to be to apply upstream patches where available: this is just for where upstream activity has stalled or where a 1.18 support patch cannot be applied cleanly to the version used in the formula.