### PR TITLE
grpcui: use go@1.17

### DIFF
--- a/Formula/grpcui.rb
+++ b/Formula/grpcui.rb
@@ -14,7 +14,8 @@ class Grpcui < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "766d62495f451b0d028066dc7bed889947c6715b0793992a51b2eaef69f44235"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}"), "./cmd/grpcui"


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
