### PR TITLE
fargatecli: use go@1.17 and deprecate

### DIFF
--- a/Formula/fargatecli.rb
+++ b/Formula/fargatecli.rb
@@ -16,7 +16,9 @@ class Fargatecli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6878839aa708ebabc144e18b0b77f0d1e7754eeaad8634741338fa2c921c6de0"
   end
 
-  depends_on "go" => :build
+  deprecate! date: "2022-03-16", because: :unsupported
+
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args


### PR DESCRIPTION
README updated upstream to denote that it is no longer maintained.
