### PR TITLE
grokj2k: min Catalina requirement

### DIFF
--- a/Formula/grokj2k.rb
+++ b/Formula/grokj2k.rb
@@ -28,6 +28,7 @@ class Grokj2k < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "little-cms2"
+  depends_on macos: :catalina
 
   uses_from_macos "perl"
   uses_from_macos "zlib"


### PR DESCRIPTION
Building on Mojave throws errors related to `std::filesystem`, which requires Catalina minimum.

`CI-syntax-only`, no rebuilds required.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?