### PR TITLE
postgresql: Enable LZ4 compression

### DIFF
--- a/Formula/postgresql.rb
+++ b/Formula/postgresql.rb
@@ -27,6 +27,7 @@ class Postgresql < Formula
   # See https://github.com/Homebrew/homebrew-core/issues/47494.
   depends_on "krb5"
 
+  depends_on "lz4"
   depends_on "openssl@1.1"
   depends_on "readline"
 
@@ -58,6 +59,7 @@ class Postgresql < Formula
       --with-ldap
       --with-libxml
       --with-libxslt
+      --with-lz4
       --with-openssl
       --with-pam
       --with-perl


### PR DESCRIPTION
This PR includes the LZ4 compression for PostgreSQL, which was introduced in [PostgreSQL 14](https://www.postgresql.org/about/news/postgresql-14-released-2318/):

Before:

```psql
postgres=# ALTER TABLE table ALTER COLUMN column SET COMPRESSION lz4;
ERROR:  compression method lz4 not supported
DETAIL:  This functionality requires the server to be built with lz4 support.
HINT:  You need to rebuild PostgreSQL using --with-lz4.
```

After:

```psql
postgres=# ALTER TABLE table ALTER COLUMN column SET COMPRESSION lz4;
ALTER TABLE
```

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
