### PR TITLE
onetime: deprecate

### DIFF
--- a/Formula/onetime.rb
+++ b/Formula/onetime.rb
@@ -22,6 +22,8 @@ class Onetime < Formula
     sha256 cellar: :any_skip_relocation, all:           "93ec90f57aaf9235f925eb7146e3446a2265b5e6d573188bc129178aa516b1ad"
   end
 
+  deprecate! date: "2022-05-26", because: :unmaintained
+
   # Fixes the Makefile to permit destination specification
   # https://github.com/kfogel/OneTime/pull/12
   patch do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
