### PR TITLE
llvm@7, llvm@8: deprecate

### DIFF
--- a/Formula/llvm@7.rb
+++ b/Formula/llvm@7.rb
@@ -17,6 +17,8 @@ class LlvmAT7 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2022-05-29", because: :versioned_formula
+
   # https://llvm.org/docs/GettingStarted.html#requirement
   depends_on "cmake" => :build
   depends_on xcode: :build

--- a/Formula/llvm@8.rb
+++ b/Formula/llvm@8.rb
@@ -19,6 +19,8 @@ class LlvmAT8 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2022-05-29", because: :versioned_formula
+
   # https://llvm.org/docs/GettingStarted.html#requirement
   depends_on "cmake" => :build
   depends_on xcode: :build if MacOS.version < :mojave


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Deprecate oldest 2 versioned `llvm`. Not used as dependencies.

As we currently have 6 total `llvm*` formulae and will most likely need `llvm@13` based on `llvm` PR, deprecating oldest/least-used 2 should give advance notice that we may remove 2 to meet documented versioned formulae limits.

In case of `llvm@7`, it doesn't build on Big Sur so will be only supported on Linux in a few months.