### PR TITLE
znapzend: add livecheck

### DIFF
--- a/Formula/znapzend.rb
+++ b/Formula/znapzend.rb
@@ -6,6 +6,14 @@ class Znapzend < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/oetiker/znapzend.git", branch: "master"
 
+  # The `stable` URL uses a download from the GitHub release, so the release
+  # needs to exist before the formula can be version bumped. It's more
+  # appropriate to check the GitHub releases instead of tags in this context.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "851d5b6216c7083c7d4d3e164f1bd60ec2b2fdaf28a8f1ef186d2a61666a95e3"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "712e06398c1865796cc896a7d8c0d6c0baf4c10a52ac5006cc4c8d69b6359fcb"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `znapzend` and correct returns the latest version, 0.21.1. However, the formula uses a release download as the `stable` URL (i.e., not a tag archive), so it's more appropriate to identify versions from releases in this context. That is to say, if we check the Git tags, livecheck may surface a version before the related release is created and the `stable` archive is available.

This formula is being added to the autobump list, so this situation is a potential problem from the standpoint of automated version bumping. This PR addresses the issue by adding a `livecheck` block that uses the `GithubLatest` strategy.

This is a fix before #99474 can be merged.