### PR TITLE
versioned_dependencies_conflicts_allowlist: remove more formulae

### DIFF
--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -1,8 +1,6 @@
 [
   "apache-arrow-glib",
   "aqbanking",
-  "anime-downloader",
-  "arxiv_latex_cleaner",
   "aws-google-auth",
   "chapel",
   "coin3d",


### PR DESCRIPTION
I think these formulae may no longer have conflicts, but let's see what
CI says.
