### PR TITLE
hugo 0.97.0 (new formula)

### DIFF
--- a/Aliases/hugo@0.97
+++ b/Aliases/hugo@0.97
@@ -1,0 +1,1 @@
+../Formula/hugo.rb

--- a/Formula/hugo@0.97.0.rb
+++ b/Formula/hugo@0.97.0.rb
@@ -1,0 +1,38 @@
+class HugoAT0970 < Formula
+  desc "Configurable static site generator"
+  homepage "https://gohugo.io/"
+  url "https://github.com/gohugoio/hugo/archive/v0.97.0.tar.gz"
+  sha256 "84cb139e43d2d8450e5712bc267b36a39d911b85d3969f5dbf74737a42439467"
+  license "Apache-2.0"
+
+  keg_only :versioned_formula
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "-tags", "extended"
+
+    # Install bash completion
+    output = Utils.safe_popen_read(bin/"hugo@0.97.0", "completion", "bash")
+    (bash_completion/"hugo").write output
+
+    # Install zsh completion
+    output = Utils.safe_popen_read(bin/"hugo@0.97.0", "completion", "zsh")
+    (zsh_completion/"_hugo").write output
+
+    # Install fish completion
+    output = Utils.safe_popen_read(bin/"hugo@0.97.0", "completion", "fish")
+    (fish_completion/"hugo.fish").write output
+
+    # Build man pages; target dir man/ is hardcoded :(
+    (Pathname.pwd/"man").mkpath
+    system bin/"hugo@0.97.0", "gen", "man"
+    man1.install Dir["man/*.1"]
+  end
+
+  test do
+    site = testpath/"hops-yeast-malt-water"
+    system "#{bin}/hugo@0.97.0", "new", "site", site
+    assert_predicate testpath/"#{site}/config.toml", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

**Notes:** 
- Downgrading from the latest version `0.97.2` to this version is currently [recommend by the maintainer](https://github.com/gohugoio/hugo/releases/tag/v0.97.2)
- This installs and works fine but has to be run like `hugo@0.97.0 [command]` instead of just `hugo [command]`. It seems like other formulas can do the latter, but I wasn't able to figure out how to achieve that here. Feel free to update this file if you know how to do this
- Sorry about the force pushes, I'm not too familiar with aliases in this repository