### PR TITLE
astro 1.0.2 (New Formula)

### DIFF
--- a/Formula/astro.rb
+++ b/Formula/astro.rb
@@ -1,0 +1,19 @@
+class Astro < Formula
+  desc "To build and run Airflow DAGs locally and interact with the Astronomer API"
+  homepage "https://www.astronomer.io/"
+  url "https://github.com/astronomer/astro-cli/archive/refs/tags/v1.0.2.tar.gz"
+  sha256 "5121b7697f7db7a85b4e35af2410cb4832fa0fb3983217e3168f3cdbc2ef72b1"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["CGO_ENABLED"] = "0"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/astronomer/astro-cli/version.CurrVersion=#{version}")
+  end
+
+  test do
+    run_output = shell_output("#{bin}/astro version")
+    assert_match "Astro CLI Version: #{version}", run_output
+  end
+end

--- a/Formula/astro.rb
+++ b/Formula/astro.rb
@@ -13,7 +13,14 @@ class Astro < Formula
   end
 
   test do
-    run_output = shell_output("#{bin}/astro version")
-    assert_match "Astro CLI Version: #{version}", run_output
+    version_output = shell_output("#{bin}/astro version")
+    assert_match("Astro CLI Version: #{version}", version_output)
+
+    run_output = shell_output("echo 'y' | #{bin}/astro dev init")
+    assert_match(/^Initializing Astro project*/, run_output)
+    assert_predicate testpath/".astro/config.yaml", :exist?
+
+    run_output = shell_output("echo 'test@invalid.io' | #{bin}/astro login astronomer.io", 1)
+    assert_match(/^Welcome to the Astro CLI*/, run_output)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Astro is the official command-line tool of Astronomer (https://github.com/astronomer/astro-cli). It is used to build and run Airflow DAGs locally, and deploy them to Astronomer-managed Airflow clusters as well as interact with the Astronomer API.

Merging this will also close out: https://github.com/astronomer/astro-cli/issues/564