### PR TITLE
Remove obsolete SDKROOT fix

### DIFF
--- a/Formula/ansible@2.9.rb
+++ b/Formula/ansible@2.9.rb
@@ -572,11 +572,6 @@ class AnsibleAT29 < Formula
   def install
     ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin"
 
-    if OS.mac? && (MacOS.version <= :sierra)
-      # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
-      ENV["SDKROOT"] = MacOS.sdk_path
-    end
-
     virtualenv_install_with_resources
 
     man1.install Dir["docs/man/man1/*.1"]

--- a/Formula/aws-google-auth.rb
+++ b/Formula/aws-google-auth.rb
@@ -178,8 +178,6 @@ class AwsGoogleAuth < Formula
   end
 
   def install
-    # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
     virtualenv_install_with_resources
   end
 

--- a/Formula/bzt.rb
+++ b/Formula/bzt.rb
@@ -193,8 +193,6 @@ class Bzt < Formula
   end
 
   def install
-    # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
     virtualenv_install_with_resources
   end
 

--- a/Formula/dnsdist.rb
+++ b/Formula/dnsdist.rb
@@ -32,9 +32,6 @@ class Dnsdist < Formula
   uses_from_macos "libedit"
 
   def install
-    # error: unknown type name 'mach_port_t'
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
-
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",

--- a/Formula/gperftools.rb
+++ b/Formula/gperftools.rb
@@ -48,9 +48,6 @@ class Gperftools < Formula
   end
 
   def install
-    # Fix "error: unknown type name 'mach_port_t'"
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
-
     ENV.append_to_cflags "-D_XOPEN_SOURCE" if OS.mac?
 
     system "autoreconf", "-fiv" if build.head?

--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -68,11 +68,6 @@ class Php < Formula
   end
 
   def install
-    if OS.mac? && (MacOS.version == :el_capitan || MacOS.version == :sierra)
-      # Ensure that libxml2 will be detected correctly in older MacOS
-      ENV["SDKROOT"] = MacOS.sdk_path
-    end
-
     # buildconf required due to system library linking bug patch
     system "./buildconf", "--force"
 

--- a/Formula/php@7.4.rb
+++ b/Formula/php@7.4.rb
@@ -66,11 +66,6 @@ class PhpAT74 < Formula
   end
 
   def install
-    if OS.mac? && (MacOS.version == :el_capitan || MacOS.version == :sierra)
-      # Ensure that libxml2 will be detected correctly in older MacOS
-      ENV["SDKROOT"] = MacOS.sdk_path
-    end
-
     # buildconf required due to system library linking bug patch
     system "./buildconf", "--force"
 

--- a/Formula/php@8.0.rb
+++ b/Formula/php@8.0.rb
@@ -65,11 +65,6 @@ class PhpAT80 < Formula
   end
 
   def install
-    if OS.mac? && (MacOS.version == :el_capitan || MacOS.version == :sierra)
-      # Ensure that libxml2 will be detected correctly in older MacOS
-      ENV["SDKROOT"] = MacOS.sdk_path
-    end
-
     # buildconf required due to system library linking bug patch
     system "./buildconf", "--force"
 

--- a/Formula/recon-ng.rb
+++ b/Formula/recon-ng.rb
@@ -5,7 +5,7 @@ class ReconNg < Formula
   homepage "https://github.com/lanmaster53/recon-ng"
   url "https://github.com/lanmaster53/recon-ng/archive/v5.1.2.tar.gz"
   sha256 "18d05030b994c9b37f624628251d3376d590f3d1eec155f67aca88fa5f3490cc"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
   revision 1
 
   bottle do
@@ -183,9 +183,6 @@ class ReconNg < Formula
   end
 
   def install
-    # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
-
     libexec.install Dir["*"]
     venv = virtualenv_create(libexec, "python3")
     venv.pip_install resources

--- a/Formula/snownews.rb
+++ b/Formula/snownews.rb
@@ -31,10 +31,6 @@ class Snownews < Formula
   end
 
   def install
-    # Fix file not found errors for /usr/lib/system/libsystem_symptoms.dylib and
-    # /usr/lib/system/libsystem_darwin.dylib on 10.11 and 10.12, respectively
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
-
     system "./configure", "--prefix=#{prefix}"
 
     # Must supply -lz because configure relies on "xml2-config --libs"

--- a/Formula/woob.rb
+++ b/Formula/woob.rb
@@ -102,8 +102,6 @@ class Woob < Formula
   end
 
   def install
-    # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
     virtualenv_install_with_resources
 
     xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"

--- a/Formula/yle-dl.rb
+++ b/Formula/yle-dl.rb
@@ -76,9 +76,6 @@ class YleDl < Formula
   end
 
   def install
-    # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
-
     xy = Language::Python.major_minor_version "python3"
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python#{xy}/site-packages"
     (resources - [resource("AdobeHDS.php")]).each do |r|


### PR DESCRIPTION
Remove instances of setting SDKROOT where it's no longer required to build formulae [on 10.12 and earlier](https://github.com/Homebrew/brew/pull/13098). At some point between version 4.5.0 and 4.6.3 the `lxml` package was updated such that it no longer causes the original issue, and the other formulae have been similarly updated. 