### PR TITLE
vulkan-loader 1.3.220 (new formula)

### DIFF
--- a/Formula/molten-vk.rb
+++ b/Formula/molten-vk.rb
@@ -4,6 +4,7 @@ class MoltenVk < Formula
   url "https://github.com/KhronosGroup/MoltenVK/archive/v1.1.10.tar.gz"
   sha256 "fac11c2501195c9ce042103685c7778e35484562e6c084963a22072dd0a602e0"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_monterey: "63331fa43116526b4c08c082fee1caf55ca667eaf74b5392d22f84838b750c47"
@@ -143,6 +144,9 @@ class MoltenVk < Formula
     include.install Dir["Package/Release/MoltenVKShaderConverter/include/" \
                         "MoltenVKShaderConverter"]
 
+    inreplace "MoltenVK/icd/MoltenVK_icd.json",
+              "./libMoltenVK.dylib",
+              (lib/"libMoltenVK.dylib").relative_path_from(share/"vulkan/icd.d")
     (share/"vulkan").install "MoltenVK/icd" => "icd.d"
   end
 

--- a/Formula/vulkan-loader.rb
+++ b/Formula/vulkan-loader.rb
@@ -1,0 +1,45 @@
+class VulkanLoader < Formula
+  desc "Vulkan ICD Loader"
+  homepage "https://github.com/KhronosGroup/Vulkan-Loader"
+  url "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v1.3.220.tar.gz"
+  sha256 "fe5b65e5d88febb1220ae59de363ed8b2794f8c861d6d74efb14aecefd464559"
+  license "Apache-2.0"
+  head "https://github.com/KhronosGroup/Vulkan-Loader.git", branch: "master"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "python@3.10" => :build
+  depends_on "vulkan-headers"
+
+  on_linux do
+    depends_on "libx11"
+    depends_on "libxcb"
+    depends_on "libxrandr" => :build
+    depends_on "wayland"
+  end
+
+  def install
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DVULKAN_HEADERS_INSTALL_DIR=#{Formula["vulkan-headers"].opt_prefix}",
+                    "-DFALLBACK_DATA_DIRS=#{HOMEBREW_PREFIX}/share:/usr/local/share:/usr/share",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    inreplace lib/"pkgconfig/vulkan.pc", /^Cflags: .*/, "Cflags: -I#{Formula["vulkan-headers"].opt_include}"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <vulkan/vulkan_core.h>
+      int main() {
+        uint32_t version;
+        vkEnumerateInstanceVersion(&version);
+        return (version >= VK_API_VERSION_1_1) ? 0 : 1;
+      }
+    EOS
+    system ENV.cc, "-o", "test", "test.c", "-I#{Formula["vulkan-headers"].opt_include}",
+                   "-L#{lib}", "-lvulkan"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Replaces #39527.

Also includes a fix to the `molten-vk` formula to make it compatible with the loader.