### PR TITLE
Delete python dependency from osinfo-db-tools

### DIFF
--- a/Formula/osinfo-db-tools.rb
+++ b/Formula/osinfo-db-tools.rb
@@ -27,7 +27,6 @@ class OsinfoDbTools < Formula
   depends_on "json-glib"
   depends_on "libarchive"
   depends_on "libsoup"
-  depends_on "python@3.9"
 
   uses_from_macos "pod2man" => :build
   uses_from_macos "libxml2"


### PR DESCRIPTION
python is optional for testing: https://gitlab.com/libosinfo/osinfo-db-tools/-/blob/master/README

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
