### PR TITLE
toxcore 0.2.18 (new formula)

### DIFF
--- a/Formula/toxcore.rb
+++ b/Formula/toxcore.rb
@@ -1,0 +1,40 @@
+class Toxcore < Formula
+  desc "C library implementing the Tox peer to peer network protocol"
+  homepage "https://tox.chat/"
+  # This repo is a fork, but it is the source used by Debian, Fedora, and Arch,
+  # and is the repo linked in the homepage.
+  url "https://github.com/TokTok/c-toxcore/releases/download/v0.2.18/c-toxcore-0.2.18.tar.gz"
+  sha256 "f2940537998863593e28bc6a6b5f56f09675f6cd8a28326b7bc31b4836c08942"
+  license "GPL-3.0-or-later"
+  head "https://github.com/TokTok/c-toxcore.git", branch: "master"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libconfig"
+  depends_on "libsodium"
+  depends_on "libvpx"
+  depends_on "opus"
+
+  def install
+    system "cmake", "-S", ".", "-B", "_build", *std_cmake_args
+    system "cmake", "--build", "_build"
+    system "cmake", "--install", "_build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <tox/tox.h>
+      int main() {
+        TOX_ERR_NEW err_new;
+        Tox *tox = tox_new(NULL, &err_new);
+        if (err_new != TOX_ERR_NEW_OK) {
+           return 1;
+        }
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{include}/toxcore", testpath/"test.c",
+                   "-L#{lib}", "-ltoxcore", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
  - It fails with only one problem: `GitHub fork (not canonical repository)`. This is intentional, for reasons described on [Tox's website](https://tox.chat/download.html#toktok-c-toxcore). A small quote, "[TokTok/c-toxcore] is the Toxcore that is being actively developed and this is also the Toxcore that all clients use."
