### PR TITLE
dotdrop 1.10.0

### DIFF
--- a/Formula/dotdrop.rb
+++ b/Formula/dotdrop.rb
@@ -3,8 +3,8 @@ class Dotdrop < Formula
 
   desc "Save your dotfiles once, deploy them everywhere"
   homepage "https://deadc0de.re/dotdrop"
-  url "https://github.com/deadc0de6/dotdrop/archive/refs/tags/v1.9.0.tar.gz"
-  sha256 "5e79deb64322fcd4f745734e8fcfa293e2f659738599012844ccd57b13592f57"
+  url "https://files.pythonhosted.org/packages/14/c6/074ccf77aca060a282d33446b24dc15c4d04b8a1534dc2b7081fa58e278c/dotdrop-1.10.0.tar.gz"
+  sha256 "836874db7f2088763ecc2e8351d068b5cb610a140a48e586717d14cbd7bd3305"
   license "GPL-3.0-or-later"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This bumps dotdrop to version 1.10.0 and changes the URL to PyPI (for gh actions integration).