### PR TITLE
tractorgen: update homepage, stable

### DIFF
--- a/Formula/tractorgen.rb
+++ b/Formula/tractorgen.rb
@@ -1,7 +1,7 @@
 class Tractorgen < Formula
   desc "Generates ASCII tractor art"
-  homepage "http://www.vergenet.net/~conrad/software/tractorgen/"
-  url "http://www.vergenet.net/~conrad/software/tractorgen/dl/tractorgen-0.31.7.tar.gz"
+  homepage "https://vergenet.net/~conrad/software/tractorgen/"
+  url "https://vergenet.net/~conrad/software/tractorgen/dl/tractorgen-0.31.7.tar.gz"
   sha256 "469917e1462c8c3585a328d035ac9f00515725301a682ada1edb3d72a5995a8f"
   license "GPL-2.0-or-later"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs for `tractorgen` redirect from http://www.vergenet.net to https://www.vergenet.net to https://vergenet.net. This PR updates these URLs to use https://vergenet.net, to avoid the redirections and use HTTPS (which we prefer whenever possible).