### PR TITLE
gitbatch: use go@1.17

### DIFF
--- a/Formula/gitbatch.rb
+++ b/Formula/gitbatch.rb
@@ -15,7 +15,8 @@ class Gitbatch < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6d447c8dc2e642b6a281df3956224ece3f45cd0f074391b8dfa9f916cf5e7dcb"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/gitbatch"


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
