### PR TITLE
gambit-scheme 4.9.4

### DIFF
--- a/Formula/gambit-scheme.rb
+++ b/Formula/gambit-scheme.rb
@@ -1,10 +1,9 @@
 class GambitScheme < Formula
   desc "Implementation of the Scheme Language"
   homepage "https://github.com/gambit/gambit"
-  url "https://github.com/gambit/gambit/archive/v4.9.3.tar.gz"
-  sha256 "a5e4e5c66a99b6039fa7ee3741ac80f3f6c4cff47dc9e0ff1692ae73e13751ca"
+  url "https://github.com/gambit/gambit/archive/v4.9.4.tar.gz"
+  sha256 "19fb44a65b669234f6c0467cdc3dbe2e2c95a442f38e4638e7d89c90e247bd08"
   license "Apache-2.0"
-  revision 2
 
   livecheck do
     url :stable
@@ -27,27 +26,24 @@ class GambitScheme < Formula
   def install
     args = %W[
       --prefix=#{prefix}
+      --infodir=#{info}
       --enable-single-host
-      --enable-multiple-versions
       --enable-default-runtime-options=f8,-8,t8
       --enable-openssl
     ]
 
     system "./configure", *args
 
-    # Fixed in gambit HEAD, but they haven't cut a release
-    inreplace "config.status" do |s|
-      s.gsub! %r{/usr/local/opt/openssl(?!@1\.1)}, "/usr/local/opt/openssl@1.1"
-    end
-    system "./config.status"
-
     system "make"
     ENV.deparallelize
     system "make", "install"
+
+    # fix lisp file install location
+    elisp.install share/"emacs/site-lisp/gambit.el"
   end
 
   test do
     assert_equal "0123456789",
-      shell_output("#{prefix}/current/bin/gsi -e \"(for-each write '(0 1 2 3 4 5 6 7 8 9))\"")
+      shell_output("#{bin}/gsi -e \"(for-each write '(0 1 2 3 4 5 6 7 8 9))\"")
   end
 end

--- a/Formula/gerbil-scheme.rb
+++ b/Formula/gerbil-scheme.rb
@@ -3,7 +3,8 @@ class GerbilScheme < Formula
   homepage "https://cons.io"
   url "https://github.com/vyzo/gerbil/archive/v0.17.tar.gz"
   sha256 "1e81265aba7e9022432649eb26b2e5c85a2bb631a315e4fa840b14cf336b2483"
-  license "Apache-2.0"
+  license all_of: ["LGPL-2.1-or-later", "Apache-2.0"]
+  revision 1
 
   livecheck do
     url "https://github.com/vyzo/gerbil.git"
@@ -19,6 +20,7 @@ class GerbilScheme < Formula
     sha256 x86_64_linux:   "6b0d5524324abcd1838483696a9e04e21cce47d7a0910e2ab20a48940454b09e"
   end
 
+  depends_on "pkg-config" => :build
   depends_on "gambit-scheme"
   depends_on "leveldb"
   depends_on "libyaml"
@@ -32,7 +34,7 @@ class GerbilScheme < Formula
     cd "src" do
       ENV.append_path "PATH", "#{Formula["gambit-scheme"].opt_prefix}/current/bin"
       system "./configure", "--prefix=#{prefix}",
-                            "--with-gambit=#{Formula["gambit-scheme"].opt_prefix}/current",
+                            "--with-gambit=#{Formula["gambit-scheme"].opt_prefix}",
                             "--enable-leveldb",
                             "--enable-libxml",
                             "--enable-libyaml",


### PR DESCRIPTION
Also made the following changes:

* Removed `--enable-multiple-versions` as superfluous, since Homebrew already uses version directories. This puts `gambit-scheme`'s binaries in the Homebrew `PATH` as intended (#103692).
* Retain a `current` symlink in `prefix`, because some users may still depend on the previous internal versioning.
* Put the info and Emacs Lisp files in brew audit-approved locations.

Also changed `gerbil-scheme` as follows:

* Revision bump, to clear segfault with rebuilt `gambit-scheme`
* Un-versioned path config to `gambit-scheme`
* Fixed license spec
* Added `pkg-config` as build dependency, due to CI build failure

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
