### PR TITLE
mpw: disable

### DIFF
--- a/Formula/mpw.rb
+++ b/Formula/mpw.rb
@@ -24,6 +24,8 @@ class Mpw < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0aaf191d28ba5c097800350caa11f37f351f8f0ff336aed7f0e479d884321e86"
   end
 
+  disable! date: "2022-06-13", because: :unmaintained
+
   depends_on "json-c"
   depends_on "libsodium"
   depends_on "ncurses"


### PR DESCRIPTION
According to the [README commit on the deprecation date](https://gitlab.com/MasterPassword/MasterPassword/-/blob/8a032ba891af7c12f649ad803cdefbfec6e4a54c/README.md):

>The project is re-launching as Spectre, still fully open-source Free Software here on GitLab.
>[...]
>All development effort has moved to the Spectre project.  Master Password is no longer actively maintained.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
