### PR TITLE
cruft: remove `poetry` dependency

### DIFF
--- a/Formula/cruft.rb
+++ b/Formula/cruft.rb
@@ -17,7 +17,6 @@ class Cruft < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "89e8752784fa125df67127d6ae43ac5b37026f9fed1378f99c62f4c6b76139da"
   end
 
-  depends_on "poetry" => :build
   depends_on "python@3.10"
   depends_on "six"
 
@@ -127,12 +126,7 @@ class Cruft < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3")
-    venv.pip_install resources
-
-    poetry = Formula["poetry"].opt_bin/"poetry"
-    system poetry, "build", "--format", "wheel", "--verbose", "--no-interaction"
-    venv.pip_install_and_link Dir["dist/cruft-*.whl"].first
+    virtualenv_install_with_resources
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Previously, our `poetry` was needed as a build dependency to avoid requiring rust. However, `cruft` has since [been updated](https://github.com/cruft/cruft/blob/637450a51600a9ba8205d7c8dec389dee28efce8/pyproject.toml#L54-L56) to build with the self-contained `poetry-core`.
