### PR TITLE
jj (Jujutsu) 0.4.0 (new formula)

### DIFF
--- a/Formula/jj.rb
+++ b/Formula/jj.rb
@@ -1,5 +1,5 @@
 class Jj < Formula
-  desc "Git-compatible DVCS"
+  desc "Git-compatible distributed version control system"
   homepage "https://github.com/martinvonz/jj"
   url "https://github.com/martinvonz/jj/archive/refs/tags/v0.4.0.tar.gz"
   sha256 "f97832d69b4e486997b9548c41f6cc945c68b8a8b546172ca92b7eb23ec71be5"

--- a/Formula/jj.rb
+++ b/Formula/jj.rb
@@ -20,7 +20,6 @@ class Jj < Formula
 
   test do
     system bin/"jj", "init", "--git"
-
     assert_predicate testpath/".jj", :exist?
   end
 end

--- a/Formula/jj.rb
+++ b/Formula/jj.rb
@@ -7,7 +7,7 @@ class Jj < Formula
   head "https://github.com/martinvonz/jj.git", branch: "main"
 
   depends_on "rust" => :build
-  uses_from_macos "openssl@1.1"
+  depends_on "openssl@1.1"
   uses_from_macos "zlib"
 
   on_linux do

--- a/Formula/jj.rb
+++ b/Formula/jj.rb
@@ -1,5 +1,5 @@
 class Jj < Formula
-  desc "Jujutsu is a Git-compatible DVCS"
+  desc "Git-compatible DVCS"
   homepage "https://github.com/martinvonz/jj"
   url "https://github.com/martinvonz/jj/archive/refs/tags/v0.4.0.tar.gz"
   sha256 "f97832d69b4e486997b9548c41f6cc945c68b8a8b546172ca92b7eb23ec71be5"
@@ -8,10 +8,12 @@ class Jj < Formula
 
   depends_on "rust" => :build
   depends_on "openssl@1.1"
+  uses_from_macos "zlib"
 
   on_linux do
     depends_on "pkg-config" => :build
   end
+
   def install
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/jj.rb
+++ b/Formula/jj.rb
@@ -12,6 +12,7 @@ class Jj < Formula
 
   on_linux do
     depends_on "pkg-config" => :build
+    depends_on "gcc"
   end
 
   def install

--- a/Formula/jj.rb
+++ b/Formula/jj.rb
@@ -1,0 +1,24 @@
+class Jj < Formula
+  desc "Jujutsu is a Git-compatible DVCS"
+  homepage "https://github.com/martinvonz/jj"
+  url "https://github.com/martinvonz/jj/archive/refs/tags/v0.4.0.tar.gz"
+  sha256 "f97832d69b4e486997b9548c41f6cc945c68b8a8b546172ca92b7eb23ec71be5"
+  license "Apache-2.0"
+  head "https://github.com/martinvonz/jj.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "openssl@1.1"
+
+  on_linux do
+    depends_on "pkg-config" => :build
+  end
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    system bin/"jj", "init", "--git"
+
+    assert_predicate testpath/".jj", :exist?
+  end
+end

--- a/Formula/jj.rb
+++ b/Formula/jj.rb
@@ -7,7 +7,7 @@ class Jj < Formula
   head "https://github.com/martinvonz/jj.git", branch: "main"
 
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
+  uses_from_macos "openssl@1.1"
   uses_from_macos "zlib"
 
   on_linux do
@@ -15,7 +15,7 @@ class Jj < Formula
   end
 
   def install
-    system "cargo", "install", *std_cargo_args
+    system "cargo", "install", "--no-default-features", *std_cargo_args
   end
 
   test do


### PR DESCRIPTION
This adds the latest release as well as the ability to install HEAD.  I
used the same structure as Starship, so it should work in all the same
places. I've tested it on Monterey and Debian.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
