### PR TITLE
mupen64plus: update 2.5_1 bottle.

### DIFF
--- a/Formula/mupen64plus.rb
+++ b/Formula/mupen64plus.rb
@@ -12,14 +12,9 @@ class Mupen64plus < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 monterey:     "5199526084ae5a1708b1448c56134710bb50d7b1768441ec137b6ff0ac25a7da"
-    sha256 cellar: :any,                 big_sur:      "5a9a16e37b0274e5c21b44f9b076f5b0b6140ff8017041f2cfb1c33963acfb9c"
-    sha256 cellar: :any,                 catalina:     "999b60faedf8eb2299f854991995c44b81898de85a73ca0568902e5b63641e42"
-    sha256 cellar: :any,                 mojave:       "c88a4d9a47cdcc6b995615d5fd4b061a7046ec72fac75560d79998b7abf60b78"
-    sha256 cellar: :any,                 high_sierra:  "4dc531259b558fe987eecd74d87afb70284d36ec4e0c3008de751b820f83e64b"
-    sha256 cellar: :any,                 sierra:       "28006559bb0cc624432b1a8b0a7dfd08e9a5a3d59d7dbaf5cde64ac29dc747d1"
-    sha256 cellar: :any,                 el_capitan:   "6d9d9900813b21abc89149ded185d4b74147a85c1a350d54511ee535acde171c"
+    sha256 cellar: :any,                 monterey:     "6b86a8fd100955661cd1425b27df33df0bf7949ef164a401e7066425c8022a77"
+    sha256 cellar: :any,                 big_sur:      "da9aa98b919af2324eb868de2c5fa5cdbb4809d84cbf238ea56a7a99deb92402"
+    sha256 cellar: :any,                 catalina:     "33554823abe8df4c756c48d9956c7edd66f6009b9ab4c57829bc2084f2a4b96f"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "84c9544695c149cbdb1d0a662e9dccc1fc004b984e3e53b0537be1fe653566ad"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew pr-upload`ed:
```
==> mupen64plus
  bottle do
    sha256 cellar: :any,                 monterey:     "6b86a8fd100955661cd1425b27df33df0bf7949ef164a401e7066425c8022a77"
    sha256 cellar: :any,                 big_sur:      "da9aa98b919af2324eb868de2c5fa5cdbb4809d84cbf238ea56a7a99deb92402"
    sha256 cellar: :any,                 catalina:     "33554823abe8df4c756c48d9956c7edd66f6009b9ab4c57829bc2084f2a4b96f"
    sha256 cellar: :any_skip_relocation, x86_64_linux: "84c9544695c149cbdb1d0a662e9dccc1fc004b984e3e53b0537be1fe653566ad"
  end
[master c7b677eb48b] mupen64plus: update 2.5_1 bottle.
 1 file changed, 3 insertions(+), 8 deletions(-)


/opt/homebrew/bin/skopeo copy --all oci:mupen64plus--2.5_1 docker://ghcr.io/homebrew/core/mupen64plus:2.5_1 --dest-creds=cho-m:******
Getting image list signatures
Copying 4 of 4 images in list
Copying image sha256:96fe41e6c4c1064f20d3deff54caca33cf296b52f81363979db5d60c119ac220 (1/4)
Getting image source signatures
Copying blob sha256:84c9544695c149cbdb1d0a662e9dccc1fc004b984e3e53b0537be1fe653566ad
Copying config sha256:b2be449caef0aaed2b34d08de316bb325d5cdab1b535f1646ea339ea8ab44013
Writing manifest to image destination
Storing signatures
Copying image sha256:e19c01e2f3d732a656531962391dabe731fcc60de84afae94aba32a08aa4899c (2/4)
Getting image source signatures
Copying blob sha256:6b86a8fd100955661cd1425b27df33df0bf7949ef164a401e7066425c8022a77
Copying config sha256:4e931707357f68d585836028a15e743fb813e96657837b15e81055b6457ad014
Writing manifest to image destination
Storing signatures
Copying image sha256:eaf6baaf1ae75468a8fcd8506ed5d4e6964ded51de85de6e6686669b6838fb90 (3/4)
Getting image source signatures
Copying blob sha256:33554823abe8df4c756c48d9956c7edd66f6009b9ab4c57829bc2084f2a4b96f
Copying config sha256:15a95ea9e283be19a94a331c9833c88c8ab83d40a366cbec17cb9f6205af72bd
Writing manifest to image destination
Storing signatures
Copying image sha256:80b8eac7d85e18c9e25ff31f3208dfd079c51b61afaf08d61be8cea01b24a6fa (4/4)
Getting image source signatures
Copying blob sha256:da9aa98b919af2324eb868de2c5fa5cdbb4809d84cbf238ea56a7a99deb92402
Copying config sha256:65cb17393649c2863f9b045bbfd1252d84013d0a1cf02d1845b0fa816488d90b
Writing manifest to image destination
Storing signatures
Writing manifest list to image destination
Storing list signatures
==> Uploaded to https://github.com/orgs/homebrew/packages/container/package/core/mupen64plus
```