### PR TITLE
tfschema: use go@1.17

### DIFF
--- a/Formula/tfschema.rb
+++ b/Formula/tfschema.rb
@@ -15,7 +15,8 @@ class Tfschema < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "650cf107f261ae4343d968e6f6569618a21b448b359c223a3ee5e8a8febb6654"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
   depends_on "terraform" => :test
 
   def install


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
