### PR TITLE
mongo-c-driver: add livecheck

### DIFF
--- a/Formula/mongo-c-driver.rb
+++ b/Formula/mongo-c-driver.rb
@@ -6,6 +6,11 @@ class MongoCDriver < Formula
   license "Apache-2.0"
   head "https://github.com/mongodb/mongo-c-driver.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "7dac05a0ed204114472e79dbcc89be5958bba10994fbd12f1079c8ec46f8a9fc"
     sha256 cellar: :any,                 arm64_big_sur:  "511dcf7efa510f5f9a5951c9fe3b7d8726e5b7f5a7bae09fa975c5f676505fb0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `mongo-c-driver` and this currently works as expected. In this case, tags with a `debian/` prefix are omitted and tags like `1.21.1` are matched, which is correct for this formula. However, I will be removing the `tags_only_debian` logic from the `Git` strategy (see Homebrew/brew#13386) and this check will wrongly return `1.21.1-1` as newest by default (from the `debian/1.21.1-1` tag).

As mentioned in the related brew PR, this situation should be handled by a contextually-appropriate `livecheck` block instead of making assumptions in the strategy. This PR adds a `livecheck` block that restricts matching to tags like `1.21.1`, omitting tags with a `debian/` prefix.