### PR TITLE
glib: migrate to python@3.10

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -22,7 +22,7 @@ class Glib < Formula
   depends_on "gettext"
   depends_on "libffi"
   depends_on "pcre"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   on_linux do
     depends_on "util-linux"


### PR DESCRIPTION
Following https://github.com/Homebrew/brew/blob/master/docs/Python-for-Formula-Authors.md#python-declarations instructions set up unconditional dependency on python3.x version, as well all brew-provided python@3 version are supported by glib according to their requirements of python to ≥ 3.5

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
