### PR TITLE
Remove most remaining SDKROOT fix instances

### DIFF
--- a/Formula/doxymacs.rb
+++ b/Formula/doxymacs.rb
@@ -30,9 +30,6 @@ class Doxymacs < Formula
   depends_on "emacs"
 
   def install
-    # Fix undefined symbols errors for _xmlCheckVersion and other symbols
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
-
     # https://sourceforge.net/p/doxymacs/support-requests/5/
     ENV.append "CFLAGS", "-std=gnu89"
 

--- a/Formula/flowgrind.rb
+++ b/Formula/flowgrind.rb
@@ -21,9 +21,6 @@ class Flowgrind < Formula
   depends_on "xmlrpc-c"
 
   def install
-    # Fix "ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
-
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/gerbil-scheme.rb
+++ b/Formula/gerbil-scheme.rb
@@ -27,7 +27,6 @@ class GerbilScheme < Formula
   def install
     cd "src" do
       ENV.append_path "PATH", "#{Formula["gambit-scheme"].opt_prefix}/current/bin"
-      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
       system "./configure", "--prefix=#{prefix}",
                             "--with-gambit=#{Formula["gambit-scheme"].opt_prefix}/current",
                             "--enable-leveldb",

--- a/Formula/libslax.rb
+++ b/Formula/libslax.rb
@@ -37,8 +37,6 @@ class Libslax < Formula
     # configure remembers "-lcrypto" but not the link path.
     ENV.append "LDFLAGS", "-L#{Formula["openssl@1.1"].opt_lib}"
 
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
-
     system "sh", "./bin/setup.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/open-scene-graph.rb
+++ b/Formula/open-scene-graph.rb
@@ -30,6 +30,7 @@ class OpenSceneGraph < Formula
   def install
     # Fix "fatal error: 'os/availability.h' file not found" on 10.11 and
     # "error: expected function body after function declarator" on 10.12
+    # Requires the CLT to be the active developer directory if Xcode is installed
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
 
     args = std_cmake_args + %w[

--- a/Formula/php@7.2.rb
+++ b/Formula/php@7.2.rb
@@ -66,9 +66,6 @@ class PhpAT72 < Formula
   end
 
   def install
-    # Ensure that libxml2 will be detected correctly in older MacOS
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra
-
     # Work around configure issues with Xcode 12
     # See https://bugs.php.net/bug.php?id=80171
     ENV.append "CFLAGS", "-Wno-implicit-function-declaration"

--- a/Formula/php@7.3.rb
+++ b/Formula/php@7.3.rb
@@ -58,11 +58,6 @@ class PhpAT73 < Formula
   end
 
   def install
-    if OS.mac? && (MacOS.version == :el_capitan || MacOS.version == :sierra)
-      # Ensure that libxml2 will be detected correctly in older MacOS
-      ENV["SDKROOT"] = MacOS.sdk_path
-    end
-
     # buildconf required due to system library linking bug patch
     system "./buildconf", "--force"
 

--- a/Formula/postgresql@9.4.rb
+++ b/Formula/postgresql@9.4.rb
@@ -41,9 +41,6 @@ class PostgresqlAT94 < Formula
   end
 
   def install
-    # Fix "configure: error: readline library not found"
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
-
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl@1.1"].opt_lib} -L#{Formula["readline"].opt_lib}"
     ENV.prepend "CPPFLAGS", "-I#{Formula["openssl@1.1"].opt_include} -I#{Formula["readline"].opt_include}"
     ENV.prepend "PG_SYSROOT", MacOS.sdk_path

--- a/Formula/sfml.rb
+++ b/Formula/sfml.rb
@@ -39,8 +39,10 @@ class Sfml < Formula
   # https://github.com/Homebrew/homebrew/issues/40301
 
   def install
-    # error: expected function body after function declarator
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
+    # Fix "fatal error: 'os/availability.h' file not found" on 10.11 and
+    # "error: expected function body after function declarator" on 10.12
+    # Requires the CLT to be the active developer directory if Xcode is installed
+    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
 
     # Always remove the "extlibs" to avoid install_name_tool failure
     # (https://github.com/Homebrew/homebrew/pull/35279) but leave the

--- a/Formula/sqliteodbc.rb
+++ b/Formula/sqliteodbc.rb
@@ -31,8 +31,6 @@ class Sqliteodbc < Formula
   end
 
   def install
-    ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :sierra
-
     lib.mkdir
     args = ["--with-odbc=#{Formula["unixodbc"].opt_prefix}",
             "--with-sqlite3=#{Formula["sqlite"].opt_prefix}"]


### PR DESCRIPTION
Remove [remaining instances](https://github.com/Homebrew/homebrew-core/pull/98945) of setting SDKROOT where it's no longer required to build formulae [on 10.12 and earlier](https://github.com/Homebrew/brew/pull/13098) that have been fixed by [always setting HOMEBREW_DEVELOPER_DIR](https://github.com/Homebrew/brew/pull/13104).