### PR TITLE
rbspy: support rust 1.62

### DIFF
--- a/Formula/rbspy.rb
+++ b/Formula/rbspy.rb
@@ -16,6 +16,12 @@ class Rbspy < Formula
 
   depends_on "rust" => :build
 
+  # Support rust 1.62+, remove after next release
+  patch do
+    url "https://github.com/rbspy/rbspy/commit/f5a8eecfbf2ad0b3ff9105115988478fb760d54d.patch?full_index=1"
+    sha256 "17a1c7d6d0eea2bbeb811f1bbe18534249553b61bedb69710b28a5ed9d4f9e2e"
+  end
+
   def install
     system "cargo", "install", *std_cargo_args
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

The latest `rbspy` release contains [code generated by `rust-bindgen 0.59.2`](https://github.com/rbspy/rbspy/blob/v0.12.1/ruby-structs/src/ruby_3_1_2.rs#L1),
which causes a compiler error in rust 1.62+ (as seen in #104819):

```
error: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
      --> ruby-structs/src/ruby_3_1_2.rs:8741:10
       |
  8741 | #[derive(Debug)]
       |          ^^^^^
       |
       = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
```

This was fixed in `rust-bindgen 0.60.0` with https://github.com/rust-lang/rust-bindgen/pull/2200 and regenerated in `rbspy` with https://github.com/rbspy/rbspy/commit/f5a8eecfbf2ad0b3ff9105115988478fb760d54d
