### PR TITLE
newrelic-infra-agent: add livecheck

### DIFF
--- a/Formula/newrelic-infra-agent.rb
+++ b/Formula/newrelic-infra-agent.rb
@@ -7,6 +7,13 @@ class NewrelicInfraAgent < Formula
   license "Apache-2.0"
   head "https://github.com/newrelic/infrastructure-agent.git", branch: "master"
 
+  # Upstream sometimes creates a tag with a stable version format but marks it
+  # as pre-release on GitHub.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, monterey:     "7554dbce8578c9355db7464dd65a5b2b3b21c46572e771e01e48e69eb399c8ad"
     sha256 cellar: :any_skip_relocation, big_sur:      "00546cc0512d4f0bff406111b137c229bc2ac745c3d6056411f01b5de3184d13"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `newrelic-infra-agent` and returns 1.24.2 as the newest version. As of the time of writing, 1.24.2 is marked as "pre-release" on GitHub and 1.24.1 is the latest stable version. Since this uses a stable version format, there's no way for us to identify whether the tag is stable or pre-release simply from the Git tags and it's necessary to use the `GithubLatest` strategy here.

This is a fix before #99474 can be merged.