### PR TITLE
cadical: install ccadical.h and ipasir.h.

### DIFF
--- a/Formula/cadical.rb
+++ b/Formula/cadical.rb
@@ -4,6 +4,7 @@ class Cadical < Formula
   url "https://github.com/arminbiere/cadical/archive/refs/tags/rel-1.5.2.tar.gz"
   sha256 "4a4251bf0191677ca8cda275cb7bf5e0cf074ae0056819642d5a7e5c1a952e6e"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable
@@ -26,6 +27,8 @@ class Cadical < Formula
       bin.install "cadical"
       lib.install "libcadical.a"
       include.install "../src/cadical.hpp"
+      include.install "../src/ccadical.h"
+      include.install "../src/ipasir.h"
     end
   end
 


### PR DESCRIPTION
Functions declared in ccadical.h and ipasir.h may be need to build
other applications.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
