### PR TITLE
fastnetmon, quick-lint-js: revision bump (boost 1.79.0)

### DIFF
--- a/Formula/fastnetmon.rb
+++ b/Formula/fastnetmon.rb
@@ -4,7 +4,7 @@ class Fastnetmon < Formula
   url "https://github.com/pavel-odintsov/fastnetmon/archive/refs/tags/v1.2.2.tar.gz"
   sha256 "4de0fe9390673f7e2fc8f3f1e3696a1455ea659049430c4870fcf82600c2ea2d"
   license "GPL-2.0-only"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "7a8b7501e874d14519610b1248facae6490f5ba81042f082b1766b1272a545c7"

--- a/Formula/quick-lint-js.rb
+++ b/Formula/quick-lint-js.rb
@@ -4,7 +4,7 @@ class QuickLintJs < Formula
   url "https://c.quick-lint-js.com/releases/2.6.0/source/quick-lint-js-2.6.0.tar.gz"
   sha256 "6fd402e1d0743adb9e862532e25b2be09f637d4c45cb964251ac0f52a1eb5d5c"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/quick-lint/quick-lint-js.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Follow up to #101577
```
Error: 4 failed steps!
brew linkage --test fastnetmon
brew test --retry --verbose fastnetmon
brew linkage --test quick-lint-js
brew test --retry --verbose quick-lint-js
```

```
==>brew linkage --test fastnetmon
==>FAILED
Full linkage --test fastnetmon output
  Missing libraries:
    unexpected (libboost_program_options-mt.so.1.78.0)
...
==>brew linkage --test quick-lint-js
==>FAILED
Full linkage --test quick-lint-js output
  Missing libraries:
    unexpected (libboost_container-mt.so.1.78.0)
```