### PR TITLE
libpcl: update urls, license

### DIFF
--- a/Formula/libpcl.rb
+++ b/Formula/libpcl.rb
@@ -1,9 +1,9 @@
 class Libpcl < Formula
   desc "C library and API for coroutines"
-  homepage "http://xmailserver.org/libpcl.html"
-  url "http://xmailserver.org/pcl-1.12.tar.gz"
+  homepage "http://www.xmailserver.org/libpcl.html"
+  url "http://www.xmailserver.org/pcl-1.12.tar.gz"
   sha256 "e7b30546765011575d54ae6b44f9d52f138f5809221270c815d2478273319e1a"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs for `libpcl` use xmailserver.org (no `www` subdomain) but `curl` gives the following error: `curl: (6) Could not resolve host: xmailserver.org`. In the browser, the `homepage` redirects to the URL using the `www` subdomain but this poses a problem for `curl`. This PR resolves the issue by updating these URLs to use the `www` subdomain, which also fixes the `livecheck` block.

`make install` failed when I tried to build this locally (macOS 12.4, ARM), so this may fail on CI:

```
pcl.c:335:2: error: "PCL: Unsupported setjmp/longjmp OSX CPU. Please report to <davidel@xmailserver.org>"
#error "PCL: Unsupported setjmp/longjmp OSX CPU. Please report to <davidel@xmailserver.org>"
```

If it fails and there's no way to reasonably resolve the issue, we may have to use the `CI-syntax-only` label to merge these changes. For what it's worth, the `sha256` of the `stable` archive remains the same and this is just a simple URL change.

-----

Past that, this also updates the license from `GPL-2.0` to `GPL-2.0-or-later`. The `COPYING` file is GPLv2 and the source files contain a license comment using the "or...later" language. For example, from `pcl/pcl.c`:

```
/*
 *  PCL by Davide Libenzi (Portable Coroutine Library)
 *  Copyright (C) 2003..2010  Davide Libenzi
 *
 *  This program is free software; you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by
 *  the Free Software Foundation; either version 2 of the License, or
 *  (at your option) any later version.
 *
 *  This program is distributed in the hope that it will be useful,
 *  but WITHOUT ANY WARRANTY; without even the implied warranty of
 *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 *  GNU General Public License for more details.
 *
 *  You should have received a copy of the GNU General Public License
 *  along with this program; if not, write to the Free Software
 *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 *
 *  Davide Libenzi <davidel@xmailserver.org>
 *
 */
```