### PR TITLE
luajit: deprecate; luajit-openresty: swap linkage

### DIFF
--- a/Formula/luajit-openresty.rb
+++ b/Formula/luajit-openresty.rb
@@ -27,7 +27,16 @@ class LuajitOpenresty < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5d4e0b55a6e9f1397b50799fd33b4f0ee86bf749c1f36a595a309ca4b866dd6f"
   end
 
-  keg_only "it conflicts with the LuaJIT formula"
+  link_overwrite "bin/luajit"
+  link_overwrite "lib/libluajit.a"
+  link_overwrite "lib/libluajit-5.1.a"
+  link_overwrite "lib/libluajit.dylib"
+  link_overwrite "lib/libluajit-5.1.dylib"
+  link_overwrite "lib/libluajit-5.1.2.dylib"
+  link_overwrite "lib/libluajit-5.1.so"
+  link_overwrite "lib/libluajit-5.1.so.2"
+  link_overwrite "lib/pkgconfig/luajit.pc"
+  link_overwrite "share/man/man1/luajit.1"
 
   def install
     # 1 - Override the hardcoded gcc.

--- a/Formula/luajit.rb
+++ b/Formula/luajit.rb
@@ -13,11 +13,6 @@ class Luajit < Formula
     patch :DATA
   end
 
-  livecheck do
-    url "https://luajit.org/download.html"
-    regex(/href=.*?LuaJIT[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 5
     sha256 cellar: :any,                 monterey:     "351112e416f845b313dc71cb2a54d349330a6c676ea381d30f5d9d1c676e795c"
@@ -25,6 +20,12 @@ class Luajit < Formula
     sha256 cellar: :any,                 catalina:     "ee0c6394223cff8789452c0fc413d91cefeea1a3b5b5e2e39931620e8037c628"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "67663e6413774ef4b8be6678e389a6adb8e23ef50f52d5bb6d44f2b1069f6e8a"
   end
+
+  keg_only "it conflicts with the LuaJIT OpenResty formula"
+
+  # LuaJIT has abandoned versioned releases and recommends build from git HEAD.
+  # See https://github.com/Homebrew/homebrew-core/issues/68013
+  deprecate! date: "2022-04-18", because: "has abandoned versioned releases. Check out `luajit-openresty` instead"
 
   def install
     # 1 - Override the hardcoded gcc.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Potential PR to close #68013. Not sure if this is best choice.

Was considering deprecating `luajit` and swaping keg status with `luajit-openresty`. And later on adding to `formula_renames.json` to migrate `luajit` to `luajit-openresty`. 

Alternatives:
- Can directly rename (though may impact users expecting older `luajit`)
- Can consider some other deletion/migration process.
- Can just keep as is.

Currently, there is 0 usage of `luajit` in `homebrew-core` with most/all being migrated to `luajit-openresty`. At this point, it seems better to link the maintained `luajit-openresty` formula rather than old `luajit`.