### PR TITLE
yarn: fix test on Linux

### DIFF
--- a/Formula/yarn.rb
+++ b/Formula/yarn.rb
@@ -38,6 +38,6 @@ class Yarn < Formula
     (testpath/"package.json").write('{"name": "test"}')
     system bin/"yarn", "add", "jquery"
     # macOS specific package
-    system bin/"yarn", "add", "fsevents", "--build-from-source=true"
+    system bin/"yarn", "add", "fsevents", "--build-from-source=true" if OS.mac?
   end
 end


### PR DESCRIPTION
Only install the macOS specific package on macOS.