### PR TITLE
exiftool: enable large file support

### DIFF
--- a/Formula/exiftool.rb
+++ b/Formula/exiftool.rb
@@ -27,6 +27,10 @@ class Exiftool < Formula
   uses_from_macos "perl"
 
   def install
+    # Enable large file support
+    # https://exiftool.org/forum/index.php?topic=3916.msg18182#msg18182
+    inreplace "lib/Image/ExifTool.pm", "LargeFileSupport => undef", "LargeFileSupport => 1"
+
     # replace the hard-coded path to the lib directory
     inreplace "exiftool", "$1/lib", libexec/"lib"
 


### PR DESCRIPTION
Enable large file support:
- https://exiftool.org/forum/index.php?topic=3916.msg18182#msg18182

Tested with 4.8G file from https://revaluniverse.com/reval-city-movie-video/:
- https://revaluniverse.com/movie/REVAL-CITY1080p.mov

----

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
