### PR TITLE
triage: add more `long build` formulae

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -135,7 +135,7 @@ jobs:
               content: system "swift", "build"
 
             - label: long build
-              path: Formula/(agda|arangodb|boost|deno|dotnet|emscripten|gcc|ghc|llvm|node|ponyc|rust|swift|texlive|qt)(@[0-9]+)?.rb
+              path: Formula/(agda|arangodb|boost|cmake|deno|dotnet|emscripten|gcc|ghc|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt)(@[0-9]+)?.rb
               keep_if_no_match: true
 
             - label: CI-build-dependents-from-source

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -135,7 +135,7 @@ jobs:
               content: system "swift", "build"
 
             - label: long build
-              path: Formula/(agda|arangodb|boost|deno|dotnet|emscripten|gcc|ghc|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt)(@[0-9]+)?.rb
+              path: Formula/(agda|arangodb|boost|deno|dotnet|emscripten|gcc|ghc|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt|v8)(@[0-9]+)?.rb
               keep_if_no_match: true
 
             - label: CI-build-dependents-from-source

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -135,7 +135,7 @@ jobs:
               content: system "swift", "build"
 
             - label: long build
-              path: Formula/(agda|arangodb|boost|cmake|deno|dotnet|emscripten|gcc|ghc|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt)(@[0-9]+)?.rb
+              path: Formula/(agda|arangodb|boost|deno|dotnet|emscripten|gcc|ghc|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt)(@[0-9]+)?.rb
               keep_if_no_match: true
 
             - label: CI-build-dependents-from-source


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
