### PR TITLE
aws-cfn-tools, elb-tools: deprecate

### DIFF
--- a/Formula/aws-cfn-tools.rb
+++ b/Formula/aws-cfn-tools.rb
@@ -10,6 +10,8 @@ class AwsCfnTools < Formula
     sha256 cellar: :any_skip_relocation, all: "62fe9878c486068d70c77637c2b2ce55d3f4fbb07b6aba7c65ecd8f1aaaee7c4"
   end
 
+  deprecate! date: "2022-04-03", because: :deprecated_upstream
+
   depends_on "ec2-api-tools"
   depends_on "openjdk"
 

--- a/Formula/elb-tools.rb
+++ b/Formula/elb-tools.rb
@@ -10,6 +10,8 @@ class ElbTools < Formula
     sha256 cellar: :any_skip_relocation, all: "8dd3007e8367fe8e0c4b4b85889a68d7196a954a27add9cb163c5965daa51da1"
   end
 
+  deprecate! date: "2022-04-03", because: :deprecated_upstream
+
   depends_on "ec2-api-tools"
   depends_on "openjdk"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Both are dependents of deprecated `ec2-api-tools` and haven't had any new releases since ~2014.

Homepages are both redirecting to general AWS page and can't find references to either.

There are still installs for `aws-cfn-tools`, but not sure if it is still usable or if it is causing confusion with `awscli` and/or `cloudformation-cli`.