### PR TITLE
angband: fix Linux build

### DIFF
--- a/Formula/angband.rb
+++ b/Formula/angband.rb
@@ -4,6 +4,7 @@ class Angband < Formula
   url "https://github.com/angband/angband/releases/download/4.2.4/Angband-4.2.4.tar.gz"
   sha256 "a07c78c1dd05e48ddbe4d8ef5d1880fcdeab55fd05f1336d9cba5dd110b15ff3"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/angband/angband.git", branch: "master"
 
   livecheck do
@@ -20,21 +21,38 @@ class Angband < Formula
     sha256 x86_64_linux:   "3cfa3f60f7b88f2aa13cbbcae6b90e0aec128f5aef92e49c2860e61075c32af3"
   end
 
+  uses_from_macos "expect" => :test
+  uses_from_macos "ncurses"
+
   def install
-    ENV["NCURSES_CONFIG"] = "#{MacOS.sdk_path}/usr/bin/ncurses5.4-config"
-    system "./configure", "--prefix=#{prefix}",
-                          "--bindir=#{bin}",
-                          "--libdir=#{libexec}",
-                          "--enable-curses",
-                          "--disable-ncursestest",
-                          "--disable-sdltest",
-                          "--disable-x11",
-                          "--with-ncurses-prefix=#{MacOS.sdk_path}/usr"
+    ENV["NCURSES_CONFIG"] = "#{MacOS.sdk_path}/usr/bin/ncurses5.4-config" if OS.mac?
+    args = %W[
+      --prefix=#{prefix}
+      --bindir=#{bin}
+      --libdir=#{libexec}
+      --enable-curses
+      --disable-ncursestest
+      --disable-sdltest
+      --disable-x11
+    ]
+    args << "--with-ncurses-prefix=#{MacOS.sdk_path}/usr" if OS.mac?
+    system "./configure", *args
     system "make"
     system "make", "install"
   end
 
   test do
-    system bin/"angband", "--help"
+    script = (testpath/"script.exp")
+    script.write <<~EOS
+      #!/usr/bin/expect -f
+      set timeout 10
+      spawn angband
+      sleep 2
+      send -- "\x18"
+      sleep 2
+      send -- "\x18"
+      expect eof
+    EOS
+    system "expect", "-f", "script.exp"
   end
 end


### PR DESCRIPTION
Current binary doesn't link to ncurses, so it exits immediately without displaying the game UI.

Before:
```
$ brew linkage angband
System libraries:
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libm.so.6
```
After:
```
$ brew linkage angband
System libraries:
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libm.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/ncurses/lib/libncursesw.so.6 (ncurses)
```

Also improved test to actually run the UI.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
