### PR TITLE
Remove livecheck blocks from deprecated formulae

### DIFF
--- a/Formula/aida-header.rb
+++ b/Formula/aida-header.rb
@@ -5,11 +5,6 @@ class AidaHeader < Formula
   sha256 "882d351bc09e830ae2eb512a2cbf44af5a82ef8efe31fbe0d047363da8314c81"
   license "LGPL-3.0-or-later"
 
-  livecheck do
-    url "https://aida.freehep.org/download.thtml"
-    regex(%r{href=.*?/AIDA/v?(\d+(?:\.\d+)+)/}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "dbbfb4a01fb14b65b959fe8666c25d894a3b0b0a6e2badb14346c8ba71673bf2"
     sha256 cellar: :any_skip_relocation, big_sur:       "eba4b33299b9ed8ed988c4c17fbffe1e17364a7d284878247c3b0a738fe2b340"

--- a/Formula/apache-ctakes.rb
+++ b/Formula/apache-ctakes.rb
@@ -5,11 +5,6 @@ class ApacheCtakes < Formula
   sha256 "f741016e3755054876f3bb27f916a8008af27175ef33785638a6292d300c972e"
   license "Apache-2.0"
 
-  livecheck do
-    url "https://ctakes.apache.org/downloads.cgi"
-    regex(/href=.*?apache-ctakes[._-]v?(\d+(?:\.\d+)+)-bin\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "4c6af60f27e2795e09763b88aa81e00faa80ba6d46e6f6cac3d2cd0b72b9f69f"

--- a/Formula/cacli.rb
+++ b/Formula/cacli.rb
@@ -5,11 +5,6 @@ class Cacli < Formula
   sha256 "e7d8fd54f16098a6ac9a612b021beea3218d9747672d49eff20a285cdee69101"
   license "MIT"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "7c6cf80205658f45979413a2c281e981988c5bab3384f4eb52517b854d024801"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ea0076fb8a8b30ee1809d70d1864a8cb2475f06bfb330d42968dc1775cd34c21"

--- a/Formula/libgaiagraphics.rb
+++ b/Formula/libgaiagraphics.rb
@@ -5,11 +5,6 @@ class Libgaiagraphics < Formula
   sha256 "ccab293319eef1e77d18c41ba75bc0b6328d0fc3c045bb1d1c4f9d403676ca1c"
   revision 8
 
-  livecheck do
-    url "https://www.gaia-gis.it/gaia-sins/gaiagraphics-sources/"
-    regex(/href=.*?libgaiagraphics[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "bed66e6333951fdaa247237dda24a2aeba7dd4da38bff9f2a5cee773ccad6179"

--- a/Formula/librasterlite.rb
+++ b/Formula/librasterlite.rb
@@ -6,10 +6,6 @@ class Librasterlite < Formula
   license any_of: ["MPL-1.1", "GPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 8
 
-  livecheck do
-    skip "No longer developed"
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "631ed6e41434a21f397ba2e46abc9a21b38a02ffb242826de1ec41279e542c47"

--- a/Formula/mariadb@10.2.rb
+++ b/Formula/mariadb@10.2.rb
@@ -5,23 +5,6 @@ class MariadbAT102 < Formula
   sha256 "851de7accdbddd2fcf8c31e4ddd4957d3c5d61bcefed1f3efaa6625e8cf200cf"
   license "GPL-2.0-only"
 
-  # This uses a placeholder regex to satisfy the `PageMatch` strategy
-  # requirement. In the future, this will be updated to use a `Json` strategy
-  # and we can remove the unused regex at that time.
-  livecheck do
-    url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"
-    regex(/unused/i)
-    strategy :page_match do |page|
-      json = JSON.parse(page)
-      json["releases"]&.map do |release|
-        next unless release["release_number"]&.start_with?(version.major_minor)
-        next unless release["status"]&.include?("stable")
-
-        release["release_number"]
-      end
-    end
-  end
-
   bottle do
     sha256 arm64_monterey: "9f4d278e33ad437ff10bdb11dffdc756a3bc74d673ef625c4ed01340f352cf4f"
     sha256 arm64_big_sur:  "5614b538b3a13a3efb09db5b149ce0f553b4ec3801543f7ebbf25c1d7df6a481"

--- a/Formula/node@12.rb
+++ b/Formula/node@12.rb
@@ -5,11 +5,6 @@ class NodeAT12 < Formula
   sha256 "bc42b7f8495b9bfc7f7850dd180bb02a5bdf139cc232b8c6f02a6967e20714f2"
   license "MIT"
 
-  livecheck do
-    url "https://nodejs.org/dist/"
-    regex(%r{href=["']?v?(12(?:\.\d+)+)/?["' >]}i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "55ac811bdbf7b23af17685ffc6ca8f856b24eb12cdacf0090ba4db180601fcd0"
     sha256 cellar: :any,                 arm64_big_sur:  "f77863889d72ff635fc8636c2c981129f77b63ca3f8089b1d3352a0f82fba82b"

--- a/Formula/nu-smv.rb
+++ b/Formula/nu-smv.rb
@@ -4,13 +4,6 @@ class NuSmv < Formula
   url "https://nusmv.fbk.eu/distrib/NuSMV-2.6.0.tar.gz"
   sha256 "dba953ed6e69965a68cd4992f9cdac6c449a3d15bf60d200f704d3a02e4bbcbb"
 
-  # The download page is behind a CAPTCHA, so we identify new versions from the
-  # the version announce links on the homepage.
-  livecheck do
-    url :homepage
-    regex(/href=.*?announce-NuSMV[._-]v?(\d+(?:\.\d+)+)\.txt/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "fe65bcdedc024ee8cb5c94fcd1cb6487a5ba85bd76e82f3f3d84dfbe18aa19e6"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "4335d0633f214a331bbdf3d060ec0fd574a257ebe1f082025d86cc3a082eac3f"

--- a/Formula/rfcmarkup.rb
+++ b/Formula/rfcmarkup.rb
@@ -5,11 +5,6 @@ class Rfcmarkup < Formula
   sha256 "369d1b1e6ed27930150b7b0e51a5fc4e068a8980c59924abc0ece10758c6cfd7"
   license "GPL-2.0-or-later"
 
-  livecheck do
-    url :homepage
-    regex(%r{>\s*Version:\s*</i>\s*v?(\d+(?:\.\d+)+)}im)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "0d97d7f0dd108bd9402c9bb0a22532f1f4f16dd8ebdd2004d865ced971d899ad"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "0d97d7f0dd108bd9402c9bb0a22532f1f4f16dd8ebdd2004d865ced971d899ad"

--- a/Formula/ruby@2.6.rb
+++ b/Formula/ruby@2.6.rb
@@ -5,11 +5,6 @@ class RubyAT26 < Formula
   sha256 "5fd8ded51321b88fdc9c1b4b0eb1b951d2eddbc293865da0151612c2e814c1f2"
   license "Ruby"
 
-  livecheck do
-    url "https://www.ruby-lang.org/en/downloads/"
-    regex(/href=.*?ruby[._-]v?(2\.6(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 arm64_monterey: "74f876ed5b99df4aac83e9493f1e35b9acd5caa40d455d74409dbb50da0e484e"
     sha256 arm64_big_sur:  "5ddd0ae653c7fb59b23b2fe4c9d009e18f3c2c747c9bc0d912ac71bb90f0f9ca"

--- a/Formula/teapot.rb
+++ b/Formula/teapot.rb
@@ -5,11 +5,6 @@ class Teapot < Formula
   sha256 "580e0cb416ae3fb3df87bc6e92e43bf72929d47b65ea2b50bc09acea3bff0b65"
   license "GPL-3.0"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?teapot[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_monterey: "7cc7392844bbae930942bf7d9a5d469b817987342f4720fd36986edd751cecdd"

--- a/Formula/tpp.rb
+++ b/Formula/tpp.rb
@@ -4,11 +4,6 @@ class Tpp < Formula
   url "https://synflood.at/tpp/tpp-1.3.1.tar.gz"
   sha256 "68e3de94fbfb62bd91a6d635581bcf8671a306fffe615d00294d388ad91e1b5f"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?tpp[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, catalina:    "e2875a7547a670ff0b23af7c9c96db096c365d4ac57f4ec706d1d9453cef9076"

--- a/Formula/youtube-dlc.rb
+++ b/Formula/youtube-dlc.rb
@@ -7,12 +7,6 @@ class YoutubeDlc < Formula
   revision 1
   head "https://github.com/blackjack4494/yt-dlc.git", branch: "master"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-    regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "3b783d95acf80bf416f5914825a6526f20a1cf2efaf796c034e7b681c77cf14d"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "3b783d95acf80bf416f5914825a6526f20a1cf2efaf796c034e7b681c77cf14d"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The formulae in this PR have been deprecated and the reasons are such that there's no reason to check for new versions. In this scenario, we should remove any `livecheck` block as part of the deprecation but this is unfortunately overlooked at times. This PR removes these `livecheck` blocks so the formulae will be automatically skipped as deprecated.