### PR TITLE
minimal-racket: run raco setup post install

### DIFF
--- a/Formula/minimal-racket.rb
+++ b/Formula/minimal-racket.rb
@@ -55,6 +55,13 @@ class MinimalRacket < Formula
     end
   end
 
+  def post_install
+    # Run raco setup to make sure core libraries are properly compiled.
+    # Sometimes the mtimes of .rkt and .zo files are messed up after a fresh
+    # install, making Racket take 15s to start up because interpreting is slow.
+    system "#{bin}/raco", "setup"
+  end
+
   def caveats
     <<~EOS
       This is a minimal Racket distribution.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Racket relies on the mtimes of compiled files (.zo) to be newer than
source files (.rkt), otherwise it falls back to interpreting. For core
libraries, this is the difference between a 200ms and 15s startup time.
Multiple users have reported these extremely slow startup times after
installing from Homebrew, which is fixed by running `raco setup`. This
change therefore runs that in the post_install step. When nothing needs
to be recompiled, `raco setup` completes in a couple seconds.

See this discussion for more details:
https://racket.discourse.group/t/minimal-racket-is-very-slow-before-installing-compiler-lib/967