### PR TITLE
voro++: add license

### DIFF
--- a/Formula/voro++.rb
+++ b/Formula/voro++.rb
@@ -3,6 +3,7 @@ class Voroxx < Formula
   homepage "http://math.lbl.gov/voro++"
   url "http://math.lbl.gov/voro++/download/dir/voro++-0.4.6.tar.gz"
   sha256 "ef7970071ee2ce3800daa8723649ca069dc4c71cc25f0f7d22552387f3ea437e"
+  license "BSD-3-Clause"
   revision 1
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

~The `math.lbl.gov` URLs in the `voro++` formula use HTTP but redirect to HTTPS. This PR updates the URLs to avoid the redirections.~

This adds `license "BSD-3-Clause"`, referencing the `LICENSE` file provided with the source files.