### PR TITLE
gomplate: use go@1.17

### DIFF
--- a/Formula/gomplate.rb
+++ b/Formula/gomplate.rb
@@ -16,7 +16,8 @@ class Gomplate < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f026fafcaeba0eb20e509c298edcd80c0158f0ab0a45a68184f754f8aa2e2754"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "make", "build", "VERSION=#{version}"


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
