### PR TITLE
prototool: deprecate

### DIFF
--- a/Formula/prototool.rb
+++ b/Formula/prototool.rb
@@ -16,6 +16,8 @@ class Prototool < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b193cacb23781483394900b2067c93a1abe8cafe846993a86171ed772c9b18ff"
   end
 
+  deprecate! date: "2022-06-26", because: :repo_archived
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `prototool`](https://github.com/uber/prototool) has been archived and the `README` states:

> Update: We recommend checking out [Buf](https://github.com/bufbuild/buf), which is under active development. There are a ton of docs for getting started, including for [migration from Prototool](https://buf.build/docs/migration-prototool).

This PR deprecates the formula accordingly.