### PR TITLE
elixir-build: deprecate

### DIFF
--- a/Formula/elixir-build.rb
+++ b/Formula/elixir-build.rb
@@ -10,6 +10,8 @@ class ElixirBuild < Formula
     sha256 cellar: :any_skip_relocation, all: "0f434ba340b50a81c737a8de0b167293c1ce596972fa15a9f57abc81c6f69499"
   end
 
+  deprecate! date: "2022-06-14", because: :repo_archived
+
   conflicts_with "narwhal", because: "both install `json` binaries"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository](https://github.com/mururu/elixir-build) for `elixir-build` was archived around 2022-04-08, so this PR deprecates the formula accordingly.