### PR TITLE
libsndfile: add mpeg dependencies

### DIFF
--- a/Formula/libsndfile.rb
+++ b/Formula/libsndfile.rb
@@ -27,8 +27,10 @@ class Libsndfile < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "flac"
+  depends_on "lame"
   depends_on "libogg"
   depends_on "libvorbis"
+  depends_on "mpg123"
   depends_on "opus"
 
   uses_from_macos "python" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Libsndfile v 1.1.0 (currently in homebrew) supports mpeg formats. That functionality is on by default, but it is only activated during build if `lame` and `mpg123` libraries are found.

I've added these libraries as dependencies, so that libsndfile gets built with mpeg support.

<details>

```sh
% brew install --build-from-source libsndfile --verbose
(...)
checking for lame/lame.h... yes
checking for library containing lame_set_VBR_q... -lmp3lame
checking for libmpg123 >= 1.25.10 ... yes
(...)
   External MPEG Lame/MPG123 : ........... yes
```
</details>

Please let me know if there's anything missing in this PR.