### PR TITLE
git-crypt: add man page

### DIFF
--- a/Formula/git-crypt.rb
+++ b/Formula/git-crypt.rb
@@ -20,10 +20,10 @@ class GitCrypt < Formula
   end
 
   depends_on "openssl@1.1"
+  uses_from_macos "libxslt" => :build
 
   def install
-    system "make"
-    bin.install "git-crypt"
+    system "make", "ENABLE_MAN=yes", "PREFIX=#{prefix}", "install"
   end
 
   test do


### PR DESCRIPTION
Builds and installs the `git-crypt(1)` man page, which isn't provided by the current formula.

`libxslt` was added as a build dependency since `xsltproc` is [required for building the man page](https://github.com/AGWA/git-crypt/blame/08dbdcfed4fb182c0efaacb32a6c46481ced095b/INSTALL.md#L43).

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?