### PR TITLE
counterfeier: use go@1.17

### DIFF
--- a/Formula/counterfeiter.rb
+++ b/Formula/counterfeiter.rb
@@ -16,14 +16,17 @@ class Counterfeiter < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e5e46a570a5d8914659a1184f373db09e096c9f3e4954daaff5bcb1328286266"
   end
 
-  depends_on "go"
+  depends_on "go@1.17"
 
   def install
+    ENV["GOROOT"] = Formula["go@1.17"].opt_libexec
+
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do
-    ENV["GOROOT"] = Formula["go"].opt_libexec
+    ENV["GOROOT"] = Formula["go@1.17"].opt_libexec
+    ENV["PATH"] = "#{ENV["PATH"]}:#{ENV["GOROOT"]}/bin"
 
     output = shell_output("#{bin}/counterfeiter -p os 2>&1")
     assert_predicate testpath/"osshim", :exist?


### PR DESCRIPTION
Update formula to use specific go version

See: #91369


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
