### PR TITLE
wellington: use go@1.17

### DIFF
--- a/Formula/wellington.rb
+++ b/Formula/wellington.rb
@@ -17,7 +17,8 @@ class Wellington < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1efe7a942728970650560a933ba9344e79cf5a63e96c18553cef995ab77445ef"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
 
   def install
     system "go", "build", "-ldflags",


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
