### PR TITLE
python-tabulate: migrate to Python@3.10

### DIFF
--- a/Formula/anime-downloader.rb
+++ b/Formula/anime-downloader.rb
@@ -6,7 +6,7 @@ class AnimeDownloader < Formula
   url "https://files.pythonhosted.org/packages/00/8b/2f354c0c2e56f1fe45e805698bd6a81c472473a48b814c44aaed2d41016d/anime-downloader-5.0.9.tar.gz"
   sha256 "40eaded9508a30f35993b2fc0f436c357d9939d58625a10bd595bfc11816ead4"
   license "Unlicense"
-  revision 1
+  revision 2
   head "https://github.com/anime-dl/anime-downloader.git", branch: "master"
 
   bottle do
@@ -19,8 +19,8 @@ class AnimeDownloader < Formula
   end
 
   depends_on "aria2"
+  depends_on "libpython-tabulate"
   depends_on "node"
-  depends_on "python-tabulate"
   depends_on "python@3.9"
 
   resource "beautifulsoup4" do

--- a/Formula/athenacli.rb
+++ b/Formula/athenacli.rb
@@ -6,6 +6,7 @@ class Athenacli < Formula
   url "https://files.pythonhosted.org/packages/38/1a/d9cd6c68a4a1cd2ce779b163f8cec390ae82c684caa920d0360094886b1f/athenacli-1.6.8.tar.gz"
   sha256 "c7733433f2795d250e3c23b134136fea571ea9868c15f424875cd194eaeb7246"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "612fbf2fee22c4c519962861dd862c90a5244e66810afb79726dd2c4a7aa5f21"
@@ -16,7 +17,7 @@ class Athenacli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5c74df7b94d58e4e2e034ba51d6971f3619103fdd203126c13f737956f7676c1"
   end
 
-  depends_on "python-tabulate"
+  depends_on "libpython-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/aws-google-auth.rb
+++ b/Formula/aws-google-auth.rb
@@ -6,6 +6,7 @@ class AwsGoogleAuth < Formula
   url "https://files.pythonhosted.org/packages/32/4c/3a1dd1781c9d3bb4a85921b3d3e6e32fc0f0bad61ace6a8e1bd1a59c5ba0/aws-google-auth-0.0.38.tar.gz"
   sha256 "7a044636df2f0ce6ceb01f8f57aba0b6a79ae58a91bef788b0ccc6474914e8ee"
   license "MIT"
+  revision 1
   head "https://github.com/cevoaustralia/aws-google-auth.git", branch: "master"
 
   bottle do
@@ -17,8 +18,8 @@ class AwsGoogleAuth < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "789407efb9f4e8d9dbd07b3964d57c36c41eda6ef61b807bf3cdb6536e604b15"
   end
 
+  depends_on "libpython-tabulate"
   depends_on "pillow"
-  depends_on "python-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/c7n.rb
+++ b/Formula/c7n.rb
@@ -6,6 +6,7 @@ class C7n < Formula
   url "https://github.com/cloud-custodian/cloud-custodian/archive/0.9.16.0.tar.gz"
   sha256 "65a20d879bee71a99f8e7717cd7287e27d23684e2a9fe6c4ee6a5b8ab5f69b5a"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,7 +22,7 @@ class C7n < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6ecfa9a54d3e75267560cf4c84052e01f49cfc033afc07f951eff3ba5d557858"
   end
 
-  depends_on "python-tabulate"
+  depends_on "libpython-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/charmcraft.rb
+++ b/Formula/charmcraft.rb
@@ -6,6 +6,7 @@ class Charmcraft < Formula
   url "https://files.pythonhosted.org/packages/1c/b1/950a8646e6fb58775f10aac2ac56abefc0511ce0bfa8ac76ffe3c62e6037/charmcraft-1.7.1.tar.gz"
   sha256 "1b9f61bd752495c23156b595a2df1c0cc5440a55aeee5f1feb1e1e1d56768049"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "60b571f978ad7b27f7b917a13b3d9ec4d2e0e4792071f4345d13d0ef9f0eaeb0"
@@ -17,9 +18,9 @@ class Charmcraft < Formula
   end
 
   depends_on "rust" => :build
+  depends_on "libpython-tabulate"
   depends_on "libsodium"
   depends_on "libyaml"
-  depends_on "python-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/checkov.rb
+++ b/Formula/checkov.rb
@@ -7,6 +7,7 @@ class Checkov < Formula
   url "https://files.pythonhosted.org/packages/01/de/f93ec52e4355940adaf2406e55da8219e827793e404bc1ea10f7ae8d981d/checkov-2.0.1215.tar.gz"
   sha256 "fccf54373886736ecdf1284569a97d888d8f951b1e7377f97d4858e6b31661b0"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "a06b308d4ab0dbe1c3b9ae40831592fb29e003e5042558ebabd2ed949340e7f2"
@@ -17,7 +18,7 @@ class Checkov < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3f3b4463755c3ef02cb31c0b60ed3c0fb7b7f2ead63d1a7564e32da1357872da"
   end
 
-  depends_on "python-tabulate"
+  depends_on "libpython-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/cryptominisat.rb
+++ b/Formula/cryptominisat.rb
@@ -6,7 +6,7 @@ class Cryptominisat < Formula
   # Everything that's needed to run/build/install/link the system is MIT licensed. This allows
   # easy distribution and running of the system everywhere.
   license "MIT"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -24,7 +24,7 @@ class Cryptominisat < Formula
 
   depends_on "cmake" => :build
   depends_on "boost"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   # Fix build error with setuptools 61+
   patch do
@@ -73,6 +73,6 @@ class Cryptominisat < Formula
       solver.add_clause([-1, 2, 3])
       print(solver.solve()[1])
     EOS
-    assert_equal "(None, True, False, True)\n", shell_output("#{Formula["python@3.9"].opt_bin}/python3 test.py")
+    assert_equal "(None, True, False, True)\n", shell_output("#{Formula["python@3.10"].opt_bin}/python3 test.py")
   end
 end

--- a/Formula/dvc.rb
+++ b/Formula/dvc.rb
@@ -6,6 +6,7 @@ class Dvc < Formula
   url "https://files.pythonhosted.org/packages/43/84/2b29a5ef7348221f0ad0ed175ca750b236e7805dace7e75455be1eca4cc2/dvc-2.11.0.tar.gz"
   sha256 "26f5ba2a89a94874a4cc5046835717f8122c6e9adcf7097f5ec93a3a816388a0"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "a2ed3472a21f69116d863403221e9b2738b493954cfaf243d39acd7cd200fb7e"
@@ -21,9 +22,9 @@ class Dvc < Formula
   depends_on "rust" => :build
   depends_on "apache-arrow"
   depends_on "libgit2"
+  depends_on "libpython-tabulate"
   depends_on "openssl@1.1"
   depends_on "protobuf"
-  depends_on "python-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/esphome.rb
+++ b/Formula/esphome.rb
@@ -6,6 +6,7 @@ class Esphome < Formula
   url "https://files.pythonhosted.org/packages/f3/b2/311b34dffd517f4d187dc97a357edda941f459af8a415966303834873e56/esphome-2022.6.1.tar.gz"
   sha256 "c1f379df53559f796de6df45ea14af77198e8edce17ca7bd614b2381aaa0de5b"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "460794a88cc0d77a4ffc7790ff822f179cbee8e60f40b0dbbcd2e50de96f0f34"
@@ -17,8 +18,8 @@ class Esphome < Formula
   end
 
   depends_on "rust" => :build # for cryptography
+  depends_on "libpython-tabulate"
   depends_on "protobuf"
-  depends_on "python-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/homeassistant-cli.rb
+++ b/Formula/homeassistant-cli.rb
@@ -6,7 +6,7 @@ class HomeassistantCli < Formula
   url "https://files.pythonhosted.org/packages/f0/f5/a90000b810751a6094761ed5fed3a6cb746c3c8be3bd1c5ed525e77be69a/homeassistant-cli-0.9.3.tar.gz"
   sha256 "daf9c2a256cd2e63fc173c7c96b3462211f045a66639778302eb4f9d125b06a2"
   license "Apache-2.0"
-  revision 2
+  revision 3
   head "https://github.com/home-assistant-ecosystem/home-assistant-cli.git", branch: "dev"
 
   bottle do
@@ -18,7 +18,7 @@ class HomeassistantCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a74e707bf8ec985f90feec282f7e939f70f2685ad9698c2b08a2301b348d7760"
   end
 
-  depends_on "python-tabulate"
+  depends_on "libpython-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/klee.rb
+++ b/Formula/klee.rb
@@ -1,10 +1,11 @@
 class Klee < Formula
+  include Language::Python::Shebang
+
   desc "Symbolic Execution Engine"
   homepage "https://klee.github.io/"
-  url "https://github.com/klee/klee/archive/v2.2.tar.gz"
-  sha256 "1ff2e37ed3128e005b89920fad7bcf98c7792a11a589dd443186658f5eb91362"
+  url "https://github.com/klee/klee/archive/v2.3.tar.gz"
+  sha256 "6155fcaa4e86e7af8a73e8e4b63102abaea3a62d17e4021beeec47b0a3a6eff9"
   license "NCSA"
-  revision 3
   head "https://github.com/klee/klee.git", branch: "master"
 
   bottle do
@@ -16,10 +17,12 @@ class Klee < Formula
   end
 
   depends_on "cmake" => :build
+  # Does not build on ARM: error: invalid application of 'sizeof' to an incomplete type 'struct stat64'
+  depends_on arch: :x86_64
   depends_on "gperftools"
-  depends_on "llvm@12"
-  depends_on "python-tabulate"
-  depends_on "python@3.9"
+  depends_on "libpython-tabulate"
+  depends_on "llvm"
+  depends_on "python@3.10"
   depends_on "sqlite"
   depends_on "stp"
   depends_on "wllvm"
@@ -35,30 +38,8 @@ class Klee < Formula
 
   # klee needs a version of libc++ compiled with wllvm
   resource "libcxx" do
-    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/llvm-project-12.0.1.src.tar.xz"
-    sha256 "129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e"
-  end
-
-  # Patches for LLVM 12 Support
-  # https://github.com/klee/klee/pull/1389
-  patch do
-    url "https://github.com/klee/klee/commit/8ac323db7d367799fba9435b64fe715c603e60ba.patch?full_index=1"
-    sha256 "e8c325ebe471b4f36eabd9d041f3ad9461061cc261c898e078d4dd211a1f3632"
-  end
-
-  patch do
-    url "https://github.com/klee/klee/commit/96aa751760b4efc3424a82b573057008bc639c3b.patch?full_index=1"
-    sha256 "1cbc17d413992f211f077687c4187f70b82d7129594fb178c7694fe1d897dac1"
-  end
-
-  patch do
-    url "https://github.com/klee/klee/commit/3d7c05a7e86a72a4fc8df115591bd1e7a50f9d84.patch?full_index=1"
-    sha256 "6eb99a36c25eaf311bcf666d4b893f9e9bdfd06b72cca63d570b6f3e8a8013bc"
-  end
-
-  patch do
-    url "https://github.com/klee/klee/commit/8775b9cf6c716f51fe90d668e734a1288c8b5404.patch?full_index=1"
-    sha256 "baefa3e332b2fb699d5329ba2e7c0d87485654dd7ae0a49e6da3a71102ef4ca0"
+    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/llvm-project-13.0.1.src.tar.xz"
+    sha256 "326335a830f2e32d06d0a36393b5455d17dc73e0bd1211065227ee014f92cbf8"
   end
 
   def llvm
@@ -149,6 +130,8 @@ class Klee < Formula
       system "make"
       system "make", "install"
     end
+
+    rewrite_shebang detected_python_shebang, *bin.children
   end
 
   # Test adapted from
@@ -182,6 +165,7 @@ class Klee < Formula
     expected_output = <<~EOS
       KLEE: done: total instructions = 33
       KLEE: done: completed paths = 3
+      KLEE: done: partially completed paths = 0
       KLEE: done: generated tests = 3
     EOS
     output = pipe_output("#{bin}/klee get_sign.bc 2>&1")

--- a/Formula/libpython-tabulate.rb
+++ b/Formula/libpython-tabulate.rb
@@ -1,0 +1,34 @@
+class LibpythonTabulate < Formula
+  desc "Pretty-print tabular data in Python"
+  homepage "https://pypi.org/project/tabulate/"
+  url "https://files.pythonhosted.org/packages/ae/3d/9d7576d94007eaf3bb685acbaaec66ff4cdeb0b18f1bf1f17edbeebffb0a/tabulate-0.8.9.tar.gz"
+  sha256 "eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7"
+  license "MIT"
+
+  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.9" => [:build, :test]
+
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/python@\d\.\d+/) }
+        .map(&:opt_bin)
+        .map { |bin| bin/"python3" }
+  end
+
+  def install
+    pythons.each do |python|
+      system python, *Language::Python.setup_install_args(prefix),
+                     "--install-lib=#{prefix/Language::Python.site_packages(python)}"
+    end
+    # Remove bin folder, use tabulate from the python-tabulate formula instead.
+    # This is necessary to keep all the Python versions as build/test
+    # dependencies only for the libpython-tabulate
+    rm_rf prefix/"bin"
+  end
+
+  test do
+    pythons.each do |python|
+      system python, "-c", "from tabulate import tabulate"
+    end
+  end
+end

--- a/Formula/litecli.rb
+++ b/Formula/litecli.rb
@@ -6,6 +6,7 @@ class Litecli < Formula
   url "https://files.pythonhosted.org/packages/c1/92/b2eb5f098446a05b9a92e548bd83442f2169f87f3e1b37ffed7a5315c264/litecli-1.9.0.tar.gz"
   sha256 "21af2cfa083dd4df1e3ccaa2a2117129b5f17212756f596ea090e296776c27a1"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "65504fcf3105e95a62a3ef67973daba12b766128677e5c64f1db9cba374041f5"
@@ -16,7 +17,7 @@ class Litecli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "62a9506cdced7134ea3002efdadbaa2565afd56c086ccd5191f25381217f46ba"
   end
 
-  depends_on "python-tabulate"
+  depends_on "libpython-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/localstack.rb
+++ b/Formula/localstack.rb
@@ -6,6 +6,7 @@ class Localstack < Formula
   url "https://files.pythonhosted.org/packages/05/06/b0de96a5bdfa4d54f11fa5fc912909a66535d68912126894776add2aa9de/localstack-0.14.3.3.tar.gz"
   sha256 "9766b3a535dae8b3a27ee01e72af69dae26095ee48069965205d85e0820977e8"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "68a7099f1c174c24febcd27493cca438a405579f461e01f804a41438d507ad07"
@@ -18,7 +19,7 @@ class Localstack < Formula
 
   depends_on "rust" => :build # for cryptography
   depends_on "docker" => :test
-  depends_on "python-tabulate"
+  depends_on "libpython-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/mycli.rb
+++ b/Formula/mycli.rb
@@ -6,6 +6,7 @@ class Mycli < Formula
   url "https://files.pythonhosted.org/packages/fb/8d/3ce24791ec6bb7914830660f4a26ac780243d643860757a53fc99e4d4639/mycli-1.25.0.tar.gz"
   sha256 "fef12ed8125fd13edf4a04977e5ab9e8895a8a1ed10218629595206cdcd96108"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "4d24cf9b505e40c7aa71640a309e8869aa38f57eea6291e48cd31dc7c7807b99"
@@ -17,8 +18,8 @@ class Mycli < Formula
   end
 
   depends_on "rust" => :build
+  depends_on "libpython-tabulate"
   depends_on "openssl@1.1"
-  depends_on "python-tabulate"
   depends_on "python@3.9"
 
   on_linux do

--- a/Formula/pgcli.rb
+++ b/Formula/pgcli.rb
@@ -6,6 +6,7 @@ class Pgcli < Formula
   url "https://files.pythonhosted.org/packages/f8/2a/f23f103e28b32fe005862441c461c9b0022cb1dd4f7b248dd983440628d5/pgcli-3.4.1.tar.gz"
   sha256 "f03930187e27d60df658ca8a04fb601ec5d7476c735f2b1542c6adec5cac8fe2"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "5b31c304fd56b94f055f1914db3cc9287ee3f59ced01436112cb70563da41960"
@@ -18,8 +19,8 @@ class Pgcli < Formula
 
   depends_on "poetry" => :build
   depends_on "libpq"
+  depends_on "libpython-tabulate"
   depends_on "openssl@1.1"
-  depends_on "python-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -6,6 +6,7 @@ class Platformio < Formula
   url "https://files.pythonhosted.org/packages/d2/9c/dc9d6373311ca5ab8c4fda3fc4c160473e730b4015dccf558acbf7e06c45/platformio-6.0.2.tar.gz"
   sha256 "e4cb9d45327d93b5888ba0c5d4c9ca22a30411952056e55b79d714c7f84f9b83"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/platformio/platformio-core.git", branch: "develop"
 
   bottle do
@@ -17,7 +18,7 @@ class Platformio < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "84dffa9399b60b8c0352d2452cceec9197ad5265c5da5bf452e35fa555f5c8ea"
   end
 
-  depends_on "python-tabulate"
+  depends_on "libpython-tabulate"
   depends_on "python@3.9"
 
   resource "aiofiles" do

--- a/Formula/python-tabulate.rb
+++ b/Formula/python-tabulate.rb
@@ -4,6 +4,7 @@ class PythonTabulate < Formula
   url "https://files.pythonhosted.org/packages/ae/3d/9d7576d94007eaf3bb685acbaaec66ff4cdeb0b18f1bf1f17edbeebffb0a/tabulate-0.8.9.tar.gz"
   sha256 "eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7"
   license "MIT"
+  revision 1
 
   bottle do
     rebuild 1
@@ -16,10 +17,12 @@ class PythonTabulate < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f5bd465f5fd9a0e3eb107c4cdd244b63090a2ce102346f7d7fecfcdbabc1812a"
   end
 
-  depends_on "python@3.9"
+  depends_on "libpython-tabulate"
+  depends_on "python@3.10"
 
   def install
-    system Formula["python@3.9"].bin/"python3", *Language::Python.setup_install_args(prefix)
+    # Install the binary only, the lib part is provided by libpython-tabulate
+    system "python3", "setup.py", "--no-user-cfg", "install_scripts", "--install-dir=#{bin}", "--skip-build"
   end
 
   test do
@@ -40,6 +43,5 @@ class PythonTabulate < Formula
     EOS
 
     assert_equal (testpath/"out.txt").read, shell_output("#{bin}/tabulate -f grid #{testpath}/in.txt")
-    system Formula["python@3.9"].opt_bin/"python3", "-c", "from tabulate import tabulate"
   end
 end

--- a/Formula/regipy.rb
+++ b/Formula/regipy.rb
@@ -6,6 +6,7 @@ class Regipy < Formula
   url "https://files.pythonhosted.org/packages/73/4a/7a5c7ccdfa0858c636ebe267c235d32a6d75e83e26477c98c4e550396ef0/regipy-2.5.3.tar.gz"
   sha256 "4d69dd28dfe0796829fa4ac032208df686242b94df90bb8ff96c286176dcd153"
   license "MIT"
+  revision 1
   head "https://github.com/mkorman90/regipy.git", branch: "master"
 
   bottle do
@@ -17,7 +18,7 @@ class Regipy < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ba2e9703f2e5d139971903eb5ad9eb9d2164324b93af0571881954c6eb62da61"
   end
 
-  depends_on "python-tabulate"
+  depends_on "libpython-tabulate"
   depends_on "python@3.9"
 
   resource "attrs" do

--- a/Formula/sqlite-utils.rb
+++ b/Formula/sqlite-utils.rb
@@ -5,6 +5,7 @@ class SqliteUtils < Formula
   url "https://files.pythonhosted.org/packages/92/b6/0a91a81b21b7be2dfdb2e964941000d299168dea582bfb899dfae5425abf/sqlite-utils-3.27.tar.gz"
   sha256 "49eadc3cad92bebabbac450b825be3ab5277155d31d1a1c72acef61e65e44c6a"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "77807ffb7a6bc884b61fd33ade6173153407ee526b551a58044f7970d3771453"
@@ -15,7 +16,7 @@ class SqliteUtils < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7c9d46bf3cbf52f51ef1dbdc6c426a2db341b2f352566fbf4bda76c53b534f7a"
   end
 
-  depends_on "python-tabulate"
+  depends_on "libpython-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/stp.rb
+++ b/Formula/stp.rb
@@ -4,6 +4,7 @@ class Stp < Formula
   url "https://github.com/stp/stp/archive/refs/tags/2.3.3.tar.gz"
   sha256 "ea6115c0fc11312c797a4b7c4db8734afcfce4908d078f386616189e01b4fffa"
   license "MIT"
+  revision 1
   head "https://github.com/stp/stp.git", branch: "master"
 
   livecheck do
@@ -28,7 +29,7 @@ class Stp < Formula
   depends_on "boost"
   depends_on "cryptominisat"
   depends_on "minisat"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   uses_from_macos "perl"
 
@@ -38,7 +39,7 @@ class Stp < Formula
     inreplace "lib/Util/GitSHA1.cpp.in", "@CMAKE_CXX_COMPILER@", ENV.cxx
 
     system "cmake", "-S", ".", "-B", "build",
-                    "-DPYTHON_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3",
+                    "-DPYTHON_EXECUTABLE=#{Formula["python@3.10"].opt_bin}/python3",
                     "-DPYTHON_LIB_INSTALL_DIR=#{site_packages}",
                     *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/todoman.rb
+++ b/Formula/todoman.rb
@@ -6,6 +6,7 @@ class Todoman < Formula
   url "https://files.pythonhosted.org/packages/2d/b0/ffe9e812fa710579d07369763262e418cadb2a99fc5d0ec0d685c7f33a69/todoman-4.1.0.tar.gz"
   sha256 "ce3caa481d923e91da9b492b46509810a754e2d3ef857f5d20bc5a8e362b50c8"
   license "ISC"
+  revision 1
   head "https://github.com/pimutils/todoman.git", branch: "main"
 
   bottle do
@@ -17,7 +18,7 @@ class Todoman < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8487a64b4a5ba1f7fa89426140d104e9c41e53de6a4008920bd2887867050194"
   end
 
-  depends_on "python-tabulate"
+  depends_on "libpython-tabulate"
   depends_on "python@3.9"
   depends_on "six"
 

--- a/Formula/wllvm.rb
+++ b/Formula/wllvm.rb
@@ -6,6 +6,7 @@ class Wllvm < Formula
   url "https://files.pythonhosted.org/packages/4b/df/31d7519052bc21d0e9771e9a6540d6310bfb13bae7dacde060d8f647b8d3/wllvm-1.3.1.tar.gz"
   sha256 "3e057a575f05c9ecc8669a8c4046f2bfdf0c69533b87b4fbfcabe0df230cc331"
   license "MIT"
+  revision 1
 
   bottle do
     rebuild 1
@@ -19,7 +20,7 @@ class Wllvm < Formula
   end
 
   depends_on "llvm" => :test
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     virtualenv_install_with_resources

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -45,6 +45,7 @@
   ["protoc-gen-gogo", "protoc-gen-gogofaster"],
   ["python-tk@3.10", "python@3.10"],
   ["python-tk@3.9", "python@3.9"],
+  ["python-tabulate", "libpython-tabulate"],
   ["qt", "qt-libiodbc", "qt-mariadb", "qt-mysql", "qt-percona-server", "qt-postgresql", "qt-unixodbc"],
   ["qwt", "qwt-qt5"],
   ["telnet", "telnetd"],


### PR DESCRIPTION
This aligns python-tabulate with other formulae like six, pillow and numpy,
which are "multi-python" to ease migrations.
Python-tabulate is used by multiple formulae and this will help decoupe
some part of the dependency tree, thus easing the migration.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
