### PR TITLE
dcmtk: fix build for Apple Silicon

### DIFF
--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -1,9 +1,20 @@
 class Dcmtk < Formula
   desc "OFFIS DICOM toolkit command-line utilities"
   homepage "https://dicom.offis.de/dcmtk.php.en"
-  url "https://dicom.offis.de/download/dcmtk/dcmtk366/dcmtk-3.6.6.tar.gz"
-  sha256 "6859c62b290ee55677093cccfd6029c04186d91cf99c7642ae43627387f3458e"
   head "https://git.dcmtk.org/dcmtk.git", branch: "master"
+
+  stable do
+    url "https://dicom.offis.de/download/dcmtk/dcmtk366/dcmtk-3.6.6.tar.gz"
+    sha256 "6859c62b290ee55677093cccfd6029c04186d91cf99c7642ae43627387f3458e"
+
+    # Fix build for Apple Silicon.
+    # Issue ref: https://support.dcmtk.org/redmine/issues/957
+    # TODO: Remove in the next release along with stable block
+    patch do
+      url "https://git.dcmtk.org/?p=dcmtk.git;a=patch;h=5fba853b6f7c13b02bed28bd9f7d3f450e4c72bb"
+      sha256 "40ca9e6f377951e2d24a509a6c95b9e572224d74d694f0d648b8b33e4d67e285"
+    end
+  end
 
   livecheck do
     url "https://dicom.offis.de/download/dcmtk/release/"
@@ -26,14 +37,18 @@ class Dcmtk < Formula
   uses_from_macos "libxml2"
 
   def install
-    mkdir "build" do
-      system "cmake", "-DBUILD_SHARED_LIBS=OFF", *std_cmake_args, ".."
-      system "make", "install"
-      system "cmake", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args, ".."
-      system "make", "install"
+    system "cmake", "-S", ".", "-B", "build/shared", *std_cmake_args,
+                    "-DBUILD_SHARED_LIBS=ON",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    system "cmake", "--build", "build/shared"
+    system "cmake", "--install", "build/shared"
 
-      inreplace lib/"cmake/dcmtk/DCMTKConfig.cmake", Superenv.shims_path, ""
-    end
+    system "cmake", "-S", ".", "-B", "build/static", *std_cmake_args,
+                    "-DBUILD_SHARED_LIBS=OFF"
+    system "cmake", "--build", "build/static"
+    lib.install Dir["build/static/lib/*.a"]
+
+    inreplace lib/"cmake/dcmtk/DCMTKConfig.cmake", "#{Superenv.shims_path}/", ""
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Didn't add revision bump since patch should only impact ARM build and install should behave the same other than final inreplace.

The inreplace is minor fix for CMake files to remove slash before compiler, which can be fixed via rebuild of bottles.