### PR TITLE
grpc: update livecheck

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -7,9 +7,13 @@ class Grpc < Formula
   license "Apache-2.0"
   head "https://github.com/grpc/grpc.git", branch: "master"
 
+  # The "latest" release on GitHub is sometimes for an older major/minor and
+  # there's sometimes a notable gap between when a version is tagged and
+  # released, so we have to check the releases page instead.
   livecheck do
-    url :stable
-    strategy :github_latest
+    url "https://github.com/grpc/grpc/releases?q=prerelease%3Afalse"
+    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `grpc` uses the `GithubLatest` strategy to identify the "latest" release from GitHub. However, this currently returns 1.46.4 as the latest version instead of 1.47.0, as 1.46.4 was released later and is the "latest" release as a result. Since upstream will apparently also create releases for older major/minor versions, we can't use the `GithubLatest` strategy here. We can't fall back to the `Git` strategy, as there can be a notable delay between when a version is tagged and released (and we don't want to update the formula until there's a release). [I also checked the first-party website but didn't see any checkable version information.]

This PR updates the `livecheck` block to check the GitHub releases page, omitting pre-release versions in the process. We only use this approach when we don't have an appropriate alternative, as checking a paginated source can potentially lead to problems in certain situations (e.g., if the versions we're interested in are pushed off the first page by releases we're not interested in).