### PR TITLE
qodem: use new upstream and fix build on Linux

### DIFF
--- a/Formula/qodem.rb
+++ b/Formula/qodem.rb
@@ -1,8 +1,8 @@
 class Qodem < Formula
   desc "Terminal emulator and BBS client"
   homepage "https://qodem.sourceforge.io/"
-  url "https://github.com/klamonte/qodem/archive/refs/tags/v1.0.1.tar.gz"
-  sha256 "84aecd322839c615c6f465128ea3231163067606704f19ffa50e5d3481b6ff01"
+  url "https://downloads.sourceforge.net/project/qodem/qodem/1.0.1/qodem-1.0.1.tar.gz"
+  sha256 "dedc73bfa73ced5c6193f1baf1ffe91f7accaad55a749240db326cebb9323359"
   license :public_domain
 
   bottle do
@@ -16,6 +16,8 @@ class Qodem < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+
+  uses_from_macos "ncurses"
 
   def install
     system "./configure", *std_configure_args,


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
