### PR TITLE
Testing GCC-related failures

### DIFF
--- a/Formula/augustus.rb
+++ b/Formula/augustus.rb
@@ -4,7 +4,7 @@ class Augustus < Formula
   url "https://github.com/Gaius-Augustus/Augustus/releases/download/v3.3.3/augustus-3.3.3.tar.gz"
   sha256 "4cc4d32074b18a8b7f853ebaa7c9bef80083b38277f8afb4d33c755be66b7140"
   license "Artistic-1.0"
-  revision 2
+  revision 3
   head "https://github.com/Gaius-Augustus/Augustus.git", branch: "master"
 
   livecheck do

--- a/Formula/kahip.rb
+++ b/Formula/kahip.rb
@@ -4,6 +4,7 @@ class Kahip < Formula
   url "https://github.com/KaHIP/KaHIP/archive/v3.14.tar.gz"
   sha256 "9da04f3b0ea53b50eae670d6014ff54c0df2cb40f6679b2f6a96840c1217f242"
   license "MIT"
+  revision 1
   head "https://github.com/KaHIP/KaHIP.git", branch: "master"
 
   bottle do

--- a/Formula/kim-api.rb
+++ b/Formula/kim-api.rb
@@ -1,9 +1,10 @@
 class KimApi < Formula
   desc "Knowledgebase of Interatomic Models (KIM) API"
   homepage "https://openkim.org"
-  url "https://s3.openkim.org/kim-api/kim-api-2.3.0.txz"
+  url "https://s3.openkim.org/kim-api/kim-api-2.3.0.txz", using: :homebrew_curl
   sha256 "93673bb8fbc0625791f2ee67915d1672793366d10cabc63e373196862c14f991"
   license "CDDL-1.0"
+  revision 1
 
   livecheck do
     url "https://openkim.org/kim-api/previous-versions/"

--- a/Formula/msc-generator.rb
+++ b/Formula/msc-generator.rb
@@ -4,6 +4,7 @@ class MscGenerator < Formula
   url "https://downloads.sourceforge.net/project/msc-generator/msc-generator/v7.x/msc-generator-7.2.tar.gz"
   sha256 "40c7a45e1bce96bc93440b604eb0fd2b7894985fa0a723bf6483565bef026a2e"
   license "AGPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_monterey: "5707ed7ae39ba1a9de555d6c11cf6f352725e196ab5fdf48e9b926e7dfa8bb17"

--- a/Formula/openkim-models.rb
+++ b/Formula/openkim-models.rb
@@ -1,8 +1,9 @@
 class OpenkimModels < Formula
   desc "All OpenKIM Models compatible with kim-api"
   homepage "https://openkim.org"
-  url "https://s3.openkim.org/archives/collection/openkim-models-2021-08-11.txz"
+  url "https://s3.openkim.org/archives/collection/openkim-models-2021-08-11.txz", using: :homebrew_curl
   sha256 "f42d241969787297d839823bdd5528bc9324cd2d85f5cf2054866e654ce576da"
+  revision 1
 
   livecheck do
     url "https://s3.openkim.org/archives/collection/"


### PR DESCRIPTION
I want to test the failures of the GCC 12 update (https://github.com/Homebrew/homebrew-core/pull/100411) in the current GCC 11 version: see what is preexisting or new.