### PR TITLE
groovy: remove JDK18 workaround since fixed in GROOVY-10610

### DIFF
--- a/Formula/groovy.rb
+++ b/Formula/groovy.rb
@@ -4,6 +4,7 @@ class Groovy < Formula
   url "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-4.0.3.zip"
   sha256 "ddfc8e26fdcf3626d1c83f28d198c3e4e616a72337ca6e46fcaca09e7a4bb37f"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/"
@@ -59,12 +60,7 @@ class Groovy < Formula
 
     libexec.install "bin", "conf", "lib"
     bin.install Dir["#{libexec}/bin/*"] - ["#{libexec}/bin/groovy.ico"]
-    env = Language::Java.overridable_java_home_env
-    # Work around for exception starting `groovysh` on OpenJDK 18:
-    # java.lang.UnsupportedOperationException: The Security Manager is deprecated ...
-    # TODO: Remove when groovy no longer uses deprecated Security Manager.
-    env["JAVA_OPTS"] = "$JAVA_OPTS -Djava.security.manager=allow"
-    bin.env_script_all_files libexec/"bin", env
+    bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env
   end
 
   def caveats


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes #103364

https://issues.apache.org/jira/browse/GROOVY-10610 fixed the JDK18 support and has already been added into 4.0.3 release.