### PR TITLE
envoy: bump tag to v1.21.2 and fix build

### DIFF
--- a/Formula/envoy.rb
+++ b/Formula/envoy.rb
@@ -4,8 +4,8 @@ class Envoy < Formula
   # Switch to a tarball when the following issue is resolved:
   # https://github.com/envoyproxy/envoy/issues/2181
   url "https://github.com/envoyproxy/envoy.git",
-      tag:      "v1.21.1",
-      revision: "af50070ee60866874b0a9383daf9364e884ded22"
+      tag:      "v1.21.2",
+      revision: "dc7f46eb44e54d5646301aa5ab4ba01f662fdf75"
   license "Apache-2.0"
   head "https://github.com/envoyproxy/envoy.git", branch: "main"
 
@@ -61,7 +61,6 @@ class Envoy < Formula
     args = %W[
       --compilation_mode=opt
       --curses=no
-      --show_task_finish
       --verbose_failures
       --action_env=PATH=#{env_path}
       --host_action_env=PATH=#{env_path}


### PR DESCRIPTION
Bumped envoy tag to v1.21.2
Removed obsoleted bazel cmd param show_task_finish.

Signed-off-by: Christoph Pakulski <christoph@tetrate.io>

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
