### PR TITLE
pgloader: update livecheck

### DIFF
--- a/Formula/pgloader.rb
+++ b/Formula/pgloader.rb
@@ -7,6 +7,11 @@ class Pgloader < Formula
   revision 2
   head "https://github.com/dimitri/pgloader.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, big_sur:  "d7f926192e26b7e8a0e5d269370590d23a1d1c28e2323b6c2001e71088b2b8cd"
     sha256 cellar: :any_skip_relocation, catalina: "89145353b5e7cd483e99f88f9db350f678ee7281ebf06d2e02263d8ffa5a626c"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `pgloader` and this currently works as expected. In this case, tags with a `debian/` prefix are omitted and tags like `v3.6.3` are matched, which is correct for this formula. However, I will be removing the `tags_only_debian` logic from the `Git` strategy (see Homebrew/brew#13386) and this check will wrongly return `3.6.3-1` as newest by default (from the `debian/3.6.3-1` tag).

As mentioned in the related brew PR, this situation should be handled by a contextually-appropriate `livecheck` block instead of making assumptions in the strategy. This PR adds a `livecheck` block that restricts matching to tags like `v3.6.3`, omitting tags with a `debian/` prefix.