### PR TITLE
apache-flink 1.15.0

### DIFF
--- a/Formula/apache-flink.rb
+++ b/Formula/apache-flink.rb
@@ -1,10 +1,10 @@
 class ApacheFlink < Formula
   desc "Scalable batch and stream data processing"
   homepage "https://flink.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=flink/flink-1.14.4/flink-1.14.4-bin-scala_2.12.tgz"
-  mirror "https://archive.apache.org/dist/flink/flink-1.14.4/flink-1.14.4-bin-scala_2.12.tgz"
-  version "1.14.4"
-  sha256 "a36aeeea1ac340a5063e837ac18293ff73bd7cca2f8d6813982dfc50abb5e6f9"
+  url "https://www.apache.org/dyn/closer.lua?path=flink/flink-1.15.0/flink-1.15.0-bin-scala_2.12.tgz"
+  mirror "https://archive.apache.org/dist/flink/flink-1.15.0/flink-1.15.0-bin-scala_2.12.tgz"
+  version "1.15.0"
+  sha256 "8d88b555453b162a62b9e7d37ec95b30f65b0219cd97819699ad5cb8e7f32964"
   license "Apache-2.0"
   head "https://github.com/apache/flink.git", branch: "master"
 
@@ -36,9 +36,11 @@ class ApacheFlink < Formula
     system libexec/"bin/start-cluster.sh"
     system bin/"flink", "run", "-p", "1",
            libexec/"examples/streaming/WordCount.jar", "--input", testpath/"input",
-           "--output", testpath/"result/1"
+           "--output", testpath/"result"
     system libexec/"bin/stop-cluster.sh"
-    assert_predicate testpath/"result/1", :exist?
-    assert_equal expected, (testpath/"result/1").read
+    assert_predicate testpath/"result", :exist?
+    result_files = Dir[testpath/"result/*/*"]
+    assert_equal 1, result_files.length
+    assert_equal expected, (testpath/result_files.first).read
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Update apache-flink to 1.15.0
Fix test to read result files generated dynamically under ourput dir such as `result/2022-05-08--18/part-76f4f715-7264-4884-8cb1-78fd69e82574-0`