### PR TITLE
ksh93 1.0.0 (new formula)

### DIFF
--- a/Formula/ksh93.rb
+++ b/Formula/ksh93.rb
@@ -1,0 +1,23 @@
+class Ksh93 < Formula
+  desc "KornShell, ksh93"
+  homepage "https://github.com/ksh93/ksh#readme"
+  url "https://github.com/ksh93/ksh/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "54f1fcfea77ec55a639e08f0fe66a1fc918c762f176cad917ee93b44f511e1ef"
+  license "EPL-2.0"
+  head "https://github.com/ksh93/ksh.git", branch: "dev"
+
+  def install
+    system "bin/package", "verbose", "make"
+    system "bin/package", "verbose", "install", prefix
+    %w[ksh93 rksh rksh93].each do |alt|
+      bin.install_symlink "ksh" => alt
+      man1.install_symlink "ksh.1" => "#{alt}.1"
+    end
+    doc.install "ANNOUNCE"
+    doc.install %w[COMPATIBILITY README RELEASE TYPES].map { |f| "src/cmd/ksh93/#{f}" }
+  end
+
+  test do
+    system "#{bin}/ksh93 -c 'A=$(((1./3)+(2./3)));test $A -eq 1'"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? 

-----

I was working on a Mac and was having problems with ksh that I recognized as being resolved 2+ years ago upstream.  This was trying to use Brew's ksh93.
                                                                                                    
The current & maintained verison of the Korn Shell is ksh93u+m, with releases available at:
https://github.com/ksh93/ksh/releases/latest/                                                                                                                                                           

~At the time of this writing, the most recent version is ksh93u+m 1.0.0-beta.2.  Despite the name, it's unquestionably more stable and less beta than the ksh 2020.0.0 release.  While this goes against the Brew guidance of shipping beta versions, an exception really should be made here, especially since the ksh2020 currently being shipped is a totally dead project, has an abandoned and archived upstream, and is full of known bugs that will never be resolved.~

~The current upstream says:~

~> Even though we don't think it's stable release quality yet, the consensus seems to be that 93u+m is already **much** better than the last AT&T release.~

~This is really an understatement.~

~In support of the exception, **almost all other mainstream distributions are shipping ksh93u+m now**, including [Red Hat and Fedora](https://koji.fedoraproject.org/koji/packageinfo?packageID=754), [Ubuntu](https://packages.ubuntu.com/jammy/ksh93u+m), [Debian](https://packages.debian.org/sid/ksh), [Slackware](https://packages.slackware.com/?r=slackware-current&p=ksh93-1.0_20220219_bc6c5dbd-i586-1.txz), and non-Linux systems like [OpenBSD](https://openports.se/shells/ksh93).~

~Brew is very much an outlier here, still shipping the abandoned version of this shell.~ 

~(I'll note that MacPorts is shipping ksh93u (which is *not* ksh2020) as *ksh* and *ksh93u+m* as *ksh-devel* - which is also bad, since the -devel version is the stable one, and the stable one is dead, but that's a problem for another repo).~

I also received a warning "`GitHub fork (not canonical repository)`" but this is misleading.  This is now the canonical repository, as the original and the ksh2020 fork will receive no future updates.

~If ksh93u+m cannot be included for whatever reason, then the buggy ksh93-2020.0.0 really needs to be removed from Brew as it's abandoned, archived upstream, and the final release ever was years ago (2019), which meets all the criteria for removal.~

I hope I did everything right!

Thanks.

Edit: ksh93u+m 1.0.0 released.