### PR TITLE
doxygen: replace variables in man pages

### DIFF
--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -41,6 +41,8 @@ class Doxygen < Formula
       system "cmake", "..", *std_cmake_args
       system "make"
       system "make", "install"
+      system "cmake", "-Dbuild_doc=1", "..", *std_cmake_args
+      man1.install Dir["man/*.1"]
     end
   end
 


### PR DESCRIPTION
Unbuilt man pages include un-replaced @VERSION@ & @DATE@ variables (and @YEAR@ in head/from next release).

Fix up manually in formula because doing it with 'make docs' introduced a cyclic dependency (Homebrew/homebrew-cask#121499).

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
