### PR TITLE
antibody: use go@1.17 and deprecate

### DIFF
--- a/Formula/antibody.rb
+++ b/Formula/antibody.rb
@@ -16,7 +16,9 @@ class Antibody < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "87285c55995d80af9cd4d1bd71a5879290bb67b2f08a7a492b4d94ddabb58455"
   end
 
-  depends_on "go" => :build
+  deprecate! date: "2022-03-16", because: :repo_archived
+
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", "-ldflags", "-s -w -X main.version=#{version}", "-trimpath", "-o", bin/"antibody"


### PR DESCRIPTION
No longer supported upstream.
