### PR TITLE
acl2: enable build on arm64

### DIFF
--- a/Formula/acl2.rb
+++ b/Formula/acl2.rb
@@ -12,9 +12,6 @@ class Acl2 < Formula
     sha256 x86_64_linux: "72514be4dcc48b2cebc9671056a66f7006c584ff62120988cd6febe765f44b3e"
   end
 
-  # Homebrew ARM CI runners hang when trying to build `acl2`.
-  # See https://github.com/Homebrew/homebrew-core/pull/96455
-  depends_on arch: :x86_64
   depends_on "sbcl"
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
