### PR TITLE
purescript: improve long line handling in REPL

### DIFF
--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -4,6 +4,7 @@ class Purescript < Formula
   url "https://hackage.haskell.org/package/purescript-0.15.4/purescript-0.15.4.tar.gz"
   sha256 "df279079a7c78c5b1fa813846797e696787f5dd567b1b6e042f7ab6a2701868f"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/purescript/purescript.git", branch: "master"
 
   bottle do
@@ -22,6 +23,11 @@ class Purescript < Formula
   uses_from_macos "zlib"
 
   def install
+    # Use ncurses in REPL, providing an improved experience when editing long
+    # lines in the REPL.
+    # See https://github.com/purescript/purescript/issues/3696#issuecomment-657282303.
+    inreplace "stack.yaml", "terminfo: false", "terminfo: true"
+
     system "stack", "install", "--system-ghc", "--no-install-ghc", "--skip-ghc-check", "--local-bin-path=#{bin}"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This used to be on by default, but it was disabled in PureScript 0.14.2. See https://github.com/purescript/purescript/pull/4069. I'm also open to keeping it disabled and removing the `ncurses` dependency.

Should I bump the revision?