### PR TITLE
ship: use go@1.17

### DIFF
--- a/Formula/ship.rb
+++ b/Formula/ship.rb
@@ -15,7 +15,8 @@ class Ship < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "c3974dea38bf106223fc9bccb8c3e2eaff6f8d951a95ddad849a63edc6040578"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
   # Switch to `node` when ship updates dependency node-sass>=6.0.0
   depends_on "node@14" => :build
   depends_on "yarn" => :build


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
