### PR TITLE
netcdf: do not adjust rpath

### DIFF
--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -47,7 +47,6 @@ class Netcdf < Formula
 
     mkdir "build" do
       args = common_args.dup
-      args << "-DNC_EXTRA_DEPS=-lmpi" if Tab.for_name("hdf5").with? "mpi"
       args << "-DENABLE_TESTS=OFF" << "-DENABLE_NETCDF_4=ON" << "-DENABLE_DOXYGEN=OFF"
 
       # Extra CMake flags for compatibility with hdf5 1.12
@@ -105,15 +104,7 @@ class Netcdf < Formula
       lib/"libnetcdf.settings", lib/"libnetcdf-cxx.settings"
     ], Superenv.shims_path/ENV.cc, ENV.cc
 
-    if OS.linux?
-      inreplace bin/"ncxx4-config", Superenv.shims_path/ENV.cxx, ENV.cxx
-    else
-      # SIP causes system Python not to play nicely with @rpath
-      libnetcdf = (lib/"libnetcdf.dylib").readlink
-      macho = MachO.open("#{lib}/libnetcdf-cxx4.dylib")
-      macho.change_dylib("@rpath/#{libnetcdf}", "#{lib}/#{libnetcdf}")
-      macho.write!
-    end
+    inreplace bin/"ncxx4-config", Superenv.shims_path/ENV.cxx, ENV.cxx if OS.linux?
   end
 
   test do


### PR DESCRIPTION
Part of https://github.com/Homebrew/homebrew-core/issues/106008

Also, fix the fact that `hdf5` does not have an `mpi` option anymore.