### PR TITLE
dotdrop 1.8.2 (new formula)

### DIFF
--- a/Formula/dotdrop.rb
+++ b/Formula/dotdrop.rb
@@ -71,16 +71,16 @@ class Dotdrop < Formula
   test do
     (testpath/"xxx.conf").write("12345678")
     (testpath/"config.yaml").write <<~EOS
-    config:
-      dotpath: .
-    dotfiles:
-      f_xxx:
-        dst: yyy.conf
-        src: xxx.conf
-    profiles:
-      home:
-        dotfiles:
-        - f_xxx
+  config:
+    dotpath: .
+  dotfiles:
+    f_xxx:
+      dst: yyy.conf
+      src: xxx.conf
+  profiles:
+    home:
+      dotfiles:
+      - f_xxx
     EOS
     system bin/"dotdrop", "install", "--profile=home"
     assert_match "12345678", File.read("yyy.conf")

--- a/Formula/dotdrop.rb
+++ b/Formula/dotdrop.rb
@@ -71,16 +71,16 @@ class Dotdrop < Formula
   test do
     (testpath/"xxx.conf").write("12345678")
     (testpath/"config.yaml").write <<~EOS
-  config:
-    dotpath: .
-  dotfiles:
-    f_xxx:
-      dst: yyy.conf
-      src: xxx.conf
-  profiles:
-    home:
+      config:
+        dotpath: .
       dotfiles:
-      - f_xxx
+        f_xxx:
+          dst: yyy.conf
+          src: xxx.conf
+      profiles:
+        home:
+          dotfiles:
+          - f_xxx
     EOS
     system bin/"dotdrop", "install", "--profile=home"
     assert_match "12345678", File.read("yyy.conf")

--- a/Formula/dotdrop.rb
+++ b/Formula/dotdrop.rb
@@ -1,0 +1,73 @@
+class Dotdrop < Formula
+  include Language::Python::Virtualenv
+
+  desc "Save your dotfiles once, deploy them everywhere"
+  homepage "https://deadc0de.re/dotdrop"
+  url "https://github.com/deadc0de6/dotdrop/archive/refs/tags/v1.8.2.tar.gz"
+  sha256 "4e81db35e47c05607e46472e2919f0840e4ec0a1c168214f0bff54b876245340"
+  license "GPL-3.0-or-later"
+
+  depends_on "python@3.10"
+
+  resource "docopt" do
+    url "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz"
+    sha256 "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+  end
+
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/1b/a5/4eab74853625505725cefdf168f48661b2cd04e7843ab836f3f63abf81da/urllib3-1.26.9.tar.gz"
+    sha256 "aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
+  end
+
+  resource "Jinja2" do
+    url "https://files.pythonhosted.org/packages/89/e3/b36266381ae7a1310a653bb85f4f3658c462a69634fa9b2fef76252a50ed/Jinja2-3.1.1.tar.gz"
+    sha256 "640bed4bb501cbd17194b3cace1dc2126f5b619cf068a726b98192a0fde74ae9"
+  end
+
+  resource "ruamel.yaml" do
+    url "https://files.pythonhosted.org/packages/46/a9/6ed24832095b692a8cecc323230ce2ec3480015fbfa4b79941bd41b23a3c/ruamel.yaml-0.17.21.tar.gz"
+    sha256 "8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af"
+  end
+
+  resource "python-magic" do
+    url "https://files.pythonhosted.org/packages/f7/46/fecfd32c126d26c8dd5287095cad01356ec0a761205f0b9255998bff96d1/python-magic-0.4.25.tar.gz"
+    sha256 "21f5f542aa0330f5c8a64442528542f6215c8e18d2466b399b0d9d39356d83fc"
+  end
+
+  resource "packaging" do
+    url "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz"
+    sha256 "dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"
+  end
+
+  resource "requests" do
+    url "https://files.pythonhosted.org/packages/60/f3/26ff3767f099b73e0efa138a9998da67890793bfa475d8278f84a30fec77/requests-2.27.1.tar.gz"
+    sha256 "68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"
+  end
+
+  resource "MarkupSafe" do
+    url "https://files.pythonhosted.org/packages/1d/97/2288fe498044284f39ab8950703e88abbac2abbdf65524d576157af70556/MarkupSafe-2.1.1.tar.gz"
+    sha256 "7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"
+  end
+
+  resource "charset-normalizer" do
+    url "https://files.pythonhosted.org/packages/56/31/7bcaf657fafb3c6db8c787a865434290b726653c912085fbd371e9b92e1c/charset-normalizer-2.0.12.tar.gz"
+    sha256 "2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"
+  end
+
+  resource "certifi" do
+    url "https://files.pythonhosted.org/packages/6c/ae/d26450834f0acc9e3d1f74508da6df1551ceab6c2ce0766a593362d6d57f/certifi-2021.10.8.tar.gz"
+    sha256 "78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"
+  end
+
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/62/08/e3fc7c8161090f742f504f40b1bccbfc544d4a4e09eb774bf40aafce5436/idna-3.3.tar.gz"
+    sha256 "9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+  end
+end

--- a/Formula/dotdrop.rb
+++ b/Formula/dotdrop.rb
@@ -69,5 +69,20 @@ class Dotdrop < Formula
   end
 
   test do
+    (testpath/"xxx.conf").write("12345678")
+    (testpath/"config.yaml").write <<~EOS
+    config:
+      dotpath: .
+    dotfiles:
+      f_xxx:
+        dst: yyy.conf
+        src: xxx.conf
+    profiles:
+      home:
+        dotfiles:
+        - f_xxx
+    EOS
+    system bin/"dotdrop", "install", "--profile=home"
+    assert_match "12345678", File.read("yyy.conf")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

> [Dotdrop](https://github.com/deadc0de6/dotdrop) makes the management of dotfiles between different hosts easy. It allows you to store your dotfiles in Git and automagically deploy different versions of the same file on different setups.

github: https://github.com/deadc0de6/dotdrop
documents: https://dotdrop.readthedocs.io/en/latest/
