### PR TITLE
highs: remove optional dependencies

### DIFF
--- a/Formula/highs.rb
+++ b/Formula/highs.rb
@@ -4,6 +4,7 @@ class Highs < Formula
   url "https://github.com/ERGO-Code/HiGHS/archive/refs/tags/v1.2.1.tar.gz"
   sha256 "8d0230369762a1835e075fe41fa4f83b403c21355958135c44dd214203a43edd"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "509970f3c2ca824ebd2bc2df412f1d5c5c3ed0fa11a1802c98dad94ba0e5ae2c"
@@ -16,8 +17,6 @@ class Highs < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "gcc" # for gfortran
-  depends_on "osi"
 
   def install
     system "cmake", "-B", "build", *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This removes optional dependencies from the recently added HiGHS formula, as requested by the project in https://github.com/ERGO-Code/HiGHS/issues/794#issuecomment-1094775955.

Fortran is only needed for the Fortran interface, and OSI for the OSI interface.