### PR TITLE
stdman: make bottles uniform

### DIFF
--- a/Formula/stdman.rb
+++ b/Formula/stdman.rb
@@ -20,6 +20,14 @@ class Stdman < Formula
     depends_on "man-db" => :test
   end
 
+  # Preserve timestamps when doing `make install`.
+  # This helps ensure uniform bottles across builds.
+  # https://github.com/jeaye/stdman/pull/49
+  patch do
+    url "https://github.com/jeaye/stdman/commit/862e5132c18275661c468083baeab42dc4c335f2.patch?full_index=1"
+    sha256 "8b2c785fc859e31fcb8c58884eff64c371bb9afd001979ad1158517c77ea1041"
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula ships only a bunch of manpages, so there's no reason for
there to not be an `:all` bottle.

~~Diffoscope chokes at comparing the bottles, but it seems to me that the~~
~~differing checksums come from the different timestamps produced when the~~
~~manpages are `gzip`ed by `make install`.~~

~~Let's try to fix that by adjusting their timestamps into something~~
~~uniform.~~
