### PR TITLE
Update u-boot-tools.rb

### DIFF
--- a/Formula/u-boot-tools.rb
+++ b/Formula/u-boot-tools.rb
@@ -25,6 +25,8 @@ class UBootTools < Formula
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
 
+  patch :p1, :DATA
+
   def install
     # Replace keyword not present in make 3.81
     inreplace "Makefile", "undefine MK_ARCH", "unexport MK_ARCH"
@@ -41,3 +43,17 @@ class UBootTools < Formula
     system bin/"dumpimage", "-V"
   end
 end
+
+__END__
+--- a/tools/Makefile    2022-04-05 00:28:56.000000000 +0200
++++ b/tools/Makefile    2022-04-05 00:29:07.000000000 +0200
+@@ -241,9 +241,6 @@
+ hostprogs-$(CONFIG_ASN1_COMPILER)      += asn1_compiler
+ HOSTCFLAGS_asn1_compiler.o = -idirafter $(srctree)/include
+ 
+-HOSTLDLIBS_mkeficapsule += -lgnutls -luuid
+-hostprogs-$(CONFIG_TOOLS_MKEFICAPSULE) += mkeficapsule
+-
+ # We build some files with extra pedantic flags to try to minimize things
+ # that won't build on some weird host compiler -- though there are lots of
+ # exceptions for files that aren't complaint.


### PR DESCRIPTION
update to version 2022.04
resolves [u-boot-tools/mkimage is broken on MacOS (bigsur) due to ASLR mechanism #90278](https://github.com/Homebrew/homebrew-core/issues/90278)

disable mkeficapsule
- it depends on 'libuuid'
- macOS has only 'uuid.h'
- brew has 'ossp-uuid' with 'ossp/uuid.h'
- ubuntu needs 'uuid/uuid.h'
