### PR TITLE
cryptominisat: Fix Python build

### DIFF
--- a/Formula/cryptominisat.rb
+++ b/Formula/cryptominisat.rb
@@ -39,6 +39,13 @@ class Cryptominisat < Formula
     # fix building C++ with the value of PY_C_CONFIG
     inreplace "python/setup.py.in", "cconf +", "cconf + ['-std=gnu++11'] +"
 
+    # fix error: could not create '/usr/local/lib/python3.10/site-packages/pycryptosat.cpython-310-darwin.so':
+    # Operation not permitted
+    site_packages = prefix/Language::Python.site_packages("python3")
+    inreplace "python/CMakeLists.txt",
+              "COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install",
+              "COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install --install-lib=#{site_packages}"
+
     system "cmake", "-S", ".", "-B", "build",
                     "-DNOM4RI=ON",
                     "-DCMAKE_INSTALL_RPATH=#{rpath}",


### PR DESCRIPTION
Fixes:
```
==> cmake --install build
-- Install configuration: "Release"
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/lib/cmake/cryptominisat5/cryptominisat5Config.cmake
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/lib/cmake/cryptominisat5/cryptominisat5Targets.cmake
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/lib/cmake/cryptominisat5/cryptominisat5Targets-release.cmake
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/lib/libcryptominisat5.5.8.dylib
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/lib/libcryptominisat5.dylib
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/include/cryptominisat5/cryptominisat_c.h
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/include/cryptominisat5/cryptominisat.h
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/include/cryptominisat5/solvertypesmini.h
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/include/cryptominisat5/dimacsparser.h
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/include/cryptominisat5/streambuffer.h
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/bin/cryptominisat5_simple
-- Installing: /usr/local/Cellar/cryptominisat/5.8.0_3/bin/cryptominisat5
running install
/usr/local/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
running build
running build_ext
running install_lib
copying build/lib.macosx-12-x86_64-3.10/pycryptosat.cpython-310-darwin.so -> /usr/local/lib/python3.10/site-packages
error: could not create '/usr/local/lib/python3.10/site-packages/pycryptosat.cpython-310-darwin.so': Operation not permitted
/usr/local/Homebrew/Library/Homebrew/shims/shared/git --version
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
