### PR TITLE
dlib: migrate `jpeg` to `jpeg-turbo`

### DIFF
--- a/Formula/dlib.rb
+++ b/Formula/dlib.rb
@@ -4,6 +4,7 @@ class Dlib < Formula
   url "http://dlib.net/files/dlib-19.24.tar.bz2"
   sha256 "28fdd1490c4d0bb73bd65dad64782dd55c23ea00647f5654d2227b7d30b784c4"
   license "BSL-1.0"
+  revision 1
   head "https://github.com/davisking/dlib.git", branch: "master"
 
   livecheck do
@@ -21,7 +22,7 @@ class Dlib < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "openblas"
 
@@ -31,8 +32,8 @@ class Dlib < Formula
     args = std_cmake_args + %W[
       -DDLIB_USE_BLAS=ON
       -DDLIB_USE_LAPACK=ON
-      -Dcblas_lib=#{Formula["openblas"].opt_lib}/libopenblas.dylib
-      -Dlapack_lib=#{Formula["openblas"].opt_lib}/libopenblas.dylib
+      -Dcblas_lib=#{Formula["openblas"].opt_lib/shared_library("libopenblas")}
+      -Dlapack_lib=#{Formula["openblas"].opt_lib/shared_library("libopenblas")}
       -DDLIB_NO_GUI_SUPPORT=ON
       -DBUILD_SHARED_LIBS=ON
     ]
@@ -42,10 +43,9 @@ class Dlib < Formula
       args << "-DUSE_SSE4_INSTRUCTIONS=ON" if MacOS.version.requires_sse4?
     end
 
-    mkdir "dlib/build" do
-      system "cmake", "..", *args
-      system "make", "install"
-    end
+    system "cmake", "-S", "dlib", "-B", "build", *args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Migration related to #103436.

`dlib` isn't a dependency for other formulae and no indirect dependency to `jpeg` based on `brew deps` on Linux and macOS Monterey.