### PR TITLE
smartmontools: enable --with-nvme-devicescan

### DIFF
--- a/Formula/smartmontools.rb
+++ b/Formula/smartmontools.rb
@@ -4,6 +4,7 @@ class Smartmontools < Formula
   url "https://downloads.sourceforge.net/project/smartmontools/smartmontools/7.3/smartmontools-7.3.tar.gz"
   sha256 "a544f8808d0c58cfb0e7424ca1841cb858a974922b035d505d4e4c248be3a22b"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_monterey: "e6dcb98550cdf4dbf6e175655a81a8413f71e974ad8b73b352492bbe65bf7b67"
@@ -24,7 +25,8 @@ class Smartmontools < Formula
                           "--sysconfdir=#{etc}",
                           "--localstatedir=#{var}",
                           "--with-savestates",
-                          "--with-attributelog"
+                          "--with-attributelog",
+                          "--with-nvme-devicescan"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This commit enables automatic scanning of the NVMe devices for the macOS. As all recent macs are using NVMe drives it is very relevant, and will make functions like `smartctl --scan-open` working. It would also allow smartd to work without configuration:
```
% smartd -d
smartd 7.3 2022-02-28 r5338 [Darwin 21.5.0 arm64] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

Opened configuration file /opt/homebrew/etc/smartd.conf
Drive: DEVICESCAN, implied '-a' Directive on line 23 of file /opt/homebrew/etc/smartd.conf
Configuration file /opt/homebrew/etc/smartd.conf was parsed, found DEVICESCAN, scanning devices
Device: IOService:/AppleARMPE/arm-io/AppleT600xIO/ans@8F400000/AppleASCWrapV4/iop-ans-nub/RTBuddyV2/RTBuddyService/AppleANS3NVMeController/NS_01@1, opened
Device: IOService:/AppleARMPE/arm-io/AppleT600xIO/ans@8F400000/AppleASCWrapV4/iop-ans-nub/RTBuddyV2/RTBuddyService/AppleANS3NVMeController/NS_01@1, APPLE SSD AP0512R, S/N:0ba0188382894422, FW:387.120., NSID:0
Device: IOService:/AppleARMPE/arm-io/AppleT600xIO/ans@8F400000/AppleASCWrapV4/iop-ans-nub/RTBuddyV2/RTBuddyService/AppleANS3NVMeController/NS_01@1, is SMART capable. Adding to "monitor" list.
Device: IOService:/AppleARMPE/arm-io/AppleT600xIO/ans@8F400000/AppleASCWrapV4/iop-ans-nub/RTBuddyV2/RTBuddyService/AppleANS3NVMeController/NS_01@1, state read from /opt/homebrew/var/lib/smartmontools/smartd.APPLE_SSD_AP0512R-0ba0188382894422-n0.nvme.state
Monitoring 0 ATA/SATA, 0 SCSI/SAS and 1 NVMe devices
Device: IOService:/AppleARMPE/arm-io/AppleT600xIO/ans@8F400000/AppleASCWrapV4/iop-ans-nub/RTBuddyV2/RTBuddyService/AppleANS3NVMeController/NS_01@1, opened NVMe device
Device: IOService:/AppleARMPE/arm-io/AppleT600xIO/ans@8F400000/AppleASCWrapV4/iop-ans-nub/RTBuddyV2/RTBuddyService/AppleANS3NVMeController/NS_01@1, state written to /opt/homebrew/var/lib/smartmontools/smartd.APPLE_SSD_AP0512R-0ba0188382894422-n0.nvme.state
```