### PR TITLE
blast: revert to using `cpio` for Linux build

### DIFF
--- a/Formula/blast.rb
+++ b/Formula/blast.rb
@@ -21,6 +21,7 @@ class Blast < Formula
 
   depends_on "lmdb"
 
+  uses_from_macos "cpio" => :build
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
@@ -29,7 +30,6 @@ class Blast < Formula
   end
 
   on_linux do
-    depends_on "libarchive" => :build
     depends_on "gcc"
   end
 
@@ -40,13 +40,17 @@ class Blast < Formula
   def install
     cd "c++" do
       # Boost is only used for unit tests.
-      args = %W[--prefix=#{prefix}
-                --with-bin-release
-                --with-mt
-                --with-strip
-                --with-experimental=Int8GI
-                --without-debug
-                --without-boost]
+      args = %W[
+        --prefix=#{prefix}
+        --with-bin-release
+        --with-mt
+        --with-strip
+        --with-experimental=Int8GI
+        --without-debug
+        --without-boost
+      ]
+      # Allow SSE4.2 on some platforms. The --with-bin-release sets --without-sse42
+      args << "--with-sse42" if Hardware::CPU.intel? && MacOS.version.requires_sse42?
 
       if OS.mac?
         args += ["OPENMP_FLAGS=-Xpreprocessor -fopenmp",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Reverting #70639 since `libarchive` should now only provide `bsdcpio`.

Some scripts like `c++/src/build-system/Makefile.in.top` directly call `cpio`, e.g.
```sh
	for d in $(includedir0) $(incdir); do \
	    cd $$d && find * -name .svn -prune -o -print | \
                cpio -pd $(pincludedir) ; \
	done
```

Also enable SSE4.2 for future macOS builds that guarantee support. `--with-bin-release` sets following defaults:
```
if test "$with_bin_release" = "yes" ; then
   # Default some other options accordingly
   : ${with_ncbi_public=yes}
   : ${with_local_lbsm=no}
   : ${with_ncbi_crypt=no}
   : ${with_connext=no}
   : ${with_libdw=no}
   : ${with_pcre=no} # Too much variation across distributions.
   : ${with_sse42=no}
```