### PR TITLE
unbound: args and deps added to install formula

### DIFF
--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -26,6 +26,7 @@ class Unbound < Formula
   depends_on "libevent"
   depends_on "libnghttp2"
   depends_on "openssl@1.1"
+  depends_on "hiredis"
 
   uses_from_macos "expat"
 
@@ -36,6 +37,8 @@ class Unbound < Formula
       --enable-event-api
       --enable-tfo-client
       --enable-tfo-server
+      --enable-cachedb
+      --with-libhiredis
       --with-libevent=#{Formula["libevent"].opt_prefix}
       --with-libnghttp2=#{Formula["libnghttp2"].opt_prefix}
       --with-ssl=#{Formula["openssl@1.1"].opt_prefix}


### PR DESCRIPTION
"--enable-cachedb --with-libhiredis" arguments 
& 
"hiredis" lib depending 

added to default unbound install formula 
for redis cache database support

# https://dnsprivacy.org/dns_privacy_clients/#unboundstubby-combination
# stubby+unbound combination for local recursive DNS(+SEC)-over-TLS server
# "unbound as a caching proxy"...? caching how?