### PR TITLE
vaulted: use go@1.17

### DIFF
--- a/Formula/vaulted.rb
+++ b/Formula/vaulted.rb
@@ -17,7 +17,8 @@ class Vaulted < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3acf911a97ce6aa9aacff3d0e39c70d497e2b2b808a5ebe620301259035988c3"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", "-o", bin/"vaulted", "."


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
