### PR TITLE
ci: Add GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -840,6 +840,9 @@ env:
     zstd
     zydis
 
+permissions:
+  contents: read
+
 jobs:
   autobump:
     if: github.repository == 'Homebrew/homebrew-core'

--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -13,6 +13,9 @@ concurrency:
 env:
   HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
 
+permissions:
+  contents: read
+
 jobs:
   autopublish:
     if: github.repository == 'Homebrew/homebrew-core'

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -29,6 +29,9 @@ env:
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_CHANGE_ARCH_TO_ARM: 1
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -18,6 +18,9 @@ env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
 
+permissions:
+  contents: read
+
 jobs:
   upload:
     runs-on: ${{github.event.inputs.self_hosted == 'true' && 'linux-self-hosted-1' || 'ubuntu-latest'}}

--- a/.github/workflows/recreate-linux-runners.yml
+++ b/.github/workflows/recreate-linux-runners.yml
@@ -10,6 +10,9 @@ concurrency:
   group: recreate-linux-runners
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   recreate:
     if: github.repository == 'Homebrew/homebrew-core'

--- a/.github/workflows/remove-disabled-formulae.yml
+++ b/.github/workflows/remove-disabled-formulae.yml
@@ -12,6 +12,9 @@ concurrency:
   group: remove-disabled-formulae
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   remove-disabled-formulae:
     if: startsWith(github.repository, 'Homebrew/')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,9 @@ concurrency:
   group: "tests-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   tap_syntax:
     if: github.repository == 'Homebrew/homebrew-core'
@@ -40,6 +43,8 @@ jobs:
         id: formulae-detect
 
   setup_tests:
+    permissions:
+      pull-requests: read  
     if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
     needs: tap_syntax

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,6 +6,9 @@ concurrency:
   group: "triage-${{ github.event.number }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows.

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue 

This project is part of the top 100 critical projects as per OpenSSF (https://github.com/ossf/wg-securing-critical-projects), so fixing the token permissions to improve security.

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
