### PR TITLE
libxcrypt 4.4.28 (new formula)

### DIFF
--- a/Formula/libxcrypt.rb
+++ b/Formula/libxcrypt.rb
@@ -1,0 +1,58 @@
+class Libxcrypt < Formula
+  desc "Extended crypt library for descrypt, md5crypt, bcrypt, and others"
+  homepage "https://github.com/besser82/libxcrypt"
+  url "https://github.com/besser82/libxcrypt/releases/download/v4.4.28/libxcrypt-4.4.28.tar.xz"
+  sha256 "9e936811f9fad11dbca33ca19bd97c55c52eb3ca15901f27ade046cc79e69e87"
+  license "LGPL-2.1-or-later"
+
+  on_macos do
+    keg_only "provided by macOS"
+  end
+
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
+  def install
+    system "./configure", *std_configure_args,
+                          "--disable-static",
+                          "--disable-obsolete-api",
+                          "--disable-xcrypt-compat-files",
+                          "--disable-failure-tokens",
+                          "--disable-valgrind"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <crypt.h>
+      #include <errno.h>
+      #include <stdio.h>
+      #include <string.h>
+
+      int main()
+      {
+        char *hash = crypt("abc", "$2b$05$abcdefghijklmnopqrstuu");
+
+        if (errno) {
+          fprintf(stderr, "Received error: %s", strerror(errno));
+          return errno;
+        }
+        if (hash == NULL) {
+          fprintf(stderr, "Hash is NULL");
+          return -1;
+        }
+        if (strcmp(hash, "$2b$05$abcdefghijklmnopqrstuuRWUgMyyCUnsDr8evYotXg5ZXVF/HhzS")) {
+          fprintf(stderr, "Unexpected hash output");
+          return -1;
+        }
+
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lcrypt", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
With the ambition to deprecate our usage of libcrypt.so.1, like some Linux distributions have done, here is a libxcrypt formula which I propose to be the replacement and we'll define as a dependency where needed.

It provides `libcrypt.so.2`.