### PR TITLE
jbig2dec: update livecheck

### DIFF
--- a/Formula/jbig2dec.rb
+++ b/Formula/jbig2dec.rb
@@ -6,11 +6,11 @@ class Jbig2dec < Formula
   license "AGPL-3.0-or-later"
 
   # Not every GhostPDL release contains a jbig2dec archive, so we have to check
-  # the GitHub releases page instead (which we otherwise avoid). This is
-  # necessary because the jbig2dec homepage hasn't been updated to link to
-  # versions after 0.17.
+  # the GitHub releases page (which we otherwise avoid) instead of the tags.
+  # We avoid checking the jbig2dec homepage because it has been very slow to
+  # update in the past when new versions were released.
   livecheck do
-    url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases"
+    url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases?q=prerelease%3Afalse"
     regex(%r{href=.*?/jbig2dec[._-]v?(\d+(?:\.\d+)+)\.t}i)
     strategy :page_match
   end


### PR DESCRIPTION
The previous livecheck block doesn't work at the moment, because the first page of https://github.com/ArtifexSoftware/ghostpdl-downloads as no jbig2dec tarballs right now.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
