### PR TITLE
gcutil: deprecate in favor of `gcloud compute`

### DIFF
--- a/Formula/gcutil.rb
+++ b/Formula/gcutil.rb
@@ -3,6 +3,7 @@ class Gcutil < Formula
   homepage "https://cloud.google.com/sdk/gcloud/reference/compute"
   url "https://dl.google.com/dl/cloudsdk/release/artifacts/gcutil-1.16.1.zip"
   sha256 "31f438c9ce3471f1404340e3411239b28b63f117d17776271fee1e1a352f3877"
+  license "Apache-2.0"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "e5de2c3ea2450af30d6797f821b9ccb3c3da8c47f3086f1c2ccb063e91e9c68c"

--- a/Formula/gcutil.rb
+++ b/Formula/gcutil.rb
@@ -1,12 +1,16 @@
 class Gcutil < Formula
   desc "Manage your Google Compute Engine resources"
-  homepage "https://cloud.google.com/compute/docs/gcutil/"
+  homepage "https://cloud.google.com/sdk/gcloud/reference/compute"
   url "https://dl.google.com/dl/cloudsdk/release/artifacts/gcutil-1.16.1.zip"
   sha256 "31f438c9ce3471f1404340e3411239b28b63f117d17776271fee1e1a352f3877"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "e5de2c3ea2450af30d6797f821b9ccb3c3da8c47f3086f1c2ccb063e91e9c68c"
   end
+
+  # deprecate in favor of gcloud compute
+  # ref, https://cloud.google.com/compute/docs/gcloud-compute/transition-gcloud-gcutil
+  deprecate! date: "2022-07-09", because: :unmaintained
 
   def install
     libexec.install "gcutil", "lib"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

gcutil should be deprecated in favor of `gcloud compute`