### PR TITLE
redis@6.2 6.2.7 (new formula)

### DIFF
--- a/Formula/redis@6.2.rb
+++ b/Formula/redis@6.2.rb
@@ -1,0 +1,47 @@
+class RedisAT62 < Formula
+  desc "Persistent key-value database, with built-in net interface"
+  homepage "https://redis.io/"
+  url "https://download.redis.io/releases/redis-6.2.7.tar.gz"
+  sha256 "b7a79cc3b46d3c6eb52fa37dde34a4a60824079ebdfb3abfbbfa035947c55319"
+  license "BSD-3-Clause"
+
+  livecheck do
+    url "https://download.redis.io/releases/"
+    regex(/href=.*?redis[._-]v?(6\.2(?:\.\d+)+)\.t/i)
+  end
+
+  keg_only :versioned_formula
+
+  disable! date: "2023-05-27", because: :deprecated_upstream
+
+  depends_on "openssl@3"
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}", "BUILD_TLS=yes"
+
+    %w[run db/redis log].each { |p| (var/p).mkpath }
+
+    # Fix up default conf file to match our paths
+    inreplace "redis.conf" do |s|
+      s.gsub! "/var/run/redis.pid", var/"run/redis.pid"
+      s.gsub! "dir ./", "dir #{var}/db/redis/"
+      s.sub!(/^bind .*$/, "bind 127.0.0.1 ::1")
+    end
+
+    etc.install "redis.conf"
+    etc.install "sentinel.conf" => "redis-sentinel.conf"
+  end
+
+  service do
+    run [opt_bin/"redis-server", etc/"redis.conf"]
+    keep_alive true
+    error_log_path var/"log/redis.log"
+    log_path var/"log/redis.log"
+    working_dir var
+  end
+
+  test do
+    system bin/"redis-server", "--test-memory", "2"
+    %w[run db/redis log].each { |p| assert_predicate var/p, :exist?, "#{var/p} doesn't exist!" }
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Redis 7.0, added in https://github.com/Homebrew/homebrew-core/pull/100324, introduces a number of [potentially breaking changes](https://raw.githubusercontent.com/redis/redis/7.0/00-RELEASENOTES). For example, the Go client is not yet fully compatible (https://github.com/go-redis/redis/issues/2082).

This pull request adds a formula for the previous major version based on [redis.rb](https://github.com/Homebrew/homebrew-core/blob/master/Formula/redis.rb).