### PR TITLE
cf-tool: use go@1.17 and deprecate

### DIFF
--- a/Formula/cf-tool.rb
+++ b/Formula/cf-tool.rb
@@ -14,7 +14,9 @@ class CfTool < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "81f6a2ad160f2f30cb4f0de13b0055581ebb55601297925c337da6efb3cd4205"
   end
 
-  depends_on "go" => :build
+  deprecate! date: "2022-03-16", because: :unmaintained
+
+  depends_on "go@1.17" => :build
   # https://github.com/shirou/gopsutil/issues/1000
   depends_on arch: :x86_64
 


### PR DESCRIPTION
No upstream activity in a while.
