### PR TITLE
libdrm: Added cairo as dependency

### DIFF
--- a/Formula/libdrm.rb
+++ b/Formula/libdrm.rb
@@ -16,6 +16,7 @@ class Libdrm < Formula
 
   depends_on "docutils" => :build
   depends_on "meson" => :build
+  depends_on "cairo" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "libpciaccess"

--- a/Formula/libdrm.rb
+++ b/Formula/libdrm.rb
@@ -13,9 +13,9 @@ class Libdrm < Formula
   bottle do
     sha256 x86_64_linux: "1ca8eb09c3a8c1b9a64dc05d030f0e544456e18fae2f30eca0a6a2729fe3943b"
   end
-
-  depends_on "docutils" => :build
+  
   depends_on "cairo" => :build
+  depends_on "docutils" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build

--- a/Formula/libdrm.rb
+++ b/Formula/libdrm.rb
@@ -15,8 +15,8 @@ class Libdrm < Formula
   end
 
   depends_on "docutils" => :build
-  depends_on "meson" => :build
   depends_on "cairo" => :build
+  depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "libpciaccess"

--- a/Formula/libdrm.rb
+++ b/Formula/libdrm.rb
@@ -13,7 +13,7 @@ class Libdrm < Formula
   bottle do
     sha256 x86_64_linux: "1ca8eb09c3a8c1b9a64dc05d030f0e544456e18fae2f30eca0a6a2729fe3943b"
   end
-  
+
   depends_on "cairo" => :build
   depends_on "docutils" => :build
   depends_on "meson" => :build

--- a/Formula/libdrm.rb
+++ b/Formula/libdrm.rb
@@ -14,7 +14,6 @@ class Libdrm < Formula
     sha256 x86_64_linux: "1ca8eb09c3a8c1b9a64dc05d030f0e544456e18fae2f30eca0a6a2729fe3943b"
   end
 
-  depends_on "cairo" => :build
   depends_on "docutils" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
@@ -24,7 +23,7 @@ class Libdrm < Formula
 
   def install
     mkdir "build" do
-      system "meson", *std_meson_args, ".."
+      system "meson", *std_meson_args, "-Dcairo-tests=false", ".."
       system "ninja"
       system "ninja", "install"
     end


### PR DESCRIPTION
Building libdrm failed because of missing cairo.h:

```
tests/util/libutil.a.p/pattern.c.o.d -o tests/util/libutil.a.p/pattern.c.o -c ../tests/util/pattern.c
../tests/util/pattern.c:34:10: fatal error: cairo.h: No such file or directory
   34 | #include <cairo.h>
      |          ^~~~~~~~~
compilation terminated.
```

After adding cairo as dependency, everything works as expected.