### PR TITLE
cmake cmake-docs 3.23.1

### DIFF
--- a/Formula/cmake-docs.rb
+++ b/Formula/cmake-docs.rb
@@ -3,6 +3,7 @@ class CmakeDocs < Formula
   homepage "https://www.cmake.org/"
   url "https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1.tar.gz"
   mirror "http://fresh-center.net/linux/misc/cmake-3.23.1.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/legacy/cmake-3.23.1.tar.gz"
   sha256 "33fd10a8ec687a4d0d5b42473f10459bb92b3ae7def2b745dc10b192760869f3"
   license "BSD-3-Clause"
   head "https://gitlab.kitware.com/cmake/cmake.git", branch: "master"

--- a/Formula/cmake-docs.rb
+++ b/Formula/cmake-docs.rb
@@ -1,10 +1,9 @@
 class CmakeDocs < Formula
   desc "Documentation for CMake"
   homepage "https://www.cmake.org/"
-  url "https://github.com/Kitware/CMake/releases/download/v3.23.0/cmake-3.23.0.tar.gz"
-  mirror "http://fresh-center.net/linux/misc/cmake-3.23.0.tar.gz"
-  mirror "http://fresh-center.net/linux/misc/legacy/cmake-3.23.0.tar.gz"
-  sha256 "5ab0a12f702f44013be7e19534cd9094d65cc9fe7b2cd0f8c9e5318e0fe4ac82"
+  url "https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/cmake-3.23.1.tar.gz"
+  sha256 "33fd10a8ec687a4d0d5b42473f10459bb92b3ae7def2b745dc10b192760869f3"
   license "BSD-3-Clause"
   head "https://gitlab.kitware.com/cmake/cmake.git", branch: "master"
 

--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -3,6 +3,7 @@ class Cmake < Formula
   homepage "https://www.cmake.org/"
   url "https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1.tar.gz"
   mirror "http://fresh-center.net/linux/misc/cmake-3.23.1.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/legacy/cmake-3.23.1.tar.gz"
   sha256 "33fd10a8ec687a4d0d5b42473f10459bb92b3ae7def2b745dc10b192760869f3"
   license "BSD-3-Clause"
   head "https://gitlab.kitware.com/cmake/cmake.git", branch: "master"

--- a/Formula/cmake.rb
+++ b/Formula/cmake.rb
@@ -1,10 +1,9 @@
 class Cmake < Formula
   desc "Cross-platform make"
   homepage "https://www.cmake.org/"
-  url "https://github.com/Kitware/CMake/releases/download/v3.23.0/cmake-3.23.0.tar.gz"
-  mirror "http://fresh-center.net/linux/misc/cmake-3.23.0.tar.gz"
-  mirror "http://fresh-center.net/linux/misc/legacy/cmake-3.23.0.tar.gz"
-  sha256 "5ab0a12f702f44013be7e19534cd9094d65cc9fe7b2cd0f8c9e5318e0fe4ac82"
+  url "https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/cmake-3.23.1.tar.gz"
+  sha256 "33fd10a8ec687a4d0d5b42473f10459bb92b3ae7def2b745dc10b192760869f3"
   license "BSD-3-Clause"
   head "https://gitlab.kitware.com/cmake/cmake.git", branch: "master"
 


### PR DESCRIPTION
- cmake: 3.23.1, remove useless mirror
- cmake-docs 3.23.1, remove useless mirror

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
