### PR TITLE
doggo 0.5.3 (new formula)

### DIFF
--- a/Formula/doggo.rb
+++ b/Formula/doggo.rb
@@ -1,10 +1,9 @@
 class Doggo < Formula
   desc "Command-line DNS Client for Humans"
   homepage "https://doggo.mrkaran.dev/"
-  url "https://github.com/mr-karan/doggo.git",
-      tag:      "v0.5.3",
-      revision: "ea7cb3c6cd0467a7db783fbd30aa8599604a76d8"
-  license "GPL-3.0-or-later"
+  url "https://github.com/mr-karan/doggo/archive/refs/tags/v0.5.3.tar.gz"
+  sha256 "4f8333662fd73c411bf9fb7ce8254d526a777b6491c1d5a49fff0f09b00754c1"
+  license "GPL-3.0"
   head "https://github.com/mr-karan/doggo.git", branch: "main"
 
   depends_on "go" => :build

--- a/Formula/doggo.rb
+++ b/Formula/doggo.rb
@@ -10,10 +10,10 @@ class Doggo < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = [
-      "-s", "-w",
-      "-X", "main.buildVersion=#{version}",
-      "-X", "main.buildDate=2022-06-02"
+    ldflags = %W[
+      -s -w
+      -X main.buildVersion=#{version}
+      -X main.buildDate=#{time.iso8601}
     ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/doggo"

--- a/Formula/doggo.rb
+++ b/Formula/doggo.rb
@@ -25,5 +25,7 @@ class Doggo < Formula
   test do
     answer = shell_output("#{bin}/doggo --short example.com NS @1.1.1.1")
     assert_equal "a.iana-servers.net.\nb.iana-servers.net.\n", answer
+
+    assert_match version.to_s, shell_output("#{bin}/doggo --version")
   end
 end

--- a/Formula/doggo.rb
+++ b/Formula/doggo.rb
@@ -18,7 +18,7 @@ class Doggo < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/doggo"
 
-    zsh_completion.install "completions/doggo.zsh"
+    zsh_completion.install "completions/doggo.zsh" => "_doggo"
     fish_completion.install "completions/doggo.fish"
   end
 

--- a/Formula/doggo.rb
+++ b/Formula/doggo.rb
@@ -1,0 +1,29 @@
+class Doggo < Formula
+  desc "Command-line DNS Client for Humans"
+  homepage "https://doggo.mrkaran.dev/"
+  url "https://github.com/mr-karan/doggo.git",
+      tag:      "v0.5.3",
+      revision: "ea7cb3c6cd0467a7db783fbd30aa8599604a76d8"
+  license "GPL-3.0-or-later"
+  head "https://github.com/mr-karan/doggo.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = [
+      "-s", "-w",
+      "-X", "main.buildVersion=#{version}",
+      "-X", "main.buildDate=2022-06-02"
+    ]
+
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/doggo"
+
+    zsh_completion.install "completions/doggo.zsh"
+    fish_completion.install "completions/doggo.fish"
+  end
+
+  test do
+    answer = shell_output("#{bin}/doggo --short example.com NS @1.1.1.1")
+    assert_equal "a.iana-servers.net.\nb.iana-servers.net.\n", answer
+  end
+end

--- a/Formula/doggo.rb
+++ b/Formula/doggo.rb
@@ -3,7 +3,7 @@ class Doggo < Formula
   homepage "https://doggo.mrkaran.dev/"
   url "https://github.com/mr-karan/doggo/archive/refs/tags/v0.5.3.tar.gz"
   sha256 "4f8333662fd73c411bf9fb7ce8254d526a777b6491c1d5a49fff0f09b00754c1"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/mr-karan/doggo.git", branch: "main"
 
   depends_on "go" => :build


### PR DESCRIPTION
Homebrew Core has a similar tool (DNS CLI) called `dog` written in Rust:

https://github.com/Homebrew/homebrew-core/blob/master/Formula/dog.rb

This is a more feature-rich tool written in Go.

I am not the author, but a user. I like `doggo`. It's nice.