### PR TITLE
libtcod: requires Catalina minimum

### DIFF
--- a/Formula/libtcod.rb
+++ b/Formula/libtcod.rb
@@ -19,6 +19,7 @@ class Libtcod < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.10" => :build
+  depends_on macos: :catalina
   depends_on "sdl2"
 
   on_linux do


### PR DESCRIPTION
Building on Mojave generates errors like:
```
../../samples/samples_cpp.cpp:1208:29: error: '~directory_iterator' is unavailable: introduced in macOS 10.15
```
No rebuilds needed, `CI-syntax-only`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? `CI-syntax-only`
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? `CI-syntax-only`
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
