### PR TITLE
libxml2: don't require icu4c headers when using libxml2 headers

### DIFF
--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -2,7 +2,7 @@ class Libxml2 < Formula
   desc "GNOME XML library"
   homepage "http://xmlsoft.org/"
   license "MIT"
-  revision 2
+  revision 3
 
   stable do
     url "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.14.tar.xz"
@@ -12,6 +12,13 @@ class Libxml2 < Formula
     patch do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
       sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+
+    # Don't require ICU headers when using libxml2's public headers.
+    # Remove with 2.10 or later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/a248d94d777c70f440d07032956a13c8158b7f0a/libxml2/2.9-icu-headers.diff"
+      sha256 "4b139cf66913fbeb60e9beef8872060c7a533d974b5a46ec81b85234a75a1430"
     end
   end
 
@@ -42,6 +49,7 @@ class Libxml2 < Formula
 
   keg_only :provided_by_macos
 
+  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.9" => [:build, :test]
   depends_on "pkg-config" => :test
   depends_on "icu4c"
@@ -69,18 +77,27 @@ class Libxml2 < Formula
                           "--without-lzma"
     system "make", "install"
 
-    # Homebrew-specific workaround to add include path for `icu4c` because
-    # it is in a different directory than `libxml2`.
-    inreplace [bin/"xml2-config", lib/"pkgconfig/libxml-2.0.pc"],
-              "-I${includedir}/libxml2 ",
-              "-I${includedir}/libxml2 -I#{Formula["icu4c"].opt_include}"
-
     cd "python" do
-      sdk_include = OS.mac? ? MacOS.sdk_path_if_needed/"usr/include" : HOMEBREW_PREFIX/"include"
+      sdk_include = if OS.mac?
+        sdk = MacOS.sdk_path_if_needed
+        sdk/"usr/include" if sdk
+      else
+        HOMEBREW_PREFIX/"include"
+      end
+
+      includes = [include, sdk_include].compact.map do |inc|
+        "'#{inc}',"
+      end.join(" ")
+
       # We need to insert our include dir first
       inreplace "setup.py", "includes_dir = [",
-                            "includes_dir = ['#{include}', '#{sdk_include}',"
+                            "includes_dir = [#{includes}"
+
       system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
+
+      site_packages_310 = Language::Python.site_packages(Formula["python@3.10"].opt_bin/"python3")
+      system Formula["python@3.10"].opt_bin/"python3", *Language::Python.setup_install_args(prefix),
+                                                       "--install-lib=#{prefix/site_packages_310}"
     end
   end
 
@@ -111,8 +128,11 @@ class Libxml2 < Formula
     system ENV.cc, *args
     system "./test"
 
-    xy = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
-    ENV.prepend_path "PYTHONPATH", lib/"python#{xy}/site-packages"
-    system Formula["python@3.9"].opt_bin/"python3", "-c", "import libxml2"
+    orig_pypath = ENV["PYTHONPATH"]
+    ["3.9", "3.10"].each do |xy|
+      ENV.prepend_path "PYTHONPATH", lib/"python#{xy}/site-packages"
+      system Formula["python@#{xy}"].opt_bin/"python3", "-c", "import libxml2"
+      ENV["PYTHONPATH"] = orig_pypath
+    end
   end
 end


### PR DESCRIPTION
Also fix #105110 by checking if `MacOS.sdk_path_if_needed` is nil and not adding the SDK include path if so.