### PR TITLE
versioned_dependencies_conflicts_allowlist: remove `watchman`

### DIFF
--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -20,6 +20,5 @@
   "qca",
   "sqoop",
   "swtpm",
-  "synergy-core",
-  "watchman"
+  "synergy-core"
 ]


### PR DESCRIPTION
I attempted to remove this in #89269 but failed because `watchman`
pulled in `python@3.9` through LLVM. LLVM no longer depends on
`python@3.9`, so I think removing this should now be safe.
