### PR TITLE
mongodb-atlas-cli 1.0.2 (new formula)

### DIFF
--- a/Formula/mongodb-atlas-cli.rb
+++ b/Formula/mongodb-atlas-cli.rb
@@ -1,0 +1,29 @@
+class MongodbAtlasCli < Formula
+  desc "Atlas CLI enables you to manage your MongoDB Atlas"
+  homepage "https://www.mongodb.com/docs/atlas/cli/stable/"
+  url "https://github.com/mongodb/mongodb-atlas-cli/archive/refs/tags/atlascli/v1.0.2.tar.gz"
+  sha256 "11b324e1024793fb0b82b98e67838e4060e137bdc176180ed94fc623a275ac24"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    with_env(
+      ATLAS_VERSION: version.to_s,
+      MCLI_GIT_SHA:  "homebrew-release",
+    ) do
+      system "make", "build-atlascli"
+    end
+    bin.install "bin/atlas"
+
+    (bash_completion/"atlas").write Utils.safe_popen_read(bin/"atlas", "completion", "bash")
+    (fish_completion/"atlas.fish").write Utils.safe_popen_read(bin/"atlas", "completion", "fish")
+    (zsh_completion/"_atlas").write Utils.safe_popen_read(bin/"atlas", "completion", "zsh")
+  end
+
+  test do
+    assert_match "atlascli version: #{version}", shell_output("#{bin}/atlas --version")
+    assert_match "Error: this action requires authentication", shell_output("#{bin}/atlas projects ls 2>&1", 1)
+    assert_match "PROFILE NAME", shell_output("#{bin}/atlas config ls")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
```
 brew install --build-from-source mongodb-atlas-cli --verbose
==> Downloading https://github.com/mongodb/mongodb-atlas-cli/archive/refs/tags/atlascli/v1.0.2.tar.gz
Already downloaded: /Users/andrea.angiolillo/Library/Caches/Homebrew/downloads/73c976d83ea0f572027c6f6903b75514378329a60ee332369b3208bb7d81fa14--mongodb-atlas-cli-atlascli-v1.0.2.tar.gz
==> Verifying checksum for '73c976d83ea0f572027c6f6903b75514378329a60ee332369b3208bb7d81fa14--mongodb-atlas-cli-atlascli-v1.0.2.tar.gz'
tar --extract --no-same-owner --file /Users/andrea.angiolillo/Library/Caches/Homebrew/downloads/73c976d83ea0f572027c6f6903b75514378329a60ee332369b3208bb7d81fa14--mongodb-atlas-cli-atlascli-v1.0.2.tar.gz --directory /private/tmp/d20220331-63381-15e9xfh
cp -pR /private/tmp/d20220331-63381-15e9xfh/mongodb-atlas-cli-atlascli-v1.0.2/. /private/tmp/mongodb-atlas-cli-20220331-63381-gwq3du/mongodb-atlas-cli-atlascli-v1.0.2
chmod -Rf +w /private/tmp/d20220331-63381-15e9xfh
==> make build-atlascli
==> Building atlas binary
go build -ldflags "-s -w -X github.com/mongodb/mongocli/internal/version.GitCommit=homebrew-release -X github.com/mongodb/mongocli/internal/config.ToolName=atlascli -X github.com/mongodb/mongocli/internal/version.Version=1.0.2" -o ./bin/atlas ./cmd/atlas
==> Cleaning
==> Finishing up
ln -s ../../Cellar/mongodb-atlas-cli/1.0.2/etc/bash_completion.d/atlas atlas
ln -s ../Cellar/mongodb-atlas-cli/1.0.2/bin/atlas atlas
ln -s ../../../Cellar/mongodb-atlas-cli/1.0.2/share/fish/vendor_completions.d/atlas.fish atlas.fish
ln -s ../../../Cellar/mongodb-atlas-cli/1.0.2/share/zsh/site-functions/_atlas _atlas
==> Caveats
zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/mongodb-atlas-cli/1.0.2: 8 files, 14.4MB, built in 11 seconds
==> Running `brew cleanup mongodb-atlas-cli`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```


```
brew test mongodb-atlas-cli
==> Testing mongodb-atlas-cli
==> /usr/local/Cellar/mongodb-atlas-cli/1.0.2/bin/atlas --version
==> /usr/local/Cellar/mongodb-atlas-cli/1.0.2/bin/atlas projects ls 2>&1
==> /usr/local/Cellar/mongodb-atlas-cli/1.0.2/bin/atlas config ls
```

This PR adds a new formula for [MongoDB Atlas CLI v1.0.2](https://www.mongodb.com/docs/atlas/cli/stable/)