### PR TITLE
tcc: add head as mob branch

### DIFF
--- a/Formula/tcc.rb
+++ b/Formula/tcc.rb
@@ -5,6 +5,7 @@ class Tcc < Formula
   sha256 "de23af78fca90ce32dff2dd45b3432b2334740bb9bb7b05bf60fdbfc396ceb9c"
   license "LGPL-2.0-or-later"
   revision 1
+  head "https://repo.or.cz/tinycc.git", branch: "mob"
 
   livecheck do
     url "https://download.savannah.nongnu.org/releases/tinycc/"
@@ -23,8 +24,9 @@ class Tcc < Formula
       --prefix=#{prefix}
       --source-path=#{buildpath}
       --sysincludepaths=/usr/local/include:#{MacOS.sdk_path}/usr/include:{B}/include
-      --enable-cross"
+      --enable-cross
     ]
+    args << "--cc=#{ENV.cc}" if build.head?
 
     ENV.deparallelize
     system "./configure", *args


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Current stable release fails test with
```
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/stdio.h:64:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/_stdio.h:68:
/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/sys/cdefs.h:81: warning: #warning "Unsupported compiler detected"
tcc: error: library 'c' not found
Error: tcc: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected: 0
  Actual: 255
```


Latest commit from `mob` branch builds and has support for M1 too. So, add that for any users who want to build a version for newer OS.