### PR TITLE
primecount 7.3 (new formula)

### DIFF
--- a/Formula/primecount.rb
+++ b/Formula/primecount.rb
@@ -10,21 +10,8 @@ class Primecount < Formula
   depends_on "primesieve"
 
   def install
-    # In 2022 integer division is slow on most CPUs,
-    # hence by default we use libdivide instead.
-    use_libdivide = "ON"
-    use_div32 = "ON"
-
-    if OS.mac? && Hardware::CPU.arm?
-      # Apple Silicon CPUs have very fast integer division
-      use_libdivide = "OFF"
-      use_div32 = "OFF"
-    end
-
     system "cmake", "-S", ".", "-B", "build", "-DBUILD_SHARED_LIBS=ON",
                                               "-DBUILD_LIBPRIMESIEVE=OFF",
-                                              "-DWITH_LIBDIVIDE=#{use_libdivide}",
-                                              "-DWITH_DIV32=#{use_div32}",
                                               "-DCMAKE_INSTALL_RPATH=#{rpath}",
                                               *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/primecount.rb
+++ b/Formula/primecount.rb
@@ -1,0 +1,37 @@
+class Primecount < Formula
+  desc "Fast prime counting function program and C/C++ library"
+  homepage "https://github.com/kimwalisch/primecount"
+  url "https://github.com/kimwalisch/primecount/archive/v7.3.tar.gz"
+  sha256 "471fe21461e42e5f28404e17ff840fb527b3ec4064853253ee22cf4a81656332"
+  license "BSD-2-Clause"
+
+  depends_on "cmake" => :build
+  depends_on "libomp"
+  depends_on "primesieve"
+
+  def install
+    # In 2022 integer division is slow on most CPUs,
+    # hence by default we use libdivide instead.
+    use_libdivide = "ON"
+    use_div32 = "ON"
+
+    if OS.mac? && Hardware::CPU.arm?
+      # Apple Silicon CPUs have very fast integer division
+      use_libdivide = "OFF"
+      use_div32 = "OFF"
+    end
+
+    system "cmake", "-S", ".", "-B", "build", "-DBUILD_SHARED_LIBS=ON",
+                                              "-DBUILD_LIBPRIMESIEVE=OFF",
+                                              "-DWITH_LIBDIVIDE=#{use_libdivide}",
+                                              "-DWITH_DIV32=#{use_div32}",
+                                              "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                                              *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    assert_equal "37607912018\n", shell_output("#{bin}/primecount 1e12")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

[primecount](https://github.com/kimwalisch/primecount) is the leading C/C++ math library for computing the prime counting function, I am its main author. I have maintained the primecount program/library as a tap [(kimwalisch/primecount)](https://github.com/kimwalisch/homebrew-primecount) for the past 5 years. Recently the primecount library has been integrated into SageMath and the SageMath developers have asked me https://github.com/kimwalisch/homebrew-primecount/issues/1#issuecomment-1025155038 to submit primecount as a core formula so that it is easier for them to install.