### PR TITLE
netcdf: update livecheck

### DIFF
--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -1,6 +1,6 @@
 class Netcdf < Formula
   desc "Libraries and data formats for array-oriented scientific data"
-  homepage "https://www.unidata.ucar.edu/software/netcdf"
+  homepage "https://www.unidata.ucar.edu/software/netcdf/"
   url "https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.8.1.tar.gz"
   sha256 "bc018cc30d5da402622bf76462480664c6668b55eb16ba205a0dfb8647161dd0"
   license "BSD-3-Clause"
@@ -8,8 +8,8 @@ class Netcdf < Formula
   head "https://github.com/Unidata/netcdf-c.git", branch: "main"
 
   livecheck do
-    url "https://downloads.unidata.ucar.edu/netcdf-c/release_info.json"
-    regex(/["']version["']:\s*["']v?(\d+(?:\.\d+)+)["']/i)
+    url :stable
+    regex(/^(?:netcdf[._-])?v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `netcdf` checks releases on the first-party site but these days the formula uses a tag archive from the GitHub repository for technical reasons (the tarball from the first-party site is missing some files, if I remember correctly). This PR updates the `livecheck` block to check the Git tags (aligning the check with the `stable` source) and use an appropriate regex to avoid unrelated tags.