### PR TITLE
aoeui: add license

### DIFF
--- a/Formula/aoeui.rb
+++ b/Formula/aoeui.rb
@@ -3,6 +3,7 @@ class Aoeui < Formula
   homepage "https://code.google.com/archive/p/aoeui/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/aoeui/aoeui-1.6.tgz"
   sha256 "0655c3ca945b75b1204c5f25722ac0a07e89dd44bbf33aca068e918e9ef2a825"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "daa6bd80f0cf479ba65187c2834ce38add2aeb37f93094596dcac9eda5001a68"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


<details>
<summary>license header ref</summary>

```
The aoeui text editor is copyright 2007 Peter Klausler and
released under the GNU General Public License version 2 only.
Any change to a later version of the license, or to another
open source license, will be explicitly stated in later editions
of this file.

A copy of this license is appended, whose text itself is copyright
by the good folks at the Free Software Foundation.

----------------------------------------

```


</details>
