### PR TITLE
xdot: depend on `graphviz` and use virtualenv

### DIFF
--- a/Formula/xdot.rb
+++ b/Formula/xdot.rb
@@ -1,9 +1,11 @@
 class Xdot < Formula
+  include Language::Python::Virtualenv
+
   desc "Interactive viewer for graphs written in Graphviz's dot language"
   homepage "https://github.com/jrfonseca/xdot.py"
   url "https://files.pythonhosted.org/packages/8b/f5/f5282a470a1c0f16b6600edae18ffdc3715cdd6ac8753205df034650cebe/xdot-1.2.tar.gz"
   sha256 "3df91e6c671869bd2a6b2a8883fa3476dbe2ba763bd2a7646cf848a9eba71b70"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
   head "https://github.com/jrfonseca/xdot.py.git", branch: "master"
 
   bottle do
@@ -17,6 +19,7 @@ class Xdot < Formula
   end
 
   depends_on "adwaita-icon-theme"
+  depends_on "graphviz"
   depends_on "gtk+3"
   depends_on "numpy"
   depends_on "py3cairo"
@@ -24,22 +27,12 @@ class Xdot < Formula
   depends_on "python@3.9"
 
   resource "graphviz" do
-    url "https://files.pythonhosted.org/packages/33/c4/82459071796f59ef218d3c22d43d35aa0fbcf74f9fcce8829672febd7f5e/graphviz-0.15.zip"
-    sha256 "2b85f105024e229ec330fe5067abbe9aa0d7708921a585ecc2bf56000bf5e027"
+    url "https://files.pythonhosted.org/packages/43/ae/a0ee0dbddc06dbecfaece65c45c8c4729c394b5eb62e04e711e6495cdf64/graphviz-0.20.zip"
+    sha256 "76bdfb73f42e72564ffe9c7299482f9d72f8e6cb8d54bce7b48ab323755e9ba5"
   end
 
   def install
-    xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
-    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python#{xy}/site-packages"
-    resource("graphviz").stage do
-      system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec/"vendor")
-    end
-
-    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{xy}/site-packages"
-    system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)
-
-    bin.install Dir[libexec/"bin/*"]
-    bin.env_script_all_files(libexec/"bin", PYTHONPATH: ENV["PYTHONPATH"])
+    virtualenv_install_with_resources
   end
 
   test do
@@ -47,6 +40,6 @@ class Xdot < Formula
     # Gtk couldn't be initialized. Use Gtk.init_check() if you want to handle this case.
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
 
-    system "#{bin}/xdot", "--help"
+    system bin/"xdot", "--help"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

- Depend on `graphviz` since by default it shells out to `dot`(https://github.com/jrfonseca/xdot.py/blob/8f0c96be5b4eac6617820401c363bc6a93b53a81/xdot/ui/window.py#L58 and https://github.com/jrfonseca/xdot.py/blob/8f0c96be5b4eac6617820401c363bc6a93b53a81/xdot/ui/window.py#L110-L117)
- Update the deprecated license (chose `-only` since I don't see "or later" in [LICENSE.txt](https://github.com/jrfonseca/xdot.py/blob/master/LICENSE.txt))
- Use `virtualenv_install_with_resources`
