### PR TITLE
libbladerf: update livecheck

### DIFF
--- a/Formula/libbladerf.rb
+++ b/Formula/libbladerf.rb
@@ -9,7 +9,7 @@ class Libbladerf < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The most recent release in the [`libbladerf` GitHub repository](https://github.com/Nuand/bladeRF) is 2021.02 but there have been 2021.03, 2021.09, and 2021.10 tags after that point. The [`CHANGELOG`](https://github.com/Nuand/bladeRF/blob/master/CHANGELOG) uses "release candidate" language when referring to versions after 2018.08 but this may just be a copy-paste holdover from the later 2018.12-rc2 version. For our purposes, it seems like 2021.10 is the latest version (i.e., the formula has been updated to use it).

Since we can't trust the "latest" release on GitHub to be correct, we shouldn't use the `GithubLatest` strategy in the `livecheck` block (i.e., we only use it when it's both correct and necessary, neither of which is true at the moment). This PR updates the `livecheck` block to remove `strategy :github_latest` (so it defaults to the `Git` strategy for the `stable` URL) and to add the standard regex for Git tags like `1.2.3`/`v1.2.3` (this is necessary to avoid other tags with prefixes in this repository).

-----

For what it's worth, the intention of this formula is a bit unclear to me. It's titled `libbladerf` but it tracks the `bladerf` version (i.e., the current `libbladerf` version is 2.4.1 and there are separate tags like `libbladeRF_v2.4.1` for it) and provides the `bladeRF-cli` application (not just `libbladerf`). The version issue can be seen on Repology.org by checking [`libbladerf`](https://repology.org/project/libbladerf/versions) and [`bladerf`](https://repology.org/project/bladerf/versions).

If it's appropriate for this to install `bladeRF-cli`, then we may want to rename this formula to `bladerf` instead. If we only intend to provide the libraries, then this formula will need changes (i.e., switch to `libbladerf` versions, modify the `install` steps, etc.).