### PR TITLE
root: remove dependency on :xcode

### DIFF
--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -2,7 +2,7 @@ class Root < Formula
   desc "Object oriented framework for large scale data analysis"
   homepage "https://root.cern.ch/"
   license "LGPL-2.1-or-later"
-  revision 1
+  revision 2
   head "https://github.com/root-project/root.git", branch: "master"
 
   stable do
@@ -43,7 +43,6 @@ class Root < Formula
   depends_on "python@3.9"
   depends_on "sqlite"
   depends_on "tbb"
-  depends_on :xcode
   depends_on "xrootd"
   depends_on "xz" # for LZMA
   depends_on "zstd"
@@ -59,6 +58,15 @@ class Root < Formula
   skip_clean "bin"
 
   fails_with gcc: "5"
+
+  patch do
+    # Pin CLING_OSX_SYSROOT to the major SDK version used at compile time instead of the latest available.
+    # This resolves compilation errors described in https://github.com/root-project/root/issues/7881 on older
+    # major macOS releases with recent CLT/XCode installations that provide macOS SDK for newer major macOS
+    # releses, e.g. on macOS 11 with CLT 13 (which contains MacOSX12.sdk)
+    url "https://github.com/dennisklein/root/commit/ee75437c09a45b362df0d1c87ea5d9f0dd8123b5.patch?full_index=1"
+    sha256 "637a1390037ffff5cb00766986312c453c0fe96cf7ad89d1db078d9984e47548"
+  end
 
   def install
     ENV.append "LDFLAGS", "-Wl,-rpath,#{lib}/root"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
   - #102135, unrelated
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I would like to start a discussion about removing the dependency on :xcode again. It is quite heavy and - I believe - over-specified. (We have built ROOT hundreds of times without XCode, CLT are just fine.)

I believe this PR (although you likely will not want to accept it as is) gives an alternative solution and hopefully more insight into the error posted in https://github.com/Homebrew/homebrew-core/pull/92497#issuecomment-1004748648.

We observed the same error a couple of years ago with an older ROOT version, too, when updating the CLT in our CI macs, but not macOS itself (e.g. macOS 10.15 + CLT which contained a `MacOSX11.sdk`). In order to satisfy the ROOT compilation we had to choose the latest available SDK version (via `$SDKROOT`). Today, with the combination macOS 11 and a CLT which contains a `MacOSX12.sdk`, we encounter the same errors once again. However, I am limited in what combinations I can test.

The root cause of those errors is not fully understood. It appears to be related to the mixing of older and newer SDKs in include search paths given to the compiler (wrong/conflicting ordering?!) when using the `<cmath>` header from `libc++`.

Let me give some more minimal examples for the errors happening from three differently configured macOS systems, which hopefully inspire someone else as to where the problem may lie:

**macOS 11 (x86_64) + CLT 13**
```console
user@node1 ~ % unset SDKROOT
user@node1 ~ % sw_vers
ProductName:    macOS
ProductVersion: 11.6.5
BuildVersion:   20G527
user@node1 ~ % brew config
HOMEBREW_VERSION: 3.4.11-94-g1045869
ORIGIN: https://github.com/Homebrew/brew
HEAD: 10458698fc07ac1e7a96cf19f1d17e2ea047f7e8
Last commit: 11 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 81d8e4b53960b078f7b4b99a046e048795318427
Core tap last commit: 4 hours ago
Core tap branch: master
HOMEBREW_PREFIX: /usr/local
HOMEBREW_CASK_OPTS: []
HOMEBREW_CORE_GIT_REMOTE: https://github.com/Homebrew/homebrew-core
HOMEBREW_MAKE_JOBS: 12
Homebrew Ruby: 2.6.8 => /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/bin/ruby
CPU: dodeca-core 64-bit kabylake
Clang: 13.0.0 build 1300
Git: 2.32.0 => /Library/Developer/CommandLineTools/usr/bin/git
Curl: 7.64.1 => /usr/bin/curl
macOS: 11.6.5-x86_64
CLT: 13.2.0.0.1.1638488800
Xcode: N/A
user@node1 ~ % cat demo.cpp
#include <cmath>
int main() { return 0; }
user@node1 ~ % xcrun --show-sdk-path
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
user@node1 ~ % xcode-select -p
/Library/Developer/CommandLineTools
user@node1 ~ % ls -l /Library/Developer/CommandLineTools/SDKs
total 0
lrwxr-xr-x  1 root  wheel   14 Jan 14 13:35 MacOSX.sdk -> MacOSX12.1.sdk
drwxr-xr-x  8 root  wheel  256 Jan 14 13:24 MacOSX10.15.sdk
drwxr-xr-x  7 root  wheel  224 Nov 30  2020 MacOSX11.1.sdk
drwxr-xr-x  7 root  wheel  224 Jan 14 13:35 MacOSX11.3.sdk
lrwxr-xr-x  1 root  wheel   14 Jan 14 13:34 MacOSX11.sdk -> MacOSX11.3.sdk
drwxr-xr-x  7 root  wheel  224 Jan 14 13:36 MacOSX12.1.sdk
lrwxr-xr-x  1 root  wheel   14 Jan 14 13:34 MacOSX12.sdk -> MacOSX12.1.sdk
user@node1 ~ % clang++ demo.cpp
user@node1 ~ % clang++ -I/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include demo.cpp
user@node1 ~ % clang++ -I/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include demo.cpp # this is what brew does by default!
In file included from demo.cpp:1:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/cmath:321:9: error: no member named 'signbit' in the global namespace
using ::signbit;
      ~~^
(...)
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
user@node1 ~ % clang++ -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include demo.cpp
In file included from demo.cpp:1:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/cmath:321:9: error: no member named 'signbit' in the global namespace
using ::signbit;
      ~~^
(...)
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
```

**macOS 12 (x86_64) + CLT 13**
```console
user@node2 ~ % unset SDKROOT
user@node2 ~ % sw_vers
ProductName:    macOS
ProductVersion: 12.3.1
BuildVersion:   21E258
user@node2 ~ % brew config
HOMEBREW_VERSION: 3.4.11-94-g1045869
ORIGIN: https://github.com/Homebrew/brew
HEAD: 10458698fc07ac1e7a96cf19f1d17e2ea047f7e8
Last commit: 11 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 81d8e4b53960b078f7b4b99a046e048795318427
Core tap last commit: 4 hours ago
Core tap branch: master
HOMEBREW_PREFIX: /usr/local
HOMEBREW_CASK_OPTS: []
HOMEBREW_CORE_GIT_REMOTE: https://github.com/Homebrew/homebrew-core
HOMEBREW_MAKE_JOBS: 12
Homebrew Ruby: 2.6.8 => /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/bin/ruby
CPU: dodeca-core 64-bit kabylake
Clang: 13.1.6 build 1316
Git: 2.32.0 => /Library/Developer/CommandLineTools/usr/bin/git
Curl: 7.79.1 => /usr/bin/curl
macOS: 12.3.1-x86_64
CLT: 13.3.1.0.1.1648687083
Xcode: N/A
user@node2 ~ % cat demo.cpp
#include <cmath>
int main() { return 0; }
user@node2 ~ % xcrun --show-sdk-path
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
user@node2 ~ % xcode-select -p
/Library/Developer/CommandLineTools
user@node2 ~ % ls -l /Library/Developer/CommandLineTools/SDKs
total 0
lrwxr-xr-x  1 root  wheel   14 Apr 15 11:55 MacOSX.sdk -> MacOSX12.3.sdk
drwxr-xr-x  7 root  wheel  224 Apr 15 11:56 MacOSX11.3.sdk
lrwxr-xr-x  1 root  wheel   14 Apr 15 11:55 MacOSX11.sdk -> MacOSX11.3.sdk
drwxr-xr-x  7 root  wheel  224 Nov 19  2021 MacOSX12.1.sdk
drwxr-xr-x  7 root  wheel  224 Apr 15 11:56 MacOSX12.3.sdk
lrwxr-xr-x  1 root  wheel   14 Apr 15 11:54 MacOSX12.sdk -> MacOSX12.3.sdk
user@node2 ~ % clang++ demo.cpp
user@node2 ~ % clang++ -I/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include demo.cpp
In file included from demo.cpp:1:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/cmath:642:26: error: no template named 'numeric_limits'
    bool _FloatBigger = (numeric_limits<_FloatT>::digits > numeric_limits<_IntT>::digits),
                         ^
(...)
11 errors generated.
```

**macOS 12 (arm64) + CLT 13**
```console
user@node3 ~ % unset SDKROOT
user@node3 ~ % sw_vers
ProductName:    macOS
ProductVersion: 12.3.1
BuildVersion:   21E258
user@node3 ~ % brew config
HOMEBREW_VERSION: 3.4.11-94-g1045869
ORIGIN: https://github.com/Homebrew/brew
HEAD: 10458698fc07ac1e7a96cf19f1d17e2ea047f7e8
Last commit: 11 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: cf96c8f531ea44c813f1dbbb9ed1b647a5de9bb9
Core tap last commit: 2 hours ago
Core tap branch: master
HOMEBREW_PREFIX: /opt/homebrew
HOMEBREW_CASK_OPTS: []
HOMEBREW_CORE_GIT_REMOTE: https://github.com/Homebrew/homebrew-core
HOMEBREW_FORCE_BREWED_CURL: set
HOMEBREW_MAKE_JOBS: 8
Homebrew Ruby: 2.6.8 => /opt/homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/bin/ruby
CPU: octa-core 64-bit arm_firestorm_icestorm
Clang: 13.1.6 build 1316
Git: 2.32.0 => /Library/Developer/CommandLineTools/usr/bin/git
Curl: 7.83.0 => /opt/homebrew/opt/curl/bin/curl
macOS: 12.3.1-arm64
CLT: 13.3.1.0.1.1648687083
Xcode: N/A
Rosetta 2: false
user@node3 ~ % cat demo.cpp
#include <cmath>
int main() { return 0; }
user@node3 ~ % xcrun --show-sdk-path
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
user@node3 ~ % xcode-select -p
/Library/Developer/CommandLineTools
user@node3 ~ % ls -l /Library/Developer/CommandLineTools/SDKs
total 0
lrwxr-xr-x  1 root  wheel   14 Apr 14 23:39 MacOSX.sdk -> MacOSX12.3.sdk
drwxr-xr-x  7 root  wheel  224 Apr 14 23:39 MacOSX11.3.sdk
lrwxr-xr-x  1 root  wheel   14 Apr 14 23:38 MacOSX11.sdk -> MacOSX11.3.sdk
drwxr-xr-x  7 root  wheel  224 Feb 23 17:14 MacOSX12.3.sdk
lrwxr-xr-x  1 root  wheel   14 Apr 14 23:38 MacOSX12.sdk -> MacOSX12.3.sdk
user@node3 ~ % clang++ demo.cpp
user@node3 ~ % clang++ -I/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include demo.cpp
In file included from demo.cpp:1:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/cmath:642:26: error: no template named 'numeric_limits'
    bool _FloatBigger = (numeric_limits<_FloatT>::digits > numeric_limits<_IntT>::digits),
                         ^
(...)
11 errors generated.
```

Somehow `<cmath>` is always taken from `MacOSX.sdk`, but `<math.h>` (which is included by `<cmath>`) is taken from a different SDK and/or from a different subdirectory within the SDK (Apple's version vs libc++'s version?).

I am puzzled and hope someone else can shed more light on this.