### PR TITLE
flyctl: add livecheck

### DIFF
--- a/Formula/flyctl.rb
+++ b/Formula/flyctl.rb
@@ -7,6 +7,11 @@ class Flyctl < Formula
   license "Apache-2.0"
   head "https://github.com/superfly/flyctl.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "fb870802df5acf376c8e63e0cf0204d145ccf1ac6346cd666f508ff1fac1e11f"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "fb870802df5acf376c8e63e0cf0204d145ccf1ac6346cd666f508ff1fac1e11f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `flyctl` from the `stable` URL but this is erroneously giving `8519` as the newest version (from a one-off `8519` tag) instead of `0.0.316`. Besides that, livecheck is also picking up pre-release tags (e.g., `0.0.317-pre-1`) because `pre` isn't part of livecheck's `UNSTABLE_VERSION_KEYWORDS` (only `prerelease` and `preview`) that are used to filter out unstable versions when a `livecheck` block isn't used.

This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which avoids unwanted tags in the repository and restricts matching to stable versions, resolving both issues.