### PR TITLE
mockery: revision bump for go 1.18

### DIFF
--- a/Formula/mockery.rb
+++ b/Formula/mockery.rb
@@ -4,6 +4,7 @@ class Mockery < Formula
   url "https://github.com/vektra/mockery/archive/v2.10.0.tar.gz"
   sha256 "a3dcfa1f0599858bbc3ac1cdb17a09702ce0236fd329ddad80f975b8ee11efd1"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/vektra/mockery.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
Needs a recompile to work against Go 1.18 at runtime.
