### PR TITLE
primecount: remove `libomp` on Linux

### DIFF
--- a/Formula/primecount.rb
+++ b/Formula/primecount.rb
@@ -15,8 +15,11 @@ class Primecount < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "libomp"
   depends_on "primesieve"
+
+  on_macos do
+    depends_on "libomp"
+  end
 
   def install
     system "cmake", "-S", ".", "-B", "build", "-DBUILD_SHARED_LIBS=ON",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

From #100700, it uses GCC's `libgomp` and not LLVM's `libomp`
```
==>brew linkage --cached primecount
System libraries:
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libgcc_s.so.1
  /lib/x86_64-linux-gnu/libm.so.6
  /usr/lib/x86_64-linux-gnu/libgomp.so.1
  /usr/lib/x86_64-linux-gnu/libstdc++.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/Cellar/primecount/7.3/bin/../lib/libprimecount.so.7 (primecount)
  /home/linuxbrew/.linuxbrew/lib/libprimesieve.so.9 (primesieve)
Dependencies with no linkage:
  libomp
```