### PR TITLE
r: remember path to gfortran

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -60,6 +60,10 @@ class R < Formula
       "--enable-R-shlib",
       "--disable-java",
       "--with-cairo",
+      # This isn't necessary to build R, but it's saved in Makeconf
+      # and helps CRAN packages find gfortran when Homebrew may not be
+      # in PATH (e.g. under RStudio, launched from Finder)
+      "FC=#{Formula["gcc"].opt_bin}/gfortran",
     ]
 
     if OS.mac?


### PR DESCRIPTION
R constructs a "Makeconf" file at R's build time that remembers paths to and flags for compilers and other important utilities.
The same compilers and settings are used to build CRAN packages when end users call install.package().

If R finds gfortran in PATH at build time (and, as Homebrew builds it, it does), it will remember the value "gfortran".
CRAN package builds will also try to invoke "gfortran", which will end up searching PATH.
If Homebrew's prefix/bin is not in PATH, these builds will fail.

Homebrew can be missing from PATH if R is running under an IDE like Rstudio, and does not inherit environment variables set in shell initialization scripts.

This change encourages R to remember the absolute path to the Fortran compiler in Makeconf so that Homebrew does not need to be in PATH.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
