### PR TITLE
workflows/tests: add test ephemeral runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,6 +189,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - runner: '12-arm64-${{github.run_id}}-${{github.run_attempt}}'
+            ephemeral: true
           - runner: '12-arm64'
           - runner: '12'
           - runner: '11-arm64'
@@ -303,7 +305,7 @@ jobs:
         run: rm -rvf bottles/failed
 
       - name: Upload bottles
-        if: always() && steps.bottles.outputs.count > 0
+        if: always() && steps.bottles.outputs.count > 0 && !matrix.ephemeral
         uses: actions/upload-artifact@main
         with:
           name: bottles


### PR DESCRIPTION
I'm going to push to this pull request a few times first to test things.

The ephemeral runner is currently excluded from bottle uploads to not conflict with regular 12-arm64 runners.