### PR TITLE
haskell-stack: Pin constraints to fix ARM build and `hpack` version

### DIFF
--- a/Formula/haskell-stack.rb
+++ b/Formula/haskell-stack.rb
@@ -38,7 +38,7 @@ class HaskellStack < Formula
 
   def install
     # https://github.com/JustusAdam/mustache/issues/41
-    cabal_install_constraints = ["--constraint=mustache^>=2.3.1"]
+    cabal_install_constraints = ["--constraint=mustache^>=2.3.1", "--constraint=persistent==2.13.3.0"]
 
     system "cabal", "v2-update"
     system "cabal", "v2-install", *std_cabal_v2_args, *cabal_install_constraints

--- a/Formula/haskell-stack.rb
+++ b/Formula/haskell-stack.rb
@@ -38,7 +38,11 @@ class HaskellStack < Formula
 
   def install
     # https://github.com/JustusAdam/mustache/issues/41
-    cabal_install_constraints = ["--constraint=mustache^>=2.3.1", "--constraint=persistent==2.13.3.0"]
+    cabal_install_constraints = [
+      "--constraint=mustache^>=2.3.1",
+      "--constraint=persistent==2.13.3.0",
+      "--constraint=hpack==0.34.4",
+    ]
 
     system "cabal", "v2-update"
     system "cabal", "v2-install", *std_cabal_v2_args, *cabal_install_constraints


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Builds `stack` with two constraints:

- `persistent` addresses existing build issue with latest version: https://github.com/commercialhaskell/stack/issues/5753
- `hpack` is pinned to the version that corresponds with what is used by the officially distributed binary.

The latter constraint resolves a conflict between users of this formula and the official binaries on other platforms, which ship with version `0.34.4`:

```
Version 2.7.5, Git revision ba147e6f59b2da75b1beb98b1888cce97f7032b1 x86_64 hpack-0.34.4
```

When the built or bottled version of `stack` is used, it will update a `.cabal` file with to note the version of `hpack`, and users with earlier versions will see:

```
/path/to/file.cabal was generated with a newer version of hpack, please upgrade and try again.
```