### PR TITLE
fabio: use go@1.17

### DIFF
--- a/Formula/fabio.rb
+++ b/Formula/fabio.rb
@@ -17,7 +17,8 @@ class Fabio < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1acc04acdcfaba5e627a62d9257c4ddad3d3dca9169720b9b6e976a38bc3a165"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
   depends_on "consul"
 
   def install


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
