### PR TITLE
jdtls: add livecheck

### DIFF
--- a/Formula/jdtls.rb
+++ b/Formula/jdtls.rb
@@ -2,8 +2,15 @@ class Jdtls < Formula
   desc "Java language specific implementation of the Language Server Protocol"
   homepage "https://github.com/eclipse/eclipse.jdt.ls"
   url "https://download.eclipse.org/jdtls/milestones/1.10.0/jdt-language-server-1.10.0-202204131925.tar.gz"
+  version "1.10.0"
   sha256 "b0faaf4ff8817cae607a6c2d54b78baad6306de3ab9104ff252b22eb33d82049"
   license "EPL-2.0"
+  version_scheme 1
+
+  livecheck do
+    url "https://download.eclipse.org/jdtls/milestones/"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "dac2e7423bcbb8be2c94bf49ef632ed89b0de0c2d4aa79fc51c38b3cece309c2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags from the `jdtls` `homepage`, which links to the GitHub project. This returns `1.10.0` as the latest version but the formula version includes a trailing timestamp (`1.10.0-202204131925`), so the formula version will always be treated as newer.

I looked around and the only way to identify the full version would be to collect versions from the version directories on the [`milestones` directory listing](https://download.eclipse.org/jdtls/milestones/), then fetch the directory listing for the newest version directory to identify the version from the tarball filename. This would take a somewhat involved `strategy` block (see [`bash`'s `livecheck` block](https://github.com/Homebrew/homebrew-core/blob/26619a63cf64187728fd5a9bc5ecf46f5eda8d37/Formula/bash.rb#L45) for reference) and I'm not convinced it's worth it when we have alternatives.

It's easier to simply use `version` to set the formula version to `1.10.0`, omitting the timestamp. The timestamp varies between [download locations](https://projects.eclipse.org/projects/eclipse.jdt.ls/downloads) (e.g., Maven has a different timestamp for the same version) and I don't see more than one release for a given version (e.g., `1.10.0`) in one place (i.e., only with different timestamps), so I don't see an issue with us only using the version here.

With that in mind, this PR adds `version "1.10.0"` and bumps the `version_scheme`. Besides that, this adds a `livecheck` block to identify versions from the `/jdtls/milestones/` directory listing, to align the check with the `stable` source.