### PR TITLE
protobuf@3.6: disable

### DIFF
--- a/Formula/protobuf@3.6.rb
+++ b/Formula/protobuf@3.6.rb
@@ -16,7 +16,7 @@ class ProtobufAT36 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2021-02-19", because: :versioned_formula
+  disable! date: "2022-07-14", because: :versioned_formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This has been deprecated for a while now. Let's disable it.

This would also potentially make room for a `protobuf@3` formula (with
version `3.20.x`) which seems like is needed given #105712.
