### PR TITLE
delta: deprecate, add license, and fix Linux test

### DIFF
--- a/Formula/delta.rb
+++ b/Formula/delta.rb
@@ -3,6 +3,7 @@ class Delta < Formula
   homepage "https://web.archive.org/web/20170805142100/delta.tigris.org/"
   url "https://deb.debian.org/debian/pool/main/d/delta/delta_2006.08.03.orig.tar.gz"
   sha256 "38184847a92b01b099bf927dbe66ef88fcfbe7d346a7304eeaad0977cb809ca0"
+  license "BSD-3-Clause"
 
   bottle do
     rebuild 2
@@ -18,6 +19,8 @@ class Delta < Formula
     sha256 cellar: :any_skip_relocation, yosemite:       "d3374cc3e84c93bb84615b1669503ea8b708ab65baf629ee0be9a728b12b10bc"
   end
 
+  deprecate! date: "2022-04-30", because: :unmaintained
+
   conflicts_with "git-delta", because: "both install a `delta` binary"
 
   def install
@@ -27,21 +30,14 @@ class Delta < Formula
 
   test do
     (testpath/"test1.c").write <<~EOS
-      #include <stdio.h>
-
       int main() {
-        int i = -1;
-        unsigned int j = i;
-        printf("%d\n", j);
+        printf("%d\n", 0);
       }
-
     EOS
     (testpath/"test1.sh").write <<~EOS
       #!/usr/bin/env bash
 
-      clang -Weverything "$(dirname "${BASH_SOURCE[0]}")"/test1.c 2>&1 | \
-      grep 'implicit conversion changes signedness'
-
+      #{ENV.cc} -Wall #{testpath}/test1.c 2>&1 | grep 'Wimplicit-function-declaration'
     EOS
 
     chmod 0755, testpath/"test1.sh"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Deprecating as it looks like it was from 2006, the homepage URLs is archive.org, and download URL is from Debian

