### PR TITLE
lefthook: use go@1.17

### DIFF
--- a/Formula/lefthook.rb
+++ b/Formula/lefthook.rb
@@ -16,7 +16,8 @@ class Lefthook < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f5d01af7de4480e289f5d132d0103610aa4c787e3bdf17ed892d2b860362dd4b"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
