### PR TITLE
xpipe 1.0 (new formula)

### DIFF
--- a/Formula/xpipe.rb
+++ b/Formula/xpipe.rb
@@ -12,6 +12,6 @@ class Xpipe < Formula
   end
 
   test do
-    system "true"
+    system "false"
   end
 end

--- a/Formula/xpipe.rb
+++ b/Formula/xpipe.rb
@@ -1,9 +1,14 @@
 class Xpipe < Formula
   desc "Split input and feed it into the given utility"
   homepage "https://www.netmeister.org/apps/xpipe.html"
-  url "http://www.netmeister.org/apps/xpipe-1.0.tar.gz"
+  url "https://www.netmeister.org/apps/xpipe-1.0.tar.gz"
   sha256 "6f15286f81720c23f1714d6f4999d388d29f67b6ac6cef427a43563322fb6dc1"
   license "BSD-2-Clause"
+
+  livecheck do
+    url "https://www.netmeister.org/apps/"
+    regex(/href=.*?xpipe[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   def install
     system "make", "PREFIX=#{prefix}", "install"

--- a/Formula/xpipe.rb
+++ b/Formula/xpipe.rb
@@ -1,0 +1,17 @@
+class Xpipe < Formula
+  desc "Split input and feed it into the given utility"
+  homepage "https://www.netmeister.org/apps/xpipe.html"
+  url "http://www.netmeister.org/apps/xpipe-1.0.tar.gz"
+  sha256 "6f15286f81720c23f1714d6f4999d388d29f67b6ac6cef427a43563322fb6dc1"
+  license "BSD-2-Clause"
+
+  def install
+    system "make"
+    bin.install "xpipe"
+    man1.install "doc/xpipe.1"
+  end
+
+  test do
+    system "false"
+  end
+end

--- a/Formula/xpipe.rb
+++ b/Formula/xpipe.rb
@@ -6,9 +6,7 @@ class Xpipe < Formula
   license "BSD-2-Clause"
 
   def install
-    system "make"
-    bin.install "xpipe"
-    man1.install "doc/xpipe.1"
+    system "make", "PREFIX=#{prefix}", "install"
   end
 
   test do

--- a/Formula/xpipe.rb
+++ b/Formula/xpipe.rb
@@ -12,6 +12,6 @@ class Xpipe < Formula
   end
 
   test do
-    system "false"
+    system "true"
   end
 end

--- a/Formula/xpipe.rb
+++ b/Formula/xpipe.rb
@@ -12,6 +12,9 @@ class Xpipe < Formula
   end
 
   test do
-    system "true"
+    system "echo foo | xpipe -b 1 -J % /bin/sh -c 'cat >%'"
+    assert_predicate testpath/"1", :exist?
+    assert_predicate testpath/"2", :exist?
+    assert_predicate testpath/"3", :exist?
   end
 end


### PR DESCRIPTION
The xpipe command reads input from stdin and splits it by the
given number of bytes, lines, or if matching the given pattern.
It then invokes the given utility repeatedly, feeding it the
generated data chunks as input.

You can think of it as a Unix love-child of the split(1), tee(1),
and xargs(1) commands.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
