### PR TITLE
libmarpa: pkgconfig support for --HEAD build

### DIFF
--- a/Formula/libmarpa.rb
+++ b/Formula/libmarpa.rb
@@ -26,6 +26,7 @@ class Libmarpa < Formula
 
   def install
     ENV.deparallelize
+    inreplace "work/etc/libmarpa.pc.in", "prefix=\".\"", "prefix=\"@CMAKE_INSTALL_PREFIX@\"" if build.head?
     system "make", "dists"
     system "cmake", "-S", "cm_dist", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/libmarpa.rb
+++ b/Formula/libmarpa.rb
@@ -26,7 +26,7 @@ class Libmarpa < Formula
 
   def install
     ENV.deparallelize
-    inreplace "work/etc/libmarpa.pc.in", "prefix=\".\"", "prefix=\"@CMAKE_INSTALL_PREFIX@\"" if build.head?
+    inreplace "work/etc/libmarpa.pc.in", "prefix=\".\"", "prefix=\"#{prefix}\"" if build.head?
     system "make", "dists"
     system "cmake", "-S", "cm_dist", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
Notes: 
1. libmarpa's latest release (8.6.2) doesn't generate
   a pkgconfig file on installation, but the HEAD does.
2. Unfortunately, libmarpa's maintainer is allergic to
   absolute paths, even in the .pc file, which makes
   the .pc file kinda useless unless we edit the 
   template from which it is generated.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
