### PR TITLE
creduce: use `llvm@13` for `HEAD`

### DIFF
--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -1,11 +1,15 @@
 class Creduce < Formula
   desc "Reduce a C/C++ program while keeping a property of interest"
   homepage "https://embed.cs.utah.edu/creduce/"
-  url "https://embed.cs.utah.edu/creduce/creduce-2.10.0.tar.gz"
-  sha256 "db1c0f123967f24d620b040cebd53001bf3dcf03e400f78556a2ff2e11fea063"
   license "BSD-3-Clause"
   revision 3
-  head "https://github.com/csmith-project/creduce.git", branch: "master"
+
+  # Remove when `head` and `stable` use the same LLVM version.
+  stable do
+    url "https://embed.cs.utah.edu/creduce/creduce-2.10.0.tar.gz"
+    sha256 "db1c0f123967f24d620b040cebd53001bf3dcf03e400f78556a2ff2e11fea063"
+    depends_on "llvm@9"
+  end
 
   livecheck do
     url :homepage
@@ -19,8 +23,13 @@ class Creduce < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "05609defa2c67b6cc907d1c30f7f4080e03211ce918fa5d6b79c256b608805a8"
   end
 
+  head do
+    # The `llvm-13.0` branch is slightly ahead of `master` and allows use of `llvm@13`.
+    url "https://github.com/csmith-project/creduce.git", branch: "llvm-13.0"
+    depends_on "llvm@13"
+  end
+
   depends_on "astyle"
-  depends_on "llvm@9"
 
   uses_from_macos "perl"
 
@@ -72,12 +81,14 @@ class Creduce < Formula
       end
     end
 
+    llvm = deps.find { |dep| dep.name.match?(/^llvm(@\d+)?$/) }
+               .to_formula
     # Work around build failure seen on Apple Clang 13.1.6 by using LLVM Clang
     # Undefined symbols for architecture x86_64:
     #   "std::__1::basic_stringbuf<char, std::__1::char_traits<char>, ...
     if DevelopmentTools.clang_build_version == 1316
-      ENV["CC"] = Formula["llvm@9"].opt_bin/"clang"
-      ENV["CXX"] = Formula["llvm@9"].opt_bin/"clang++"
+      ENV["CC"] = llvm.opt_bin/"clang"
+      ENV["CXX"] = llvm.opt_bin/"clang++"
     end
 
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This will allow users on Apple Silicon to install this with
`brew install --HEAD`.

We need to use the `llvm-13.0` branch to support usage with `llvm@13`.
At the time of writing, it is only two commits ahead of `master`.
