### PR TITLE
jython: fix setting JAVA_HOME on Catalina

### DIFF
--- a/Formula/jython.rb
+++ b/Formula/jython.rb
@@ -4,13 +4,13 @@ class Jython < Formula
   url "https://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.2/jython-installer-2.7.2.jar"
   sha256 "36e40609567ce020a1de0aaffe45e0b68571c278c14116f52e58cc652fb71552"
   license "PSF-2.0"
+  revision 1
 
   livecheck do
     url "https://search.maven.org/remotecontent?filepath=org/python/jython-installer/"
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  # This isn't accidental; there is actually a compile process here.
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "6f573f01ccb166b2988aef09b26f6a4a6e88bd8919c138fde090fad93698d053"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "6f573f01ccb166b2988aef09b26f6a4a6e88bd8919c138fde090fad93698d053"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fixes https://github.com/Homebrew/homebrew-core/pull/97702#issuecomment-1081276494