### PR TITLE
libcython: add livecheck

### DIFF
--- a/Formula/libcython.rb
+++ b/Formula/libcython.rb
@@ -5,6 +5,10 @@ class Libcython < Formula
   sha256 "d6fac2342802c30e51426828fe084ff4deb1b3387367cf98976bb2e64b6f8e45"
   license "Apache-2.0"
 
+  livecheck do
+    formula "cython"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "15b21f47a97041f16f9d0143e6b011920491267b1dd71fdb1683ef7a8ab6722c"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "2e8c9c60bc707275e42d135c69f72517b5f0d601a12d89699b53238c18a4bc65"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `cython` and `libcython` formulae share the same `stable` URL and the versions are synced in `synced_versions_formulae.json`.

This PR adds a `livecheck` block to `libcython` that uses `formula "cython"`, to make this relationship clear from the standpoint of livecheck. In this context, `cython` is the parent formula and `libcython` is the child, so `libcython` references `cython`. We only use the `#formula` and `#cask` methods in `livecheck` blocks when a clear parent/child relationship exists (i.e., not siblings like the `*beat` formulae).

Since `libcython` has the same `stable` URL as `cython`, the check remains the same but this change ensures that `libcython` would automatically inherit a `livecheck` block from `cython`, if one is added in the future. This saves us from having to manually keep these formulae in parity from the standpoint of livecheck.