### PR TITLE
openshift-cli: use go@1.17

### DIFF
--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -32,7 +32,8 @@ class OpenshiftCli < Formula
   end
 
   depends_on "coreutils" => :build
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release.
+  depends_on "go@1.17" => :build
   depends_on "heimdal" => :build
   depends_on "socat"
 


### PR DESCRIPTION
Should support 1.18 in the next release.
