### PR TITLE
gotify: use go@1.17

### DIFF
--- a/Formula/gotify.rb
+++ b/Formula/gotify.rb
@@ -15,7 +15,8 @@ class Gotify < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "899b0f7b64c293f6053be2d747661a5baff2d9783b505dbf5b4d118ead2fb29c"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-X main.Version=#{version}


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
