### PR TITLE
mbt 1.2.10 (new formula)

### DIFF
--- a/Formula/mbt.rb
+++ b/Formula/mbt.rb
@@ -1,0 +1,21 @@
+class Mbt < Formula
+  desc "Multi-Target Application (MTA) build tool for Cloud Applications"
+  homepage "https://sap.github.io/cloud-mta-build-tool"
+  url "https://github.com/SAP/cloud-mta-build-tool/archive/v1.2.10.tar.gz"
+  sha256 "46d548342e2fe3abd51d4c5d5702602b835a2cfd53eb09b86a2abf45825823a4"
+  license "Apache-2.0"
+  head "https://github.com/SAP/cloud-mta-build-tool.git", branch: "master"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[ -s -w -X main.Version=#{version}
+                  -X main.BuildDate=#{time.iso8601} ]
+    system "go", "build", *std_go_args(ldflags: ldflags)
+  end
+
+  test do
+    assert_match(/generating the "Makefile_\d+.mta" file/, shell_output("#{bin}/mbt build", 1))
+    assert_match("Cloud MTA Build Tool", shell_output("#{bin}/mbt --version"))
+  end
+end


### PR DESCRIPTION

The Cloud MTA Build Tool is a standalone command-line tool that builds a deployment-ready multitarget application (MTA) archive .mtar file from the artifacts of an MTA project according to the project’s MTA development descriptor (mta.yaml file) or from module build artifacts according to the MTA deployment descriptor (mtad.yaml file). Also, it provides commands for running intermediate build process steps; for example, the mta.yaml file validations, building a single module according to the configurations in the development descriptor, generating the deployment descriptor, and so on.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
