### PR TITLE
xcode-kotlin 1.2.0 (new formula)

### DIFF
--- a/Formula/xcode-kotlin.rb
+++ b/Formula/xcode-kotlin.rb
@@ -1,0 +1,29 @@
+class XcodeKotlin < Formula
+  desc "Kotlin Native Xcode Plugin"
+  homepage "https://github.com/touchlab/xcode-kotlin"
+  url "https://github.com/touchlab/xcode-kotlin.git",
+    tag:      "1.2.0",
+    revision: "3af7e5d921c3756a3adc83ad504ac0db2a5643e8"
+  license "Apache-2.0"
+  head "https://github.com/touchlab/xcode-kotlin.git", branch: "main"
+
+  depends_on "gradle" => :build
+  depends_on xcode: ["12.5", :build]
+  depends_on :macos
+
+  def install
+    suffix = Hardware::CPU.arch == :x86_64 ? "X64" : "Arm64"
+    system "gradle", "--no-daemon", "linkReleaseExecutableMacos#{suffix}", "preparePlugin"
+    bin.install "build/bin/macos#{suffix}/releaseExecutable/xcode-kotlin.kexe" => "xcode-kotlin"
+    share.install Dir["build/share/*"]
+  end
+
+  test do
+    output = shell_output(bin/"xcode-kotlin info --only")
+    assert_match "Bundled plugin version:\t\t#{version}", output
+    assert_match(/Installed plugin version:\s*(?:(?:\d+)\.(?:\d+)\.(?:\d+)|none)/, output)
+    assert_match(/Language spec installed:\s*(?:Yes|No)/, output)
+    assert_match(/LLDB init installed:\s*(?:Yes|No)/, output)
+    assert_match(/LLDB Xcode init sources main LLDB init:\s*(?:Yes|No)/, output)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

xcode-kotlin is for iOS developers who work with Kotlin Multiplatform. Previously developers had to use a shell script to install the Xcode plugin, but it wasn't versatile enough. This CLI helps with installing the plugin, sychronizing compatibility when new Xcode version is installed and debugging if something goes wrong.