### PR TITLE
wownero: add livecheck

### DIFF
--- a/Formula/wownero.rb
+++ b/Formula/wownero.rb
@@ -7,6 +7,22 @@ class Wownero < Formula
   license "BSD-3-Clause"
   revision 2
 
+  # The `strategy` code below can be removed if/when this software exceeds
+  # version 10.0.0. Until then, it's used to omit a malformed tag that would
+  # always be treated as newest.
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :git do |tags, regex|
+      malformed_tags = ["10.0.0"].freeze
+      tags.map do |tag|
+        next if malformed_tags.include?(tag)
+
+        tag[regex, 1]
+      end
+    end
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "d25b719116fec944ea8974444252576cd9312b095d1cbf88b82498ff63b75843"
     sha256 cellar: :any,                 arm64_big_sur:  "bb97e22c03ad3eb74ecb8222032eb02263a902e4a5fdf51c4f8520e1686a114d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `wownero` but it's currently giving 10.0.0 as the newest version, instead of 0.10.1.0. This is because of a one-off `10.0.0` tag (the typical format is `v0.10.1.0`), which appears when you use `git ls-remote --tags https://git.wownero.com/wownero/wownero.git` but doesn't show up on the [web interface](https://git.wownero.com/wownero/wownero/tags). My guess is that this was supposed to correspond to 0.10.0.0 but was a mistake.

This PR resolves the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3` (avoiding a variety of unwanted tags in this repository) and a `strategy` block that omits the `10.0.0` tag. If the version ever reaches 10.0.0 in the future, livecheck will miss the version but this is the best solution for this particular upstream issue.