### PR TITLE
restic 0.13.0

### DIFF
--- a/Formula/restic.rb
+++ b/Formula/restic.rb
@@ -1,6 +1,6 @@
 class Restic < Formula
   desc "Fast, efficient and secure backup program"
-  homepage "https://restic.github.io/"
+  homepage "https://restic.net/"
   url "https://github.com/restic/restic/archive/v0.13.0.tar.gz"
   sha256 "b3c09137b462548f44d764f98909534bef6e85fe029d4daf60545642cdefd3dd"
   license "BSD-2-Clause"
@@ -19,10 +19,7 @@ class Restic < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
-    ENV["CGO_ENABLED"] = "1"
-
-    system "go", "run", "-mod=vendor", "build.go", "--enable-cgo"
+    system "go", "run", "build.go"
 
     mkdir "completions"
     system "./restic", "generate", "--bash-completion", "completions/restic"

--- a/Formula/restic.rb
+++ b/Formula/restic.rb
@@ -1,8 +1,8 @@
 class Restic < Formula
   desc "Fast, efficient and secure backup program"
   homepage "https://restic.github.io/"
-  url "https://github.com/restic/restic/archive/v0.12.1.tar.gz"
-  sha256 "a9c88d5288ce04a6cc78afcda7590d3124966dab3daa9908de9b3e492e2925fb"
+  url "https://github.com/restic/restic/archive/v0.13.0.tar.gz"
+  sha256 "b3c09137b462548f44d764f98909534bef6e85fe029d4daf60545642cdefd3dd"
   license "BSD-2-Clause"
   head "https://github.com/restic/restic.git", branch: "master"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 23,855,262 bytes
- formula fetch time: 2.1 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.