### PR TITLE
crystal-icr: add `readline` dependency

### DIFF
--- a/Formula/crystal-icr.rb
+++ b/Formula/crystal-icr.rb
@@ -19,6 +19,7 @@ class CrystalIcr < Formula
   depends_on "libevent"
   depends_on "libyaml"
   depends_on "openssl@1.1"
+  depends_on "readline"
 
   def install
     system "make", "install", "PREFIX=#{prefix}"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Existing bottles have indirect linkage to `readline`.

Removing LLVM's hard `python@3.10` dependency, results in missing `readline` dependency in #103879:
```
==>brew linkage --cached --test --strict crystal-icr
==>FAILED
Full linkage --cached --test --strict crystal-icr output
  Undeclared dependencies with linkage:
    readline
```