### PR TITLE
kotlin: update livecheck

### DIFF
--- a/Formula/kotlin.rb
+++ b/Formula/kotlin.rb
@@ -5,9 +5,11 @@ class Kotlin < Formula
   sha256 "632166fed89f3f430482f5aa07f2e20b923b72ef688c8f5a7df3aa1502c6d8ba"
   license "Apache-2.0"
 
+  # This repository has thousands of development tags, so the `GithubLatest`
+  # strategy is used to minimize data transfer in this extreme case.
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `kotlin` checks the Git tags but there are thousands of tags in the repository and less than 100 of them are for stable versions. This fetches over 3 MB of unnecessary data (and growing), so we're better off with a different approach for this formula. This PR updates the `livecheck` block to use `GithubLatest`, which is only ~30 KB.

There are a handful of other checks that fetch more than a MB of data and I plan to address those as well. The `Npm` strategy suffers from a similar issue (i.e., some package pages are bloated with unstable/development versions, like `typescript`) and I'm testing out alternative approaches to minimize the strategy's data usage.