### PR TITLE
bitcoin: min Catalina requirement

### DIFF
--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -27,6 +27,7 @@ class Bitcoin < Formula
   depends_on "berkeley-db@4"
   depends_on "boost@1.76"
   depends_on "libevent"
+  depends_on macos: :catalina
   depends_on "miniupnpc"
   depends_on "zeromq"
 


### PR DESCRIPTION
`bitcoin` requires `std::filesystem`, which is only supported from Catalina onwards.

`CI-syntax-only`, no rebuilds required.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
