### PR TITLE
charm: use go@1.17

### DIFF
--- a/Formula/charm.rb
+++ b/Formula/charm.rb
@@ -15,7 +15,8 @@ class Charm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "623e2d62e1dc1210de466ff4e4ea1d8e0c8ea059dbdc491ff5b8f3ec1cc9603e"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args, "./cmd/charm"


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
