### PR TITLE
duo_unix: remove livecheck

### DIFF
--- a/Formula/duo_unix.rb
+++ b/Formula/duo_unix.rb
@@ -5,10 +5,6 @@ class DuoUnix < Formula
   sha256 "a4479f893e036f38a5809d71ce47f69118f6ef61822cc1c66afccf143c5d71f8"
   license "GPL-2.0-or-later"
 
-  livecheck do
-    url "https://github.com/duosecurity/duo_unix.git"
-  end
-
   bottle do
     sha256 arm64_monterey: "d0a13ed5c65f4f57bde81d5145ade4c2940136462b5a0b4f3f43dced52966290"
     sha256 arm64_big_sur:  "4b7eebf362ed0e9bd22ee9137d1b0effeda2e1cd21d9bdceedd71e7ee99bd0c9"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the `stable` URL for `duo_unix`, using the `Git` strategy to identify versions from Git tags. The `stable` URL is processed into the Git URL used in the `livecheck` block, so the existing `livecheck` block isn't necessary. As such, this PR removes the `livecheck` block and simply relies on the default check for the time being.

For what it's worth, I'll be adding a RuboCop to surface this type of issue in the future (after I finish expanding support for existing livecheck RuboCops to casks).