### PR TITLE
openssl@3: fix AVX-512-specific buffer overflow

### DIFF
--- a/Formula/openssl@3.rb
+++ b/Formula/openssl@3.rb
@@ -5,6 +5,7 @@ class OpensslAT3 < Formula
   mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-3.0.4.tar.gz"
   sha256 "2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://www.openssl.org/source/"
@@ -62,6 +63,15 @@ class OpensslAT3 < Formula
       args += (ENV.ldflags || "").split
     end
     args
+  end
+
+  # Fix AVX512-specific heap buffer overflow
+  # See https://github.com/openssl/openssl/pull/18626
+  #
+  # Remove in the next release
+  patch do
+    url "https://github.com/openssl/openssl/commit/71ad6a8da3e39bd4caf5c6c767287ddd9bce8bae.patch?full_index=1"
+    sha256 "ab26fe6240a1d3b9d7214fa3937fe36f22d69acf6a6819903e8ebf2884711f26"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR fixes possible AVX512-specific RCE. 
See:
- https://github.com/openssl/openssl/issues/18625
- https://github.com/openssl/openssl/pull/18626
- https://guidovranken.com/2022/06/27/notes-on-openssl-remote-memory-corruption/

Fix already applied by NixOS: https://github.com/NixOS/nixpkgs/pull/179333