### PR TITLE
perl: use absolute path for perl in post_install step

### DIFF
--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -57,7 +57,7 @@ class Perl < Formula
 
   def post_install
     if OS.linux?
-      perl_archlib = Utils.safe_popen_read(opt_bin/"perl", "-MConfig", "-e", "print $Config{archlib}")
+      perl_archlib = Utils.safe_popen_read(bin/"perl", "-MConfig", "-e", "print $Config{archlib}")
       perl_core = Pathname.new(perl_archlib)/"CORE"
       if File.readlines("#{perl_core}/perl.h").grep(/include <xlocale.h>/).any? &&
          (OS::Linux::Glibc.system_version >= "2.26" ||

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -57,7 +57,7 @@ class Perl < Formula
 
   def post_install
     if OS.linux?
-      perl_archlib = Utils.safe_popen_read("perl", "-MConfig", "-e", "print $Config{archlib}")
+      perl_archlib = Utils.safe_popen_read(opt_bin/"perl", "-MConfig", "-e", "print $Config{archlib}")
       perl_core = Pathname.new(perl_archlib)/"CORE"
       if File.readlines("#{perl_core}/perl.h").grep(/include <xlocale.h>/).any? &&
          (OS::Linux::Glibc.system_version >= "2.26" ||


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The error is as follows, `perl.h` can't be found correctly when perl already exists in current environment, so we need to use the absolution path for brew's perl in post_install stage.

- brew's perl version: 5.34.0
- system's perl version: 5.26.2

```
❯ brew postinstall perl --verbose --debug
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/perl.rb
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/shared/git --version
==> Postinstalling perl
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FromPathLoader): loading /home/linuxbrew/.linuxbrew/opt/perl/.brew/perl.rb
Warning: The post-install step did not complete successfully
You can try again using:
  brew postinstall perl
==> An exception occurred within a child process:
  Errno::ENOENT: No such file or directory @ rb_sysopen - .../../lib/5.26.2/x86_64-linux-thread-multi/CORE/perl.h

/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/perl.rb:62:in `readlines'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/perl.rb:62:in `post_install'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1128:in `block (2 levels) in run_post_install'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:945:in `with_logging'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1127:in `block in run_post_install'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils.rb:605:in `with_env'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1116:in `run_post_install'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/postinstall.rb:22:in `<main>'
20:46:04 @cicada in /home/linuxbrew/.linuxbrew at n251-250-205 
❯ brew postinstall perl --verbose --debug
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/perl.rb
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/shared/git --version
==> Postinstalling perl
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FromPathLoader): loading /home/linuxbrew/.linuxbrew/opt/perl/.brew/perl.rb

```