### PR TITLE
chamber: use go@1.17

### DIFF
--- a/Formula/chamber.rb
+++ b/Formula/chamber.rb
@@ -21,7 +21,8 @@ class Chamber < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5923595f91a382a8011156d13957538e329300d654098eeed7353b4622126976"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", "-ldflags", "-s -w -X main.Version=v#{version}", "-trimpath", "-o", bin/"chamber"


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
