### PR TITLE
sfml: drop unused `jpeg` dependency

### DIFF
--- a/Formula/sfml.rb
+++ b/Formula/sfml.rb
@@ -23,7 +23,6 @@ class Sfml < Formula
   depends_on "doxygen" => :build
   depends_on "flac"
   depends_on "freetype"
-  depends_on "jpeg"
   depends_on "libogg"
   depends_on "libvorbis"
 
@@ -35,8 +34,6 @@ class Sfml < Formula
     depends_on "openal-soft"
     depends_on "systemd"
   end
-
-  # https://github.com/Homebrew/homebrew/issues/40301
 
   def install
     # Fix "fatal error: 'os/availability.h' file not found" on 10.11 and
@@ -56,8 +53,9 @@ class Sfml < Formula
 
     args << "-DSFML_USE_SYSTEM_DEPS=ON" if OS.linux?
 
-    system "cmake", ".", *std_cmake_args, *args
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream: https://github.com/SFML/SFML/pull/1279

Since **2.5.0**.
