### PR TITLE
appstream-glib: fix remove unneeded dependency

### DIFF
--- a/Formula/appstream-glib.rb
+++ b/Formula/appstream-glib.rb
@@ -27,7 +27,10 @@ class AppstreamGlib < Formula
   depends_on "json-glib"
   depends_on "libarchive"
   depends_on "libsoup@2"
-  depends_on "util-linux"
+
+  on_linux do
+    depends_on "util-linux"
+  end
 
   # see https://github.com/hughsie/appstream-glib/issues/258
   patch :DATA


### PR DESCRIPTION
Note: uuid is not included on Macosx

https://github.com/hughsie/appstream-glib/blob/master/meson.build#L67-L75

Additionally, `util-linux` conflicts with MacOS so not having it is a benefit.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
