### PR TITLE
gcc: remove unnecessary file

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -135,6 +135,10 @@ class Gcc < Formula
     Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
     # Even when we disable building info pages some are still installed.
     info.rmtree
+
+    # Work around GCC install bug
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105664
+    rm_rf Dir[bin/"*-gcc-tmp"]
   end
 
   def add_suffix(file, suffix)


### PR DESCRIPTION
Remove an unnecessary file, installed by a GCC make bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105664
Will help with linking different GCC versions simultaneously.