### PR TITLE
formulae: use `generate_completions`

### DIFF
--- a/Formula/arduino-cli.rb
+++ b/Formula/arduino-cli.rb
@@ -32,14 +32,7 @@ class ArduinoCli < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    output = Utils.safe_popen_read(bin/"arduino-cli", "completion", "bash")
-    (bash_completion/"arduino-cli").write output
-
-    output = Utils.safe_popen_read(bin/"arduino-cli", "completion", "zsh")
-    (zsh_completion/"_arduino-cli").write output
-
-    output = Utils.safe_popen_read(bin/"arduino-cli", "completion", "fish")
-    (fish_completion/"arduino-cli.fish").write output
+    generate_completions_from_executable(bin/"arduino-cli", "completion")
   end
 
   test do

--- a/Formula/argo.rb
+++ b/Formula/argo.rb
@@ -25,10 +25,7 @@ class Argo < Formula
     system "make", "dist/argo"
     bin.install "dist/argo"
 
-    output = Utils.safe_popen_read("#{bin}/argo", "completion", "bash")
-    (bash_completion/"argo").write output
-    output = Utils.safe_popen_read("#{bin}/argo", "completion", "zsh")
-    (zsh_completion/"_argo").write output
+    generate_completions_from_executable(bin/"argo", "completion", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/argocd.rb
+++ b/Formula/argocd.rb
@@ -30,10 +30,7 @@ class Argocd < Formula
     system "make", "cli-local"
     bin.install "dist/argocd"
 
-    output = Utils.safe_popen_read("#{bin}/argocd", "completion", "bash")
-    (bash_completion/"argocd").write output
-    output = Utils.safe_popen_read("#{bin}/argocd", "completion", "zsh")
-    (zsh_completion/"_argocd").write output
+    generate_completions_from_executable(bin/"argocd", "completion", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/arkade.rb
+++ b/Formula/arkade.rb
@@ -32,9 +32,7 @@ class Arkade < Formula
 
     bin.install_symlink "arkade" => "ark"
 
-    (zsh_completion/"_arkade").write Utils.safe_popen_read(bin/"arkade", "completion", "zsh")
-    (bash_completion/"arkade").write Utils.safe_popen_read(bin/"arkade", "completion", "bash")
-    (fish_completion/"arkade.fish").write Utils.safe_popen_read(bin/"arkade", "completion", "fish")
+    generate_completions_from_executable(bin/"arkade", "completion")
     # make zsh completion also work for `ark` symlink
     inreplace zsh_completion/"_arkade", "#compdef arkade", "#compdef arkade ark=arkade"
   end

--- a/Formula/atlas.rb
+++ b/Formula/atlas.rb
@@ -26,14 +26,7 @@ class Atlas < Formula
       system "go", "build", *std_go_args(ldflags: ldflags)
     end
 
-    bash_output = Utils.safe_popen_read(bin/"atlas", "completion", "bash")
-    (bash_completion/"atlas").write bash_output
-
-    zsh_output = Utils.safe_popen_read(bin/"atlas", "completion", "zsh")
-    (zsh_completion/"_atlas").write zsh_output
-
-    fish_output = Utils.safe_popen_read(bin/"atlas", "completion", "fish")
-    (fish_completion/"atlas.fish").write fish_output
+    generate_completions_from_executable(bin/"atlas", "completion")
   end
 
   test do

--- a/Formula/authoscope.rb
+++ b/Formula/authoscope.rb
@@ -27,12 +27,7 @@ class Authoscope < Formula
     system "cargo", "install", *std_cargo_args
     man1.install "docs/authoscope.1"
 
-    bash_output = Utils.safe_popen_read(bin/"authoscope", "completions", "bash")
-    (bash_completion/"authoscope").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"authoscope", "completions", "zsh")
-    (zsh_completion/"_authoscope").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"authoscope", "completions", "fish")
-    (fish_completion/"authoscope.fish").write fish_output
+    generate_completions_from_executable(bin/"authoscope", "completions")
   end
 
   test do

--- a/Formula/autorestic.rb
+++ b/Formula/autorestic.rb
@@ -20,9 +20,7 @@ class Autorestic < Formula
 
   def install
     system "go", "build", *std_go_args, "./main.go"
-    (bash_completion/"autorestic").write Utils.safe_popen_read("#{bin}/autorestic", "completion", "bash")
-    (zsh_completion/"_autorestic").write Utils.safe_popen_read("#{bin}/autorestic", "completion", "zsh")
-    (fish_completion/"autorestic.fish").write Utils.safe_popen_read("#{bin}/autorestic", "completion", "fish")
+    generate_completions_from_executable(bin/"autorestic", "completion")
   end
 
   test do

--- a/Formula/aws-nuke.rb
+++ b/Formula/aws-nuke.rb
@@ -35,9 +35,7 @@ class AwsNuke < Formula
 
     pkgshare.install "config"
 
-    (bash_completion/"aws-nuke").write Utils.safe_popen_read("#{bin}/aws-nuke", "completion", "bash")
-    (fish_completion/"aws-nuke.fish").write Utils.safe_popen_read("#{bin}/aws-nuke", "completion", "fish")
-    (zsh_completion/"_aws-nuke").write Utils.safe_popen_read("#{bin}/aws-nuke", "completion", "zsh")
+    generate_completions_from_executable(bin/"aws-nuke", "completion")
   end
 
   test do

--- a/Formula/cdktf.rb
+++ b/Formula/cdktf.rb
@@ -23,12 +23,8 @@ class Cdktf < Formula
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
 
-    # completion script currently requires --help run without error https://github.com/hashicorp/terraform-cdk/issues/1905
-    output = Utils.safe_popen_read({ "SHELL" => "bash" }, libexec/"bin/cdktf", "completion", "--help")
-    (bash_completion/"cdktf").write output
-
-    output = Utils.safe_popen_read({ "SHELL" => "zsh" }, libexec/"bin/cdktf", "completion", "--help")
-    (zsh_completion/"_cdktf").write output
+    generate_completions_from_executable(libexec/"bin/cdktf", "completion",
+                                         shells: [:bash, :zsh], shell_parameter_format: :none)
   end
 
   test do

--- a/Formula/certigo.rb
+++ b/Formula/certigo.rb
@@ -26,13 +26,8 @@ class Certigo < Formula
     system "./build"
     bin.install "bin/certigo"
 
-    # Install bash completion
-    output = Utils.safe_popen_read("#{bin}/certigo", "--completion-script-bash")
-    (bash_completion/"certigo").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read("#{bin}/certigo", "--completion-script-zsh")
-    (zsh_completion/"_certigo").write output
+    generate_completions_from_executable(bin/"certigo", shell_parameter_format: "--completion-script-",
+                                                        shells:                 [:bash, :zsh])
   end
 
   test do

--- a/Formula/cilium-cli.rb
+++ b/Formula/cilium-cli.rb
@@ -20,12 +20,7 @@ class CiliumCli < Formula
     ldflags = "-s -w -X github.com/cilium/cilium-cli/internal/cli/cmd.Version=#{version}"
     system "go", "build", *std_go_args(output: bin/"cilium", ldflags: ldflags), "./cmd/cilium"
 
-    bash_output = Utils.safe_popen_read(bin/"cilium", "completion", "bash")
-    (bash_completion/"cilium").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"cilium", "completion", "zsh")
-    (zsh_completion/"_cilium").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"cilium", "completion", "fish")
-    (fish_completion/"cilium.fish").write fish_output
+    generate_completions_from_executable(bin/"cilium", "completion", base_name: "cilium")
   end
 
   test do

--- a/Formula/circleci.rb
+++ b/Formula/circleci.rb
@@ -32,11 +32,8 @@ class Circleci < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    output = Utils.safe_popen_read("#{bin}/circleci", "--skip-update-check", "completion", "bash")
-    (bash_completion/"circleck").write output
-
-    output = Utils.safe_popen_read("#{bin}/circleci", "--skip-update-check", "completion", "zsh")
-    (zsh_completion/"_circleci").write output
+    generate_completions_from_executable(bin/"circleci", "--skip-update-check", "completion",
+                                        shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/clusterctl.rb
+++ b/Formula/clusterctl.rb
@@ -36,11 +36,7 @@ class Clusterctl < Formula
     system "make", "clusterctl"
     prefix.install "bin"
 
-    bash_output = Utils.safe_popen_read(bin/"clusterctl", "completion", "bash")
-    (bash_completion/"clusterctl").write bash_output
-
-    zsh_output = Utils.safe_popen_read(bin/"clusterctl", "completion", "zsh")
-    (zsh_completion/"_clusterctl").write zsh_output
+    generate_completions_from_executable(bin/"clusterctl", "completion", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/colima.rb
+++ b/Formula/colima.rb
@@ -34,9 +34,7 @@ class Colima < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/colima"
 
-    (bash_completion/"colima").write Utils.safe_popen_read(bin/"colima", "completion", "bash")
-    (zsh_completion/"_colima").write Utils.safe_popen_read(bin/"colima", "completion", "zsh")
-    (fish_completion/"colima.fish").write Utils.safe_popen_read(bin/"colima", "completion", "fish")
+    generate_completions_from_executable(bin/"colima", "completion")
   end
 
   test do

--- a/Formula/conftest.rb
+++ b/Formula/conftest.rb
@@ -20,14 +20,7 @@ class Conftest < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-X github.com/open-policy-agent/conftest/internal/commands.version=#{version}")
 
-    bash_output = Utils.safe_popen_read(bin/"conftest", "completion", "bash")
-    (bash_completion/"conftest").write bash_output
-
-    zsh_output = Utils.safe_popen_read(bin/"conftest", "completion", "zsh")
-    (zsh_completion/"_conftest").write zsh_output
-
-    fish_output = Utils.safe_popen_read(bin/"conftest", "completion", "fish")
-    (fish_completion/"conftest.fish").write fish_output
+    generate_completions_from_executable(bin/"conftest", "completion")
   end
 
   test do

--- a/Formula/copilot.rb
+++ b/Formula/copilot.rb
@@ -35,14 +35,7 @@ class Copilot < Formula
 
     bin.install "bin/local/copilot"
 
-    output = Utils.safe_popen_read(bin/"copilot", "completion", "bash")
-    (bash_completion/"copilot").write output
-
-    output = Utils.safe_popen_read(bin/"copilot", "completion", "zsh")
-    (zsh_completion/"_copilot").write output
-
-    output = Utils.safe_popen_read(bin/"copilot", "completion", "fish")
-    (fish_completion/"copilot.fish").write output
+    generate_completions_from_executable(bin/"copilot", "completion")
   end
 
   test do

--- a/Formula/cri-tools.rb
+++ b/Formula/cri-tools.rb
@@ -26,14 +26,7 @@ class CriTools < Formula
       system "make", "install", "VERSION=#{version}"
     end
 
-    output = Utils.safe_popen_read("#{bin}/crictl", "completion", "bash")
-    (bash_completion/"crictl").write output
-
-    output = Utils.safe_popen_read("#{bin}/crictl", "completion", "zsh")
-    (zsh_completion/"_crictl").write output
-
-    output = Utils.safe_popen_read("#{bin}/crictl", "completion", "fish")
-    (fish_completion/"crictl.fish").write output
+    generate_completions_from_executable(bin/"crictl", "completion", base_name: "crictl")
   end
 
   test do

--- a/Formula/ctlptl.rb
+++ b/Formula/ctlptl.rb
@@ -24,17 +24,7 @@ class Ctlptl < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/ctlptl"
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"ctlptl", "completion", "bash")
-    (bash_completion/"ctlptl").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"ctlptl", "completion", "zsh")
-    (zsh_completion/"_ctlptl").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(bin/"ctlptl", "completion", "fish")
-    (fish_completion/"ctlptl.fish").write output
+    generate_completions_from_executable(bin/"ctlptl", "completion")
   end
 
   test do

--- a/Formula/cue.rb
+++ b/Formula/cue.rb
@@ -20,12 +20,7 @@ class Cue < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w -X cuelang.org/go/cmd/cue/cmd.version=v#{version}"), "./cmd/cue"
 
-    bash_output = Utils.safe_popen_read(bin/"cue", "completion", "bash")
-    (bash_completion/"cue").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"cue", "completion", "zsh")
-    (zsh_completion/"_cue").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"cue", "completion", "fish")
-    (fish_completion/"cue.fish").write fish_output
+    generate_completions_from_executable(bin/"cue", "completion")
   end
 
   test do

--- a/Formula/dagger.rb
+++ b/Formula/dagger.rb
@@ -28,14 +28,7 @@ class Dagger < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/dagger"
 
-    output = Utils.safe_popen_read(bin/"dagger", "completion", "bash")
-    (bash_completion/"dagger").write output
-
-    output = Utils.safe_popen_read(bin/"dagger", "completion", "zsh")
-    (zsh_completion/"_dagger").write output
-
-    output = Utils.safe_popen_read(bin/"dagger", "completion", "fish")
-    (fish_completion/"dagger.fish").write output
+    generate_completions_from_executable(bin/"dagger", "completion")
   end
 
   test do

--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -119,12 +119,7 @@ class Deno < Formula
     # Issue ref: https://github.com/denoland/deno/issues/9244
     system "cargo", "install", "-vv", "-j1", *std_cargo_args(path: "cli")
 
-    bash_output = Utils.safe_popen_read(bin/"deno", "completions", "bash")
-    (bash_completion/"deno").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"deno", "completions", "zsh")
-    (zsh_completion/"_deno").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"deno", "completions", "fish")
-    (fish_completion/"deno.fish").write fish_output
+    generate_completions_from_executable(bin/"deno", "completions")
   end
 
   test do

--- a/Formula/diesel.rb
+++ b/Formula/diesel.rb
@@ -31,12 +31,7 @@ class Diesel < Formula
       system "cargo", "install", *std_cargo_args
     end
 
-    bash_output = Utils.safe_popen_read(bin/"diesel", "completions", "bash")
-    (bash_completion/"diesel").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"diesel", "completions", "zsh")
-    (zsh_completion/"_diesel").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"diesel", "completions", "fish")
-    (fish_completion/"diesel.fish").write fish_output
+    generate_completions_from_executable(bin/"diesel", "completions")
   end
 
   test do

--- a/Formula/doctl.rb
+++ b/Formula/doctl.rb
@@ -28,9 +28,7 @@ class Doctl < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/doctl"
 
-    (bash_completion/"doctl").write `#{bin}/doctl completion bash`
-    (zsh_completion/"_doctl").write `#{bin}/doctl completion zsh`
-    (fish_completion/"doctl.fish").write `#{bin}/doctl completion fish`
+    generate_completions_from_executable(bin/"doctl", "completion")
   end
 
   test do

--- a/Formula/doitlive.rb
+++ b/Formula/doitlive.rb
@@ -54,11 +54,8 @@ class Doitlive < Formula
   def install
     virtualenv_install_with_resources
 
-    output = Utils.safe_popen_read({ "SHELL" => "bash" }, libexec/"bin/doitlive", "completion")
-    (bash_completion/"doitlive").write output
-
-    output = Utils.safe_popen_read({ "SHELL" => "zsh" }, libexec/"bin/doitlive", "completion")
-    (zsh_completion/"_doitlive").write output
+    generate_completions_from_executable(libexec/"bin/doitlive", "completion",
+                                         shells: [:bash, :zsh], shell_parameter_format: :none)
   end
 
   test do

--- a/Formula/driftctl.rb
+++ b/Formula/driftctl.rb
@@ -27,14 +27,7 @@ class Driftctl < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    output = Utils.safe_popen_read("#{bin}/driftctl", "completion", "bash")
-    (bash_completion/"driftctl").write output
-
-    output = Utils.safe_popen_read("#{bin}/driftctl", "completion", "zsh")
-    (zsh_completion/"_driftctl").write output
-
-    output = Utils.safe_popen_read("#{bin}/driftctl", "completion", "fish")
-    (fish_completion/"driftctl.fish").write output
+    generate_completions_from_executable(bin/"driftctl", "completion")
   end
 
   test do

--- a/Formula/dvc.rb
+++ b/Formula/dvc.rb
@@ -699,8 +699,7 @@ class Dvc < Formula
 
     virtualenv_install_with_resources
 
-    (bash_completion/"dvc").write Utils.safe_popen_read(bin/"dvc", "completion", "-s", "bash")
-    (zsh_completion/"_dvc").write Utils.safe_popen_read(bin/"dvc", "completion", "-s", "zsh")
+    generate_completions_from_executable(bin/"dvc", "completion", "-s", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/earthly.rb
+++ b/Formula/earthly.rb
@@ -29,10 +29,7 @@ class Earthly < Formula
     tags = "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork"
     system "go", "build", "-tags", tags, *std_go_args(ldflags: ldflags), "./cmd/earthly"
 
-    bash_output = Utils.safe_popen_read("#{bin}/earthly", "bootstrap", "--source", "bash")
-    (bash_completion/"earthly").write bash_output
-    zsh_output = Utils.safe_popen_read("#{bin}/earthly", "bootstrap", "--source", "zsh")
-    (zsh_completion/"_earthly").write zsh_output
+    generate_completions_from_executable(bin/"earthly", "bootstrap", "--source", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/eksctl.rb
+++ b/Formula/eksctl.rb
@@ -42,12 +42,7 @@ class Eksctl < Formula
     system "make", "build"
     bin.install "eksctl"
 
-    bash_output = Utils.safe_popen_read(bin/"eksctl", "completion", "bash")
-    (bash_completion/"eksctl").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"eksctl", "completion", "zsh")
-    (zsh_completion/"_eksctl").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"eksctl", "completion", "fish")
-    (fish_completion/"eksctl.fish").write fish_output
+    generate_completions_from_executable(bin/"eksctl", "completion")
   end
 
   test do

--- a/Formula/elan-init.rb
+++ b/Formula/elan-init.rb
@@ -32,12 +32,7 @@ class ElanInit < Formula
       bin.install_symlink "elan-init" => link
     end
 
-    bash_output = Utils.safe_popen_read(bin/"elan", "completions", "bash")
-    (bash_completion/"elan").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"elan", "completions", "zsh")
-    (zsh_completion/"_elan").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"elan", "completions", "fish")
-    (fish_completion/"elan.fish").write fish_output
+    generate_completions_from_executable(bin/"elan", "completions", base_name: "elan")
   end
 
   test do

--- a/Formula/faas-cli.rb
+++ b/Formula/faas-cli.rb
@@ -35,8 +35,7 @@ class FaasCli < Formula
     system "go", "build", *std_go_args(ldflags: ldflags), "-a", "-installsuffix", "cgo"
     bin.install_symlink "faas-cli" => "faas"
 
-    (bash_completion/"faas-cli").write Utils.safe_popen_read(bin/"faas-cli", "completion", "--shell", "bash")
-    (zsh_completion/"_faas-cli").write Utils.safe_popen_read(bin/"faas-cli", "completion", "--shell", "zsh")
+    generate_completions_from_executable(bin/"faas-cli", "completion", "--shell", shells: [:bash, :zsh])
     # make zsh completions also work for `faas` symlink
     inreplace zsh_completion/"_faas-cli", "#compdef faas-cli", "#compdef faas-cli\ncompdef faas=faas-cli"
   end

--- a/Formula/flyctl.rb
+++ b/Formula/flyctl.rb
@@ -38,12 +38,7 @@ class Flyctl < Formula
 
     bin.install_symlink "flyctl" => "fly"
 
-    bash_output = Utils.safe_popen_read("#{bin}/flyctl", "completion", "bash")
-    (bash_completion/"flyctl").write bash_output
-    zsh_output = Utils.safe_popen_read("#{bin}/flyctl", "completion", "zsh")
-    (zsh_completion/"_flyctl").write zsh_output
-    fish_output = Utils.safe_popen_read("#{bin}/flyctl", "completion", "fish")
-    (fish_completion/"flyctl.fish").write fish_output
+    generate_completions_from_executable(bin/"flyctl", "completion")
   end
 
   test do

--- a/Formula/fnm.rb
+++ b/Formula/fnm.rb
@@ -27,9 +27,7 @@ class Fnm < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    (bash_completion/"fnm").write Utils.safe_popen_read(bin/"fnm", "completions", "--shell=bash")
-    (fish_completion/"fnm.fish").write Utils.safe_popen_read(bin/"fnm", "completions", "--shell=fish")
-    (zsh_completion/"_fnm").write Utils.safe_popen_read(bin/"fnm", "completions", "--shell=zsh")
+    generate_completions_from_executable(bin/"fnm", "completions", "--shell")
   end
 
   test do

--- a/Formula/frum.rb
+++ b/Formula/frum.rb
@@ -27,9 +27,7 @@ class Frum < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    (bash_completion/"frum").write Utils.safe_popen_read(bin/"frum", "completions", "--shell=bash")
-    (fish_completion/"frum.fish").write Utils.safe_popen_read(bin/"frum", "completions", "--shell=fish")
-    (zsh_completion/"_frum").write Utils.safe_popen_read(bin/"frum", "completions", "--shell=zsh")
+    generate_completions_from_executable(bin/"frum", "completions", "--shell")
   end
 
   test do

--- a/Formula/gh.rb
+++ b/Formula/gh.rb
@@ -32,9 +32,7 @@ class Gh < Formula
     end
     bin.install "bin/gh"
     man1.install Dir["share/man/man1/gh*.1"]
-    (bash_completion/"gh").write `#{bin}/gh completion -s bash`
-    (fish_completion/"gh.fish").write `#{bin}/gh completion -s fish`
-    (zsh_completion/"_gh").write `#{bin}/gh completion -s zsh`
+    generate_completions_from_executable(bin/"gh", "completion", "-s")
   end
 
   test do

--- a/Formula/git-absorb.rb
+++ b/Formula/git-absorb.rb
@@ -22,9 +22,7 @@ class GitAbsorb < Formula
     system "cargo", "install", *std_cargo_args
     man1.install "Documentation/git-absorb.1"
 
-    (zsh_completion/"_git-absorb").write Utils.safe_popen_read("#{bin}/git-absorb", "--gen-completions", "zsh")
-    (bash_completion/"git-absorb").write Utils.safe_popen_read("#{bin}/git-absorb", "--gen-completions", "bash")
-    (fish_completion/"git-absorb.fish").write Utils.safe_popen_read("#{bin}/git-absorb", "--gen-completions", "fish")
+    generate_completions_from_executable(bin/"git-absorb", "--gen-completions")
   end
 
   test do

--- a/Formula/git-town.rb
+++ b/Formula/git-town.rb
@@ -25,9 +25,7 @@ class GitTown < Formula
     system "go", "build", *std_go_args(ldflags: ldflags)
 
     # Install shell completions
-    (bash_completion/"git-town").write Utils.safe_popen_read(bin/"git-town", "completions", "bash")
-    (zsh_completion/"_git-town").write Utils.safe_popen_read(bin/"git-town", "completions", "zsh")
-    (fish_completion/"git-town.fish").write Utils.safe_popen_read(bin/"git-town", "completions", "fish")
+    generate_completions_from_executable(bin/"git-town", "completions")
   end
 
   test do

--- a/Formula/gitleaks.rb
+++ b/Formula/gitleaks.rb
@@ -20,14 +20,7 @@ class Gitleaks < Formula
     ldflags = "-X github.com/zricethezav/gitleaks/v#{version.major}/cmd.Version=#{version}"
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    bash_output = Utils.safe_popen_read(bin/"gitleaks", "completion", "bash")
-    (bash_completion/"gitleaks").write bash_output
-
-    zsh_output = Utils.safe_popen_read(bin/"gitleaks", "completion", "zsh")
-    (zsh_completion/"_gitleaks").write zsh_output
-
-    fish_output = Utils.safe_popen_read(bin/"gitleaks", "completion", "fish")
-    (fish_completion/"gitleaks.fish").write fish_output
+    generate_completions_from_executable(bin/"gitleaks", "completion")
   end
 
   test do

--- a/Formula/glab.rb
+++ b/Formula/glab.rb
@@ -22,9 +22,7 @@ class Glab < Formula
 
     system "make", "GLAB_VERSION=#{version}"
     bin.install "bin/glab"
-    (bash_completion/"glab").write Utils.safe_popen_read(bin/"glab", "completion", "--shell=bash")
-    (zsh_completion/"_glab").write Utils.safe_popen_read(bin/"glab", "completion", "--shell=zsh")
-    (fish_completion/"glab.fish").write Utils.safe_popen_read(bin/"glab", "completion", "--shell=fish")
+    generate_completions_from_executable(bin/"glab", "completion", "--shell")
   end
 
   test do

--- a/Formula/golangci-lint.rb
+++ b/Formula/golangci-lint.rb
@@ -29,14 +29,7 @@ class GolangciLint < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/golangci-lint"
 
-    output = Utils.safe_popen_read("#{bin}/golangci-lint", "completion", "bash")
-    (bash_completion/"golangci-lint").write output
-
-    output = Utils.safe_popen_read("#{bin}/golangci-lint", "completion", "zsh")
-    (zsh_completion/"_golangci-lint").write output
-
-    output = Utils.safe_popen_read("#{bin}/golangci-lint", "completion", "fish")
-    (fish_completion/"golangci-lint.fish").write output
+    generate_completions_from_executable(bin/"golangci-lint", "completion")
   end
 
   test do

--- a/Formula/goreleaser.rb
+++ b/Formula/goreleaser.rb
@@ -29,14 +29,7 @@ class Goreleaser < Formula
     system "go", "build", *std_go_args(ldflags: ldflags)
 
     # Install shell completions
-    output = Utils.safe_popen_read("#{bin}/goreleaser", "completion", "bash")
-    (bash_completion/"goreleaser").write output
-
-    output = Utils.safe_popen_read("#{bin}/goreleaser", "completion", "zsh")
-    (zsh_completion/"_goreleaser").write output
-
-    output = Utils.safe_popen_read("#{bin}/goreleaser", "completion", "fish")
-    (fish_completion/"goreleaser.fish").write output
+    generate_completions_from_executable(bin/"goreleaser", "completion")
   end
 
   test do

--- a/Formula/gum.rb
+++ b/Formula/gum.rb
@@ -23,14 +23,7 @@ class Gum < Formula
     man_page = Utils.safe_popen_read(bin/"gum", "man")
     (man1/"gum.1").write man_page
 
-    bash_output = Utils.safe_popen_read(bin/"gum", "completion", "bash")
-    (bash_completion/"gum").write bash_output
-
-    zsh_output = Utils.safe_popen_read(bin/"gum", "completion", "zsh")
-    (zsh_completion/"_gum").write zsh_output
-
-    fish_output = Utils.safe_popen_read(bin/"gum", "completion", "fish")
-    (fish_completion/"gum.fish").write fish_output
+    generate_completions_from_executable(bin/"gum", "completion")
   end
 
   test do

--- a/Formula/hasura-cli.rb
+++ b/Formula/hasura-cli.rb
@@ -42,10 +42,7 @@ class HasuraCli < Formula
       cp "../cli-ext/bin/cli-ext-hasura", "./internal/cliext/static-bin/#{os}/#{arch}/cli-ext"
       system "go", "build", *std_go_args(output: bin/"hasura", ldflags: ldflags), "./cmd/hasura/"
 
-      output = Utils.safe_popen_read("#{bin}/hasura", "completion", "bash")
-      (bash_completion/"hasura").write output
-      output = Utils.safe_popen_read("#{bin}/hasura", "completion", "zsh")
-      (zsh_completion/"_hasura").write output
+      generate_completions_from_executable(bin/"hasura", "completion", base_name: "hasura", shells: [:bash, :zsh])
     end
   end
 

--- a/Formula/hatch.rb
+++ b/Formula/hatch.rb
@@ -177,11 +177,8 @@ class Hatch < Formula
   def install
     virtualenv_install_with_resources
 
-    output = Utils.safe_popen_read({ "_HATCH_COMPLETE" => "zsh_source" }, bin/"hatch")
-    (zsh_completion/"_hatch").write output
-
-    output = Utils.safe_popen_read({ "_HATCH_COMPLETE" => "fish_source" }, bin/"hatch")
-    (fish_completion/"hatch.fish").write output
+    (zsh_completion/"_hatch").write Utils.safe_popen_read({ "_HATCH_COMPLETE" => "zsh_source" }, bin/"hatch")
+    (fish_completion/"hatch.fish").write Utils.safe_popen_read({ "_HATCH_COMPLETE" => "fish_source" }, bin/"hatch")
   end
 
   test do

--- a/Formula/hcloud.rb
+++ b/Formula/hcloud.rb
@@ -20,12 +20,7 @@ class Hcloud < Formula
     ldflags = "-s -w -X github.com/hetznercloud/cli/internal/version.Version=v#{version}"
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/hcloud"
 
-    output = Utils.safe_popen_read(bin/"hcloud", "completion", "bash")
-    (bash_completion/"hcloud").write output
-    output = Utils.safe_popen_read(bin/"hcloud", "completion", "zsh")
-    (zsh_completion/"_hcloud").write output
-    output = Utils.safe_popen_read(bin/"hcloud", "completion", "fish")
-    (fish_completion/"hcloud.fish").write output
+    generate_completions_from_executable(bin/"hcloud", "completion")
   end
 
   test do

--- a/Formula/helm.rb
+++ b/Formula/helm.rb
@@ -30,14 +30,7 @@ class Helm < Formula
       man1.install Dir["*"]
     end
 
-    output = Utils.safe_popen_read(bin/"helm", "completion", "bash")
-    (bash_completion/"helm").write output
-
-    output = Utils.safe_popen_read(bin/"helm", "completion", "zsh")
-    (zsh_completion/"_helm").write output
-
-    output = Utils.safe_popen_read(bin/"helm", "completion", "fish")
-    (fish_completion/"helm.fish").write output
+    generate_completions_from_executable(bin/"helm", "completion")
   end
 
   test do

--- a/Formula/helm@2.rb
+++ b/Formula/helm@2.rb
@@ -41,11 +41,7 @@ class HelmAT2 < Formula
       bin.install "bin/tiller"
       man1.install Dir["docs/man/man1/*"]
 
-      output = Utils.safe_popen_read({ "SHELL" => "bash" }, bin/"helm", "completion", "bash")
-      (bash_completion/"helm").write output
-
-      output = Utils.safe_popen_read({ "SHELL" => "zsh" }, bin/"helm", "completion", "zsh")
-      (zsh_completion/"_helm").write output
+      generate_completions_from_executable(bin/"helm", "completion", base_name: "helm", shells: [:bash, :zsh])
 
       prefix.install_metafiles
     end

--- a/Formula/homeassistant-cli.rb
+++ b/Formula/homeassistant-cli.rb
@@ -175,8 +175,8 @@ class HomeassistantCli < Formula
   def install
     virtualenv_install_with_resources
     bin.install_symlink libexec/"bin/hass-cli"
-    (bash_completion/"hass-cli").write Utils.safe_popen_read(bin/"hass-cli", "completion", "bash")
-    (zsh_completion/"_hass-cli").write Utils.safe_popen_read(bin/"hass-cli", "completion", "zsh")
+    generate_completions_from_executable(bin/"hass-cli", "completion", base_name: "hass-cli",
+                                                                       shells:    [:bash, :zsh])
   end
 
   test do

--- a/Formula/hubble.rb
+++ b/Formula/hubble.rb
@@ -20,12 +20,7 @@ class Hubble < Formula
     ldflags = "-s -w -X github.com/cilium/hubble/pkg.Version=#{version}"
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    bash_output = Utils.safe_popen_read(bin/"hubble", "completion", "bash")
-    (bash_completion/"hubble").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"hubble", "completion", "zsh")
-    (zsh_completion/"_hubble").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"hubble", "completion", "fish")
-    (fish_completion/"hubble.fish").write fish_output
+    generate_completions_from_executable(bin/"hubble", "completion")
   end
 
   test do

--- a/Formula/hugo.rb
+++ b/Formula/hugo.rb
@@ -20,17 +20,7 @@ class Hugo < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "-tags", "extended"
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"hugo", "completion", "bash")
-    (bash_completion/"hugo").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"hugo", "completion", "zsh")
-    (zsh_completion/"_hugo").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(bin/"hugo", "completion", "fish")
-    (fish_completion/"hugo.fish").write output
+    generate_completions_from_executable(bin/"hugo", "completion")
 
     # Build man pages; target dir man/ is hardcoded :(
     (Pathname.pwd/"man").mkpath

--- a/Formula/idris2.rb
+++ b/Formula/idris2.rb
@@ -25,7 +25,8 @@ class Idris2 < Formula
     system "make", "install", "PREFIX=#{libexec}"
     bin.install_symlink libexec/"bin/idris2"
     lib.install_symlink Dir["#{libexec}/lib/#{shared_library("*")}"]
-    (bash_completion/"idris2").write Utils.safe_popen_read(bin/"idris2", "--bash-completion-script", "idris2")
+    generate_completions_from_executable(bin/"idris2", "--bash-completion-script", "idris2",
+                                         shells: [:bash], shell_parameter_format: :none)
   end
 
   test do

--- a/Formula/influxdb-cli.rb
+++ b/Formula/influxdb-cli.rb
@@ -35,11 +35,7 @@ class InfluxdbCli < Formula
 
     system "go", "build", *std_go_args(output: bin/"influx", ldflags: ldflags), "./cmd/influx"
 
-    output = Utils.safe_popen_read(bin/"influx", "completion", "bash")
-    (bash_completion/"influx").write output
-
-    output = Utils.safe_popen_read(bin/"influx", "completion", "zsh")
-    (zsh_completion/"_influx").write output
+    generate_completions_from_executable(bin/"influx", "completion", base_name: "influx", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -32,8 +32,7 @@ class Ipfs < Formula
     system "make", "build"
     bin.install "cmd/ipfs/ipfs"
 
-    bash_output = Utils.safe_popen_read(bin/"ipfs", "commands", "completion", "bash")
-    (bash_completion/"ipfs-completion.bash").write bash_output
+    generate_completions_from_executable(bin/"ipfs", "commands", "completion", shells: [:bash])
   end
 
   service do

--- a/Formula/istioctl.rb
+++ b/Formula/istioctl.rb
@@ -38,17 +38,7 @@ class Istioctl < Formula
     system "make", "istioctl"
     bin.install "out/#{os}_#{arch}/istioctl"
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"istioctl", "completion", "bash")
-    (bash_completion/"istioctl").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"istioctl", "completion", "zsh")
-    (zsh_completion/"_istioctl").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(bin/"istioctl", "completion", "fish")
-    (fish_completion/"istioctl.fish").write output
+    generate_completions_from_executable(bin/"istioctl", "completion")
   end
 
   test do

--- a/Formula/jfrog-cli.rb
+++ b/Formula/jfrog-cli.rb
@@ -20,17 +20,7 @@ class JfrogCli < Formula
     system "go", "build", *std_go_args(ldflags: "-s -w -extldflags '-static'", output: bin/"jf")
     bin.install_symlink "jf" => "jfrog"
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"jf", "completion", "bash")
-    (bash_completion/"jf").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"jf", "completion", "zsh")
-    (zsh_completion/"_jf").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(bin/"jf", "completion", "fish")
-    (fish_completion/"jf.fish").write output
+    generate_completions_from_executable(bin/"jf", "completion", base_name: "jf")
   end
 
   test do

--- a/Formula/jrsonnet.rb
+++ b/Formula/jrsonnet.rb
@@ -28,12 +28,12 @@ class Jrsonnet < Formula
       system "cargo", "install", *std_cargo_args
     end
 
-    bash_output = Utils.safe_popen_read(bin/"jrsonnet", "--generate", "bash", "-")
-    (bash_completion/"jrsonnet").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"jrsonnet", "--generate", "zsh", "-")
-    (zsh_completion/"_jrsonnet").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"jrsonnet", "--generate", "fish", "-")
-    (fish_completion/"jrsonnet.fish").write fish_output
+    generate_completions_from_executable(bin/"jrsonnet", "--generate", "bash", "-",
+                                         shells: [:bash], shell_parameter_format: :none)
+    generate_completions_from_executable(bin/"jrsonnet", "--generate", "zsh", "-",
+                                         shells: [:zsh], shell_parameter_format: :none)
+    generate_completions_from_executable(bin/"jrsonnet", "--generate", "fish", "-",
+                                         shells: [:fish], shell_parameter_format: :none)
   end
 
   test do

--- a/Formula/k3d.rb
+++ b/Formula/k3d.rb
@@ -41,17 +41,7 @@ class K3d < Formula
            "-mod", "vendor",
            *std_go_args(ldflags: ldflags)
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"k3d", "completion", "bash")
-    (bash_completion/"k3d").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"k3d", "completion", "zsh")
-    (zsh_completion/"_k3d").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(bin/"k3d", "completion", "fish")
-    (fish_completion/"k3d.fish").write output
+    generate_completions_from_executable(bin/"k3d", "completion")
   end
 
   test do

--- a/Formula/k3sup.rb
+++ b/Formula/k3sup.rb
@@ -32,9 +32,7 @@ class K3sup < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    (bash_completion/"k3sup").write Utils.safe_popen_read(bin/"k3sup", "completion", "bash")
-    (zsh_completion/"_k3sup").write Utils.safe_popen_read(bin/"k3sup", "completion", "zsh")
-    (fish_completion/"k3sup.fish").write Utils.safe_popen_read(bin/"k3sup", "completion", "fish")
+    generate_completions_from_executable(bin/"k3sup", "completion")
   end
 
   test do

--- a/Formula/k9s.rb
+++ b/Formula/k9s.rb
@@ -26,14 +26,7 @@ class K9s < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    bash_output = Utils.safe_popen_read(bin/"k9s", "completion", "bash")
-    (bash_completion/"k9s").write bash_output
-
-    zsh_output = Utils.safe_popen_read(bin/"k9s", "completion", "zsh")
-    (zsh_completion/"_k9s").write zsh_output
-
-    fish_output = Utils.safe_popen_read(bin/"k9s", "completion", "fish")
-    (fish_completion/"k9s.fish").write fish_output
+    generate_completions_from_executable(bin/"k9s", "completion")
   end
 
   test do

--- a/Formula/kamel.rb
+++ b/Formula/kamel.rb
@@ -30,11 +30,7 @@ class Kamel < Formula
     system "make", "build-kamel"
     bin.install "kamel"
 
-    output = Utils.safe_popen_read("#{bin}/kamel", "completion", "bash")
-    (bash_completion/"kamel").write output
-
-    output = Utils.safe_popen_read("#{bin}/kamel", "completion", "zsh")
-    (zsh_completion/"_kamel").write output
+    generate_completions_from_executable(bin/"kamel", "completion", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/kind.rb
+++ b/Formula/kind.rb
@@ -21,17 +21,7 @@ class Kind < Formula
   def install
     system "go", "build", *std_go_args
 
-    # Install bash completion
-    output = Utils.safe_popen_read("#{bin}/kind", "completion", "bash")
-    (bash_completion/"kind").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read("#{bin}/kind", "completion", "zsh")
-    (zsh_completion/"_kind").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read("#{bin}/kind", "completion", "fish")
-    (fish_completion/"kind.fish").write output
+    generate_completions_from_executable(bin/"kind", "completion")
   end
 
   test do

--- a/Formula/ko.rb
+++ b/Formula/ko.rb
@@ -19,14 +19,7 @@ class Ko < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/google/ko/pkg/commands.Version=#{version}")
 
-    bash_output = Utils.safe_popen_read(bin/"ko", "completion", "bash")
-    (bash_completion/"ko").write bash_output
-
-    zsh_output = Utils.safe_popen_read(bin/"ko", "completion", "zsh")
-    (zsh_completion/"_ko").write zsh_output
-
-    fish_output = Utils.safe_popen_read(bin/"ko", "completion", "fish")
-    (fish_completion/"ko.fish").write fish_output
+    generate_completions_from_executable(bin/"ko", "completion")
   end
 
   test do

--- a/Formula/kompose.rb
+++ b/Formula/kompose.rb
@@ -20,14 +20,7 @@ class Kompose < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
 
-    output = Utils.safe_popen_read(bin/"kompose", "completion", "bash")
-    (bash_completion/"kompose").write output
-
-    output = Utils.safe_popen_read(bin/"kompose", "completion", "zsh")
-    (zsh_completion/"_kompose").write output
-
-    output = Utils.safe_popen_read(bin/"kompose", "completion", "fish")
-    (fish_completion/"kompose.fish").write output
+    generate_completions_from_executable(bin/"kompose", "completion")
   end
 
   test do

--- a/Formula/kopia.rb
+++ b/Formula/kopia.rb
@@ -28,11 +28,8 @@ class Kopia < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    output = Utils.safe_popen_read(bin/"kopia", "--completion-script-bash")
-    (bash_completion/"kopia").write output
-
-    output = Utils.safe_popen_read(bin/"kopia", "--completion-script-zsh")
-    (zsh_completion/"_kopia").write output
+    generate_completions_from_executable(bin/"kopia", shells:                 [:bash, :zsh],
+                                                      shell_parameter_format: "--completion-script-")
 
     output = Utils.safe_popen_read(bin/"kopia", "--help-man")
     (man1/"kopia.1").write output

--- a/Formula/kops.rb
+++ b/Formula/kops.rb
@@ -27,12 +27,7 @@ class Kops < Formula
     ldflags = "-s -w -X k8s.io/kops.Version=#{version}"
     system "go", "build", *std_go_args(ldflags: ldflags), "k8s.io/kops/cmd/kops"
 
-    bash_output = Utils.safe_popen_read(bin/"kops", "completion", "bash")
-    (bash_completion/"kops").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"kops", "completion", "zsh")
-    (zsh_completion/"_kops").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"kops", "completion", "fish")
-    (fish_completion/"kops.fish").write fish_output
+    generate_completions_from_executable(bin/"kops", "completion")
   end
 
   test do

--- a/Formula/kt-connect.rb
+++ b/Formula/kt-connect.rb
@@ -21,17 +21,7 @@ class KtConnect < Formula
     ldflags = "-s -w -X main.version=#{version}"
     system "go", "build", *std_go_args(ldflags: ldflags, output: bin/"ktctl"), "./cmd/ktctl"
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"ktctl", "completion", "bash")
-    (bash_completion/"ktctl").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"ktctl", "completion", "zsh")
-    (zsh_completion/"_ktctl").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(bin/"ktctl", "completion", "fish")
-    (fish_completion/"ktctl.fish").write output
+    generate_completions_from_executable(bin/"ktctl", "completion", base_name: "ktctl")
   end
 
   test do

--- a/Formula/kube-linter.rb
+++ b/Formula/kube-linter.rb
@@ -22,14 +22,7 @@ class KubeLinter < Formula
     ldflags = "-s -w -X golang.stackrox.io/kube-linter/internal/version.version=#{version}"
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/kube-linter"
 
-    bash_output = Utils.safe_popen_read(bin/"kube-linter", "completion", "bash")
-    (bash_completion/"kube-linter").write bash_output
-
-    zsh_output = Utils.safe_popen_read(bin/"kube-linter", "completion", "zsh")
-    (zsh_completion/"_kube-linter").write zsh_output
-
-    fish_output = Utils.safe_popen_read(bin/"kube-linter", "completion", "fish")
-    (fish_completion/"kube-linter.fish").write fish_output
+    generate_completions_from_executable(bin/"kube-linter", "completion")
   end
 
   test do

--- a/Formula/kubebuilder.rb
+++ b/Formula/kubebuilder.rb
@@ -31,12 +31,7 @@ class Kubebuilder < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd"
 
-    output = Utils.safe_popen_read(bin/"kubebuilder", "completion", "bash")
-    (bash_completion/"kubebuilder").write output
-    output = Utils.safe_popen_read(bin/"kubebuilder", "completion", "zsh")
-    (zsh_completion/"_kubebuilder").write output
-    output = Utils.safe_popen_read(bin/"kubebuilder", "completion", "fish")
-    (fish_completion/"kubebuilder.fish").write output
+    generate_completions_from_executable(bin/"kubebuilder", "completion")
   end
 
   test do

--- a/Formula/kubecfg.rb
+++ b/Formula/kubecfg.rb
@@ -26,10 +26,7 @@ class Kubecfg < Formula
       prefix.install_metafiles
     end
 
-    output = Utils.safe_popen_read("#{bin}/kubecfg", "completion", "--shell", "bash")
-    (bash_completion/"kubecfg").write output
-    output = Utils.safe_popen_read("#{bin}/kubecfg", "completion", "--shell", "zsh")
-    (zsh_completion/"_kubecfg").write output
+    generate_completions_from_executable(bin/"kubecfg", "completion", "--shell", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/kubecm.rb
+++ b/Formula/kubecm.rb
@@ -20,17 +20,7 @@ class Kubecm < Formula
     ldflags = "-s -w -X github.com/sunny0826/kubecm/cmd.kubecmVersion=#{version}"
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"kubecm", "completion", "bash")
-    (bash_completion/"kubecm").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"kubecm", "completion", "zsh")
-    (zsh_completion/"_kubecm").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(bin/"kubecm", "completion", "fish")
-    (fish_completion/"kubecm.fish").write output
+    generate_completions_from_executable(bin/"kubecm", "completion")
   end
 
   test do

--- a/Formula/kubekey.rb
+++ b/Formula/kubekey.rb
@@ -26,8 +26,7 @@ class Kubekey < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags, output: bin/"kk"), "./cmd"
 
-    (zsh_completion/"_kk").write Utils.safe_popen_read(bin/"kk", "completion", "--type", "zsh")
-    (bash_completion/"kk").write Utils.safe_popen_read(bin/"kk", "completion", "--type", "bash")
+    generate_completions_from_executable(bin/"kk", "completion", "--type", shells: [:bash, :zsh], base_name: "kk")
   end
 
   test do

--- a/Formula/kubernetes-cli.rb
+++ b/Formula/kubernetes-cli.rb
@@ -40,17 +40,7 @@ class KubernetesCli < Formula
     system "make", "WHAT=cmd/kubectl"
     bin.install "_output/bin/kubectl"
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"kubectl", "completion", "bash")
-    (bash_completion/"kubectl").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"kubectl", "completion", "zsh")
-    (zsh_completion/"_kubectl").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(bin/"kubectl", "completion", "fish")
-    (fish_completion/"kubectl.fish").write output
+    generate_completions_from_executable(bin/"kubectl", "completion", base_name: "kubectl")
 
     # Install man pages
     # Leave this step for the end as this dirties the git tree

--- a/Formula/kubernetes-cli@1.22.rb
+++ b/Formula/kubernetes-cli@1.22.rb
@@ -45,13 +45,7 @@ class KubernetesCliAT122 < Formula
     system "make", "WHAT=cmd/kubectl"
     bin.install "_output/bin/kubectl"
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"kubectl", "completion", "bash")
-    (bash_completion/"kubectl").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"kubectl", "completion", "zsh")
-    (zsh_completion/"_kubectl").write output
+    generate_completions_from_executable(bin/"kubectl", "completion", base_name: "kubectl", shells: [:bash, :zsh])
 
     # Install man pages
     # Leave this step for the end as this dirties the git tree

--- a/Formula/kubescape.rb
+++ b/Formula/kubescape.rb
@@ -29,12 +29,7 @@ class Kubescape < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    output = Utils.safe_popen_read(bin/"kubescape", "completion", "bash")
-    (bash_completion/"kubescape").write output
-    output = Utils.safe_popen_read(bin/"kubescape", "completion", "zsh")
-    (zsh_completion/"_kubescape").write output
-    output = Utils.safe_popen_read(bin/"kubescape", "completion", "fish")
-    (fish_completion/"kubescape.fish").write output
+    generate_completions_from_executable(bin/"kubescape", "completion")
   end
 
   test do

--- a/Formula/kumactl.rb
+++ b/Formula/kumactl.rb
@@ -31,14 +31,7 @@ class Kumactl < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./app/kumactl"
 
-    output = Utils.safe_popen_read("#{bin}/kumactl", "completion", "bash")
-    (bash_completion/"kumactl").write output
-
-    output = Utils.safe_popen_read("#{bin}/kumactl", "completion", "zsh")
-    (zsh_completion/"_kumactl").write output
-
-    output = Utils.safe_popen_read("#{bin}/kumactl", "completion", "fish")
-    (fish_completion/"kumactl.fish").write output
+    generate_completions_from_executable(bin/"kumactl", "completion")
   end
 
   test do

--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -37,14 +37,7 @@ class Kustomize < Formula
       system "go", "build", *std_go_args(ldflags: ldflags)
     end
 
-    output = Utils.safe_popen_read("#{bin}/kustomize", "completion", "bash")
-    (bash_completion/"kustomize").write output
-
-    output = Utils.safe_popen_read("#{bin}/kustomize", "completion", "zsh")
-    (zsh_completion/"_kustomize").write output
-
-    output = Utils.safe_popen_read("#{bin}/kustomize", "completion", "fish")
-    (fish_completion/"kustomize.fish").write output
+    generate_completions_from_executable(bin/"kustomize", "completion")
   end
 
   test do

--- a/Formula/kyverno.rb
+++ b/Formula/kyverno.rb
@@ -35,9 +35,7 @@ class Kyverno < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/cli/kubectl-kyverno"
 
-    (bash_completion/"kyverno").write Utils.safe_popen_read(bin/"kyverno", "completion", "bash")
-    (zsh_completion/"_kyverno").write Utils.safe_popen_read(bin/"kyverno", "completion", "zsh")
-    (fish_completion/"kyverno.fish").write Utils.safe_popen_read(bin/"kyverno", "completion", "fish")
+    generate_completions_from_executable(bin/"kyverno", "completion")
   end
 
   test do

--- a/Formula/lab.rb
+++ b/Formula/lab.rb
@@ -21,12 +21,8 @@ class Lab < Formula
   def install
     ldflags = "-X main.version=#{version} -s -w"
     system "go", "build", *std_go_args(ldflags: ldflags)
-    output = Utils.safe_popen_read("#{bin}/lab", "completion", "bash")
-    (bash_completion/"lab").write output
-    output = Utils.safe_popen_read("#{bin}/lab", "completion", "zsh")
-    (zsh_completion/"_lab").write output
-    output = Utils.safe_popen_read("#{bin}/lab", "completion", "fish")
-    (fish_completion/"lab.fish").write output
+
+    generate_completions_from_executable(bin/"lab", "completion")
   end
 
   test do

--- a/Formula/lima.rb
+++ b/Formula/lima.rb
@@ -25,12 +25,7 @@ class Lima < Formula
     share.install Dir["_output/share/*"]
 
     # Install shell completions
-    output = Utils.safe_popen_read("#{bin}/limactl", "completion", "bash")
-    (bash_completion/"limactl").write output
-    output = Utils.safe_popen_read("#{bin}/limactl", "completion", "zsh")
-    (zsh_completion/"_limactl").write output
-    output = Utils.safe_popen_read("#{bin}/limactl", "completion", "fish")
-    (fish_completion/"limactl.fish").write output
+    generate_completions_from_executable(bin/"limactl", "completion", base_name: "limactl")
   end
 
   test do

--- a/Formula/linkerd.rb
+++ b/Formula/linkerd.rb
@@ -29,17 +29,7 @@ class Linkerd < Formula
     bin.install Dir["target/cli/*/linkerd"]
     prefix.install_metafiles
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"linkerd", "completion", "bash")
-    (bash_completion/"linkerd").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"linkerd", "completion", "zsh")
-    (zsh_completion/"_linkerd").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(bin/"linkerd", "completion", "fish")
-    (fish_completion/"linkerd.fish").write output
+    generate_completions_from_executable(bin/"linkerd", "completion")
   end
 
   test do

--- a/Formula/liqoctl.rb
+++ b/Formula/liqoctl.rb
@@ -26,12 +26,7 @@ class Liqoctl < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/liqoctl"
 
-    output = Utils.safe_popen_read(bin/"liqoctl", "completion", "bash")
-    (bash_completion/"liqoctl").write output
-    output = Utils.safe_popen_read(bin/"liqoctl", "completion", "zsh")
-    (zsh_completion/"_liqoctl").write output
-    output = Utils.safe_popen_read(bin/"liqoctl", "completion", "fish")
-    (fish_completion/"liqoctl").write output
+    generate_completions_from_executable(bin/"liqoctl", "completion")
   end
 
   test do

--- a/Formula/maturin.rb
+++ b/Formula/maturin.rb
@@ -21,12 +21,7 @@ class Maturin < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    bash_output = Utils.safe_popen_read(bin/"maturin", "completions", "bash")
-    (bash_completion/"maturin").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"maturin", "completions", "zsh")
-    (zsh_completion/"_maturin").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"maturin", "completions", "fish")
-    (fish_completion/"maturin.fish").write fish_output
+    generate_completions_from_executable(bin/"maturin", "completions")
   end
 
   test do

--- a/Formula/mesheryctl.rb
+++ b/Formula/mesheryctl.rb
@@ -31,14 +31,7 @@ class Mesheryctl < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./mesheryctl/cmd/mesheryctl"
 
-    output = Utils.safe_popen_read("#{bin}/mesheryctl", "completion", "bash")
-    (bash_completion/"mesheryctl").write output
-
-    output = Utils.safe_popen_read("#{bin}/mesheryctl", "completion", "zsh")
-    (zsh_completion/"_mesheryctl").write output
-
-    output = Utils.safe_popen_read("#{bin}/mesheryctl", "completion", "fish")
-    (fish_completion/"mesheryctl.fish").write output
+    generate_completions_from_executable(bin/"mesheryctl", "completion")
   end
 
   test do

--- a/Formula/minikube.rb
+++ b/Formula/minikube.rb
@@ -24,14 +24,7 @@ class Minikube < Formula
     system "make"
     bin.install "out/minikube"
 
-    output = Utils.safe_popen_read(bin/"minikube", "completion", "bash")
-    (bash_completion/"minikube").write output
-
-    output = Utils.safe_popen_read(bin/"minikube", "completion", "zsh")
-    (zsh_completion/"_minikube").write output
-
-    output = Utils.safe_popen_read(bin/"minikube", "completion", "fish")
-    (fish_completion/"minikube.fish").write output
+    generate_completions_from_executable(bin/"minikube", "completion")
   end
 
   test do

--- a/Formula/miniserve.rb
+++ b/Formula/miniserve.rb
@@ -19,12 +19,7 @@ class Miniserve < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    bash_output = Utils.safe_popen_read("#{bin}/miniserve", "--print-completions", "bash")
-    (bash_completion/"miniserve").write bash_output
-    zsh_output = Utils.safe_popen_read("#{bin}/miniserve", "--print-completions", "zsh")
-    (zsh_completion/"_miniserve").write zsh_output
-    fish_output = Utils.safe_popen_read("#{bin}/miniserve", "--print-completions", "fish")
-    (fish_completion/"miniserve.fish").write fish_output
+    generate_completions_from_executable(bin/"miniserve", "--print-completions")
   end
 
   test do

--- a/Formula/mmctl.rb
+++ b/Formula/mmctl.rb
@@ -28,10 +28,7 @@ class Mmctl < Formula
     system "go", "build", *std_go_args(ldflags: ldflags), "-mod=vendor"
 
     # Install shell completions
-    output = Utils.safe_popen_read(bin/"mmctl", "completion", "bash")
-    (bash_completion/"mmctl").write output
-    output = Utils.safe_popen_read(bin/"mmctl", "completion", "zsh")
-    (zsh_completion/"_mmctl").write output
+    generate_completions_from_executable(bin/"mmctl", "completion", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/mongocli.rb
+++ b/Formula/mongocli.rb
@@ -31,9 +31,7 @@ class Mongocli < Formula
     end
     bin.install "bin/mongocli"
 
-    (bash_completion/"mongocli").write Utils.safe_popen_read(bin/"mongocli", "completion", "bash")
-    (fish_completion/"mongocli.fish").write Utils.safe_popen_read(bin/"mongocli", "completion", "fish")
-    (zsh_completion/"_mongocli").write Utils.safe_popen_read(bin/"mongocli", "completion", "zsh")
+    generate_completions_from_executable(bin/"mongocli", "completion")
   end
 
   test do

--- a/Formula/mongodb-atlas-cli.rb
+++ b/Formula/mongodb-atlas-cli.rb
@@ -32,9 +32,7 @@ class MongodbAtlasCli < Formula
     end
     bin.install "bin/atlas"
 
-    (bash_completion/"atlas").write Utils.safe_popen_read(bin/"atlas", "completion", "bash")
-    (fish_completion/"atlas.fish").write Utils.safe_popen_read(bin/"atlas", "completion", "fish")
-    (zsh_completion/"_atlas").write Utils.safe_popen_read(bin/"atlas", "completion", "zsh")
+    generate_completions_from_executable(bin/"atlas", "completion", base_name: "atlas")
   end
 
   test do

--- a/Formula/nali.rb
+++ b/Formula/nali.rb
@@ -19,9 +19,7 @@ class Nali < Formula
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
-    (bash_completion/"nali").write Utils.safe_popen_read(bin/"nali", "completion", "bash")
-    (fish_completion/"nali.fish").write Utils.safe_popen_read(bin/"nali", "completion", "fish")
-    (zsh_completion/"_nali").write Utils.safe_popen_read(bin/"nali", "completion", "zsh")
+    generate_completions_from_executable(bin/"nali", "completion")
   end
 
   test do

--- a/Formula/newrelic-cli.rb
+++ b/Formula/newrelic-cli.rb
@@ -22,12 +22,7 @@ class NewrelicCli < Formula
     system "make", "compile-only"
     bin.install "bin/#{OS.kernel_name.downcase}/newrelic"
 
-    output = Utils.safe_popen_read(bin/"newrelic", "completion", "--shell", "bash")
-    (bash_completion/"newrelic").write output
-    output = Utils.safe_popen_read(bin/"newrelic", "completion", "--shell", "zsh")
-    (zsh_completion/"_newrelic").write output
-    output = Utils.safe_popen_read(bin/"newrelic", "completion", "--shell", "fish")
-    (fish_completion/"newrelic.fish").write output
+    generate_completions_from_executable(bin/"newrelic", "completion", "--shell", base_name: "newrelic")
   end
 
   test do

--- a/Formula/octosql.rb
+++ b/Formula/octosql.rb
@@ -21,14 +21,7 @@ class Octosql < Formula
     ldflags = "-s -w -X github.com/cube2222/octosql/cmd.VERSION=#{version}"
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    bash_output = Utils.safe_popen_read(bin/"octosql", "completion", "bash")
-    (bash_completion/"octosql").write bash_output
-
-    zsh_output = Utils.safe_popen_read(bin/"octosql", "completion", "zsh")
-    (zsh_completion/"_octosql").write zsh_output
-
-    fish_output = Utils.safe_popen_read(bin/"octosql", "completion", "fish")
-    (fish_completion/"octosql.fish").write fish_output
+    generate_completions_from_executable(bin/"octosql", "completion")
   end
 
   test do

--- a/Formula/okteto.rb
+++ b/Formula/okteto.rb
@@ -22,12 +22,7 @@ class Okteto < Formula
     tags = "osusergo netgo static_build"
     system "go", "build", *std_go_args(ldflags: ldflags), "-tags", tags
 
-    bash_output = Utils.safe_popen_read(bin/"okteto", "completion", "bash")
-    (bash_completion/"okteto").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"okteto", "completion", "zsh")
-    (zsh_completion/"_okteto").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"okteto", "completion", "fish")
-    (fish_completion/"okteto.fish").write fish_output
+    generate_completions_from_executable(bin/"okteto", "completion")
   end
 
   test do

--- a/Formula/opa.rb
+++ b/Formula/opa.rb
@@ -23,14 +23,7 @@ class Opa < Formula
     system "./build/gen-man.sh", "man1"
     man.install "man1"
 
-    bash_output = Utils.safe_popen_read(bin/"opa", "completion", "bash")
-    (bash_completion/"opa").write bash_output
-
-    zsh_output = Utils.safe_popen_read(bin/"opa", "completion", "zsh")
-    (zsh_completion/"_opa").write zsh_output
-
-    fish_output = Utils.safe_popen_read(bin/"opa", "completion", "fish")
-    (fish_completion/"opa.fish").write fish_output
+    generate_completions_from_executable(bin/"opa", "completion")
   end
 
   test do

--- a/Formula/operator-sdk.rb
+++ b/Formula/operator-sdk.rb
@@ -27,17 +27,7 @@ class OperatorSdk < Formula
     ENV["GOBIN"] = libexec/"bin"
     system "make", "install"
 
-    # Install bash completion
-    output = Utils.safe_popen_read(libexec/"bin/operator-sdk", "completion", "bash")
-    (bash_completion/"operator-sdk").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(libexec/"bin/operator-sdk", "completion", "zsh")
-    (zsh_completion/"_operator-sdk").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(libexec/"bin/operator-sdk", "completion", "fish")
-    (fish_completion/"operator-sdk.fish").write output
+    generate_completions_from_executable(libexec/"bin/operator-sdk", "completion")
 
     output = libexec/"bin/operator-sdk"
     (bin/"operator-sdk").write_env_script(output, PATH: "$PATH:#{Formula["go@1.17"].opt_bin}")

--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -24,7 +24,8 @@ class Pandoc < Formula
   def install
     system "cabal", "v2-update"
     system "cabal", "v2-install", *std_cabal_v2_args
-    (bash_completion/"pandoc").write `#{bin}/pandoc --bash-completion`
+    generate_completions_from_executable(bin/"pandoc", "--bash-completion",
+                                         shells: [:bash], shell_parameter_format: :none)
     man1.install "man/pandoc.1"
   end
 

--- a/Formula/pdm.rb
+++ b/Formula/pdm.rb
@@ -172,9 +172,7 @@ class Pdm < Formula
 
   def install
     virtualenv_install_with_resources
-    (bash_completion/"pdm").write Utils.safe_popen_read("#{bin}/pdm", "completion", "bash")
-    (zsh_completion/"_pdm").write Utils.safe_popen_read("#{bin}/pdm", "completion", "zsh")
-    (fish_completion/"pdm.fish").write Utils.safe_popen_read("#{bin}/pdm", "completion", "fish")
+    generate_completions_from_executable(bin/"pdm", "completion")
   end
 
   test do

--- a/Formula/periscope.rb
+++ b/Formula/periscope.rb
@@ -27,17 +27,7 @@ class Periscope < Formula
     ]
     system "go", "build", *std_go_args(output: bin/"psc", ldflags: ldflags), "./cmd/psc"
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"psc", "completion", "bash")
-    (bash_completion/"psc").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"psc", "completion", "zsh")
-    (zsh_completion/"_psc").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(bin/"psc", "completion", "fish")
-    (fish_completion/"psc.fish").write output
+    generate_completions_from_executable(bin/"psc", "completion", base_name: "psc")
   end
 
   test do

--- a/Formula/pipenv.rb
+++ b/Formula/pipenv.rb
@@ -66,15 +66,10 @@ class Pipenv < Formula
     }
     (bin/"pipenv").write_env_script(libexec/"bin/pipenv", env)
 
-    output = Utils.safe_popen_read(
-      { "_PIPENV_COMPLETE" => "zsh_source" }, libexec/"bin/pipenv", { err: :err }
-    )
-    (zsh_completion/"_pipenv").write output
-
-    output = Utils.safe_popen_read(
-      { "_PIPENV_COMPLETE" => "fish_source" }, libexec/"bin/pipenv", { err: :err }
-    )
-    (fish_completion/"pipenv.fish").write output
+    (zsh_completion/"_pipenv").write Utils.safe_popen_read({ "_PIPENV_COMPLETE" => "zsh_source" },
+                                                           libexec/"bin/pipenv", { err: :err })
+    (fish_completion/"pipenv.fish").write Utils.safe_popen_read({ "_PIPENV_COMPLETE" => "fish_source" },
+                                                                libexec/"bin/pipenv", { err: :err })
   end
 
   # Avoid relative paths

--- a/Formula/pipx.rb
+++ b/Formula/pipx.rb
@@ -48,12 +48,8 @@ class Pipx < Formula
     virtualenv_install_with_resources
     bin.install_symlink libexec/"bin/register-python-argcomplete"
 
-    # Install shell completions
-    output = Utils.safe_popen_read(libexec/"bin/register-python-argcomplete", "--shell=bash", "pipx")
-    (bash_completion/"pipx").write output
-
-    output = Utils.safe_popen_read(libexec/"bin/register-python-argcomplete", "--shell=fish", "pipx")
-    (fish_completion/"pipx.fish").write output
+    generate_completions_from_executable(libexec/"bin/register-python-argcomplete", "pipx", "--shell",
+                                         shells: [:bash, :fish])
   end
 
   test do

--- a/Formula/poetry.rb
+++ b/Formula/poetry.rb
@@ -173,10 +173,7 @@ class Poetry < Formula
   def install
     virtualenv_install_with_resources
 
-    # Install shell completions
-    (bash_completion/"poetry").write Utils.safe_popen_read(libexec/"bin/poetry", "completions", "bash")
-    (fish_completion/"poetry.fish").write Utils.safe_popen_read(libexec/"bin/poetry", "completions", "fish")
-    (zsh_completion/"_poetry").write Utils.safe_popen_read(libexec/"bin/poetry", "completions", "zsh")
+    generate_completions_from_executable(libexec/"bin/poetry", "completions")
   end
 
   test do

--- a/Formula/pulumi.rb
+++ b/Formula/pulumi.rb
@@ -31,9 +31,7 @@ class Pulumi < Formula
     bin.install Dir["#{ENV["GOPATH"]}/bin/pulumi*"]
 
     # Install shell completions
-    (bash_completion/"pulumi.bash").write Utils.safe_popen_read(bin/"pulumi", "gen-completion", "bash")
-    (zsh_completion/"_pulumi").write Utils.safe_popen_read(bin/"pulumi", "gen-completion", "zsh")
-    (fish_completion/"pulumi.fish").write Utils.safe_popen_read(bin/"pulumi", "gen-completion", "fish")
+    generate_completions_from_executable(bin/"pulumi", "gen-completion")
   end
 
   test do

--- a/Formula/py-spy.rb
+++ b/Formula/py-spy.rb
@@ -24,12 +24,7 @@ class PySpy < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    bash_output = Utils.safe_popen_read(bin/"py-spy", "completions", "bash")
-    (bash_completion/"py-spy").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"py-spy", "completions", "zsh")
-    (zsh_completion/"_py-spy").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"py-spy", "completions", "fish")
-    (fish_completion/"py-spy.fish").write fish_output
+    generate_completions_from_executable(bin/"py-spy", "completions")
   end
 
   test do

--- a/Formula/rabbitmq.rb
+++ b/Formula/rabbitmq.rb
@@ -51,7 +51,8 @@ class Rabbitmq < Formula
 
     sbin.install prefix/"plugins/rabbitmq_management-#{version}/priv/www/cli/rabbitmqadmin"
     (sbin/"rabbitmqadmin").chmod 0755
-    (bash_completion/"rabbitmqadmin.bash").write Utils.safe_popen_read("#{sbin}/rabbitmqadmin", "--bash-completion")
+    generate_completions_from_executable(sbin/"rabbitmqadmin", "--bash-completion", shells: [:bash],
+                                         base_name: "rabbitmqadmin", shell_parameter_format: :none)
   end
 
   def caveats

--- a/Formula/railway.rb
+++ b/Formula/railway.rb
@@ -23,12 +23,7 @@ class Railway < Formula
     system "go", "build", *std_go_args(ldflags: ldflags)
 
     # Install shell completions
-    output = Utils.safe_popen_read(bin/"railway", "completion", "bash")
-    (bash_completion/"railway").write output
-    output = Utils.safe_popen_read(bin/"railway", "completion", "zsh")
-    (zsh_completion/"_railway").write output
-    output = Utils.safe_popen_read(bin/"railway", "completion", "fish")
-    (fish_completion/"railway.fish").write output
+    generate_completions_from_executable(bin/"railway", "completion")
   end
 
   test do

--- a/Formula/rbw.rb
+++ b/Formula/rbw.rb
@@ -21,14 +21,7 @@ class Rbw < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    bash_output = Utils.safe_popen_read(bin/"rbw", "gen-completions", "bash")
-    (bash_completion/"rbw").write bash_output
-
-    zsh_output = Utils.safe_popen_read(bin/"rbw", "gen-completions", "zsh")
-    (zsh_completion/"_rbw").write zsh_output
-
-    fish_output = Utils.safe_popen_read(bin/"rbw", "gen-completions", "fish")
-    (fish_completion/"rbw.fish").write fish_output
+    generate_completions_from_executable(bin/"rbw", "gen-completions")
   end
 
   test do

--- a/Formula/regula.rb
+++ b/Formula/regula.rb
@@ -27,12 +27,7 @@ class Regula < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    bash_output = Utils.safe_popen_read(bin/"regula", "completion", "bash")
-    (bash_completion/"regula").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"regula", "completion", "zsh")
-    (zsh_completion/"_regula").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"regula", "completion", "fish")
-    (fish_completion/"regula.fish").write fish_output
+    generate_completions_from_executable(bin/"regula", "completion")
   end
 
   test do

--- a/Formula/rosa-cli.rb
+++ b/Formula/rosa-cli.rb
@@ -26,9 +26,7 @@ class RosaCli < Formula
 
   def install
     system "go", "build", *std_go_args(output: bin/"rosa"), "./cmd/rosa"
-    (bash_completion/"rosa").write Utils.safe_popen_read("#{bin}/rosa", "completion", "bash")
-    (zsh_completion/"_rosa").write Utils.safe_popen_read("#{bin}/rosa", "completion", "zsh")
-    (fish_completion/"rosa.fish").write Utils.safe_popen_read("#{bin}/rosa", "completion", "fish")
+    generate_completions_from_executable(bin/"rosa", "completion", base_name: "rosa")
   end
 
   test do

--- a/Formula/s-search.rb
+++ b/Formula/s-search.rb
@@ -20,14 +20,7 @@ class SSearch < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"s"
 
-    output = Utils.safe_popen_read("#{bin}/s", "--completion", "bash")
-    (bash_completion/"s-completion.bash").write output
-
-    output = Utils.safe_popen_read("#{bin}/s", "--completion", "zsh")
-    (zsh_completion/"_s").write output
-
-    output = Utils.safe_popen_read("#{bin}/s", "--completion", "fish")
-    (fish_completion/"s.fish").write output
+    generate_completions_from_executable(bin/"s", "--completion", base_name: "s")
   end
 
   test do

--- a/Formula/scw.rb
+++ b/Formula/scw.rb
@@ -19,14 +19,7 @@ class Scw < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-X main.Version=#{version}"), "./cmd/scw"
 
-    zsh_output = Utils.safe_popen_read({ "SHELL" => "zsh" }, bin/"scw", "autocomplete", "script")
-    (zsh_completion/"_scw").write zsh_output
-
-    bash_output = Utils.safe_popen_read({ "SHELL" => "bash" }, bin/"scw", "autocomplete", "script")
-    (bash_completion/"scw").write bash_output
-
-    fish_output = Utils.safe_popen_read({ "SHELL" => "fish" }, bin/"scw", "autocomplete", "script")
-    (fish_completion/"scw.fish").write fish_output
+    generate_completions_from_executable(bin/"scw", "autocomplete", "script", shell_parameter_format: :none)
   end
 
   test do

--- a/Formula/sftpgo.rb
+++ b/Formula/sftpgo.rb
@@ -24,9 +24,7 @@ class Sftpgo < Formula
     system "go", "build", *std_go_args(ldflags: ldflags)
     system bin/"sftpgo", "gen", "man", "-d", man1
 
-    (zsh_completion/"_sftpgo").write Utils.safe_popen_read(bin/"sftpgo", "gen", "completion", "zsh")
-    (bash_completion/"sftpgo").write Utils.safe_popen_read(bin/"sftpgo", "gen", "completion", "bash")
-    (fish_completion/"sftpgo.fish").write Utils.safe_popen_read(bin/"sftpgo", "gen", "completion", "fish")
+    generate_completions_from_executable(bin/"sftpgo", "gen", "completion")
 
     inreplace "sftpgo.json" do |s|
       s.gsub! "\"users_base_dir\": \"\"", "\"users_base_dir\": \"#{var}/sftpgo/data\""

--- a/Formula/skaffold.rb
+++ b/Formula/skaffold.rb
@@ -38,10 +38,7 @@ class Skaffold < Formula
   def install
     system "make"
     bin.install "out/skaffold"
-    output = Utils.safe_popen_read("#{bin}/skaffold", "completion", "bash")
-    (bash_completion/"skaffold").write output
-    output = Utils.safe_popen_read("#{bin}/skaffold", "completion", "zsh")
-    (zsh_completion/"_skaffold").write output
+    generate_completions_from_executable(bin/"skaffold", "completion", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/skopeo.rb
+++ b/Formula/skopeo.rb
@@ -48,12 +48,7 @@ class Skopeo < Formula
     (etc/"containers").install "default-policy.json" => "policy.json"
     (etc/"containers/registries.d").install "default.yaml"
 
-    bash_output = Utils.safe_popen_read(bin/"skopeo", "completion", "bash")
-    (bash_completion/"skopeo").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"skopeo", "completion", "zsh")
-    (zsh_completion/"_skopeo").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"skopeo", "completion", "fish")
-    (fish_completion/"skopeo.fish").write fish_output
+    generate_completions_from_executable(bin/"skopeo", "completion")
   end
 
   test do

--- a/Formula/sn0int.rb
+++ b/Formula/sn0int.rb
@@ -28,12 +28,7 @@ class Sn0int < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    bash_output = Utils.safe_popen_read(bin/"sn0int", "completions", "bash")
-    (bash_completion/"sn0int").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"sn0int", "completions", "zsh")
-    (zsh_completion/"_sn0int").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"sn0int", "completions", "fish")
-    (fish_completion/"sn0int.fish").write fish_output
+    generate_completions_from_executable(bin/"sn0int", "completions")
 
     system "make", "-C", "docs", "man"
     man1.install "docs/_build/man/sn0int.1"

--- a/Formula/spago.rb
+++ b/Formula/spago.rb
@@ -55,8 +55,10 @@ class Spago < Formula
     end
 
     system "stack", "install", "--system-ghc", "--no-install-ghc", "--skip-ghc-check", "--local-bin-path=#{bin}"
-    (bash_completion/"spago").write `#{bin}/spago --bash-completion-script #{bin}/spago`
-    (zsh_completion/"_spago").write `#{bin}/spago --zsh-completion-script #{bin}/spago`
+    generate_completions_from_executable(bin/"spago", "--bash-completion-script", bin/"spago",
+                                         shells: [:bash], shell_parameter_format: :none)
+    generate_completions_from_executable(bin/"spago", "--zsh-completion-script", bin/"spago",
+                                         shells: [:zsh], shell_parameter_format: :none)
   end
 
   test do

--- a/Formula/starship.rb
+++ b/Formula/starship.rb
@@ -28,14 +28,7 @@ class Starship < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    bash_output = Utils.safe_popen_read("#{bin}/starship", "completions", "bash")
-    (bash_completion/"starship").write bash_output
-
-    zsh_output = Utils.safe_popen_read("#{bin}/starship", "completions", "zsh")
-    (zsh_completion/"_starship").write zsh_output
-
-    fish_output = Utils.safe_popen_read("#{bin}/starship", "completions", "fish")
-    (fish_completion/"starship.fish").write fish_output
+    generate_completions_from_executable(bin/"starship", "completions")
   end
 
   test do

--- a/Formula/stern.rb
+++ b/Formula/stern.rb
@@ -21,14 +21,7 @@ class Stern < Formula
     system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/stern/stern/cmd.version=#{version}")
 
     # Install shell completion
-    output = Utils.safe_popen_read("#{bin}/stern", "--completion=bash")
-    (bash_completion/"stern").write output
-
-    output = Utils.safe_popen_read("#{bin}/stern", "--completion=zsh")
-    (zsh_completion/"_stern").write output
-
-    output = Utils.safe_popen_read("#{bin}/stern", "--completion=fish")
-    (fish_completion/"stern.fish").write output
+    generate_completions_from_executable(bin/"stern", "--completion")
   end
 
   test do

--- a/Formula/tektoncd-cli.rb
+++ b/Formula/tektoncd-cli.rb
@@ -25,12 +25,7 @@ class TektoncdCli < Formula
     system "make", "bin/tkn"
     bin.install "bin/tkn" => "tkn"
 
-    output = Utils.safe_popen_read(bin/"tkn", "completion", "bash")
-    (bash_completion/"tkn").write output
-    output = Utils.safe_popen_read(bin/"tkn", "completion", "zsh")
-    (zsh_completion/"_tkn").write output
-    output = Utils.safe_popen_read(bin/"tkn", "completion", "fish")
-    (fish_completion/"tkn.fish").write output
+    generate_completions_from_executable(bin/"tkn", "completion", base_name: "tkn")
   end
 
   test do

--- a/Formula/tilt.rb
+++ b/Formula/tilt.rb
@@ -33,17 +33,8 @@ class Tilt < Formula
       -X main.date=#{time.iso8601}
     ].join(" ")
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/tilt"
-    # Install bash completion
-    output = Utils.safe_popen_read("#{bin}/tilt", "completion", "bash")
-    (bash_completion/"tilt").write output
 
-    # Install zsh completion
-    output = Utils.safe_popen_read("#{bin}/tilt", "completion", "zsh")
-    (zsh_completion/"_tilt").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read("#{bin}/tilt", "completion", "fish")
-    (fish_completion/"tilt.fish").write output
+    generate_completions_from_executable(bin/"tilt", "completion")
   end
 
   test do

--- a/Formula/tremor-runtime.rb
+++ b/Formula/tremor-runtime.rb
@@ -36,9 +36,7 @@ class TremorRuntime < Formula
 
     system "cargo", "install", *std_cargo_args(path: "tremor-cli")
 
-    (bash_completion/"tremor").write Utils.safe_popen_read("#{bin}/tremor", "completions", "bash")
-    (zsh_completion/"_tremor").write Utils.safe_popen_read("#{bin}/tremor", "completions", "zsh")
-    (fish_completion/"tremor.fish").write Utils.safe_popen_read("#{bin}/tremor", "completions", "fish")
+    generate_completions_from_executable(bin/"tremor", "completions", base_name: "tremor")
 
     # main binary
     bin.install "target/release/tremor"

--- a/Formula/triton.rb
+++ b/Formula/triton.rb
@@ -21,7 +21,7 @@ class Triton < Formula
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
-    (bash_completion/"triton").write `#{bin}/triton completion`
+    generate_completions_from_executable(bin/"triton", "completion", shells: [:bash], shell_parameter_format: :none)
   end
 
   test do

--- a/Formula/tygo.rb
+++ b/Formula/tygo.rb
@@ -28,9 +28,7 @@ class Tygo < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags)
 
-    (zsh_completion/"_tygo").write Utils.safe_popen_read(bin/"tygo", "completion", "zsh")
-    (bash_completion/"tygo").write Utils.safe_popen_read(bin/"tygo", "completion", "bash")
-    (fish_completion/"tygo.fish").write Utils.safe_popen_read(bin/"tygo", "completion", "fish")
+    generate_completions_from_executable(bin/"tygo", "completion")
     pkgshare.install "examples"
   end
 

--- a/Formula/vcluster.rb
+++ b/Formula/vcluster.rb
@@ -28,8 +28,7 @@ class Vcluster < Formula
       -X main.version=#{version}
     ]
     system "go", "build", "-mod", "vendor", *std_go_args(ldflags: ldflags), "./cmd/vclusterctl/main.go"
-    (zsh_completion/"_vcluster").write Utils.safe_popen_read(bin/"vcluster", "completion", "zsh")
-    (bash_completion/"vcluster").write Utils.safe_popen_read(bin/"vcluster", "completion", "bash")
+    generate_completions_from_executable(bin/"vcluster", "completion", shells: [:zsh, :bash])
   end
 
   test do

--- a/Formula/velero.rb
+++ b/Formula/velero.rb
@@ -23,17 +23,7 @@ class Velero < Formula
     ]
     system "go", "build", *std_go_args(ldflags: ldflags), "-installsuffix", "static", "./cmd/velero"
 
-    # Install bash completion
-    output = Utils.safe_popen_read(bin/"velero", "completion", "bash")
-    (bash_completion/"velero").write output
-
-    # Install zsh completion
-    output = Utils.safe_popen_read(bin/"velero", "completion", "zsh")
-    (zsh_completion/"_velero").write output
-
-    # Install fish completion
-    output = Utils.safe_popen_read(bin/"velero", "completion", "fish")
-    (fish_completion/"velero.fish").write output
+    generate_completions_from_executable(bin/"velero", "completion")
   end
 
   test do

--- a/Formula/vespa-cli.rb
+++ b/Formula/vespa-cli.rb
@@ -29,9 +29,7 @@ class VespaCli < Formula
       end
       bin.install "bin/vespa"
       man1.install Dir["share/man/man1/vespa*.1"]
-      (bash_completion/"vespa").write Utils.safe_popen_read(bin/"vespa", "completion", "bash")
-      (fish_completion/"vespa.fish").write Utils.safe_popen_read(bin/"vespa", "completion", "fish")
-      (zsh_completion/"_vespa").write Utils.safe_popen_read(bin/"vespa", "completion", "zsh")
+      generate_completions_from_executable(bin/"vespa", "completion", base_name: "vespa")
     end
   end
 

--- a/Formula/virustotal-cli.rb
+++ b/Formula/virustotal-cli.rb
@@ -22,11 +22,7 @@ class VirustotalCli < Formula
             "-X cmd.Version=#{version}",
             "-o", bin/"vt", "./vt/main.go"
 
-    output = Utils.safe_popen_read("#{bin}/vt", "completion", "bash")
-    (bash_completion/"vt").write output
-
-    output = Utils.safe_popen_read("#{bin}/vt", "completion", "zsh")
-    (zsh_completion/"_vt").write output
+    generate_completions_from_executable(bin/"vt", "completion", base_name: "vt", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/volta.rb
+++ b/Formula/volta.rb
@@ -31,12 +31,7 @@ class Volta < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    bash_output = Utils.safe_popen_read(bin/"volta", "completions", "bash")
-    (bash_completion/"volta").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"volta", "completions", "zsh")
-    (zsh_completion/"_volta").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"volta", "completions", "fish")
-    (fish_completion/"volta.fish").write fish_output
+    generate_completions_from_executable(bin/"volta", "completions")
   end
 
   test do

--- a/Formula/werf.rb
+++ b/Formula/werf.rb
@@ -32,12 +32,7 @@ class Werf < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags), "-tags", tags, "./cmd/werf"
 
-    bash_output = Utils.safe_popen_read(bin/"werf", "completion", "bash")
-    (bash_completion/"werf").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"werf", "completion", "zsh")
-    (zsh_completion/"_werf").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"werf", "completion", "fish")
-    (fish_completion/"werf.fish").write fish_output
+    generate_completions_from_executable(bin/"werf", "completion")
   end
 
   test do

--- a/Formula/yq.rb
+++ b/Formula/yq.rb
@@ -29,9 +29,7 @@ class Yq < Formula
     system "go", "build", *std_go_args(ldflags: "-s -w")
 
     # Install shell completions
-    (bash_completion/"yq").write Utils.safe_popen_read(bin/"yq", "shell-completion", "bash")
-    (zsh_completion/"_yq").write Utils.safe_popen_read(bin/"yq", "shell-completion", "zsh")
-    (fish_completion/"yq.fish").write Utils.safe_popen_read(bin/"yq", "shell-completion", "fish")
+    generate_completions_from_executable(bin/"yq", "shell-completion")
 
     # Install man pages
     system "./scripts/generate-man-page-md.sh"

--- a/Formula/zellij.rb
+++ b/Formula/zellij.rb
@@ -19,12 +19,7 @@ class Zellij < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    bash_output = Utils.safe_popen_read(bin/"zellij", "setup", "--generate-completion", "bash")
-    (bash_completion/"zellij").write bash_output
-    zsh_output = Utils.safe_popen_read(bin/"zellij", "setup", "--generate-completion", "zsh")
-    (zsh_completion/"_zellij").write zsh_output
-    fish_output = Utils.safe_popen_read(bin/"zellij", "setup", "--generate-completion", "fish")
-    (fish_completion/"zellij.fish").write fish_output
+    generate_completions_from_executable(bin/"zellij", "setup", "--generate-completion")
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

needs https://github.com/Homebrew/brew/pull/13536

cc @MikeMcQuaid 

As requested in https://github.com/Homebrew/brew/pull/13536, here is a sample PR to showcase the use of the new `generate_completions` DSL.

This PR does not contain all formulae that would benefit from this, but only those that could be autocorrected by the RuboCop from https://github.com/Homebrew/brew/pull/13553 (with manual modifications to merge autodetected shells, since the Cop is not yet able to do that).
This means that this PR only contains formulae previously using the following pattern
```
(bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")
```

Once the RuboCop is finalized, I will update this PR to also include formulae using something along the lines of 
```
output = Utils.safe_popen_read(bin/"foo", "completion", "bash")
(bash_completion/"foo").write output
```

But in the meantime, I think these selected formulae showcase the new DSL quite well 😄 