### PR TITLE
vgrep: update livecheck

### DIFF
--- a/Formula/vgrep.rb
+++ b/Formula/vgrep.rb
@@ -7,9 +7,15 @@ class Vgrep < Formula
   version_scheme 1
   head "https://github.com/vrothberg/vgrep.git", branch: "main"
 
+  # The leading `v` in this regex is intentionally non-optional, as we need to
+  # exclude a few older tags that use a different version scheme and would
+  # erroneously appear as newer than the newest version. We can't check the
+  # "latest" release on GitHub because it's sometimes a lower version that was
+  # released after a higher version (i.e., "latest" is the most recent release
+  # but not necessarily the newest version in this context).
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `vgrep` uses the `GithubLatest` strategy but this is currently reporting 2.5.6 as newest instead of 2.6.0, simply because 2.5.6 was released after 2.6.0.

We've been using the `GithubLatest` strategy because checking the Git tags isn't entirely straightforward. The project originally used a version scheme like 15.05, 15.11, 16.09, etc. but 16.09.1 was followed by 2.0.0 (and so forth). With 2.1.0, the tag format switched to include a leading `v` (e.g., `v2.1.0`) and this has been the tag format since then.

This PR resolves the version issue by removing `strategy :github_latest` (livecheck will use the `Git` strategy) and adding a version of the standard regex for Git tags like `1.2.3`/`v1.2.3` where the leading `v` isn't optional. Requiring a leading `v` effectively omits the earlier versions (which would always be treated as newest, since 16 > 2) but it will be a problem if a version tag ever omits the leading `v` in the future.

This should be fine for now but if it becomes a problem in the future, we'll have to make an exception and check the GitHub releases page (omitting pre-release versions), as our options are limited due to the upstream situation.