### PR TITLE
qbe 1.0 (new formula)

### DIFF
--- a/Formula/qbe.rb
+++ b/Formula/qbe.rb
@@ -1,0 +1,16 @@
+class Qbe < Formula
+  desc "Compiler Backend"
+  homepage "https://c9x.me/compile/"
+  url "https://c9x.me/compile/release/qbe-1.0.tar.xz"
+  sha256 "257ef3727c462795f8e599771f18272b772beb854aacab97e0fda70c13745e0c"
+  license "MIT"
+
+  def install
+    system "make", "PREFIX=#{prefix}"
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    system "#{bin}/qbe", "-h"
+  end
+end

--- a/Formula/qbe.rb
+++ b/Formula/qbe.rb
@@ -11,6 +11,22 @@ class Qbe < Formula
   end
 
   test do
-    system "#{bin}/qbe", "-h"
+    (testpath/"main.ssa").write <<~EOS
+      function w $add(w %a, w %b) {        # Define a function add
+      @start
+        %c =w add %a, %b                   # Adds the 2 arguments
+        ret %c                             # Return the result
+      }
+      export function w $main() {          # Main function
+      @start
+        %r =w call $add(w 1, w 1)          # Call add(1, 1)
+        call $printf(l $fmt, ..., w %r)    # Show the result
+        ret 0
+      }
+      data $fmt = { b "One and one make %d!\n", b 0 }
+    EOS
+
+    system "#{bin}/qbe", "-o", "out.s", "main.ssa"
+    assert_predicate testpath/"out.s", :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds a formula for the QBE compiler backend.

https://github.com/Homebrew/homebrew-core/pull/79681 is related. Back then, QBE didn't have a stable release version, which it does now.