### PR TITLE
Ibazel 0.16.2 (new formula)

### DIFF
--- a/Formula/ibazel.rb
+++ b/Formula/ibazel.rb
@@ -1,0 +1,63 @@
+class Ibazel < Formula
+  desc "Tools for building Bazel targets when source files change"
+  homepage "https://github.com/bazelbuild/bazel-watcher"
+  url "https://github.com/bazelbuild/bazel-watcher/archive/refs/tags/v0.16.2.tar.gz"
+  sha256 "a927520e7ab3a1fb749043e543c57bb211666cd627d053fbe0e8245730beee75"
+  license "Apache-2.0"
+
+  depends_on "bazel" => [:build, :test]
+  depends_on xcode: :build
+
+  def install
+    system "bazel", "build", "--config=release", "--workspace_status_command", "echo STABLE_GIT_VERSION #{version}", "//ibazel"
+    bin.install "bazel-bin/ibazel/ibazel_/ibazel"
+  end
+
+  test do
+    # Test building a sample Go program
+    (testpath/"WORKSPACE").write <<~EOS
+      load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+      http_archive(
+        name = "io_bazel_rules_go",
+        sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+        ],
+      )
+
+      load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+      go_rules_dependencies()
+
+      go_register_toolchains(version = "1.18")
+    EOS
+
+    (testpath/"test.go").write <<~EOS
+      package main
+      import "fmt"
+      func main() {
+        fmt.Println("Hi!")
+      }
+    EOS
+
+    (testpath/"BUILD").write <<~EOS
+      load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+      go_binary(
+        name = "bazel-test",
+        srcs = glob(["*.go"])
+      )
+    EOS
+
+    pid = fork { exec("ibazel", "build", "//:bazel-test") }
+    out_file = "bazel-bin/bazel-test_/bazel-test"
+    sleep 1 until File.exist?(out_file)
+    assert_equal "Hi!\n", pipe_output(out_file)
+  ensure
+    Process.kill("TERM", pid)
+    sleep 1
+    Process.kill("TERM", pid)
+  end
+end


### PR DESCRIPTION
Ibazel is a tool for automatically running Bazel when source code changes. This formula allows building from source and adds support for Apple Silicon.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
