### PR TITLE
ultralist: use go@1.17

### DIFF
--- a/Formula/ultralist.rb
+++ b/Formula/ultralist.rb
@@ -16,7 +16,8 @@ class Ultralist < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c1d287b06c14adcd326d8dd626209fcfa7a287919dce6f755f80a6513b2ed6e7"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", *std_go_args


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
