### PR TITLE
ip_relay: update urls, add license

### DIFF
--- a/Formula/ip_relay.rb
+++ b/Formula/ip_relay.rb
@@ -1,8 +1,9 @@
 class IpRelay < Formula
   desc "TCP traffic shaping relay application"
-  homepage "http://www.stewart.com.au/ip_relay/"
-  url "http://www.stewart.com.au/ip_relay/ip_relay-0.71.tgz"
+  homepage "https://stewart.com.au/ip_relay/"
+  url "https://stewart.com.au/ip_relay/ip_relay-0.71.tgz"
   sha256 "0cf6c7db64344b84061c64e848e8b4f547b5576ad28f8f5e67163fc0382d9ed3"
+  license "GPL-2.0-only"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `homepage` and `stable` URLs for `ip_relay` are redirecting from http://www.stewart.com.au to https://stewart.com.au. This PR updates the URLs to avoid the redirections.

This also adds `license "GPL-2.0-only"`, as the `COPYING` file is GPLv2 but `ip_relay.pl` doesn't contain a license comment and the `README` is vague about the license:

```
ip_relay has been released under the GPL, however the code remains
copyrighted by me, Gavin Stewart.
```

Since there's no use of the "or...later" language, I went with `GPL-2.0-only` by default.