### PR TITLE
fonttools: install `Brotli` package

### DIFF
--- a/Formula/fonttools.rb
+++ b/Formula/fonttools.rb
@@ -6,6 +6,7 @@ class Fonttools < Formula
   url "https://files.pythonhosted.org/packages/5a/a4/a97cff4c4af6764a04cc202299e5205b2e101cb1543bcaf9737be29f78ab/fonttools-4.34.4.zip"
   sha256 "9a1c52488045cd6c6491fd07711a380f932466e317cb8e016fc4e99dc7eac2f0"
   license "MIT"
+  revision 1
   head "https://github.com/fonttools/fonttools.git", branch: "main"
 
   bottle do
@@ -19,6 +20,11 @@ class Fonttools < Formula
 
   depends_on "python@3.10"
 
+  resource "Brotli" do
+    url "https://files.pythonhosted.org/packages/2a/18/70c32fe9357f3eea18598b23aa9ed29b1711c3001835f7cf99a9818985d0/Brotli-1.0.9.zip"
+    sha256 "4d1b810aa0ed773f81dceda2cc7b403d01057458730e309856356d4ef4188438"
+  end
+
   def install
     virtualenv_install_with_resources
   end
@@ -27,6 +33,7 @@ class Fonttools < Formula
     if OS.mac?
       cp "/System/Library/Fonts/ZapfDingbats.ttf", testpath
       system bin/"ttx", "ZapfDingbats.ttf"
+      system bin/"fonttools", "ttLib.woff2", "compress", "ZapfDingbats.ttf"
     else
       assert_match "usage", shell_output("#{bin}/ttx -h")
     end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`fonttools` requires `Brotli` package in order to handle WOFF2 fonts.