### PR TITLE
pjproject: fix build on macos/arm

### DIFF
--- a/Formula/pjproject.rb
+++ b/Formula/pjproject.rb
@@ -28,12 +28,10 @@ class Pjproject < Formula
     system "make"
     system "make", "install"
 
-    arch = Utils.safe_popen_read("uname", "-m").chomp
-    if OS.mac?
-      bin.install "pjsip-apps/bin/pjsua-#{arch}-apple-darwin#{OS.kernel_version}" => "pjsua"
-    else
-      bin.install "pjsip-apps/bin/pjsua-#{arch}-unknown-linux-gnu" => "pjsua"
-    end
+    arch = OS.mac? && Hardware::CPU.arm? ? "arm" : Hardware::CPU.arch.to_s
+    target = OS.mac? ? "apple-darwin#{OS.kernel_version}" : "unknown-linux-gnu"
+
+    bin.install "pjsip-apps/bin/pjsua-#{arch}-#{target}" => "pjsua"
   end
 
   test do


### PR DESCRIPTION
The resulting binary is named pjsua-arm-apple...
instead of pjsua-arm64-apple...
Use the correct name to install the binary.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
