### PR TITLE
grafana-agent: update deprecated flags in test

### DIFF
--- a/Formula/grafana-agent.rb
+++ b/Formula/grafana-agent.rb
@@ -69,7 +69,7 @@ class GrafanaAgent < Formula
 
     fork do
       exec bin/"grafana-agent", "-config.file=#{testpath}/grafana-agent.yaml",
-        "-prometheus.wal-directory=#{testpath}/wal"
+        "-metrics.wal-directory=#{testpath}/wal"
     end
     sleep 10
 


### PR DESCRIPTION
This updates deprecated/removed flags in the Grafana Agent which are used during the formula test.

See https://github.com/grafana/agent/pull/1540 for more info.