### PR TITLE
predictionio: disable

### DIFF
--- a/Formula/predictionio.rb
+++ b/Formula/predictionio.rb
@@ -11,7 +11,8 @@ class Predictionio < Formula
     sha256 cellar: :any_skip_relocation, all: "483dfcfe76371f6e4ecc93cd47c905cddce97b0db57c015cefa3fda6dbc80392"
   end
 
-  deprecate! date: "2020-09-01", because: :unmaintained
+  # Original deprecation date: 2020-09-01
+  disable! date: "2022-05-25", because: :unmaintained
 
   depends_on "apache-spark"
   depends_on "elasticsearch@6"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Deprecated for over a year and very low installs so may be broken or just unpopular:
```
==> Analytics
install: 0 (30 days), 0 (90 days), 6 (365 days)
install-on-request: 0 (30 days), 0 (90 days), 6 (365 days)
build-error: 0 (30 days)
```

Once removed next year, we can remove from `versioned_dependencies_conflicts_allowlist.json` (has `openjdk@8`, `openjdk@11`, and `openjdk`) in dependency tree