### PR TITLE
noti: use go@1.17

### DIFF
--- a/Formula/noti.rb
+++ b/Formula/noti.rb
@@ -16,7 +16,8 @@ class Noti < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8b5e7f6ed05b1d96d96059281319cbb3fd5cfb95b7b81c58aa7cfc115698cffb"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", "-mod=vendor", "-o", "#{bin}/noti", "cmd/noti/main.go"


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
