### PR TITLE
ucloud: use go@1.17

### DIFF
--- a/Formula/ucloud.rb
+++ b/Formula/ucloud.rb
@@ -14,7 +14,8 @@ class Ucloud < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e5326dd1f207ab2ac02a00c06d8231ec5895735a595d543fe3a670a2c93854e3"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     dir = buildpath/"src/github.com/ucloud/ucloud-cli"


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
