### PR TITLE
lua@5.1: undeprecate

### DIFF
--- a/Formula/lua@5.1.rb
+++ b/Formula/lua@5.1.rb
@@ -21,8 +21,6 @@ class LuaAT51 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4b5ebc378db8f01127fdec3922b58252ede872cd6b70cbbde2adde311f1f699a"
   end
 
-  deprecate! date: "2012-02-17", because: :unsupported
-
   uses_from_macos "unzip"
 
   on_macos do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula still has dependents, so, per our policy, this shouldn't be
deprecated. Leaving this deprecated also leads to users complaining.
See, for example, #105067.

I haven't marked this as closing #105067 since there may still be other things
we can do about `libquvi`.
