### PR TITLE
vcluster: 0.7.1 (new formula)

### DIFF
--- a/Formula/vcluster.rb
+++ b/Formula/vcluster.rb
@@ -1,0 +1,37 @@
+class Vcluster < Formula
+  desc "Creates fully functional virtual k8s cluster inside host k8s cluster's namespace"
+  homepage "https://www.vcluster.com"
+  url "https://github.com/loft-sh/vcluster.git",
+      tag:      "v0.7.1",
+      revision: "dc0ff6f96e9c96fe2caa77e79c2dffc921b4fd49"
+  license "Apache-2.0"
+  head "https://github.com/loft-sh/vcluster.git", branch: "main"
+
+  depends_on "go" => :build
+  depends_on "helm"
+  depends_on "kubernetes-cli"
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.commitHash=#{Utils.git_head}
+      -X main.buildDate=#{time.iso8601}
+      -X main.version=#{version}
+    ]
+    system "go", "build", "-mod", "vendor", *std_go_args(ldflags: ldflags), "./cmd/vclusterctl/main.go"
+    (zsh_completion/"_vcluster").write Utils.safe_popen_read(bin/"vcluster", "completion", "zsh")
+    (bash_completion/"vcluster").write Utils.safe_popen_read(bin/"vcluster", "completion", "bash")
+  end
+
+  test do
+    help_output = "vcluster root command"
+    assert_match help_output, shell_output("#{bin}/vcluster --help")
+
+    create_output = "there is an error loading your current kube config "\
+                    "(invalid configuration: no configuration has been provided, "\
+                    "try setting KUBERNETES_MASTER environment variable), "\
+                    "please make sure you have access to a kubernetes cluster and the command "\
+                    "`kubectl get namespaces` is working"
+    assert_match create_output, shell_output("#{bin}/vcluster create vcluster -n vcluster --create-namespace", 1)
+  end
+end


### PR DESCRIPTION
This PR adds a formula for vcluster cli.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
