### PR TITLE
x264: update livecheck

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -23,27 +23,21 @@ class X264 < Formula
 
       # Fetch the `stable` Git branch Atom feed
       stable_page_data = Homebrew::Livecheck::Strategy.page_content("https://code.videolan.org/videolan/x264/-/commits/stable?format=atom")
-      next [] if stable_page_data[:content].blank?
+      next if stable_page_data[:content].blank?
 
       # Extract commit hashes from the feed content
       commit_hashes = stable_page_data[:content].scan(%r{/commit/([\da-z]+)}i).flatten
-      next [] if commit_hashes.blank?
+      next if commit_hashes.blank?
 
       # Only keep versions with a matching commit hash in the `stable` branch
       matches.map do |match|
-        next nil unless match.length >= 2
-
         release_hash = match[1]
-        commit_in_stable = false
-        commit_hashes.each do |commit_hash|
-          next unless commit_hash.start_with?(release_hash)
-
-          commit_in_stable = true
-          break
+        commit_in_stable = commit_hashes.any? do |commit_hash|
+          commit_hash.start_with?(release_hash)
         end
 
-        commit_in_stable ? match[0] : nil
-      end.compact
+        match[0] if commit_in_stable
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I originally added the `strategy` block in the `x264` `livecheck` block in #75260. This PR simply updates the `strategy` block to refactor some areas and remove unnecessary bits. For example:

* A `nil` return from a `strategy` block is fine these days, so we can simply use `next if ...`.
* `match` objects from `#scan` are guaranteed to have two parts with this regex, so we don't need the guard.
* livecheck runs `#compact` internally on an array returned from a `strategy` block, so we can omit it from the `strategy` block.

Basically, this accomplishes the same thing (and produces the same output) but is less verbose.