### PR TITLE
libvirt-glib: add -std=c++11 to test

### DIFF
--- a/Formula/libvirt-glib.rb
+++ b/Formula/libvirt-glib.rb
@@ -33,10 +33,8 @@ class LibvirtGlib < Formula
 
   def install
     system "meson", "setup", "builddir", *std_meson_args, "-Dintrospection=enabled"
-    cd "builddir" do
-      system "meson", "compile"
-      system "meson", "install"
-    end
+    system "meson", "compile", "-C", "builddir"
+    system "meson", "install", "-C", "builddir"
   end
 
   test do
@@ -56,18 +54,18 @@ class LibvirtGlib < Formula
     else
       Formula["libxml2"].opt_include/"libxml2"
     end
-    system ENV.cc, "test.cpp",
-                   "-I#{libxml2}",
-                   "-I#{Formula["glib"].include}/glib-2.0",
-                   "-I#{Formula["glib"].lib}/glib-2.0/include",
-                   "-I#{include}/libvirt-gconfig-1.0",
-                   "-I#{include}/libvirt-glib-1.0",
-                   "-I#{include}/libvirt-gobject-1.0",
-                   "-L#{lib}",
-                   "-lvirt-gconfig-1.0",
-                   "-lvirt-glib-1.0",
-                   "-lvirt-gobject-1.0",
-                   "-o", "test"
+    system ENV.cxx, "-std=c++11", "test.cpp",
+                    "-I#{libxml2}",
+                    "-I#{Formula["glib"].include}/glib-2.0",
+                    "-I#{Formula["glib"].lib}/glib-2.0/include",
+                    "-I#{include}/libvirt-gconfig-1.0",
+                    "-I#{include}/libvirt-glib-1.0",
+                    "-I#{include}/libvirt-gobject-1.0",
+                    "-L#{lib}",
+                    "-lvirt-gconfig-1.0",
+                    "-lvirt-glib-1.0",
+                    "-lvirt-gobject-1.0",
+                    "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Test failure seen in #104974. Need to check if build needs `ENV.cxx11`.

Impacted by adding `icu4c` support to `libxml2`.