### PR TITLE
goproxy: fix test for go 1.18

### DIFF
--- a/Formula/goproxy.rb
+++ b/Formula/goproxy.rb
@@ -23,15 +23,16 @@ class Goproxy < Formula
   end
 
   test do
+    ENV["GOPATH"] = testpath.to_s
     bind_address = "127.0.0.1:#{free_port}"
     begin
       server = IO.popen("#{bin}/goproxy -proxy=https://goproxy.io -listen=#{bind_address}", err: [:child, :out])
       sleep 1
       ENV["GOPROXY"] = "http://#{bind_address}"
-      system "go", "get", "golang.org/x/net@latest"
+      system "go", "install", "golang.org/x/tools/cmd/guru@latest"
     ensure
       Process.kill("SIGINT", server.pid)
     end
-    assert_match "200 /golang.org/x/net/", server.read
+    assert_match "200 /golang.org/x/tools/", server.read
   end
 end


### PR DESCRIPTION
`go get` outside of modules is deprecated.
