### PR TITLE
chronograf: depend on newer `node` for build

### DIFF
--- a/Formula/chronograf.rb
+++ b/Formula/chronograf.rb
@@ -19,15 +19,17 @@ class Chronograf < Formula
 
   depends_on "go" => :build
   depends_on "go-bindata" => :build
-  # Switch to `node` when chronograf updates dependency node-sass>=6.0.0
-  depends_on "node@14" => :build
+  depends_on "node" => :build
+  depends_on "python@3.10" => :build if MacOS.version >= :monterey
   depends_on "yarn" => :build
   depends_on "influxdb"
   depends_on "kapacitor"
 
   def install
-    Language::Node.setup_npm_environment
+    # Work around older version of gyp-mac-tool: env: python: No such file or directory
+    ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin" if MacOS.version >= :monterey
 
+    Language::Node.setup_npm_environment
     system "make", "dep"
     system "make", ".jssrc"
     system "make", "chronograf"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
