### PR TITLE
sdf: deprecate

### DIFF
--- a/Formula/sdf.rb
+++ b/Formula/sdf.rb
@@ -13,6 +13,8 @@ class Sdf < Formula
     sha256 cellar: :any, high_sierra:   "e4229bab3c8cfda42089e5371aef014a0fea214be9b7c8a99537077268fec106"
   end
 
+  deprecate! date: "2022-03-23", because: :unmaintained
+
   depends_on "pkg-config" => :build
   depends_on "aterm"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Dependency `aterm` was deprecated in #88732

Homebrew started using 2.6.3 version back in 2014 (https://github.com/Homebrew/homebrew-core/commit/7ea0ea88477fdbf504cb2366498c1c527f501d86) though it may be even older. Bug tracker and other links are dead.