### PR TITLE
camlp5: update livecheck

### DIFF
--- a/Formula/camlp5.rb
+++ b/Formula/camlp5.rb
@@ -7,8 +7,8 @@ class Camlp5 < Formula
   head "https://github.com/camlp5/camlp5.git", branch: "master"
 
   livecheck do
-    url :homepage
-    regex(%r{The current distributed version is <b>v?(\d+(?:\.\d+)+)</b>}i)
+    url :stable
+    regex(/^rel[._-]?v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `camlp5` checks the homepage and identifies version from certain text. However, the homepage only provides a version with two parts (e.g., 8.00), whereas the versions from GitHub use three parts (e.g., 8.00.03). Currently, the version from livecheck, 8.00, is seen as lower than the formula version [from GitHub], 8.00.03.

This PR resolves the issue by updating the `livecheck` block to check the tags from the GitHub project (aligning the check with the `stable` source in the process).