### PR TITLE
mpw: remove livecheck

### DIFF
--- a/Formula/mpw.rb
+++ b/Formula/mpw.rb
@@ -7,13 +7,6 @@ class Mpw < Formula
   license "GPL-3.0-or-later"
   head "https://gitlab.com/MasterPassword/MasterPassword.git", branch: "master"
 
-  # The first-party site doesn't seem to list version information, so it's
-  # necessary to check the tags from the `head` repository instead.
-  livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+[._-]cli[._-]?\d+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "e9888d9cfb2d36d1b764cb66f63f6dd46007a1971a4103207cb443029c1d12ee"
     sha256 cellar: :any,                 arm64_big_sur:  "ae3c6d9c4698beed61f7d0ee6330d1afa63b993c8ff3ecd3dae5fea25dc052be"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `mpw` formula was disabled in #103536. This PR removes the existing `livecheck` block, so the formula will be automatically skipped.