### PR TITLE
ocl-icd 2.3.1 (new formula)

### DIFF
--- a/Formula/ocl-icd.rb
+++ b/Formula/ocl-icd.rb
@@ -1,0 +1,52 @@
+class OclIcd < Formula
+  desc "OpenCL ICD loader"
+  homepage "https://github.com/OCL-dev/ocl-icd/"
+  url "https://github.com/OCL-dev/ocl-icd/archive/refs/tags/v2.3.1.tar.gz"
+  sha256 "a32b67c2d52ffbaf490be9fc18b46428ab807ab11eff7664d7ff75e06cfafd6d"
+  license "BSD-2-Clause"
+  head "https://github.com/OCL-dev/ocl-icd.git", branch: "master"
+
+  keg_only :shadowed_by_macos, "macOS provides OpenCL.framework"
+
+  depends_on "asciidoc" => :build
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "opencl-headers" => [:build, :test]
+  depends_on "xmlto" => :build
+
+  uses_from_macos "libxml2" => :build
+  uses_from_macos "libxslt" => :build
+  uses_from_macos "ruby" => :build
+
+  def install
+    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
+    system "./bootstrap"
+    system "./configure", *std_configure_args,
+                          "--disable-silent-rules",
+                          "--enable-custom-vendordir=#{etc}/OpenCL/vendors"
+    system "make", "install"
+    pkgshare.install "ocl_test.c"
+  end
+
+  def caveats
+    s = "The default vendors directory is #{etc}/OpenCL/vendors\n"
+    on_linux do
+      s += <<~EOS
+        No OpenCL implementation is pre-installed, so all dependents will require either
+        installing a compatible formula or creating an ".icd" file mapping to an externally
+        installed implementation. Any ".icd" files copied or symlinked into
+        `#{etc}/OpenCL/vendors` will automatically be detected by `ocl-icd`.
+        A portable OpenCL implementation is available via the `pocl` formula.
+      EOS
+    end
+    s
+  end
+
+  test do
+    cp pkgshare/"ocl_test.c", testpath
+    system ENV.cc, "ocl_test.c", "-o", "test", "-I#{Formula["opencl-headers"].opt_include}", "-L#{lib}", "-lOpenCL"
+    ENV["OCL_ICD_VENDORS"] = testpath/"vendors"
+    assert_equal "No platforms found!", shell_output("./test").chomp
+  end
+end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Split off from #103141

See other PR for why this we need to use this instead of `opencl-icd-loader`.

Also, this is the option most major Linux distros have picked (https://repology.org/project/ocl-icd/versions) like Debian/Ubuntu, Fedora, Arch, Gentoo, ...