### PR TITLE
threemux: use go@1.17

### DIFF
--- a/Formula/threemux.rb
+++ b/Formula/threemux.rb
@@ -16,7 +16,8 @@ class Threemux < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "33200f3fd9175837129386fdfa67575eebacc806d9da099d98b0888aaff56124"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args, "-o", bin/"3mux"


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
