### PR TITLE
oh-my-posh: Moved themes to std location

### DIFF
--- a/Formula/oh-my-posh.rb
+++ b/Formula/oh-my-posh.rb
@@ -26,8 +26,8 @@ class OhMyPosh < Formula
       system "go", "build", *std_go_args(ldflags: ldflags)
     end
 
-    mv "themes", prefix
-    pkgshare.install_symlink "#{prefix}/themes"
+    prefix.install "themes"
+    pkgshare.install_symlink prefix/"themes"
   end
 
   test do

--- a/Formula/oh-my-posh.rb
+++ b/Formula/oh-my-posh.rb
@@ -25,7 +25,9 @@ class OhMyPosh < Formula
     cd "src" do
       system "go", "build", *std_go_args(ldflags: ldflags)
     end
-    pkgshare.install "themes"
+
+    mv "themes", prefix
+    pkgshare.install_symlink "#{prefix}/themes"
   end
 
   test do


### PR DESCRIPTION
Per the oh-my-posh docs (https://ohmyposh.dev/docs/installation/macos) standard themes should be at $(brew --prefix)/themes.
Fixed the formula so that they are, and symlinked them to pkgshare in case people using this formula made dependencies.

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
