### PR TITLE
zinc: disable

### DIFF
--- a/Formula/zinc.rb
+++ b/Formula/zinc.rb
@@ -8,7 +8,8 @@ class Zinc < Formula
     sha256 cellar: :any_skip_relocation, all: "86fb3d24eab6f75b51641311d7f9f574a31878f1c93ec1af0938ae2428178cc5"
   end
 
-  deprecate! date: "2018-06-10", because: :repo_archived
+  # Deprecated since 2020-08-19 in homebrew
+  disable! date: "2022-04-18", because: :repo_archived
 
   depends_on "openjdk@11"
 


### PR DESCRIPTION
This formula has been deprecated for more than a year
and upstream has been archived since 2018.
This gives the formula one more year to live before
it gets automatically cleaned up.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
