### PR TITLE
xmrig: change head branch to `dev`

### DIFF
--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -4,7 +4,7 @@ class Xmrig < Formula
   url "https://github.com/xmrig/xmrig/archive/v6.17.0.tar.gz"
   sha256 "748a989390202ba2d1ccbd9d9a6b8cbd6551149cbab63b347fd1ed6df0254faa"
   license "GPL-3.0-or-later"
-  head "https://github.com/xmrig/xmrig.git", branch: "master"
+  head "https://github.com/xmrig/xmrig.git", branch: "dev"
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
regarding the test:

in my case, xmrig returned `[2022-05-20 12:44:46.219]  net      donotexist.localhost:65535 connect error: "connection refused"` on macOS, but not what's expected by the formula.
as such, the test didn't pass, and the box has not been checked.

-----

the `master` branch (https://github.com/xmrig/xmrig/tree/master) on the
xmrig repository does not contain the latest development changes (and
instead is mostly equivalent to the latest stable version), which are
located at the `dev` branch (https://github.com/xmrig/xmrig/tree/dev).
as such, this commit changes the branch that's used for HEAD
installations from `master` to `dev` so that HEAD installations will get
the latest development changes as the user would likely desire.