### PR TITLE
jfrog-cli: call 'jf intro' command after CLI installation

### DIFF
--- a/Formula/jfrog-cli.rb
+++ b/Formula/jfrog-cli.rb
@@ -31,6 +31,8 @@ class JfrogCli < Formula
     # Install fish completion
     output = Utils.safe_popen_read(bin/"jf", "completion", "fish")
     (fish_completion/"jf.fish").write output
+
+    system "jf", "-v"
   end
 
   test do

--- a/Formula/jfrog-cli.rb
+++ b/Formula/jfrog-cli.rb
@@ -32,7 +32,7 @@ class JfrogCli < Formula
     output = Utils.safe_popen_read(bin/"jf", "completion", "fish")
     (fish_completion/"jf.fish").write output
 
-    system "jf", "-v"
+    exec "#{bin}/jf intro"
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
The Intro command is a new command that guides the users through the environment setup and configuration right after CLI installation. The command should run automatically after installation.