### PR TITLE
doxygen: build docs/man pages

### DIFF
--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -24,6 +24,9 @@ class Doxygen < Formula
 
   depends_on "bison" => :build
   depends_on "cmake" => :build
+  depends_on "ghostscript" => :build
+  depends_on "graphviz" => :build
+  depends_on "texlive" => :build
 
   uses_from_macos "flex" => :build
 
@@ -37,11 +40,11 @@ class Doxygen < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-Dbuild_doc=1", "..", *std_cmake_args
       system "make"
+      system "make", "docs"
+      system "make", "install"
     end
-    bin.install Dir["build/bin/*"]
-    man1.install Dir["doc/*.1"]
   end
 
   test do


### PR DESCRIPTION
Unbuilt man pages include un-replaced `@VERSION@` variable (and `@YEAR@` from next release), so build them and install the built man pages instead.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
