### PR TITLE
go: add go@1.18 alias

### DIFF
--- a/Aliases/go@1.18
+++ b/Aliases/go@1.18
@@ -1,0 +1,1 @@
+../Formula/go.rb


### PR DESCRIPTION
I forgot about this. Looks like the audit is broken and doesn't detect this - I'll fix that.