### PR TITLE
scrollkeeper: fix flat namespace usage

### DIFF
--- a/Formula/scrollkeeper.rb
+++ b/Formula/scrollkeeper.rb
@@ -21,6 +21,13 @@ class Scrollkeeper < Formula
   uses_from_macos "libxslt"
   uses_from_macos "perl"
 
+  on_macos do
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "intltool" => :build
+    depends_on "libtool" => :build
+  end
+
   conflicts_with "rarian",
     because: "scrollkeeper and rarian install the same binaries"
 
@@ -45,6 +52,9 @@ class Scrollkeeper < Formula
       end
     end
 
+    # Run autoreconf on macOS to rebuild configure script so that it doesn't try
+    # to build with a flat namespace.
+    system "autoreconf", "--force", "--verbose", "--install" if OS.mac?
     system "./configure", "--prefix=#{prefix}",
                           "--mandir=#{man}",
                           "--with-xml-catalog=#{etc}/xml/catalog"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
