### PR TITLE
xz: apply upstream fix for CVE-2022-1271 / ZDI-CAN-16587

### DIFF
--- a/Formula/xz.rb
+++ b/Formula/xz.rb
@@ -12,6 +12,7 @@ class Xz < Formula
     "GPL-2.0-or-later",
     "GPL-3.0-or-later",
   ]
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_monterey: "fcda3e81efe284f7e07effcb4ba03a87c8d828833351ac3f41e1e808e7753b0a"
@@ -22,6 +23,13 @@ class Xz < Formula
     sha256 cellar: :any, mojave:         "44483961b5d2b535b0ece1936c9d40b4bc7d9c7281646cca0fb476291ab9d4dc"
     sha256 cellar: :any, high_sierra:    "1491b2b20c40c3cb0b990f520768d7e876e4ab4a7dc1da9994d0150da34ba5c6"
     sha256               x86_64_linux:   "c94b4200b32d1e4e917f3b502eafc39579a84533ef6b6a0d58469fa845511612"
+  end
+
+  # Fix arbitrary-file-write vulnerability in `xzgrep`.
+  # https://seclists.org/oss-sec/2022/q2/18
+  patch do
+    url "https://tukaani.org/xz/xzgrep-ZDI-CAN-16587.patch"
+    sha256 "98c6cb1042284fe704ec30083f3fc87364ce9ed2ea51f62bbb0ee9d3448717ec"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes a CVE in `xzgrep`. See:

https://www.zerodayinitiative.com/advisories/ZDI-22-619/
https://www.mail-archive.com/xz-devel@tukaani.org/msg00551.html
