### PR TITLE
devtodo: deprecate

### DIFF
--- a/Formula/devtodo.rb
+++ b/Formula/devtodo.rb
@@ -3,6 +3,7 @@ class Devtodo < Formula
   homepage "https://swapoff.org/devtodo.html"
   url "https://swapoff.org/files/devtodo/devtodo-0.1.20.tar.gz"
   sha256 "379c6ac4499fc97e9676075188f7217e324e7ece3fb6daeda7bf7969c7093e09"
+  license "GPL-2.0-only"
   revision 2
 
   bottle do

--- a/Formula/devtodo.rb
+++ b/Formula/devtodo.rb
@@ -17,6 +17,10 @@ class Devtodo < Formula
     sha256 x86_64_linux:   "3e73efa42394be4e0be78fe83c13b693f42a84d743fbc8e9248cdcaea13da1c2"
   end
 
+  # DevTodo1 still compiles and installs, but is now unmaintained.
+  # https://swapoff.org/devtodo1.html
+  deprecate! date: "2022-07-15", because: :unmaintained
+
   depends_on "readline"
 
   uses_from_macos "expect" => :test
@@ -75,6 +79,6 @@ index a979d1b..6aef728 100644
  #include <curses.h>
  #include <term.h>
 +#include <stdlib.h>
- 
+
  static char info[2048];
  static bool term_initialized;


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
