### PR TITLE
alpine: move to new upstream website

### DIFF
--- a/Formula/alpine.rb
+++ b/Formula/alpine.rb
@@ -1,7 +1,8 @@
 class Alpine < Formula
   desc "News and email agent"
-  homepage "https://alpine.x10host.com/alpine/release/"
-  url "https://alpine.x10host.com/alpine/release/src/alpine-2.25.tar.xz"
+  homepage "https://alpineapp.email"
+  url "https://alpineapp.email/alpine/release/src/alpine-2.25.tar.xz"
+  mirror "https://alpineapp.email/alpine/release/src/Old/alpine-2.25.tar.xz"
   sha256 "658a150982f6740bb4128e6dd81188eaa1212ca0bf689b83c2093bb518ecf776"
   license "Apache-2.0"
   revision 1


### PR DESCRIPTION
Proof: https://repo.or.cz/alpine.git/commit/7067668689e75c24830e75bb2972bafca6e253af

Also add mirror for non-latest versions. They get moved into a subdirectory called "Old".

The audit is expected to fail until we update to 2.26.