### PR TITLE
gateway-go: use go@1.17

### DIFF
--- a/Formula/gateway-go.rb
+++ b/Formula/gateway-go.rb
@@ -17,7 +17,8 @@ class GatewayGo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "81394624d4f5bf2a35f565dfa9342f49badf78495b124d0a6ad14103f581050c"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     ldflags = %W[


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
