### PR TITLE
cli53: patch for go 1.18

### DIFF
--- a/Formula/cli53.rb
+++ b/Formula/cli53.rb
@@ -4,6 +4,7 @@ class Cli53 < Formula
   url "https://github.com/barnybug/cli53/archive/0.8.18.tar.gz"
   sha256 "aa9ee59a52fc45f426680da48f45a79f2ac8365c15d8d7beed83a8ed71a891e4"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "e1285195c10242659d35858428692fd398a97c3031096f4cfeb4f7c94f5a1519"
@@ -16,6 +17,13 @@ class Cli53 < Formula
   end
 
   depends_on "go" => :build
+
+  # Update AWS SDK. Fixes build on Go 1.18.
+  # https://github.com/barnybug/cli53/pull/318
+  patch do
+    url "https://github.com/barnybug/cli53/commit/c60679c9171a4f8f04d09224ac4aacc316eed849.patch?full_index=1"
+    sha256 "19842038d57cc78d738754772d4535cc59a77f9da3d00982dec533a565fa193d"
+  end
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/cli53"


### PR DESCRIPTION
Updates the AWS SDK and by extension the x/sys dependency
