### PR TITLE
pianod: use `libxcrypt` on Linux

### DIFF
--- a/Formula/pianod.rb
+++ b/Formula/pianod.rb
@@ -4,7 +4,7 @@ class Pianod < Formula
   url "https://deviousfish.com/Downloads/pianod2/pianod2-388.tar.gz"
   sha256 "a677a86f0cbc9ada0cf320873b3f52b466d401a25a3492ead459500f49cdcd99"
   license "MIT"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://deviousfish.com/Downloads/pianod2/"
@@ -25,6 +25,8 @@ class Pianod < Formula
   depends_on "libao"
   depends_on "libgcrypt"
 
+  uses_from_macos "libxcrypt"
+
   on_macos do
     depends_on "ncurses"
   end
@@ -41,10 +43,7 @@ class Pianod < Formula
 
   def install
     ENV["OBJCXXFLAGS"] = "-std=c++14"
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

From #103275
```
==>brew linkage --cached --test --strict pianod
==>FAILED
Full linkage --cached --test --strict pianod output
  Error: Calling linkage to libcrypt.so.1 is disabled! Use libcrypt.so.2 in the libxcrypt formula instead.
```