### PR TITLE
sdl2_image 2.6.0

### DIFF
--- a/Formula/sdl2_image.rb
+++ b/Formula/sdl2_image.rb
@@ -1,13 +1,15 @@
 class Sdl2Image < Formula
   desc "Library for loading images as SDL surfaces and textures"
-  homepage "https://www.libsdl.org/projects/SDL_image/"
-  url "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.0.5.tar.gz"
-  sha256 "bdd5f6e026682f7d7e1be0b6051b209da2f402a2dd8bd1c4bd9c25ad263108d0"
+  homepage "https://github.com/libsdl-org/SDL_image"
+  url "https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.0/SDL2_image-2.6.0.tar.gz"
+  sha256 "611c862f40de3b883393aabaa8d6df350aa3ae4814d65030972e402edae85aaa"
   license "Zlib"
 
+  # This formula uses a file from a GitHub release, so we check the latest
+  # release version instead of Git tags.
   livecheck do
-    url :homepage
-    regex(/href=.*?SDL2_image[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `sdl2_image` to the latest version, 2.6.0. Notable changes to the formula are as follows:

* Update the homepage to the GitHub repository, as the existing homepage now only contains a message about redirecting to the GitHub repository ("This has been moved to GitHub. You should be redirected there shortly, or you can click [this link](https://github.com/libsdl-org/SDL_image) to continue.").
* Update the `livecheck` block to use the `GithubLatest` strategy, aligning the check with the new `stable` source. The formula now uses a tarball from a GitHub release, so we have to check release versions instead of Git tags (otherwise livecheck could report a new version before it's released and a tarball is available to use).

Like #105642, my primary goal was to fix the broken `livecheck` block and I'm not familiar with `sdl2_image`, so do let me know if there's anything that needs to be changed here with respect to the new version. I can at least say that it builds and tests successfully on ARM macOS 12.4.