### PR TITLE
libqalculate and qalculate-gtk 4.1.0

### DIFF
--- a/Formula/libqalculate.rb
+++ b/Formula/libqalculate.rb
@@ -1,8 +1,8 @@
 class Libqalculate < Formula
   desc "Library for Qalculate! program"
   homepage "https://qalculate.github.io/"
-  url "https://github.com/Qalculate/libqalculate/releases/download/v4.0.0/libqalculate-4.0.0.tar.gz"
-  sha256 "1bddd1aa5fc5c0915308400845acf376dcb685bcbd8da90360b3d75b87d4c666"
+  url "https://github.com/Qalculate/libqalculate/releases/download/v4.1.0/libqalculate-4.1.0.tar.gz"
+  sha256 "d943e5285bdc0b3cd77b8f7a10391d7c753fc19b0ddd48e5d4179decf709d6ff"
   license "GPL-2.0-or-later"
 
   bottle do

--- a/Formula/qalculate-gtk.rb
+++ b/Formula/qalculate-gtk.rb
@@ -1,8 +1,8 @@
 class QalculateGtk < Formula
   desc "Multi-purpose desktop calculator"
   homepage "https://qalculate.github.io/"
-  url "https://github.com/Qalculate/qalculate-gtk/releases/download/v4.0.0/qalculate-gtk-4.0.0.tar.gz"
-  sha256 "51f705737fe6defb6b57058ddd357ca1dd11af57655a90f9e41a40e8dbb9d81c"
+  url "https://github.com/Qalculate/qalculate-gtk/releases/download/v4.1.0/qalculate-gtk-4.1.0.tar.gz"
+  sha256 "8bab126f4f87e9321572f10e9262bf095c7e72470d4b61e2a173d273673bdeca"
   license "GPL-2.0-or-later"
 
   bottle do


### PR DESCRIPTION
Update libqalculate and qalculate-gtk to 4.1.0 in a single PR so that it can pass all tests.
