### PR TITLE
hub: use go@1.17

### DIFF
--- a/Formula/hub.rb
+++ b/Formula/hub.rb
@@ -17,7 +17,8 @@ class Hub < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "213636e856404251ffd7897357ab91cc9519d3852e4b28cbb43575988d9bbc1b"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   uses_from_macos "groff" => :build
   uses_from_macos "ruby" => :build


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
