### PR TITLE
universal_binary_allowlist: remove `gitversion`

### DIFF
--- a/audit_exceptions/universal_binary_allowlist.json
+++ b/audit_exceptions/universal_binary_allowlist.json
@@ -5,7 +5,6 @@
   "contentful-cli",
   "firebase-cli",
   "gatsby-cli",
-  "gitversion",
   "infer",
   "joplin-cli",
   "llvm",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Original issue: https://github.com/Homebrew/homebrew-core/pull/82111#issuecomment-889541203

`libgit2` upstream seems to now use native binaries in newer releases.

Tried installing current `gitversion` and no issues:
```console
❯ file /usr/local/opt/gitversion/libexec/libgit2-b7bad55.dylib
/usr/local/opt/gitversion/libexec/libgit2-b7bad55.dylib: Mach-O 64-bit dynamically linked shared library x86_64

❯ file /opt/homebrew/opt/gitversion/libexec/libgit2-b7bad55.dylib
/opt/homebrew/opt/gitversion/libexec/libgit2-b7bad55.dylib: Mach-O 64-bit dynamically linked shared library arm64

❯ brew audit --strict gitversion; echo $?
0
```
