### PR TITLE
minizinc: remove comment for already removed patch

### DIFF
--- a/Formula/minizinc.rb
+++ b/Formula/minizinc.rb
@@ -23,9 +23,6 @@ class Minizinc < Formula
     depends_on "gcc"
   end
 
-  # Workaround for https://github.com/MiniZinc/libminizinc/issues/546 by undoing commit
-  # 894d2d97b5d7c9a24a1b87d71f4c27f9e6a5f0e7, as suggested by a comment there.  Remove
-  # this patch when upstream resolves that issue.
   fails_with gcc: "5"
 
   def install


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR simply removes the comment that was added when MiniZinc 2.6.2 was patched. When this patch was removed with the release of MiniZinc 2.6.3, the comment was not removed.

Because this is simple comment cleanup, I admit that I did not spend the time to build and test the formula locally.
