### PR TITLE
sevenzip: add livecheck

### DIFF
--- a/Formula/sevenzip.rb
+++ b/Formula/sevenzip.rb
@@ -6,6 +6,11 @@ class Sevenzip < Formula
   sha256 "213d594407cb8efcba36610b152ca4921eda14163310b43903d13e68313e1e39"
   license all_of: ["LGPL-2.1-or-later", "BSD-3-Clause"]
 
+  livecheck do
+    url "https://7-zip.org/download.html"
+    regex(/>\s*Download\s+7-Zip\s+v?(\d+(?:\.\d+)+)[\s<]/im)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_monterey: "b7283890b7e26f7049acc6b39f4f39d0d0bb6e1d70cb06173bcef4c51e7ce9a0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check the `sevenzip` formula. This PR adds a `livecheck` block that checks the first-party download page and identifies versions from text like "Download 7-Zip 21.07" that appears before the related table of download links. Unfortunately, the version in the source tarball filename doesn't include dots (e.g., `7z2107-src.tar.xz` for version 21.07), so we can't use that without having to naively insert dots (which we try to avoid because it can be error-prone).