### PR TITLE
rocksdb 7.3.1

### DIFF
--- a/Formula/rocksdb.rb
+++ b/Formula/rocksdb.rb
@@ -1,8 +1,8 @@
 class Rocksdb < Formula
   desc "Embeddable, persistent key-value store for fast storage"
   homepage "https://rocksdb.org/"
-  url "https://github.com/facebook/rocksdb/archive/v7.0.3.tar.gz"
-  sha256 "85bcdcd4adcd77eed6748804d5672d5725b5d2a469694e2a3dbd21b175cf4fd2"
+  url "https://github.com/facebook/rocksdb/archive/v7.3.1.tar.gz"
+  sha256 "51a44b8f151d1a39793a8cf37d9de248b980f9aaed0c7bbeee06304e4d7b8d95"
   license any_of: ["GPL-2.0-only", "Apache-2.0"]
   head "https://github.com/facebook/rocksdb.git", branch: "main"
 


### PR DESCRIPTION
This builds and installs the pkgconfig file (`rocksdb.pc`). There is no rule for it in the Makefile generated by CMake, but there *is* in the original Makefile, and since the `gen-pc` rule is not coupled with any of the rest of the file, it makes sense to use that.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----