### PR TITLE
protobuf: remove dependency on 'six'

### DIFF
--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -30,7 +30,6 @@ class Protobuf < Formula
   depends_on "python@3.10" => [:build, :test]
   # The Python3.9 bindings can be removed when Python3.9 is made keg-only.
   depends_on "python@3.9" => [:build, :test]
-  depends_on "six"
 
   uses_from_macos "zlib"
 


### PR DESCRIPTION
The protobuf package has not depended on the 'six' Python package since v3.19.0, and this formula installs v3.19.4.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
