### PR TITLE
easy-git: deprecate

### DIFF
--- a/Formula/easy-git.rb
+++ b/Formula/easy-git.rb
@@ -1,17 +1,15 @@
 class EasyGit < Formula
   desc "Wrapper to simplify learning and using git"
-  homepage "https://people.gnome.org/~newren/eg/"
-  url "https://people.gnome.org/~newren/eg/download/1.7.5.2/eg"
-  sha256 "59bb4f8b267261ab3d48c66b957af851d1a61126589173ebcc20ba9f43c382fb"
-
-  livecheck do
-    url "https://people.gnome.org/~newren/eg/download/"
-    regex(%r{href=.*?(\d+(?:\.\d+)+)/eg["' >]}i)
-  end
+  homepage "https://github.com/newren/easygit/"
+  url "https://github.com/newren/easygit/archive/v1.8.5.tar.gz"
+  sha256 "e2c6ac7fb390de1440a15808e5460b959bfb5000add11af91757ab61c48dead7"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "d32fde25bfa6487f1ed7b4ca157b3d38cf64100b77d20c3ec35a0bf9b88894b9"
   end
+
+  deprecate! date: "2022-04-12", because: :unmaintained
 
   def install
     bin.install "eg"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage`, `stable`, and `livecheck` block URLs for `easy-git` return a `404 Not Found` response, as https://people.gnome.org/~newren/ has seemingly been removed. This PR updates the formula to use the author's [GitHub repository for easy-git](https://github.com/newren/easygit), so the formula will continue to work for the time being. The repository contains a 1.8.5 version, so this PR also updates the formula to this version.

That said, the repository `README` states:

> I no longer maintain easygit.  Please go look at github.com/dfabulich/easygit. I pushed this version here because apparently when gitorious died, my online copy of commits I had made in v1.8.5 went missing and others didn't have them.  I haven't done maintenance work on easygit for over 4 years now.

This text was published on 2018-03-15 and the prior commit for the 1.8.5 release was on 2014-03-08. The referenced dfabulich/easygit repository hasn't been updated since 2013-11-21, so it's fair to say this project isn't being maintained. There's another [easygit snapshot on GitHub](https://github.com/chocolateboy/easygit) that has some more recent commits after the 1.8.5 release but generally we don't migrate a formula to an alternative unless it's officially recognized by the author(s) of a project.

With that in mind, this PR also deprecates the `easy-git` formula as unmaintained and removes the `livecheck` block accordingly, so it will automatically skip. Considering the status of this project and the low install count (30 days: 7, 90 days: 24, 365 days: 72), deprecation seems like a reasonable course of action.

Lastly, this adds `license "GPL-2.0-only"`, referencing the `eg` file which contains the following license comment:

```
## Easy GIT (eg), a frontend for git designed for former cvs and svn users
## Version 1.8.5
## Copyright 2008-2013 by Elijah Newren and others
## Licensed under GNU GPL, version 2.
```

This is the only license reference in the repository (it doesn't even contain the GPLv2 license text), so this seems to be all we have to go on at this point.