### PR TITLE
libgtop: depend on libxau on macOS

### DIFF
--- a/Formula/libgtop.rb
+++ b/Formula/libgtop.rb
@@ -19,10 +19,7 @@ class Libgtop < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "glib"
-
-  on_linux do
-    depends_on "libxau"
-  end
+  depends_on "libxau"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
