### PR TITLE
crystal: restrict linux builds to x86-64 #105566

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -48,6 +48,7 @@ class Crystal < Formula
 
   on_linux do
     depends_on "gcc"
+    depends_on arch: :x86_64
   end
 
   fails_with gcc: "5"
@@ -67,11 +68,14 @@ class Crystal < Formula
       "darwin-universal" => "e7f9b3e1e866dc909a0a310238907182f1ee8b3c09bd8da5ecd0072d99c1fc5c",
       "linux-x86_64"     => "a5bdf1b78897b3cdc7d715b5f7adff79e84401d39b7ab546ab3249dc17fc770c",
     }
-    boot_version = Version.new("1.4.1-1")
 
-    url "https://github.com/crystal-lang/crystal/releases/download/#{boot_version.major_minor_patch}/crystal-#{boot_version}-#{platform}.tar.gz"
-    version boot_version
-    sha256 checksums[platform]
+    if checksums.include? platform
+      boot_version = Version.new("1.4.1-1")
+
+      url "https://github.com/crystal-lang/crystal/releases/download/#{boot_version.major_minor_patch}/crystal-#{boot_version}-#{platform}.tar.gz"
+      version boot_version
+      sha256 checksums[platform]
+    end
   end
 
   # Check version in `shard.lock` in shards repo.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

——

Please let me know if there’s a better way to do this.
