### PR TITLE
wartremover: add livecheck

### DIFF
--- a/Formula/wartremover.rb
+++ b/Formula/wartremover.rb
@@ -6,6 +6,11 @@ class Wartremover < Formula
   license "Apache-2.0"
   head "https://github.com/wartremover/wartremover.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "796eaeafeae5f9b8b4573ffa23c5c828764d0699d9289311febb108481132f7a"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `wartremover` and successfully identifies the latest version as 3.0.1. However, livecheck's built-in unstable version filtering (used when a `livecheck` block isn't present) doesn't filter out all the unstable version tags and we get a few like `2.1.1-SNAPSHOT` or `3.0.0-RC6`.

This PR addresses the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which will match stable versions while omitting the unstable tags.

This is a fix before #99474 is merged.