### PR TITLE
deheader: update dependencies and only make for head build

### DIFF
--- a/Formula/deheader.rb
+++ b/Formula/deheader.rb
@@ -6,7 +6,6 @@ class Deheader < Formula
   url "http://www.catb.org/~esr/deheader/deheader-1.8.tar.gz"
   sha256 "ebf144b441cc12ff5003e3e36c16e772382a153968c44334d5d6a892b44cab06"
   license "BSD-2-Clause"
-  head "https://gitlab.com/esr/deheader.git", branch: "master"
 
   livecheck do
     url :homepage
@@ -17,17 +16,19 @@ class Deheader < Formula
     sha256 cellar: :any_skip_relocation, all: "35fcae1dfb59ef0c9fce339453c212eabfc380c70b1820ca4b69275606cc2678"
   end
 
-  depends_on "xmlto" => :build
-  depends_on "python@3.10"
-
-  on_linux do
-    depends_on "libarchive" => :build
+  head do
+    url "https://gitlab.com/esr/deheader.git", branch: "master"
+    depends_on "xmlto" => :build
   end
 
-  def install
-    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+  depends_on "python@3.10"
 
-    system "make"
+  def install
+    if build.head?
+      ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
+      system "make"
+    end
+
     bin.install "deheader"
     man1.install "deheader.1"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`make` is used to create manpage.

In release tarballs, it is already packaged, so it is a no-op:
```console
❯ make
make: Nothing to be done for `all'.
```