### PR TITLE
cmus ffmpeg ffmpeg@4 mpv vice: depends on `alsa-lib` on Linux

### DIFF
--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -26,6 +26,10 @@ class Cmus < Formula
   depends_on "mp4v2"
   depends_on "opusfile"
 
+  on_linux do
+    depends_on "alsa-lib"
+  end
+
   fails_with gcc: "5" # ffmpeg is compiled with GCC
 
   def install

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -64,8 +64,9 @@ class Ffmpeg < Formula
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "libxv"
+    depends_on "alsa-lib"
     depends_on "gcc" # because rubberband is compiled with gcc
+    depends_on "libxv"
   end
 
   fails_with gcc: "5"

--- a/Formula/ffmpeg@4.rb
+++ b/Formula/ffmpeg@4.rb
@@ -65,8 +65,9 @@ class FfmpegAT4 < Formula
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "libxv"
+    depends_on "alsa-lib"
     depends_on "gcc" # because rubberband is compiled with gcc
+    depends_on "libxv"
   end
 
   fails_with gcc: "5"

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -32,6 +32,10 @@ class Mpv < Formula
   depends_on "vapoursynth"
   depends_on "yt-dlp"
 
+  on_linux do
+    depends_on "alsa-lib"
+  end
+
   fails_with gcc: "5" # ffmpeg is compiled with GCC
 
   def install

--- a/Formula/vice.rb
+++ b/Formula/vice.rb
@@ -43,6 +43,10 @@ class Vice < Formula
 
   uses_from_macos "flex" => :build
 
+  on_linux do
+    depends_on "alsa-lib"
+  end
+
   def install
     configure_flags = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Missing `alsa-lib` linkage from #105339 when removing `openjdk` dependency