### PR TITLE
nss, googletest: remove conflicts

### DIFF
--- a/Formula/googletest.rb
+++ b/Formula/googletest.rb
@@ -17,8 +17,6 @@ class Googletest < Formula
 
   depends_on "cmake" => :build
 
-  conflicts_with "nss", because: "both install `libgtest.a`"
-
   def install
     system "cmake", ".", *std_cmake_args
     system "make", "install"

--- a/Formula/nss.rb
+++ b/Formula/nss.rb
@@ -29,7 +29,6 @@ class Nss < Formula
   uses_from_macos "zlib"
 
   conflicts_with "resty", because: "both install `pp` binaries"
-  conflicts_with "googletest", because: "both install `libgtest.a`"
 
   def install
     ENV.deparallelize


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- googletest: remove conflict with `nss`.
- nss: remove conflict with `googletest`.

This conflict was resolved in #103098.
