### PR TITLE
dtrx 8.3.1 (new formula)

### DIFF
--- a/Formula/dtrx.rb
+++ b/Formula/dtrx.rb
@@ -1,0 +1,44 @@
+class Dtrx < Formula
+  include Language::Python::Virtualenv
+
+  desc "Intelligent archive extraction"
+  homepage "https://pypi.org/project/dtrx/"
+  url "https://files.pythonhosted.org/packages/25/cb/1ef093d762f4d5963e9e571daec239acc5f4971eb9daeda77b131d7cf39f/dtrx-8.3.1.tar.gz"
+  sha256 "5587258e762074d5395a6824fd7968ca4f4a1dc481f4852fb84d14e7624433fb"
+  license "GPL-3.0-only"
+
+  # Include a few common decompression handlers in addition to the python dep
+  depends_on "p7zip"
+  depends_on "python@3.10"
+  depends_on "xz"
+  uses_from_macos "zip" => :test
+  uses_from_macos "bzip2"
+  uses_from_macos "unzip"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  # Test a simple unzip. Sample taken from unzip formula
+  test do
+    (testpath/"test1").write "Hello!"
+    (testpath/"test2").write "Bonjour!"
+    (testpath/"test3").write "Hej!"
+
+    system "zip", "test.zip", "test1", "test2", "test3"
+    %w[test1 test2 test3].each do |f|
+      rm f
+      refute_predicate testpath/f, :exist?, "Text files should have been removed!"
+    end
+
+    system "#{bin}/dtrx", "--flat", "test.zip"
+
+    %w[test1 test2 test3].each do |f|
+      assert_predicate testpath/f, :exist?, "Failure unzipping test.zip!"
+    end
+
+    assert_equal "Hello!", (testpath/"test1").read
+    assert_equal "Bonjour!", (testpath/"test2").read
+    assert_equal "Hej!", (testpath/"test3").read
+  end
+end

--- a/Formula/dtrx.rb
+++ b/Formula/dtrx.rb
@@ -5,7 +5,7 @@ class Dtrx < Formula
   homepage "https://pypi.org/project/dtrx/"
   url "https://files.pythonhosted.org/packages/25/cb/1ef093d762f4d5963e9e571daec239acc5f4971eb9daeda77b131d7cf39f/dtrx-8.3.1.tar.gz"
   sha256 "5587258e762074d5395a6824fd7968ca4f4a1dc481f4852fb84d14e7624433fb"
-  license "GPL-3.0-only"
+  license "GPL-3.0-or-later"
 
   # Include a few common decompression handlers in addition to the python dep
   depends_on "p7zip"


### PR DESCRIPTION
dtrx formula was removed due to a dependency with an incompatible
license, and being unmaintained, see #66609 .

I've taken co-stewardship of the dtrx tool, and was asked for a brew
package (see https://github.com/dtrx-py/dtrx/issues/20).

- [ :heavy_check_mark: ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ :heavy_check_mark: ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ :heavy_check_mark: ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ :heavy_check_mark: ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ :heavy_check_mark: ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [  :heavy_check_mark: ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
