### PR TITLE
gost: use go@1.17

### DIFF
--- a/Formula/gost.rb
+++ b/Formula/gost.rb
@@ -17,7 +17,8 @@ class Gost < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "32d9a2df2bee7fb06e9da9ba7d7e24cd13463b5c868fee95564d4783351b6f3f"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args, "./cmd/gost"


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
