### PR TITLE
kcat: add livecheck

### DIFF
--- a/Formula/kcat.rb
+++ b/Formula/kcat.rb
@@ -7,6 +7,14 @@ class Kcat < Formula
   license "BSD-2-Clause"
   head "https://github.com/edenhill/kcat.git", branch: "master"
 
+  # Upstream sometimes creates a tag with a stable version format but does not
+  # create a release on GitHub. Versions that are tagged but not released don't
+  # appear to be appropriate for this formula, so we check releases instead.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "fd220a7e002772622e581f636e59c4a198ec883cbb813d2b31857d0bf24d089d"
     sha256 cellar: :any,                 arm64_big_sur:  "f930080248bb0eff245599536bbc12465c6bf6e256acb283e6d2d5a5d047f11e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `kcat` and this is currently giving 1.7.1 as the newest version but 1.7.0 is the "latest" release on GitHub. The 1.7.1 version was tagged simply for the Docker image and there isn't a corresponding release. With this in mind, it seems like we should be checking releases instead of tags for this project, so this PR adds a `livecheck` block that uses the `GithubLatest` strategy.

This is a fix before #99474 can be merged.