### PR TITLE
leapp-cli 0.1.13 (new formula)

### DIFF
--- a/Formula/leapp-cli.rb
+++ b/Formula/leapp-cli.rb
@@ -1,0 +1,36 @@
+require "language/node"
+
+class LeappCli < Formula
+  desc "Cloud credentials manager cli"
+  homepage "https://github.com/noovolari/leapp"
+  url "https://registry.npmjs.org/@noovolari/leapp-cli/-/leapp-cli-0.1.13.tgz"
+  sha256 "944ce4928c2d2dd562890310ea6f2f96d3ace5f1c3b7e8bbc9ef8323403359d8"
+  license "MPL-2.0"
+
+  depends_on "pkg-config" => :build
+  depends_on "python@3.10" => :build
+  depends_on "node"
+
+  on_linux do
+    depends_on "libsecret"
+  end
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  def caveats
+    <<~EOS
+      This formula only installs the command-line utilities by default.
+
+      Install Leapp.app with Homebrew Cask:
+        brew install --cask leapp
+    EOS
+  end
+
+  test do
+    assert_match "Leapp app must be running to use this CLI",
+      shell_output("#{bin}/leapp idp-url create --idpUrl https://example.com 2>&1", 2).strip
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
FORMULA=Formula/leapp-cli.rb
brew install --build-from-source $FORMULA
brew test $FORMULA
brew audit --strict $FORMULA
brew audit --new $FORMULA
```

<hr>

The ci tests were returning

```
npm ERR! gyp sill build/config.gypi
```

Adding `pkg-config` to the build and `libsecret` only to linux builds was enough to get `node-gyp` and `keytar` to compile cross platform!