### PR TITLE
Use `on_{system}` blocks instead of `if` statements

### DIFF
--- a/Formula/alure.rb
+++ b/Formula/alure.rb
@@ -32,8 +32,8 @@ class Alure < Formula
 
   # Fix missing unistd include
   # Reported by email to author on 2017-08-25
-  if MacOS.version >= :high_sierra
-    patch do
+  patch do
+    on_high_sierra :or_newer do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/eed63e836e/alure/unistd.patch"
       sha256 "7852a7a365f518b12a1afd763a6a80ece88ac7aeea3c9023aa6c1fe46ac5a1ae"
     end

--- a/Formula/bison@2.7.rb
+++ b/Formula/bison@2.7.rb
@@ -23,8 +23,8 @@ class BisonAT27 < Formula
 
   uses_from_macos "m4"
 
-  if MacOS.version >= :high_sierra
-    patch :p0 do
+  patch :p0 do
+    on_high_sierra :or_newer do
       url "https://raw.githubusercontent.com/macports/macports-ports/b76d1e48dac/editors/nano/files/secure_snprintf.patch"
       sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
     end

--- a/Formula/bwa.rb
+++ b/Formula/bwa.rb
@@ -19,9 +19,11 @@ class Bwa < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3d875f0b64143cfb58e44681e47102158b46e0004c408d8fc5f10dc976383a94"
   end
 
-  depends_on "sse2neon" => :build if Hardware::CPU.arm?
-
   uses_from_macos "zlib"
+
+  on_arm do
+    depends_on "sse2neon" => :build
+  end
 
   def install
     # PR ref: https://github.com/lh3/bwa/pull/344

--- a/Formula/ca-certificates.rb
+++ b/Formula/ca-certificates.rb
@@ -71,7 +71,9 @@ class CaCertificates < Formula
         -c #{tmpfile.path}
         -p ssl
       ]
-      verify_args << "-R" << "offline" if MacOS.version >= :high_sierra
+      on_high_sierra :or_newer do
+        verify_args << "-R" << "offline"
+      end
 
       valid_certs.select do |cert|
         tmpfile.rewind

--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -20,10 +20,11 @@ class CabalInstall < Formula
 
   resource "bootstrap" do
     on_macos do
-      if Hardware::CPU.intel?
+      on_intel do
         url "https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-apple-darwin17.7.0.tar.xz"
         sha256 "9197c17d2ece0f934f5b33e323cfcaf486e4681952687bc3d249488ce3cbe0e9"
-      else
+      end
+      on_arm do
         # https://github.com/haskell/cabal/issues/7433#issuecomment-858590474
         url "https://downloads.haskell.org/~ghcup/unofficial-bindists/cabal/3.6.0.0/cabal-install-3.6.0.0-aarch64-darwin-big-sur.tar.xz"
         sha256 "7acf740946d996ede835edf68887e6b2f1e16d1b95e94054d266463f38d136d9"

--- a/Formula/chapel.rb
+++ b/Formula/chapel.rb
@@ -21,14 +21,13 @@ class Chapel < Formula
   # when Python dependency matches LLVM's Python for all OS versions.
   depends_on "python@3.9"
 
-  on_macos do
-    depends_on "llvm" if MacOS.version > :catalina
-    # fatal error: cannot open file './sys_basic.h': No such file or directory
-    # Issue ref: https://github.com/Homebrew/homebrew-core/issues/96915
-    depends_on "llvm@11" if MacOS.version <= :catalina
+  # fatal error: cannot open file './sys_basic.h': No such file or directory
+  # Issue ref: https://github.com/Homebrew/homebrew-core/issues/96915
+  on_catalina :or_older do
+    depends_on "llvm@11"
   end
 
-  on_linux do
+  on_system :linux, macos: :big_sur_or_newer do
     depends_on "llvm"
   end
 

--- a/Formula/chronograf.rb
+++ b/Formula/chronograf.rb
@@ -20,10 +20,13 @@ class Chronograf < Formula
   depends_on "go" => :build
   depends_on "go-bindata" => :build
   depends_on "node" => :build
-  depends_on "python@3.10" => :build if MacOS.version >= :monterey
   depends_on "yarn" => :build
   depends_on "influxdb"
   depends_on "kapacitor"
+
+  on_monterey :or_newer do
+    depends_on "python@3.10" => :build
+  end
 
   def install
     # Work around older version of gyp-mac-tool: env: python: No such file or directory

--- a/Formula/cocoapods.rb
+++ b/Formula/cocoapods.rb
@@ -15,10 +15,12 @@ class Cocoapods < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "ruby" if Hardware::CPU.arm?
-
   uses_from_macos "libffi", since: :catalina
   uses_from_macos "ruby", since: :catalina
+
+  on_arm do
+    depends_on "ruby"
+  end
 
   def install
     if MacOS.version >= :mojave && MacOS::CLT.installed?

--- a/Formula/composer.rb
+++ b/Formula/composer.rb
@@ -23,7 +23,9 @@ class Composer < Formula
 
   # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
   on_macos do
-    pour_bottle? only_if: :default_prefix if Hardware::CPU.intel?
+    on_intel do
+      pour_bottle? only_if: :default_prefix
+    end
   end
 
   def install

--- a/Formula/dar.rb
+++ b/Formula/dar.rb
@@ -19,11 +19,14 @@ class Dar < Formula
     sha256               x86_64_linux:   "c66a42b6b25ceeef4304473a7347ec3a62ac5b0bd2dbd79ba7227d2d69b21d03"
   end
 
-  depends_on "upx" => :build unless Hardware::CPU.arm?
   depends_on "libgcrypt"
   depends_on "lzo"
 
   uses_from_macos "zlib"
+
+  on_intel do
+    depends_on "upx" => :build
+  end
 
   def install
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/dscanner.rb
+++ b/Formula/dscanner.rb
@@ -16,9 +16,11 @@ class Dscanner < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5cf437aaf0802ae3aab2a37476e0506351b1da609c6470acded10962537a639b"
   end
 
-  if Hardware::CPU.arm?
+  on_arm do
     depends_on "ldc" => :build
-  else
+  end
+
+  on_intel do
     depends_on "dmd" => :build
   end
 

--- a/Formula/easyengine.rb
+++ b/Formula/easyengine.rb
@@ -19,7 +19,9 @@ class Easyengine < Formula
 
   # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
   on_macos do
-    pour_bottle? only_if: :default_prefix if Hardware::CPU.intel?
+    on_intel do
+      pour_bottle? only_if: :default_prefix
+    end
   end
 
   def install

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -36,7 +36,9 @@ class Emscripten < Formula
   # OpenJDK is needed as a dependency on Linux and ARM64 for google-closure-compiler,
   # an emscripten dependency, because the native GraalVM image will not work.
   on_macos do
-    depends_on "openjdk" if Hardware::CPU.arm?
+    on_arm do
+      depends_on "openjdk"
+    end
   end
 
   on_linux do

--- a/Formula/etcd-cpp-apiv3.rb
+++ b/Formula/etcd-cpp-apiv3.rb
@@ -85,13 +85,11 @@ class EtcdCppApiv3 < Formula
 
     # prepare etcd
     etcd_pid = fork do
-      on_macos do
-        if Hardware::CPU.arm?
-          # etcd isn't officially supported on arm64
-          # https://github.com/etcd-io/etcd/issues/10318
-          # https://github.com/etcd-io/etcd/issues/10677
-          ENV["ETCD_UNSUPPORTED_ARCH"]="arm64"
-        end
+      if OS.mac? && Hardware::CPU.arm?
+        # etcd isn't officially supported on arm64
+        # https://github.com/etcd-io/etcd/issues/10318
+        # https://github.com/etcd-io/etcd/issues/10677
+        ENV["ETCD_UNSUPPORTED_ARCH"]="arm64"
       end
 
       exec "#{Formula["etcd"].opt_prefix}/bin/etcd",

--- a/Formula/etcd.rb
+++ b/Formula/etcd.rb
@@ -36,13 +36,11 @@ class Etcd < Formula
   test do
     test_string = "Hello from brew test!"
     etcd_pid = fork do
-      on_macos do
-        if Hardware::CPU.arm?
-          # etcd isn't officially supported on arm64
-          # https://github.com/etcd-io/etcd/issues/10318
-          # https://github.com/etcd-io/etcd/issues/10677
-          ENV["ETCD_UNSUPPORTED_ARCH"]="arm64"
-        end
+      if OS.mac? && Hardware::CPU.arm?
+        # etcd isn't officially supported on arm64
+        # https://github.com/etcd-io/etcd/issues/10318
+        # https://github.com/etcd-io/etcd/issues/10677
+        ENV["ETCD_UNSUPPORTED_ARCH"]="arm64"
       end
 
       exec bin/"etcd",

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -44,8 +44,8 @@ class Gcc < Formula
 
   # Branch from the Darwin maintainer of GCC, with a few generic fixes and
   # Apple Silicon support, located at https://github.com/iains/gcc-11-branch
-  if Hardware::CPU.arm?
-    patch do
+  patch do
+    on_arm do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/07e71538/gcc/gcc-11.3.0-arm.diff"
       sha256 "857390a7f32dbfc4c7e6163a3b3b9d5e1d392e5d9c74c3ebb98701c1d0629565"
     end

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -79,8 +79,8 @@ class GccAT49 < Formula
   end
 
   # Fix issues with macOS 10.13 headers and parallel build on APFS
-  if MacOS.version == :high_sierra
-    patch do
+  patch do
+    on_high_sierra do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/b7c7883d/gcc%404.9/high_sierra_2.patch"
       sha256 "c7bcad4657292f6939b7322eb5e821c4a110c4f326fd5844890f0e9a85da8cae"
     end

--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -48,8 +48,8 @@ class GccAT5 < Formula
   # Fix Apple headers, otherwise they trigger a build failure in libsanitizer
   # GCC bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83531
   # Apple radar 36176941
-  if MacOS.version == :high_sierra
-    patch do
+  patch do
+    on_high_sierra do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/413cfac6/gcc%405/10.13_headers.patch"
       sha256 "94aaec20c8c7bfd3c41ef8fb7725bd524b1c0392d11a411742303a3465d18d09"
     end

--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -26,17 +26,24 @@ class Ghc < Formula
 
   depends_on "python@3.9" => :build
   depends_on "sphinx-doc" => :build
-  # GHC 8.10.7 user manual recommend use LLVM 9 through 12
-  # https://downloads.haskell.org/~ghc/8.10.7/docs/html/users_guide/8.10.7-notes.html
-  # and we met some unknown issue w/ LLVM 13 before https://gitlab.haskell.org/ghc/ghc/-/issues/20559
-  # so conservatively use LLVM 12 here
-  depends_on "llvm@12" if Hardware::CPU.arm?
 
   uses_from_macos "m4" => :build
   uses_from_macos "ncurses"
 
-  on_macos do
-    resource "gmp" do
+  on_linux do
+    depends_on "gmp" => :build
+  end
+
+  # GHC 8.10.7 user manual recommend use LLVM 9 through 12
+  # https://downloads.haskell.org/~ghc/8.10.7/docs/html/users_guide/8.10.7-notes.html
+  # and we met some unknown issue w/ LLVM 13 before https://gitlab.haskell.org/ghc/ghc/-/issues/20559
+  # so conservatively use LLVM 12 here
+  on_arm do
+    depends_on "llvm@12"
+  end
+
+  resource "gmp" do
+    on_macos do
       url "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz"
       mirror "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz"
       mirror "https://ftpmirror.gnu.org/gmp/gmp-6.2.1.tar.xz"
@@ -44,19 +51,16 @@ class Ghc < Formula
     end
   end
 
-  on_linux do
-    depends_on "gmp" => :build
-  end
-
   # https://www.haskell.org/ghc/download_ghc_8_10_7.html#macosx_x86_64
   # "This is a distribution for Mac OS X, 10.7 or later."
   # A binary of ghc is needed to bootstrap ghc
   resource "binary" do
     on_macos do
-      if Hardware::CPU.intel?
+      on_intel do
         url "https://downloads.haskell.org/~ghc/8.10.7/ghc-8.10.7-x86_64-apple-darwin.tar.xz"
         sha256 "287db0f9c338c9f53123bfa8731b0996803ee50f6ee847fe388092e5e5132047"
-      else
+      end
+      on_arm do
         url "https://downloads.haskell.org/ghc/8.10.7/ghc-8.10.7-aarch64-apple-darwin.tar.xz"
         sha256 "dc469fc3c35fd2a33a5a575ffce87f13de7b98c2d349a41002e200a56d9bba1c"
       end

--- a/Formula/ghc@9.rb
+++ b/Formula/ghc@9.rb
@@ -27,20 +27,23 @@ class GhcAT9 < Formula
   depends_on "libtool" => :build
   depends_on "python@3.10" => :build
   depends_on "sphinx-doc" => :build
-  depends_on "llvm@12" if Hardware::CPU.arm?
-
   uses_from_macos "m4" => :build
   uses_from_macos "ncurses"
+
+  on_arm do
+    depends_on "llvm@12"
+  end
 
   # https://www.haskell.org/ghc/download_ghc_9_0_2.html#macosx_x86_64
   # "This is a distribution for Mac OS X, 10.7 or later."
   # A binary of ghc is needed to bootstrap ghc
   resource "binary" do
     on_macos do
-      if Hardware::CPU.intel?
+      on_intel do
         url "https://downloads.haskell.org/~ghc/9.0.2/ghc-9.0.2-x86_64-apple-darwin.tar.xz"
         sha256 "e1fe990eb987f5c4b03e0396f9c228a10da71769c8a2bc8fadbc1d3b10a0f53a"
-      else
+      end
+      on_arm do
         url "https://downloads.haskell.org/~ghc/9.0.2/ghc-9.0.2-aarch64-apple-darwin.tar.xz"
         sha256 "b1fcab17fe48326d2ff302d70c12bc4cf4d570dfbbce68ab57c719cfec882b05"
       end

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -30,13 +30,22 @@ class Go < Formula
       "linux-amd64"  => "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2",
     }
 
-    arch = Hardware::CPU.intel? ? :amd64 : Hardware::CPU.arch
-    platform = "#{OS.kernel_name.downcase}-#{arch}"
+    arch = "arm64"
+    platform = "darwin"
+
+    on_intel do
+      arch = "amd64"
+    end
+
+    on_linux do
+      platform = "linux"
+    end
+
     boot_version = "1.16"
 
-    url "https://storage.googleapis.com/golang/go#{boot_version}.#{platform}.tar.gz"
+    url "https://storage.googleapis.com/golang/go#{boot_version}.#{platform}-#{arch}.tar.gz"
     version boot_version
-    sha256 checksums[platform]
+    sha256 checksums["#{platform}-#{arch}"]
   end
 
   def install

--- a/Formula/haskell-language-server.rb
+++ b/Formula/haskell-language-server.rb
@@ -25,13 +25,13 @@ class HaskellLanguageServer < Formula
   depends_on "cabal-install" => [:build, :test]
   depends_on "ghc" => [:build, :test]
 
-  if Hardware::CPU.intel?
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
+  on_intel do
     depends_on "ghc@8.6" => [:build, :test]
     depends_on "ghc@8.8" => [:build, :test]
   end
-
-  uses_from_macos "ncurses"
-  uses_from_macos "zlib"
 
   def ghcs
     deps.map(&:to_formula)

--- a/Formula/haskell-stack.rb
+++ b/Formula/haskell-stack.rb
@@ -25,6 +25,9 @@ class HaskellStack < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
+
+  uses_from_macos "zlib"
+
   # All ghc versions before 9.2.1 requires LLVM Code Generator as a backend on
   # ARM. GHC 8.10.7 user manual recommend use LLVM 9 through 12 and we met some
   # unknown issue with LLVM 13 before so conservatively use LLVM 12 here.
@@ -32,9 +35,9 @@ class HaskellStack < Formula
   # References:
   #   https://downloads.haskell.org/~ghc/8.10.7/docs/html/users_guide/8.10.7-notes.html
   #   https://gitlab.haskell.org/ghc/ghc/-/issues/20559
-  depends_on "llvm@12" if Hardware::CPU.arm?
-
-  uses_from_macos "zlib"
+  on_arm do
+    depends_on "llvm@12"
+  end
 
   def install
     # https://github.com/JustusAdam/mustache/issues/41

--- a/Formula/haste-client.rb
+++ b/Formula/haste-client.rb
@@ -26,15 +26,15 @@ class HasteClient < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f58ba7733cf6b73c7ad7be755d4d31c88af9577a43f9cd4658d8732bdd8bad3b"
   end
 
-  depends_on "ruby" if MacOS.version <= :sierra
+  uses_from_macos "ruby", since: :high_sierra
 
   resource "faraday" do
     url "https://rubygems.org/gems/faraday-0.17.4.gem"
     sha256 "11677b5b261fbbfd4d959f702078d81c0bb66006c00ab2f329f32784778e4d9c"
   end
 
-  if MacOS.version <= :sierra
-    resource "json" do
+  resource "json" do
+    on_system :linux, macos: :sierra_or_older do
       url "https://rubygems.org/gems/json-2.5.1.gem"
       sha256 "918d8c41dacb7cfdbe0c7bbd6014a5372f0cf1c454ca150e9f4010fe80cc3153"
     end

--- a/Formula/help2man.rb
+++ b/Formula/help2man.rb
@@ -15,9 +15,11 @@ class Help2man < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "457df4779894e46898cb3ae03f9b7d2650a0bd42e75ab7cdf4aacbe0e6bb90d6"
   end
 
-  depends_on "gettext" if Hardware::CPU.intel?
-
   uses_from_macos "perl", since: :mojave
+
+  on_intel do
+    depends_on "gettext"
+  end
 
   resource "Locale::gettext" do
     url "https://cpan.metacpan.org/authors/id/P/PV/PVANDRY/gettext-1.07.tar.gz"

--- a/Formula/idutils.rb
+++ b/Formula/idutils.rb
@@ -19,8 +19,8 @@ class Idutils < Formula
 
   conflicts_with "coreutils", because: "both install `gid` and `gid.1`"
 
-  if MacOS.version >= :high_sierra
-    patch :p0 do
+  patch :p0 do
+    on_high_sierra :or_newer do
       url "https://raw.githubusercontent.com/macports/macports-ports/b76d1e48dac/editors/nano/files/secure_snprintf.patch"
       sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
     end

--- a/Formula/imapsync.rb
+++ b/Formula/imapsync.rb
@@ -122,8 +122,8 @@ class Imapsync < Formula
     sha256 "2b7f80da87f5a6fe0360d9ee521051053017442c3a26e85db68dfac9f8307623"
   end
 
-  if MacOS.version <= :catalina
-    resource "Module::Build" do
+  resource "Module::Build" do
+    on_system :linux, macos: :catalina_or_older do
       url "https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-0.4231.tar.gz"
       sha256 "7e0f4c692c1740c1ac84ea14d7ea3d8bc798b2fb26c09877229e04f430b2b717"
     end

--- a/Formula/inetutils.rb
+++ b/Formula/inetutils.rb
@@ -30,7 +30,9 @@ class Inetutils < Formula
   def noshadow
     # List of binaries that do not shadow macOS utils
     list = %w[dnsdomainname rcp rexec rlogin rsh]
-    list += %w[ftp telnet] if MacOS.version >= :high_sierra
+    on_high_sierra :or_newer do
+      list += %w[ftp telnet]
+    end
     list
   end
 

--- a/Formula/inlets.rb
+++ b/Formula/inlets.rb
@@ -71,10 +71,9 @@ class Inlets < Formula
     EOS
 
     mock_upstream_server_pid = fork do
-      on_macos do
+      if OS.mac?
         exec "ruby mock_upstream_server.rb"
-      end
-      on_linux do
+      elsif OS.linux?
         exec "#{Formula["ruby"].opt_bin}/ruby mock_upstream_server.rb"
       end
     end

--- a/Formula/lastpass-cli.rb
+++ b/Formula/lastpass-cli.rb
@@ -23,13 +23,16 @@ class LastpassCli < Formula
   depends_on "cmake" => :build
   depends_on "docbook-xsl" => :build
   depends_on "pkg-config" => :build
-  # Avoid crashes on Mojave's version of libcurl (https://github.com/lastpass/lastpass-cli/issues/427)
-  depends_on "curl" if MacOS.version >= :mojave
   depends_on "openssl@1.1"
   depends_on "pinentry"
 
   uses_from_macos "curl"
   uses_from_macos "libxslt"
+
+  # Avoid crashes on Mojave's version of libcurl (https://github.com/lastpass/lastpass-cli/issues/427)
+  on_mojave :or_newer do
+    depends_on "curl"
+  end
 
   def install
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"

--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -33,10 +33,12 @@ class Ldc < Formula
 
   resource "ldc-bootstrap" do
     on_macos do
-      if Hardware::CPU.intel?
+      on_intel do
         url "https://github.com/ldc-developers/ldc/releases/download/v1.28.1/ldc2-1.28.1-osx-x86_64.tar.xz"
         sha256 "9aa43e84d94378f3865f69b08041331c688e031dd2c5f340eb1f3e30bdea626c"
-      else
+      end
+
+      on_arm do
         url "https://github.com/ldc-developers/ldc/releases/download/v1.28.1/ldc2-1.28.1-osx-arm64.tar.xz"
         sha256 "9bddeb1b2c277019cf116b2572b5ee1819d9f99fe63602c869ebe42ffb813aed"
       end

--- a/Formula/librealsense.rb
+++ b/Formula/librealsense.rb
@@ -22,12 +22,14 @@ class Librealsense < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  # Build on Apple Silicon fails when generating Unix Makefiles.
-  # Ref: https://github.com/IntelRealSense/librealsense/issues/8090
-  depends_on xcode: :build if Hardware::CPU.arm?
   depends_on "glfw"
   depends_on "libusb"
   depends_on "openssl@1.1"
+  # Build on Apple Silicon fails when generating Unix Makefiles.
+  # Ref: https://github.com/IntelRealSense/librealsense/issues/8090
+  on_arm do
+    depends_on xcode: :build
+  end
 
   def install
     ENV["OPENSSL_ROOT_DIR"] = Formula["openssl@1.1"].prefix

--- a/Formula/licensefinder.rb
+++ b/Formula/licensefinder.rb
@@ -15,7 +15,9 @@ class Licensefinder < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8fad2104fa2186844235e5628d8afe03f34b08e7b9c62631399dde2b3947b493"
   end
 
-  depends_on "ruby@2.7" if MacOS.version <= :mojave
+  on_system :linux, macos: :mojave_or_older do
+    depends_on "ruby@2.7"
+  end
 
   def install
     ENV["GEM_HOME"] = libexec

--- a/Formula/llvm@8.rb
+++ b/Formula/llvm@8.rb
@@ -22,7 +22,6 @@ class LlvmAT8 < Formula
 
   # https://llvm.org/docs/GettingStarted.html#requirement
   depends_on "cmake" => :build
-  depends_on xcode: :build if MacOS.version < :mojave
   depends_on arch: :x86_64
   depends_on "python@3.8"
   depends_on "swig"
@@ -32,6 +31,10 @@ class LlvmAT8 < Formula
   uses_from_macos "libxml2"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
+
+  on_high_sierra :or_older do
+    depends_on xcode: :build
+  end
 
   on_linux do
     depends_on "glibc" if Formula["glibc"].any_version_installed?
@@ -44,7 +47,7 @@ class LlvmAT8 < Formula
     sha256 "70effd69f7a8ab249f66b0a68aba8b08af52aa2ab710dfb8a0fba102685b1646"
 
     # Fix include paths on Big Sur
-    if MacOS.version >= :big_sur
+    on_big_sur :or_newer do
       # Refactor header search path logic into driver
       # https://github.com/llvm/llvm-project/commit/e97b5f5cf37e382643b567affd714823215d0e75
       patch :p2 do

--- a/Formula/lolcat.rb
+++ b/Formula/lolcat.rb
@@ -16,7 +16,7 @@ class Lolcat < Formula
     sha256 cellar: :any_skip_relocation, all:           "2413429a0ccae2c204b12dc59fbc9cd780947f6f4d5af51e8b6d9ecb6de5772d"
   end
 
-  depends_on "ruby" if MacOS.version <= :sierra
+  uses_from_macos "ruby", since: :high_sierra
 
   def install
     ENV["GEM_HOME"] = libexec

--- a/Formula/lrzip.rb
+++ b/Formula/lrzip.rb
@@ -23,13 +23,16 @@ class Lrzip < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "nasm" => :build if Hardware::CPU.intel?
   depends_on "pkg-config" => :build
   depends_on "lz4"
   depends_on "lzo"
 
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
+
+  on_intel do
+    depends_on "nasm" => :build
+  end
 
   def install
     # Attempting to build the ASM/x86 folder as a compilation unit fails (even on Intel). Removing this compilation

--- a/Formula/lsyncd.rb
+++ b/Formula/lsyncd.rb
@@ -69,10 +69,10 @@ class Lsyncd < Formula
       "12.3"    => ["xnu-8020.101.4.tar.gz",      "df715e7b2bd5db0ba212b5b0613fbbc85c3cbc4e61f6ee355a8b6cf9a87d3374"],
     }
 
-    macos_version = if MacOS.version >= :big_sur
-      MacOS.full_version.major_minor # Ignore bugfix/security updates
-    else
-      MacOS.full_version
+    macos_version = MacOS.full_version.major_minor # Ignore bugfix/security updates
+
+    on_catalina :or_older do
+      macos_version = MacOS.full_version
     end
     tarball, checksum = if xnu_headers.key? macos_version
       xnu_headers.fetch(macos_version)

--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -16,9 +16,10 @@ class Mas < Formula
   end
 
   depends_on :macos
-  if Hardware::CPU.arm?
+  on_arm do
     depends_on xcode: ["12.2", :build]
-  else
+  end
+  on_intel do
     depends_on xcode: ["12.0", :build]
   end
 

--- a/Formula/md5deep.rb
+++ b/Formula/md5deep.rb
@@ -22,11 +22,13 @@ class Md5deep < Formula
 
   # Fix compilation error due to very old GNU config scripts in source repo
   # reported upstream at https://github.com/jessek/hashdeep/issues/400
-  patch :DATA if Hardware::CPU.arm?
+  on_arm do
+    patch :DATA
+  end
 
   # Fix compilation error due to pointer comparison
-  if MacOS.version >= :sierra
-    patch do
+  patch do
+    on_sierra :or_newer do
       url "https://github.com/jessek/hashdeep/commit/8776134.patch?full_index=1"
       sha256 "3d4e3114aee5505d1336158b76652587fd6f76e1d3af784912277a1f93518c64"
     end

--- a/Formula/mit-scheme.rb
+++ b/Formula/mit-scheme.rb
@@ -31,10 +31,11 @@ class MitScheme < Formula
   uses_from_macos "ncurses"
 
   resource "bootstrap" do
-    if Hardware::CPU.intel?
+    on_intel do
       url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/11.2/mit-scheme-11.2-x86-64.tar.gz"
       sha256 "7ca848cccf29f2058ab489b41c5b3a101fb5c73dc129b1e366fb009f3414029d"
-    else
+    end
+    on_arm do
       url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/11.2/mit-scheme-11.2-aarch64le.tar.gz"
       sha256 "49679bcf76c8b5896fda8998239c4dff0721708de4162dcbc21c88d9688faa86"
     end

--- a/Formula/mkcue.rb
+++ b/Formula/mkcue.rb
@@ -33,10 +33,9 @@ class Mkcue < Formula
     system "#{bin}/mkcue", "test" unless ENV["HOMEBREW_GITHUB_ACTIONS"]
 
     if ENV["HOMEBREW_GITHUB_ACTIONS"]
-      on_macos do
+      if OS.mac?
         system "#{bin}/mkcue", "test"
-      end
-      on_linux do
+      elsif OS.linux?
         assert_match "Cannot read table of contents", shell_output("#{bin}/mkcue test 2>&1", 2)
       end
     end

--- a/Formula/net-snmp.rb
+++ b/Formula/net-snmp.rb
@@ -22,13 +22,13 @@ class NetSnmp < Formula
 
   keg_only :provided_by_macos
 
-  if Hardware::CPU.arm?
+  depends_on "openssl@1.1"
+
+  on_arm do
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
-
-  depends_on "openssl@1.1"
 
   # Fix -flat_namespace being used on x86_64 Big Sur and later.
   patch do

--- a/Formula/ocp.rb
+++ b/Formula/ocp.rb
@@ -31,14 +31,16 @@ class Ocp < Formula
   depends_on "libvorbis"
   depends_on "mad"
 
-  if MacOS.version < :catalina
-    depends_on "sdl"
-  else
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
+  on_catalina :or_newer do
     depends_on "sdl2"
   end
 
-  uses_from_macos "ncurses"
-  uses_from_macos "zlib"
+  on_system :linux, macos: :mojave_or_older do
+    depends_on "sdl"
+  end
 
   on_linux do
     depends_on "util-linux" => :build # for `hexdump`

--- a/Formula/openj9.rb
+++ b/Formula/openj9.rb
@@ -27,11 +27,9 @@ class Openj9 < Formula
   depends_on "autoconf" => :build
   depends_on "bash" => :build
   depends_on "cmake" => :build
-  depends_on "nasm" => :build if Hardware::CPU.intel?
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on arch: :x86_64 # https://github.com/eclipse-openj9/openj9/issues/11164
-
   depends_on "fontconfig"
   depends_on "giflib"
   depends_on "harfbuzz"
@@ -56,6 +54,10 @@ class Openj9 < Formula
     depends_on "libxt"
     depends_on "libxtst"
     depends_on "numactl"
+  end
+
+  on_intel do
+    depends_on "nasm" => :build
   end
 
   # From https://github.com/eclipse-openj9/openj9/blob/openj9-#{version}/doc/build-instructions/

--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -48,10 +48,11 @@ class Openjdk < Formula
   # From https://jdk.java.net/archive/
   resource "boot-jdk" do
     on_macos do
-      if Hardware::CPU.arm?
+      on_arm do
         url "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_macos-aarch64_bin.tar.gz"
         sha256 "602d7de72526368bb3f80d95c4427696ea639d2e0cc40455f53ff0bbb18c27c8"
-      else
+      end
+      on_intel do
         url "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_macos-x64_bin.tar.gz"
         sha256 "b85c4aaf7b141825ad3a0ea34b965e45c15d5963677e9b27235aa05f65c6df06"
       end

--- a/Formula/openjdk@11.rb
+++ b/Formula/openjdk@11.rb
@@ -43,10 +43,11 @@ class OpenjdkAT11 < Formula
 
   resource "boot-jdk" do
     on_macos do
-      if Hardware::CPU.arm?
+      on_arm do
         url "https://cdn.azul.com/zulu/bin/zulu11.54.25-ca-jdk11.0.14.1-macosx_aarch64.tar.gz"
         sha256 "2076f8ce51c0e9ad7354e94b79513513b1697aa222f9503121d800c368b620a3"
-      else
+      end
+      on_intel do
         url "https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_osx-x64_bin.tar.gz"
         sha256 "77ea7675ee29b85aa7df138014790f91047bfdafbc997cb41a1030a0417356d7"
       end

--- a/Formula/openjdk@17.rb
+++ b/Formula/openjdk@17.rb
@@ -47,10 +47,11 @@ class OpenjdkAT17 < Formula
   # From https://jdk.java.net/archive/
   resource "boot-jdk" do
     on_macos do
-      if Hardware::CPU.arm?
+      on_arm do
         url "https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_macos-aarch64_bin.tar.gz"
         sha256 "602d7de72526368bb3f80d95c4427696ea639d2e0cc40455f53ff0bbb18c27c8"
-      else
+      end
+      on_intel do
         url "https://download.java.net/java/GA/jdk16.0.2/d4a915d82b4c4fbb9bde534da945d746/7/GPL/openjdk-16.0.2_osx-x64_bin.tar.gz"
         sha256 "e65f2437585f16a01fa8e10139d0d855e8a74396a1dfb0163294ed17edd704b8"
       end

--- a/Formula/openjdk@8.rb
+++ b/Formula/openjdk@8.rb
@@ -16,9 +16,12 @@ class OpenjdkAT8 < Formula
   keg_only :versioned_formula
 
   depends_on "autoconf" => :build
-  depends_on "gawk" => :build if MacOS.version > :big_sur
   depends_on "pkg-config" => :build
   depends_on "freetype"
+
+  on_monterey :or_newer do
+    depends_on "gawk" => :build
+  end
 
   on_linux do
     depends_on "alsa-lib"

--- a/Formula/pce.rb
+++ b/Formula/pce.rb
@@ -18,9 +18,12 @@ class Pce < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b219c1e06cdb370c7865c4e2a39eb50df89889585a7b77320acfb758bbe13696"
   end
 
-  depends_on "nasm" => :build if MacOS.version >= :high_sierra
   depends_on "readline"
   depends_on "sdl"
+
+  on_high_sierra :or_newer do
+    depends_on "nasm" => :build
+  end
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/phpbrew.rb
+++ b/Formula/phpbrew.rb
@@ -19,7 +19,9 @@ class Phpbrew < Formula
 
   # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
   on_macos do
-    pour_bottle? only_if: :default_prefix if Hardware::CPU.intel?
+    on_intel do
+      pour_bottle? only_if: :default_prefix
+    end
   end
 
   def install

--- a/Formula/phpstan.rb
+++ b/Formula/phpstan.rb
@@ -18,7 +18,9 @@ class Phpstan < Formula
 
   # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
   on_macos do
-    pour_bottle? only_if: :default_prefix if Hardware::CPU.intel?
+    on_intel do
+      pour_bottle? only_if: :default_prefix
+    end
   end
 
   def install

--- a/Formula/pickle.rb
+++ b/Formula/pickle.rb
@@ -18,7 +18,9 @@ class Pickle < Formula
 
   # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
   on_macos do
-    pour_bottle? only_if: :default_prefix if Hardware::CPU.intel?
+    on_intel do
+      pour_bottle? only_if: :default_prefix
+    end
   end
 
   def install

--- a/Formula/pig.rb
+++ b/Formula/pig.rb
@@ -16,9 +16,10 @@ class Pig < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "12c02619e8fbfee0603e8d11ffa0facfed80717df4eae3f4176a9fe5b33a4076"
   end
 
-  if Hardware::CPU.arm?
+  on_arm do
     depends_on "openjdk@11"
-  else
+  end
+  on_intel do
     depends_on "openjdk"
   end
 

--- a/Formula/psalm.rb
+++ b/Formula/psalm.rb
@@ -19,7 +19,9 @@ class Psalm < Formula
 
   # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
   on_macos do
-    pour_bottle? only_if: :default_prefix if Hardware::CPU.intel?
+    on_intel do
+      pour_bottle? only_if: :default_prefix
+    end
   end
 
   def install

--- a/Formula/pyoxidizer.rb
+++ b/Formula/pyoxidizer.rb
@@ -23,7 +23,9 @@ class Pyoxidizer < Formula
   depends_on "rust" => :build
   # Currently needs macOS 11 SDK due to checking for DeploymentTargetSettingName
   # Remove when issue is fixed: https://github.com/indygreg/PyOxidizer/issues/431
-  depends_on xcode: "12.2" if MacOS.version <= :catalina
+  on_catalina :or_older do
+    depends_on xcode: "12.2"
+  end
 
   def install
     system "cargo", "install", *std_cargo_args(path: "pyoxidizer")

--- a/Formula/qt@5.rb
+++ b/Formula/qt@5.rb
@@ -134,8 +134,8 @@ class QtAT5 < Formula
 
   # Patch for qmake on ARM
   # https://codereview.qt-project.org/c/qt/qtbase/+/327649
-  if Hardware::CPU.arm?
-    patch do
+  patch do
+    on_arm do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/9dc732/qt/qt-split-arch.patch"
       sha256 "36915fde68093af9a147d76f88a4e205b789eec38c0c6f422c21ae1e576d45c0"
       directory "qtbase"

--- a/Formula/reposurgeon.rb
+++ b/Formula/reposurgeon.rb
@@ -16,11 +16,14 @@ class Reposurgeon < Formula
   end
 
   depends_on "asciidoctor" => :build
-  depends_on "gawk" => :build if MacOS.version <= :catalina
   depends_on "go" => :build
   depends_on "git" # requires >= 2.19.2
 
   uses_from_macos "ruby"
+
+  on_system :linux, macos: :catalina_or_older do
+    depends_on "gawk" => :build
+  end
 
   def install
     ENV.append_path "GEM_PATH", Formula["asciidoctor"].opt_libexec

--- a/Formula/rpm.rb
+++ b/Formula/rpm.rb
@@ -47,8 +47,8 @@ class Rpm < Formula
   # Fix `fstat64` detection for Apple Silicon.
   # https://github.com/rpm-software-management/rpm/pull/1775
   # https://github.com/rpm-software-management/rpm/pull/1897
-  if Hardware::CPU.arm?
-    patch do
+  patch do
+    on_arm do
       url "https://github.com/rpm-software-management/rpm/commit/ad87ced3990c7e14b6b593fa411505e99412e248.patch?full_index=1"
       sha256 "a129345c6ba026b337fe647763874bedfcaf853e1994cf65b1b761bc2c7531ad"
     end

--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -45,10 +45,11 @@ class Rust < Formula
   resource "cargobootstrap" do
     on_macos do
       # From https://github.com/rust-lang/rust/blob/#{version}/src/stage0.json
-      if Hardware::CPU.arm?
+      on_arm do
         url "https://static.rust-lang.org/dist/2022-05-19/cargo-1.61.0-aarch64-apple-darwin.tar.gz"
         sha256 "8099a35548e1ae4773dbbcbe797301c500ec10236435fde0073f52b4937be6c3"
-      else
+      end
+      on_intel do
         url "https://static.rust-lang.org/dist/2022-05-19/cargo-1.61.0-x86_64-apple-darwin.tar.gz"
         sha256 "f2b10ef8c56f37014d2f3e4c36d5e666e3be368d24c597e99cf2e4b21dc40455"
       end

--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -21,7 +21,7 @@ class Sdl < Formula
     end
 
     # Fix mouse cursor transparency on 10.13, https://bugzilla.libsdl.org/show_bug.cgi?id=4076
-    if MacOS.version == :high_sierra
+    on_high_sierra do
       patch do
         url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=3721"
         sha256 "954875a277d9246bcc444b4e067e75c29b7d3f3d2ace5318a6aab7d7a502f740"
@@ -29,7 +29,7 @@ class Sdl < Formula
     end
 
     # Fix display issues on 10.14+, https://bugzilla.libsdl.org/show_bug.cgi?id=4788
-    if MacOS.version >= :mojave
+    on_mojave :or_newer do
       patch do
         url "https://bugzilla-attachments.libsdl.org/attachment.cgi?id=4288"
         sha256 "5a89ddce5deaf72348792d33e12b5f66d0dab4f9747718bb5021d3067bdab283"
@@ -38,7 +38,7 @@ class Sdl < Formula
 
     # Fix audio initialization issues on Big Sur, upstream patch
     # https://github.com/libsdl-org/SDL-1.2/commit/a2047dc403ffb58b89b717929637352045699743
-    if MacOS.version >= :big_sur
+    on_big_sur :or_newer do
       patch do
         url "https://github.com/libsdl-org/SDL-1.2/commit/a2047dc403ffb58b89b717929637352045699743.patch?full_index=1"
         sha256 "7684a923dfd0c13f1a78e09ca0cea2632850e4d41023867b504707946ec495d4"

--- a/Formula/snort.rb
+++ b/Formula/snort.rb
@@ -22,8 +22,6 @@ class Snort < Formula
   depends_on "daq"
   depends_on "gperftools" # for tcmalloc
   depends_on "hwloc"
-  # Hyperscan improves IPS performance, but is only available for x86_64 arch.
-  depends_on "hyperscan" if Hardware::CPU.intel?
   depends_on "libdnet"
   depends_on "libpcap" # macOS version segfaults
   depends_on "luajit-openresty"
@@ -36,6 +34,11 @@ class Snort < Formula
   on_linux do
     depends_on "libunwind"
     depends_on "gcc"
+  end
+
+  # Hyperscan improves IPS performance, but is only available for x86_64 arch.
+  on_intel do
+    depends_on "hyperscan"
   end
 
   fails_with gcc: "5"

--- a/Formula/swift.rb
+++ b/Formula/swift.rb
@@ -456,7 +456,7 @@ class Swift < Formula
 
     # Test Swift Package Manager
     mkdir "swiftpmtest" do
-      on_macos do
+      if OS.mac?
         # Swift Package Manager does not currently support using SDKROOT.
         ENV.remove_macosxsdk
       end

--- a/Formula/swiftgen.rb
+++ b/Formula/swiftgen.rb
@@ -13,9 +13,10 @@ class Swiftgen < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "d23540aaccbe68f26fc50260a29904afa1e84f97c678e76d4c842927215e91e9"
   end
 
-  depends_on "ruby" => :build if MacOS.version <= :sierra
   depends_on xcode: ["13.0", :build]
   depends_on :macos
+
+  uses_from_macos "ruby" => :build, since: :high_sierra
 
   resource("testdata") do
     url "https://github.com/SwiftGen/SwiftGen/archive/6.5.1.tar.gz"

--- a/Formula/texinfo.rb
+++ b/Formula/texinfo.rb
@@ -16,12 +16,14 @@ class Texinfo < Formula
     sha256 x86_64_linux:   "9addf0b22ab845a8071f0d3dc742c65de4fde1a06a7f41df5cccb2e1c9f6afe2"
   end
 
-  depends_on "gettext" if MacOS.version <= :high_sierra
-
   keg_only :provided_by_macos
 
   uses_from_macos "ncurses"
   uses_from_macos "perl"
+
+  on_system :linux, macos: :high_sierra_or_older do
+    depends_on "gettext"
+  end
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/tmux.rb
+++ b/Formula/tmux.rb
@@ -37,7 +37,9 @@ class Tmux < Formula
 
   # Old versions of macOS libc disagree with utf8proc character widths.
   # https://github.com/tmux/tmux/issues/2223
-  depends_on "utf8proc" if MacOS.version >= :high_sierra
+  on_high_sierra :or_newer do
+    depends_on "utf8proc"
+  end
 
   resource "completion" do
     url "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/f5d53239f7658f8e8fbaf02535cc369009c436d6/completions/tmux"

--- a/Formula/trafshow.rb
+++ b/Formula/trafshow.rb
@@ -38,8 +38,8 @@ class Trafshow < Formula
   end
 
   # libpcap on 10.12 has pcap_lib_version() instead of pcap_version
-  if MacOS.version >= :sierra
-    patch :p0 do
+  patch :p0 do
+    on_sierra :or_newer do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/7ad7c77/trafshow/patch-pcap-version-sierra.diff"
       sha256 "03213c8b8b46241ecef8f427cdbec9b09f5fdc35b9d67672ad4b370a1186aed5"
     end

--- a/Formula/volk.rb
+++ b/Formula/volk.rb
@@ -19,12 +19,15 @@ class Volk < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "cpu_features" if Hardware::CPU.intel?
   depends_on "orc"
   depends_on "python@3.9"
 
   on_linux do
     depends_on "gcc"
+  end
+
+  on_intel do
+    depends_on "cpu_features"
   end
 
   fails_with gcc: "5" # https://github.com/gnuradio/volk/issues/375

--- a/Formula/wp-cli.rb
+++ b/Formula/wp-cli.rb
@@ -23,7 +23,9 @@ class WpCli < Formula
 
   # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
   on_macos do
-    pour_bottle? only_if: :default_prefix if Hardware::CPU.intel?
+    on_intel do
+      pour_bottle? only_if: :default_prefix
+    end
   end
 
   def install

--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -52,7 +52,7 @@ class X264 < Formula
 
   depends_on "nasm" => :build
 
-  if MacOS.version <= :high_sierra
+  on_system :linux, macos: :high_sierra_or_older do
     # Stack realignment requires newer Clang
     # https://code.videolan.org/videolan/x264/-/commit/b5bc5d69c580429ff716bafcd43655e855c31b02
     depends_on "gcc"

--- a/Formula/x265.rb
+++ b/Formula/x265.rb
@@ -18,7 +18,10 @@ class X265 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "nasm" => :build if Hardware::CPU.intel?
+
+  on_intel do
+    depends_on "nasm" => :build
+  end
 
   def install
     # Build based off the script at ./build/linux/multilib.sh


### PR DESCRIPTION
This PR changes all formulae to use `on_{system}` blocks instead of `if` statements for differentiating macOS and Linux, ARM and Intel, and macOS versions. It also changes instances of `on_{system}` blocks back into `if` statements within `test` and `install` blocks/methods (this was supposed to happen before but there was something wrong with the style check, I believe).

See https://github.com/Homebrew/brew/pull/13451 for more information about `on_{system}` blocks, and see https://github.com/Homebrew/brew/pull/13503 and https://github.com/Homebrew/brew/pull/13493 for more information about the specific RuboCop changes that accompany this.

Most formulae in this PR were changed using only `brew style --fix homebrew/core` (with https://github.com/Homebrew/brew/pull/13493 checked out). I did have to manually update some formulae (listed below and in their commit description) because the style checks weren't enough (and it wasn't worth making the autocorrector more complicated for these situations).

The formulae that were updated manually are as follows. Most of them were simple changes because the autocorrector deleted a comment or something small like that. There are a few weirder cases which I've documented.

- [`chapel`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-0c9742fd008239155d7d6c8acb7ba65f603920010e388b6fe5c80e32e631d91b)
- [`dar`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-5464dccf3f0b2b95fb468be69e9f4f8c587c297bf7ede6a2321cf9816e12bbfc) (it used an `unless` instead of an `if`)
- [`gcc`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-dfa1423326b0276262edc6c5001ce9221a06007cbaec2f1ae73b1f60b2efdce2)
- [`gcc@4.9`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-1c770b57070b6ec7c5743018f25ba6d52597beda37b310d30acd572dc099e076)
- [`gcc@5`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-f1a5b55e4f76dfc3531985e3e96a2e9ee4265091dd583cac8cf42219c82f3244)
- [`ghc`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-394b5bab1587332757eec97a117afab443919fd7617e180bb08a4aa6f049594f)
- [`go`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-2b4628657de5dd65ff1afe2817f23c4deb13e2ba587b1fe8a7605479c5e0c660) (this is a weird case because of the way the variables are used)
- [`haskell-stack`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-7262ae90068953c6fc17eb4ec7deac3a69c7edf2ed4e32edc4ce2e4dc00d73df)
- [`haste-client`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-67cf2f9902a726dbc57fe1d085275467c34085307dd89ddebd8e931db61404a5) (resources needed to be re-ordered)
- [`lastpass-cli`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-6ea4214c3fb91a1221cdb52302274b635896b209f8381261d08956c25b4fb7ce)
- [`llvm@8`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-9bb4f93f7405915ef559ccc49479d3e750d66d2a25fe6008df86d04e2489a445)
- [`lrzip`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-1f89affe51e49ebe3722cad4e2cb28673ac82ff2bf23f7896f42c456da2cd022) (not sure what went wrong tbh but the autocorrector didn't do the right thing)
- [`lsyncd`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-01dd8a4bcf9736d6af87f821628bf7ccb6caf10c435d1341b38b6039fbc2bf0f) (this is a weird case because there's a variable and inline-comment involved)
- [`ocp`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-402a7c00cbbb5d64ac413b2cf53c9b3e528860e461c54f3cefcdb9f7b0315b10)
- [`openj9`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-e9c8d8c73415156f3b979d5d328a092d3bd27240e36e580eea11a627f03feac4)
- [`openjdk@8`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-4b9a693eb6dafdec69980da6d115096691500b5d5af09dfe2c26ea0e63910586) (used `MacOS.version >` instead of `<`... `brew style` will pick this up but won't autocorrect)
- [`qt@5`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-bba851c8a71e26f2969ad46028a9abcd0b1dd552f18c42ccb922c112bf065099) (it has a weird case in the `caveats` block)
- [`reposurgeon`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-c025b6b5190f9526c55bee802649fdf490b668a2e95729a6d8cd252da299b84f)
- [`snort`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-f292c1096579c3c530aa4016ed8e8e752b5df3b69c263cdca3bdee3629199c5d)
- [`volk`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-5cdcfcc418cf0f6c8357ae49f001032c11285fa5c3415d4672b5475af8947247)
- [`x264`](https://github.com/Homebrew/homebrew-core/pull/105149/files#diff-318a52baff36863f732059e8e4a104569f55e712ce6fa7bbf5b1a347cbf2f7ed)