### PR TITLE
zig: depends_on llvm@13

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -4,6 +4,7 @@ class Zig < Formula
   url "https://ziglang.org/download/0.9.1/zig-0.9.1.tar.xz"
   sha256 "38cf4e84481f5facc766ba72783e7462e08d6d29a5d47e3b75c8ee3142485210"
   license "MIT"
+  revision 1
   head "https://github.com/ziglang/zig.git", branch: "master"
 
   bottle do

--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -4,7 +4,7 @@ class Zig < Formula
   url "https://ziglang.org/download/0.9.1/zig-0.9.1.tar.xz"
   sha256 "38cf4e84481f5facc766ba72783e7462e08d6d29a5d47e3b75c8ee3142485210"
   license "MIT"
-  head "https://github.com/ziglang/zig.git"
+  head "https://github.com/ziglang/zig.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "61d958015313e75d98c407902e6aba1b4f359e392eda0c090199eec76d20534a"
@@ -16,7 +16,7 @@ class Zig < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "llvm"
+  depends_on "llvm@13"
 
   fails_with gcc: "5" # LLVM is built with GCC
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- llvm 14 support is ongoing, https://github.com/ziglang/zig/pull/12001

head build failure log
```
-- Configuring zig version 0.10.0-dev.2855+aab1284e1
CMake Error at cmake/Findllvm.cmake:101 (message):
  expected LLVM 13.x but found 14.0.6 using
  /opt/homebrew/opt/llvm/bin/llvm-config
Call Stack (most recent call first):
  CMakeLists.txt:107 (find_package)
```