### PR TITLE
libpython-tabulate: add livecheck

### DIFF
--- a/Formula/libpython-tabulate.rb
+++ b/Formula/libpython-tabulate.rb
@@ -5,6 +5,10 @@ class LibpythonTabulate < Formula
   sha256 "6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519"
   license "MIT"
 
+  livecheck do
+    formula "python-tabulate"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "761c33fc48f6ed2af1a83df2cddbdcd4f8090569a50cb8b0f25fcce1bfe0b091"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `python-tabulate` and `libpython-tabulate` formulae have their versions synced in `synced_versions_formulae.json`, so this PR ensures that the check for `libpython-tabulate` is also synced with `python-tabulate`.

This doesn't make a functional difference at the moment, as these formulae have the same `stable` URL and livecheck does the same default check for both (using the `Pypi` strategy). However, adding this `livecheck` block reference will ensure that the check for `libpython-tabulate` remains aligned if a `livecheck` block is added to `python-tabulate` in the future. Similarly, if we need to override part of the default check in a `livecheck` block in the future, we only have to worry about making the change in `python-tabulate`.