### PR TITLE
jenv: Don't link export shim

### DIFF
--- a/Formula/jenv.rb
+++ b/Formula/jenv.rb
@@ -13,7 +13,7 @@ class Jenv < Formula
   def install
     libexec.install Dir["*"]
     bin.write_exec_script libexec/"bin/jenv"
-    fish_function.install_symlink Dir[libexec/"fish/*.fish"]
+    fish_function.install_symlink libexec/"fish/jenv.fish"
   end
 
   def caveats


### PR DESCRIPTION
Modern versions of fish ship one, and this shim breaks other scripts.
Specifically, unlike the built-in version, this is unable to handle setting
than one variable in a given invocation.
