### PR TITLE
quvi, libquvi: deprecate

### DIFF
--- a/Formula/libquvi.rb
+++ b/Formula/libquvi.rb
@@ -23,6 +23,8 @@ class Libquvi < Formula
     sha256 x86_64_linux:   "86842f87a749f377843293787a9ce31911d10715e08e783cebe404d8ecd64e21"
   end
 
+  deprecate! date: "2022-07-04", because: :unmaintained
+
   depends_on "pkg-config" => :build
   depends_on "lua@5.1"
 

--- a/Formula/quvi.rb
+++ b/Formula/quvi.rb
@@ -23,6 +23,8 @@ class Quvi < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "bde81ca6c65e967a5f18c0552cbe4823bc393e5e943c24d809f55dbefc6ea59d"
   end
 
+  deprecate! date: "2022-07-04", because: :unmaintained
+
   depends_on "pkg-config" => :build
   depends_on "libquvi"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Last commits were from 2013.

Alternate official GitHub repos were archived; however, repo.or.cz might be main repositories (http://quvi.sourceforge.net/r/dev/source/repos/)

Related to #105069