### PR TITLE
jenv: Patch out the obsolete export.fish shim

### DIFF
--- a/Formula/jenv.rb
+++ b/Formula/jenv.rb
@@ -4,11 +4,16 @@ class Jenv < Formula
   url "https://github.com/jenv/jenv/archive/0.5.4.tar.gz"
   sha256 "15a78dab7310fb487d2c2cad7f69e05d5d797dc13f2d5c9e7d0bbec4ea3f2980"
   license "MIT"
+  revision 1
   head "https://github.com/jenv/jenv.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "521a1ad6e28b90f1e37893d279950e35957a0580464d639ec74c398f8da6d466"
   end
+
+  # Upstream ships an unnecessary export shim for fish shell, which breaks scripts
+  # https://github.com/Homebrew/homebrew-core/pull/100234#issuecomment-1111862141
+  patch :DATA
 
   def install
     libexec.install Dir["*"]
@@ -35,3 +40,14 @@ class Jenv < Formula
     shell_output("eval \"$(#{bin}/jenv init -)\" && jenv versions")
   end
 end
+__END__
+diff --git a/fish/export.fish b/fish/export.fish
+deleted file mode 100644
+index 14dbbec..0000000
+--- a/fish/export.fish
++++ /dev/null
+@@ -1,4 +0,0 @@
+-function export
+-  set arr (echo $argv|tr = \n)
+-  set -gx $arr[1] $arr[2]
+-end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See: https://github.com/Homebrew/homebrew-core/pull/100234#issuecomment-1111862141