### PR TITLE
mupdf: add linux-only flag

### DIFF
--- a/Formula/mupdf.rb
+++ b/Formula/mupdf.rb
@@ -28,11 +28,11 @@ class Mupdf < Formula
     because: "mupdf and mupdf-tools install the same binaries"
 
   def install
-    ENV.append_to_cflags "-fPIC" if OS.linux?
     glut_cflags = `pkg-config --cflags glut gl`.chomp
     glut_libs = `pkg-config --libs glut gl`.chomp
     system "make", "install",
            "build=release",
+           "shared=yes",
            "verbose=yes",
            "CC=#{ENV.cc}",
            "SYS_GLUT_CFLAGS=#{glut_cflags}",
@@ -42,6 +42,8 @@ class Mupdf < Formula
     # Symlink `mutool` as `mudraw` (a popular shortcut for `mutool draw`).
     bin.install_symlink bin/"mutool" => "mudraw"
     man1.install_symlink man1/"mutool.1" => "mudraw.1"
+
+    lib.install_symlink lib/shared_library("libmupdf") => shared_library("libmupdf-third")
   end
 
   test do

--- a/Formula/mupdf.rb
+++ b/Formula/mupdf.rb
@@ -28,6 +28,7 @@ class Mupdf < Formula
     because: "mupdf and mupdf-tools install the same binaries"
 
   def install
+    ENV.append_to_cflags "-fPIC" if OS.linux?
     glut_cflags = `pkg-config --cflags glut gl`.chomp
     glut_libs = `pkg-config --libs glut gl`.chomp
     system "make", "install",

--- a/Formula/mupdf.rb
+++ b/Formula/mupdf.rb
@@ -5,6 +5,7 @@ class Mupdf < Formula
   sha256 "b5eac663fe74f33c430eda342f655cf41fa73d71610f0884768a856a82e3803e"
   license "AGPL-3.0-or-later"
   head "https://git.ghostscript.com/mupdf.git", branch: "master"
+  revision 1
 
   livecheck do
     url "https://mupdf.com/downloads/archive/"

--- a/Formula/mupdf.rb
+++ b/Formula/mupdf.rb
@@ -4,8 +4,8 @@ class Mupdf < Formula
   url "https://mupdf.com/downloads/archive/mupdf-1.19.1-source.tar.xz"
   sha256 "b5eac663fe74f33c430eda342f655cf41fa73d71610f0884768a856a82e3803e"
   license "AGPL-3.0-or-later"
-  head "https://git.ghostscript.com/mupdf.git", branch: "master"
   revision 1
+  head "https://git.ghostscript.com/mupdf.git", branch: "master"
 
   livecheck do
     url "https://mupdf.com/downloads/archive/"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I am trying to build a python app that depends on [PyMuPDF](https://github.com/pymupdf/PyMuPDF) which requires `mupdf` to compile.
It compiles OK on Mac, but on Linux the linker fails with `can not be used when making a shared object; recompile with -fPIC` error. You can see it in the [build log](https://github.com/vzhd1701/homebrew-tap/runs/6409706183) for my package.

The problem goes away after proposed change in `mupdf` install script.