### PR TITLE
apollo-ios-cli 1.0.0-alpha.8 (new formula)

### DIFF
--- a/Formula/apollo-ios-cli.rb
+++ b/Formula/apollo-ios-cli.rb
@@ -1,0 +1,27 @@
+class ApolloIosCli < Formula
+  desc "Generate Swift code for your GraphQL client"
+  homepage "https://github.com/apollographql/apollo-ios/tree/release/1.0/CodegenCLI"
+  url "https://github.com/apollographql/apollo-ios/releases/download/1.0.0-alpha.8/apollo-ios-cli_source.tar.gz"
+  sha256 "16b14b6f032f0e2d4b9a2a41fe53bbea1a08f414a66c486346f7788ff61eb43e"
+  license "MIT"
+
+  depends_on xcode: ["13.3", :build, :test]
+
+  uses_from_macos "swift"
+
+  def install
+    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    bin.install ".build/release/apollo-ios-cli"
+  end
+
+  test do
+    assert_match "New configuration output to ./apollo-codegen-config.json.",
+      shell_output("#{bin}/apollo-ios-cli init").strip
+
+    assert_predicate testpath/"apollo-codegen-config.json", :exist?
+    (testpath/"schema.graphqls").write ""
+
+    assert_match "The configuration is valid.",
+      shell_output("#{bin}/apollo-ios-cli validate").strip
+  end
+end


### PR DESCRIPTION
New formula for the command line tool of apollo-ios; a popular open-source GraphQL code generator and client.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

1. `brew audit --new apollo-ios-cli` does not pass - this is because the formula is for an alpha release. I read the guideline on acceptable casks and there is [mention](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version) that formula can be accepted into homebrew-core when there is no stable version yet. [apollo-ios](https://github.com/apollographql/apollo-ios/blob/main/ROADMAP.md) about to move into a Beta release stage, from the current Alphas, and with a stable version following shortly after that.