### PR TITLE
Tests: set the default timeout to 90 minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,7 +129,7 @@ jobs:
               core.setOutput('timeout-minutes', '4320')
             } else {
               console.log('No CI-long-timeout label found. Setting short GitHub Actions timeout.')
-              core.setOutput('timeout-minutes', '60')
+              core.setOutput('timeout-minutes', '90')
 
               if (label_names.includes('long build')) {
                 core.setFailed('PR requires the CI-long-timeout label but it is not set!')


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
I feel like this small change will save a lot of maintainer work.