### PR TITLE
moz-git-tools: fix license and use tarball

### DIFF
--- a/Formula/moz-git-tools.rb
+++ b/Formula/moz-git-tools.rb
@@ -1,10 +1,9 @@
 class MozGitTools < Formula
   desc "Tools for working with Git at Mozilla"
   homepage "https://github.com/mozilla/moz-git-tools"
-  url "https://github.com/mozilla/moz-git-tools.git",
-      tag:      "v0.1",
-      revision: "cfe890e6f81745c8b093b20a3dc22d28f9fc0032"
-  license "GPL-2.0"
+  url "https://github.com/mozilla/moz-git-tools/archive/refs/tags/v0.1.tar.gz"
+  sha256 "defb5c369ff94f72d272692282404044fa21aa616487bcb4d26e51635c3bc188"
+  license all_of: ["GPL-2.0-only", "CC0-1.0"]
   head "https://github.com/mozilla/moz-git-tools.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
The licensing situation is clarified in https://github.com/mozilla/moz-git-tools/blob/master/LICENSE. I'd be open to publishing `git-new-workdir` in a separate formula (or removing from this formula) for licensing purposes since it is the only GPL'd piece in the repo.

I'd also like to see if we can build a platform-agnostic bottle here but will need to go through CI bottles to see what differs. The existing bottles seem to have some differing fields in the bottle JSON file.