### PR TITLE
qemu: expose RDTSCP to guests

### DIFF
--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -51,6 +51,13 @@ class Qemu < Formula
     sha256 "81237c7b42dc0ffc8b32a2f5734e3480a3f9a470c50c14a9c4576a2561a35807"
   end
 
+  # Fixes RDTSCP not being exposed to hosts
+  # See https://gitlab.com/qemu-project/qemu/-/issues/1011
+  patch do
+    url "https://gitlab.com/qemu-project/qemu/-/commit/d8cf2c29cc1077cd8f8ab0580b285bff92f09d1c.diff"
+    sha256 "b7c0db81e136fb3b9692e56f4c95abbcbd196dc0b7feb517241dda20d9ec3166"
+  end
+
   def install
     ENV["LIBTOOL"] = "glibtool"
 


### PR DESCRIPTION
👋 Homebrew maintainers!

This is my first time contribution, I hope I did it right, apologies in advance if I didn't!

This is to fix a QEMU bug where the RDTSCP instruction, while available on the host, will not be exposed in the guest. Patch is taken from the QEMU mailing list - it has been recently proposed but it is not in master yet.

Original issue: https://gitlab.com/qemu-project/qemu/-/issues/1011

Issues indirectly caused: https://github.com/rancher-sandbox/rancher-desktop/issues/1324, https://github.com/m3db/m3/issues/3105 https://github.com/m3db/m3/issues/3659 https://github.com/m3db/m3/issues/3827

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
