### PR TITLE
docker-credential-helper: remove GOPATH usage

### DIFF
--- a/Formula/docker-credential-helper.rb
+++ b/Formula/docker-credential-helper.rb
@@ -1,5 +1,5 @@
 class DockerCredentialHelper < Formula
-  desc "macOS Credential Helper for Docker"
+  desc "Platform keystore credential helper for Docker"
   homepage "https://github.com/docker/docker-credential-helpers"
   url "https://github.com/docker/docker-credential-helpers/archive/v0.6.4.tar.gz"
   sha256 "b97d27cefb2de7a18079aad31c9aef8e3b8a38313182b73aaf8b83701275ac83"
@@ -23,24 +23,16 @@ class DockerCredentialHelper < Formula
   end
 
   def install
-    ENV["GOPATH"] = buildpath
-    ENV["GO111MODULE"] = "auto"
-    dir = buildpath/"src/github.com/docker/docker-credential-helpers"
-    dir.install buildpath.children - [buildpath/".brew_home"]
-
-    cd dir do
-      if OS.mac?
-        system "make", "vet_osx"
-        system "make", "osxkeychain"
-        bin.install "bin/docker-credential-osxkeychain"
-      else
-        system "make", "vet_linux"
-        system "make", "pass"
-        system "make", "secretservice"
-        bin.install "bin/docker-credential-pass"
-        bin.install "bin/docker-credential-secretservice"
-      end
-      prefix.install_metafiles
+    if OS.mac?
+      system "make", "vet_osx"
+      system "make", "osxkeychain"
+      bin.install "bin/docker-credential-osxkeychain"
+    else
+      system "make", "vet_linux"
+      system "make", "pass"
+      system "make", "secretservice"
+      bin.install "bin/docker-credential-pass"
+      bin.install "bin/docker-credential-secretservice"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Could add `CI-no-bottles` if we want to keep the Mojave bottle (the new binaries produced here should be functionally the same as before).