### PR TITLE
camlp5: update livecheck

### DIFF
--- a/Formula/camlp5.rb
+++ b/Formula/camlp5.rb
@@ -7,8 +7,8 @@ class Camlp5 < Formula
   head "https://github.com/camlp5/camlp5.git", branch: "master"
 
   livecheck do
-    url :homepage
-    regex(%r{The current distributed version is <b>v?(\d+(?:\.\d+)+)</b>}i)
+    url :stable
+    regex(/^rel[._-]?v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `camlp5` checks the homepage and matches the version from some specific text but this only provides the latest major/minor version (e.g., 8.00), not patch releases (e.g., 8.00.03). As a result, livecheck returns 8.00 as the latest version instead of the 8.00.03 version used in the formula.

This PR addresses the issue by updating the `livecheck` block to use the `stable` URL to check the Git tags (using the `Git` strategy), along with an appropriate regex. Besides that, this approach also aligns the check with the `stable` source, which is generally preferable.