### PR TITLE
qpdf: use `jpeg-turbo`

### DIFF
--- a/Formula/qpdf.rb
+++ b/Formula/qpdf.rb
@@ -4,6 +4,7 @@ class Qpdf < Formula
   url "https://github.com/qpdf/qpdf/releases/download/release-qpdf-10.6.3/qpdf-10.6.3.tar.gz"
   sha256 "e8fc23b2a584ea68c963a897515d3eb3129186741dd19d13c86d31fa33493811"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -19,7 +20,7 @@ class Qpdf < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b60263aafd42b76e159d8571dec80efa1ca5e411b592e92df1ea1d81935df399"
   end
 
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "openssl@1.1"
 
   uses_from_macos "zlib"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Avoid duplicate libjpeg in `pdftilecut`
```console
❯ brew deps --tree pdftilecut
pdftilecut
├── jpeg-turbo
└── qpdf
    ├── jpeg
    └── openssl@1.1
        └── ca-certificates
```