### PR TITLE
swagger2markup-cli: add livecheck

### DIFF
--- a/Formula/swagger2markup-cli.rb
+++ b/Formula/swagger2markup-cli.rb
@@ -6,6 +6,11 @@ class Swagger2markupCli < Formula
   license "Apache-2.0"
   revision 3
 
+  livecheck do
+    url "https://search.maven.org/remotecontent?filepath=io/github/swagger2markup/swagger2markup-cli/maven-metadata.xml"
+    regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "021cfe09374afb56b84233fa154091cb7178b45d0c07ed5b4f90c2c8ab1f6ab2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `swagger2markup-cli` from the `homepage` Git repository. However, the `stable` jar file comes from Maven, so we should be checking for versions there instead.

This PR adds a `livecheck` block that checks the Maven metadata where version information is found. This is the standard approach for Maven `stable` URLs and I plan to add a `Maven` strategy to replace related `livecheck` blocks in the future (as time permits).

This is related to #99474 but isn't strictly a blocker.