### PR TITLE
netpbm: fix subversion dependency

### DIFF
--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -24,6 +24,7 @@ class Netpbm < Formula
     sha256 x86_64_linux:   "9ab2fffdc4eebc47be06d97c5eb5849d55df9ce27a22d7de445d48a0061ef77c"
   end
 
+  depends_on "subversion" => :build
   depends_on "jasper"
   depends_on "jpeg"
   depends_on "libpng"


### PR DESCRIPTION
Subversion is not installed by default. This means formula depending on netpbm are likely to fail.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
