### PR TITLE
goplus: build with "--build" instead of "--install"

### DIFF
--- a/Formula/goplus.rb
+++ b/Formula/goplus.rb
@@ -19,7 +19,7 @@ class Goplus < Formula
 
   def install
     ENV["GOPROOT_FINAL"] = libexec
-    system "go", "run", "cmd/make.go", "--install"
+    system "go", "run", "cmd/make.go", "--build"
 
     libexec.install Dir["*"] - Dir[".*"]
     bin.install_symlink (libexec/"bin").children


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
