### PR TITLE
coq 8.15.2, math-comp 1.15.0

### DIFF
--- a/Formula/coq.rb
+++ b/Formula/coq.rb
@@ -1,8 +1,8 @@
 class Coq < Formula
   desc "Proof assistant for higher-order logic"
   homepage "https://coq.inria.fr/"
-  url "https://github.com/coq/coq/archive/V8.15.0.tar.gz"
-  sha256 "73466e61f229b23b4daffdd964be72bd7a110963b9d84bd4a86bb05c5dc19ef3"
+  url "https://github.com/coq/coq/archive/V8.15.2.tar.gz"
+  sha256 "13a67c0a4559ae22e9765c8fdb88957b16c2b335a2d5f47e4d6d9b4b8b299926"
   license "LGPL-2.1-only"
   head "https://github.com/coq/coq.git", branch: "master"
 
@@ -22,6 +22,7 @@ class Coq < Formula
 
   depends_on "dune" => :build
   depends_on "ocaml-findlib" => :build
+  depends_on "gmp"
   depends_on "ocaml"
   depends_on "ocaml-zarith"
 
@@ -29,9 +30,10 @@ class Coq < Formula
   uses_from_macos "unzip" => :build
 
   def install
+    ENV.prepend_path "OCAMLPATH", Formula["ocaml-zarith"].opt_lib/"ocaml"
     system "./configure", "-prefix", prefix,
                           "-mandir", man,
-                          "-docdir", "#{pkgshare}/latex",
+                          "-docdir", pkgshare/"latex",
                           "-coqide", "no",
                           "-with-doc", "no"
     system "make", "world"
@@ -64,6 +66,6 @@ class Coq < Formula
       intros; lia.
       Qed.
     EOS
-    system("#{bin}/coqc", "#{testpath}/testing.v")
+    system bin/"coqc", testpath/"testing.v"
   end
 end

--- a/Formula/math-comp.rb
+++ b/Formula/math-comp.rb
@@ -1,8 +1,8 @@
 class MathComp < Formula
   desc "Mathematical Components for the Coq proof assistant"
   homepage "https://math-comp.github.io/math-comp/"
-  url "https://github.com/math-comp/math-comp/archive/mathcomp-1.14.0.tar.gz"
-  sha256 "d259cc95a2f8f74c6aa5f3883858c9b79c6e87f769bde9a415115fa4876ebb31"
+  url "https://github.com/math-comp/math-comp/archive/mathcomp-1.15.0.tar.gz"
+  sha256 "33105615c937ae1661e12e9bc00e0dbad143c317a6ab78b1a15e1d28339d2d95"
   license "CECILL-B"
   head "https://github.com/math-comp/math-comp.git", branch: "master"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`gmp` is an indirect dependency (via `ocaml-zarith`) with linkage. Looks like we need to explicitly set `OCAMLPATH` to let the build work find `omcal-zarith`. See [documentation on how Dune finds external libraries](https://dune.readthedocs.io/en/stable/usage.html#finding-external-libraries).