### PR TITLE
wasi-sdk 16.0 (new formula)

### DIFF
--- a/Formula/wasi-sdk.rb
+++ b/Formula/wasi-sdk.rb
@@ -14,6 +14,11 @@ class WasiSdk < Formula
   depends_on "python@3.10" => :build
   depends_on "rsync" => :build
 
+  on_linux do
+    depends_on "gcc"
+  end
+  fails_with gcc: "5"
+
   def install
     # The `build` target in wasi-sdk's Makefile sets all of the options
     # appropriately.

--- a/Formula/wasi-sdk.rb
+++ b/Formula/wasi-sdk.rb
@@ -2,9 +2,9 @@ class WasiSdk < Formula
   desc "WASI-enabled WebAssembly C/C++ toolchain"
   homepage "https://github.com/WebAssembly/wasi-sdk"
   url "https://github.com/WebAssembly/wasi-sdk.git",
-    tag:      "wasi-sdk-15",
-    revision: "e025da6b1099c730af4809484ad0ea84e0c3edbe"
-  version "15.0"
+    tag:      "wasi-sdk-16",
+    revision: "7b7b8a974a31f527d71467499b0d5be3b12f2fa9"
+  version "16.0"
   license "Apache-2.0"
 
   keg_only "provides alternative LLVM/Clang binaries specific to WASI"

--- a/Formula/wasi-sdk.rb
+++ b/Formula/wasi-sdk.rb
@@ -1,0 +1,54 @@
+class WasiSdk < Formula
+  desc "WASI-enabled WebAssembly C/C++ toolchain"
+  homepage "https://github.com/WebAssembly/wasi-sdk"
+  url "https://github.com/WebAssembly/wasi-sdk.git",
+    tag:      "wasi-sdk-15",
+    revision: "e025da6b1099c730af4809484ad0ea84e0c3edbe"
+  version "15.0"
+  license "Apache-2.0"
+
+  keg_only "provides alternative LLVM/Clang binaries specific to WASI"
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  depends_on "rsync" => :build
+
+  def install
+    # The `build` target in wasi-sdk's Makefile sets all of the options
+    # appropriately.
+    system "make", "build", "PREFIX=#{prefix}", "NINJA_FLAGS=-v"
+
+    # The `build` target installs everything into a DESTDIR of build/install/
+    # (with the tree starting with `prefix` under that). This is because the
+    # wasi-sdk build process is intended to produce a standalone binary
+    # tarball. We instead want to install locally, so let's copy the whole tree
+    # into `/`. Note that the tree only has content within `prefix` (e.g.
+    # /opt/homebrew/Cellar/wasi-sdk/...).
+    system "rsync", "-rlv", "build/install/", "/"
+  end
+
+  def caveats
+    <<~EOS
+      wasi-sdk provides `clang` and other binaries specifically for building
+      WASI binaries. In order to avoid conflict with your system compiler, these
+      are not put in your PATH by default. Instead, the binaries have been installed
+      in:
+
+        #{bin}
+    EOS
+  end
+
+  test do
+    testc = <<~EOS
+      #include <stdio.h>
+      int main() {
+        printf("hello world");
+      }
+    EOS
+    (testpath/"test.c").write(testc)
+    # Environment variable $CPATH set by Homebrew interferes with this clang
+    # invocation. Unset it.
+    ENV.delete "CPATH"
+    system "#{bin}/clang", testpath/"test.c", "-o", testpath/"test.wasm"
+  end
+end

--- a/Formula/wasi-sdk.rb
+++ b/Formula/wasi-sdk.rb
@@ -11,8 +11,8 @@ class WasiSdk < Formula
 
   depends_on "cmake" => :build
   depends_on "ninja" => :build
+  depends_on "python@3.10" => :build
   depends_on "rsync" => :build
-  depends_on "python" => :build
 
   def install
     # The `build` target in wasi-sdk's Makefile sets all of the options

--- a/Formula/wasi-sdk.rb
+++ b/Formula/wasi-sdk.rb
@@ -12,6 +12,7 @@ class WasiSdk < Formula
   depends_on "cmake" => :build
   depends_on "ninja" => :build
   depends_on "rsync" => :build
+  depends_on "python" => :build
 
   def install
     # The `build` target in wasi-sdk's Makefile sets all of the options


### PR DESCRIPTION
WASI-SDK is a distribution of a custom libc (wasi-libc) with clang/LLVM
to target the WASI (WebAssembly System Interface) platform. WASI is a
definition of a POSIX-like set of syscalls for WebAssembly modules to
use. A program compiled for the `wasm32-wasi` target can run in various
WebAssembly-outside-the-browser environments (server-side, cloud/edge
computing, command-line runtimes like Wasmtime, etc) and within browsers
with the appropriate shims.

This formula is a fairly thin wrapper around the custom Makefile in the
`wasi-sdk` repository [1], which itself is a fairly thin wrapper around
an LLVM/Clang build with specific options and defaults together with a
build of the custom sysroot.

An alternative strategy might be to provide a formula that builds just
the sysroot (or downloads it as a tarball from the `wasi-sdk` releases),
depends on Clang from the `clang` formula, and provides some shell-script
wrappers that alter the default target and specify the sysroot. That is a bit
more work, however, and diverges a bit further from "upstream" (the SDK
as intended by its authors), so I wanted to get a reading on whether this
current approach might work first. Thanks!

[1] https://github.com/WebAssembly/wasi-sdk/

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
