### PR TITLE
ipfs: use go@1.17

### DIFF
--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -24,7 +24,8 @@ class Ipfs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "25043e8f6570aa51aaac1a5205cfcfe82bd6d7f8db828c9dc2caca06c55529f5"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "make", "build"


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
