### PR TITLE
Remove unnecessary livecheck strategy calls

### DIFF
--- a/Formula/a52dec.rb
+++ b/Formula/a52dec.rb
@@ -7,7 +7,6 @@ class A52dec < Formula
 
   livecheck do
     url "https://liba52.sourceforge.io/downloads.html"
-    strategy :page_match
     regex(/href=.*?a52dec[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/abook.rb
+++ b/Formula/abook.rb
@@ -3,12 +3,11 @@ class Abook < Formula
   homepage "https://abook.sourceforge.io/"
   url "https://abook.sourceforge.io/devel/abook-0.6.1.tar.gz"
   sha256 "f0a90df8694fb34685ecdd45d97db28b88046c15c95e7b0700596028bd8bc0f9"
-  license "GPL-2.0"
+  license all_of: ["GPL-2.0-only", "GPL-2.0-or-later", "GPL-3.0-or-later", :public_domain, "X11"]
   head "https://git.code.sf.net/p/abook/git.git", branch: "master"
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/href=.*?abook[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/bcrypt.rb
+++ b/Formula/bcrypt.rb
@@ -6,8 +6,7 @@ class Bcrypt < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "http://bcrypt.sourceforge.net/"
-    strategy :page_match
+    url :homepage
     regex(/href=.*?bcrypt[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/foremost.rb
+++ b/Formula/foremost.rb
@@ -7,8 +7,7 @@ class Foremost < Formula
   revision 1
 
   livecheck do
-    url "http://foremost.sourceforge.net/"
-    strategy :page_match
+    url :homepage
     regex(/href=.*?foremost[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/potrace.rb
+++ b/Formula/potrace.rb
@@ -6,8 +6,7 @@ class Potrace < Formula
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "http://potrace.sourceforge.net/"
-    strategy :page_match
+    url :homepage
     regex(/href=.*?potrace[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR removes unnecessary `#strategy` calls in `livecheck` blocks, where the specified strategy is the same as the default strategy for the `url`. [I'm aiming to add a RuboCop for this after I've reworked the existing livecheck RuboCops to also apply to casks (not just formulae). At the moment, I'm catching these issues using a somewhat convoluted script and the challenge will be to convert the checks in the script to RuboCops in the future.]

This also updates a few SourceForge `url` strings to a `:homepage` symbol, to ensure that they stay aligned. The `livecheck` block URLs were originally added to avoid the redirection from sourceforge.io to sourceforge.net but I think it's maybe better to simply keep these URLs aligned.

Lastly, this updates the `abook` `license` from `"GPL-2.0"` to `all_of: ["GPL-2.0-only", "GPL-2.0-or-later", "GPL-3.0-or-later", :public_domain, "X11"]`. The `COPYING` file is GPLv2 and the `README` simply states that `abook` is released under GPL (referencing the `COPYING` file) but the source files that contain a license comment use a variety of licenses.