### PR TITLE
pdf2djvu: use formula patch from central repo

### DIFF
--- a/Formula/pdf2djvu.rb
+++ b/Formula/pdf2djvu.rb
@@ -35,9 +35,9 @@ class Pdf2djvu < Formula
   end
 
   # poppler 22.04.0 compatibility, remove in next release
-  # TODO: switch to main repo after this PR is merged: https://github.com/Homebrew/formula-patches/pull/858
+
   patch do
-    url "https://raw.githubusercontent.com/yurikoles/formula-patches/4c18443/pdf2djvu/main-use-pdf-link-Destination-copy-constructor.patch"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/e0c880b/pdf2djvu/main-use-pdf-link-Destination-copy-constructor.patch"
     sha256 "3d1e9fc0d7f2861142721befff9e33b5c2665dacc78ac12b613af7b1e6fb0ce6"
   end
 


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
