### PR TITLE
uade 3.01

### DIFF
--- a/Formula/uade.rb
+++ b/Formula/uade.rb
@@ -1,14 +1,15 @@
 class Uade < Formula
   desc "Play Amiga tunes through UAE emulation"
   homepage "https://zakalwe.fi/uade/"
-  head "https://gitlab.com/uade-music-player/uade.git", branch: "master"
+  license "GPL-2.0-only"
 
   stable do
-    url "https://zakalwe.fi/uade/uade2/uade-2.13.tar.bz2"
-    sha256 "3b194e5aebbfa99d3708d5a0b5e6bd7dc5d1caaecf4ae9b52f8ff87e222dd612"
+    url "https://zakalwe.fi/uade/uade3/uade-3.01.tar.bz2"
+    sha256 "a669c215970db2595027c16ee01149613fcfa4b81be67216ce6d7add871ef62a"
 
-    # Upstream patch to fix compiler detection under superenv
-    patch :DATA
+    resource "bencode-tools" do
+      url "https://gitlab.com/heikkiorsila/bencodetools.git", revision: "5a1ccf65393ee50af3a029d0632f29567467873c"
+    end
   end
 
   livecheck do
@@ -30,45 +31,31 @@ class Uade < Formula
     sha256 x86_64_linux:   "4e9995eda253cbfa248aa486080c04cca295f348e1682d2c10b7ec45a967d46f"
   end
 
+  head do
+    url "https://gitlab.com/uade-music-player/uade.git", branch: "master"
+
+    resource "bencode-tools" do
+      url "https://gitlab.com/heikkiorsila/bencodetools.git", branch: "master"
+    end
+  end
+
   depends_on "pkg-config" => :build
   depends_on "libao"
 
-  resource "bencode-tools" do
-    url "https://github.com/heikkiorsila/bencode-tools.git", branch: "master"
-  end
-
   def install
-    if build.head?
-      resource("bencode-tools").stage do
-        system "./configure", "--prefix=#{prefix}", "--without-python"
-        system "make"
-        system "make", "install"
-      end
+    resource("bencode-tools").stage do
+      system "./configure", "--prefix=#{prefix}", "--without-python"
+      system "make"
+      system "make", "install"
     end
 
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}",
+           "--without-write-audio"
     system "make", "install"
   end
+
+  test do
+    output = shell_output("#{bin}/uade123 --get-info #{test_fixtures("test.mp3")} 2>&1", 1).chomp
+    assert_equal "Unknown format: #{test_fixtures("test.mp3")}", output
+  end
 end
-
-__END__
-diff --git a/configure b/configure
-index 05bfa9b..a73608e 100755
---- a/configure
-+++ b/configure
-@@ -399,13 +399,13 @@ if test -n "$sharedir"; then
-     uadedatadir="$sharedir"
- fi
-
--$NATIVECC -v 2>/dev/null >/dev/null
-+$NATIVECC --version 2>/dev/null >/dev/null
- if test "$?" != "0"; then
-     echo Native CC "$NATIVECC" not found, please install a C compiler
-     exit 1
- fi
-
--$TARGETCC -v 2>/dev/null >/dev/null
-+$TARGETCC --version 2>/dev/null >/dev/null
- if test "$?" != "0"; then
-     echo Target CC "$TARGETCC" not found, please install a C compiler
-     exit 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Patch no longer needed in this version. `bencode-tools` is now mandatory; I've pinned the stable build at the most recent commit for repeatability.