### PR TITLE
vim: Amend disable GUI configure flag

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -54,7 +54,7 @@ class Vim < Formula
                           "--enable-perlinterp",
                           "--enable-rubyinterp",
                           "--enable-python3interp",
-                          "--enable-gui=no",
+                          "--disable-gui",
                           "--without-x",
                           "--enable-luainterp",
                           "--with-lua-prefix=#{Formula["lua"].opt_prefix}"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Disabling vim GUI should be configured with `--disable-gui` flag instead.

Installing from existing vim bottle and building from source with the `--disable-gui` flag do not seem to differ. Both installs `(2,034 files, 36.0MB)`. Probably GUI is disabled anyway with `--without-x` flag.

References:

  - [vim Makefile][1]
  - [Arch Linux's vim build][2]
  - [`--without-x` documentation][3]

[1]: https://github.com/vim/vim/blob/05cf63e9bdca1ac070df3e7d9c6dfc45e68ac916/src/Makefile#L329
[2]: https://github.com/archlinux/svntogit-packages/blob/f5d177ef1aae59ffb73f7aef3e7d3d216cae409e/trunk/PKGBUILD#L55
[3]: https://github.com/vim/vim/blob/05cf63e9bdca1ac070df3e7d9c6dfc45e68ac916/src/Makefile#L549-L554

