### PR TITLE
Add completion file path

### DIFF
--- a/Formula/zsh-completions.rb
+++ b/Formula/zsh-completions.rb
@@ -21,8 +21,8 @@ class ZshCompletions < Formula
       To activate these completions, add the following to your .zshrc:
 
         if type brew &>/dev/null; then
-          FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
-
+          FPATH="$(brew --prefix)/share/zsh-completions:${FPATH}"
+          FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
           autoload -Uz compinit
           compinit
         fi


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This text is a machine translation.

When I copy and paste the content displayed in `brew info`, tab completion such as "brew" does not work.
The reason is that `$(brew --prefix)/share/zsh/site-functions` is not registered in $FPATH.`site-functions` stores the completion files that come with `_brew` and other packages that will be installed in the future.

Reference Links
 https://docs.brew.sh/Shell-Completion

I think I am not knowledgeable enough on these matters. Please check.



