### PR TITLE
monkeysphere: Replace dead URIs

### DIFF
--- a/Formula/monkeysphere.rb
+++ b/Formula/monkeysphere.rb
@@ -1,11 +1,10 @@
 class Monkeysphere < Formula
   desc "Use the OpenPGP web of trust to verify ssh connections"
-  homepage "https://web.monkeysphere.info/"
+  homepage "https://tracker.debian.org/pkg/monkeysphere"
   url "https://deb.debian.org/debian/pool/main/m/monkeysphere/monkeysphere_0.44.orig.tar.gz"
   sha256 "6ac6979fa1a4a0332cbea39e408b9f981452d092ff2b14ed3549be94918707aa"
   license "GPL-3.0-or-later"
   revision 4
-  head "git://git.monkeysphere.info/monkeysphere"
 
   livecheck do
     url "https://deb.debian.org/debian/pool/main/m/monkeysphere/"


### PR DESCRIPTION
The `homepage` currently referenced in the formula points to a shady-looking
domain parking website (which, at the moment, also happens to have an expired
HTTPS certificate). Notably, the current `homepage` appears to have nothing
to do with monkeysphere. The closest thing I can find to a new homepage is the
debian tracker entry for the monkeysphere package.

Also, the repository referenced by `head` in the formula no longer exists, so
I have deleted that.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? (I actually used `brew reinstall --build-from-source <formula>`.)
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
