### PR TITLE
codec2: add livecheck

### DIFF
--- a/Formula/codec2.rb
+++ b/Formula/codec2.rb
@@ -7,6 +7,19 @@ class Codec2 < Formula
   sha256 "d1b156035b806fd89a29371a5ab0eefca3ccecfeff303dac0672c59d5c0c1235"
   license "LGPL-2.1-only"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :git do |tags, regex|
+      malformed_tags = ["v1.03"].freeze
+      tags.map do |tag|
+        next if malformed_tags.include?(tag)
+
+        tag[regex, 1]
+      end
+    end
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "090856f39e5957c5d3badc83d370aa70bb89d1d5cc6120446d6c3b877581d94d"
     sha256 cellar: :any,                 arm64_big_sur:  "ae72433df0f211abb44fa154af2f7d404a56202a4caec2b5716816e8d69471e3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `codec2` but version 1.0.3 was tagged as both `1.0.3` and `1.03`. When comparing `Version` objects, the leading zero is ignored and 1.03 is treated as 1.3, which is higher than 1.0.3. The related 1.0.3 release uses the `1.0.3` tag and `1.03` has been the only tag using this format, so it seems like a mistake.

This PR addresses the issue by adding a `livecheck` block with a `strategy` block that omits the `1.03` tag, so `1.0.3` is correctly given as the newest version.

---

Past that, the formula is using the `1.03` tag archive in the `stable` URL but the GitHub release uses the `1.0.3` tag. These tags both reference [the same commit](https://github.com/drowe67/codec2/commit/199a9e13c7cfda099e3c7671bd34a8950c5a0152) but the `sha256` is naturally different for the `1.0.3` tag archive. If desired, I can update the `stable` URL in this PR for the sake of consistency. Otherwise, we can simply remove the `version` override with the next version.