### PR TITLE
antlr 4.10.1

### DIFF
--- a/Formula/antlr.rb
+++ b/Formula/antlr.rb
@@ -1,12 +1,12 @@
 class Antlr < Formula
   desc "ANother Tool for Language Recognition"
   homepage "https://www.antlr.org/"
-  url "https://www.antlr.org/download/antlr-4.9.3-complete.jar"
-  sha256 "afcd40946d3de4d81e28d7c88d467289e0587285d27adb172aecc5494a17df36"
+  url "https://www.antlr.org/download/antlr-4.10.1-complete.jar"
+  sha256 "41949d41f20d31d5b8277187735dd755108df52b38db6c865108d3382040f918"
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://www.antlr.org/download/"
+    url "https://www.antlr.org/download.html"
     regex(/href=.*?antlr[._-]v?(\d+(?:\.\d+)+)-complete\.jar/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates the `antlr` formula to the latest version, 4.10.1.

Besides that, the existing `livecheck` block for `antlr` checks the first-party `/download/` page (previously a directory listing, I believe) but this now gives a 404. The current download page URL is `/download.html`, so this PR updates the URL accordingly.