### PR TITLE
cassandra-reaper: depend on openjdk@11

### DIFF
--- a/Formula/cassandra-reaper.rb
+++ b/Formula/cassandra-reaper.rb
@@ -4,6 +4,7 @@ class CassandraReaper < Formula
   url "https://github.com/thelastpickle/cassandra-reaper/releases/download/3.1.1/cassandra-reaper-3.1.1-release.tar.gz"
   sha256 "8d71f6e74306f4ef33cc1af6822d7a3702f347355589d66cd899ce546df12d1e"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, monterey:     "ff2caf27f8ba961fff6b24980c4fb9b8d7d19b28bc7b13a71a60999e0e1ee3db"
@@ -12,26 +13,30 @@ class CassandraReaper < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "5ef86195c0f8f1b9ef8620e9d4abdf3cfaee2b5b6a68503252bb78d8f0375b6c"
   end
 
-  depends_on "openjdk@8"
+  depends_on "openjdk@11"
 
   def install
-    inreplace "bin/cassandra-reaper", "/usr/share", prefix
+    inreplace Dir["resource/*.yaml"], " /var/log", " #{var}/log"
+    inreplace "bin/cassandra-reaper", "/usr/local/share", share
+    inreplace "bin/cassandra-reaper", "/usr/local/etc", etc
+
+    libexec.install "bin/cassandra-reaper"
     prefix.install "bin"
     etc.install "resource" => "cassandra-reaper"
     share.install "server/target" => "cassandra-reaper"
-    inreplace Dir[etc/"cassandra-reaper/*.yaml"], " /var/log", " #{var}/log"
+
+    (bin/"cassandra-reaper").write_env_script libexec/"cassandra-reaper",
+      Language::Java.overridable_java_home_env("11")
   end
 
   service do
     run opt_bin/"cassandra-reaper"
-    environment_variables JAVA_HOME: Formula["openjdk@8"].opt_prefix
     keep_alive true
     error_log_path var/"log/cassandra-reaper/service.err"
     log_path var/"log/cassandra-reaper/service.log"
   end
 
   test do
-    ENV["JAVA_HOME"] = Formula["openjdk@8"].opt_prefix
     cp etc/"cassandra-reaper/cassandra-reaper.yaml", testpath
     port = free_port
     inreplace "cassandra-reaper.yaml" do |s|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Testing this out. Commit https://github.com/thelastpickle/cassandra-reaper/commit/e9cfc202ddcca549165ebbf6aa5841241ade5d0b says JDK11 is supported as of v3.1.0.
