### PR TITLE
avrdude: drop libelf dependency

### DIFF
--- a/Formula/avrdude.rb
+++ b/Formula/avrdude.rb
@@ -43,10 +43,6 @@ class Avrdude < Formula
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
 
-  on_macos do
-    depends_on "libelf" => :build
-  end
-
   on_linux do
     depends_on "elfutils"
     depends_on "readline"


### PR DESCRIPTION
libelf is deprecated
It looks like elfutils, the newer equivalent, is only needed on Linux

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
