### PR TITLE
apache-pulsar: update use jdk17

### DIFF
--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -22,6 +22,7 @@ class ApachePulsar < Formula
   depends_on "maven" => :build
   depends_on "pkg-config" => :build
   depends_on "protobuf" => :build
+  depends_on arch: :x86_64
   depends_on "openjdk@17"
 
   def install

--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -5,6 +5,7 @@ class ApachePulsar < Formula
   mirror "https://archive.apache.org/dist/pulsar/pulsar-2.10.0/apache-pulsar-2.10.0-src.tar.gz"
   sha256 "fadf27077c5a15852791bea45f34191de1edc25799ecd6e2730a9ff656789c0b"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apache/pulsar.git", branch: "master"
 
   bottle do
@@ -21,11 +22,10 @@ class ApachePulsar < Formula
   depends_on "maven" => :build
   depends_on "pkg-config" => :build
   depends_on "protobuf" => :build
-  depends_on arch: :x86_64
-  depends_on "openjdk@11"
+  depends_on "openjdk@17"
 
   def install
-    with_env("TMPDIR" => buildpath, **Language::Java.java_home_env("11")) do
+    with_env("TMPDIR" => buildpath, **Language::Java.java_home_env("17")) do
       system "mvn", "-X", "clean", "package", "-DskipTests", "-Pcore-modules"
     end
 
@@ -47,7 +47,7 @@ class ApachePulsar < Formula
     libexec.glob("bin/*") do |path|
       if !path.fnmatch?("*common.sh") && !path.directory?
         bin_name = path.basename
-        (bin/bin_name).write_env_script libexec/"bin"/bin_name, Language::Java.java_home_env("11")
+        (bin/bin_name).write_env_script libexec/"bin"/bin_name, Language::Java.java_home_env("17")
       end
     end
   end


### PR DESCRIPTION
Latest `master` for Pulsar has a hard dependency on JDK17. JDK17 has been supported and is tested working on the current bottled version (2.10) as well, so this should be backwards compatible.

ARM Mac builds should now also be possible, though we'll see how brew CI does with them since I've had some difficulty getting it to build on my m1.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
