### PR TITLE
kubespy: use go@1.17

### DIFF
--- a/Formula/kubespy.rb
+++ b/Formula/kubespy.rb
@@ -16,7 +16,8 @@ class Kubespy < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "aa4dd3522e26e234773a2cdd5ba837ccadcbe4babb7f5889faf8c11dda1bb10d"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-X github.com/pulumi/kubespy/version.Version=#{version}")


### PR DESCRIPTION
Has an outdated x/sys dependency. I will open an issue tracking upstreaming 1.18 support soon.
