### PR TITLE
ettercap: set `CMAKE_INSTALL_RPATH`

### DIFF
--- a/Formula/ettercap.rb
+++ b/Formula/ettercap.rb
@@ -27,6 +27,7 @@ class Ettercap < Formula
   depends_on "pcre"
 
   uses_from_macos "curl"
+  uses_from_macos "flex"
   uses_from_macos "libpcap"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
@@ -41,6 +42,7 @@ class Ettercap < Formula
 
     args = std_cmake_args + %W[
       -DBUNDLED_LIBS=OFF
+      -DCMAKE_INSTALL_RPATH=#{rpath}
       -DENABLE_CURSES=ON
       -DENABLE_GTK=ON
       -DENABLE_IPV6=ON


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Fixes audit warning `Files with missing rpath` from #97325

Not sure if `flex` is needed at runtime