### PR TITLE
ocaml: update livecheck

### DIFF
--- a/Formula/ocaml.rb
+++ b/Formula/ocaml.rb
@@ -20,8 +20,8 @@ class Ocaml < Formula
   head "https://github.com/ocaml/ocaml.git", branch: "trunk"
 
   livecheck do
-    url "https://ocaml.org/releases/"
-    regex(/href=.*?v?(\d+(?:\.\d+)+)\.html/i)
+    url "https://ocaml.org/releases"
+    regex(%r{href=.*?/releases/v?(\d+(?:\.\d+)+)/?["']}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `ocaml` is now giving an `Unable to get versions` error, as the website has been updated and the existing regex no longer works. This PR updates the regex to identify versions from the release note links for each version release.

This also updates the `livecheck` block URL, as the existing URL redirects to the same path without a trailing forward slash.

For what it's worth, there's an open `ocaml` PR (#97717) but it will need to be updated for 4.14.0 and should be rebased in the process anyway (i.e., it's over a month old).