### PR TITLE
k3sup: use go@1.17

### DIFF
--- a/Formula/k3sup.rb
+++ b/Formula/k3sup.rb
@@ -21,7 +21,8 @@ class K3sup < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1e7d21a5c3b460560123484eb0d9fb10150f64b75410a7d455ff64282de3fd1f"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     ldflags = %W[


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
