### PR TITLE
coreutils: enable install program hostname

### DIFF
--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -57,6 +57,7 @@ class Coreutils < Formula
       --program-prefix=g
       --with-gmp
       --without-selinux
+      --enable-install-program=hostname
     ]
 
     system "./configure", *args


### PR DESCRIPTION
I noticed that I didn't have GNU hostname program installed, which should be included with coreutils. It turns out, it's optional at configure time and disabled by default. This PR will enable it.

Signed-off-by: Robbie Lankford <robert.lankford@grafana.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
