### PR TITLE
Expand synced_versions_formulae.json

### DIFF
--- a/Formula/boost-bcp.rb
+++ b/Formula/boost-bcp.rb
@@ -1,7 +1,6 @@
 class BoostBcp < Formula
   desc "Utility for extracting subsets of the Boost library"
   homepage "https://www.boost.org/doc/tools/bcp/"
-  # Please add to synced_versions_formulae.json once version synced with boost
   url "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2"
   sha256 "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc"
   license "BSL-1.0"

--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -1,7 +1,6 @@
 class BoostMpi < Formula
   desc "C++ library for C++/MPI interoperability"
   homepage "https://www.boost.org/"
-  # Please add to synced_versions_formulae.json once version synced with boost
   url "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2"
   sha256 "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc"
   license "BSL-1.0"

--- a/Formula/boost-python3.rb
+++ b/Formula/boost-python3.rb
@@ -1,7 +1,6 @@
 class BoostPython3 < Formula
   desc "C++ library for C++/Python3 interoperability"
   homepage "https://www.boost.org/"
-  # Please add to synced_versions_formulae.json once version synced with boost
   url "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2"
   sha256 "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc"
   license "BSL-1.0"

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -5,6 +5,7 @@
   ["apache-pulsar", "libpulsar"],
   ["avro-c", "avro-cpp", "avro-tools"],
   ["aws-console", "cfn-format", "rain"],
+  ["boost", "boost-bcp", "boost-mpi", "boost-python3"],
   ["bundler-completion", "gem-completion", "rails-completion", "ruby-completion"],
   ["buildifier", "buildozer"],
   ["cmake", "cmake-docs"],
@@ -31,6 +32,7 @@
   ["logcli", "loki", "promtail"],
   ["mame", "rom-tools"],
   ["mecab-unidic", "mecab-unidic-extended"],
+  ["minuit2", "root"],
   ["moarvm", "nqp", "rakudo"],
   ["moreutils", "sponge"],
   ["mupdf", "mupdf-tools"],
@@ -44,6 +46,7 @@
   ["python-tk@3.10", "python@3.10"],
   ["python-tk@3.9", "python@3.9"],
   ["qt", "qt-libiodbc", "qt-mariadb", "qt-mysql", "qt-percona-server", "qt-postgresql", "qt-unixodbc"],
+  ["qwt", "qwt-qt5"],
   ["telnet", "telnetd"],
   ["tmuxinator", "tmuxinator-completion"]
 ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates `synced_versions_formulae.json` to include additional formulae that are currently using the same `stable` URL. The `boost` formulae are straightforward but please review the others to double check my work.

We had already added/updated `livecheck` blocks in child formulae to use `#formula` to borrow the `livecheck` block from the related parent formula, so this formally syncs the version of these formulae. I went through formulae with the same `stable` URL again and didn't see any new candidates, so this should bring things up to date (with the exception of `minizip`/`zlib`).