### PR TITLE
restic 0.13.1

### DIFF
--- a/Formula/restic.rb
+++ b/Formula/restic.rb
@@ -1,8 +1,8 @@
 class Restic < Formula
   desc "Fast, efficient and secure backup program"
   homepage "https://restic.net/"
-  url "https://github.com/restic/restic/archive/v0.13.0.tar.gz"
-  sha256 "b3c09137b462548f44d764f98909534bef6e85fe029d4daf60545642cdefd3dd"
+  url "https://github.com/restic/restic/archive/v0.13.1.tar.gz"
+  sha256 "8430f80dc17b98fd78aca6f7d635bf12a486687677e15989a891ff4f6d8490a9"
   license "BSD-2-Clause"
   head "https://github.com/restic/restic.git", branch: "master"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 23,855,387 bytes
- formula fetch time: 2.5 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.