### PR TITLE
nvs 1.6.1 (new formula)

### DIFF
--- a/Formula/nvs.rb
+++ b/Formula/nvs.rb
@@ -1,0 +1,61 @@
+class Nvs < Formula
+  desc "Cross-platform tool for switching between versions and forks of Node.js"
+  homepage "https://github.com/jasongin/nvs"
+  url "https://github.com/jasongin/nvs/archive/refs/tags/v1.6.1.tar.gz"
+  sha256 "2259610ffc1700d0dbf4586f76377981b6f73025c1a10775dd2ee04e3cbb6210"
+  license "MIT"
+
+  def install
+    prefix.install "nvs.sh", "package.json", "defaults.json", "deps", "lib"
+  end
+
+  def caveats
+    <<~EOS
+      Please note that upstream has asked us to make explicit managing
+      nvm via Homebrew is unsupported by them and you should check any
+      problems against the standard nvm install method prior to reporting.
+
+      Add the following to #{shell_profile} or your desired shell
+      configuration file:
+
+        export NVS_HOME="$HOME/.nvs"
+        NVS_ROOT=#{opt_prefix}
+        [ -s "$NVS_ROOT/nvs.sh" ] && . "$NVS_ROOT/nvs.sh"
+
+      You can set $NVS_HOME to any location, but leaving it unchanged from
+      #{prefix} will destroy any nvs-installed Node installations
+      upon upgrade/reinstall.
+
+      Type `nvs help` for further information.
+    EOS
+  end
+
+  test do
+    # Install bootstrapping Node.js
+    system "NVS_HOME=$(pwd) \. #{prefix}/nvs.sh install"
+
+    # Checking path for a non-existent Node.js version/alias should report errors
+    output = pipe_output("NVS_HOME=$(pwd) \. #{prefix}/nvs.sh && nvs which homebrewtest 2>&1")
+    refute_match(/No such file or directory/, output)
+    refute_match(/nvs: command not found/, output)
+    assert_match "Specified version not found.\nTo add this version now: nvs add null", output
+
+    # Adding a non-existent Node.js version should report errors
+    output = pipe_output("NVS_HOME=$(pwd) \. #{prefix}/nvs.sh && nvs add homebrewtest 2>&1")
+    refute_match(/No such file or directory/, output)
+    refute_match(/nvs: command not found/, output)
+    assert_match "Version homebrewtest not found in remote: node", output
+
+    # Removing a non-existent Node.js version/alias should report errors
+    output = pipe_output("NVS_HOME=$(pwd) \. #{prefix}/nvs.sh && nvs rm homebrewtest 2>&1")
+    refute_match(/No such file or directory/, output)
+    refute_match(/nvs: command not found/, output)
+    assert_match "Specify a semantic version.", output
+
+    # Adding a Node.js version 16.14.2 should succeed
+    output = pipe_output("NVS_HOME=$(pwd) \. #{prefix}/nvs.sh && nvs add v16.14.2 2>/dev/null")
+    refute_match(/No such file or directory/, output)
+    refute_match(/nvs: command not found/, output)
+    assert_match "Added at: ~/node/16.14.2", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The formula is failing `brew audit --new nvs` with the following warning:
```
Installing non-libraries to "lib" is discouraged.
```

However, `brew audit --strict --online nvs` passes.

The package uses Node.js javascript libraries that are expected to be in `./lib`, so it is impossible to resolve unless placing the directory structure in other locations. Open to suggestions if you have better solutions to avoid the warning. 

Another caveat is that the package will install a bootstrapping Node.js in `$NVS_HOME` if it isn't already installed. This is unavoidable behavior and cannot be addressed with adding `node` to dependencies. 