### PR TITLE
lean-cli: add tds as alias

### DIFF
--- a/Formula/lean-cli.rb
+++ b/Formula/lean-cli.rb
@@ -22,6 +22,8 @@ class LeanCli < Formula
     build_from = build.head? ? "homebrew-head" : "homebrew"
     system "go", "build", *std_go_args(output: bin/"lean", ldflags: "-s -w -X main.pkgType=#{build_from}"), "./lean"
 
+    bin.install_symlink "lean" => "tds"
+
     bash_completion.install "misc/lean-bash-completion" => "lean"
     zsh_completion.install "misc/lean-zsh-completion" => "_lean"
   end


### PR DESCRIPTION
Users can use lean-cli under two brands: LeanCloud(lean) and TapTap Developer Services(tds),
In v0.29.2, lean-cli starts [distinguish itself by binary name](https://github.com/leancloud/lean-cli/commit/dc2296ef7fe63c38ee44be418d01bef5c3c29c32), so we add `tds` as a alias for it.

I am one of the official maintainers of [lean-cli](https://github.com/leancloud/lean-cli).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
