### PR TITLE
freebayes: update livecheck

### DIFF
--- a/Formula/freebayes.rb
+++ b/Formula/freebayes.rb
@@ -6,9 +6,14 @@ class Freebayes < Formula
   license "MIT"
   head "https://github.com/freebayes/freebayes.git", branch: "master"
 
+  # The Git repository contains a few older tags that erroneously omit a
+  # leading zero in the version (e.g., `v9.9.2` should have been `v0.9.9.2`)
+  # and these would appear as the newest versions until the current version
+  # exceeds 9.9.2. `stable` uses a tarball from a release (not a tag archive),
+  # so using the `GithubLatest` strategy is appropriate here overall.
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #101772, as I didn't get around to reviewing it before it was merged.

The existing `livecheck` block checks the Git tags using the standard regex for tags like `1.2.3`/`v1.2.3`. However, this isn't sufficient to identify the correct latest version because the Git repository contains a few malformed tags. A couple tags like `v9.9.2` should actually be `v0.9.9.2` whereas `v9.9.13` should be `v0.9.13`. Three out of four related tags starting with `v0` are present and were created around the same time but the presence of the tags starting with `v9` will still cause problems for us.

We could technically use a `strategy` block to omit the four offending tags and continue to use the `Git` strategy. However, this formula's `stable` URL is a release download (not a tag archive), so we should arguably use `GithubLatest` to check for new versions anyway (i.e., this would avoid any lag between when a tag is created and the release is created).