### PR TITLE
jack-example-tools 3 (new formula), jack: don't build example clients and tools

### DIFF
--- a/Formula/jack-example-tools.rb
+++ b/Formula/jack-example-tools.rb
@@ -1,0 +1,46 @@
+class JackExampleTools < Formula
+  desc "Example clients and tools for JACK"
+  homepage "https://jackaudio.org/"
+  url "https://github.com/jackaudio/jack-example-tools/archive/3.tar.gz"
+  sha256 "661a95d43c276d444b03756564ceaa3b53a2a0b78c8147631383f31fa85135c6"
+  license "GPL-2.0-or-later"
+  head "https://github.com/jackaudio/jack-example-tools.git", branch: "main"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "jack"
+
+  def install
+    mkdir "build" do
+      system "meson", *std_meson_args, ".."
+      system "ninja", "-v"
+      system "ninja", "-v", "install"
+    end
+  end
+
+  test do
+    source_name = "test_source"
+    sink_name = "test_sink"
+    fork do
+      if OS.mac?
+        exec "#{Formula["jack"].bin}/jackd", "-X", "coremidi", "-d", "dummy"
+      else
+        exec "#{Formula["jack"].bin}/jackd", "-d", "dummy"
+      end
+    end
+    system "#{bin}/jack_wait", "--wait", "--timeout", "10"
+    fork do
+      exec "#{bin}/jack_midiseq", source_name, "16000", "0", "60", "8000"
+    end
+    midi_sink = IO.popen "#{bin}/jack_midi_dump #{sink_name}"
+    sleep 1
+    system "#{bin}/jack_connect", "#{source_name}:out", "#{sink_name}:input"
+    sleep 1
+    Process.kill "TERM", midi_sink.pid
+
+    midi_dump = midi_sink.read
+    assert_match "90 3c 40", midi_dump
+    assert_match "80 3c 40", midi_dump
+  end
+end

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -4,6 +4,7 @@ class Jack < Formula
   url "https://github.com/jackaudio/jack2/archive/v1.9.21.tar.gz"
   sha256 "8b044a40ba5393b47605a920ba30744fdf8bf77d210eca90d39c8637fe6bc65d"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -44,7 +45,7 @@ class Jack < Formula
       ENV.append "LDFLAGS", "-Wl,-compatibility_version,1"
       ENV.append "LDFLAGS", "-Wl,-current_version,#{version}"
     end
-    system Formula["python@3.10"].opt_bin/"python3", "./waf", "configure", "--prefix=#{prefix}", "--example-tools"
+    system Formula["python@3.10"].opt_bin/"python3", "./waf", "configure", "--prefix=#{prefix}"
     system Formula["python@3.10"].opt_bin/"python3", "./waf", "build"
     system Formula["python@3.10"].opt_bin/"python3", "./waf", "install"
   end
@@ -57,8 +58,6 @@ class Jack < Formula
   end
 
   test do
-    source_name = "test_source"
-    sink_name = "test_sink"
     fork do
       if OS.mac?
         exec "#{bin}/jackd", "-X", "coremidi", "-d", "dummy"
@@ -66,18 +65,5 @@ class Jack < Formula
         exec "#{bin}/jackd", "-d", "dummy"
       end
     end
-    system "#{bin}/jack_wait", "--wait", "--timeout", "10"
-    fork do
-      exec "#{bin}/jack_midiseq", source_name, "16000", "0", "60", "8000"
-    end
-    midi_sink = IO.popen "#{bin}/jack_midi_dump #{sink_name}"
-    sleep 1
-    system "#{bin}/jack_connect", "#{source_name}:out", "#{sink_name}:input"
-    sleep 1
-    Process.kill "TERM", midi_sink.pid
-
-    midi_dump = midi_sink.read
-    assert_match "90 3c 40", midi_dump
-    assert_match "80 3c 40", midi_dump
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR modifies the `jack` formula to remove the build and test for example clients and tools, which will be removed in the next release. These have been moved to a separate repository, and following discussion in #99640, it is better to have a separate formula for these tools.

The `jack-example-tools` formula will fail the notability audit but I think we should go ahead with it as those tools used to be provided with `jack` and should continue to be installable through `brew`. It currently requires a patch but I've created an issue to ask for a new release (jackaudio/jack-example-tools#76).