### PR TITLE
imgur-screenshot: deprecate

### DIFF
--- a/Formula/imgur-screenshot.rb
+++ b/Formula/imgur-screenshot.rb
@@ -10,6 +10,8 @@ class ImgurScreenshot < Formula
     sha256 cellar: :any_skip_relocation, all: "938fd215acee5d33c41263cd86d05eec350574c671df2eb16adf724f522e30c4"
   end
 
+  deprecate! date: "2022-06-23", because: :repo_archived
+
   depends_on "bash"
   depends_on "jq"
   depends_on "terminal-notifier"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `imgur-screenshot`](https://github.com/jomo/imgur-screenshot) has been archived, so this PR deprecates the formula accordingly.