### PR TITLE
build2 0.14.0 (new formula)

### DIFF
--- a/Formula/build2.rb
+++ b/Formula/build2.rb
@@ -1,0 +1,30 @@
+class Build2 < Formula
+  desc "C/C++ Build Toolchain"
+  homepage "https://build2.org"
+  url "https://download.build2.org/0.14.0/build2-toolchain-0.14.0.tar.gz"
+  sha256 "36781e9fce483e431dcf1d4d73dbef267b1712fb8679dbe968334aae6242237f"
+  license "MIT"
+
+  def install
+    # Don't build the build tool hermetically, to avoid baking Homebrew-specific
+    # paths into the final dylibs
+    inreplace "./build.sh", "config.config.hermetic=true", "config.config.hermetic=false"
+
+    args = %W[
+      --jobs #{ENV.make_jobs}
+      --sudo false
+      --local
+      --private
+      --make make
+      --install-dir #{prefix}
+    ]
+
+    system "./build.sh", *args, ENV.cxx
+  end
+
+  test do
+    (testpath/"test.cxx").write("int main() {}")
+    (testpath/"buildfile").write("using cxx\nexe{test}: cxx{test.cxx}")
+    system "#{bin}/b"
+  end
+end


### PR DESCRIPTION
Build2 (https://build2.org) is a build system and package manager
for C and C++, roughly like Cargo is for Rust.

Because it's a build system, build2 uses multi-stage bootstrapping
to build itself, rather than using cmake or the like. This formula
downloads and uses upstream build script with the following options:

 * --jobs #{ENV.make_jobs}
     overrides build2's default parallelism detection
 * --sudo false
     prevents the install script from trying to install things as root
 * --local
     by default build2 will create a configuration whereby it can be used
     to update itself. The --local option instead says this is a local
     installation which will be managed by, in this case, Homebrew
 * --private
     installs shared libraries as $prefix/lib/build2/libxxx.dylib rather than
     just $prefix/lib/libxxx.dylib. Avoids conflicts with other Homebrew
     packages like sqlite
 * --install-dir #{prefix}
     The installation directory

The included test makes sure that a minimal C++ file can be built using
the newly-install build tool.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

EDIT: `brew audit --new build2` now working correctly
