### PR TITLE
tarantool: add livecheck

### DIFF
--- a/Formula/tarantool.rb
+++ b/Formula/tarantool.rb
@@ -7,6 +7,11 @@ class Tarantool < Formula
   version_scheme 1
   head "https://github.com/tarantool/tarantool.git", branch: "master"
 
+  livecheck do
+    url :head
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "fa79d91a265eaadd770342ed9a3276b53c516da511215a11871bb79dc3eddf33"
     sha256 cellar: :any,                 arm64_big_sur:  "dd4db0ad19a1c866a78c7ffb5cd2d87cfdc95b8a211fc4dc428834a435adf212"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `tarantool` from the `head` URL but it's currently giving `2.11.0-entrypoint` as newest. If we use the standard regex for Git tags like `1.2.3`/`v1.2.3`, it would give 2.9.0 as newest but 2.8.4.0 is the latest stable version and there haven't been any 2.9.x releases. At present, checking the Git tags won't give us the correct latest version.

The [first-party download page](https://www.tarantool.io/en/download/os-installation/os-x/) simply directs users to use `brew install tarantool` and doesn't provide any version information. The "[Building from source code](https://www.tarantool.io/en/doc/latest/dev_guide/building_from_source/)" instructions reference the GitHub Git repository (e.g., `git clone https://github.com/tarantool/tarantool.git --recursive`), not any specific version.

download.tarantool.org continues to publish newer versions (e.g., 2.8.4.0 is from 2022-04-29) but it doesn't seem like the first-party website actually links to these files. The release notes for a given version (e.g., [2.8.4](https://www.tarantool.io/en/doc/latest/release/2.8.4/)) include links to GitHub but not the download.tarantool.org archive file. We can technically check the [release notes archive](https://www.tarantool.io/en/doc/latest/release/notes/) to identify the latest stable version but there isn't much point when it references a release on GitHub.

This PR resolves the issue by adding a `livecheck` block that uses the `GithubLatest` strategy, as checking the latest release appears to be the correct approach here.

-----

Looking to the future, if the "latest" release becomes a problem over time (i.e., references an older version due to the order releases were created), we would have to fall back to checking the first page of releases on GitHub (omitting prerelease versions), as checking the Git tags isn't tenable if there will be tags that use the stable version format (e.g., `2.9.0` instead of `2.10.0-beta1`) but haven't been released.

We try to avoid checking the GitHub releases page whenever possible (since pagination can cause the check to break if there are more than 10 releases after the one we're interested in) but it sometimes becomes necessary when there are unavoidable problems with the Git tags and the first-party website doesn't provide version information. Anyway, we can cross that bridge if/when we come to it.