### PR TITLE
synergy-core 1.14.4.37 (new formula)

### DIFF
--- a/Aliases/synergy
+++ b/Aliases/synergy
@@ -1,0 +1,1 @@
+../Formula/synergy-core.rb

--- a/Formula/synergy-core.rb
+++ b/Formula/synergy-core.rb
@@ -1,0 +1,108 @@
+class SynergyCore < Formula
+  desc "Synergy, the keyboard and mouse sharing tool"
+  homepage "https://symless.com/synergy"
+
+  # The synergy-core/LICENSE file contains the following preamble:
+  #   This program is released under the GPL with the additional exemption
+  #   that compiling, linking, and/or using OpenSSL is allowed.
+  # This preamble is followed by the text of the GPL-2.0.
+  #
+  # The synergy-core license is a free software license but it cannot be
+  # represented with the brew `license` statement.
+  #
+  # The GitHub Licenses API incorrectly says that this project is licensed
+  # strictly under GPLv2 (rather than GPLv2 plus a special exception).
+  # This requires synergy-core to appear as an exception in:
+  #   audit_exceptions/permitted_formula_license_mismatches.json
+  # That exception can be removed if the nonfree GitHub Licenses API is fixed.
+  license :cannot_represent
+
+  head "https://github.com/symless/synergy-core.git", branch: "master"
+
+  stable do
+    url "https://github.com/symless/synergy-core/archive/refs/tags/v1.14.4.37-stable.tar.gz"
+    sha256 "081735f032a2909c65322d43bcaf463bca05f88a05882c706762c959cd4bbec6"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "openssl@3"
+  depends_on "pugixml"
+  depends_on "qt@5"
+
+  on_linux do
+    depends_on "pkg-config" => :build
+    depends_on "gcc" # For C++17 support.
+    depends_on "gdk-pixbuf"
+    depends_on "glib"
+    depends_on "libnotify"
+    depends_on "libxkbfile"
+  end
+
+  fails_with gcc: "5" do
+    cause "synergy-core requires C++17 support"
+  end
+
+  def install
+    # Use the standard brew installation path.
+    inreplace "CMakeLists.txt",
+              "set (SYNERGY_BUNDLE_DIR ${CMAKE_BINARY_DIR}/bundle)",
+              "set (SYNERGY_BUNDLE_DIR ${CMAKE_INSTALL_PREFIX}/bundle)"
+
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args,
+                    "-DBUILD_TESTS:BOOL=OFF", "-DCMAKE_INSTALL_DO_STRIP=1",
+                    "-DSYSTEM_PUGIXML:BOOL=ON"
+
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    if OS.mac?
+      bin.install_symlink prefix/"bundle/Synergy.app/Contents/MacOS/synergy"  # main GUI program
+      bin.install_symlink prefix/"bundle/Synergy.app/Contents/MacOS/synergys" # server
+      bin.install_symlink prefix/"bundle/Synergy.app/Contents/MacOS/synergyc" # client
+    end
+  end
+
+  service do
+    run [opt_bin/"synergy"]
+    run_type :immediate
+  end
+
+  def caveats
+    # Because we used `license :cannot_represent` above, tell the user how to
+    # read the license.
+    s = <<~EOS
+      Read the synergy-core license here:
+        #{opt_prefix}/LICENSE
+    EOS
+    # The binaries built by brew are not signed by a trusted certificate, so the
+    # user may need to revoke all permissions for 'Accessibility' and re-grant
+    # them when upgrading synergy-core.
+    on_macos do
+      s += "\n" + <<~EOS
+        Synergy requires the 'Accessibility' permission.
+        You can grant this permission by navigating to:
+          System Preferences -> Security & Privacy -> Privacy -> Accessibility
+
+        If Synergy still doesn't work, try clearing the 'Accessibility' list:
+          sudo tccutil reset Accessibility
+        You can then grant the 'Accessibility' permission again.
+        You may need to clear this list each time you upgrade synergy-core.
+      EOS
+    end
+    s
+  end
+
+  test do
+    assert_equal shell_output("#{opt_bin}/synergys", 4),
+                 "synergys: no configuration available\n"
+    assert_equal shell_output("#{opt_bin}/synergyc", 3).split("\n")[0],
+                 "synergyc: a server address or name is required"
+    return if head?
+
+    version_string = Regexp.quote(version.major_minor_patch)
+    assert_match(/synergys #{version_string}[\-.0-9a-z]*, protocol version/,
+                 shell_output("#{opt_bin}/synergys --version", 3).lines.first)
+    assert_match(/synergyc #{version_string}[\-.0-9a-z]*, protocol version/,
+                 shell_output("#{opt_bin}/synergyc --version", 3).lines.first)
+  end
+end

--- a/audit_exceptions/permitted_formula_license_mismatches.json
+++ b/audit_exceptions/permitted_formula_license_mismatches.json
@@ -1,3 +1,4 @@
 [
-  "scummvm"
+  "scummvm",
+  "synergy-core"
 ]


### PR DESCRIPTION
Synergy is a free and open source program for sharing a mouse and keyboard
among multiple computers. It supports 64-bit Intel Mac, 64-bit ARM Mac,
64-bit GNU/Linux, and other platforms.

Synergy was previously available in brew as a cask named `synergy`. That
cask installed binaries published by Symless, the corporate sponsor of
Synergy. However, at some point in the last couple months, Symless decided
to start charging money for access to the binaries on its website. As part
of this change, the Symless binaries were placed behind an authentication
webpage. As a result, the `synergy` cask was removed from brew:
> https://github.com/Homebrew/homebrew-cask/commit/0037f2409

However, even though Symless no longer publishes binaries, Synergy remains
fully free and open source software, licensed under GPL version 2 (with an
exception allowing "compiling, linking, and/or using OpenSSL"). As a result,
nothing stops us from building our own binaries from the source code. This
new `synergy-core` formula does exactly that: it builds Synergy from source
and installs it.

This formula supports 64-bit Intel Mac, 64-bit ARM Mac, and 64-bit GNU/Linux.
I have tested the formula on all three platforms. (For GNU/Linux testing, I
used Fedora 35, although that probably doesn't matter.)

This formula sets up a `synergy-core` daemon that can be run and managed
using `brew services`. This daemon is currently how I recommend running
the binaries built by this formula.

***

The `synergy-core` project is distributed under the GPLv2 license with an
exception that grants additional rights to the user. The project's LICENSE
file reads as follows:
> This program is released under the GPL with the additional exemption
> that compiling, linking, and/or using OpenSSL is allowed.
This preamble is followed by the text of the GPL-2.0.

This is a free software license but it cannot be represented with the `brew`
license statement, so the formula uses `license :cannot_represent`.
Unfortunately, the GitHub Licenses API incorrectly states that `synergy-core`
is licensed strictly under the GPLv2. So we need to add `synergy-core` to
  audit_exceptions/permitted_formula_license_mismatches.json
to avoid `brew audit` objecting that the license specified in the
`license` statement is different from the license returned by the
GitHub Licenses API.

-----

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?