### PR TITLE
solr@7.7: deprecate

### DIFF
--- a/Formula/solr@7.7.rb
+++ b/Formula/solr@7.7.rb
@@ -7,20 +7,15 @@ class SolrAT77 < Formula
   license "Apache-2.0"
   revision 1
 
-  # Remove the `livecheck` block (so the check is automatically skipped) once
-  # the 7.7.x series is reported as EOL on the first-party downloads page:
-  # https://solr.apache.org/downloads.html#about-versions-and-support
-  livecheck do
-    url "https://solr.apache.org/downloads.html"
-    regex(/href=.*?solr[._-]v?(7(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "2ece595725317381657387652c053d0e88069f7238c8ce9decbd91794ab5fc7e"
   end
 
   keg_only :versioned_formula
+
+  # The 7.7 series is end of life (EOL) as of 2022-05.
+  deprecate! date: "2022-05-12", because: :unsupported
 
   depends_on "openjdk@11"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The Solr 7.x series appears to have become end of life (EOL) when 9.0.0 was released on 2022-05-12. The supported versions table on the [Downloads page](https://solr.apache.org/downloads.html) shows "All older versions are End Of Life (EOL)" for versions < 8.11.

This PR deprecates the formula accordingly and removes the `livecheck` block, so it will be automatically skipped as deprecated.