### PR TITLE
exiftool: Fix path that's provided to @INC to be correct

### DIFF
--- a/Formula/exiftool.rb
+++ b/Formula/exiftool.rb
@@ -30,7 +30,7 @@ class Exiftool < Formula
     inreplace "lib/Image/ExifTool.pm", "LargeFileSupport => undef", "LargeFileSupport => 1"
 
     # replace the hard-coded path to the lib directory
-    inreplace "exiftool", "$1/lib", libexec/"lib"
+    inreplace "exiftool", "unshift @INC, $incDir;", "unshift @INC, \"#{libexec}/lib\";"
 
     system "perl", "Makefile.PL"
     system "make", "all"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR aims to fix running version 12.42 of `exiftool` as it currently fails with the error message:

```sh
$ exiftool -ver
Can't locate Image/ExifTool.pm in @INC (you may need to install the Image::ExifTool module) (@INC contains: /opt/homebrew/bin/../Cellar/exiftool/12.42/bin/lib /Library/Perl/5.30/darwin-thread-multi-2level /Library/Perl/5.30 /Network/Library/Perl/5.30/darwin-thread-multi-2level /Network/Library/Perl/5.30 /Library/Perl/Updates/5.30.3 /System/Library/Perl/5.30/darwin-thread-multi-2level /System/Library/Perl/5.30 /System/Library/Perl/Extras/5.30/darwin-thread-multi-2level /System/Library/Perl/Extras/5.30) at /opt/homebrew/bin/exiftool line 40.
BEGIN failed--compilation aborted at /opt/homebrew/bin/exiftool line 40.
```

It looks like the logic in `exiftool` that sets `@INC` changed around about 12.35 (https://github.com/exiftool/exiftool/commit/eb12965dae45997c387e33248c90cc9631e2ba1d#diff-0747314e16d27a5ae07a3326e52544a2f5871891995fecb4492929c32ed2166d) which rendered the method the `exiftool.rb` formula was using to patch the path ineffective.