### PR TITLE
rtv: disable

### DIFF
--- a/Formula/rtv.rb
+++ b/Formula/rtv.rb
@@ -19,7 +19,8 @@ class Rtv < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "927350083466dd294f9391c50b9ed188cfbe213875683267be60d3a8b2740d5e"
   end
 
-  deprecate! date: "2019-06-02", because: :repo_archived
+  # Deprecation added 2020-06-15 / deprecated since 2019-06-02
+  disable! date: "2022-06-08", because: :repo_archived
 
   depends_on "python@3.10"
   depends_on "six"


### PR DESCRIPTION
This can now go through our usual 1 year removal cycle.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
