### PR TITLE
onetime: remove livecheck

### DIFF
--- a/Formula/onetime.rb
+++ b/Formula/onetime.rb
@@ -6,11 +6,6 @@ class Onetime < Formula
   license "MIT"
   revision 1
 
-  livecheck do
-    url "https://www.red-bean.com/onetime/get"
-    regex(/href=.*?onetime[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d6b4a7ac553f33266044258c1b8cc8e703428990ec7c329ec1abcec649c94eaf"
     sha256 cellar: :any_skip_relocation, big_sur:       "3537657d8ff718b94fa84714b0105b95ef613fe778d04ff573a19df687798747"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `onetime` formula was deprecated in #102391. This PR removes the `livecheck` block, so it will be automatically skipped.