### PR TITLE
btop: fix finding themes directory on ARM

### DIFF
--- a/Formula/btop.rb
+++ b/Formula/btop.rb
@@ -1,10 +1,23 @@
 class Btop < Formula
   desc "Resource monitor. C++ version and continuation of bashtop and bpytop"
   homepage "https://github.com/aristocratos/btop"
-  url "https://github.com/aristocratos/btop/archive/refs/tags/v1.2.8.tar.gz"
-  sha256 "7944b06e3181cc1080064adf1e9eb4f466af0b84a127df6697430736756a89ac"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/aristocratos/btop.git", branch: "main"
+
+  # Remove stable block when patch is no longer needed.
+  stable do
+    url "https://github.com/aristocratos/btop/archive/refs/tags/v1.2.8.tar.gz"
+    sha256 "7944b06e3181cc1080064adf1e9eb4f466af0b84a127df6697430736756a89ac"
+
+    # Fix finding themes on ARM
+    # https://github.com/aristocratos/btop/issues/344
+    # https://github.com/Homebrew/homebrew-core/issues/105708
+    patch do
+      url "https://github.com/aristocratos/btop/commit/a84a7e6a5c3fe16b5e1d1a9824422638aca2f975.patch?full_index=1"
+      sha256 "f7dd836f5fcb06fe4497e9d7f2c0706bbe91a1b8a1d9b95187762527372fb38c"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "2047180f8bce7ebd6cf3c3ce644c41cdcff0a9962546757cb0e0fbae09324389"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes #105708.
