### PR TITLE
killswitch: use go@1.17

### DIFF
--- a/Formula/killswitch.rb
+++ b/Formula/killswitch.rb
@@ -15,7 +15,8 @@ class Killswitch < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:    "82a98dbef512e928dfcee02d0c7c50889856ce88740645ec1af0fcac7edfab12"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", "-mod=readonly", "-ldflags", "-s -w -X main.version=#{version}",


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
