### PR TITLE
bash-language-server: remove unneeded `NODE_OPTIONS`

### DIFF
--- a/Formula/bash-language-server.rb
+++ b/Formula/bash-language-server.rb
@@ -24,8 +24,6 @@ class BashLanguageServer < Formula
   end
 
   test do
-    ENV["NODE_OPTIONS"] = "--no-experimental-fetch"
-
     json = <<~JSON
       {
         "jsonrpc": "2.0",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

This was added for Node 18 compatability, but has since been addressed upstream: https://github.com/bash-lsp/bash-language-server/commit/69f1adff06734667cff73dae253ebfc6c2019785
