### PR TITLE
kubernetes-service-catalog-client: use go@1.17

### DIFF
--- a/Formula/kubernetes-service-catalog-client.rb
+++ b/Formula/kubernetes-service-catalog-client.rb
@@ -16,7 +16,8 @@ class KubernetesServiceCatalogClient < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c41818d0040c8d3943167a585393487deef56e651c0308ef50cde5cf0692e3ae"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     ENV["NO_DOCKER"] = "1"


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
