### PR TITLE
tig: add `ncurses` dependency

### DIFF
--- a/Formula/tig.rb
+++ b/Formula/tig.rb
@@ -4,6 +4,7 @@ class Tig < Formula
   url "https://github.com/jonas/tig/releases/download/tig-2.5.5/tig-2.5.5.tar.gz"
   sha256 "24ba2c8beae889e6002ea7ced0e29851dee57c27fde8480fb9c64d5eb8765313"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "a7d0bf9c1f535420cd5855c037280d5f7e3f7061c8a8f5c3178e567d92e8839c"
@@ -23,6 +24,8 @@ class Tig < Formula
     depends_on "xmlto" => :build
   end
 
+  # https://github.com/jonas/tig/issues/1210
+  depends_on "ncurses"
   depends_on "readline"
 
   def install


### PR DESCRIPTION
`tig` is not using the brew version of ncurses

As per this issue in tig, it seems that vim and other cli's use the brew version of ncurses and `tig` uses the system version.

https://github.com/jonas/tig/issues/1210
I've confirmed this resolves the above issue

Also I saw this PR from 5 years ago. The reasoning doesn't seem like it makes sense now that ncurses is a fairly ubiquitous dependency. https://github.com/Homebrew/homebrew-core/pull/18934

TBH I don't now the impacts of this but it seems like a reasonable solution so feel free to close if it's not.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
