### PR TITLE
openfortivpn: add `service do` block

### DIFF
--- a/Formula/openfortivpn.rb
+++ b/Formula/openfortivpn.rb
@@ -27,6 +27,15 @@ class Openfortivpn < Formula
                           "--sysconfdir=#{etc}/openfortivpn"
     system "make", "install"
   end
+
+  plist_options startup: true
+  service do
+    run [opt_bin/"openfortivpn", "-c", etc/"openfortivpn/openfortivpn/config"]
+    keep_alive true
+    log_path var/"log/openfortivpn.log"
+    error_log_path var/"log/openfortivpn.log"
+  end
+
   test do
     system bin/"openfortivpn", "--version"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds support for `brew services` to the `openfortivpn` formula.