### PR TITLE
sdl2_net: update homepage and livecheck

### DIFF
--- a/Formula/sdl2_net.rb
+++ b/Formula/sdl2_net.rb
@@ -1,13 +1,16 @@
 class Sdl2Net < Formula
   desc "Small sample cross-platform networking library"
-  homepage "https://www.libsdl.org/projects/SDL_net/"
+  homepage "https://github.com/libsdl-org/SDL_net"
   url "https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.0.1.tar.gz"
   sha256 "15ce8a7e5a23dafe8177c8df6e6c79b6749a03fff1e8196742d3571657609d21"
   license "Zlib"
 
+  # NOTE: This should be updated to use the `GithubLatest` strategy if/when the
+  # GitHub releases provide downloadable artifacts and the formula uses one as
+  # the `stable` URL (like `sdl2_image`, `sdl2_mixer`, etc.).
   livecheck do
-    url :homepage
-    regex(/href=.*?SDL2_net[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :head
+    regex(/^release[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates the `homepage` for `sdl2_net` to use the GitHub repository, as the existing homepage now only contains a message about redirecting to the GitHub repository ("This has been moved to GitHub. You should be redirected there shortly, or you can click [this link](https://github.com/libsdl-org/SDL_net) to continue.")

This also updates the `livecheck` block to check the Git tags for the time being (fixing the broken check). If the next `sdl2_net` release on GitHub provides downloadable artifacts and the `stable` URL is updated to use one, then the `livecheck` block should be updated to use the `GithubLatest` strategy (as seen in #105642 and #105647).