### PR TITLE
xdg-ninja: fix dependent formula on macos.

### DIFF
--- a/Formula/xdg-ninja.rb
+++ b/Formula/xdg-ninja.rb
@@ -13,6 +13,10 @@ class XdgNinja < Formula
   depends_on "glow"
   depends_on "jq"
 
+  on_macos do
+    depends_on "coreutils"
+  end
+
   def install
     pkgshare.install "programs/"
     pkgshare.install "xdg-ninja.sh" => "xdg-ninja"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

xdg-ninja executes `realpath` command by the following step.

* ref. https://github.com/b3nj5m1n/xdg-ninja/blob/v0.2.0.1/xdg-ninja.sh#L209

But macOS does not provide `realpath` command by default.