### PR TITLE
avahi: enable mDNSResponder compatibility

### DIFF
--- a/Formula/avahi.rb
+++ b/Formula/avahi.rb
@@ -4,6 +4,7 @@ class Avahi < Formula
   url "https://github.com/lathiat/avahi/archive/v0.8.tar.gz"
   sha256 "c15e750ef7c6df595fb5f2ce10cac0fee2353649600e6919ad08ae8871e4945f"
   license "LGPL-2.1-or-later"
+  revision 1
 
   bottle do
     rebuild 1
@@ -24,10 +25,8 @@ class Avahi < Formula
   depends_on :linux
 
   def install
-    system "./bootstrap.sh", "--disable-debug",
-                             "--disable-dependency-tracking",
+    system "./bootstrap.sh", *std_configure_args,
                              "--disable-silent-rules",
-                             "--prefix=#{prefix}",
                              "--sysconfdir=#{prefix}/etc",
                              "--localstatedir=#{prefix}/var",
                              "--disable-mono",
@@ -38,9 +37,13 @@ class Avahi < Formula
                              "--disable-gtk",
                              "--disable-gtk3",
                              "--disable-libevent",
+                             "--enable-compat-libdns_sd",
                              "--with-distro=none",
                              "--with-systemdsystemunitdir=no"
     system "make", "install"
+
+    # mDNSResponder compatibility
+    ln_s include/"avahi-compat-libdns_sd/dns_sd.h", include/"dns_sd.h"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

At least needed for `serialosc`.

Similar to Arch Linux package where compatibility is enabled and symlink is added https://github.com/archlinux/svntogit-packages/blob/packages/avahi/trunk/PKGBUILD