### PR TITLE
dhall-lsp-server 1.1.1

### DIFF
--- a/Formula/dhall-lsp-server.rb
+++ b/Formula/dhall-lsp-server.rb
@@ -1,8 +1,8 @@
 class DhallLspServer < Formula
   desc "Language Server Protocol (LSP) server for Dhall"
   homepage "https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-lsp-server"
-  url "https://hackage.haskell.org/package/dhall-lsp-server-1.0.18/dhall-lsp-server-1.0.18.tar.gz"
-  sha256 "f27a3132ca04eaff5901cb2d184308b595b6bf7c58b60b4af37aae8509eb8cba"
+  url "https://hackage.haskell.org/package/dhall-lsp-server-1.1.1/dhall-lsp-server-1.1.1.tar.gz"
+  sha256 "86b22a14be0ebe016e29cfd3436e4f9776f8817dfd72a9966437fceb8e608f7c"
   license "BSD-3-Clause"
   head "https://github.com/dhall-lang/dhall-haskell.git", branch: "master"
 
@@ -32,7 +32,13 @@ class DhallLspServer < Formula
       "\r\n" \
       "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"" \
       "processId\":88075,\"rootUri\":null,\"capabilities\":{},\"trace\":\"ver" \
-      "bose\",\"workspaceFolders\":null}}\r\n"
+      "bose\",\"workspaceFolders\":null}}\r\n" \
+      "Content-Length: 46\r\n" \
+      "\r\n" \
+      "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"shutdown\"}\r\n" \
+      "Content-Length: 42\r\n" \
+      "\r\n" \
+      "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"exit\"}\r\n"
 
     output = pipe_output("#{bin}/dhall-lsp-server", input, 0)
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is an attempt to revive https://github.com/Homebrew/homebrew-core/pull/99071

I root-caused the issue, which was that `dhall-lsp-server-1.1.*` switched from the
`haskell-lsp` package to the `lsp` package, and the latter package is stricter about
the language server protocol.  Specifically, the latter package requires a shutdown and
exit request, otherwise it will exit with exit code 1.