### PR TITLE
kmod 29 (new formula)

### DIFF
--- a/Formula/kmod.rb
+++ b/Formula/kmod.rb
@@ -1,0 +1,28 @@
+class Kmod < Formula
+  desc "Linux kernel module handling"
+  homepage "https://git.kernel.org/?p=utils/kernel/kmod/kmod.git"
+  url "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-29.tar.xz"
+  sha256 "0b80eea7aa184ac6fd20cafa2a1fdf290ffecc70869a797079e2cc5c6225a52a"
+  license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
+
+  depends_on :linux
+
+  def install
+    system "./configure", "--with-bashcompletiondir=#{bash_completion}",
+      *std_configure_args, "--disable-silent-rules"
+    system "make"
+    system "make", "install"
+
+    bin.install_symlink "kmod" => "depmod"
+    bin.install_symlink "kmod" => "lsmod"
+    bin.install_symlink "kmod" => "modinfo"
+    bin.install_symlink "kmod" => "insmod"
+    bin.install_symlink "kmod" => "modprobe"
+    bin.install_symlink "kmod" => "rmmod"
+  end
+
+  test do
+    system "#{bin}/kmod", "help"
+    assert_match "Module", shell_output("#{bin}/kmod list")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


This is a linux-only tool that allows working with kernel modules, therefore tests are difficult to implement (like listing modules) as they rely on the system below.