### PR TITLE
portmidi 2.0.3: install pkg-config file.

### DIFF
--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -25,6 +25,7 @@ class Portmidi < Formula
     # need to create include/lib directories since make won't create them itself
     include.mkpath
     lib.mkpath
+    (lib/"pkgconfig").mkpath
 
     if OS.mac?
       # Fix "fatal error: 'os/availability.h' file not found" on 10.11 and
@@ -37,6 +38,8 @@ class Portmidi < Formula
       system "make", "-f", "pm_mac/Makefile.osx"
       system "make", "-f", "pm_mac/Makefile.osx", "install"
       mv lib/shared_library("libportmidi"), lib/shared_library("libportmidi", version)
+      # awaiting https://github.com/PortMidi/portmidi/issues/24
+      (lib/"pkgconfig").install "Release/packaging/portmidi.pc"
     else
       system "cmake", ".", *std_cmake_args, "-DCMAKE_CACHEFILE_DIR=#{buildpath}/build"
       system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since the latest release `portmidi` [has](https://github.com/PortMidi/portmidi/issues/1) a pkg-config file. The default mac install does however not seem to install it. This tweaks the package into installing it. 


