### PR TITLE
termrec: add livecheck, update license

### DIFF
--- a/Formula/termrec.rb
+++ b/Formula/termrec.rb
@@ -3,8 +3,13 @@ class Termrec < Formula
   homepage "https://angband.pl/termrec.html"
   url "https://github.com/kilobyte/termrec/archive/v0.19.tar.gz"
   sha256 "0550c12266ac524a8afb764890c420c917270b0a876013592f608ed786ca91dc"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
   head "https://github.com/kilobyte/termrec.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "3c45928def623126f5999ab77cd48cc6711731a44cfa28c5746841ee19f313c3"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `termrec` and this currently works as expected. In this case, tags with a `debian/` prefix are omitted and tags like `v0.19` are matched, which is correct for this formula. However, I will be removing the `tags_only_debian` logic from the `Git` strategy (see Homebrew/brew#13386) and this check will wrongly return `0.19-1` as newest by default (from the `debian/0.19-1` tag).

As mentioned in the related brew PR, this situation should be handled by a contextually-appropriate `livecheck` block instead of making assumptions in the strategy. This PR adds a `livecheck` block that restricts matching to tags like `v0.19`, omitting tags with a `debian/` prefix.

-----

This also updates the `license` from `"LGPL-3.0"` to `"LGPL-3.0-or-later"`. The [`README` file](https://github.com/kilobyte/termrec/blob/576bf6aa5c148b79325bfe299b20ea031f3c2ee4/README) contains the following:

> License:
>   LGPL-2 -- or, at your option, any higher version other than any
>   licenses from the Affero branch.

However, the [`COPYING.LIB` file](https://github.com/kilobyte/termrec/blob/576bf6aa5c148b79325bfe299b20ea031f3c2ee4/COPYING.LIB) is LGPL version 3.