### PR TITLE
ca-certificates: check cert is trusted for SSL use

### DIFF
--- a/Formula/ca-certificates.rb
+++ b/Formula/ca-certificates.rb
@@ -4,6 +4,7 @@ class CaCertificates < Formula
   url "https://curl.se/ca/cacert-2022-07-19.pem"
   sha256 "6ed95025fba2aef0ce7b647607225745624497f876d74ef6ec22b26e73e9de77"
   license "MPL-2.0"
+  revision 1
 
   livecheck do
     url :homepage
@@ -68,6 +69,7 @@ class CaCertificates < Formula
       verify_args = %W[
         -l -L
         -c #{tmpfile.path}
+        -p ssl
       ]
       verify_args << "-R" << "offline" if MacOS.version >= :high_sierra
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

currently, only "Always Trust"ed (for everything) certificates (in keychain) are added to ca-certificates.

but ca-certificates is for verify SSL CAs, so it would be good to include certs that are trusted only as SSL CAs.

Note, I'm not sure about `security verify-cert`'s `-p` options are works on old macOS (since currently I dont have a old OS installs), so you might be want to test it on older OS.