### PR TITLE
aws-es-proxy: use go@1.17

### DIFF
--- a/Formula/aws-es-proxy.rb
+++ b/Formula/aws-es-proxy.rb
@@ -15,7 +15,8 @@ class AwsEsProxy < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "927e9fcca53a19b16b22d363737b24111ecfd333dc9f969086b0e312c3d30a74"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
