### PR TITLE
sdl2_mixer 2.6.0

### DIFF
--- a/Formula/sdl2_mixer.rb
+++ b/Formula/sdl2_mixer.rb
@@ -1,24 +1,15 @@
 class Sdl2Mixer < Formula
   desc "Sample multi-channel audio mixer library"
-  homepage "https://www.libsdl.org/projects/SDL_mixer/"
+  homepage "https://github.com/libsdl-org/SDL_mixer"
+  url "https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.6.0/SDL2_mixer-2.6.0.tar.gz"
+  sha256 "f94a4d3e878cb191c386a714be561838240012250fe17d496f4ff4341d59a391"
   license "Zlib"
-  revision 3
 
-  stable do
-    url "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.tar.gz"
-    sha256 "b4cf5a382c061cd75081cf246c2aa2f9df8db04bdda8dcdc6b6cca55bede2419"
-
-    # Fix fluidsynth use-after-free bug until the release after 2.0.4, upstream patch
-    # https://github.com/libsdl-org/SDL_mixer/commit/6160668079f91d57a5d7bf0b40ffdd843be70daf
-    patch :p3 do
-      url "https://github.com/libsdl-org/SDL_mixer/commit/6160668079f91d57a5d7bf0b40ffdd843be70daf.patch?full_index=1"
-      sha256 "73e5ebf9136818b7a65f1e8fcbeb99c350654d7d9e53629adc26887e9e169d8d"
-    end
-  end
-
+  # This formula uses a file from a GitHub release, so we check the latest
+  # release version instead of Git tags.
   livecheck do
-    url :homepage
-    regex(/href=.*?SDL2_mixer[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do
@@ -31,7 +22,7 @@ class Sdl2Mixer < Formula
   end
 
   head do
-    url "https://github.com/libsdl-org/SDL_mixer.git"
+    url "https://github.com/libsdl-org/SDL_mixer.git", branch: "main"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `sdl2_mixer` to the latest version, 2.6.0. Notable changes to the formula are as follows:

* Update the homepage to the GitHub repository, as the existing homepage now only contains a message about redirecting to the GitHub repository ("This has been moved to GitHub. You should be redirected there shortly, or you can click [this link](https://github.com/libsdl-org/SDL_mixer) to continue.").
* The existing patch is part of the 2.6.0 release, so we can remove it (and get rid of the `stable` block).
* Update the `livecheck` block to use the `GithubLatest` strategy, aligning the check with the new `stable` source. The formula now uses a tarball from a GitHub release, so we have to check release versions instead of Git tags (otherwise livecheck could report a new version before it's released and a tarball is available to use).
* Add `branch: "main"` to the `head` URL, to resolve the related audit error.

My primary goal was to fix the broken `livecheck` block and I'm not familiar with `sdl2_mixer`, so do let me know if there's anything that needs to be changed here with respect to the new version. I can at least say that it builds and tests successfully on ARM macOS 12.4.