### PR TITLE
libsignal-protocol-c: deprecate

### DIFF
--- a/Formula/libsignal-protocol-c.rb
+++ b/Formula/libsignal-protocol-c.rb
@@ -3,7 +3,7 @@ class LibsignalProtocolC < Formula
   homepage "https://github.com/signalapp/libsignal-protocol-c"
   url "https://github.com/signalapp/libsignal-protocol-c/archive/v2.3.3.tar.gz"
   sha256 "c22e7690546e24d46210ca92dd808f17c3102e1344cd2f9a370136a96d22319d"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "28c12c6c31a0950b035347de5e67aca8a0057793bf35feb2b4dbe1d342a2682d"
@@ -15,6 +15,8 @@ class LibsignalProtocolC < Formula
     sha256 cellar: :any,                 high_sierra:    "9dc54604cd42340d8e1ab2da73b54fd19d4cfdb87144921bdb6bcf03e2b41993"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3d3f06b8dc3938b4dc6912a65606713000e6ad910c4bfcb4af4e9c0dca899e0c"
   end
+
+  deprecate! date: "2022-06-27", because: :repo_archived
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `libsignal-protocol-c`](https://github.com/signalapp/libsignal-protocol-c/) has been archived, so this PR deprecates the formula accordingly.