### PR TITLE
tty-share: use go@1.17

### DIFF
--- a/Formula/tty-share.rb
+++ b/Formula/tty-share.rb
@@ -14,7 +14,8 @@ class TtyShare < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2fb65f718d04bf4102ae9453766f769f4770612c367b99d55b6b610dfaf075fc"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     ldflags = "-s -w -X main.version=#{version}"


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
