### PR TITLE
tfproviderlint: fix test for go 1.18

### DIFF
--- a/Formula/tfproviderlint.rb
+++ b/Formula/tfproviderlint.rb
@@ -40,9 +40,6 @@ class Tfproviderlint < Formula
   end
 
   test do
-    assert_match "tfproviderlint: ./... matched no packages",
-      shell_output(bin/"tfproviderlint -fix ./... 2>&1", 1)
-
     testpath.install resource("test_resource")
     assert_match "S006: schema of TypeMap should include Elem",
       shell_output(bin/"tfproviderlint -fix #{testpath}/... 2>&1", 3)


### PR DESCRIPTION
The error message has changed, and is not particularly important to test for - we test actual working operation below.
