### PR TITLE
regldg 1.0.1

### DIFF
--- a/Formula/regldg.rb
+++ b/Formula/regldg.rb
@@ -1,11 +1,12 @@
 class Regldg < Formula
   desc "Regular expression grammar language dictionary generator"
   homepage "https://regldg.com/"
-  url "https://regldg.com/regldg-1.0.0.tar.gz"
-  sha256 "cd550592cc7a2f29f5882dcd9cf892875dd4e84840d8fe87133df9814c8003f1"
+  url "https://regldg.com/regldg-1.0.1.tar.gz"
+  sha256 "f5f401c645a94d4c737cefa2bbcb62f23407d25868327902b9c93b501335dc99"
+  license "MIT"
 
   livecheck do
-    url "https://regldg.com/download.php"
+    url "https://regldg.com/download.html"
     regex(/href=.*?regldg[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `regldg` to the latest version, 1.0.1. This also updates the `livecheck` block to use the current first-party download page URL (the extension changed from `php` to `html`), which fixes the broken check.

This also sets the `license` to MIT, referencing the `LICENSE` file in the tarball. This appears to be the only license reference in the source files.