### PR TITLE
jmxterm: Depend on openjdk instead of openjdk@8

### DIFF
--- a/Formula/jmxterm.rb
+++ b/Formula/jmxterm.rb
@@ -11,11 +11,11 @@ class Jmxterm < Formula
     sha256 cellar: :any_skip_relocation, all: "2e3d2fb1fd7afec204e7556a5c7567cab6c7ce3484e91730dcf0b34c1e8729aa"
   end
 
-  depends_on "openjdk@8"
+  depends_on "openjdk"
 
   def install
     libexec.install "jmxterm-#{version}-uber.jar"
-    bin.write_jar_script libexec/"jmxterm-#{version}-uber.jar", "jmxterm", "", java_version: "1.8"
+    bin.write_jar_script libexec/"jmxterm-#{version}-uber.jar", "jmxterm", ""
   end
 
   test do


### PR DESCRIPTION
jmxterm works fine with the latest Java version, as new Java versions are basically always backwards compatible.

Looking at the commit history, I don't see any reason why it was pinned to openjdk@8.

Requiring openjdk@8 prevents jmxterm from being installed on M1 Macs, since openjdk@8 does not currently build on Apple silicon. This also means that you need fewer Java versions installed (and don't need to have an 8 year old Java installed).

- ✅ Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- ✅ Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- ✅ Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- ✅ Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- ✅ Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- ✅ Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
