### PR TITLE
phpmyadmin 5.2.0

### DIFF
--- a/Formula/phpmyadmin.rb
+++ b/Formula/phpmyadmin.rb
@@ -1,8 +1,8 @@
 class Phpmyadmin < Formula
   desc "Web interface for MySQL and MariaDB"
   homepage "https://www.phpmyadmin.net"
-  url "https://files.phpmyadmin.net/phpMyAdmin/5.1.3/phpMyAdmin-5.1.3-all-languages.tar.gz"
-  sha256 "7a85454d82d88cc1a6beb09114a67fa40230c4eff2ae1778b434fa74e80dc6d7"
+  url "https://files.phpmyadmin.net/phpMyAdmin/5.2.0/phpMyAdmin-5.2.0-all-languages.tar.gz"
+  sha256 "f794528eebf1b723a29b89d239963e979a251fb484fd6e788919bf8cbca7db39"
 
   livecheck do
     url "https://www.phpmyadmin.net/files/"


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 12,474,799 bytes
- formula fetch time: 1.3 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.