### PR TITLE
hapi-fhir-cli: update livecheck

### DIFF
--- a/Formula/hapi-fhir-cli.rb
+++ b/Formula/hapi-fhir-cli.rb
@@ -5,9 +5,14 @@ class HapiFhirCli < Formula
   sha256 "9779b9ac721a93ec59fe88c202290682c79bf6f23fc2f5e55b652aafac004f66"
   license "Apache-2.0"
 
+  # The "latest" release on GitHub is sometimes for an older major/minor, so we
+  # can't rely on it being the newest version. The formula's `stable` URL is a
+  # release archive, so it's also not appropriate to check the Git tags here.
+  # Instead we have to check tags of releases (omitting pre-release versions).
   livecheck do
-    url :stable
-    strategy :github_latest
+    url "https://github.com/hapifhir/hapi-fhir/releases?q=prerelease%3Afalse"
+    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `hapi-fhir-cli` uses the `GithubLatest` strategy to check the "latest" release version on GitHub but this currently gives 5.6.4 instead of 6.0.1. Upstream also creates releases for older major/minor versions, so we can't rely on the "latest" version being the correct newest version (as the "latest" release is simply the one with the newest date, even if it's an older major/minor version).

This PR resolves the issue by updating the `livecheck` block to check the releases page (making sure to omit "pre-release" versions) and identify versions from tag links like the `GithubLatest` strategy. We only use this approach when we don't have an appropriate alternative, as checking a paginated source can potentially lead to problems in certain situations (e.g., if the versions we're interested in are pushed off the first page by releases we're not interested in). To be clear, we can't use the `Git` strategy in this case because the `stable` URL is a release archive and checking Git tags can cause livecheck to report a new version before the release is created and the appropriate archive is available to download.