### PR TITLE
kmod: update homepage

### DIFF
--- a/Formula/kmod.rb
+++ b/Formula/kmod.rb
@@ -1,6 +1,6 @@
 class Kmod < Formula
   desc "Linux kernel module handling"
-  homepage "https://git.kernel.org/?p=utils/kernel/kmod/kmod.git"
+  homepage "https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
   url "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-29.tar.xz"
   sha256 "0b80eea7aa184ac6fd20cafa2a1fdf290ffecc70869a797079e2cc5c6225a52a"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` for `kmod` redirects from https://git.kernel.org/?p=utils/kernel/kmod/kmod.git to https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git, so this PR updates the URL accordingly. livecheck's `Git` strategy was giving a `fatal: repository 'https://git.kernel.org/?p=utils/kernel/kmod/kmod.git/' not found` error and this change fixes the issue.