### PR TITLE
tradcpp 0.5.3 (new formula)

### DIFF
--- a/Formula/tradcpp.rb
+++ b/Formula/tradcpp.rb
@@ -1,0 +1,22 @@
+class Tradcpp < Formula
+  desc "K&R-style C preprocessor"
+  homepage "https://www.netbsd.org/~dholland/tradcpp"
+  url "https://cdn.netbsd.org/pub/NetBSD/misc/dholland/tradcpp-0.5.3.tar.gz"
+  sha256 "e17b9f42cf74b360d5691bc59fb53f37e41581c45b75fcd64bb965e5e2fe4c5e"
+  license "BSD-2-Clause"
+
+  depends_on "bmake" => :build
+
+  def install
+    system "bmake"
+    system "bmake", "prefix=#{prefix}", "MK_INSTALL_AS_USER=yes", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #define FOO bar
+      FOO
+    EOS
+    assert_match "bar", shell_output(bin/"tradcpp ./test.c")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Lightweight replacement of `gcc -traditional-cpp`, may replace `gcc` in `imake`. It can generate formatted `xinitrc` for `xinit`.