### PR TITLE
cfonts: add livecheck and head build

### DIFF
--- a/Formula/cfonts.rb
+++ b/Formula/cfonts.rb
@@ -8,7 +8,7 @@ class Cfonts < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)rust$/i)
+    regex(/^v?(\d+(?:\.\d+)+)[._-]?rust$/i)
   end
 
   bottle do

--- a/Formula/cfonts.rb
+++ b/Formula/cfonts.rb
@@ -4,6 +4,12 @@ class Cfonts < Formula
   url "https://github.com/dominikwilkowski/cfonts/archive/refs/tags/v1.1.0rust.tar.gz"
   sha256 "45c40dfc867234efc5c5a2df687ccfc40a6702fa5a82f2380b555f9e755508e6"
   license "GPL-3.0-or-later"
+  head "https://github.com/dominikwilkowski/cfonts.git", branch: "released"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)rust$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "f0c159afb368d8b9e13fb37a74541565a42dd93b87bcd8c0da87db15a7badde2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add livecheck to ignore [`nodejs` release](https://github.com/dominikwilkowski/cfonts/releases/tag/v3.1.1nodejs)