### PR TITLE
awsweeper: use go@1.17

### DIFF
--- a/Formula/awsweeper.rb
+++ b/Formula/awsweeper.rb
@@ -15,7 +15,8 @@ class Awsweeper < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "81776b638e309f839a362f70ba7d0621c2ca9e80f6472f334c5472049cbc3374"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     ldflags = %W[


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
