### PR TITLE
idnits: remove livecheck

### DIFF
--- a/Formula/idnits.rb
+++ b/Formula/idnits.rb
@@ -5,11 +5,6 @@ class Idnits < Formula
   sha256 "986ff822cdd6f4bf1bca943dcd22ed5804c6e9725063401317f291d9f5481725"
   license "GPL-2.0-or-later"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?idnits[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "c6ad8398fb0962f27699d3cdbc897d636d8a118d18902f24a0d61bda419f6c29"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `idnits` homepage previously listed the version information in the top-right of the page (e.g., [the last archive.org snapshot in this format](https://web.archive.org/web/20211111024543/https://tools.ietf.org/tools/idnits/)) but it was updated around 2021-11-18 to redirect to `https://www6.ietf.org/tools/idnits`, which doesn't provide version information.

Looking around, it appears that the related [GitHub repository](https://github.com/ietf-tools/idnits) has been promoted from a mirror to the active repository for `idnits`. They haven't tagged any versions yet, so we can't check it for version information in this state. I'll open an upstream issue to see if they will tag the current version and commit to tagging new versions as they're released.

In the interim time, this PR removes the `livecheck` block, as it has been broken for the past six months (I've been watching it and hoping something would change but it's time to call it).