### PR TITLE
ijq 0.4.0 (new formula)

### DIFF
--- a/Formula/ijq.rb
+++ b/Formula/ijq.rb
@@ -1,0 +1,44 @@
+class Ijq < Formula
+  desc "Interactive jq"
+  homepage "https://sr.ht/~gpanders/ijq/"
+  url "https://git.sr.ht/~gpanders/ijq",
+      tag:      "v0.4.0",
+      revision: "41aabdc0a6801cc31b6828bd677cb5e7766b7dd1"
+  license "GPL-3.0-or-later"
+  head "https://git.sr.ht/~gpanders/ijq", branch: "master"
+
+  depends_on "go" => :build
+  depends_on "scdoc" => :build
+  depends_on "jq"
+
+  uses_from_macos "expect" => :test
+
+  def install
+    system "make", "prefix=#{prefix}", "install"
+  end
+
+  test do
+    ENV["TERM"] = "xterm"
+
+    (testpath/"filterfile.jq").write '["foo", "bar", "baz"] | sort | add'
+
+    (testpath/"ijq.exp").write <<~EOS
+      #!/usr/bin/expect -f
+      proc succeed {} {
+        puts success
+        exit 0
+      }
+      proc fail {} {
+        puts failure
+        exit 1
+      }
+      set timeout 5
+      spawn ijq -H '' -M -n -f filterfile.jq
+      expect {
+        barbazfoo   succeed
+        timeout     fail
+      }
+    EOS
+    system "expect", "-f", "ijq.exp"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds [ijq](https://git.sr.ht/~gpanders/ijq), an interactive terminal UI for [jq](https://github.com/stedolan/jq).

~At present the test is very crude: just matching the reported version of ijq. This is because [one of the libraries](https://github.com/gdamore/tcell) used by ijq panics when faced with a terminal that is not "cursor addressable". I have an expect script that otherwise works reliably, but I can't find a way of fooling the library in the automated test.~

Edit: Setting the environment variable `TERM` via Ruby worked. I've updated the PR to include a proper test via expect.