### PR TITLE
workflows/tests: temporarily stop dispatching jobs for ephemeral

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,8 +189,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: '12-arm64-${{github.run_id}}-${{github.run_attempt}}'
-            ephemeral: true
+          # - runner: '12-arm64-${{github.run_id}}-${{github.run_attempt}}'
+          #   ephemeral: true
           - runner: '12-arm64'
           - runner: '12'
           - runner: '11-arm64'


### PR DESCRIPTION
We've tested this very extensively to the point that we've managed to hammer the nodes so much that they are now unusable even after a reboot.

Despite that, we've managed to successfully demonstrate the system works, so much so that I don't think any further development is required before replacing our existing nodes. We've managed to test most edge cases now at this point (except maybe a GitHub outage).

It's just a case now of waiting for the nodes to become stable again, ideally in the long-term next time rather than for a couple days at a time. When this happens is however out of our direct control.