### PR TITLE
gitwatch: fix gitwatch brew test ci errors

### DIFF
--- a/Formula/gitwatch.rb
+++ b/Formula/gitwatch.rb
@@ -26,6 +26,8 @@ class Gitwatch < Formula
 
   test do
     repo = testpath/"repo"
+    system "git", "config", "--global", "user.email", "gitwatch-ci-test@brew.sh"
+    system "git", "config", "--global", "user.name", "gitwatch"
     system "git", "init", repo
     pid = spawn "gitwatch", "-m", "Update", repo, pgroup: true
     sleep 15


### PR DESCRIPTION
See #99563 for more details on this failure.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
