### PR TITLE
udpxy: deprecate, update urls, add license

### DIFF
--- a/Formula/udpxy.rb
+++ b/Formula/udpxy.rb
@@ -1,15 +1,11 @@
 class Udpxy < Formula
   desc "UDP-to-HTTP multicast traffic relay daemon"
-  homepage "http://www.udpxy.com/"
-  url "http://www.udpxy.com/download/1_23/udpxy.1.0.23-12-prod.tar.gz"
-  mirror "https://fossies.org/linux/www/udpxy.1.0.23-12-prod.tar.gz"
+  homepage "http://gigapxy.com/udpxy-en.html"
+  url "http://gigapxy.com/download/1_23/udpxy.1.0.23-12-prod.tar.gz"
+  mirror "https://fossies.org/linux/www/old/udpxy.1.0.23-12-prod.tar.gz"
   version "1.0.23-12"
   sha256 "16bdc8fb22f7659e0427e53567dc3e56900339da261199b3d00104d699f7e94c"
-
-  livecheck do
-    url "http://www.udpxy.com/download/1_23/"
-    regex(/href=.*?udpxy[._-]v?(\d+(?:\.\d+)+-\d+)-prod\.t/i)
-  end
+  license "GPL-3.0-or-later"
 
   bottle do
     rebuild 1
@@ -21,6 +17,16 @@ class Udpxy < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "4688df2c4fd1ce7749d6d032f77cdae700129fa42284d9fc5ce1792ae9121151"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "cd123b142b4fa0ceb6a8d078a307499332c0911634be090bce60dfd8cf42d7dd"
   end
+
+  # As of writing, www.udpxy.com is a parked domain page (though gigapxy.com
+  # hosts the same site). The homepage states, "development has been on hold
+  # since 2012, with most of the effort routed toward enterprise-grade products,
+  # such as Gigapxy, RoWAN, GigA+ and GigaTools." The udpxy `README` (last
+  # modified 2018-01-18) has a "Project Status" section that states, "udpxy has
+  # not been extended or supported for 4+ years, having been replaced by
+  # Gigapxy - a superior enterprise-oriented product. Please see more info at
+  # http://gigapxy.com, thank you."
+  deprecate! date: "2022-05-03", because: :unsupported
 
   def install
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `udpxy` homepage disappeared sometime after 2022-03-16 (the last [archive.org snapshot](https://web.archive.org/web/20220316191744/http://www.udpxy.com/) that worked) and is now a parked domain page. However, gigapxy.com hosts the same website and `udpxy` continues to be available there.

This PR updates the `homepage` and `stable` URLs to use gigapxy.com instead. This also updates the mirror to avoid the redirection from `/linux/www/` to `/linux/www/old/`.

-----

I was originally thinking about deprecating this formula since the `homepage`/`stable` URLs no longer worked but I'm fine leaving this alone since there's an alternative. That said, there may still be a case to be made for deprecating this. [Install analytics totals are: 30 days: 7, 90 days: 15, 365 days: 41.]

The homepage states:

> udpxy has been around since 2008, it is included in the firmware of many IPTV-enabled routers. However, its development has been on hold since 2012, with most of the effort routed toward enterprise-grade products, such as [Gigapxy](http://gigapxy.com/gigapxy-en.html), [RoWAN](http://gigapxy.com/rowan-en.html), [GigA+](http://gigapxy.com/gigaplus-en.html) and [GigaTools](http://gigapxy.com/gigatools-en.html).

The "Project Status" section of the [`README`](http://gigapxy.com/download/udpxy/README.txt) (last updated 2018-01-18) stated:

> udpxy has not been extended or supported for 4+ years, having been replaced by Gigapxy - a superior enterprise-oriented product. Please see more info at <http://gigapxy.com>, thank you.

The `udpxy` formula was originally introduced on 2014-07-30 and upstream has only incremented the trailing number after the main `1.0.23` version in the interim time (i.e, from `1.0.23-9` when the formula was added to `1.0.23-12` on 2018-01-30).

Lastly, fossies.org has moved the related archive file from `/linux/www/` to `/linux/www/old`, suggesting this isn't actively developed/maintained.