### PR TITLE
operator-sdk: update go to latest (1.18.x)

### DIFF
--- a/Formula/operator-sdk.rb
+++ b/Formula/operator-sdk.rb
@@ -23,7 +23,7 @@ class OperatorSdk < Formula
 
   # Resolves upstream issue: https://github.com/operator-framework/operator-sdk/issues/5689
   # Should be updated to "go" when the following upstream issue is resolved: https://github.com/operator-framework/operator-sdk/issues/5740
-  depends_on "go@1.17"
+  depends_on "go"
 
   def install
     ENV["GOBIN"] = libexec/"bin"


### PR DESCRIPTION
In a previous PR [1] I downgraded the Go dependency of Operator-SDK to Go 1.17 as Operator-SDK did not yet support Go 1.18.

The next release of Operator-SDK (v1.22.0) is going to support Go 1.18. It has not yet been released but I am creating this PR prior to the next release so it can be ready to merge when the next release is created and used in the formula.

If there is anything else that I need to do, just let me know!

[1] - https://github.com/Homebrew/homebrew-core/pull/101238

operator-sdk issue for tracking this change: https://github.com/operator-framework/operator-sdk/issues/5740

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Leaving some of the checks unmarked as it is currently expected that the tests will fail because the release to support Go 1.18 has not been released yet.