### PR TITLE
help2man: fix build pre mojave

### DIFF
--- a/Formula/help2man.rb
+++ b/Formula/help2man.rb
@@ -17,7 +17,7 @@ class Help2man < Formula
 
   depends_on "gettext" if Hardware::CPU.intel?
 
-  uses_from_macos "perl"
+  uses_from_macos "perl", since: :mojave
 
   resource "Locale::gettext" do
     url "https://cpan.metacpan.org/authors/id/P/PV/PVANDRY/gettext-1.07.tar.gz"


### PR DESCRIPTION
System perl pre-mojave can't build help2man.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
