### PR TITLE
rtmidi: fix checksum mismatch

### DIFF
--- a/Formula/rtmidi.rb
+++ b/Formula/rtmidi.rb
@@ -2,8 +2,9 @@ class Rtmidi < Formula
   desc "API for realtime MIDI input/output"
   homepage "https://www.music.mcgill.ca/~gary/rtmidi/"
   url "https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-5.0.0.tar.gz"
-  sha256 "c0f57eca5e7ebc8773375d5e9f56405d2b37a255a509fa57d2dc4f7e87d2c564"
+  sha256 "48db0ed58c8c0e207b5d7327a0210b5bcaeb50e26387935d02829239b0f3c2b9"
   license "MIT"
+  revision 1
 
   livecheck do
     url :homepage

--- a/Formula/rtmidi.rb
+++ b/Formula/rtmidi.rb
@@ -4,7 +4,6 @@ class Rtmidi < Formula
   url "https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-5.0.0.tar.gz"
   sha256 "48db0ed58c8c0e207b5d7327a0210b5bcaeb50e26387935d02829239b0f3c2b9"
   license "MIT"
-  revision 1
 
   livecheck do
     url :homepage


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

fixes #97713