### PR TITLE
activemq: run service as foreground process

### DIFF
--- a/Formula/activemq.rb
+++ b/Formula/activemq.rb
@@ -36,7 +36,7 @@ class Activemq < Formula
   end
 
   service do
-    run [opt_bin/"activemq", "start"]
+    run [opt_bin/"activemq", "console"]
     working_dir opt_libexec
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes #96511

```console
% brew services run activemq
==> Successfully ran `activemq` (label: homebrew.mxcl.activemq)

% brew services info activemq
activemq (homebrew.mxcl.activemq)
Running: ✔
Loaded: ✔
Schedulable: ✘
User:
PID: 44026

% brew services stop activemq
Stopping `activemq`... (might take a while)

% brew services info activemq
activemq (homebrew.mxcl.activemq)
Running: ✘
Loaded: ✘
Schedulable: ✘

% brew services list
Name     Status User File
activemq none

% ps aux | grep activemq
cho-m            45047   0.0  0.0 33725040    832 s005  R+   10:08PM   0:00.00 grep activemq
```