### PR TITLE
clamav: remove unused libtool dependency

### DIFF
--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -25,7 +25,6 @@ class Clamav < Formula
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "json-c"
-  depends_on "libtool"
   depends_on "openssl@1.1"
   depends_on "pcre2"
   depends_on "yara"


### PR DESCRIPTION
`libtool` doesn't seem to be used anymore (see https://github.com/Homebrew/homebrew-core/pull/57734#issuecomment-663853688).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
