### PR TITLE
triage: add labels for boost, icu4c, ffmpeg dependents

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -73,6 +73,14 @@ jobs:
               path: Formula/.+
               content: license .*"(GPL|LGPL|AGPL|GFDL)-[0-9].[0-9][+]?".*
 
+            - label: boost
+              path: Formula/.+
+              content: depends_on "boost(@[0-9.]+)?"
+
+            - label: ffmpeg
+              path: Formula/.+
+              content: depends_on "ffmpeg(@[0-9.]+)?"
+
             - label: go
               path: Formula/.+
               content: depends_on "go(@[0-9.]+)?"
@@ -80,6 +88,10 @@ jobs:
             - label: haskell
               path: Formula/.+
               content: depends_on "(ghc|haskell-stack)(@[0-9.]+)?"
+
+            - label: icu4c
+              path: Formula/.+
+              content: depends_on "icu4c(@[0-9.]+)?"
 
             - label: java
               path: Formula/.+


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We often struggle with merging boost and icu4c updates due to merge
conflicts. The same occasionally happens with ffmpeg updates.

Let's make it easier to identify PRs that could potentially cause merge
conflicts with appropriate labels.
