### PR TITLE
gradle: update livecheck

### DIFF
--- a/Formula/gradle.rb
+++ b/Formula/gradle.rb
@@ -6,8 +6,8 @@ class Gradle < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://services.gradle.org/distributions/"
-    regex(/href=.*?gradle[._-]v?(\d+(?:\.\d+)+)-all\.(?:[tz])/i)
+    url "https://gradle.org/install/"
+    regex(/href=.*?gradle[._-]v?(\d+(?:\.\d+)+)-all\.(?:zip|t)/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `gradle` checks the directory listing page where the `stable` archive is found. However, this is a rather data-heavy page and it can be a bit slow to load in a browser (less so when using `curl`).

This PR updates the `livecheck` block to check the [first-party installation page](https://gradle.org/install/), as it links to the `stable` archive and isn't quite as heavy (i.e., it only provides information for the latest version).

This also updates the regex to make the extension a little more explicit (only `zip` is used and the `t` extension is just a backup so we don't miss versions if they switch to tarballs in the future). We could technically check the `data-version` attribute on download links (e.g., `data-version="7.4.2"`) and avoid any issues with the filename/extension changing in the future but this could also break if the `data-version` attribute is removed in the future, so I'm fine with the current approach.