### PR TITLE
csound: build on Linux

### DIFF
--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -5,8 +5,8 @@ class Csound < Formula
       tag:      "6.17.0",
       revision: "f5b4258794a82c99f7d85f1807c6638f2e80ccac"
   license "LGPL-2.1-or-later"
-  revision 5
-  head "https://github.com/csound/csound.git", branch: "develop"
+  revision 6
+  head "https://github.com/csound/csound.git", branch: "master"
 
   livecheck do
     url :stable
@@ -43,12 +43,15 @@ class Csound < Formula
   depends_on "portmidi"
   depends_on "python@3.9"
   depends_on "stk"
-  depends_on "wiiuse"
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
   uses_from_macos "curl"
   uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "wiiuse"
+  end
 
   conflicts_with "libextractor", because: "both install `extract` binaries"
   conflicts_with "pkcrack", because: "both install `extract` binaries"
@@ -75,19 +78,23 @@ class Csound < Formula
   end
 
   def install
-    ENV["JAVA_HOME"] = Formula["openjdk"].libexec/"openjdk.jdk/Contents/Home"
+    ENV["JAVA_HOME"] = Formula["openjdk"].libexec/(OS.mac? ? "openjdk.jdk/Contents/Home" : "lib")
 
-    system "cmake", "-S", ".", "-B", "build",
-                    "-DBUILD_JAVA_INTERFACE=ON",
-                    "-DBUILD_LUA_INTERFACE=OFF",
-                    "-DCMAKE_INSTALL_RPATH=@loader_path/../Frameworks;#{rpath}",
-                    "-DCS_FRAMEWORK_DEST=#{frameworks}",
-                    "-DJAVA_MODULE_INSTALL_DIR=#{libexec}",
-                    *std_cmake_args
+    args = [
+      "-DBUILD_JAVA_INTERFACE=ON",
+      "-DBUILD_LUA_INTERFACE=OFF",
+      "-DCS_FRAMEWORK_DEST=#{frameworks}",
+      "-DJAVA_MODULE_INSTALL_DIR=#{libexec}",
+    ]
+    args << "-DCMAKE_INSTALL_RPATH=@loader_path/../Frameworks;#{rpath}" if OS.mac?
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 
-    include.install_symlink frameworks/"CsoundLib64.framework/Headers" => "csound"
+    # On Linux, csound depends on binutils, but both formulae install `srconv` binaries
+    rm_f bin/"srconv" if OS.linux?
+
+    include.install_symlink frameworks/"CsoundLib64.framework/Headers" => "csound" if OS.mac?
 
     libexec.install buildpath/"interfaces/ctcsound.py"
 
@@ -99,43 +106,65 @@ class Csound < Formula
       resource("ableton-link").stage buildpath/"ableton-link"
       resource("getfem").stage { cp_r "src/gmm", buildpath }
 
-      system "cmake", "-S", ".", "-B", "build",
-                      "-DABLETON_LINK_HOME=#{buildpath}/ableton-link",
-                      "-DBUILD_ABLETON_LINK_OPCODES=ON",
-                      "-DBUILD_CHUA_OPCODES=ON",
-                      "-DBUILD_CUDA_OPCODES=OFF",
-                      "-DBUILD_FAUST_OPCODES=ON",
-                      "-DBUILD_FLUID_OPCODES=ON",
-                      "-DBUILD_HDF5_OPCODES=ON",
-                      "-DBUILD_IMAGE_OPCODES=ON",
-                      "-DBUILD_JACK_OPCODES=ON",
-                      "-DBUILD_LINEAR_ALGEBRA_OPCODES=ON",
-                      "-DBUILD_MP3OUT_OPCODE=ON",
-                      "-DBUILD_OPENCL_OPCODES=OFF",
-                      "-DBUILD_P5GLOVE_OPCODES=ON",
-                      "-DBUILD_PYTHON_OPCODES=ON",
-                      "-DBUILD_STK_OPCODES=ON",
-                      "-DBUILD_WEBSOCKET_OPCODE=ON",
-                      "-DBUILD_WIIMOTE_OPCODES=ON",
-                      "-DCSOUND_FRAMEWORK=#{frameworks}/CsoundLib64.framework",
-                      "-DCSOUND_INCLUDE_DIR=#{include}/csound",
-                      "-DGMM_INCLUDE_DIR=#{buildpath}",
-                      "-DPLUGIN_INSTALL_DIR=#{frameworks}/CsoundLib64.framework/Resources/Opcodes64",
-                      "-DUSE_FLTK=ON",
-                      *std_cmake_args
+      args = [
+        "-DABLETON_LINK_HOME=#{buildpath}/ableton-link",
+        "-DBUILD_ABLETON_LINK_OPCODES=ON",
+        "-DBUILD_CHUA_OPCODES=ON",
+        "-DBUILD_CUDA_OPCODES=OFF",
+        "-DBUILD_FAUST_OPCODES=ON",
+        "-DBUILD_FLUID_OPCODES=ON",
+        "-DBUILD_HDF5_OPCODES=ON",
+        "-DBUILD_IMAGE_OPCODES=ON",
+        "-DBUILD_JACK_OPCODES=ON",
+        "-DBUILD_LINEAR_ALGEBRA_OPCODES=ON",
+        "-DBUILD_MP3OUT_OPCODE=ON",
+        "-DBUILD_OPENCL_OPCODES=OFF",
+        "-DBUILD_PYTHON_OPCODES=ON",
+        "-DBUILD_STK_OPCODES=ON",
+        "-DBUILD_WEBSOCKET_OPCODE=ON",
+        "-DGMM_INCLUDE_DIR=#{buildpath}",
+        "-DUSE_FLTK=ON",
+      ]
+      if OS.mac?
+        args << "-DBUILD_P5GLOVE_OPCODES=ON"
+        args << "-DBUILD_WIIMOTE_OPCODES=ON"
+        args << "-DCSOUND_FRAMEWORK=#{frameworks}/CsoundLib64.framework"
+        args << "-DCSOUND_INCLUDE_DIR=#{include}/csound"
+        args << "-DPLUGIN_INSTALL_DIR=#{frameworks}/CsoundLib64.framework/Resources/Opcodes64"
+      else
+        args << "-DBUILD_P5GLOVE_OPCODES=OFF"
+        args << "-DBUILD_WIIMOTE_OPCODES=OFF"
+      end
+      system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
       system "cmake", "--build", "build"
       system "cmake", "--install", "build"
     end
   end
 
   def caveats
-    <<~EOS
+    caveats = <<~EOS
       To use the Java bindings, you may need to add to #{shell_profile}:
         export CLASSPATH="#{opt_libexec}/csnd6.jar:."
       and link the native shared library into your Java Extensions folder:
-        mkdir -p ~/Library/Java/Extensions
-        ln -s "#{opt_libexec}/lib_jcsound6.jnilib" ~/Library/Java/Extensions
     EOS
+    on_macos do
+      caveats = <<~EOS
+        #{caveats}\
+          mkdir -p ~/Library/Java/Extensions
+          ln -s "#{opt_libexec}/lib_jcsound6.jnilib" ~/Library/Java/Extensions
+      EOS
+    end
+    on_linux do
+      caveats = <<~EOS
+        srconv is not installed because it conflicts with binutils. To run srconv:
+          csound --utility=srconv
+
+        #{caveats}\
+          sudo mkdir -p /usr/java/packages/lib
+          sudo ln -s "#{opt_libexec}/lib_jcsound6.jnilib" /usr/java/packages/lib
+      EOS
+    end
+    caveats
   end
 
   test do
@@ -162,25 +191,38 @@ class Csound < Formula
       e
     EOS
 
-    ENV["OPCODE6DIR64"] = frameworks/"CsoundLib64.framework/Resources/Opcodes64"
+    if OS.mac?
+      ENV["OPCODE6DIR64"] = frameworks/"CsoundLib64.framework/Resources/Opcodes64"
+      ENV["SADIR"] = frameworks/"CsoundLib64.framework/Versions/Current/samples"
+    else
+      ENV["OPCODE6DIR64"] = lib/"csound/plugins64-6.0"
+      ENV["SADIR"] = share/"samples"
+    end
     ENV["RAWWAVE_PATH"] = Formula["stk"].pkgshare/"rawwaves"
-    ENV["SADIR"] = frameworks/"CsoundLib64.framework/Versions/Current/samples"
 
-    system bin/"csound", "test.orc", "test.sco"
+    system bin/"csound", "test.orc", "test.sco", "--format=wav"
 
-    assert_predicate testpath/"test.aif", :exist?
+    assert_predicate testpath/"test.wav", :exist?
     assert_predicate testpath/"test.h5", :exist?
     assert_predicate testpath/"test.mp3", :exist?
 
     (testpath/"opcode-existence.orc").write <<~EOS
       JackoInfo
       instr 1
-          p5gconnect
-          i_output websocket 8888, 0
-          i_success wiiconnect 1, 1
+          i_ websocket 8888, 0
       endin
     EOS
     system bin/"csound", "--orc", "--syntax-check-only", "opcode-existence.orc"
+
+    if OS.mac?
+      (testpath/"mac-opcode-existence.orc").write <<~EOS
+        instr 1
+            p5gconnect
+            i_ wiiconnect 1, 1
+        endin
+      EOS
+      system bin/"csound", "--orc", "--syntax-check-only", "mac-opcode-existence.orc"
+    end
 
     system Formula["python@3.9"].bin/"python3", "-c", "import ctcsound"
 

--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -5,7 +5,7 @@ class Csound < Formula
       tag:      "6.17.0",
       revision: "f5b4258794a82c99f7d85f1807c6638f2e80ccac"
   license "LGPL-2.1-or-later"
-  revision 6
+  revision 5
   head "https://github.com/csound/csound.git", branch: "master"
 
   livecheck do
@@ -84,7 +84,7 @@ class Csound < Formula
   end
 
   def install
-    ENV["JAVA_HOME"] = Formula["openjdk"].libexec/(OS.mac? ? "openjdk.jdk/Contents/Home" : "lib")
+    ENV["JAVA_HOME"] = Language::Java.overridable_java_home_env
 
     args = [
       "-DBUILD_JAVA_INTERFACE=ON",

--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -81,6 +81,7 @@ class Csound < Formula
     ENV["JAVA_HOME"] = Formula["openjdk"].libexec/(OS.mac? ? "openjdk.jdk/Contents/Home" : "lib")
 
     args = [
+      "-DBUILD_DSSI_OPCODES=OFF", # Csound segfaults on Linux CI if DSSI opcodes are built
       "-DBUILD_JAVA_INTERFACE=ON",
       "-DBUILD_LUA_INTERFACE=OFF",
       "-DCS_FRAMEWORK_DEST=#{frameworks}",

--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -209,9 +209,9 @@ class Csound < Formula
     end
     ENV["RAWWAVE_PATH"] = Formula["stk"].pkgshare/"rawwaves"
 
-    system bin/"csound", "test.orc", "test.sco", "--format=wav"
+    system bin/"csound", "test.orc", "test.sco"
 
-    assert_predicate testpath/"test.wav", :exist?
+    assert_predicate testpath/"test.#{OS.mac? ? "aif" : "wav"}", :exist?
     assert_predicate testpath/"test.h5", :exist?
     assert_predicate testpath/"test.mp3", :exist?
 

--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -53,6 +53,10 @@ class Csound < Formula
     depends_on "wiiuse"
   end
 
+  on_linux do
+    depends_on "gcc" => :build
+  end
+
   conflicts_with "libextractor", because: "both install `extract` binaries"
   conflicts_with "pkcrack", because: "both install `extract` binaries"
 
@@ -81,7 +85,6 @@ class Csound < Formula
     ENV["JAVA_HOME"] = Formula["openjdk"].libexec/(OS.mac? ? "openjdk.jdk/Contents/Home" : "lib")
 
     args = [
-      "-DBUILD_DSSI_OPCODES=OFF", # Csound segfaults on Linux CI if DSSI opcodes are built
       "-DBUILD_JAVA_INTERFACE=ON",
       "-DBUILD_LUA_INTERFACE=OFF",
       "-DCS_FRAMEWORK_DEST=#{frameworks}",

--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -84,7 +84,7 @@ class Csound < Formula
   end
 
   def install
-    ENV["JAVA_HOME"] = Language::Java.overridable_java_home_env
+    ENV["JAVA_HOME"] = Language::Java.java_home
 
     args = [
       "-DBUILD_JAVA_INTERFACE=ON",

--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -54,11 +54,13 @@ class Csound < Formula
   end
 
   on_linux do
-    depends_on "gcc" => :build
+    depends_on "gcc"
   end
 
   conflicts_with "libextractor", because: "both install `extract` binaries"
   conflicts_with "pkcrack", because: "both install `extract` binaries"
+
+  fails_with gcc: "5"
 
   resource "ableton-link" do
     url "https://github.com/Ableton/link/archive/Link-3.0.5.tar.gz"
@@ -151,6 +153,7 @@ class Csound < Formula
         export CLASSPATH="#{opt_libexec}/csnd6.jar:."
       and link the native shared library into your Java Extensions folder:
     EOS
+
     on_macos do
       caveats = <<~EOS
         #{caveats}\
@@ -158,6 +161,7 @@ class Csound < Formula
           ln -s "#{opt_libexec}/lib_jcsound6.jnilib" ~/Library/Java/Extensions
       EOS
     end
+
     on_linux do
       caveats = <<~EOS
         srconv is not installed because it conflicts with binutils. To run srconv:
@@ -168,6 +172,7 @@ class Csound < Formula
           sudo ln -s "#{opt_libexec}/lib_jcsound6.jnilib" /usr/java/packages/lib
       EOS
     end
+
     caveats
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is an attempt to build Csound on Linux. A few things worth pointing out:

* On macOS, Csound depends on [WiiUse](https://github.com/wiiuse/wiiuse), which [does not currently have a Linux bottle](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/wiiuse.rb). I made Csound depend on WiiUse only on macOS. (It *is* possible to build WiiUse on Linux, but I had to do `sudo apt-get install libbluetooth-dev` first, and I’m not sure how to encapsulate that into Homebrew.)

* Csound’s Java bindings work on Linux (locally, at least), but this makes the `caveats` a bit complicated (and also requires, as best as I can determine, having `sudo` commands in the `caveats` on Linux). I’m not sure if this is acceptable.