### PR TITLE
dcos-cli: use go@1.17

### DIFF
--- a/Formula/dcos-cli.rb
+++ b/Formula/dcos-cli.rb
@@ -22,7 +22,8 @@ class DcosCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2ca96957a95df6e3084eeddf3d45cd52a26bdd69446647af7e52f297c6b1f1ce"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     ENV["NO_DOCKER"] = "1"


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
