### PR TITLE
liblockfile: fix build on Linux

### DIFF
--- a/Formula/liblockfile.rb
+++ b/Formula/liblockfile.rb
@@ -18,12 +18,13 @@ class Liblockfile < Formula
     # brew runs without root privileges (and the group is named "wheel" anyway)
     inreplace "Makefile.in", " -g root ", " "
 
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-debug",
-                          "--with-mailgroup=staff",
-                          "--prefix=#{prefix}",
-                          "--sysconfdir=#{etc}",
-                          "--mandir=#{man}"
+    args = %W[
+      --sysconfdir=#{etc}
+      --mandir=#{man}
+    ]
+    args << "--with-mailgroup=staff" if OS.mac?
+
+    system "./configure", *std_configure_args, *args
     bin.mkpath
     lib.mkpath
     include.mkpath


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
