### PR TITLE
git-flow-avh: fix fish completion

### DIFF
--- a/Formula/git-flow-avh.rb
+++ b/Formula/git-flow-avh.rb
@@ -48,7 +48,7 @@ class GitFlowAvh < Formula
     resource("completion").stage do
       bash_completion.install "git-flow-completion.bash"
       zsh_completion.install "git-flow-completion.zsh"
-      fish_completion.install "git.fish"
+      fish_completion.install "git.fish" => "git-flow.fish"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The previous completion would override the default `git` completion, resulting in error messages like:

```
Error: git completion not found
```

which came from: https://github.com/petervanderdoes/git-flow-completion/blob/db3c032411c2d6fd897b2bfc52d15a6fc4e3bfa3/git.fish#L41

By renaming the included completions to `git-flow.fish`, we ensure that they are scoped to the correct formula.