### PR TITLE
clap-host 1.0 (new formula)

### DIFF
--- a/Formula/clap-host.rb
+++ b/Formula/clap-host.rb
@@ -1,7 +1,9 @@
 class ClapHost < Formula
   desc "CLAP example host"
   homepage "https://github.com/free-audio/clap-host"
-  url "https://github.com/free-audio/clap-host", using: :git, tag: "1.0.1", revision: "4602d26b91a526ac80933bdc9f6fcafdf2423bbf"
+  url "https://github.com/free-audio/clap-host", 
+        tag: "1.0.1",
+        revision: "4602d26b91a526ac80933bdc9f6fcafdf2423bbf"
   license "MIT"
   head "https://github.com/free-audio/clap-host", using: :git, branch: "main"
 

--- a/Formula/clap-host.rb
+++ b/Formula/clap-host.rb
@@ -5,7 +5,7 @@ class ClapHost < Formula
         tag: "1.0.1",
         revision: "4602d26b91a526ac80933bdc9f6fcafdf2423bbf"
   license "MIT"
-  head "https://github.com/free-audio/clap-host", using: :git, branch: "main"
+  head "https://github.com/free-audio/clap-host.git", branch: "main"
 
   depends_on "catch2" => :build
   depends_on "cmake" => :build

--- a/Formula/clap-host.rb
+++ b/Formula/clap-host.rb
@@ -1,7 +1,7 @@
 class ClapHost < Formula
   desc "CLAP example host"
   homepage "https://github.com/free-audio/clap-host"
-  url "https://github.com/free-audio/clap-host", 
+  url "https://github.com/free-audio/clap-host.git",
         tag: "1.0.1",
         revision: "4602d26b91a526ac80933bdc9f6fcafdf2423bbf"
   license "MIT"

--- a/Formula/clap-host.rb
+++ b/Formula/clap-host.rb
@@ -1,0 +1,24 @@
+class ClapHost < Formula
+  desc "CLAP example host"
+  homepage "https://github.com/free-audio/clap-host"
+  url "https://github.com/free-audio/clap-host", using: :git, tag: "1.0.1", revision: "4602d26b91a526ac80933bdc9f6fcafdf2423bbf"
+  license "MIT"
+  head "https://github.com/free-audio/clap-host", using: :git, branch: "main"
+
+  depends_on "catch2" => :build
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "qt"
+  depends_on "rtaudio"
+  depends_on "rtmidi"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DCLAP_HOST_BUNDLE=FALSE", *std_cmake_args
+    system "cmake", "--build", "build", "--target", "clap-host"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    system "clap-host", "--help"
+  end
+end

--- a/Formula/clap-host.rb
+++ b/Formula/clap-host.rb
@@ -2,7 +2,7 @@ class ClapHost < Formula
   desc "CLAP example host"
   homepage "https://github.com/free-audio/clap-host"
   url "https://github.com/free-audio/clap-host.git",
-        tag: "1.0.1",
+        tag:      "1.0.1",
         revision: "4602d26b91a526ac80933bdc9f6fcafdf2423bbf"
   license "MIT"
   head "https://github.com/free-audio/clap-host.git", branch: "main"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hi,
clap-host may not have so much stars or watch, but it is part of a bigger project: [clap](https://github.com/free-audio/clap).

Please see the press release:
- https://u-he.com/community/clap/
- https://www.bitwig.com/stories/clap-the-new-audio-plug-in-standard-201/

A lot of developers are getting started with CLAP, and it would be very helpful for them and all the companies listed in the press release to be able to install clap-host using brew.

Regards,
Alex