### PR TITLE
rsync: pass rsync_cv_SIGNED_CHAR_OK=yes to configure to bypass faulty signed char usability check

### DIFF
--- a/Formula/rsync.rb
+++ b/Formula/rsync.rb
@@ -6,6 +6,7 @@ class Rsync < Formula
   mirror "https://www.mirrorservice.org/sites/rsync.samba.org/rsync-3.2.4.tar.gz"
   sha256 "6f761838d08052b0b6579cf7f6737d93e47f01f4da04c5d24d3447b7f2a5fad1"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://rsync.samba.org/ftp/rsync/?C=M&O=D"
@@ -51,6 +52,10 @@ class Rsync < Formula
     # SIMD code throws ICE or is outright unsupported due to lack of support for
     # function multiversioning on older versions of macOS
     args << "--disable-simd" if MacOS.version < :catalina
+
+    # Fixes https://github.com/WayneD/rsync/issues/317
+    # remove with the next release
+    args << "rsync_cv_SIGNED_CHAR_OK=yes" if Hardware::CPU.arm?
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
Fixes https://github.com/WayneD/rsync/issues/317