### PR TITLE
libstrophe: update license and remove unused dep

### DIFF
--- a/Formula/libstrophe.rb
+++ b/Formula/libstrophe.rb
@@ -3,7 +3,7 @@ class Libstrophe < Formula
   homepage "https://strophe.im/libstrophe/"
   url "https://github.com/strophe/libstrophe/archive/0.12.1.tar.gz"
   sha256 "91fc40a89528a32b0bda975d84f8f567b57e687898e22e328b3733c2ae0393d8"
-  license any_of: ["GPL-3.0", "MIT"]
+  license all_of: ["GPL-3.0-only", "MIT"]
   head "https://github.com/strophe/libstrophe.git", branch: "master"
 
   bottle do
@@ -19,7 +19,6 @@ class Libstrophe < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "check"
   depends_on "openssl@1.1"
 
   uses_from_macos "expat"


### PR DESCRIPTION
See
https://github.com/Homebrew/homebrew-core/pull/105102#pullrequestreview-1029027205.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
