### PR TITLE
GROMACS: add apple silicon SIMD (NEON) support

### DIFF
--- a/Formula/gromacs.rb
+++ b/Formula/gromacs.rb
@@ -54,8 +54,15 @@ class Gromacs < Formula
       -DGROMACS_CXX_COMPILER=#{cxx}
       -DGMX_VERSION_STRING_OF_FORK=#{tap.user}
     ]
-    # Force SSE2/SSE4.1 for compatibility when building Intel bottles
-    args << "-DGMX_SIMD=#{MacOS.version.requires_sse41? ? "SSE4.1" : "SSE2"}" if Hardware::CPU.intel? && build.bottle?
+
+    # Enable SIMD
+    simd = if Hardware::CPU.intel?
+      MacOS.version.requires_sse41? ? "SSE4.1" : "SSE2"
+    else
+      # Apple silicon
+      "ARM_NEON_ASIMD"
+    end
+    args << "-DGMX_SIMD=#{simd}" if build.bottle?
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

According to the [installation guide of GROMACS 2022.1](https://manual.gromacs.org/current/install-guide/index.html), `ARM_NEON_ASIMD` is supported by gromacs and available with apple silicon. I verified that, on my MacBook Pro (with M1 Pro chip) the locally installed formula was indeed able to make use of NEON SIMD, by checking the log files of sample MD runs.

I also found that OpenMP was not properly configured, and that the GPU in Apple silicon, which is actually supported via OpenCL by GROMACS, is not configured in the formula. I'll open separate issues/PRs with each of them.