### PR TITLE
go: clean up `gobootstrap` declaration

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -23,29 +23,20 @@ class Go < Formula
 
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do
-    on_macos do
-      if Hardware::CPU.arm?
-        url "https://storage.googleapis.com/golang/go1.16.darwin-arm64.tar.gz"
-        version "1.16"
-        sha256 "4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810"
-      else
-        url "https://storage.googleapis.com/golang/go1.16.darwin-amd64.tar.gz"
-        version "1.16"
-        sha256 "6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8"
-      end
-    end
+    checksums = {
+      "darwin-arm64" => "4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810",
+      "darwin-amd64" => "6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8",
+      "linux-arm64"  => "3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098",
+      "linux-amd64"  => "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2",
+    }
 
-    on_linux do
-      if Hardware::CPU.arm?
-        url "https://storage.googleapis.com/golang/go1.16.linux-arm64.tar.gz"
-        version "1.16"
-        sha256 "3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098"
-      else
-        url "https://storage.googleapis.com/golang/go1.16.linux-amd64.tar.gz"
-        version "1.16"
-        sha256 "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2"
-      end
-    end
+    arch = Hardware::CPU.intel? ? :amd64 : Hardware::CPU.arch
+    platform = "#{OS.kernel_name.downcase}-#{arch}"
+    boot_version = "1.16"
+
+    url "https://storage.googleapis.com/golang/go#{boot_version}.#{platform}.tar.gz"
+    version boot_version
+    sha256 checksums[platform]
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There's a lot of repitition here we can avoid, so let's do that. It does
come at the cost of interpolation in the `url` (which we generally
avoid), but I think the clean up is worth it.
