### PR TITLE
luvit: fix ARM and Linux build

### DIFF
--- a/Formula/luv.rb
+++ b/Formula/luv.rb
@@ -4,6 +4,7 @@ class Luv < Formula
   url "https://github.com/luvit/luv/archive/1.44.2-0.tar.gz"
   sha256 "44ccda27035bfe683e6325a2a93f2c254be1eb76bde6efc2bd37c56a7af7b00a"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/luvit/luv.git", branch: "master"
 
   bottle do
@@ -16,7 +17,7 @@ class Luv < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "luajit-openresty" => [:build, :test]
+  depends_on "luajit" => [:build, :test]
   depends_on "libuv"
 
   resource "lua-compat-5.3" do
@@ -43,8 +44,6 @@ class Luv < Formula
   end
 
   test do
-    ENV["LUA_CPATH"] = opt_lib/"lua/5.1/?.so"
-    ENV.prepend_path "PATH", Formula["luajit-openresty"].opt_bin
     (testpath/"test.lua").write <<~EOS
       local uv = require('luv')
       local timer = uv.new_timer()

--- a/Formula/luvit.rb
+++ b/Formula/luvit.rb
@@ -4,6 +4,7 @@ class Luvit < Formula
   url "https://github.com/luvit/luvit/archive/2.18.1.tar.gz"
   sha256 "b792781d77028edb7e5761e96618c96162bd68747b8fced9a6fc52f123837c2c"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/luvit/luvit.git", branch: "master"
 
   bottle do
@@ -13,10 +14,10 @@ class Luvit < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "luajit-openresty" => :build
-  depends_on "luv" => :build
   depends_on "pkg-config" => :build
   depends_on "libuv"
+  depends_on "luajit"
+  depends_on "luv"
   depends_on "openssl@1.1"
   depends_on "pcre"
 
@@ -34,11 +35,19 @@ class Luvit < Formula
     url "https://github.com/luvit/luvi.git",
         tag:      "v2.12.0",
         revision: "5d1052f11e813ff9edc3ec75b5282b3e6cb0f3bf"
+
+    # Remove outdated linker flags that break the ARM build.
+    # https://github.com/luvit/luvi/pull/261
+    patch do
+      url "https://github.com/luvit/luvi/commit/b2e501deb407c44a9a3e7f4d8e4b5dc500e7a196.patch?full_index=1"
+      sha256 "be3315f7cf8a9e43f1db39d0ef55698f09e871bea0f508774d0135c6375f4291"
+    end
   end
 
   def install
     ENV["PREFIX"] = prefix
-    luajit = Formula["luajit-openresty"]
+    luajit = Formula["luajit"]
+    luv = Formula["luv"]
 
     resource("luvi").stage do
       # Build scripts set LUA_PATH before invoking LuaJIT, but that causes errors.
@@ -59,10 +68,10 @@ class Luvit < Formula
         -DWithLPEG=ON
         -DWithSharedPCRE=ON
         -DWithSharedLibluv=ON
-        -DLIBLUV_INCLUDE_DIR=#{Formula["luv"].opt_include}/luv
-        -DLIBLUV_LIBRARIES=#{Formula["luv"].opt_lib}/libluv_a.a
+        -DLIBLUV_INCLUDE_DIR=#{luv.opt_include}/luv
+        -DLIBLUV_LIBRARIES=#{luv.opt_lib/shared_library("libluv")}
         -DLUAJIT_INCLUDE_DIR=#{luajit.opt_include}/luajit-2.1
-        -DLUAJIT_LIBRARIES=#{luajit.opt_lib}/libluajit.a
+        -DLUAJIT_LIBRARIES=#{luajit.opt_lib/shared_library("libluajit")}
       ]
 
       system "cmake", ".", "-B", "build", *luvi_args

--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -2,6 +2,7 @@ class Neovim < Formula
   desc "Ambitious Vim-fork focused on extensibility and agility"
   homepage "https://neovim.io/"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/neovim/neovim.git", branch: "master"
 
   # Remove `stable` block when `gperf` is no longer needed.
@@ -36,7 +37,7 @@ class Neovim < Formula
   depends_on "gettext"
   depends_on "libtermkey"
   depends_on "libuv"
-  depends_on "luajit-openresty"
+  depends_on "luajit"
   depends_on "luv"
   depends_on "msgpack"
   depends_on "tree-sitter"
@@ -79,7 +80,7 @@ class Neovim < Formula
     # Don't clobber the default search path
     ENV.append "LUA_PATH", ";", ";"
     ENV.append "LUA_CPATH", ";", ";"
-    lua_path = "--lua-dir=#{Formula["luajit-openresty"].opt_prefix}"
+    lua_path = "--lua-dir=#{Formula["luajit"].opt_prefix}"
 
     cd "deps-build/build/src" do
       %w[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- luvit: fix ARM build
- luv: switch to upstream LuaJIT
- neovim: switch to upstream LuaJIT

The ARM build for `luvit` is broken by (1) a LuaJIT bug and (2) outdated linker flags in the `luvi` build.

The LuaJIT bug is fixed in upstream LuaJIT, so let's use that. We also use a newer version of `luvi` in order to avoid the outdated linker flags. I've opted to update `luvi` instead of using a patch because the new version of `luvi` is also the one that matches our versions of `luajit` and `luv`.

To avoid potential risks of binary incompatibility, let's use upstream LuaJIT in `luv` and `neovim` too. `luv` is a dependency of `luvit`, and `neovim` depends on `luv`. The risks are admittedly relatively small, but it's probably better to play it safe here.

Finally, let's also avoid static linkage when building `luvit`, since that's more in line with what we do everywhere else.
