### PR TITLE
mcap 0.0.6 (new formula)

### DIFF
--- a/Formula/mcap.rb
+++ b/Formula/mcap.rb
@@ -22,11 +22,10 @@ class Mcap < Formula
 
   test do
     resource("testdata").stage do
-      assert_equal File.binread("OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap", 8), "\x89MCAP0\r\n".b
-      assert_equal "v#{version}", shell_output("#{bin}/mcap version").strip
+      assert_equal "v#{version}", pipe_output("#{bin}/mcap version").strip
 
-      assert_equal "2 example [Example] [1 2 3 7 25 0 0 0 0 0]...",
-        shell_output("#{bin}/mcap cat OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap").strip
+      assert_equal "2 example [Example] [1 2 3 0 0 0 102 111 111 3]...",
+        shell_output("cat OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap | #{bin}/mcap cat").strip
 
       expected_info = <<~EOF
         library:

--- a/Formula/mcap.rb
+++ b/Formula/mcap.rb
@@ -22,6 +22,7 @@ class Mcap < Formula
 
   test do
     resource("testdata").stage do
+      assert_equal File.binread("OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap", 8), "\x89MCAP0\r\n".b
       assert_equal "v#{version}", shell_output("#{bin}/mcap version").strip
 
       assert_equal "2 example [Example] [1 2 3 7 25 0 0 0 0 0]...",

--- a/Formula/mcap.rb
+++ b/Formula/mcap.rb
@@ -1,0 +1,47 @@
+class Mcap < Formula
+  desc "Serialization-agnostic container file format for pub/sub messages"
+  homepage "https://mcap.dev"
+  url "https://github.com/foxglove/mcap/archive/refs/tags/releases/mcap-cli/v0.0.5.tar.gz"
+  sha256 "165ab4d47ca893a92f87829a1bf8dc1aa877e44dba3139d09c8552e04855e464"
+  license "Apache-2.0"
+  head "https://github.com/foxglove/mcap.git", branch: "main"
+
+  depends_on "go" => :build
+
+  resource "testdata" do
+    url "https://media.githubusercontent.com/media/foxglove/mcap/releases/mcap-cli/v0.0.5/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap"
+    sha256 "9db644f7fad2a256b891946a011fb23127b95d67dc03551b78224aa6cad8c5db"
+  end
+
+  def install
+    cd "go/cli/mcap" do
+      system "make", "build", "VERSION=v#{version}"
+      bin.install "bin/mcap"
+    end
+  end
+
+  test do
+    resource("testdata").stage do
+      assert_equal "v#{version}", shell_output("#{bin}/mcap version").strip
+
+      assert_equal "2 example [Example] [1 2 3 7 25 0 0 0 0 0]...",
+        shell_output("#{bin}/mcap cat OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap").strip
+
+      expected_info = <<~EOF
+        library:
+        profile:
+        messages: 1
+        duration: 0s
+        start: 0.000
+        end: 0.000
+        compression:
+        	: [1/1 chunks] (0.00%)
+        channels:
+          	(1) example  1 msgs (+Inf Hz)   : Example [c]
+        attachments: 0
+      EOF
+      assert_equal expected_info.lines.map(&:strip),
+        shell_output("#{bin}/mcap info OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap").lines.map(&:strip)
+    end
+  end
+end

--- a/Formula/mcap.rb
+++ b/Formula/mcap.rb
@@ -8,7 +8,7 @@ class Mcap < Formula
 
   depends_on "go" => :build
 
-  resource "testdata" do
+  resource "homebrew-testdata" do
     url "https://media.githubusercontent.com/media/foxglove/mcap/releases/mcap-cli/v0.0.6/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap"
     sha256 "9db644f7fad2a256b891946a011fb23127b95d67dc03551b78224aa6cad8c5db"
   end
@@ -21,11 +21,11 @@ class Mcap < Formula
   end
 
   test do
-    resource("testdata").stage do
-      assert_equal "v#{version}", pipe_output("#{bin}/mcap version").strip
+    assert_equal "v#{version}", pipe_output("#{bin}/mcap version").strip
 
+    resource("homebrew-testdata").stage do
       assert_equal "2 example [Example] [1 2 3]",
-        shell_output("cat OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap | #{bin}/mcap cat").strip
+      pipe_output("#{bin}/mcap cat", File.read("OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap")).strip
 
       expected_info = <<~EOF
         library:

--- a/Formula/mcap.rb
+++ b/Formula/mcap.rb
@@ -1,15 +1,15 @@
 class Mcap < Formula
   desc "Serialization-agnostic container file format for pub/sub messages"
   homepage "https://mcap.dev"
-  url "https://github.com/foxglove/mcap/archive/refs/tags/releases/mcap-cli/v0.0.5.tar.gz"
-  sha256 "165ab4d47ca893a92f87829a1bf8dc1aa877e44dba3139d09c8552e04855e464"
+  url "https://github.com/foxglove/mcap/archive/refs/tags/releases/mcap-cli/v0.0.6.tar.gz"
+  sha256 "f2adc1a2c1f81d4c5f5b684829013dcdf28f24f15ce34e4a72139ee01355d93a"
   license "Apache-2.0"
   head "https://github.com/foxglove/mcap.git", branch: "main"
 
   depends_on "go" => :build
 
   resource "testdata" do
-    url "https://media.githubusercontent.com/media/foxglove/mcap/releases/mcap-cli/v0.0.5/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap"
+    url "https://media.githubusercontent.com/media/foxglove/mcap/releases/mcap-cli/v0.0.6/tests/conformance/data/OneMessage/OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap"
     sha256 "9db644f7fad2a256b891946a011fb23127b95d67dc03551b78224aa6cad8c5db"
   end
 
@@ -24,7 +24,7 @@ class Mcap < Formula
     resource("testdata").stage do
       assert_equal "v#{version}", pipe_output("#{bin}/mcap version").strip
 
-      assert_equal "2 example [Example] [1 2 3 0 0 0 102 111 111 3]...",
+      assert_equal "2 example [Example] [1 2 3]",
         shell_output("cat OneMessage-ch-chx-mx-pad-rch-rsh-st-sum.mcap | #{bin}/mcap cat").strip
 
       expected_info = <<~EOF
@@ -37,7 +37,7 @@ class Mcap < Formula
         compression:
         	: [1/1 chunks] (0.00%)
         channels:
-          	(1) example  1 msgs (+Inf Hz)   : Example [c]
+          	(1) example  1 msgs (0.00 Hz)   : Example [c]
         attachments: 0
       EOF
       assert_equal expected_info.lines.map(&:strip),


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds a new formula for the [MCAP](https://github.com/foxglove/mcap) project's CLI tool. MCAP is a modular, performant, and serialization-agnostic container file format for pub/sub messages, primarily intended for use in robotics applications.

MCAP also has libraries available for several languages (Go, C++, Python, TypeScript, Swift) but this formula is for the CLI tool only.