### PR TITLE
qsv: build with apply feature

### DIFF
--- a/Formula/qsv.rb
+++ b/Formula/qsv.rb
@@ -18,7 +18,7 @@ class Qsv < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", *std_cargo_args, "--features", "full"
+    system "cargo", "install", *std_cargo_args, "--features", "apply,full"
   end
 
   test do

--- a/Formula/qsv.rb
+++ b/Formula/qsv.rb
@@ -18,7 +18,8 @@ class Qsv < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", *std_cargo_args, "--features", "full"
+#    system "cargo", "install", *std_cargo_args, "--features", "full,","apply"
+    system "cargo", "install", *std_cargo_args, "--features", "apply,full"
   end
 
   test do

--- a/Formula/qsv.rb
+++ b/Formula/qsv.rb
@@ -18,7 +18,6 @@ class Qsv < Formula
   depends_on "rust" => :build
 
   def install
-#    system "cargo", "install", *std_cargo_args, "--features", "full,","apply"
     system "cargo", "install", *std_cargo_args, "--features", "apply,full"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
The build in this formula results in a very hobbled version of qsv. Almost all of the cookbook tutorials on the qsv repo include `apply`, and for anyone installing qsv from brew and going to the qsv site to try out the tutorials will get errors because the brew version does not include apply. Building with the `apply` feature admittedly doubles the install size, but it is worth it for the functionality included. Otherwise, there's no real point in installing qsv as it is in this formula.

The best solution would be to rebuild the bottles with `apply`, but until then, including `apply` in the build-from-source option is better.