### PR TITLE
sile 0.13.0

### DIFF
--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -1,8 +1,8 @@
 class Sile < Formula
   desc "Modern typesetting system inspired by TeX"
   homepage "https://sile-typesetter.org"
-  url "https://github.com/sile-typesetter/sile/releases/download/v0.12.5/sile-0.12.5.tar.xz"
-  sha256 "de97ff483dd4cd5150ae3ec5b60ca11515bc47e143eb0ee980da67c5716c3c7d"
+  url "https://github.com/sile-typesetter/sile/releases/download/v0.13.0/sile-0.13.0.tar.xz"
+  sha256 "c32fe58e20f0753e150771678db0e0bc9e2c6c767eda406d2ac2e4a51c7bc439"
   license "MIT"
 
   bottle do
@@ -60,6 +60,11 @@ class Sile < Formula
     sha256 "9c83d50c8b734c0d405f97df9940ddb27578214033fd0e3cfc3e7420c999b9a9"
   end
 
+  resource "loadkit" do
+    url "https://luarocks.org/manifests/leafo/loadkit-1.1.0-1.src.rock"
+    sha256 "6a631cb08a78324cb5f92b1cb8e2f59502d7113407d0d9b0d95045d8a4febccb"
+  end
+
   resource "lua_cliargs" do
     url "https://luarocks.org/manifests/amireh/lua_cliargs-3.0-2.src.rock"
     sha256 "3c79981292aab72dbfba9eb5c006bb37c5f42ee73d7062b15fdd840c00b70d63"
@@ -75,6 +80,7 @@ class Sile < Formula
     sha256 "b55908fcd7df490a59aab25284460add8283f1c6b94ab584900fe3e49775172a"
   end
 
+  # depends on lpeg
   resource "luaepnf" do
     url "https://luarocks.org/manifests/siffiejoe/luaepnf-0.3-2.src.rock"
     sha256 "7abbe5888abfa183878751e4010239d799e0dfca6139b717f375c26292876f07"
@@ -91,26 +97,38 @@ class Sile < Formula
   end
 
   resource "luasocket" do
-    url "https://luarocks.org/manifests/luasocket/luasocket-3.0rc1-2.src.rock"
-    sha256 "3882f2a1e1c6145ceb43ead385b861b97fa2f8d487e8669ec5b747406ab251c7"
-    version "3.0rc1-2"
+    url "https://luarocks.org/manifests/lunarmodules/luasocket-3.0.0-1.src.rock"
+    sha256 "63fd2dd18dfe242ca5bcc1203839e86a9c8936261a9ca9f3200f2deab431da88"
   end
 
-  # depends on `luasocket`
+  # depends on luasocket
   resource "luasec" do
-    url "https://luarocks.org/manifests/brunoos/luasec-1.0.1-1.src.rock"
-    sha256 "0e91f9686ccda7d373d74518da85d22f678a1b0de35e38b4a444041eba53040d"
+    url "https://luarocks.org/manifests/brunoos/luasec-1.1.0-1.src.rock"
+    sha256 "534e16ead4bcddb9d536869fdaf0cac049c8bc710a01749f99df3b63b68e2e24"
   end
 
+  # depends on luafilesystem
   resource "penlight" do
-    url "https://luarocks.org/manifests/tieske/penlight-1.12.0-1.src.rock"
-    sha256 "99e2d88d5539901989f785100c8d216ef8e9461e08f93a850e9ea6abc9952927"
+    url "https://luarocks.org/manifests/tieske/penlight-1.12.0-2.src.rock"
+    sha256 "bcf2b591fb0ff650007211a99256c15acbfb927a7e7e779cae15ae52cb8d6bea"
   end
 
-  # Depends on luafilesystem and penlight
+  # depends on penlight
+  resource "cldr" do
+    url "https://luarocks.org/manifests/alerque/cldr-0.2.0-0.src.rock"
+    sha256 "965e2917b2d06b1c416935be4d7a59aa438e9bad5015b2aefd055f0efdd79758"
+  end
+
+  # Depends on cldr, luaepnf, penlight
+  resource "fluent" do
+    url "https://luarocks.org/manifests/alerque/fluent-0.2.0-0.src.rock"
+    sha256 "ea915c689dfce2a7ef5551eb3c09d4620bae60a51c20d48d85c14b69bf3f28ba"
+  end
+
+  # Depends on luafilesystem, penlight
   resource "cassowary" do
-    url "https://luarocks.org/manifests/simoncozens/cassowary-2.3.1-2.src.rock"
-    sha256 "bf2ac4c04999402aab9bfa3b38868514f625a9e79c6884aa724b9560714aa500"
+    url "https://luarocks.org/manifests/simoncozens/cassowary-2.3.2-1.src.rock"
+    sha256 "2d3c3954eeb8b5da1d7b1b56c209ed3ae11d221220967c159f543341917ce726"
   end
 
   resource "luautf8" do
@@ -160,7 +178,6 @@ class Sile < Formula
         unpack_dir = Utils.safe_popen_read("luarocks", "unpack", rock).split("\n")[-2]
 
         spec = "#{r.name}-#{r.version}.rockspec"
-        spec = "cassowary-scm-0.rockspec" if r.name == "cassowary"
         cd(unpack_dir) { system "luarocks", "make", *args, spec }
       end
     end


### PR DESCRIPTION
Upstream release, [release notes here](https://github.com/sile-typesetter/sile/releases/tag/v0.13.0).

The overall build scheme for this release is unchanged, but there are 3 new Lua dependencies: loadkit, fluent, and cldr. All three have been added and the rest bumped as appropriate, but this is not tested on my end locally (not on macOS).

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
