### PR TITLE
ircd-hybrid, expect: conflicts with due to mkpasswd

### DIFF
--- a/Formula/expect.rb
+++ b/Formula/expect.rb
@@ -28,6 +28,8 @@ class Expect < Formula
   depends_on "libtool" => :build
   depends_on "tcl-tk"
 
+  conflicts_with "ircd-hybrid", because: "both install an `mkpasswd` binary"
+
   def install
     args = %W[
       --prefix=#{prefix}

--- a/Formula/ircd-hybrid.rb
+++ b/Formula/ircd-hybrid.rb
@@ -22,6 +22,7 @@ class IrcdHybrid < Formula
 
   depends_on "openssl@1.1"
 
+  conflicts_with "expect", because: "both install an `mkpasswd` binary"
   conflicts_with "ircd-irc2", because: "both install an `ircd` binary"
 
   # ircd-hybrid needs the .la files


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in #96920
```
==> Pouring ircd-hybrid--8.2.39.x86_64_linux.bottle.tar.gz
  Error: The `brew link` step did not complete successfully
  The formula built, but is not symlinked into /home/linuxbrew/.linuxbrew
  Could not symlink bin/mkpasswd
  Target /home/linuxbrew/.linuxbrew/bin/mkpasswd
  is a symlink belonging to expect. You can unlink it:
    brew unlink expect
  
  To force the link and overwrite all conflicting files:
    brew link --overwrite ircd-hybrid
  
  To list all files that would be deleted:
    brew link --overwrite --dry-run ircd-hybrid
```

Alternatively, could do Debian approach and delete `mkpasswd` from `ircd-hybrid`

See: https://salsa.debian.org/dom/ircd-hybrid/-/blob/master/debian/rules#L138

---

Can be seen on macOS too:
```
==> Pouring expect--5.45.4_1.monterey.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/mkpasswd
Target /usr/local/bin/mkpasswd
is a symlink belonging to ircd-hybrid. You can unlink it:
  brew unlink ircd-hybrid

To force the link and overwrite all conflicting files:
  brew link --overwrite expect

To list all files that would be deleted:
  brew link --overwrite --dry-run expect

Possible conflicting files are:
/usr/local/bin/mkpasswd -> /usr/local/Cellar/ircd-hybrid/8.2.39/bin/mkpasswd
```