### PR TITLE
cpio: delete conflicting rmt and add license

### DIFF
--- a/Formula/cpio.rb
+++ b/Formula/cpio.rb
@@ -4,7 +4,8 @@ class Cpio < Formula
   url "https://ftp.gnu.org/gnu/cpio/cpio-2.13.tar.bz2"
   mirror "https://ftpmirror.gnu.org/cpio/cpio-2.13.tar.bz2"
   sha256 "eab5bdc5ae1df285c59f2a4f140a98fc33678a0bf61bdba67d9436ae26b46f6d"
-  revision 2
+  license "GPL-3.0-or-later"
+  revision 3
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "86744e53b4827c9247d7e4bb5a35c6bb1a018da2a060fae5d1bb3691ea2fd13a"
@@ -20,12 +21,14 @@ class Cpio < Formula
   keg_only :shadowed_by_macos, "macOS provides cpio"
 
   def install
-    system "./configure",
-      "--disable-debug",
-      "--disable-dependency-tracking",
-      "--disable-silent-rules",
-      "--prefix=#{prefix}"
+    system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install"
+
+    return if OS.mac?
+
+    # Delete rmt, which causes conflict with `gnu-tar`
+    (libexec/"rmt").unlink
+    (man8/"rmt.8").unlink
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`rmt` is not built on macOS since it depends on `sys/mtio.h`.

Deleting conflicting files is the approach used by Arch and Debian, e.g.
- **Arch**
  - NOTE: for `gnu-tar`, they leave `rmt` as is
  - https://github.com/archlinux/svntogit-packages/blob/packages/cpio/trunk/PKGBUILD#L31-L32=
    ```
      rm -rf "${pkgdir}/usr/libexec"
      rm -f "${pkgdir}/usr/share/man/man8/rmt.8"
    ```
- **Debian** 
  - NOTE: for `gnu-tar`, they rename `rmt` to `rmt-tar`
  - https://salsa.debian.org/lamby/pkg-cpio/-/blob/debian/experimental/debian/rules#L117-118
    ```
	    rm -rf debian/tmp/usr/libexec
	    rm -rf debian/tmp/usr/share/man/man8/rmt.8
    ```


**Fedora** creates a `rmt` package and uses that during build via `--with-rmt=...`, but there doesn't seem to be an up-to-date source tarball. The code is from `paxutils` https://www.gnu.org/software/paxutils/ which is still Alpha quality and has no tarballs.