### PR TITLE
blackbox v1.20220610: update/downgrade

### DIFF
--- a/Formula/blackbox.rb
+++ b/Formula/blackbox.rb
@@ -4,6 +4,7 @@ class Blackbox < Formula
   url "https://github.com/StackExchange/blackbox/archive/v1.20220610.tar.gz"
   sha256 "f1efcca6680159f244eb44fdb78e92b521760b875fa5a36e4c433b93ed0f87c1"
   license "MIT"
+  version_scheme 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "6910c4f3a0b2b04288b9ca0eedc866e6b83d14ac5276d4eb46651a0bb0c14333"

--- a/Formula/blackbox.rb
+++ b/Formula/blackbox.rb
@@ -6,6 +6,11 @@ class Blackbox < Formula
   license "MIT"
   version_scheme 1
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)*\.\d{6,8}(?:\.\d+)*)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "6910c4f3a0b2b04288b9ca0eedc866e6b83d14ac5276d4eb46651a0bb0c14333"
   end

--- a/Formula/blackbox.rb
+++ b/Formula/blackbox.rb
@@ -1,8 +1,8 @@
 class Blackbox < Formula
   desc "Safely store secrets in Git/Mercurial/Subversion"
   homepage "https://github.com/StackExchange/blackbox"
-  url "https://github.com/StackExchange/blackbox/archive/v2.0.0.tar.gz"
-  sha256 "0a8fee39dc46436472528ea3a5743c42ebefc068519545fe6fca57041f42deae"
+  url "https://github.com/StackExchange/blackbox/archive/v1.20220610.tar.gz"
+  sha256 "f1efcca6680159f244eb44fdb78e92b521760b875fa5a36e4c433b93ed0f87c1"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
v1.20220610 was just released, but the formula is already on 2.0.0. This looks like a downgrade, because the [author says](https://github.com/StackExchange/blackbox/issues/354#issuecomment-1152902701) v2.0.0 was not supposed to be released. How can we make `brew update` handle this correctly?

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
