### PR TITLE
dpkg: patch upstream config code

### DIFF
--- a/Formula/dpkg.rb
+++ b/Formula/dpkg.rb
@@ -7,6 +7,7 @@ class Dpkg < Formula
   url "https://deb.debian.org/debian/pool/main/d/dpkg/dpkg_1.21.2.tar.xz"
   sha256 "b8fc67fca696c6bea2f40f737c80574d53384db25202f72effc7e4de4662e1ac"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url "https://deb.debian.org/debian/pool/main/d/dpkg/"
@@ -35,6 +36,14 @@ class Dpkg < Formula
 
   on_linux do
     keg_only "not linked to prevent conflicts with system dpkg"
+  end
+
+  # enables fully-qualified tool paths needed for config below
+  # review for deletion when new version is released
+  # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1007816
+  patch do
+    url "https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=1007816;filename=dpkg.diff;msg=5"
+    sha256 "66b0cb11813df2b6135345afe40a4570058048bab880229e76d3d22a48d8f818"
   end
 
   patch :DATA


### PR DESCRIPTION
Original code tests for tools by blindly concatenating configured TAR, PATCH, etc. onto each PATH component, so the fully-qualified paths used in the Homebrew formula can never match anything.

Fixes https://github.com/Homebrew/discussions/discussions/3087. I haven't been able to find a `dpkg` invocation that triggers the bug without also requiring root, so I haven't added a test to catch any regressions.

Before:
```
$ sudo dpkg -i ~/tmp/zoom_amd64.deb
Password:
dpkg: warning: '/usr/local/opt/gnu-tar/bin/gtar' not found in PATH or not executable
dpkg: error: 1 expected program not found in PATH or not executable
Note: root's PATH should usually contain /usr/local/sbin, /usr/sbin and /sbin
```

After:
```
$ sudo dpkg -i ~/tmp/zoom_amd64.deb
Password:
dpkg: error processing archive /Users/aho/tmp/zoom_amd64.deb (--install):
 package architecture (amd64) does not match system (darwin-amd64)
Errors were encountered while processing:
 /Users/aho/tmp/zoom_amd64.deb
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
