### PR TITLE
brew-pip: deprecate

### DIFF
--- a/Formula/brew-pip.rb
+++ b/Formula/brew-pip.rb
@@ -14,6 +14,9 @@ class BrewPip < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "d2cc472aef77f711ebb4890a1f669e9d7bf1668c5e024ef97b8e09fb8e6565aa"
   end
 
+  # Repository is not maintained in 9+ years
+  deprecate! date: "2022-04-16", because: :unmaintained
+
   def install
     bin.install "bin/brew-pip"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR deprecates brew-pip as it's not updated in years. Solve one of the task in #93940
