### PR TITLE
workflows/tests: show job summaries of each runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -236,32 +236,52 @@ jobs:
       - name: Failures summary for brew test-bot ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
         if: always()
         run: |
-          touch bottles/steps_output.txt
+          if [[ "${{ runner.os }}" == "Linux" ]]
+          then
+            # `GITHUB_STEP_SUMMARY` is unique to each step, so we have to
+            # chown it in each step that we wish to write to it.
+            sudo chown "$(whoami)" "$GITHUB_STEP_SUMMARY"
+          fi
 
-          echo "# Build failure summary on ${{ matrix.runner }}" >> "$GITHUB_STEP_SUMMARY"
+          touch bottles/steps_output.txt
+          echo "### Build failure summary on ${{ matrix.runner }}" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          cat bottles/steps_output.txt | tee -a "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          tee -a "$GITHUB_STEP_SUMMARY" <bottles/steps_output.txt
+          echo '\n```' >> "$GITHUB_STEP_SUMMARY"
 
           rm bottles/steps_output.txt
 
       - name: Output brew linkage result
         if: always()
         run: |
-          echo '# `brew linkage` output on ${{ matrix.runner }}' >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${{ runner.os }}" == "Linux" ]]
+          then
+            # `GITHUB_STEP_SUMMARY` is unique to each step, so we have to
+            # chown it in each step that we wish to write to it.
+            sudo chown "$(whoami)" "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo '### `brew linkage` output on ${{ matrix.runner }}' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          cat bottles/linkage_output.txt | tee -a "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          tee -a "GITHUB_STEP_SUMMARY" <bottles/linkage_output.txt
+          echo '\n```' >> "$GITHUB_STEP_SUMMARY"
 
           rm bottles/linkage_output.txt
 
       - name: Output brew bottle result
         if: always()
         run: |
-          echo '# `brew bottle` output on ${{ matrix.runner }}' >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${{ runner.os }}" == "Linux" ]]
+          then
+            # `GITHUB_STEP_SUMMARY` is unique to each step, so we have to
+            # chown it in each step that we wish to write to it.
+            sudo chown "$(whoami)" "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo '### `brew bottle` output on ${{ matrix.runner }}' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          cat bottles/bottle_output.txt | tee -a "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          tee -a "$GITHUB_STEP_SUMMARY" <bottles/bottle_output.txt
+          echo '\n```' >> "$GITHUB_STEP_SUMMARY"
 
           rm bottles/bottle_output.txt
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -294,12 +294,18 @@ jobs:
       - name: Failures summary for brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
         if: ${{always() && fromJson(needs.setup_tests.outputs.test-dependents) == true}}
         run: |
-          touch bottles/steps_output.txt
+          if [[ "${{ runner.os }}" == "Linux" ]]
+          then
+            # `GITHUB_STEP_SUMMARY` is unique to each step, so we have to
+            # chown it in each step that we wish to write to it.
+            sudo chown "$(whoami)" "$GITHUB_STEP_SUMMARY"
+          fi
 
+          touch bottles/steps_output.txt
           echo "# Dependent failure summary on ${{ matrix.runner }}" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          cat bottles/steps_output.txt | tee -a "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          tee -a "$GITHUB_STEP_SUMMARY" <bottles/steps_output.txt
+          echo '\n```' >> "$GITHUB_STEP_SUMMARY"
 
           rm bottles/steps_output.txt
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
 
   setup_tests:
     permissions:
-      pull-requests: read  
+      pull-requests: read
     if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
     needs: tap_syntax
@@ -237,19 +237,32 @@ jobs:
         if: always()
         run: |
           touch bottles/steps_output.txt
-          cat bottles/steps_output.txt
+
+          echo "# Build failure summary on ${{ matrix.runner }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat bottles/steps_output.txt | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
           rm bottles/steps_output.txt
 
       - name: Output brew linkage result
         if: always()
         run: |
-          cat bottles/linkage_output.txt
+          echo '# `brew linkage` output on ${{ matrix.runner }}' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat bottles/linkage_output.txt | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
           rm bottles/linkage_output.txt
 
       - name: Output brew bottle result
         if: always()
         run: |
-          cat bottles/bottle_output.txt
+          echo '# `brew bottle` output on ${{ matrix.runner }}' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat bottles/bottle_output.txt | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
           rm bottles/bottle_output.txt
 
       - name: Run brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
@@ -262,7 +275,12 @@ jobs:
         if: ${{always() && fromJson(needs.setup_tests.outputs.test-dependents) == true}}
         run: |
           touch bottles/steps_output.txt
-          cat bottles/steps_output.txt
+
+          echo "# Dependent failure summary on ${{ matrix.runner }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat bottles/steps_output.txt | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
           rm bottles/steps_output.txt
 
       - name: Upload logs


### PR DESCRIPTION
This will display some results of the CI run in the workflow run summary
page, so you won't need to click on individual jobs to see what happened
there.

See https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/

There's probably room for improvement in what exactly we put in
`$GITHUB_STEP_SUMMARY`, but that's something we can try later on.
