### PR TITLE
thrift@0.9: Fix the broken url.

### DIFF
--- a/Formula/thrift@0.9.rb
+++ b/Formula/thrift@0.9.rb
@@ -1,7 +1,7 @@
 class ThriftAT09 < Formula
   desc "Framework for scalable cross-language services development"
   homepage "https://thrift.apache.org"
-  url "https://github.com/apache/thrift/archive/0.9.3.1.tar.gz"
+  url "https://github.com/apache/thrift/archive/refs/tags/0.9.3.1.tar.gz"
   sha256 "1f7ca02d88a603f2845b2c7abcab74f8107dd7285056284d65241eb7965e143c"
   license "Apache-2.0"
 


### PR DESCRIPTION
- [ x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
The download url of thrift@0.9 is broken, which returns "the given path has multiple possibilities: #<Git::Ref:0x00007fc7b9c77670>, #<Git::Ref:0x00007fc7b9cc32f0>"