### PR TITLE
pinot: persistent volume

### DIFF
--- a/Formula/pinot.rb
+++ b/Formula/pinot.rb
@@ -25,7 +25,8 @@ class Pinot < Formula
   end
 
   service do
-    run [opt_bin/"pinot-admin", "QuickStart", "-type", "DEFAULT", "-dataDir", var/"lib/pinot/data", "-zkAddress", "localhost:2181"]
+    run [opt_bin/"pinot-admin", "QuickStart", "-type", "DEFAULT",
+         "-dataDir", var/"lib/pinot/data", "-zkAddress", "localhost:2181"]
     keep_alive true
     working_dir var/"lib/pinot"
     log_path var/"log/pinot/pinot_output.log"

--- a/Formula/pinot.rb
+++ b/Formula/pinot.rb
@@ -11,6 +11,7 @@ class Pinot < Formula
   end
 
   depends_on "openjdk"
+  depends_on "zookeeper"
 
   def install
     (var/"lib/pinot/data").mkpath
@@ -24,7 +25,7 @@ class Pinot < Formula
   end
 
   service do
-    run [opt_bin/"pinot-admin", "QuickStart", "-type", "BATCH", "-dataDir", var/"lib/pinot/data"]
+    run [opt_bin/"pinot-admin", "QuickStart", "-type", "DEFAULT", "-dataDir", var/"lib/pinot/data", "-zkAddress", "localhost:2181"]
     keep_alive true
     working_dir var/"lib/pinot"
     log_path var/"log/pinot/pinot_output.log"


### PR DESCRIPTION
This commit adds the ability to run Pinot with a persistent volume that uses an external Zookeeper dependency that is now included in the formula. This change was necessary as of 0.10.0 to allow users to persist their database state after a restart.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
