### PR TITLE
swift: update livecheck

### DIFF
--- a/Formula/swift.rb
+++ b/Formula/swift.rb
@@ -8,9 +8,12 @@ class Swift < Formula
   sha256 "39e4e2b7343756e26627b945a384e1b828e38778b34cc5b0f3ecc23f18d22fd6"
   license "Apache-2.0"
 
+  # This uses the `GithubLatest` strategy because a `-RELEASE` tag is often
+  # created several days before the version is officially released.
   livecheck do
-    url "https://www.swift.org/download/"
-    regex(/Releases<.*?>Swift v?(\d+(?:\.\d+)+)</im)
+    url :stable
+    regex(%r{href=["']?[^"' >]*?/tag/swift[._-]v?(\d+(?:\.\d+)+)[^"' >]*?["' >]}i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `swift` checks the first-party download page to identify the swift version from loose text. This is a legacy check that was originally created years ago and doesn't follow current standards.

This PR updates the `livecheck` block to check for the latest release from GitHub, aligning the check with the `stable` source. We have to use the `GithubLatest` strategy here because `-RELEASE` tags are often created several days before the version is released (i.e., surfacing the version when it's tagged would be premature).