### PR TITLE
open-scene-graph: fix build when asio library is installed

### DIFF
--- a/Formula/open-scene-graph.rb
+++ b/Formula/open-scene-graph.rb
@@ -1,11 +1,20 @@
 class OpenSceneGraph < Formula
   desc "3D graphics toolkit"
   homepage "https://github.com/openscenegraph/OpenSceneGraph"
-  url "https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.6.5.tar.gz"
-  sha256 "aea196550f02974d6d09291c5d83b51ca6a03b3767e234a8c0e21322927d1e12"
   license "LGPL-2.1-or-later" => { with: "WxWindows-exception-3.1" }
   revision 1
   head "https://github.com/openscenegraph/OpenSceneGraph.git", branch: "master"
+
+  stable do
+    url "https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.6.5.tar.gz"
+    sha256 "aea196550f02974d6d09291c5d83b51ca6a03b3767e234a8c0e21322927d1e12"
+
+    # patch to fix build from source when asio library is present
+    patch do
+      url "https://github.com/openscenegraph/OpenSceneGraph/commit/21f5a0adfb57dc4c28b696e93beface45de28194.patch?full_index=1"
+      sha256 "d1e4e33b50ab006420417c7998d7e0d43d0349e6f407b5eb92a3fc6636523fbf"
+    end
+  end
 
   bottle do
     sha256 arm64_big_sur: "83350482064d3e55281b5c4a808f4629ce0c243a49fb57e68e5f63d2d5a411c4"


### PR DESCRIPTION
When the asio library is installed, building open-scene-graph from source will fail with:

    error: no member named 'error' in namespace 'asio::placeholders'

and other similar errors. This has already been fixed upstream but no release has been made in several years, so we just pick up the upstream patch.

Also see: https://github.com/openscenegraph/OpenSceneGraph/issues/921

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
