### PR TITLE
geoip: deprecate

### DIFF
--- a/Formula/geoip.rb
+++ b/Formula/geoip.rb
@@ -17,6 +17,8 @@ class Geoip < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "fb045793a66f36a2737a3bdc3c8513c5822702778c223123dceceff61e847080"
   end
 
+  deprecate! date: "2022-06-19", because: :repo_archived
+
   resource "database" do
     url "https://src.fedoraproject.org/lookaside/pkgs/GeoIP/GeoIP.dat.gz/4bc1e8280fe2db0adc3fe48663b8926e/GeoIP.dat.gz"
     sha256 "7fd7e4829aaaae2677a7975eeecd170134195e5b7e6fc7d30bf3caf34db41bcd"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `geoip`](https://github.com/maxmind/geoip-api-c) has been archived and the `README` states:

> # End of Life
>
> MaxMind will be retiring the GeoIP Legacy databases at the end of May 2022. Until then, this library will only receive critical security and bug fixes. Support for this library will end completely with the last release of the legacy GeoIP databases.
>
> We recommend that you upgrade to our GeoIP2 databases. You can read these from C using [libmaxminddb](https://github.com/maxmind/libmaxminddb).
>
> See [our blog post](https://blog.maxmind.com/2020/06/01/retirement-of-geoip-legacy-downloadable-databases-in-may-2022/) for more information.

This PR deprecates the formula accordingly.