### PR TITLE
objfw: fix build on Linux

### DIFF
--- a/Formula/objfw.rb
+++ b/Formula/objfw.rb
@@ -22,16 +22,23 @@ class Objfw < Formula
   end
 
   head do
-    url "https://github.com/ObjFW/ObjFW.git"
+    url "https://github.com/ObjFW/ObjFW.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
   end
 
+  on_linux do
+    depends_on "llvm"
+  end
+
+  fails_with :gcc
+
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
+    inreplace bin/"objfw-config", "llvm_clang", "clang" if OS.linux?
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Testing out some things.

`gcc` didn't work for me locally, but trying before just disabling entirely.

`llvm` did build but failed test as it saves `llvm_clang` to file. Passed test after overwriting value.