### PR TITLE
pilosa: remove GOPATH usage

### DIFF
--- a/Formula/pilosa.rb
+++ b/Formula/pilosa.rb
@@ -18,13 +18,17 @@ class Pilosa < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
+    # Fix compilation with Go 1.18 - see https://github.com/golang/go/issues/51706
+    inreplace "go.mod",
+              "golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872",
+              "golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a"
 
-    (buildpath/"src/github.com/pilosa/pilosa").install buildpath.children
-    cd "src/github.com/pilosa/pilosa" do
-      system "make", "build", "FLAGS=-o #{bin}/pilosa", "VERSION=v#{version}"
-      prefix.install_metafiles
-    end
+    (buildpath/"go.sum").append_lines <<~EOS
+      golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+      golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+    EOS
+
+    system "make", "build", "FLAGS=-o #{bin}/pilosa", "VERSION=v#{version}"
   end
 
   service do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `CI-no-bottles` label can be removed if we don't want to keep older bottles (my thought is that this change is negligible enough to avoid losing old bottles).