### PR TITLE
fontconfig: add python@3.9 as build dependency on Mojave and below

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -29,6 +29,7 @@ class Fontconfig < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "python@3.10" => :build if MacOS.version <= :high_sierra
   depends_on "freetype"
 
   uses_from_macos "gperf" => :build

--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -29,10 +29,10 @@ class Fontconfig < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build if MacOS.version <= :high_sierra
   depends_on "freetype"
 
   uses_from_macos "gperf" => :build
+  uses_from_macos "python" => :build, since: :catalina
   uses_from_macos "bzip2"
   uses_from_macos "expat"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)? 
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I find it magical that Homebrew's building environment does not catch such omission of dependency, and produces working bottles nonetheless… 

Anyhow, since I'm using High Sierra and need to build every upgrade myself, I caught this silly error. A simple `depends_on "python3"` resolved `configure`'s complaints of not finding python3. `brew audit` demands I follow the alias to `python@3.9`, and I obeyed.

One last thought: will this new dependency cause `fontconfig` to rebuild for every python 3.9 upgrade later on? I mean rebuilding python3.9 is too much overkill when all I want is upgrading something that depends on this inert program (whose 2018 bottle was _current_ until hours ago).

Edit: now only requires `python@3.10` with High Sierra and lower, since Apple provides python3 starting from Mojave and Linux distros usually do this too.

Edit: now uses `uses_from_macos` format which, unfortunately, requires `python@3.9` again until `python` links to python 3.10 someday. Also makes Mojave users use Homebrew's python because some use an older CLT that doesn't have python3.