### PR TITLE
earthly 0.6.15

### DIFF
--- a/Formula/earthly.rb
+++ b/Formula/earthly.rb
@@ -1,9 +1,9 @@
 class Earthly < Formula
   desc "Build automation tool for the container era"
   homepage "https://earthly.dev/"
-  url "https://github.com/earthly/earthly/archive/v0.5.17.tar.gz"
-  sha256 "1dcc56b419413480fa2e116606cab2c8003483e0b8052443aa7b7da0572ce47f"
-  license "BUSL-1.1"
+  url "https://github.com/earthly/earthly/archive/v0.6.15.tar.gz"
+  sha256 "b9c9c1ea4be45b9dc13b465b8282b2085e43c5ad4f1d5ddc842ca13949482184"
+  license "MPL-2.0"
   head "https://github.com/earthly/earthly.git", branch: "main"
 
   bottle do
@@ -14,13 +14,15 @@ class Earthly < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "78f6b33643db61f1944ceaf27d27ad001f8ba7a865b358a040cf1374fd618a96"
   end
 
-  disable! date: "2021-07-15", because: "has an incompatible license"
-
   depends_on "go" => :build
 
   def install
+    # the earthly_gitsha variable is required by the earthly release script, moving this value it into
+    # the ldflags string will break the upstream release process.
+    earthly_gitsha = "05fc449487ad0c8a1721b4fbfc527eb9870dfcfd"
+
     ldflags = "-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} " \
-              "-X main.GitSha=bdeda2542465cb0bc0c8985a905aa2e3579a3f7b "
+              "-X main.GitSha=#{earthly_gitsha}"
     tags = "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork"
     system "go", "build",
         "-tags", tags,
@@ -35,13 +37,14 @@ class Earthly < Formula
   end
 
   test do
-    (testpath/"build.earthly").write <<~EOS
-
-      default:
+    # earthly requires docker to run; therefore doing a complete end-to-end test here is not
+    # possible; however the "earthly ls" command is able to run without docker.
+    (testpath/"Earthfile").write <<~EOS
+      VERSION 0.6
+      mytesttarget:
       \tRUN echo Homebrew
     EOS
-
-    output = shell_output("#{bin}/earthly --buildkit-host 127.0.0.1 +default 2>&1", 6).strip
-    assert_match "buildkitd failed to start", output
+    output = shell_output("#{bin}/earthly ls").strip
+    assert_match "+mytesttarget", output
   end
 end

--- a/Formula/earthly.rb
+++ b/Formula/earthly.rb
@@ -44,7 +44,7 @@ class Earthly < Formula
       mytesttarget:
       \tRUN echo Homebrew
     EOS
-    output = shell_output("#{bin}/earthly ls").strip
+    output = shell_output("#{bin}/earthly ls")
     assert_match "+mytesttarget", output
   end
 end


### PR DESCRIPTION
earthly v0.6.15 has been released under MPL-2.0 and is once-again open
source.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
