### PR TITLE
synced_versions_formulae: remove advancemame/advancemenu

### DIFF
--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -1,6 +1,5 @@
 [
   ["aarch64-elf-gcc", "i686-elf-gcc", "x86_64-elf-gcc"],
-  ["advancemame", "advancemenu"],
   ["apache-arrow", "apache-arrow-glib"],
   ["apache-pulsar", "libpulsar"],
   ["avro-c", "avro-cpp", "avro-tools"],


### PR DESCRIPTION
These formulae merged into one in 11897fc5aa7f6b3749b590e63bc9a287288fda46.