### PR TITLE
release-it 15.0.0 (new formula)

### DIFF
--- a/Formula/release-it.rb
+++ b/Formula/release-it.rb
@@ -1,0 +1,24 @@
+require "language/node"
+
+class ReleaseIt < Formula
+  desc "Generic CLI tool to automate versioning and package publishing related tasks"
+  homepage "https://github.com/release-it/release-it"
+  url "https://registry.npmjs.org/release-it/-/release-it-15.0.0.tgz"
+  sha256 "52a22039887a5a131db2a3b8c524bd57f9bda4a091567711f5c5ee9cee8f8751"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/release-it -v")
+    (testpath/"package.json").write("{\"name\":\"test-pkg\",\"version\":\"1.0.0\"}")
+    assert_match(/Let's release test-pkg.+\(1\.0\.0\.\.\.1\.0\.1\).+Empty changelog.+Done \(in \d+s\.\)/m,
+      shell_output("#{bin}/release-it --npm.skipChecks --no-npm.publish --ci"))
+    assert_match "1.0.1", (testpath/"package.json").read
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

With this pull request I would like to add the release-it formula. I read you're not too fond of folks submitting their own package. However, since [release-it](https://github.com/release-it/release-it) is a generic release tool (not tied to npm packages for instance), I believe it serves a wide purpose to add it.

In case you agree, I would like some help with adding tests to this formula. The [release-it test suite](https://github.com/release-it/release-it/actions/workflows/test.yml) is fairly heavy and would take too long to finish (~30 seconds on my MacBook M1) with a regular `brew install`, I suppose.

Alternatively, it could also be an option to package release-it into an executable with a tool such as [pkg](https://github.com/vercel/pkg), to remove the dependency on Node.js. But I'm not sure if that would really make a difference, and what exactly that would entail (happy to dive into this, though).