### PR TITLE
youtube-dlc: deprecate

### DIFF
--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -22,6 +22,8 @@ class YoutubeDlc < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1f1a851f379d37a98f7753ed90d6935b5075e02e19d62ae6f3584fdd9e377fa2"
   end
 
+  deprecate! date: "2022-03-21", because: :unmaintained
+
   depends_on "pandoc" => :build
   depends_on "python@3.10"
   uses_from_macos "zip" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Last meaningful commit to youtube-dlc dates back to Dec 2, 2020 (the rest ones are just meta changes and never released). At this stage the youtube-dl community has essentially shifted contributions to [yt-dlp](https://github.com/yt-dlp/yt-dlp), which has merged youtube-dlc's latest commits as well.