### PR TITLE
manticoresearch 5.0.2

### DIFF
--- a/Formula/manticoresearch.rb
+++ b/Formula/manticoresearch.rb
@@ -1,11 +1,22 @@
 class Manticoresearch < Formula
   desc "Open source text search engine"
   homepage "https://www.manticoresearch.com"
-  url "https://github.com/manticoresoftware/manticoresearch/archive/refs/tags/4.2.0.tar.gz"
-  sha256 "6b4af70fcc56b40aa83e606240b237e47e54c0bfbfdd32c47788d59469ef7146"
   license "GPL-2.0-only"
   version_scheme 1
   head "https://github.com/manticoresoftware/manticoresearch.git", branch: "master"
+
+  stable do
+    url "https://github.com/manticoresoftware/manticoresearch/archive/refs/tags/5.0.2.tar.gz"
+    sha256 "ca7828a6841ed8bdbc330516f85ad3a85749998f443b9de319cec60e12c64c07"
+
+    # Allow system ICU usage and tune build (config from homebrew; release build; don't split symbols).
+    # (Remove this instruction and the patch at the bottom of the formula with next release)
+    # https://github.com/manticoresoftware/manticoresearch/commit/70ede046a1ed4f783a293871748dbcbe43c9bb62
+    patch do
+      url "https://github.com/manticoresoftware/manticoresearch/commit/70ede046a1ed.patch?full_index=1"
+      sha256 "8c15dc5373898c2788cea5c930c4301b9a21d8dc35d22a1bbb591ddcf94cf7ff"
+    end
+  end
 
   bottle do
     sha256 arm64_monterey: "f55f960076fbee621f9292de41f671db7aab5587eec035e9ee9060268b3f306c"
@@ -18,12 +29,17 @@ class Manticoresearch < Formula
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
+  depends_on "icu4c"
   depends_on "libpq"
-  depends_on "mysql"
+  depends_on "mysql-client"
   depends_on "openssl@1.1"
+  depends_on "unixodbc"
+  depends_on "zstd"
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
+  uses_from_macos "libxml2"
+  uses_from_macos "zlib"
 
   on_linux do
     depends_on "gcc"
@@ -34,33 +50,23 @@ class Manticoresearch < Formula
   fails_with gcc: "5"
 
   def install
+    # ENV["DIAGNOSTIC"] = "1"
+    ENV["ICU_ROOT"] = Formula["icu4c"].opt_prefix.to_s
+    ENV["OPENSSL_ROOT_DIR"] = Formula["openssl"].opt_prefix.to_s
+    ENV["MYSQL_ROOT_DIR"] = Formula["mysql-client"].opt_prefix.to_s
+    ENV["PostgreSQL_ROOT"] = Formula["libpq"].opt_prefix.to_s
+
     args = %W[
-      -DCMAKE_INSTALL_LOCALSTATEDIR=#{var}
-      -DBoost_NO_BOOST_CMAKE=ON
-      -DWITH_ICU=OFF
-      -DWITH_ODBC=OFF
+      -DDISTR_BUILD=homebrew
+      -DWITH_ICU_FORCE_STATIC=OFF
+      -D_LOCALSTATEDIR=#{var}
+      -D_RUNSTATEDIR=#{var}/run
+      -D_SYSCONFDIR=#{etc}
     ]
 
-    if OS.mac?
-      args << "-DDISTR_BUILD=macosbrew"
-    else
-      args += %W[
-        -DCMAKE_INSTALL_BINDIR=#{bin}
-        -DCMAKE_INSTALL_DATAROOTDIR=#{share}
-        -DCMAKE_INSTALL_INCLUDEDIR=#{include}
-        -DCMAKE_INSTALL_LIBDIR=#{lib}
-        -DCMAKE_INSTALL_MANDIR=#{man}
-        -DCMAKE_INSTALL_SYSCONFDIR=#{etc}
-      ]
-    end
-
-    # Disable support for Manticore Columnar Library on ARM (since the library itself doesn't support it as well)
-    args << "-DWITH_COLUMNAR=OFF" if Hardware::CPU.arm?
-
-    mkdir "build" do
-      system "cmake", "..", *std_cmake_args, *args
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   def post_install
@@ -70,7 +76,7 @@ class Manticoresearch < Formula
   end
 
   service do
-    run [opt_bin/"searchd", "--config", etc/"manticore/manticore.conf", "--nodetach"]
+    run [opt_bin/"searchd", "--config", etc/"manticoresearch/manticore.conf", "--nodetach"]
     keep_alive false
     working_dir HOMEBREW_PREFIX
   end

--- a/Formula/manticoresearch.rb
+++ b/Formula/manticoresearch.rb
@@ -10,8 +10,8 @@ class Manticoresearch < Formula
     sha256 "ca7828a6841ed8bdbc330516f85ad3a85749998f443b9de319cec60e12c64c07"
 
     # Allow system ICU usage and tune build (config from homebrew; release build; don't split symbols).
-    # (Remove this instruction and the patch at the bottom of the formula with next release)
-    # https://github.com/manticoresoftware/manticoresearch/commit/70ede046a1ed4f783a293871748dbcbe43c9bb62
+    # Remove with next release
+
     patch do
       url "https://github.com/manticoresoftware/manticoresearch/commit/70ede046a1ed.patch?full_index=1"
       sha256 "8c15dc5373898c2788cea5c930c4301b9a21d8dc35d22a1bbb591ddcf94cf7ff"

--- a/Formula/manticoresearch.rb
+++ b/Formula/manticoresearch.rb
@@ -73,6 +73,9 @@ class Manticoresearch < Formula
     (var/"run/manticore").mkpath
     (var/"log/manticore").mkpath
     (var/"manticore/data").mkpath
+
+    # Fix old config path (actually it was always wrong and never worked; however let's check)
+    mv etc/"manticore/manticore.conf", etc/"manticoresearch/manticore.conf" if (etc/"manticore/manticore.conf").exist?
   end
 
   service do


### PR DESCRIPTION
Fix using of system icu instead of vendored one.

Fix dependencies: manticore support indexing different kind of sources,
however they are 'soft' dependencies - they're not linked, but loaded
with dlopen if you try to index special kind of source. So, they're
strictly 'build' dependencies, but not need in runtime unless you're
going to use them.

Fix paths on M1 - CMAKE_INSTALL_SYSCONFDIR as `etc` borns
CMAKE_INSTALL_FULL_SYSCONFDIR became `/etc/opt/homebrew...` instead of
`/opt/homebrew/etc...` after GNUInstallDirs.
Setting CMAKE_INSTALL_SYSCONFDIR to absolute path
before GNUInstallDirs works well, but causes files to be copied instead
of symlinked, and then expect manual steps on formula removing.

As 5.0.2 already release, changes are now accumulated into patches, but
they're already upstream. Patch is provided only because releases are
quite seldom.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
