### PR TITLE
ea-command 0.1.0 (new formula)

### DIFF
--- a/Formula/ea-command.rb
+++ b/Formula/ea-command.rb
@@ -1,0 +1,22 @@
+class EaCommand < Formula
+  desc "Ea: make your CLI output actionable"
+  homepage "https://github.com/dduan/ea"
+  url "https://github.com/dduan/ea/archive/0.1.0.tar.gz"
+  sha256 "269d57cf78645bd2b238bd3dbde965c05d1be631bcaffc354d9fcff4c77e06e7"
+  license "MIT"
+  head "https://github.com/dduan/ea.git"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked",
+                               "--root", prefix,
+                               "--path", "."
+  end
+
+  test do
+    (testpath/"foo.txt").write("")
+    assert_match("foo.txt", shell_output("#{bin}/ea run linear find -- ."))
+    assert_match("foo.txt", shell_output("#{bin}/ea"))
+  end
+end


### PR DESCRIPTION
[ea][] is a command-line tool that parses file paths from outputs of
other tools, and make them available for latter use.

[ea]: https://github.com/dduan/ea

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
