### PR TITLE
kepubify: remove GOPATH usage

### DIFF
--- a/Formula/kepubify.rb
+++ b/Formula/kepubify.rb
@@ -18,16 +18,12 @@ class Kepubify < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = HOMEBREW_CACHE/"go_cache"
-
     %w[
       kepubify
       covergen
       seriesmeta
     ].each do |p|
-      system "go", "build", "-o", bin/p,
-                   "-ldflags", "-s -w -X main.version=#{version}",
-                   "./cmd/#{p}"
+      system "go", "build", *std_go_args(output: bin/p, ldflags: "-s -w -X main.version=#{version}"), "./cmd/#{p}"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The default `GOPATH` in modules-aware build mode is `HOMEBREW_CACHE/"go_mod_cache"` anyways; no need to explicitly point it towards `HOMEBREW_CACHE/"go_cache"` (the current version already supports Go modules).