### PR TITLE
vitess: fix VCS build error with go 1.18

### DIFF
--- a/Formula/vitess.rb
+++ b/Formula/vitess.rb
@@ -18,7 +18,13 @@ class Vitess < Formula
   depends_on "etcd"
 
   def install
-    system "make", "install-local", "PREFIX=#{prefix}", "VTROOT=#{buildpath}"
+    # TODO: remove this after 1.18 update
+    buildvcs = if Formula["go"].version >= "1.18"
+      "-buildvcs=false"
+    else
+      ""
+    end
+    system "make", "install-local", "PREFIX=#{prefix}", "VTROOT=#{buildpath}", "VT_EXTRA_BUILD_FLAGS=#{buildvcs}"
     pkgshare.install "examples"
   end
 


### PR DESCRIPTION
This is a bit of a temporary hack, but it's easier to do it this way rather than coupling new bottles for this with the go 1.18 PR.