### PR TITLE
zsh: update livecheck

### DIFF
--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -7,8 +7,7 @@ class Zsh < Formula
   license "MIT-Modern-Variant"
 
   livecheck do
-    url :stable
-    regex(%r{url=.*?/zsh/files/zsh/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i)
+    url "https://sourceforge.net/projects/zsh/rss?path=/zsh"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A `livecheck` block was added to `zsh` in #99307 to restrict matching to only files in the `/zsh` directory of the SourceForge project but it was merged before I could review it. When it's appropriate to only match files in a directory of a SourceForge project, it's preferable to accomplish this by using the `path` query string parameter in the SourceForge RSS feed URL (we already do this a fair bit in homebrew/cask `livecheck` blocks).

Restricting which items appear in the RSS feed is the better solution because we don't have to worry about extraneous items from sibling directories pushing out the items in the `/zsh` directory (at which point the check would temporarily fail to find versions). This PR updates the `livecheck` block to use an appropriate URL and removes the `regex`, as the default regex generated by the strategy is fine in this context.