### PR TITLE
clipsafe: add license

### DIFF
--- a/Formula/clipsafe.rb
+++ b/Formula/clipsafe.rb
@@ -3,6 +3,7 @@ class Clipsafe < Formula
   homepage "https://waxandwane.org/clipsafe.html"
   url "https://waxandwane.org/download/clipsafe-1.1.tar.gz"
   sha256 "7a70b4f467094693a58814a42d272e98387916588c6337963fa7258bda7a3e48"
+  license "GPL-2.0-or-later"
   revision 1
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
license ref on the project page, https://waxandwane.org/clipsafe.html

> Licensed under the [GNU GPLv2](http://www.gnu.org/licenses/old-licenses/gpl-2.0.html) for now.

