### PR TITLE
gnu-tar: add acl support on Linux

### DIFF
--- a/Formula/gnu-tar.rb
+++ b/Formula/gnu-tar.rb
@@ -5,6 +5,7 @@ class GnuTar < Formula
   mirror "https://ftpmirror.gnu.org/tar/tar-1.34.tar.gz"
   sha256 "03d908cf5768cfe6b7ad588c921c6ed21acabfb2b79b788d1330453507647aed"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "be51eda1c4fe90214822f47ff0e49b3e6cf87791890cd69bb198ef6fb9ac082d"
@@ -17,11 +18,15 @@ class GnuTar < Formula
   end
 
   head do
-    url "https://git.savannah.gnu.org/git/tar.git"
+    url "https://git.savannah.gnu.org/git/tar.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "gettext" => :build
+  end
+
+  on_linux do
+    depends_on "acl"
   end
 
   def install
@@ -47,12 +52,11 @@ class GnuTar < Formula
     system "./configure", *args
     system "make", "install"
 
-    if OS.mac?
-      # Symlink the executable into libexec/gnubin as "tar"
-      (libexec/"gnubin").install_symlink bin/"gtar" =>"tar"
-      (libexec/"gnuman/man1").install_symlink man1/"gtar.1" => "tar.1"
-    end
+    return unless OS.mac?
 
+    # Symlink the executable into libexec/gnubin as "tar"
+    (libexec/"gnubin").install_symlink bin/"gtar" => "tar"
+    (libexec/"gnuman/man1").install_symlink man1/"gtar.1" => "tar.1"
     libexec.install_symlink "gnuman" => "man"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seems to be commonly enabled feature based on other Linux distro `tar` packages. 

For example:
- Arch - https://archlinux.org/packages/core/x86_64/tar/
- Debian - https://packages.debian.org/sid/tar
- Fedora - https://src.fedoraproject.org/rpms/tar/blob/rawhide/f/tar.spec

As opposed to SELinux feature which varies by distro, e.g.: not enabled in Arch, enabled in Debian, and optionally enabled in Fedora (default is enabled).

Docs: https://www.gnu.org/software/tar/manual/html_node/Extended-File-Attributes.html

Allows preserving ACLs created by `acl` formula in tarballs.

---

Also, added some changes to avoid creating dead symlink on Linux (`gnuman`).