### PR TITLE
lean-cli: use go@1.17

### DIFF
--- a/Formula/lean-cli.rb
+++ b/Formula/lean-cli.rb
@@ -15,7 +15,8 @@ class LeanCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "099834ac3c6bc5ac2d6157e0bf6a9d1b219daf6316cc672810deeedc26621301"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     build_from = build.head? ? "homebrew-head" : "homebrew"


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
