### PR TITLE
server-go: use go@1.17

### DIFF
--- a/Formula/server-go.rb
+++ b/Formula/server-go.rb
@@ -21,7 +21,8 @@ class ServerGo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3c575de6caf4916eedf3791c3efb703153f171d9b12c3ba9e9bac579b86d2fe6"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     (etc/"server-go").mkpath


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
