### PR TITLE
ladspa-sdk: fixes wrong shasum

### DIFF
--- a/Formula/ladspa-sdk.rb
+++ b/Formula/ladspa-sdk.rb
@@ -2,7 +2,7 @@ class LadspaSdk < Formula
   desc "Linux Audio Developer's Simple Plugin"
   homepage "https://www.ladspa.org"
   url "https://www.ladspa.org/download/ladspa_sdk_1.17.tgz"
-  sha256 "d9d596171d93f9c226fcdb7e27c6f917422ac487efe2c05e0a18094df4268061"
+  sha256 "27d24f279e4b81bd17ecbdcc38e4c42991bb388826c0b200067ce0eb59d3da5b"
   license "LGPL-2.1-only"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
fixes #100346

The author (Richarc Furse) of this package has told me on email that there is no unintended change except for a repackage done by the server (for some strange reason), but since shasum is a security measure, it might be good for a maintainer to write him an email just to confirm. 
