### PR TITLE
pulp: add livecheck, update homepage and license

### DIFF
--- a/Formula/pulp.rb
+++ b/Formula/pulp.rb
@@ -2,10 +2,15 @@ require "language/node"
 
 class Pulp < Formula
   desc "Build tool for PureScript projects"
-  homepage "https://github.com/bodil/pulp"
+  homepage "https://github.com/purescript-contrib/pulp"
   url "https://registry.npmjs.org/pulp/-/pulp-16.0.0-0.tgz"
   sha256 "77b8a5ff21291257766f54289dbe92d2558fc64e9a034513647a76400c0e7d94"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
+
+  livecheck do
+    url :stable
+    regex(%r{href=.*?/package/pulp/v/(\d+(?:[.-]\d+)+)["']}i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "c2b46cd6552c65509f86882217f616c80344e5e53a2f22866c958da790694762"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck identifies `pulp` versions from npm using the `Npm` strategy. This has been working fine up to this point but the current version now includes a hyphenated suffix (16.0.0-0) which the default strategy regex doesn't match. As a result, livecheck is incorrectly reporting 15.0.0 as the latest version.

This PR addresses the issue by adding a `livecheck` block using a modified version of the default `Npm` strategy regex for `pulp` that also allows for hyphen delimiters in the version.