### PR TITLE
openjdk: min Catalina required

### DIFF
--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -23,6 +23,7 @@ class Openjdk < Formula
 
   depends_on "autoconf" => :build
   depends_on xcode: :build
+  depends_on macos: :catalina
 
   on_linux do
     depends_on "pkg-config" => :build


### PR DESCRIPTION
Specified upstream at https://wiki.openjdk.java.net/display/Build/Supported+Build+Platforms, confirmed by build failure on Mojave.

Note that OpenJDK 17 is also specified as requiring Catalina minimum, but I confirmed build and test success on Mojave, so I'm not including `openjdk@17` in this PR.

`CI-syntax-only`, no rebuilds required.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
