### PR TITLE
synced_versions_formulae: remove zlib and minizip sync

### DIFF
--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -28,7 +28,6 @@
   ["logcli", "loki", "promtail"],
   ["mame", "rom-tools"],
   ["mecab-unidic", "mecab-unidic-extended"],
-  ["minizip", "zlib"],
   ["moarvm", "nqp", "rakudo"],
   ["moreutils", "sponge"],
   ["mupdf", "mupdf-tools"],


### PR DESCRIPTION
zlib needs the Wheezy container.
minizip does not.

For this reason, they should be updated in separate PRs.