### PR TITLE
ship: deprecate

### DIFF
--- a/Formula/ship.rb
+++ b/Formula/ship.rb
@@ -15,6 +15,9 @@ class Ship < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "c3974dea38bf106223fc9bccb8c3e2eaff6f8d951a95ddad849a63edc6040578"
   end
 
+  # depends indirectly on python@2 and is superseded by kots
+  deprecate! date: "2019-11-22", because: :deprecated_upstream
+
   # Bump to 1.18 on the next release, if possible.
   depends_on "go@1.17" => :build
   # Switch to `node` when ship updates dependency node-sass>=6.0.0

--- a/Formula/ship.rb
+++ b/Formula/ship.rb
@@ -16,7 +16,7 @@ class Ship < Formula
   end
 
   # depends indirectly on python@2 and is superseded by kots
-  deprecate! date: "2019-11-22", because: :deprecated_upstream
+  deprecate! date: "2022-03-25", because: :deprecated_upstream
 
   # Bump to 1.18 on the next release, if possible.
   depends_on "go@1.17" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Related to https://github.com/Homebrew/homebrew-core/issues/93940

I used the date of the [commit announcing the supersede of `ship` by `kots`](https://github.com/replicatedhq/ship/commit/42b4ac8a522f29125de7c54e6b254022b25b3d88).