### PR TITLE
mongo-cxx-driver: add livecheck

### DIFF
--- a/Formula/mongo-cxx-driver.rb
+++ b/Formula/mongo-cxx-driver.rb
@@ -6,6 +6,11 @@ class MongoCxxDriver < Formula
   license "Apache-2.0"
   head "https://github.com/mongodb/mongo-cxx-driver.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^[rv]?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "e953ef9f1244187c03e35b5c63cc56fe78a346b6961375883bfdb20882389ff3"
     sha256 cellar: :any,                 arm64_big_sur:  "fe2c413af917d8fbc92cf070ac83de24056be996536f548a15e68378016da14a"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `mongo-cxx-driver` and this currently works as expected. In this case, tags with a `debian/` prefix are omitted and tags like `r3.6.7` are matched, which is correct for this formula (albeit, tags with a `legacy-` prefix are also matched, so we encounter some versions like `0.0-26compat-2.6.9`). However, I will be removing the `tags_only_debian` logic from the `Git` strategy (see Homebrew/brew#13386) and this check will wrongly return `3.6.7-1` as newest by default (from the `debian/3.6.7-1` tag).

As mentioned in the related brew PR, this situation should be handled by a contextually-appropriate `livecheck` block instead of making assumptions in the strategy. This PR adds a `livecheck` block that restricts matching to tags like `r3.6.7`, omitting tags with a `debian/`  (or `legacy-`) prefix.