### PR TITLE
licensor 2.1.0 (new formula)

### DIFF
--- a/Formula/licensor.rb
+++ b/Formula/licensor.rb
@@ -1,0 +1,21 @@
+class Licensor < Formula
+  desc "Write licenses to stdout"
+  homepage "https://github.com/raftario/licensor"
+  url "https://github.com/raftario/licensor/archive/refs/tags/v2.1.0.tar.gz"
+  sha256 "d061ce9fd26d58b0c6ababa7acdaf35222a4407f0b5ea9c4b78f6835527611fd"
+  license "MIT"
+  head "https://github.com/raftario/licensor.git", branch: "master"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/licensor --version")
+
+    assert_match "MIT License", shell_output("#{bin}/licensor MIT")
+    assert_match "Bobby Tables", shell_output("#{bin}/licensor MIT 'Bobby Tables'")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

[`licensor` is a tool to write licenses to stdout](https://github.com/raftario/licensor)

This formula was originally proposed in #44462, but it did not meet the notability requirements for Homebrew. It has now reached a high enough notability to be added.