### PR TITLE
virgil: use go@1.17

### DIFF
--- a/Formula/virgil.rb
+++ b/Formula/virgil.rb
@@ -16,7 +16,8 @@ class Virgil < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "05da77ebed1e01c11281b7f148441a6aa22f9be8d219037913c238d95c615425"
   end
 
-  depends_on "go" => :build
+  # Bump to 1.18 on the next release, if possible.
+  depends_on "go@1.17" => :build
   # https://github.com/VirgilSecurity/virgil-cli/issues/58
   depends_on arch: :x86_64
 


### PR DESCRIPTION
I will open an issue tracking upstreaming 1.18 support soon.
