### PR TITLE
solang 0.1.12 (new formula)

### DIFF
--- a/Formula/solang.rb
+++ b/Formula/solang.rb
@@ -16,7 +16,7 @@ class Solang < Formula
 
   def install
     resource("llvm").stage do
-      system "cmake", "-S", "llvm-project", "-B", "build",
+      system "cmake", "-S", "llvm", "-B", "build",
                       *std_cmake_args(install_prefix: buildpath/"solana-llvm"),
                       "-DLLVM_ENABLE_ASSERTIONS=ON",
                       "-DLLVM_ENABLE_PROJECTS=lld",

--- a/Formula/solang.rb
+++ b/Formula/solang.rb
@@ -48,8 +48,8 @@ class Solang < Formula
 	        }
         }
     EOS
-    system "#{bin}/solang", "--target", "solana", "flipper.sol"
-    assert File.file?("#{testpath}/flipper.abi")
-    assert File.file?("#{testpath}/bundle.so")
+    system bin/"solang", "--target", "solana", "flipper.sol"
+    assert_predicate testpath/"flipper.abi", :file?
+    assert_predicate testpath/"bundle.so", :file?
   end
 end

--- a/Formula/solang.rb
+++ b/Formula/solang.rb
@@ -6,7 +6,6 @@ class Solang < Formula
   license "Apache-2.0"
 
   depends_on "cmake" => :build
-  depends_on "ninja" => :build
   depends_on "python@3.10" => :build
   depends_on "rust" => :build
 

--- a/Formula/solang.rb
+++ b/Formula/solang.rb
@@ -1,0 +1,48 @@
+class Solang < Formula
+  desc "Solidity Compiler for Solana, Substrate, and ewasm"
+  homepage "https://solang.readthedocs.io/en/latest/"
+  url "https://github.com/hyperledger-labs/solang/archive/refs/tags/v0.1.12.tar.gz"
+  sha256 "ee0cdf17469a3a8db8db5c3e37632d9a51a85000604ff05e77ced3d23f28b393"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  depends_on "python@3.10" => :build
+  depends_on "rust" => :build
+
+  def install
+    system "git", "clone", "--depth", "1", "--branch", "solana-rustc/13.0-2021-08-08", "https://github.com/solana-labs/llvm-project"
+    mkdir "solana-llvm13.0"
+    cd "llvm-project" do
+      system "cmake", "-G", "Ninja", "-DLLVM_ENABLE_ASSERTIONS=On", "-DLLVM_ENABLE_PROJECTS=lld",
+      "-DLLVM_ENABLE_TERMINFO=Off", "-DLLVM_ENABLE_LIBXML2=Off", "-DLLVM_ENABLE_ZLIB=Off",
+      "-DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'", "-DCMAKE_BUILD_TYPE=Release",
+      "-DCMAKE_INSTALL_PREFIX=../solana-llvm13.0", "-B", "build", "llvm"
+      system "cmake", "--build", "build", "--target", "install"
+    end
+    ENV["PATH"]="#{buildpath}/solana-llvm13.0/bin:" + ENV["PATH"]
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    (testpath/"flipper.sol").write <<~EOS
+      contract flipper {
+	      bool private value;
+          constructor(bool initvalue) {
+            value = initvalue;
+          }
+
+	        function flip() public {
+		        value = !value;
+	        }
+
+      	  function get() public view returns (bool) {
+		        return value;
+	        }
+        }
+    EOS
+    system "#{bin}/solang", "--target", "solana", "flipper.sol"
+    assert File.file?("#{testpath}/flipper.abi")
+    assert File.file?("#{testpath}/bundle.so")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR introduces a formula for Solang, an open-source Solidity compiler. Solang is a front-end for LLVM and we statically link it with LLVM libraries.

To build it from source, we need Solana's LLVM fork, whose changes are not on LLVM official repository. To bypass this, we clone the code and compile it.
