### PR TITLE
qt@5: qtwebengine 5.15.9

### DIFF
--- a/Formula/qt@5.rb
+++ b/Formula/qt@5.rb
@@ -8,6 +8,7 @@ class QtAT5 < Formula
   mirror "https://mirrors.ocf.berkeley.edu/qt/archive/qt/5.15/5.15.3/single/qt-everywhere-opensource-src-5.15.3.tar.xz"
   sha256 "b7412734698a87f4a0ae20751bab32b1b07fdc351476ad8e35328dbe10efdedb"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "5ac5153ebd4c55455f4e66c8ff709a8f6e5eaa4585b771d3713ff4157533c535"
@@ -60,8 +61,8 @@ class QtAT5 < Formula
 
   resource "qtwebengine" do
     url "https://code.qt.io/qt/qtwebengine.git",
-        tag:      "v5.15.8-lts",
-        revision: "96e932d73057c3e705b849249fb02e1837b7576d"
+        tag:      "v5.15.9-lts",
+        revision: "4f570bd7add21725d66ac8396dcf21917c3a603f"
   end
 
   # Backport of https://code.qt.io/cgit/qt/qtbase.git/commit/src/plugins/platforms/cocoa?id=dece6f5840463ae2ddf927d65eb1b3680e34a547


### PR DESCRIPTION
Before merging this I'd like to fix the large amount of Cellar references which I believe have a knock on effect downstream. Though I don't really know the best way to do that.

```
$ grep -RIP 'Cellar/(?!qt@5)' /home/linuxbrew/.linuxbrew/opt/qt@5
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_XCB = /home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include /home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include /home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include /home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_XCB_ICCCM = /home/linuxbrew/.linuxbrew/Cellar/xcb-util-wm/0.4.1/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_XCB_IMAGE = /home/linuxbrew/.linuxbrew/Cellar/xcb-util-image/0.4.0/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_XCB_KEYSYMS = /home/linuxbrew/.linuxbrew/Cellar/xcb-util-keysyms/0.4.0/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_XCB_RENDERUTIL = /home/linuxbrew/.linuxbrew/Cellar/xcb-util-renderutil/0.3.9/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_XKBCOMMON = /home/linuxbrew/.linuxbrew/Cellar/libxkbcommon/1.4.0/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_XKBCOMMON_X11 = /home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include /home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include /home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include /home/linuxbrew/.linuxbrew/Cellar/libxkbcommon/1.4.0/include /home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_ATSPI = /home/linuxbrew/.linuxbrew/Cellar/libffi/3.4.2/include /home/linuxbrew/.linuxbrew/Cellar/dbus/1.14.0/include/dbus-1.0 /home/linuxbrew/.linuxbrew/Cellar/dbus/1.14.0/lib/dbus-1.0/include /home/linuxbrew/.linuxbrew/Cellar/pcre/8.45/include /home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/include /home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/include/glib-2.0 /home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib/glib-2.0/include /home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include /home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include /home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include /home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/include /home/linuxbrew/.linuxbrew/Cellar/libxext/1.3.4/include /home/linuxbrew/.linuxbrew/Cellar/libxfixes/6.0.0/include /home/linuxbrew/.linuxbrew/Cellar/libxi/1.8/include /home/linuxbrew/.linuxbrew/Cellar/libxtst/1.2.3/include /home/linuxbrew/.linuxbrew/Cellar/at-spi2-core/2.42.0/include/at-spi-2.0 /home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_OPENGL = /home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include /home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include /home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include /home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/include /home/linuxbrew/.linuxbrew/Cellar/libxext/1.3.4/include /home/linuxbrew/.linuxbrew/Cellar/libxfixes/6.0.0/include /home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include /home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include/libdrm /home/linuxbrew/.linuxbrew/Cellar/libxxf86vm/1.1.4/include /home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/include /home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_DRM = /home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include /home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include/libdrm
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_EGL = /home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include /home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include /home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include /home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/include /home/linuxbrew/.linuxbrew/Cellar/libxext/1.3.4/include /home/linuxbrew/.linuxbrew/Cellar/libxfixes/6.0.0/include /home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include /home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include/libdrm /home/linuxbrew/.linuxbrew/Cellar/libxxf86vm/1.1.4/include /home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/include /home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_GBM = /home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_XCB_XLIB = /home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_INCDIR_X11SM = /home/linuxbrew/.linuxbrew/Cellar/libice/1.0.10/include /home/linuxbrew/.linuxbrew/Cellar/libsm/1.2.3/include /home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_XCB = -L/home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/lib -lxcb
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_XCB_ICCCM = -L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-wm/0.4.1/lib -lxcb-icccm
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_XCB_IMAGE = -L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-image/0.4.0/lib -lxcb-image
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_XCB_KEYSYMS = -L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-keysyms/0.4.0/lib -lxcb-keysyms
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_XCB_RENDERUTIL = -L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-renderutil/0.3.9/lib -lxcb-render-util
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_XKBCOMMON = -L/home/linuxbrew/.linuxbrew/Cellar/libxkbcommon/1.4.0/lib -lxkbcommon
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_XKBCOMMON_X11 = -L/home/linuxbrew/.linuxbrew/Cellar/libxkbcommon/1.4.0/lib -lxkbcommon-x11 -lxkbcommon
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_ATSPI = -L/home/linuxbrew/.linuxbrew/Cellar/dbus/1.14.0/lib -L/home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib -L/home/linuxbrew/.linuxbrew/Cellar/at-spi2-core/2.42.0/lib -latspi -ldbus-1 -lglib-2.0
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_OPENGL = -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_DRM = -L/home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/lib -ldrm
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_EGL = -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lEGL
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_GBM = -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lgbm
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_XCB_XLIB = -L/home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/lib -lX11-xcb
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_gui_private.pri:QMAKE_LIBS_X11SM = -L/home/linuxbrew/.linuxbrew/Cellar/libice/1.0.10/lib -L/home/linuxbrew/.linuxbrew/Cellar/libsm/1.2.3/lib -lSM -lICE
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_multimedia_private.pri:QMAKE_INCDIR_PULSEAUDIO = /home/linuxbrew/.linuxbrew/Cellar/pcre/8.45/include /home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/include/glib-2.0 /home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib/glib-2.0/include /home/linuxbrew/.linuxbrew/Cellar/pulseaudio/14.2/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_multimedia_private.pri:QMAKE_LIBS_PULSEAUDIO = -L/home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib -L/home/linuxbrew/.linuxbrew/Cellar/pulseaudio/14.2/lib -lpulse-mainloop-glib -lpulse -lglib-2.0
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandcompositor_private.pri:QMAKE_INCDIR_WAYLAND_SERVER = /home/linuxbrew/.linuxbrew/Cellar/libffi/3.4.2/include /home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandcompositor_private.pri:QMAKE_INCDIR_WAYLAND_EGL = /home/linuxbrew/.linuxbrew/Cellar/libffi/3.4.2/include /home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandcompositor_private.pri:QMAKE_INCDIR_XCOMPOSITE = /home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include /home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include /home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include /home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/include /home/linuxbrew/.linuxbrew/Cellar/libxfixes/6.0.0/include /home/linuxbrew/.linuxbrew/Cellar/libxcomposite/0.4.5/include /home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandcompositor_private.pri:QMAKE_INCDIR_GLX = /home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include /home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include /home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include /home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/include /home/linuxbrew/.linuxbrew/Cellar/libxext/1.3.4/include /home/linuxbrew/.linuxbrew/Cellar/libxfixes/6.0.0/include /home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include /home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include/libdrm /home/linuxbrew/.linuxbrew/Cellar/libxxf86vm/1.1.4/include /home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/include /home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandcompositor_private.pri:QMAKE_LIBS_WAYLAND_SERVER = -L/home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/lib -lwayland-server
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandcompositor_private.pri:QMAKE_LIBS_WAYLAND_EGL = -L/home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/lib -lwayland-egl -lwayland-client
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandcompositor_private.pri:QMAKE_LIBS_XCOMPOSITE = -L/home/linuxbrew/.linuxbrew/Cellar/libxcomposite/0.4.5/lib -lXcomposite
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandcompositor_private.pri:QMAKE_LIBS_GLX = -L/home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/lib -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lX11 -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_core_private.pri:QMAKE_INCDIR_GLIB = /home/linuxbrew/.linuxbrew/Cellar/pcre/8.45/include /home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/include /home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/include/glib-2.0 /home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib/glib-2.0/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_core_private.pri:QMAKE_LIBS_GLIB = -L/home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib -lgthread-2.0 -lglib-2.0
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandclient_private.pri:QMAKE_INCDIR_WAYLAND_CLIENT = /home/linuxbrew/.linuxbrew/Cellar/libffi/3.4.2/include /home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandclient_private.pri:QMAKE_INCDIR_WAYLAND_EGL = /home/linuxbrew/.linuxbrew/Cellar/libffi/3.4.2/include /home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandclient_private.pri:QMAKE_INCDIR_XCOMPOSITE = /home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include /home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include /home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include /home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/include /home/linuxbrew/.linuxbrew/Cellar/libxfixes/6.0.0/include /home/linuxbrew/.linuxbrew/Cellar/libxcomposite/0.4.5/include /home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandclient_private.pri:QMAKE_INCDIR_GLX = /home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include /home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include /home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include /home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/include /home/linuxbrew/.linuxbrew/Cellar/libxext/1.3.4/include /home/linuxbrew/.linuxbrew/Cellar/libxfixes/6.0.0/include /home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include /home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include/libdrm /home/linuxbrew/.linuxbrew/Cellar/libxxf86vm/1.1.4/include /home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/include /home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandclient_private.pri:QMAKE_LIBS_WAYLAND_CLIENT = -L/home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/lib -lwayland-client
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandclient_private.pri:QMAKE_LIBS_WAYLAND_EGL = -L/home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/lib -lwayland-egl -lwayland-client
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandclient_private.pri:QMAKE_LIBS_XCOMPOSITE = -L/home/linuxbrew/.linuxbrew/Cellar/libxcomposite/0.4.5/lib -lXcomposite
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/modules/qt_lib_waylandclient_private.pri:QMAKE_LIBS_GLX = -L/home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/lib -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lX11 -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/qmodule.pri:QMAKE_LIBS_LIBUDEV = -L/home/linuxbrew/.linuxbrew/Cellar/systemd/250/lib -ludev
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/qmodule.pri:QMAKE_INCDIR_LIBUDEV = /home/linuxbrew/.linuxbrew/Cellar/systemd/250/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/qmodule.pri:QMAKE_LIBS_ZSTD = -L/home/linuxbrew/.linuxbrew/Cellar/zstd/1.5.2/lib -lzstd
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/qmodule.pri:QMAKE_INCDIR_ZSTD = /home/linuxbrew/.linuxbrew/Cellar/zstd/1.5.2/include
/home/linuxbrew/.linuxbrew/opt/qt@5/mkspecs/qmodule.pri:QT_HOST_CFLAGS_DBUS += -I/home/linuxbrew/.linuxbrew/Cellar/dbus/1.14.0/include/dbus-1.0 -I/home/linuxbrew/.linuxbrew/Cellar/dbus/1.14.0/lib/dbus-1.0/include
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5WaylandClient.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -lwayland-cursor -L/home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/lib -lwayland-client
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5WaylandClient.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-lwayland-cursor;-L/home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/lib;-lwayland-client;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5UiTools.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Widgets.so $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread $$[QT_INSTALL_LIBS]/libQt5Widgets.so $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5UiTools.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Widgets.so;$$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;$$[QT_INSTALL_LIBS]/libQt5Widgets.so;$$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5ServiceSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5DBus.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5ServiceSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5DBus.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5AccessibilitySupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5AccessibilitySupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5VirtualKeyboard.prl:QMAKE_PRL_LIBS = -L/home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/lib -lxcb -lxcb-xfixes $$[QT_INSTALL_LIBS]/libQt5Quick.so $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5QmlModels.so $$[QT_INSTALL_LIBS]/libQt5Qml.so $$[QT_INSTALL_LIBS]/libQt5Network.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5VirtualKeyboard.prl:QMAKE_PRL_LIBS_FOR_CMAKE = -L/home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/lib;-lxcb;-lxcb-xfixes;$$[QT_INSTALL_LIBS]/libQt5Quick.so;$$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5QmlModels.so;$$[QT_INSTALL_LIBS]/libQt5Qml.so;$$[QT_INSTALL_LIBS]/libQt5Network.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5XcbQpa.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5ServiceSupport.a -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib $$[QT_INSTALL_LIBS]/libQt5ThemeSupport.a $$[QT_INSTALL_LIBS]/libQt5FontDatabaseSupport.a $$[QT_INSTALL_LIBS]/libqtfreetype.a $$[QT_INSTALL_LIBS]/libqtlibpng.a $$[QT_INSTALL_LIBS]/libQt5XkbCommonSupport.a -L/home/linuxbrew/.linuxbrew/Cellar/libxkbcommon/1.4.0/lib $$[QT_INSTALL_LIBS]/libQt5LinuxAccessibilitySupport.a $$[QT_INSTALL_LIBS]/libQt5AccessibilitySupport.a -lGL $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5EdidSupport.a $$[QT_INSTALL_LIBS]/libQt5DBus.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/lib -lX11-xcb -L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-wm/0.4.1/lib -lxcb-icccm -L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-image/0.4.0/lib -lxcb-image -lxcb-shm -L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-keysyms/0.4.0/lib -lxcb-keysyms -lxcb-randr -L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-renderutil/0.3.9/lib -lxcb-render-util -lxcb-render -lxcb-shape -lxcb-sync -lxcb-xfixes -lxcb-xinerama -lxcb-xkb -lxcb-xinput -L/home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/lib -lxcb -lXext -lX11 -lm -L/home/linuxbrew/.linuxbrew/Cellar/libice/1.0.10/lib -L/home/linuxbrew/.linuxbrew/Cellar/libsm/1.2.3/lib -lSM -lICE -lxkbcommon-x11 -lxkbcommon -ldl
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5XcbQpa.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5ServiceSupport.a;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;$$[QT_INSTALL_LIBS]/libQt5ThemeSupport.a;$$[QT_INSTALL_LIBS]/libQt5FontDatabaseSupport.a;$$[QT_INSTALL_LIBS]/libqtfreetype.a;$$[QT_INSTALL_LIBS]/libqtlibpng.a;$$[QT_INSTALL_LIBS]/libQt5XkbCommonSupport.a;-L/home/linuxbrew/.linuxbrew/Cellar/libxkbcommon/1.4.0/lib;$$[QT_INSTALL_LIBS]/libQt5LinuxAccessibilitySupport.a;$$[QT_INSTALL_LIBS]/libQt5AccessibilitySupport.a;-lGL;$$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5EdidSupport.a;$$[QT_INSTALL_LIBS]/libQt5DBus.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/lib;-lX11-xcb;-L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-wm/0.4.1/lib;-lxcb-icccm;-L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-image/0.4.0/lib;-lxcb-image;-lxcb-shm;-L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-keysyms/0.4.0/lib;-lxcb-keysyms;-lxcb-randr;-L/home/linuxbrew/.linuxbrew/Cellar/xcb-util-renderutil/0.3.9/lib;-lxcb-render-util;-lxcb-render;-lxcb-shape;-lxcb-sync;-lxcb-xfixes;-lxcb-xinerama;-lxcb-xkb;-lxcb-xinput;-L/home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/lib;-lxcb;-lXext;-lX11;-lm;-L/home/linuxbrew/.linuxbrew/Cellar/libice/1.0.10/lib;-L/home/linuxbrew/.linuxbrew/Cellar/libsm/1.2.3/lib;-lSM;-lICE;-lxkbcommon-x11;-lxkbcommon;-ldl;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5OpenGLExtensions.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5OpenGLExtensions.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5InputSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5DeviceDiscoverySupport.a -L/home/linuxbrew/.linuxbrew/Cellar/systemd/250/lib -ludev $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL -L/home/linuxbrew/.linuxbrew/Cellar/systemd/250/lib -ludev
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5InputSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5DeviceDiscoverySupport.a;-L/home/linuxbrew/.linuxbrew/Cellar/systemd/250/lib;-ludev;$$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;-L/home/linuxbrew/.linuxbrew/Cellar/systemd/250/lib;-ludev;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5GlxSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -lXext -lX11 -lm -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5GlxSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-lXext;-lX11;-lm;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5EglFsKmsSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5EglFSDeviceIntegration.so $$[QT_INSTALL_LIBS]/libQt5EventDispatcherSupport.a -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -L/home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib -lgthread-2.0 -lglib-2.0 $$[QT_INSTALL_LIBS]/libQt5ServiceSupport.a $$[QT_INSTALL_LIBS]/libQt5ThemeSupport.a $$[QT_INSTALL_LIBS]/libQt5FontDatabaseSupport.a $$[QT_INSTALL_LIBS]/libqtfreetype.a $$[QT_INSTALL_LIBS]/libqtlibpng.a $$[QT_INSTALL_LIBS]/libQt5FbSupport.a $$[QT_INSTALL_LIBS]/libQt5EglSupport.a -lEGL -lXext -lX11 -lm $$[QT_INSTALL_LIBS]/libQt5InputSupport.a -L/home/linuxbrew/.linuxbrew/Cellar/systemd/250/lib $$[QT_INSTALL_LIBS]/libQt5PlatformCompositorSupport.a $$[QT_INSTALL_LIBS]/libQt5KmsSupport.a -L/home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/lib -lGL $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5DeviceDiscoverySupport.a -ludev $$[QT_INSTALL_LIBS]/libQt5EdidSupport.a $$[QT_INSTALL_LIBS]/libQt5DBus.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -ldrm -ldl
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5EglFsKmsSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5EglFSDeviceIntegration.so;$$[QT_INSTALL_LIBS]/libQt5EventDispatcherSupport.a;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-L/home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib;-lgthread-2.0;-lglib-2.0;$$[QT_INSTALL_LIBS]/libQt5ServiceSupport.a;$$[QT_INSTALL_LIBS]/libQt5ThemeSupport.a;$$[QT_INSTALL_LIBS]/libQt5FontDatabaseSupport.a;$$[QT_INSTALL_LIBS]/libqtfreetype.a;$$[QT_INSTALL_LIBS]/libqtlibpng.a;$$[QT_INSTALL_LIBS]/libQt5FbSupport.a;$$[QT_INSTALL_LIBS]/libQt5EglSupport.a;-lEGL;-lXext;-lX11;-lm;$$[QT_INSTALL_LIBS]/libQt5InputSupport.a;-L/home/linuxbrew/.linuxbrew/Cellar/systemd/250/lib;$$[QT_INSTALL_LIBS]/libQt5PlatformCompositorSupport.a;$$[QT_INSTALL_LIBS]/libQt5KmsSupport.a;-L/home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/lib;-lGL;$$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5DeviceDiscoverySupport.a;-ludev;$$[QT_INSTALL_LIBS]/libQt5EdidSupport.a;$$[QT_INSTALL_LIBS]/libQt5DBus.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-ldrm;-ldl;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5ThemeSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread $$[QT_INSTALL_LIBS]/libQt5DBus.so $$[QT_INSTALL_LIBS]/libQt5Core.so -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5ThemeSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;$$[QT_INSTALL_LIBS]/libQt5DBus.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5FbSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5FbSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5EglFSDeviceIntegration.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5EventDispatcherSupport.a -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -L/home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib -lgthread-2.0 -lglib-2.0 $$[QT_INSTALL_LIBS]/libQt5ServiceSupport.a $$[QT_INSTALL_LIBS]/libQt5ThemeSupport.a $$[QT_INSTALL_LIBS]/libQt5FontDatabaseSupport.a $$[QT_INSTALL_LIBS]/libqtfreetype.a $$[QT_INSTALL_LIBS]/libqtlibpng.a $$[QT_INSTALL_LIBS]/libQt5FbSupport.a $$[QT_INSTALL_LIBS]/libQt5EglSupport.a -lEGL -lXext -lX11 -lm $$[QT_INSTALL_LIBS]/libQt5InputSupport.a -L/home/linuxbrew/.linuxbrew/Cellar/systemd/250/lib $$[QT_INSTALL_LIBS]/libQt5PlatformCompositorSupport.a -lGL $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5DeviceDiscoverySupport.a -ludev $$[QT_INSTALL_LIBS]/libQt5DBus.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -ldl
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5EglFSDeviceIntegration.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5EventDispatcherSupport.a;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-L/home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib;-lgthread-2.0;-lglib-2.0;$$[QT_INSTALL_LIBS]/libQt5ServiceSupport.a;$$[QT_INSTALL_LIBS]/libQt5ThemeSupport.a;$$[QT_INSTALL_LIBS]/libQt5FontDatabaseSupport.a;$$[QT_INSTALL_LIBS]/libqtfreetype.a;$$[QT_INSTALL_LIBS]/libqtlibpng.a;$$[QT_INSTALL_LIBS]/libQt5FbSupport.a;$$[QT_INSTALL_LIBS]/libQt5EglSupport.a;-lEGL;-lXext;-lX11;-lm;$$[QT_INSTALL_LIBS]/libQt5InputSupport.a;-L/home/linuxbrew/.linuxbrew/Cellar/systemd/250/lib;$$[QT_INSTALL_LIBS]/libQt5PlatformCompositorSupport.a;-lGL;$$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5DeviceDiscoverySupport.a;-ludev;$$[QT_INSTALL_LIBS]/libQt5DBus.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-ldl;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5DeviceDiscoverySupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/systemd/250/lib -ludev
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5DeviceDiscoverySupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/systemd/250/lib;-ludev;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5FontDatabaseSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL $$[QT_INSTALL_LIBS]/libqtfreetype.a $$[QT_INSTALL_LIBS]/libqtlibpng.a -lpthread $$[QT_INSTALL_LIBS]/libQt5Core.so
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5FontDatabaseSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;$$[QT_INSTALL_LIBS]/libqtfreetype.a;$$[QT_INSTALL_LIBS]/libqtlibpng.a;-lpthread;$$[QT_INSTALL_LIBS]/libQt5Core.so;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake:set(_GL_INCDIRS "/home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include" "/home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include" "/home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include" "/home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/include" "/home/linuxbrew/.linuxbrew/Cellar/libxext/1.3.4/include" "/home/linuxbrew/.linuxbrew/Cellar/libxfixes/6.0.0/include" "/home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include" "/home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include/libdrm" "/home/linuxbrew/.linuxbrew/Cellar/libxxf86vm/1.1.4/include" "/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/include" "/home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include")
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake:_qt5gui_find_extra_libs(EGL "EGL" "" "/home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include;/home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include;/home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include;/home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/include;/home/linuxbrew/.linuxbrew/Cellar/libxext/1.3.4/include;/home/linuxbrew/.linuxbrew/Cellar/libxfixes/6.0.0/include;/home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include;/home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include/libdrm;/home/linuxbrew/.linuxbrew/Cellar/libxxf86vm/1.1.4/include;/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/include;/home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include")
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/cmake/Qt5Gui/Qt5GuiConfigExtras.cmake:_qt5gui_find_extra_libs(OPENGL "GL" "" "/home/linuxbrew/.linuxbrew/Cellar/libxau/1.0.9/include;/home/linuxbrew/.linuxbrew/Cellar/libxdmcp/1.1.3/include;/home/linuxbrew/.linuxbrew/Cellar/libxcb/1.14_2/include;/home/linuxbrew/.linuxbrew/Cellar/libx11/1.7.3.1/include;/home/linuxbrew/.linuxbrew/Cellar/libxext/1.3.4/include;/home/linuxbrew/.linuxbrew/Cellar/libxfixes/6.0.0/include;/home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include;/home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/include/libdrm;/home/linuxbrew/.linuxbrew/Cellar/libxxf86vm/1.1.4/include;/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/include;/home/linuxbrew/.linuxbrew/Cellar/xorgproto/2021.5/include")
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5EglSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -ldl -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lEGL -lGL -lXext -lX11 -lm
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5EglSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-ldl;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lEGL;-lGL;-lXext;-lX11;-lm;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5KmsSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/lib -ldrm -ldl -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5KmsSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/libdrm/2.4.110/lib;-ldrm;-ldl;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5WaylandCompositor.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Quick.so $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5QmlModels.so $$[QT_INSTALL_LIBS]/libQt5Qml.so $$[QT_INSTALL_LIBS]/libQt5Network.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/lib -lwayland-server -L/home/linuxbrew/.linuxbrew/Cellar/libxkbcommon/1.4.0/lib -lxkbcommon
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5WaylandCompositor.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Quick.so;$$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5QmlModels.so;$$[QT_INSTALL_LIBS]/libQt5Qml.so;$$[QT_INSTALL_LIBS]/libQt5Network.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/wayland/1.20.0/lib;-lwayland-server;-L/home/linuxbrew/.linuxbrew/Cellar/libxkbcommon/1.4.0/lib;-lxkbcommon;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5LinuxAccessibilitySupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5AccessibilitySupport.a -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL $$[QT_INSTALL_LIBS]/libQt5DBus.so $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5LinuxAccessibilitySupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5AccessibilitySupport.a;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;$$[QT_INSTALL_LIBS]/libQt5DBus.so;$$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/pkgconfig/Qt5UiTools.pc:Libs.private: /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.3/lib/libQt5Widgets.so /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.3/lib/libQt5Gui.so /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.3/lib/libQt5Core.so -lpthread /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.3/lib/libQt5Widgets.so /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.3/lib/libQt5Gui.so /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.3/lib/libQt5Core.so -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL   
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/pkgconfig/Qt5OpenGLExtensions.pc:Libs.private: /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.3/lib/libQt5Gui.so /home/linuxbrew/.linuxbrew/Cellar/qt@5/5.15.3/lib/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL   
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5XkbCommonSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/libxkbcommon/1.4.0/lib -lxkbcommon -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5XkbCommonSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/libxkbcommon/1.4.0/lib;-lxkbcommon;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5EventDispatcherSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL -L/home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib -lgthread-2.0 -lglib-2.0
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5EventDispatcherSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;-L/home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib;-lgthread-2.0;-lglib-2.0;;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5MultimediaQuick.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Quick.so $$[QT_INSTALL_LIBS]/libQt5Multimedia.so $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5QmlModels.so $$[QT_INSTALL_LIBS]/libQt5Qml.so $$[QT_INSTALL_LIBS]/libQt5Network.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib -L/home/linuxbrew/.linuxbrew/Cellar/pulseaudio/14.2/lib -lpulse-mainloop-glib -lpulse -lglib-2.0
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5MultimediaQuick.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Quick.so;$$[QT_INSTALL_LIBS]/libQt5Multimedia.so;$$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5QmlModels.so;$$[QT_INSTALL_LIBS]/libQt5Qml.so;$$[QT_INSTALL_LIBS]/libQt5Network.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/glib/2.70.4/lib;-L/home/linuxbrew/.linuxbrew/Cellar/pulseaudio/14.2/lib;-lpulse-mainloop-glib;-lpulse;-lglib-2.0;
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5PlatformCompositorSupport.prl:QMAKE_PRL_LIBS = $$[QT_INSTALL_LIBS]/libQt5Gui.so $$[QT_INSTALL_LIBS]/libQt5Core.so -lpthread -L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib -lGL
/home/linuxbrew/.linuxbrew/opt/qt@5/lib/libQt5PlatformCompositorSupport.prl:QMAKE_PRL_LIBS_FOR_CMAKE = $$[QT_INSTALL_LIBS]/libQt5Gui.so;$$[QT_INSTALL_LIBS]/libQt5Core.so;-lpthread;-L/home/linuxbrew/.linuxbrew/Cellar/mesa/22.0.0/lib;-lGL;;
```