### PR TITLE
tradcpp: various improvements

### DIFF
--- a/Formula/tradcpp.rb
+++ b/Formula/tradcpp.rb
@@ -4,6 +4,7 @@ class Tradcpp < Formula
   url "https://cdn.netbsd.org/pub/NetBSD/misc/dholland/tradcpp-0.5.3.tar.gz"
   sha256 "e17b9f42cf74b360d5691bc59fb53f37e41581c45b75fcd64bb965e5e2fe4c5e"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "9584ff61e602fe8001d9c39dcaec1e348731955bd65583155953edc41ef989a3"
@@ -17,8 +18,14 @@ class Tradcpp < Formula
   depends_on "bmake" => :build
 
   def install
+    ENV.append_to_cflags %Q(-DCONFIG_SYSTEMINCLUDE=\\"#{MacOS.sdk_path}/usr/include\\") if OS.mac?
+    bmake_args = %W[
+      prefix=#{prefix}
+      MK_INSTALL_AS_USER=yes
+      MANDIR=#{man}
+    ]
     system "bmake"
-    system "bmake", "prefix=#{prefix}", "MK_INSTALL_AS_USER=yes", "install"
+    system "bmake", *bmake_args, "install"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Install man page correctly.
- Set system include directory correctly on macOS.
- Use `bash`, `bmake` has some code snippets (after simplification) like
  ```SHELL
  for i in 0; do if :; then :; fi done
  ```
  this is valid in `bash` but invalid in `zsh`. When user uses `zsh`, `  brew install -s tradcpp` will fail with
  ```
  --- proginstall ---
  [ -d /usr/local/Cellar/tradcpp/0.5.3/bin ] ||  install -d  -m 775 /usr/local/Cellar/tradcpp/0.5.3/bin
  install -c -s  -m 555  tradcpp /usr/local/Cellar/tradcpp/0.5.3/bin/
  --- maninstall ---
  zsh: parse error near `done'
  zsh: parse error near `}'
  *** [maninstall] Error code 1
  ```
