### PR TITLE
go 1.18

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -1,9 +1,9 @@
 class Go < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.17.8.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.17.8.src.tar.gz"
-  sha256 "2effcd898140da79a061f3784ca4f8d8b13d811fb2abe9dad2404442dabbdf7a"
+  url "https://go.dev/dl/go1.18.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.18.src.tar.gz"
+  sha256 "38f423db4cc834883f2b52344282fa7a39fbb93650dc62a11fdf0be6409bdad6"
   license "BSD-3-Clause"
   head "https://go.googlesource.com/go.git", branch: "master"
 
@@ -25,25 +25,25 @@ class Go < Formula
   resource "gobootstrap" do
     on_macos do
       if Hardware::CPU.arm?
-        url "https://storage.googleapis.com/golang/go1.16.darwin-arm64.tar.gz"
-        version "1.16"
-        sha256 "4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810"
+        url "https://storage.googleapis.com/golang/go1.18.darwin-arm64.tar.gz"
+        version "1.18"
+        sha256 "9cab6123af9ffade905525d79fc9ee76651e716c85f1f215872b5f2976782480"
       else
-        url "https://storage.googleapis.com/golang/go1.16.darwin-amd64.tar.gz"
-        version "1.16"
-        sha256 "6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8"
+        url "https://storage.googleapis.com/golang/go1.18.darwin-amd64.tar.gz"
+        version "1.18"
+        sha256 "70bb4a066997535e346c8bfa3e0dfe250d61100b17ccc5676274642447834969"
       end
     end
 
     on_linux do
       if Hardware::CPU.arm?
-        url "https://storage.googleapis.com/golang/go1.16.linux-arm64.tar.gz"
-        version "1.16"
-        sha256 "3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098"
+        url "https://storage.googleapis.com/golang/go1.18.linux-arm64.tar.gz"
+        version "1.18"
+        sha256 "7ac7b396a691e588c5fb57687759e6c4db84a2a3bbebb0765f4b38e5b1c5b00e"
       else
-        url "https://storage.googleapis.com/golang/go1.16.linux-amd64.tar.gz"
-        version "1.16"
-        sha256 "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"
+        url "https://storage.googleapis.com/golang/go1.18.linux-amd64.tar.gz"
+        version "1.18"
+        sha256 "e85278e98f57cdb150fe8409e6e5df5343ecb13cebf03a5d5ff12bd55a80264f"
       end
     end
   end


### PR DESCRIPTION
Update go to newest version.

New Version 1.18 can be bootstraped by 1.18


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
