### PR TITLE
skaffold: update livecheck

### DIFF
--- a/Formula/skaffold.rb
+++ b/Formula/skaffold.rb
@@ -7,12 +7,20 @@ class Skaffold < Formula
   license "Apache-2.0"
   head "https://github.com/GoogleContainerTools/skaffold.git", branch: "main"
 
-  # This uses the `GithubLatest` strategy to work around an old `v2.2.3` tag
-  # that is always seen as newer than the latest version. If Skaffold ever
-  # reaches version 2.2.3, we can switch back to the `Git` strategy.
+  # The `strategy` code below can be removed if/when this software exceeds
+  # version 2.2.3. Until then, it's used to omit an older tag that would always
+  # be treated as newest.
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :git do |tags, regex|
+      malformed_tags = ["v2.2.3"].freeze
+      tags.map do |tag|
+        next if malformed_tags.include?(tag)
+
+        tag[regex, 1]
+      end
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `skaffold` uses the `GithubLatest` strategy but this gives 1.37.2 as the newest version instead of 1.38.0. This is because 1.37.2 was released after 1.38.0, so the later release date makes it the "latest" release on GitHub.

As the comment before the `livecheck` block explained, we're using the `GithubLatest` strategy as a way of avoiding an old `v2.2.3` tag that will always be treated as the newest version until the current version exceeds it. Since the "latest" GitHub release can't be trusted to be the newest version in this repository, we can't use the `GithubLatest` strategy to work around this issue anymore.

This PR resolves this issue by removing `strategy :github_latest` (so livecheck uses the `Git` strategy for the `stable` URL by default), adding the standard regex for Git tags like `1.2.3`/`v1.2.3`, and adding a `strategy` block that skips the problematic `v2.2.3` tag. This works fine at the moment but, since `v2.2.3` uses the correct tag format, this will also omit version 2.2.3 if/when the project naturally reaches that version. Due to the upstream situation, there isn't any way around this.