### PR TITLE
circumflex: use newer less on Big Sur or older

### DIFF
--- a/Formula/circumflex.rb
+++ b/Formula/circumflex.rb
@@ -4,6 +4,7 @@ class Circumflex < Formula
   url "https://github.com/bensadeh/circumflex/archive/refs/tags/2.2.tar.gz"
   sha256 "6a2467bf6bad00fb3fe3a7b9bdb4e6ea6d8a721b1c9905e6161324cfb3f34c01"
   license "AGPL-3.0-only"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "f87e23f7e960ab3286fbea050e7ae77417595f573f09e2f6d087b56ba7cdd9ae"
@@ -16,11 +17,17 @@ class Circumflex < Formula
 
   depends_on "go" => :build
 
+  # Requires less 576 or later for --use-color
+  depends_on "less" if MacOS.version <= :big_sur
+
   def install
     system "go", "build", *std_go_args(output: bin/"clx", ldflags: "-s -w")
   end
 
   test do
     assert_match "List of visited IDs cleared", shell_output("#{bin}/clx clear 2>&1")
+    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"].present?
+
+    assert_match "Y Combinator", shell_output("#{bin}/clx view 1")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/pull/105444#issuecomment-1180713172

`--use-color` was added in `less` version 576 (https://github.com/gwsw/less/commit/cd1fa3cdde4cb041269dc6e83dbeaa42878d54c5)

macOS 12.4 has `less` version 581.2

Here are the flags that `circumflex` passes to `less`: https://github.com/bensadeh/circumflex/blob/main/cli/cli.go#L12-L20