### PR TITLE
tunnel: use go@1.17

### DIFF
--- a/Formula/tunnel.rb
+++ b/Formula/tunnel.rb
@@ -15,7 +15,8 @@ class Tunnel < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9a079e012dffd514c536355269716695a150db0dc30cd3ea2c27aee789615805"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", "-o", bin/"tunnel", "./cmd/tunnel"


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
