### PR TITLE
subliminal: deprecate

### DIFF
--- a/Formula/subliminal.rb
+++ b/Formula/subliminal.rb
@@ -18,6 +18,9 @@ class Subliminal < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1840458efc8a0b046a0b45ed8a223c02a94bb47848b292e89d9013e28ee093dd"
   end
 
+  # https://github.com/Diaoul/subliminal/issues/1046
+  deprecate! date: "2022-04-07", because: :unmaintained
+
   depends_on "python@3.9"
 
   resource "appdirs" do


### PR DESCRIPTION
No more activity since a few months.
No release since 2020
See https://github.com/Diaoul/subliminal/issues/1046

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
