### PR TITLE
quvi, libquvi: remove livecheck

### DIFF
--- a/Formula/libquvi.rb
+++ b/Formula/libquvi.rb
@@ -5,11 +5,6 @@ class Libquvi < Formula
   sha256 "f5a2fb0571634483e8a957910f44e739f5a72eb9a1900bd10b453c49b8d5f49d"
   revision 2
 
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/libquvi[._-]v?(\d+(?:\.\d+)+)\.t}i)
-  end
-
   bottle do
     sha256 arm64_monterey: "c7334e914191fed570ebfb0c19f3d99c2d6558d9e585f6c7618507e8fa768bf4"
     sha256 arm64_big_sur:  "167718e2a3981fdbfa9b34cddc3c94ed4e0c80f4cbe82749535cd7b7c644d9a5"

--- a/Formula/quvi.rb
+++ b/Formula/quvi.rb
@@ -5,11 +5,6 @@ class Quvi < Formula
   sha256 "1f4e40c14373cb3d358ae1b14a427625774fd09a366b6da0c97d94cb1ff733c3"
   license "LGPL-2.1"
 
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/quvi[._-]v?(\d+(?:\.\d+)+)\.t}i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "5507b545d2705556712e4548c8cb6a62777163a7b496fc69cbc6974845c5fe28"
     sha256 cellar: :any,                 arm64_big_sur:  "195d1401be4ab2b454d97e611163251bb4ed1986cab9c39b089268969fe67ff1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `quvi` and `libquvi` formulae were recently deprecated in #105106. This PR removes the `livecheck` blocks, so the formulae will be automatically skipped as deprecated.