### PR TITLE
Formula: fix curl mirror URL

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -2,7 +2,7 @@ class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server"
   homepage "https://curl.se"
   url "https://curl.se/download/curl-7.83.1.tar.bz2"
-  mirror "https://github.com/curl/curl/releases/download/curl-7_82_0/curl-7.83.1.tar.bz2"
+  mirror "https://github.com/curl/curl/releases/download/curl-7_83_1/curl-7.83.1.tar.bz2"
   mirror "http://fresh-center.net/linux/www/curl-7.83.1.tar.bz2"
   mirror "http://fresh-center.net/linux/www/legacy/curl-7.83.1.tar.bz2"
   sha256 "f539a36fb44a8260ec5d977e4e0dbdd2eee29ed90fcedaa9bc3c9f78a113bff0"


### PR DESCRIPTION
The old URL returns a 404 and this URL returns a 302.
