### PR TITLE
aida-header: deprecate

### DIFF
--- a/Formula/aida-header.rb
+++ b/Formula/aida-header.rb
@@ -17,6 +17,8 @@ class AidaHeader < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "d4559d46451c98728a32679f6d62b7ee4c9a5fa57c18e7ba9315e33d2e7150b8"
   end
 
+  deprecate! date: "2022-03-30", because: :unmaintained
+
   def install
     include.install "src/cpp/AIDA"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Last release was October 2003.

FTP server for source tarball is unreachable.
No history from archive.org and none of our commonly used mirrors have tarball.

So, cannot be bottled on Monterey and Linux.