### PR TITLE
knock: update urls and livecheck

### DIFF
--- a/Formula/knock.rb
+++ b/Formula/knock.rb
@@ -1,13 +1,15 @@
 class Knock < Formula
   desc "Port-knock server"
-  homepage "https://zeroflux.org/projects/knock"
-  url "https://zeroflux.org/proj/knock/files/knock-0.8.tar.gz"
+  homepage "https://github.com/jvinet/knock"
+  url "https://github.com/jvinet/knock/releases/download/v0.8/knock-0.8.tar.gz"
   sha256 "698d8c965624ea2ecb1e3df4524ed05afe387f6d20ded1e8a231209ad48169c7"
   license "GPL-2.0-or-later"
 
+  # This formula uses a file from a GitHub release, so we check the latest
+  # release version instead of Git tags.
   livecheck do
-    url "https://www.zeroflux.org/projects/knock"
-    regex(%r{The current version of knockd is <strong>v?(\d+(?:\.\d+)+)</strong>}i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do
@@ -21,7 +23,7 @@ class Knock < Formula
   end
 
   head do
-    url "https://github.com/jvinet/knock.git"
+    url "https://github.com/jvinet/knock.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs for `knock` currently return a 404 (Not Found) error. The current [first-party Projects page](https://zeroflux.org/projects.html) links to the [GitHub repository](https://github.com/jvinet/knock), so this PR updates the aforementioned URLs accordingly.

The `livecheck` block is also broken and doesn't adhere to current standards (it was added ~5 years ago), so this updates it to align with the new `stable` source. The formula now uses a tarball from a GitHub release, so we have to check release versions (e.g., using the `GithubLatest` strategy) instead of Git tags (otherwise livecheck could report a new version before it's released and a tarball is available to use).

Lastly, this adds `branch: "master"` to the `head` URL, to resolve the related audit error.