### PR TITLE
fastnetmon 1.2.2 (new formula).

### DIFF
--- a/Formula/fastnetmon.rb
+++ b/Formula/fastnetmon.rb
@@ -1,0 +1,83 @@
+class Fastnetmon < Formula
+  desc "DDoS detection tool with sFlow, Netflow, IPFIX and port mirror support"
+  homepage "https://github.com/pavel-odintsov/fastnetmon/"
+  url "https://github.com/pavel-odintsov/fastnetmon/archive/refs/tags/v1.2.2.tar.gz"
+  sha256 "4de0fe9390673f7e2fc8f3f1e3696a1455ea659049430c4870fcf82600c2ea2d"
+  license "GPL-2.0-only"
+
+  depends_on "cmake" => :build
+  depends_on "abseil"
+  depends_on "boost"
+  depends_on "capnp"
+  depends_on "grpc"
+  depends_on "hiredis"
+  depends_on "json-c"
+  depends_on "log4cpp"
+  depends_on macos: :big_sur # We need C++ 20 available for build which is available from Big Sur
+  depends_on "mongo-c-driver"
+  depends_on "openssl@1.1"
+  uses_from_macos "ncurses"
+
+  on_linux do
+    depends_on "gcc"
+    depends_on "libpcap"
+    depends_on "ncurses"
+  end
+
+  fails_with gcc: "5"
+
+  def install
+    system "cmake", "-S", "src", "-B", "build",
+                    "-DENABLE_CUSTOM_BOOST_BUILD=FALSE",
+                    "-DDO_NOT_USE_SYSTEM_LIBRARIES_FOR_BUILD=FALSE",
+                    "-DLINK_WITH_ABSL=TRUE",
+                    "-DSET_ABSOLUTE_INSTALL_PATH=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  service do
+    run [
+      opt_sbin/"fastnetmon",
+      "--configuration_file",
+      etc/"fastnetmon.conf",
+      "--log_to_console",
+      "--disable_pid_logic",
+    ]
+    keep_alive false
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/fastnetmon.log"
+    error_log_path var/"log/fastnetmon.log"
+  end
+
+  test do
+    cp etc/"fastnetmon.conf", testpath
+
+    inreplace testpath/"fastnetmon.conf", "/tmp/fastnetmon.dat", testpath/"fastnetmon.dat"
+
+    inreplace testpath/"fastnetmon.conf", "/tmp/fastnetmon_ipv6.dat", testpath/"fastnetmon_ipv6.dat"
+
+    fastnetmon_pid = fork do
+      exec opt_sbin/"fastnetmon",
+           "--configuration_file",
+           testpath/"fastnetmon.conf",
+           "--log_to_console",
+           "--disable_pid_logic"
+    end
+
+    sleep 15
+
+    assert_path_exists testpath/"fastnetmon.dat"
+
+    ipv4_stats_output = (testpath/"fastnetmon.dat").read
+    assert_match("Incoming traffic", ipv4_stats_output)
+
+    assert_path_exists testpath/"fastnetmon_ipv6.dat"
+
+    ipv6_stats_output = (testpath/"fastnetmon_ipv6.dat").read
+    assert_match("Incoming traffic", ipv6_stats_output)
+  ensure
+    Process.kill "SIGTERM", fastnetmon_pid
+  end
+end

--- a/Formula/fastnetmon.rb
+++ b/Formula/fastnetmon.rb
@@ -21,7 +21,6 @@ class Fastnetmon < Formula
   on_linux do
     depends_on "gcc"
     depends_on "libpcap"
-    depends_on "ncurses"
   end
 
   fails_with gcc: "5"


### PR DESCRIPTION
Hello!

I would like to add our tool FastNetMon to Homebrew. FastNetMon is a DDoS detection tool with sFlow, Netflow, IPFIX and port mirror support.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?