### PR TITLE
xdk 0.4.2 (new formula)

### DIFF
--- a/Formula/xdk.rb
+++ b/Formula/xdk.rb
@@ -1,0 +1,23 @@
+class Xdk < Formula
+  desc "Ecstasy Development Kit (XDK)"
+  homepage "https://github.com/xtclang/xvm/"
+  url "https://github.com/xtclang/xvm/releases/download/v0.4.2/xdk-0.4.2.tar.gz"
+  version "0.4.2"
+  sha256 "b0b5217abf05de986e6211a7c8665b304fa89df1726749e4f1dd7eff1cbbe1fe"
+  license "Apache-2.0"
+
+  depends_on "openjdk"
+
+  def install
+    libexec.mkpath
+    cp_r Dir[buildpath/"*"], libexec
+    osname = OS.linux? ? "linux" : "macos"
+    bin.install_symlink "#{libexec}/bin/#{osname}_launcher" => "xec"
+    bin.install_symlink "#{libexec}/bin/#{osname}_launcher" => "xtc"
+    bin.install_symlink "#{libexec}/bin/#{osname}_launcher" => "xam"
+  end
+
+  test do
+    assert shell_output("xec", 255).include? "Error: Module file required"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Notes:
There was one error reported by audit: "* 21: col 12: Use `assert_match` instead of `assert ...include?`"
Unfortunately, on my environment, assert_match would not work; it always failed. (It may have been because additional text was present due to the way that the test changes the environment temporarily when auditing, but I am not a Ruby or Homebrew expert, so I am only hypothesizing.) Regardless, I modified the assertion so that it would work, even when running the brew test, but unfortunately the audit now flags it.

