### PR TITLE
zig: depends on llvm@14

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -17,7 +17,7 @@ class Zig < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "llvm@13"
+  depends_on "llvm@14"
 
   fails_with gcc: "5" # LLVM is built with GCC
 


### PR DESCRIPTION
Zig now depends on llvm@14.

LLVM14 changes were merged yesterday: https://github.com/ziglang/zig/pull/12001

<img width="962" alt="image" src="https://user-images.githubusercontent.com/11695209/178269419-e3a11043-05de-40a6-bd03-ef133ff7aca3.png">
