### PR TITLE
csound: update resources

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -5,7 +5,7 @@ class Csound < Formula
       tag:      "6.17.0",
       revision: "f5b4258794a82c99f7d85f1807c6638f2e80ccac"
   license "LGPL-2.1-or-later"
-  revision 4
+  revision 5
   head "https://github.com/csound/csound.git", branch: "develop"
 
   livecheck do
@@ -54,13 +54,19 @@ class Csound < Formula
   conflicts_with "pkcrack", because: "both install `extract` binaries"
 
   resource "ableton-link" do
-    url "https://github.com/Ableton/link/archive/Link-3.0.4.tar.gz"
-    sha256 "c7bb6f75ec805e1314d0181332285c3b3d7a81c9ec7d962b54f727283dac442a"
+    url "https://github.com/Ableton/link/archive/Link-3.0.5.tar.gz"
+    sha256 "74a470c8ae8f9c325e65e981839852e821ec56b980f8b923cb77ca833c4603ed"
   end
 
   resource "csound-plugins" do
     url "https://github.com/csound/plugins/archive/refs/tags/1.0.2.tar.gz"
     sha256 "8c2f0625ad1d38400030f414b92d82cfdec5c04b7dc178852f3e1935abf75d30"
+
+    # Fix build on macOS 12.3+ by replacing old system Python/Python.h with Homebrew's Python.h
+    patch do
+      url "https://github.com/csound/plugins/commit/13800c4dd58e3c214e5d7207180ad7115b4e2f27.patch?full_index=1"
+      sha256 "e088cc300845408f3956f070fa34a900b700c7860678bc6d37f7506d615787a6"
+    end
   end
 
   resource "getfem" do
@@ -90,12 +96,6 @@ class Csound < Formula
     EOS
 
     resource("csound-plugins").stage do
-      # Fix build on macOS 12.3+ by replacing old system Python/Python.h with Homebrew's Python.h
-      # TODO: Remove when fixed upstream.
-      inreplace Dir["py/src/{pythonopcodes.c,pythonopcodes.h,pythonhelper.h}"],
-                "include <Python/Python.h>",
-                "include <Python.h>"
-
       resource("ableton-link").stage buildpath/"ableton-link"
       resource("getfem").stage { cp_r "src/gmm", buildpath }
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This pull request updates Csound to use the latest version of [Ableton Link](https://github.com/Ableton/link). It also replaces an `inreplace` (used to fix an issue exposed by the removal of Python from macOS 12.3) with a patch from https://github.com/csound/plugins/pull/14.