### PR TITLE
icon: configure specifically for Macintosh

### DIFF
--- a/Formula/icon.rb
+++ b/Formula/icon.rb
@@ -23,7 +23,7 @@ class Icon < Formula
   def install
     ENV.deparallelize
     target = if OS.mac?
-      "posix"
+      "macintosh"
     else
       "linux"
     end


### PR DESCRIPTION
Configure the build using name=macintosh instead of the more generic
name=posix.  The posix variant builds a version in which co-expressions
do not work because the Mac does not have anonymous pthreads semaphores.

Also run the normal test suite to validate the build.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)? yes
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)? yes
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? yes
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? yes
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? yes
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? yes

-----
