### PR TITLE
libarchive: don't create conflicting symlinks on Linux

### DIFF
--- a/Formula/libarchive.rb
+++ b/Formula/libarchive.rb
@@ -4,6 +4,7 @@ class Libarchive < Formula
   url "https://www.libarchive.org/downloads/libarchive-3.6.0.tar.xz"
   sha256 "df283917799cb88659a5b33c0a598f04352d61936abcd8a48fe7b64e74950de7"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     url :homepage
@@ -45,6 +46,8 @@ class Libarchive < Formula
            "--with-expat"       # best xar hashing option
 
     system "make", "install"
+
+    return unless OS.mac?
 
     # Just as apple does it.
     ln_s bin/"bsdtar", bin/"tar"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seemed a bit odd for Homebrew to create its own conflicting symlinks on Linux that aren't provided on most Linux distros.

Looks like some formulae have been changed to use these BSD `tar` and `cpio` when we should prefer GNU equivalents on Linux.

---

Testing rebuild of direct dependents since some formulae that use `libarchive` as build-only may be broken due to expecting `tar` or `cpio`.

In some cases, may still pass since Ubuntu may have these pre-installed.