### PR TITLE
portmidi: switch to the cmake build.

### DIFF
--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -4,6 +4,7 @@ class Portmidi < Formula
   url "https://github.com/PortMidi/portmidi/archive/refs/tags/v2.0.3.tar.gz"
   sha256 "934f80e1b09762664d995e7ab5a9932033bc70639e8ceabead817183a54c60d0"
   license "MIT"
+  revision 1
   version_scheme 1
 
   bottle do
@@ -23,31 +24,17 @@ class Portmidi < Formula
   end
 
   def install
-    # need to create include/lib directories since make won't create them itself
-    include.mkpath
-    lib.mkpath
-    (lib/"pkgconfig").mkpath
-
-    if OS.mac?
+    if OS.mac? && MacOS.version <= :sierra
       # Fix "fatal error: 'os/availability.h' file not found" on 10.11 and
       # "error: expected function body after function declarator" on 10.12
-      # Requires the CLT to be the active developer directory if Xcode is installed
-      ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version <= :sierra
-
-      inreplace "pm_mac/Makefile.osx", "PF=/usr/local", "PF=#{prefix}"
-
-      system "make", "-f", "pm_mac/Makefile.osx"
-      system "make", "-f", "pm_mac/Makefile.osx", "install"
-      mv lib/shared_library("libportmidi"), lib/shared_library("libportmidi", version)
-      # awaiting https://github.com/PortMidi/portmidi/issues/24
-      (lib/"pkgconfig").install "Release/packaging/portmidi.pc"
-    else
-      system "cmake", ".", *std_cmake_args, "-DCMAKE_CACHEFILE_DIR=#{buildpath}/build"
-      system "make", "install"
-      lib.install_symlink shared_library("libportmidi", version) => shared_library("libportmidi", 0)
+      # Requires the CLT to be the active developer directory if Xcode is
+      # installed
+      ENV["SDKROOT"] = MacOS.sdk_path
     end
-    lib.install_symlink shared_library("libportmidi", version) => shared_library("libportmidi")
-    lib.install_symlink shared_library("libportmidi", version) => shared_library("libportmidi", version.major.to_s)
+
+    system "cmake", ".", *std_cmake_args
+    system "make"
+    system "make", "install"
   end
 
   test do


### PR DESCRIPTION
This PR changes the build procedure to the official build procedure.
The current build procedure uses a makefile that is no longer meant
to be used and will be removed in the future (see [this issue][1]).

This is the correct fix for #99370.

[1]: https://github.com/PortMidi/portmidi/issues/24

-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
