### PR TITLE
cython, numpy: build for mixed Python versions

### DIFF
--- a/Formula/breezy.rb
+++ b/Formula/breezy.rb
@@ -17,8 +17,8 @@ class Breezy < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c914a0b4b10bf2eed4c6f6cfa8a218b9f0a7204ce41652cea707b3dd446b5905"
   end
 
-  depends_on "cython" => :build
   depends_on "gettext" => :build
+  depends_on "libcython" => :build
   depends_on "openssl@1.1"
   depends_on "python@3.10"
   depends_on "six"

--- a/Formula/cassandra.rb
+++ b/Formula/cassandra.rb
@@ -18,7 +18,7 @@ class Cassandra < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8719f63db4e26e335895e243ce9f317b448cf9eeb83559530d6126e96ebe25dd"
   end
 
-  depends_on "cython" => :build
+  depends_on "libcython" => :build
   depends_on "openjdk@11"
   depends_on "python@3.9"
   depends_on "six"

--- a/Formula/libcython.rb
+++ b/Formula/libcython.rb
@@ -1,0 +1,48 @@
+class Libcython < Formula
+  desc "Compiler for writing C extensions for the Python language"
+  homepage "https://cython.org/"
+  url "https://files.pythonhosted.org/packages/cb/da/54a5d7a7d9afc90036d21f4b58229058270cc14b4c81a86d9b2c77fd072e/Cython-0.29.28.tar.gz"
+  sha256 "d6fac2342802c30e51426828fe084ff4deb1b3387367cf98976bb2e64b6f8e45"
+  license "Apache-2.0"
+
+  keg_only <<~EOS
+    this formula is mainly used internally by other formulae.
+    Users are advised to use `pip` to install cython
+  EOS
+
+  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.9" => [:build, :test]
+
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/python@\d\.\d+/) }
+        .map(&:opt_bin)
+        .map { |bin| bin/"python3" }
+  end
+
+  def install
+    pythons.each do |python|
+      ENV.prepend_create_path "PYTHONPATH", libexec/Language::Python.site_packages(python)
+      system python, *Language::Python.setup_install_args(libexec),
+             "--install-lib=#{libexec/Language::Python.site_packages(python)}"
+    end
+  end
+
+  test do
+    phrase = "You are using Homebrew"
+    (testpath/"package_manager.pyx").write "print '#{phrase}'"
+    (testpath/"setup.py").write <<~EOS
+      from distutils.core import setup
+      from Cython.Build import cythonize
+
+      setup(
+        ext_modules = cythonize("package_manager.pyx")
+      )
+    EOS
+    pythons.each do |python|
+      ENV.prepend_path "PYTHONPATH", libexec/Language::Python.site_packages(python)
+      system python, "setup.py", "build_ext", "--inplace"
+      assert_match phrase, shell_output("#{python} -c 'import package_manager'")
+    end
+  end
+end

--- a/Formula/mpi4py.rb
+++ b/Formula/mpi4py.rb
@@ -14,7 +14,7 @@ class Mpi4py < Formula
     sha256               x86_64_linux:   "eef31e997cf6327384c7c9b861dfe7133c91448f30382c45cef0e8e1f4a31b21"
   end
 
-  depends_on "cython" => :build
+  depends_on "libcython" => :build
   depends_on "open-mpi"
   depends_on "python@3.9"
 

--- a/Formula/networkit.rb
+++ b/Formula/networkit.rb
@@ -16,7 +16,7 @@ class Networkit < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "cython" => :build
+  depends_on "libcython" => :build
   depends_on "ninja" => :build
   depends_on "tlx" => :build
 
@@ -30,7 +30,7 @@ class Networkit < Formula
     rpath_addons = Formula["libnetworkit"].opt_lib
 
     ENV.prepend_create_path "PYTHONPATH", libexec+"lib/python#{xy}/site-packages/"
-    ENV.append_path "PYTHONPATH", Formula["cython"].opt_libexec/"lib/python#{xy}/site-packages"
+    ENV.append_path "PYTHONPATH", Formula["libcython"].opt_libexec/"lib/python#{xy}/site-packages"
     system Formula["python@3.9"].opt_bin/"python3", "setup.py", "build_ext",
           "--networkit-external-core",
           "--external-tlx=#{Formula["tlx"].opt_prefix}",

--- a/Formula/numpy.rb
+++ b/Formula/numpy.rb
@@ -4,6 +4,7 @@ class Numpy < Formula
   url "https://files.pythonhosted.org/packages/64/4a/b008d1f8a7b9f5206ecf70a53f84e654707e7616a771d84c05151a4713e9/numpy-1.22.3.zip"
   sha256 "dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/numpy/numpy.git", branch: "main"
 
   bottle do
@@ -15,12 +16,20 @@ class Numpy < Formula
     sha256               x86_64_linux:   "4a5591fa46462c0f7b4d589c3854c8a3bc3e21f0f04065c2c4596840f6df3ef0"
   end
 
-  depends_on "cython" => :build
   depends_on "gcc" => :build # for gfortran
+  depends_on "libcython" => :build
+  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.9" => [:build, :test]
   depends_on "openblas"
-  depends_on "python@3.9"
 
   fails_with gcc: "5"
+
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/python@\d\.\d+/) }
+        .map(&:opt_bin)
+        .map { |bin| bin/"python3" }
+  end
 
   def install
     openblas = Formula["openblas"].opt_prefix
@@ -36,20 +45,25 @@ class Numpy < Formula
 
     Pathname("site.cfg").write config
 
-    xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
-    ENV.prepend_create_path "PYTHONPATH", Formula["cython"].opt_libexec/"lib/python#{xy}/site-packages"
+    pythons.each do |python|
+      xy = Language::Python.major_minor_version python
+      ENV.prepend_create_path "PYTHONPATH", Formula["libcython"].opt_libexec/"lib/python#{xy}/site-packages"
 
-    system Formula["python@3.9"].opt_bin/"python3", "setup.py", "build",
-        "--fcompiler=#{Formula["gcc"].opt_bin}/gfortran", "--parallel=#{ENV.make_jobs}"
-    system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
+      system python, "setup.py", "build",
+             "--fcompiler=#{Formula["gcc"].opt_bin}/gfortran", "--parallel=#{ENV.make_jobs}"
+      system python, *Language::Python.setup_install_args(prefix),
+                     "--install-lib=#{prefix/Language::Python.site_packages(python)}"
+    end
   end
 
   test do
-    system Formula["python@3.9"].opt_bin/"python3", "-c", <<~EOS
-      import numpy as np
-      t = np.ones((3,3), int)
-      assert t.sum() == 9
-      assert np.dot(t, t).sum() == 27
-    EOS
+    pythons.each do |python|
+      system python, "-c", <<~EOS
+        import numpy as np
+        t = np.ones((3,3), int)
+        assert t.sum() == 9
+        assert np.dot(t, t).sum() == 27
+      EOS
+    end
   end
 end

--- a/Formula/scipy.rb
+++ b/Formula/scipy.rb
@@ -15,7 +15,7 @@ class Scipy < Formula
     sha256               x86_64_linux:   "b953884a721170689cec7207e3e416606a030a1e61542a83502dd643b086cc45"
   end
 
-  depends_on "cython" => :build
+  depends_on "libcython" => :build
   depends_on "pythran" => :build
   depends_on "swig" => :build
   depends_on "gcc" # for gfortran
@@ -46,7 +46,7 @@ class Scipy < Formula
     Pathname("site.cfg").write config
 
     site_packages = Language::Python.site_packages("python3")
-    ENV.prepend_create_path "PYTHONPATH", Formula["cython"].opt_libexec/site_packages
+    ENV.prepend_create_path "PYTHONPATH", Formula["libcython"].opt_libexec/site_packages
     ENV.prepend_create_path "PYTHONPATH", Formula["pythran"].opt_libexec/site_packages
     ENV.prepend_create_path "PYTHONPATH", Formula["numpy"].opt_prefix/site_packages
     ENV.prepend_create_path "PYTHONPATH", site_packages

--- a/Formula/urh.rb
+++ b/Formula/urh.rb
@@ -4,6 +4,7 @@ class Urh < Formula
   url "https://files.pythonhosted.org/packages/c2/3d/9cbaac6d7101f50c408ac428d9e37668916a4a3e22292f38748b230239e0/urh-2.9.3.tar.gz"
   sha256 "037b91bb87a113ac03d0695e0c2b5cce35d0886469b3ef46ba52d2342c8cfd8c"
   license "GPL-3.0-only"
+  revision 1
   head "https://github.com/jopohl/urh.git", branch: "master"
 
   bottle do
@@ -16,8 +17,8 @@ class Urh < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "cython"
   depends_on "hackrf"
+  depends_on "libcython"
   depends_on "numpy"
   depends_on "pyqt@5"
   depends_on "python@3.9"
@@ -36,7 +37,7 @@ class Urh < Formula
       end
     end
 
-    ENV.prepend_create_path "PYTHONPATH", Formula["cython"].opt_libexec/"lib/python#{xy}/site-packages"
+    ENV.prepend_create_path "PYTHONPATH", Formula["libcython"].opt_libexec/"lib/python#{xy}/site-packages"
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{xy}/site-packages"
 
     system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -7,6 +7,7 @@
   ["bundler-completion", "gem-completion", "rails-completion", "ruby-completion"],
   ["buildifier", "buildozer"],
   ["cmake", "cmake-docs"],
+  ["cython", "libcython"],
   ["dbhash", "sqldiff", "sqlite", "sqlite-analyzer"],
   ["docker", "docker-completion"],
   ["etl", "synfig"],


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is inspired by what we did for `Pillow`. The idea is to allow mixed Python dependencies. We can later on extend the idea to `scipy`, I just wanted to start small.
This change should ease the Python 3.10 migration, as both formulae are quite low in the dependency tree, and my hope is to be able to decouple things a little bit, to be able to handle bits of the dependency tree separately.

I still have one bug with `numpy` and Python 3.10, the build currently fails; I need to check that.
We might also need to add some `python@xy` dependencies to formulae that use `cython` or `numpy` as these will be missing now. I shifted the responsibility to choose which `python@xy` formula to install to the upper formulae in the dependency tree.

This is a draft and needs further testing / thinking / tweaking. I would like some feedback on the strategy too.