### PR TITLE
pgbouncer: update livecheck

### DIFF
--- a/Formula/pgbouncer.rb
+++ b/Formula/pgbouncer.rb
@@ -6,7 +6,8 @@ class Pgbouncer < Formula
   license "ISC"
 
   livecheck do
-    url "https://github.com/pgbouncer/pgbouncer"
+    url "https://www.pgbouncer.org/downloads/"
+    regex(/href=.*?pgbouncer[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `pgbouncer` was originally created on 2018-01-01 in the old homebrew-livecheck repository. This `livecheck` block is a holdover from a different time and doesn't adhere to current standards.

This PR updates the `livecheck` block to check the first-party download page, which links to the `stable` archive. This aligns the check with the `stable` source, which is preferred when possible.

This is related to #99474 but isn't a blocker.