### PR TITLE
lazydocker: use go@1.17

### DIFF
--- a/Formula/lazydocker.rb
+++ b/Formula/lazydocker.rb
@@ -15,7 +15,8 @@ class Lazydocker < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "fb946c3fa3d69068bd29ffa13eb6bbda0d987bf398bb60d34bf9c1dfb01a2007"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", "-mod=vendor", "-o", bin/"lazydocker",


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
