### PR TITLE
jvm-mon: fix build for Linux

### DIFF
--- a/Formula/jvm-mon.rb
+++ b/Formula/jvm-mon.rb
@@ -4,7 +4,7 @@ class JvmMon < Formula
   url "https://github.com/ajermakovics/jvm-mon/releases/download/0.3/jvm-mon-0.3.tar.gz"
   sha256 "9b5dd3d280cb52b6e2a9a491451da2ee41c65c770002adadb61b02aa6690c940"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -22,12 +22,11 @@ class JvmMon < Formula
     rm_f Dir["bin/*.bat"]
     libexec.install Dir["*"]
 
-    (bin/"jvm-mon").write_env_script "#{libexec}/bin/jvm-mon",
-      Language::Java.java_home_env("1.8")
-    system "unzip", "-j", libexec/"lib/j2v8_macosx_x86_64-4.6.0.jar", "libj2v8_macosx_x86_64.dylib", "-d", libexec
+    (bin/"jvm-mon").write_env_script libexec/"bin/jvm-mon", Language::Java.java_home_env("1.8")
   end
 
   test do
+    ENV.append "_JAVA_OPTIONS", "-Duser.home=#{testpath}"
     system "echo q | #{bin}/jvm-mon"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Issue of `all` bottle that is macOS-specific seen in #96852

```
Full test jvm-mon output
  ==> Testing jvm-mon
  ==> echo q | /home/linuxbrew/.linuxbrew/Cellar/jvm-mon/0.3_2/bin/jvm-mon
  Picked up _JAVA_OPTIONS: -Duser.home=/github/home/.cache/Homebrew/java_cache -Djava.io.tmpdir=/tmp
  Exception in thread "main" java.lang.ExceptionInInitializerError
  Caused by: java.lang.IllegalStateException: J2V8 native library not loaded
  	at com.eclipsesource.v8.V8.checkNativeLibraryLoaded(V8.java:195)
  	at com.eclipsesource.v8.V8.createV8Runtime(V8.java:149)
  	at com.eclipsesource.v8.V8.createV8Runtime(V8.java:125)
  	at com.eclipsesource.v8.NodeJS.createNodeJS(NodeJS.java:58)
  	at com.eclipsesource.v8.NodeJS.createNodeJS(NodeJS.java:45)
  	at JvmMon.<clinit>(JvmMon.java:18)
  Caused by: java.lang.UnsatisfiedLinkError: Could not load J2V8 library. Reasons: 
  	no j2v8_linux_x86_64 in java.library.path
  
  	at com.eclipsesource.v8.LibraryLoader.loadLibrary(LibraryLoader.java:75)
  	at com.eclipsesource.v8.V8.load(V8.java:71)
  	at com.eclipsesource.v8.V8.createV8Runtime(V8.java:145)
  	... 4 more
```