### PR TITLE
vectorscan 5.4.7 (new formula)

### DIFF
--- a/Formula/vectorscan.rb
+++ b/Formula/vectorscan.rb
@@ -34,6 +34,6 @@ class Vectorscan < Formula
       }
     EOS
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lhs", "-o", "test"
-    assert_match "hyperscan v5.4.7 2022-05-05", shell_output("./test")
+    assert_match "hyperscan v#{version}", shell_output("./test")
   end
 end

--- a/Formula/vectorscan.rb
+++ b/Formula/vectorscan.rb
@@ -34,6 +34,6 @@ class Vectorscan < Formula
       }
     EOS
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lhs", "-o", "test"
-    system "./test"
+    assert_match "hyperscan v5.4.7 2022-05-05", shell_output("./test")
   end
 end

--- a/Formula/vectorscan.rb
+++ b/Formula/vectorscan.rb
@@ -1,0 +1,40 @@
+class Vectorscan < Formula
+  desc "High-performance regular expression matching library"
+  homepage "https://github.com/VectorCamp/vectorscan"
+  url "https://github.com/VectorCamp/vectorscan/archive/refs/tags/vectorscan/5.4.7.tar.gz"
+  sha256 "cd70c2a7bf632b5374083a450019703605520c10c5614a4c12011c99ab8435dd"
+  license "BSD-3-Clause"
+
+  depends_on "boost" => :build
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "ragel" => :build
+  depends_on arch: :arm64
+  depends_on "pcre"
+
+  def install
+    cmake_args = std_cmake_args + [
+      "-DBUILD_STATIC_AND_SHARED=ON",
+      "-DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3",
+    ]
+
+    mkdir "build" do
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include <hs/hs.h>
+      int main()
+      {
+        printf("hyperscan v%s", hs_version());
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lhs", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/vectorscan.rb
+++ b/Formula/vectorscan.rb
@@ -15,7 +15,7 @@ class Vectorscan < Formula
   def install
     cmake_args = [
       "-DBUILD_STATIC_AND_SHARED=ON",
-      "-DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3",
+      "-DPYTHON_EXECUTABLE:FILEPATH=python3",
     ]
 
     system "cmake", "-S", ".", "-B", "build", *cmake_args, *std_cmake_args

--- a/Formula/vectorscan.rb
+++ b/Formula/vectorscan.rb
@@ -18,10 +18,9 @@ class Vectorscan < Formula
       "-DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3",
     ]
 
-    mkdir "build" do
-      system "cmake", "..", *cmake_args
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build", *cmake_args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do

--- a/Formula/vectorscan.rb
+++ b/Formula/vectorscan.rb
@@ -7,10 +7,10 @@ class Vectorscan < Formula
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
+  depends_on "pcre" => :build
   depends_on "pkg-config" => :build
   depends_on "ragel" => :build
   depends_on arch: :arm64
-  depends_on "pcre"
 
   def install
     cmake_args = [

--- a/Formula/vectorscan.rb
+++ b/Formula/vectorscan.rb
@@ -9,8 +9,8 @@ class Vectorscan < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "ragel" => :build
+  depends_on arch: :arm64
   depends_on "pcre"
-
 
   def install
     cmake_args = [

--- a/Formula/vectorscan.rb
+++ b/Formula/vectorscan.rb
@@ -11,7 +11,6 @@ class Vectorscan < Formula
   depends_on "ragel" => :build
   depends_on "pcre"
 
-  conflicts_with "hyperscan", because: "vectorscan installs include files and libraries of the same name"
 
   def install
     cmake_args = [

--- a/Formula/vectorscan.rb
+++ b/Formula/vectorscan.rb
@@ -9,8 +9,9 @@ class Vectorscan < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "ragel" => :build
-  depends_on arch: :arm64
   depends_on "pcre"
+
+  conflicts_with "hyperscan", because: "vectorscan installs include files and libraries of the same name"
 
   def install
     cmake_args = [

--- a/Formula/vectorscan.rb
+++ b/Formula/vectorscan.rb
@@ -13,7 +13,7 @@ class Vectorscan < Formula
   depends_on "pcre"
 
   def install
-    cmake_args = std_cmake_args + [
+    cmake_args = [
       "-DBUILD_STATIC_AND_SHARED=ON",
       "-DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3",
     ]


### PR DESCRIPTION
Hyperscan is a regex matching library that achieves high performance by exploiting a CPU's vector instructions.  Since the product is sponsored by Intel it supports only Intel-based instruction sets and cannot, therefore, be compiled on Apple silicon. Arm sponsored an effort to provide multi-arch support but [the eventual PR was rejected](https://github.com/intel/hyperscan/pull/287#issuecomment-746558138).  The original fork became a project in its own right, [Vectorscan](https://github.com/VectorCamp/vectorscan), but since it remained a fork `brew audit` complains to that effect.

Note that vectorscan and hyperscan deliver the same libraries;  however, since the former is arm64 and the latter x86_64, the two should install to different prefixes.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
