### PR TITLE
openshift-cli: remove `heimdal` build dependency

### DIFF
--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -27,7 +27,6 @@ class OpenshiftCli < Formula
   depends_on "coreutils" => :build
   # Bump to 1.18 on the next release.
   depends_on "go@1.17" => :build
-  depends_on "heimdal" => :build
   depends_on "socat"
 
   uses_from_macos "krb5"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Try to remove odd build dependency tree consisting of 2 Kerberos implementations on Linux (`heimdal` and `krb5`).
