### PR TITLE
cql-proxy 0.1.1 (new formula)

### DIFF
--- a/Formula/cql-proxy.rb
+++ b/Formula/cql-proxy.rb
@@ -12,6 +12,8 @@ class CqlProxy < Formula
   end
 
   test do
-    assert_match "astra-bundle", shell_output("cql-proxy --help 2>&1")
+    exec("touch secure.txt")
+    assert_match "unable to open", shell_output("cql-proxy -b secure.txt --bind 127.0.0.1 2>&1")
+    exec("rm secure.txt")
   end
 end

--- a/Formula/cql-proxy.rb
+++ b/Formula/cql-proxy.rb
@@ -1,0 +1,17 @@
+class CqlProxy < Formula
+  desc "DataStax cql-proxy enables Cassandra apps to use Astra DB without code changes"
+  homepage "https://github.com/datastax/cql-proxy"
+  url "https://github.com/datastax/cql-proxy/archive/refs/tags/v0.1.1.tar.gz"
+  sha256 "25cd9a87078c11caed7da14d2b8b85e5240bfe1aff5b666d0dcad9e73c15b305"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    assert_match "astra-bundle", shell_output("cql-proxy --help 2>&1")
+  end
+end

--- a/Formula/cql-proxy.rb
+++ b/Formula/cql-proxy.rb
@@ -13,7 +13,7 @@ class CqlProxy < Formula
 
   test do
     touch "secure.txt"
-    output = shell_output("cql-proxy -b secure.txt --bind 127.0.0.1 2>&1", 1)
+    output = shell_output("#{bin}/cql-proxy -b secure.txt --bind 127.0.0.1 2>&1", 1)
     assert_match "unable to open", output
   end
 end

--- a/Formula/cql-proxy.rb
+++ b/Formula/cql-proxy.rb
@@ -12,7 +12,8 @@ class CqlProxy < Formula
   end
 
   test do
-    exec("touch secure.txt")
-    assert_match "unable to open", shell_output("cql-proxy -b secure.txt --bind 127.0.0.1 2>&1")
+    touch "secure.txt"
+    output = shell_output("cql-proxy -b secure.txt --bind 127.0.0.1 2>&1", 1)
+    assert_match "unable to open", output
   end
 end

--- a/Formula/cql-proxy.rb
+++ b/Formula/cql-proxy.rb
@@ -14,6 +14,5 @@ class CqlProxy < Formula
   test do
     exec("touch secure.txt")
     assert_match "unable to open", shell_output("cql-proxy -b secure.txt --bind 127.0.0.1 2>&1")
-    exec("rm secure.txt")
   end
 end


### PR DESCRIPTION
cql-proxy is a lightweight sidecar to allow easier connectivity to Cassandra, AstraDB and compatible databases.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
