### PR TITLE
video-compare 20220412 (new formula)

### DIFF
--- a/Formula/video-compare.rb
+++ b/Formula/video-compare.rb
@@ -1,0 +1,21 @@
+class VideoCompare < Formula
+  desc "Split screen video comparison tool using FFmpeg and SDL2"
+  homepage "https://github.com/pixop/video-compare"
+  url "https://github.com/pixop/video-compare/archive/refs/tags/20220412.tar.gz"
+  sha256 "425eafd0095e8043c240658618c14c8a4e92954c41cd1adf5a3b01d275a3581c"
+  license "GPL-2.0-only"
+
+  depends_on "ffmpeg"
+  depends_on "sdl2"
+  depends_on "sdl2_ttf"
+
+  def install
+    system "make"
+    bin.install "video-compare"
+  end
+
+  test do
+    output = shell_output("#{bin}/video-compare 2>&1")
+    assert_match "Usage: ", output
+  end
+end


### PR DESCRIPTION
[pixop/video-compare](https://github.com/pixop/video-compare) – Split screen video comparison tool using FFmpeg and SDL2

- ✅ Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- ✅ Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- ✅ Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- ✅ Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- ✅ Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- ✅ Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
