### PR TITLE
exenv: deprecate

### DIFF
--- a/Formula/exenv.rb
+++ b/Formula/exenv.rb
@@ -10,6 +10,8 @@ class Exenv < Formula
     sha256 cellar: :any_skip_relocation, all: "ae3d33c35709202895d8d27bff0ea95075cd1455cc20207b139c43b73ca34322"
   end
 
+  deprecate! date: "2022-06-15", because: :repo_archived
+
   def install
     inreplace "libexec/exenv", "/usr/local", HOMEBREW_PREFIX
     prefix.install Dir["*"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `exenv`](https://github.com/mururu/exenv) has been archived, so this PR deprecates the formula accordingly.