### PR TITLE
mesa: depend on gzip for linux

### DIFF
--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -37,6 +37,7 @@ class Mesa < Formula
   on_linux do
     depends_on "elfutils"
     depends_on "gcc"
+    depends_on "gzip"
     depends_on "libdrm"
     depends_on "libva"
     depends_on "libvdpau"


### PR DESCRIPTION
Avoids error:

```
  /usr/bin/gzip: invalid option -- 'k'
  Try `gzip --help' for more information.
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
