### PR TITLE
age-plugin-yubikey 0.3.0 (new formula)

### DIFF
--- a/Formula/age-plugin-yubikey.rb
+++ b/Formula/age-plugin-yubikey.rb
@@ -1,0 +1,26 @@
+class AgePluginYubikey < Formula
+  desc "Plugin for encrypting files with age and PIV tokens such as YubiKeys"
+  homepage "https://github.com/str4d/age-plugin-yubikey"
+  url "https://github.com/str4d/age-plugin-yubikey/archive/v0.3.0.tar.gz"
+  sha256 "3dfd7923dcbd7b02d0bce1135ff4ba55a7860d8986d1b3b2d113d9553f439ba9"
+  license "MIT"
+  head "https://github.com/str4d/age-plugin-yubikey.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  uses_from_macos "pcsc-lite"
+
+  on_linux do
+    depends_on "pkg-config" => :build
+  end
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    ENV["LANG"] = "en_US.UTF-8"
+    assert_match "Let's get your YubiKey set up for age!",
+      shell_output("#{bin}/age-plugin-yubikey 2>&1", 1)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

age-plugin-yubikey is a plugin for age (or rage) that provides support for PIV tokens such as YubiKeys.

https://github.com/str4d/age-plugin-yubikey

https://github.com/str4d/age-plugin-yubikey/releases/tag/v0.3.0