### PR TITLE
openconnect: improve `vpnc-script` handling

### DIFF
--- a/Formula/openconnect.rb
+++ b/Formula/openconnect.rb
@@ -5,7 +5,7 @@ class Openconnect < Formula
   mirror "https://fossies.org/linux/privat/openconnect-9.01.tar.gz"
   sha256 "b3d7faf830e9793299d6a41e81d84cd4a3e2789c148c9e598e4585010090e4c7"
   license "LGPL-2.1-only"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://www.infradead.org/openconnect/download.html"
@@ -40,8 +40,8 @@ class Openconnect < Formula
   end
 
   def install
-    etc.install resource("vpnc-script")
-    chmod 0755, "#{etc}/vpnc-script"
+    (etc/"vpnc").install resource("vpnc-script")
+    chmod 0755, etc/"vpnc/vpnc-script"
 
     if build.head?
       ENV["LIBTOOLIZE"] = "glibtoolize"
@@ -52,14 +52,31 @@ class Openconnect < Formula
       --prefix=#{prefix}
       --sbindir=#{bin}
       --localstatedir=#{var}
-      --with-vpnc-script=#{etc}/vpnc-script
+      --with-vpnc-script=#{etc}/vpnc/vpnc-script
     ]
 
     system "./configure", *args
     system "make", "install"
   end
 
+  def caveats
+    s = <<~EOS
+      A `vpnc-script` has been installed at #{etc}/vpnc/vpnc-script.
+    EOS
+
+    s += if (etc/"vpnc/vpnc-script.default").exist?
+      <<~EOS
+
+        To avoid destroying any local changes you have made, a newer version of this script has
+        been installed as `vpnc-script.default`.
+      EOS
+    end.to_s
+
+    s
+  end
+
   test do
-    assert_match "POST https://localhost/", pipe_output("#{bin}/openconnect localhost 2>&1")
+    # We need to pipe an empty string to `openconnect` for this test to work.
+    assert_match "POST https://localhost/", pipe_output("#{bin}/openconnect localhost 2>&1", "")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

1. The default location of this script is `/etc/vpnc`, so let's use the
   analogous location in `HOMEBREW_PREFIX`.
2. Add caveats that flag the install location of the vpnc-script and
   warn the user when a newer version exists.

The change in location has the added benefit of switching users to a
newer version of the vpnc-script automatically, since there have been
recent updates to this script.

Also, let's make the use of `pipe_output` instead of `shell_output` in
the `test` block clearer by beign explicit about passing an empty string
and adding a comment.
