### PR TITLE
lean-cli: fix tests for 1.0.0

### DIFF
--- a/Formula/lean-cli.rb
+++ b/Formula/lean-cli.rb
@@ -1,8 +1,8 @@
 class LeanCli < Formula
   desc "Command-line tool to develop and manage LeanCloud apps"
   homepage "https://github.com/leancloud/lean-cli"
-  url "https://github.com/leancloud/lean-cli/archive/v0.29.2.tar.gz"
-  sha256 "b5d39383335ced9f7b9adb5bf9701cd3e4b4df19bae251b8a603c71b896ec32b"
+  url "https://github.com/leancloud/lean-cli/archive/v1.0.0.tar.gz"
+  sha256 "4e8b9d33fd57e68e2f3e94f69572945ae2860e4eaf25a72fd6d72b8580dce8ba"
   license "Apache-2.0"
   head "https://github.com/leancloud/lean-cli.git", branch: "master"
 
@@ -31,6 +31,6 @@ class LeanCli < Formula
 
   test do
     assert_match "lean version #{version}", shell_output("#{bin}/lean --version")
-    assert_match "Please log in first.", shell_output("#{bin}/lean init 2>&1", 1)
+    assert_match "Invalid access token.", shell_output("#{bin}/lean login --region us-w1 --token foobar 2>&1", 1)
   end
 end


### PR DESCRIPTION
Due to the breaking change made in [v1.0.0](https://github.com/leancloud/lean-cli/releases/tag/v1.0.0), `lean init` was renamed and always interactive, So I changed it to another subcommand: initiate a invalid login request.

I am one of the official maintainers of [lean-cli](https://github.com/leancloud/lean-cli/releases/tag/v1.0.0).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? **Yes, however that PR ( https://github.com/Homebrew/homebrew-core/pull/99587 ) was failed on tests.**
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
