### PR TITLE
aws-nuke 2.19.0 (new formula)

### DIFF
--- a/Formula/aws-nuke.rb
+++ b/Formula/aws-nuke.rb
@@ -1,0 +1,41 @@
+class AwsNuke < Formula
+  desc "Nuke a whole AWS account and delete all its resources"
+  homepage "https://github.com/rebuy-de/aws-nuke"
+  url "https://github.com/rebuy-de/aws-nuke.git",
+      tag:      "v2.19.0",
+      revision: "357aa44f5a04df9d1faa8c57bb5ce924871a910a"
+  license "MIT"
+  head "https://github.com/rebuy-de/aws-nuke.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    build_xdst="github.com/rebuy-de/aws-nuke/v#{version.major}/cmd"
+    ldflags = %W[
+      -s -w
+      -X #{build_xdst}.BuildVersion=#{version}
+      -X #{build_xdst}.BuildDate=#{time.strftime("%F")}
+      -X #{build_xdst}.BuildHash=#{Utils.git_head}
+      -X #{build_xdst}.BuildEnvironment=#{tap.user}
+    ]
+    with_env(
+      "CGO_ENABLED" => "0",
+    ) do
+      system "go", "build", *std_go_args(ldflags: ldflags)
+    end
+
+    pkgshare.install "config"
+
+    (bash_completion/"aws-nuke").write Utils.safe_popen_read("#{bin}/aws-nuke", "completion", "bash")
+    (fish_completion/"aws-nuke.fish").write Utils.safe_popen_read("#{bin}/aws-nuke", "completion", "fish")
+    (zsh_completion/"_aws-nuke").write Utils.safe_popen_read("#{bin}/aws-nuke", "completion", "zsh")
+  end
+
+  test do
+    assert_match "InvalidClientTokenId", shell_output(
+      "#{bin}/aws-nuke --config #{pkgshare}/config/example.yaml --access-key-id fake --secret-access-key fake 2>&1",
+      255,
+    )
+    assert_match "IAMUser", shell_output("#{bin}/aws-nuke resource-types")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

aws-nuke is a commonly-used cli tool for cleaning up aws accounts (for example, removing resources periodically from developer sandbox accounts). I searched brew for this yesterday when I needed it for a project and could not find it. 

Merging this will also close out https://github.com/rebuy-de/aws-nuke/issues/125.