### PR TITLE
redo: modify test to ignore CI-related failure

### DIFF
--- a/Formula/redo.rb
+++ b/Formula/redo.rb
@@ -48,23 +48,23 @@ class Redo < Formula
       #include <stdio.h>
 
       int main() {
-          printf(\"Hello, world!\\n\");
-          return 0;
+        printf("Hello, world!\\n");
+        return 0;
       }
     EOS
     (testpath/"hello.do").write <<~EOS
       redo-ifchange hello.c
       cc -o $3 hello.c -Wall
     EOS
-    assert_equal "redo  hello", shell_output("redo hello 2>&1").strip
+    assert_match "redo  hello", shell_output("#{bin}/redo hello 2>&1").strip
     assert_predicate testpath/"hello", :exist?
     assert_equal "Hello, world!\n", shell_output("./hello")
-    assert_equal "redo  hello", shell_output("redo hello 2>&1").strip
-    assert_equal "", shell_output("redo-ifchange hello 2>&1").strip
+    assert_match "redo  hello", shell_output("#{bin}/redo hello 2>&1").strip
+    refute_match "redo", shell_output("#{bin}/redo-ifchange hello 2>&1").strip
     touch "hello.c"
-    assert_equal "redo  hello", shell_output("redo-ifchange hello 2>&1").strip
+    assert_match "redo  hello", shell_output("#{bin}/redo-ifchange hello 2>&1").strip
     (testpath/"all.do").write("redo-ifchange hello")
-    (testpath/"hello").delete
-    assert_equal "redo  all\nredo    hello", shell_output("redo 2>&1").strip
+    (testpath/"hello").unlink
+    assert_match "redo  all\nredo    hello", shell_output("#{bin}/redo 2>&1").strip
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in #97010 where test failed due to CI runners printing unrelated ObjC warnings.

```
==> redo hello 2>&1
  Error: redo: failed
  An exception occurred within a child process:
    Minitest::Assertion: --- expected
  +++ actual
  @@ -1 +1,3 @@
  -"redo  hello"
  +"redo  hello
  +objc[83132]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libauthinstall.dylib (0x1ec807788) and /System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x10e9002b8). One of the two will be used. Which one is undefined.
  +objc[83132]: Class AMSupportURLSession is implemented in both /usr/lib/libauthinstall.dylib (0x1ec8077d8) and /System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x10e900308). One of the two will be used. Which one is undefined."
```