### PR TITLE
QuestDB: fix source sha256 hash

### DIFF
--- a/Formula/questdb.rb
+++ b/Formula/questdb.rb
@@ -2,7 +2,7 @@ class Questdb < Formula
   desc "Time Series Database"
   homepage "https://questdb.io"
   url "https://github.com/questdb/questdb/releases/download/6.2.1/questdb-6.2.1-no-jre-bin.tar.gz"
-  sha256 "607d95346841846e015e6723af25b4047dc1acdf1912d0a259ffff15c314b93e"
+  sha256 "4c7411c5585c4a2d39994a28004dd0f2fa3fba2c8c42d01a8ac3777e1bcca02e"
   license "Apache-2.0"
 
   bottle do
@@ -18,6 +18,7 @@ class Questdb < Formula
     rm_rf "questdb.exe"
     libexec.install Dir["*"]
     (bin/"questdb").write_env_script libexec/"questdb.sh", Language::Java.overridable_java_home_env("11")
+    inreplace libexec/"questdb.sh", "/usr/local/var/questdb", var/"questdb"
   end
 
   plist_options manual: "questdb start"


### PR DESCRIPTION
The 6.2.1 formula has a wrong hash. As a result it fails when used
with `--build-from-source` flag. This PR fixes this. This is the failure:
```
==> Verifying checksum for '18f7f06c5dab0d85cf10c021b9f930aa99d06d801ebc9224b14d1764064af591--questdb-6.2.1-no-jre-bin.tar.gz'
Error: questdb: SHA256 mismatch
Expected: 607d95346841846e015e6723af25b4047dc1acdf1912d0a259ffff15c314b93e
  Actual: 4c7411c5585c4a2d39994a28004dd0f2fa3fba2c8c42d01a8ac3777e1bcca02e
```

The change also introduces inreplace to fix the installation
prefix to match the homebrew layout.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
I'm new to homebrew and the macos ecosystem in general. I wasn't sure whether the replacement should use `opt_prefix` or just `prefix`, any guidance is appreciated!