### PR TITLE
cacli: use go@1.17 and deprecate

### DIFF
--- a/Formula/cacli.rb
+++ b/Formula/cacli.rb
@@ -21,7 +21,9 @@ class Cacli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9bf9422e0ae9c895130c789b2261af291f1cb4126c72a299bb2c850ecc6266fc"
   end
 
-  depends_on "go" => :build
+  deprecate! date: "2022-03-16", because: :unsupported
+
+  depends_on "go@1.17" => :build
 
   def install
     cd "cacli" do


### PR DESCRIPTION
All mentions of cacli have been wiped from existence upstream.
