### PR TITLE
dcraw, ufraw, zbar: migrate `jpeg` to `jpeg-turbo`

### DIFF
--- a/Formula/dcraw.rb
+++ b/Formula/dcraw.rb
@@ -4,7 +4,7 @@ class Dcraw < Formula
   url "https://www.dechifro.org/dcraw/archive/dcraw-9.28.0.tar.gz"
   mirror "https://mirrorservice.org/sites/distfiles.macports.org/dcraw/dcraw-9.28.0.tar.gz"
   sha256 "2890c3da2642cd44c5f3bfed2c9b2c1db83da5cec09cc17e0fa72e17541fb4b9"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://distfiles.macports.org/dcraw/"
@@ -21,12 +21,12 @@ class Dcraw < Formula
   end
 
   depends_on "jasper"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "little-cms2"
 
   def install
-    ENV.append_to_cflags "-I#{HOMEBREW_PREFIX}/include -L#{HOMEBREW_PREFIX}/lib"
-    system ENV.cc, "-o", "dcraw", ENV.cflags, "dcraw.c", "-lm", "-ljpeg", "-llcms2", "-ljasper"
+    ENV.append "LDLIBS", "-lm -ljpeg -llcms2 -ljasper"
+    system "make", "dcraw"
     bin.install "dcraw"
     man1.install "dcraw.1"
   end

--- a/Formula/ufraw.rb
+++ b/Formula/ufraw.rb
@@ -3,7 +3,7 @@ class Ufraw < Formula
   homepage "https://ufraw.sourceforge.io"
   url "https://downloads.sourceforge.net/project/ufraw/ufraw/ufraw-0.22/ufraw-0.22.tar.gz"
   sha256 "f7abd28ce587db2a74b4c54149bd8a2523a7ddc09bedf4f923246ff0ae09a25e"
-  revision 4
+  revision 5
 
   bottle do
     sha256 arm64_monterey: "65712db00e593e27aba98df72a8cf42cfc4e9f2ea1b9735aa53ac6cc8e0be630"
@@ -19,7 +19,7 @@ class Ufraw < Formula
   depends_on "gettext"
   depends_on "glib"
   depends_on "jasper"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "little-cms2"
@@ -38,8 +38,7 @@ class Ufraw < Formula
   end
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
+    system "./configure", *std_configure_args,
                           "--without-gtk",
                           "--without-gimp"
     system "make", "install"

--- a/Formula/zbar.rb
+++ b/Formula/zbar.rb
@@ -4,7 +4,7 @@ class Zbar < Formula
   url "https://github.com/mchehab/zbar/archive/0.23.90.tar.gz"
   sha256 "25fdd6726d5c4c6f95c95d37591bfbb2dde63d13d0b10cb1350923ea8b11963b"
   license "LGPL-2.1-only"
-  revision 1
+  revision 2
   head "https://github.com/mchehab/zbar.git", branch: "master"
 
   livecheck do
@@ -30,7 +30,7 @@ class Zbar < Formula
   depends_on "xmlto" => :build
   depends_on "freetype"
   depends_on "imagemagick"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libtool"
   depends_on "ufraw"
   depends_on "xz"
@@ -39,20 +39,16 @@ class Zbar < Formula
     depends_on "dbus"
   end
 
+  fails_with gcc: "5" # imagemagick is built with GCC
+
   def install
-    system "autoreconf", "-fvi"
-
-    args = %W[
-      --disable-dependency-tracking
-      --prefix=#{prefix}
-      --without-python
-      --without-qt
-      --disable-video
-      --without-gtk
-      --without-x
-    ]
-
-    system "./configure", *args
+    system "autoreconf", "--force", "--install", "--verbose"
+    system "./configure", *std_configure_args,
+                          "--without-python",
+                          "--without-qt",
+                          "--disable-video",
+                          "--without-gtk",
+                          "--without-x"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying this out to with many (not all) `jpeg`-dependent formulae.

Most other major repositories switched to `jpeg-turbo` earlier on. These include MacPorts, Debian/Ubuntu, Fedora, Arch, Gentoo, Alpine, FreeBSD, Vcpkg.

The ones that may be using `jpeg` (v9) are NixOS and Spack. Conan seems to default to `jpeg` but allows for using `jpeg-turbo`.