### PR TITLE
versioned_dependencies_conflicts_allowlist: remove `anjuta` and `gjs`

### DIFF
--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -1,9 +1,7 @@
 [
-  "anjuta",
   "coin3d",
   "emscripten",
   "freedink",
-  "gjs",
   "hive",
   "libgaiagraphics",
   "librasterlite",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- `anjuta` was mentioned in https://github.com/Homebrew/homebrew-core/issues/65831#issuecomment-995258745
- `gjs` was originally added in https://github.com/Homebrew/homebrew-core/commit/049de3d062aacecd00b47b089de2f0b3eb95e074 due to `llvm`. I had refactored in #94905 and dropped dependency but didn't update the allowlist.