### PR TITLE
mmctl: update livecheck

### DIFF
--- a/Formula/mmctl.rb
+++ b/Formula/mmctl.rb
@@ -9,7 +9,7 @@ class Mmctl < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `mmctl` uses the `GithubLatest` strategy to check the "latest" release on GitHub. Unfortunately, this seems to be one of those repositories that maintains more than one major/minor version at a time and can create out-of-order releases that breaks "latest". In this case, the newest version is 6.6.1 but there have been 6.3.8, 6.4.3, and 6.5.1 releases after the 6.6.1 release was created. As a result, 6.5.1 is the "latest" release on GitHub, so livecheck is erroneously reporting 6.5.1 as newest.

We only use the `GithubLatest` strategy when it's both correct and necessary but neither is true in this case. The existing `livecheck` block was added at a time when we were less restrictive about use of `GithubLatest`. Checking the Git tags would have been fine but, in this case, it's necessary.

This PR addresses the issue by updating the `livecheck` block to remove `strategy :github_latest` (so livecheck defaults to the `Git` strategy for the `stable` URL) and add the standard regex for Git tags like `1.2.3`/`v1.2.3` (which will omit unwanted tags in the repository like `cloud-2022-04-28-1`).