### PR TITLE
buku: fix test on self-hosted Linux

### DIFF
--- a/Formula/buku.rb
+++ b/Formula/buku.rb
@@ -207,12 +207,6 @@ class Buku < Formula
     ENV["LC_ALL"] = "en_US.UTF-8"
     ENV["XDG_DATA_HOME"] = "#{testpath}/.local/share"
 
-    expect = if OS.mac?
-      "/usr/bin/expect"
-    else
-      Formula["expect"].opt_bin/"expect"
-    end
-
     # Firefox exported bookmarks file
     (testpath/"bookmarks.html").write <<~EOS
       <!DOCTYPE NETSCAPE-Bookmark-file-1>
@@ -229,26 +223,15 @@ class Buku < Formula
       </DL>
     EOS
 
-    (testpath/"import").write <<~EOS
-      spawn #{bin}/buku --nc --import bookmarks.html
-      expect -re "DB file is being created at .*"
-      expect "You should encrypt it."
-      expect "Generate auto-tag (YYYYMonDD)? (y/n): "
-      send "y\r"
-      expect "Append tags when bookmark exist? (y/n): "
-      send "y\r"
-      expect "Add parent folder names as tags? (y/n): "
-      send "y\r"
-      expect {
-          -re ".*ERROR.*" { exit 1 }
-          "1. Title unknown"
-      }
-      spawn sleep 10
+    system bin/"buku", "--nostdin", "--nc", "--tacit", "--import", "bookmarks.html"
+    assert_equal <<~EOS, shell_output("#{bin}/buku --nostdin --nc --print").chomp
+      1. Title unknown
+         > https://github.com/Homebrew/brew
+         # bookmarks toolbar
     EOS
-    system expect, "-f", "import"
 
     # Test online components -- fetch titles
-    system bin/"buku", "--update"
+    assert_match "Index 1: updated", shell_output("#{bin}/buku --nostdin --nc --update")
 
     # Test crypto functionality
     (testpath/"crypto-test").write <<~EOS
@@ -272,7 +255,7 @@ class Buku < Formula
           "File decrypted"
       }
     EOS
-    system expect, "-f", "crypto-test"
+    system "expect", "-f", "crypto-test"
 
     # Test database content and search
     result = shell_output("#{bin}/buku --np --sany Homebrew")
@@ -284,15 +267,20 @@ class Buku < Formula
     assert_match version.to_s, result
 
     port = free_port
-    fork do
+    pid = fork do
       $stdout.reopen("/dev/null")
       $stderr.reopen("/dev/null")
-      exec "#{bin}/bukuserver run --host 127.0.0.1 --port #{port}"
+      exec "#{bin}/bukuserver", "run", "--host", "127.0.0.1", "--port", port.to_s
     end
-    sleep 10
 
-    result = shell_output("curl -s 127.0.0.1:#{port}/api/bookmarks")
-    assert_match "https://github.com/Homebrew/brew", result
-    assert_match "The missing package manager for macOS", result
+    begin
+      sleep 10
+      result = shell_output("curl -s 127.0.0.1:#{port}/api/bookmarks")
+      assert_match "https://github.com/Homebrew/brew", result
+      assert_match "The missing package manager for macOS", result
+    ensure
+      Process.kill "SIGINT", pid
+      Process.wait pid
+    end
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Testing if can reproduce `buku` failure on self-hosted Linux by itself.

Otherwise, will just have to blindly increase timeout and hope it fixes issue