### PR TITLE
qpdf: add livecheck

### DIFF
--- a/Formula/qpdf.rb
+++ b/Formula/qpdf.rb
@@ -5,6 +5,11 @@ class Qpdf < Formula
   sha256 "e8fc23b2a584ea68c963a897515d3eb3129186741dd19d13c86d31fa33493811"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^release-qpdf[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "24944d4bf95fe2c8074f56a971fb02fc690debd23918e9167da0382610caca9f"
     sha256 cellar: :any,                 arm64_big_sur:  "8f49d18dd8988cc2c63edbc62ca3fdfe588d8da7c42ed166ed3eb47a891d93e4"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `qpdf` and is currently giving `10.6.3.0cmake1` as newest but this is marked as "pre-release" on GitHub. This PR addresses the issue by adding a `livecheck` block with a regex that restricts matching to stable version tags (e.g., `release-qpdf-10.6.3`), so this will correctly give 10.6.3 as the latest version.