### PR TITLE
git-annex: remove gsasl and quvi dependencies

### DIFF
--- a/Formula/git-annex.rb
+++ b/Formula/git-annex.rb
@@ -17,9 +17,7 @@ class GitAnnex < Formula
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
   depends_on "pkg-config" => :build
-  depends_on "gsasl"
   depends_on "libmagic"
-  depends_on "quvi"
 
   def install
     system "cabal", "v2-update"


### PR DESCRIPTION
git-annex has replaced `quvi` with `youtube-dl` (optional dependency which is searched dynamically at runtime, so we don't really need to force it).