### PR TITLE
slackcat: use go@1.17

### DIFF
--- a/Formula/slackcat.rb
+++ b/Formula/slackcat.rb
@@ -15,7 +15,8 @@ class Slackcat < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "96518aa5c2d2ddc1c62a1ee163748bc0909be294eebc290156a6ca1908d6216a"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}")


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
