### PR TITLE
kim-api, openkim-models: use brewed curl

### DIFF
--- a/Formula/kim-api.rb
+++ b/Formula/kim-api.rb
@@ -1,7 +1,7 @@
 class KimApi < Formula
   desc "Knowledgebase of Interatomic Models (KIM) API"
   homepage "https://openkim.org"
-  url "https://s3.openkim.org/kim-api/kim-api-2.3.0.txz"
+  url "https://s3.openkim.org/kim-api/kim-api-2.3.0.txz", using: :homebrew_curl
   sha256 "93673bb8fbc0625791f2ee67915d1672793366d10cabc63e373196862c14f991"
   license "CDDL-1.0"
 

--- a/Formula/openkim-models.rb
+++ b/Formula/openkim-models.rb
@@ -1,7 +1,7 @@
 class OpenkimModels < Formula
   desc "All OpenKIM Models compatible with kim-api"
   homepage "https://openkim.org"
-  url "https://s3.openkim.org/archives/collection/openkim-models-2021-08-11.txz"
+  url "https://s3.openkim.org/archives/collection/openkim-models-2021-08-11.txz", using: :homebrew_curl
   sha256 "f42d241969787297d839823bdd5528bc9324cd2d85f5cf2054866e654ce576da"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Formulae that use an openkim.org `livecheck` block encounter a `curl: (35) error:1400442E:SSL routines:CONNECT_CR_SRVR_HELLO:tlsv1 alert protocol version` error on CI (i.e., openkim.org only supports TLS 1.3) but the checks work fine when tested locally (macOS 12.3.1 and also in a Linux `brew` Docker container). In the past, the `juman` formula had a check that worked fine locally but failed on CI (see #88309) but it was a bit different as it would time out on CI (despite responding in 1 second locally).

This PR isolates these formulae so we can test them without the overhead of the aforementioned GCC PR. Adding `using: homebrew_curl` reportedly didn't help before but I figured this would be a good place to start, as brewed curl is a typical solution for servers that only support TLS 1.3.