### PR TITLE
libsndfile: fix sndfile.pc unsubstituted variable

### DIFF
--- a/Formula/libsndfile.rb
+++ b/Formula/libsndfile.rb
@@ -28,6 +28,14 @@ class Libsndfile < Formula
   depends_on "libvorbis"
   depends_on "opus"
 
+  # Fix unsubstituted variable @EXTERNAL_MPEG_LIBS@ in sndfile.pc
+  # PR ref: https://github.com/libsndfile/libsndfile/pull/828
+  # Remove in the next release.
+  patch do
+    url "https://github.com/libsndfile/libsndfile/commit/e4fdaeefddd39bae1db27d48ccb7db7733e0c009.patch?full_index=1"
+    sha256 "af1e9faf1b7f414ff81ef3f1641e2e37f3502f0febd17f70f0db6ecdd02dc910"
+  end
+
   def install
     system "autoreconf", "-fvi"
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Only impacts Libs.private so not sure if we want to also revision bump.

Needed for `faust` #98755