### PR TITLE
pillow: drop python@3.7 support

### DIFF
--- a/Formula/pillow.rb
+++ b/Formula/pillow.rb
@@ -31,10 +31,6 @@ class Pillow < Formula
 
   uses_from_macos "zlib"
 
-  on_macos do
-    depends_on "python@3.7" => [:build, :test] unless Hardware::CPU.arm?
-  end
-
   def pythons
     deps.map(&:to_formula)
         .select { |f| f.name.match?(/python@\d\.\d+/) }


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There has been a postinstall issue for `python@3.7` for `importlib-metadata`, which may be related to `setuptools_scm` changes or something else that recently occurred.

The only remaining non-deprecated usage of `python@3.7` is `pillow` as `gradio` and `ansible@2.8` are deprecated.