### PR TITLE
doxygen: don't build docs/man pages

### DIFF
--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -25,9 +25,6 @@ class Doxygen < Formula
 
   depends_on "bison" => :build
   depends_on "cmake" => :build
-  depends_on "ghostscript" => :build
-  depends_on "graphviz" => :build
-  depends_on "texlive" => :build
 
   uses_from_macos "flex" => :build
 
@@ -41,9 +38,8 @@ class Doxygen < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "-Dbuild_doc=1", "..", *std_cmake_args
+      system "cmake", "..", *std_cmake_args
       system "make"
-      system "make", "docs"
       system "make", "install"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We added these in #97187, but this causes a cyclic dependency. See
Homebrew/homebrew-cask#121499.

This reverts commit a65eff02fbd028f097125615ed94c7c895e0e15b.
