### PR TITLE
gnupg: upstream patch for yubikey regression

### DIFF
--- a/Formula/gnupg.rb
+++ b/Formula/gnupg.rb
@@ -4,6 +4,7 @@ class Gnupg < Formula
   url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.3.7.tar.bz2"
   sha256 "ee163a5fb9ec99ffc1b18e65faef8d086800c5713d15a672ab57d3799da83669"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gnupg/"
@@ -34,6 +35,14 @@ class Gnupg < Formula
 
   on_linux do
     depends_on "libidn"
+  end
+
+  # Fixes a regression using Yubikey devices as smart cards.
+  # Committed upstream, will be in the next release.
+  # https://dev.gnupg.org/T6070
+  patch do
+    url "https://dev.gnupg.org/rGf34b9147eb3070bce80d53febaa564164cd6c977?diff=1"
+    sha256 "0a54359e00ea5e5f0e53220571a4502b28a05cf687cb73b360fb4c777e2f421b"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

GnuPG 2.3.7 has a significant regression which breaks support for using Yubikey devices as smart cards: https://dev.gnupg.org/T6070 This has been patched upstream, so I've backported that patch to 2.3.7. Thankfully the upstream patch applies as-is.