### PR TITLE
yazpp: replace `yaz` cellar path

### DIFF
--- a/Formula/yazpp.rb
+++ b/Formula/yazpp.rb
@@ -4,6 +4,7 @@ class Yazpp < Formula
   url "https://ftp.indexdata.com/pub/yazpp/yazpp-1.8.0.tar.gz"
   sha256 "e6c32c90fa83241e44e506a720aff70460dfbd0a73252324b90b9489eaeb050d"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url "https://ftp.indexdata.com/pub/yazpp/"
@@ -23,9 +24,12 @@ class Yazpp < Formula
   depends_on "yaz"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    ENV.cxx11 if OS.linux? # due to `icu4c` dependency in `libxml2`
+    system "./configure", *std_configure_args
     system "make", "install"
+
+    # Replace `yaz` cellar paths, which break on `yaz` version or revision bumps
+    inreplace bin/"yazpp-config", Formula["yaz"].prefix.realpath, Formula["yaz"].opt_prefix
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixed `yaz` in #104925, but `yazpp` saved copies of `libxml2`/etc paths (probably from `yaz-config` or pkgconfig output), so needs a rebuild.

Also, bottle has a `yaz` cellar path, so update that at same time.