### PR TITLE
fbthrift: update Linux `gcc` dependency

### DIFF
--- a/Formula/fbthrift.rb
+++ b/Formula/fbthrift.rb
@@ -4,6 +4,7 @@ class Fbthrift < Formula
   url "https://github.com/facebook/fbthrift/archive/v2022.06.06.00.tar.gz"
   sha256 "add554f5f4139f5fe16502a279f3b1233e3f30e56efa387728d59a10dcf6a053"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/fbthrift.git", branch: "main"
 
   bottle do
@@ -35,7 +36,7 @@ class Fbthrift < Formula
   end
 
   on_linux do
-    depends_on "gcc@10"
+    depends_on "gcc"
   end
 
   fails_with :clang do
@@ -46,7 +47,6 @@ class Fbthrift < Formula
   end
 
   fails_with gcc: "5" # C++ 17
-  fails_with gcc: "11" # https://github.com/facebook/folly#ubuntu-lts-centos-stream-fedora
 
   def install
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I think GCC 11 issue is the one mentioned in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104008 as referenced by commit https://github.com/facebook/folly/commit/5e6bef20c0805e87bea5d3e4a7183ec1a3590f7a 

It seems to be fixed in GCC 11.3 so trying newer `gcc` formula to reduce multiple GCC versions in dependency tree (since `folly`/`fizz`/... use `gcc`).