### PR TITLE
sdl12-compat: set `CMAKE_SHARED_LINKER_FLAGS`

### DIFF
--- a/Formula/sdl12-compat.rb
+++ b/Formula/sdl12-compat.rb
@@ -4,6 +4,7 @@ class Sdl12Compat < Formula
   url "https://github.com/libsdl-org/sdl12-compat/archive/refs/tags/release-1.2.52.tar.gz"
   sha256 "5bd7942703575554670a8767ae030f7921a0ac3c5e2fd173a537b7c7a8599014"
   license all_of: ["Zlib", "MIT-0"]
+  revision 1
   head "https://github.com/libsdl-org/sdl12-compat.git", branch: "main"
 
   bottle do
@@ -23,6 +24,7 @@ class Sdl12Compat < Formula
   def install
     system "cmake", "-S", ".", "-B", "build",
                     "-DSDL2_PATH=#{Formula["sdl2"].opt_prefix}",
+                    "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-rpath,#{Formula["sdl2"].opt_lib}",
                     "-DSDL12DEVEL=ON",
                     "-DSDL12TESTS=OFF",
                     *std_cmake_args
@@ -49,7 +51,6 @@ class Sdl12Compat < Formula
       }
     EOS
     flags = Utils.safe_popen_read(bin/"sdl-config", "--cflags", "--libs").split
-    flags << "-Wl,-rpath,#{lib},-rpath,#{Formula["sdl2"].opt_lib}"
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The current build requires any users of this formula on macOS to add an
`RPATH` pointing to SDL2's `lib` directory for things to work. We can
avoid users (which potentially include other formulae) having to do this
by setting it ourselves at build-time.

See discussion at #96377.
