### PR TITLE
vsts-cli: disable formula

### DIFF
--- a/Formula/vsts-cli.rb
+++ b/Formula/vsts-cli.rb
@@ -17,7 +17,7 @@ class VstsCli < Formula
   end
 
   # https://github.com/Azure/azure-devops-cli-extension/pull/219#issuecomment-456404611
-  deprecate! date: "2019-01-22", because: :unsupported
+  disable! date: "2022-05-27", because: :unsupported
 
   depends_on "rust" => :build
   depends_on "python@3.9"


### PR DESCRIPTION
It has been deprecated for more than 3 years and has very low usage per brew's analytics.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
