### PR TITLE
solarus: needs `mesa` at runtime and matching GLIBCXX on Linux

### DIFF
--- a/Formula/solarus.rb
+++ b/Formula/solarus.rb
@@ -29,8 +29,12 @@ class Solarus < Formula
   depends_on "sdl2_ttf"
 
   on_linux do
+    depends_on "gcc"
+    depends_on "mesa"
     depends_on "openal-soft"
   end
+
+  fails_with gcc: "5" # needs same GLIBCXX as mesa at runtime
 
   def install
     ENV.append_to_cflags "-I#{Formula["glm"].opt_include}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Finishing up some local testing.

Tried running bottle built after #98027 but had issues due to OpenGL.