### PR TITLE
Sync versions on GDB- and GCC-related formulas

### DIFF
--- a/Formula/i386-elf-gdb.rb
+++ b/Formula/i386-elf-gdb.rb
@@ -1,7 +1,6 @@
 class I386ElfGdb < Formula
   desc "GNU debugger for i386-elf cross development"
   homepage "https://www.gnu.org/software/gdb/"
-  # Please add to synced_versions_formulae.json once version synced with gdb
   url "https://ftp.gnu.org/gnu/gdb/gdb-12.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/gdb/gdb-12.1.tar.xz"
   sha256 "0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed"

--- a/Formula/x86_64-elf-gdb.rb
+++ b/Formula/x86_64-elf-gdb.rb
@@ -1,7 +1,6 @@
 class X8664ElfGdb < Formula
   desc "GNU debugger for x86_64-elf cross development"
   homepage "https://www.gnu.org/software/gdb/"
-  # Please add to synced_versions_formulae.json once version synced with gdb
   url "https://ftp.gnu.org/gnu/gdb/gdb-12.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/gdb/gdb-12.1.tar.xz"
   sha256 "0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed"

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -1,4 +1,5 @@
 [
+  ["aarch64-elf-gcc", "i686-elf-gcc", "x86_64-elf-gcc"],
   ["advancemame", "advancemenu"],
   ["apache-arrow", "apache-arrow-glib"],
   ["apache-pulsar", "libpulsar"],
@@ -15,6 +16,7 @@
   ["fb303", "fbthrift", "fizz", "folly", "wangle", "watchman"],
   ["frpc", "frps"],
   ["gcc", "libgccjit"],
+  ["gdb", "i386-elf-gdb", "x86_64-elf-gdb"],
   ["ghz", "ghz-web"],
   ["git", "git-credential-libsecret", "git-gui", "git-svn"],
   ["hdf5", "hdf5-mpi"],


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/homebrew-core/pull/100618

I'm not include `gcc` and `libgccjit` in the same check as the other GCC-derived formulas, because the main `gcc` is already **huge** and we don't want to make updates worse…