### PR TITLE
zstd: use shared linkage, remove `zlib` dependency

### DIFF
--- a/Formula/zstd.rb
+++ b/Formula/zstd.rb
@@ -20,13 +20,12 @@ class Zstd < Formula
 
   depends_on "cmake" => :build
 
-  uses_from_macos "zlib"
-
   def install
     # Legacy support is the default after
     # https://github.com/facebook/zstd/commit/db104f6e839cbef94df4df8268b5fecb58471274
     # Set it to `ON` to be explicit about the configuration.
     system "cmake", "-S", "build/cmake", "-B", "builddir",
+                    "-DZSTD_PROGRAMS_LINK_SHARED=ON", # link `zstd` to `libzstd`
                     "-DZSTD_BUILD_CONTRIB=ON",
                     "-DCMAKE_INSTALL_RPATH=#{rpath}",
                     "-DZSTD_LEGACY_SUPPORT=ON",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula has no linkage with `zlib` on macOS and Linux, so it seems
likely that `zlib` is not actually needed.

Additionally, set `ZSTD_PROGRAMS_LINK_SHARED` so that the `zstd` binary
links dynamically with `libzstd` instead of linking statically.

Shared linking decreases the size of the `zstd` binary and creates
opportunities for more efficient use of system resources (at the minor
cost of overhead care of dynamic linking).

Neither of these changes are probably enough to warrant a revision bump,
but building new bottles won't hurt.
