### PR TITLE
eksctl: use go@1.17

### DIFF
--- a/Formula/eksctl.rb
+++ b/Formula/eksctl.rb
@@ -17,13 +17,13 @@ class Eksctl < Formula
   end
 
   depends_on "counterfeiter" => :build
-  depends_on "go" => :build
   depends_on "go-bindata" => :build
+  depends_on "go@1.17" => :build
   depends_on "mockery" => :build
   depends_on "aws-iam-authenticator"
 
   def install
-    ENV["GOBIN"] = HOMEBREW_PREFIX/"bin"
+    ENV["GOBIN"] = Formula["go@1.17"].opt_libexec/"bin"
     system "make", "build"
     bin.install "eksctl"
 


### PR DESCRIPTION
Update formula to use specific go version

See: https://github.com/Homebrew/homebrew-core/pull/91369

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
