### PR TITLE
okteto: add completion scripts

### DIFF
--- a/Formula/okteto.rb
+++ b/Formula/okteto.rb
@@ -21,6 +21,13 @@ class Okteto < Formula
     ldflags = "-s -w -X github.com/okteto/okteto/pkg/config.VersionString=#{version}"
     tags = "osusergo netgo static_build"
     system "go", "build", *std_go_args(ldflags: ldflags), "-tags", tags
+
+    bash_output = Utils.safe_popen_read(bin/"okteto", "completion", "bash")
+    (bash_completion/"okteto").write bash_output
+    zsh_output = Utils.safe_popen_read(bin/"okteto", "completion", "zsh")
+    (zsh_completion/"_okteto").write zsh_output
+    fish_output = Utils.safe_popen_read(bin/"okteto", "completion", "fish")
+    (fish_completion/"okteto.fish").write fish_output
   end
 
   test do


### PR DESCRIPTION
This PR adds support for generating shell autocompletion scripts
when installing/upgrading. Since okteto uses spf13/cobra,
this is already supported in current binaries.

https://github.com/spf13/cobra/blob/master/shell_completions.md

Signed-off-by: Javier Provecho Fernández (Okteto) <92427625+jpf-okteto@users.noreply.github.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
