### PR TITLE
libpthread-stubs: mark pkg-config as build/test dependency

### DIFF
--- a/Formula/libpthread-stubs.rb
+++ b/Formula/libpthread-stubs.rb
@@ -16,7 +16,7 @@ class LibpthreadStubs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "06a9f3556eefaa9d243d18b484a38f89bcc999b84d3e9722ddf3645479bce44b"
   end
 
-  depends_on "pkg-config"
+  depends_on "pkg-config" => [:build, :test]
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
From [README](https://gitlab.freedesktop.org/xorg/app/xlogo/-/blob/master/README.md) of `libpthread-stubs`

> Currently the project provides only a pkg-config [.pc] file, pthread-stubs.pc.

I'm not sure we should modify other formulae depend on it, e.g. `libxcb`.