### PR TITLE
rocksdb@6 6.29.3 (new formula)

### DIFF
--- a/Aliases/rocksdb@7
+++ b/Aliases/rocksdb@7
@@ -1,0 +1,1 @@
+../Formula/rocksdb.rb

--- a/Formula/rocksdb@6.rb
+++ b/Formula/rocksdb@6.rb
@@ -1,0 +1,131 @@
+class RocksdbAT6 < Formula
+  desc "Embeddable, persistent key-value store for fast storage"
+  homepage "https://rocksdb.org/"
+  url "https://github.com/facebook/rocksdb/archive/v6.29.4.tar.gz"
+  sha256 "e93002ebf6250b0bdbde7ea81492bff562a88680bf3cf42b56c716b6e9c5c96b"
+  license any_of: ["GPL-2.0-only", "Apache-2.0"]
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "gflags"
+  depends_on "lz4"
+  depends_on "snappy"
+  depends_on "zstd"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
+  def install
+    ENV.cxx11
+    base_args = std_cmake_args + %W[
+      -DPORTABLE=ON
+      -DUSE_RTTI=ON
+      -DWITH_BENCHMARK_TOOLS=OFF
+      -DWITH_BZ2=ON
+      -DWITH_LZ4=ON
+      -DWITH_SNAPPY=ON
+      -DWITH_ZLIB=ON
+      -DWITH_ZSTD=ON
+      -DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,#{rpath}
+    ]
+
+    # build rocksdb_lite
+    lite_args = base_args + %w[
+      -DROCKSDB_LITE=ON
+      -DARTIFACT_SUFFIX=_lite
+      -DWITH_CORE_TOOLS=OFF
+      -DWITH_TOOLS=OFF
+    ]
+    mkdir "build_lite" do
+      system "cmake", "..", *lite_args
+      system "make", "install"
+    end
+    p = lib/"cmake/rocksdb/RocksDB"
+    ["Targets.cmake", "Targets-release.cmake"].each do |s|
+      File.rename "#{p}#{s}", "#{p}_Lite#{s}"
+    end
+
+    # build regular rocksdb
+    mkdir "build" do
+      system "cmake", "..", *base_args
+      system "make", "install"
+
+      cd "tools" do
+        bin.install "sst_dump" => "rocksdb_sst_dump"
+        bin.install "db_sanity_test" => "rocksdb_sanity_test"
+        bin.install "write_stress" => "rocksdb_write_stress"
+        bin.install "ldb" => "rocksdb_ldb"
+        bin.install "db_repl_stress" => "rocksdb_repl_stress"
+        bin.install "rocksdb_dump"
+        bin.install "rocksdb_undump"
+      end
+      bin.install "db_stress_tool/db_stress" => "rocksdb_stress"
+    end
+
+    # build pkgconfig file
+    system "make", "gen-pc", "PREFIX=#{prefix}"
+    (lib/"pkgconfig").install "rocksdb.pc"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <assert.h>
+      #include <rocksdb/options.h>
+      #include <rocksdb/memtablerep.h>
+      using namespace rocksdb;
+      int main() {
+        Options options;
+        return 0;
+      }
+    EOS
+
+    extra_args = []
+    on_macos do
+      extra_args << "-stdlib=libc++"
+      extra_args << "-lstdc++"
+    end
+    system ENV.cxx, "test.cpp", "-o", "db_test", "-v",
+                                "-std=c++11",
+                                *extra_args,
+                                "-lz", "-lbz2",
+                                "-L#{lib}", "-lrocksdb",
+                                "-L#{Formula["snappy"].opt_lib}", "-lsnappy",
+                                "-L#{Formula["lz4"].opt_lib}", "-llz4",
+                                "-L#{Formula["zstd"].opt_lib}", "-lzstd",
+                                "-I#{include}"
+    system "./db_test"
+    system ENV.cxx, "test.cpp", "-o", "db_test_lite", "-v",
+                                "-std=c++11",
+                                *extra_args,
+                                "-lz", "-lbz2",
+                                "-L#{lib}", "-lrocksdb_lite",
+                                "-DROCKSDB_LITE=1",
+                                "-L#{Formula["snappy"].opt_lib}", "-lsnappy",
+                                "-L#{Formula["lz4"].opt_lib}", "-llz4",
+                                "-L#{Formula["zstd"].opt_lib}", "-lzstd",
+                                "-I#{include}"
+    system "./db_test_lite"
+
+    assert_match "sst_dump --file=", shell_output("#{bin}/rocksdb_sst_dump --help 2>&1")
+    assert_match "rocksdb_sanity_test <path>", shell_output("#{bin}/rocksdb_sanity_test --help 2>&1", 1)
+    assert_match "rocksdb_stress [OPTIONS]...", shell_output("#{bin}/rocksdb_stress --help 2>&1", 1)
+    assert_match "rocksdb_write_stress [OPTIONS]...", shell_output("#{bin}/rocksdb_write_stress --help 2>&1", 1)
+    assert_match "ldb - RocksDB Tool", shell_output("#{bin}/rocksdb_ldb --help 2>&1")
+    assert_match "rocksdb_repl_stress:", shell_output("#{bin}/rocksdb_repl_stress --help 2>&1", 1)
+    assert_match "rocksdb_dump:", shell_output("#{bin}/rocksdb_dump --help 2>&1", 1)
+    assert_match "rocksdb_undump:", shell_output("#{bin}/rocksdb_undump --help 2>&1", 1)
+
+    db = testpath / "db"
+    %w[no snappy zlib bzip2 lz4 zstd].each_with_index do |comp, idx|
+      key = "key-#{idx}"
+      value = "value-#{idx}"
+
+      put_cmd = "#{bin}/rocksdb_ldb put --db=#{db} --create_if_missing --compression_type=#{comp} #{key} #{value}"
+      assert_equal "OK", shell_output(put_cmd).chomp
+
+      get_cmd = "#{bin}/rocksdb_ldb get --db=#{db} #{key}"
+      assert_equal value, shell_output(get_cmd).chomp
+    end
+  end
+end


### PR DESCRIPTION
Most software that uses rocksdb seems to still depend on v6, since v7 was only stabilised very recently. Thus, it makes sense to introduce a versioned formula for v6, I think.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----