### PR TITLE
cmu-sphinxbase: deprecate

### DIFF
--- a/Formula/cmu-sphinxbase.rb
+++ b/Formula/cmu-sphinxbase.rb
@@ -14,11 +14,6 @@ class CmuSphinxbase < Formula
     end
   end
 
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/sphinxbase[._-]v?(\d+(?:\.\d+)+)\.t}i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "10c702ad300d51ffac6ed0251cf3b64952d549ad0a67792b80fe055a182014f2"
@@ -33,13 +28,15 @@ class CmuSphinxbase < Formula
   end
 
   head do
-    url "https://github.com/cmusphinx/sphinxbase.git"
+    url "https://github.com/cmusphinx/sphinxbase.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
     depends_on "swig" => :build
   end
+
+  deprecate! date: "2022-06-12", because: :repo_archived
 
   depends_on "pkg-config" => :build
   # If these are found, they will be linked against and there is no configure


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [`cmu-sphinxbase` GitHub repository](https://github.com/cmusphinx/sphinxbase) has been archived and the `README` contains the following message at the top:

> # DEPRECATED: Please depend on PocketSphinx instead
>
> SphinxBase has been integrated into PocketSphinx, so if you were linking against it or otherwise depending on it, please switch to use that instead as of the next release. Thanks! You can find it at https://github.com/cmusphinx/pocketsphinx

This PR deprecates the formula and removes the `livecheck` block accordingly. Besides that, this adds `branch: "master"` to the `head` URL to resolve the related audit.