### PR TITLE
libindy 1.16.0 (new formula)

### DIFF
--- a/Formula/libindy.rb
+++ b/Formula/libindy.rb
@@ -1,8 +1,8 @@
 class Libindy < Formula
   desc "Indy-sdk for macOS including libindy and indy-cli"
   homepage "https://github.com/hyperledger/indy-sdk"
-  url "https://github.com/hyperledger/indy-sdk/archive/refs/tags/v1.16.0.tar.gz"
-  sha256 "63e42389cd53c66574b8af0979d6ff7acfb5ff0da7a9d5bf37c789ac99ca0dd4"
+  url "https://github.com/conanoc/indy-sdk/archive/refs/tags/v1.16.1.tar.gz"
+  sha256 "27fe05b8231fee5e36b63a76f516ad4bbe1a30a56dc7da701e749aa8479255aa"
   license "Apache-2.0"
 
   depends_on "autoconf" => :build

--- a/Formula/libindy.rb
+++ b/Formula/libindy.rb
@@ -1,0 +1,32 @@
+class Libindy < Formula
+  desc "Indy-sdk for macOS including libindy and indy-cli"
+  homepage "https://github.com/hyperledger/indy-sdk"
+  url "https://github.com/hyperledger/indy-sdk/archive/refs/tags/v1.16.0.tar.gz"
+  sha256 "63e42389cd53c66574b8af0979d6ff7acfb5ff0da7a9d5bf37c789ac99ca0dd4"
+  license "Apache-2.0"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "rust" => :build
+  depends_on "libsodium"
+  depends_on "openssl@1.1"
+  depends_on "zeromq"
+
+  def install
+    chdir "libindy" do
+      system "cargo", "build", "--release"
+    end
+    chdir "cli" do
+      ENV["LIBRARY_PATH"] = "../libindy/target/release"
+      system "cargo", "build", "--release"
+    end
+    lib.install "libindy/target/release/libindy.dylib"
+    bin.install "cli/target/release/indy-cli"
+  end
+
+  test do
+    system "indy-cli", "--help"
+  end
+end


### PR DESCRIPTION
Signed-off-by: conanoc <conanoc@gmail.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
brew audit --new libindy says:
```
  * 19: col 7: use "cargo", "install", *std_cargo_args
  * 23: col 7: use "cargo", "install", *std_cargo_args
Error: 2 problems in 1 formula detected
```
But, I can not use `cargo install`. `cargo build` is the only available command in libindy.