### PR TITLE
ghostscript 9.56.1

### DIFF
--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -1,15 +1,16 @@
 class Ghostscript < Formula
   desc "Interpreter for PostScript and PDF"
   homepage "https://www.ghostscript.com/"
-  url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9550/ghostpdl-9.55.0.tar.gz"
-  sha256 "b73cdfcb7b1c2a305748d23b00a765bcba48310564940b1eff1457f19f898172"
+  url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9561/ghostpdl-9.56.1.tar.xz"
+  sha256 "05e64c19853e475290fd608a415289dc21892c4d08ee9086138284b6addcb299"
   license "AGPL-3.0-or-later"
 
   # We check the tags from the `head` repository because the GitHub tags are
   # formatted ambiguously, like `gs9533` (corresponding to version 9.53.3).
   livecheck do
-    url :head
-    regex(/^ghostpdl[._-]v?(\d+(?:\.\d+)+)$/i)
+    url "https://github.com/ArtifexSoftware/ghostpdl-downloads"
+    strategy :page_match
+    regex(/^ghostpdl(?:\s)?v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do
@@ -24,7 +25,7 @@ class Ghostscript < Formula
 
   head do
     # Can't use shallow clone. Doing so = fatal errors.
-    url "https://git.ghostscript.com/ghostpdl.git"
+    url "https://git.ghostscript.com/ghostpdl.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -55,11 +56,6 @@ class Ghostscript < Formula
   resource "fonts" do
     url "https://downloads.sourceforge.net/project/gs-fonts/gs-fonts/8.11%20%28base%2035%2C%20GPL%29/ghostscript-fonts-std-8.11.tar.gz"
     sha256 "0eb6f356119f2e49b2563210852e17f57f9dcc5755f350a69a46a0d641a0c401"
-  end
-
-  patch do
-    url "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=830afae5454dea3bff903869d82022306890a96c"
-    sha256 "9c282e3f732b5c182ab761e187850d9f4c29d938a93e3785d9cb6ced13111d6c"
   end
 
   def install

--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -8,9 +8,9 @@ class Ghostscript < Formula
   # We check the tags from the `head` repository because the GitHub tags are
   # formatted ambiguously, like `gs9533` (corresponding to version 9.53.3).
   livecheck do
-    url "https://github.com/ArtifexSoftware/ghostpdl-downloads"
-    strategy :page_match
-    regex(/^ghostpdl(?:\s)?v?(\d+(?:\.\d+)+)$/i)
+    url :stable
+    regex(/href=.*?ghostpdl[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -4,6 +4,7 @@ class Imagemagick < Formula
   url "https://www.imagemagick.org/download/releases/ImageMagick-7.1.0-29.tar.xz"
   sha256 "a89df63da5ec823ae77049d747bf6b370bc867a06659b410f42652e5773fc62c"
   license "ImageMagick"
+  revision 1
   head "https://github.com/ImageMagick/ImageMagick.git", branch: "main"
 
   livecheck do

--- a/Formula/imagemagick@6.rb
+++ b/Formula/imagemagick@6.rb
@@ -4,6 +4,7 @@ class ImagemagickAT6 < Formula
   url "https://www.imagemagick.org/download/releases/ImageMagick-6.9.12-44.tar.xz"
   sha256 "2fa4a31d239cb5e37c544469570bfa17f99af6fc7322765a4d8e992ec97d2d8d"
   license "ImageMagick"
+  revision 1
   head "https://github.com/imagemagick/imagemagick6.git", branch: "main"
 
   livecheck do

--- a/Formula/libspectre.rb
+++ b/Formula/libspectre.rb
@@ -4,6 +4,7 @@ class Libspectre < Formula
   url "https://libspectre.freedesktop.org/releases/libspectre-0.2.10.tar.gz"
   sha256 "cf60b2a80f6bfc9a6b110e18f08309040ceaa755210bf94c465a969da7524d07"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://libspectre.freedesktop.org/releases/"

--- a/Formula/pqiv.rb
+++ b/Formula/pqiv.rb
@@ -4,7 +4,7 @@ class Pqiv < Formula
   url "https://github.com/phillipberndt/pqiv/archive/2.12.tar.gz"
   sha256 "1538128c88a70bbad2b83fbde327d83e4df9512a2fb560eaf5eaf1d8df99dbe5"
   license "GPL-3.0"
-  revision 3
+  revision 4
   head "https://github.com/phillipberndt/pqiv.git", branch: "master"
 
   bottle do

--- a/Formula/xfig.rb
+++ b/Formula/xfig.rb
@@ -4,7 +4,7 @@ class Xfig < Formula
   url "https://downloads.sourceforge.net/mcj/xfig-3.2.8b.tar.xz"
   sha256 "b2cc8181cfb356f6b75cc28771970447f69aba1d728a2dac0e0bcf1aea7acd3a"
   license "MIT"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable


### PR DESCRIPTION
- ghostscript 9.56.1
- xfig: revision bump (ghostscript 9.56.1)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Old livecheck reports 9.56.0, so I tried to use :page_match on github repo readme with no luck for now.