### PR TITLE
libhid: deprecate

### DIFF
--- a/Formula/libhid.rb
+++ b/Formula/libhid.rb
@@ -5,11 +5,6 @@ class Libhid < Formula
   sha256 "f6809ab3b9c907cbb05ceba9ee6ca23a705f85fd71588518e14b3a7d9f2550e5"
   license "GPL-2.0"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?libhid[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "b69b1ff4ecd6f24b292da9085e8aa30694f24081c5183bdcb6c95d7f535c55dc"
@@ -24,6 +19,8 @@ class Libhid < Formula
     sha256 cellar: :any,                 yosemite:       "4920ff4278cbc288fc8c84ef9b3137d99010ba047d6f072b9a6eccf07588721a"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "fb334329832a5847225997b9b7bb0f54a0e26c69636f34cd3b1af77475eef922"
   end
+
+  deprecate! date: "2022-06-22", because: :unmaintained
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Last remaining usage is being removed in #104235 

Our download URL is FreeBSD mirror. Lots of links from https://directory.fsf.org/wiki/Libhid are dead and Debian had removed package https://tracker.debian.org/pkg/libhid 
