### PR TITLE
phpunit: update livecheck

### DIFF
--- a/Formula/phpunit.rb
+++ b/Formula/phpunit.rb
@@ -6,8 +6,9 @@ class Phpunit < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://phar.phpunit.de/"
-    regex(/href=.*?phpunit[._-]v?(\d+(?:\.\d+)+)\.phar/i)
+    url "https://phar.phpunit.de/phpunit.phar"
+    regex(%r{/phpunit[._-]v?(\d+(?:\.\d+)+)\.phar}i)
+    strategy :header_match
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `phpunit` checks the page where the related phar files are found but this contains quite a lot of versions as well as ancillary software we don't need. The transfer size is only ~70 KB but the content length is over 1 MB.

We can reduce the amount of content to fetch/parse by checking the `location` header of the generic `phpunit.phar` file, which redirects to the phar file for the latest version. This approach only transfers a few KB, so it's lighter overall.