### PR TITLE
qt-mariadb: fix test error on linux

### DIFF
--- a/Formula/qt-mariadb.rb
+++ b/Formula/qt-mariadb.rb
@@ -41,6 +41,11 @@ class QtMariadb < Formula
       system "cmake", ".", *args
       system "cmake", "--build", "."
       system "cmake", "--install", "."
+
+      if OS.linux?
+        sqldrivers_dir = `qmake -query QT_INSTALL_PLUGINS`.strip + "/sqldrivers/"
+        cp "share/qt/plugins/sqldrivers/libqsqlmysql.so", sqldrivers_dir
+      end
     end
   end
 


### PR DESCRIPTION
Stored the driver file to the correct dir on linux to complete the test successfully.
If this patch is OK, it should be applied to other SQL drivers as well.

see https://github.com/Homebrew/homebrew-core/pull/99225

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
