### PR TITLE
cayley: use go@1.17

### DIFF
--- a/Formula/cayley.rb
+++ b/Formula/cayley.rb
@@ -19,7 +19,8 @@ class Cayley < Formula
   end
 
   depends_on "breezy" => :build
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
   depends_on "mercurial" => :build
 
   def install


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
