### PR TITLE
gofish: deprecate

### DIFF
--- a/Formula/gofish.rb
+++ b/Formula/gofish.rb
@@ -1,6 +1,6 @@
 class Gofish < Formula
   desc "Cross-platform systems package manager"
-  homepage "https://gofi.sh"
+  homepage "https://github.com/fishworks/gofish"
   url "https://github.com/fishworks/gofish.git",
       tag:      "v0.15.1",
       revision: "5d14f73963cfc0c226e8b06c0f5c3404d2ec2e77"
@@ -14,6 +14,8 @@ class Gofish < Formula
     sha256 cellar: :any_skip_relocation, catalina:       "f47a1458fcf3225657bfac99adead69fa765ee10b2058fe038085d81c6f1e93d"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "917decf5660f645a7ec7feaac8959f8d1cf3ca6a28cf085fdc6c74544274f83a"
   end
+
+  deprecate! date: "2022-06-21", because: :repo_archived
 
   depends_on "go" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `gofish`](https://github.com/fishworks/gofish) has been archived and the `README` states:

> ## THIS PROJECT IS BEING ARCHIVED
>
> Due to the amount of time and money required to maintain this side project, I am archiving it. Please feel free to [send me an email](mailto:matt.fisher@fishworks.io) if you have any questions or comments.

This PR deprecates the formula accordingly. Besides that, this also updates the homepage to the GitHub repository, as https://gofi.sh doesn't work anymore.