### PR TITLE
clockywock: deprecate and use alternative urls

### DIFF
--- a/Formula/clockywock.rb
+++ b/Formula/clockywock.rb
@@ -1,7 +1,8 @@
 class Clockywock < Formula
   desc "Ncurses analog clock"
-  homepage "https://soomka.com/"
-  url "https://soomka.com/clockywock-0.3.1a.tar.gz"
+  homepage "https://web.archive.org/web/20210519013044/https://soomka.com/"
+  url "https://web.archive.org/web/20160401181746/https://soomka.com/clockywock-0.3.1a.tar.gz"
+  mirror "https://mirrors.kernel.org/gentoo/distfiles/11/clockywock-0.3.1a.tar.gz"
   sha256 "278c01e0adf650b21878e593b84b3594b21b296d601ee0f73330126715a4cce4"
 
   bottle do
@@ -14,6 +15,10 @@ class Clockywock < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:    "12ce1b232f8dfa658e774f8ae08b99f40ca6ae12ee2d5df41af67412412c2b43"
     sha256 cellar: :any_skip_relocation, yosemite:      "fccbf3e83841993156fa544c0b0f30a92058facf07ce5b1e622aec78e2573aff"
   end
+
+  deprecate! date: "2022-03-30", because: :unmaintained
+
+  uses_from_macos "ncurses"
 
   def install
     system "make"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
