### PR TITLE
luajit: fix symlink creation for `--HEAD`

### DIFF
--- a/Formula/luajit.rb
+++ b/Formula/luajit.rb
@@ -67,7 +67,8 @@ class Luajit < Formula
     system "make", "amalg", "PREFIX=#{prefix}", "Q="
     system "make", "install", "PREFIX=#{prefix}", "Q="
 
-    upstream_version = version.to_s.sub(/-\d+\.\d+$/, "")
+    # We need `stable.version` here to avoid breaking symlink generation for HEAD.
+    upstream_version = stable.version.to_s.sub(/-\d+\.\d+$/, "")
     # v2.1 branch doesn't install symlink for luajit.
     # This breaks tools like `luarocks` that require the `luajit` bin to be present.
     bin.install_symlink "luajit-#{upstream_version}" => "luajit"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I broke the `luajit` symlink creation for `--HEAD` installs in #104765.
This change fixes that.
