### PR TITLE
zstd: enable zlib/lzma/lz4 support

### DIFF
--- a/Formula/zstd.rb
+++ b/Formula/zstd.rb
@@ -19,6 +19,9 @@ class Zstd < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "lz4"
+  depends_on "xz"
+  uses_from_macos "zlib"
 
   def install
     # Legacy support is the default after
@@ -29,16 +32,24 @@ class Zstd < Formula
                     "-DZSTD_BUILD_CONTRIB=ON",
                     "-DCMAKE_INSTALL_RPATH=#{rpath}",
                     "-DZSTD_LEGACY_SUPPORT=ON",
+                    "-DZSTD_ZLIB_SUPPORT=ON",
+                    "-DZSTD_LZMA_SUPPORT=ON",
+                    "-DZSTD_LZ4_SUPPORT=ON",
                     *std_cmake_args
     system "cmake", "--build", "builddir"
     system "cmake", "--install", "builddir"
   end
 
   test do
-    assert_equal "hello\n",
-      pipe_output("#{bin}/zstd | #{bin}/zstd -d", "hello\n", 0)
-
-    assert_equal "hello\n",
-      pipe_output("#{bin}/pzstd | #{bin}/pzstd -d", "hello\n", 0)
+    [bin/"zstd", bin/"pzstd", "xz", "lz4", "gzip"].each do |prog|
+      data = "Hello, #{prog}"
+      assert_equal data, pipe_output("#{bin}/zstd -d", pipe_output(prog, data))
+      if prog.to_s.end_with?("zstd")
+        # `pzstd` can only decompress zstd-compressed data.
+        assert_equal data, pipe_output("#{bin}/pzstd -d", pipe_output(prog, data))
+      else
+        assert_equal data, pipe_output("#{prog} -d", pipe_output("#{bin}/zstd --format=#{prog}", data))
+      end
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Many major distros (e.g. Debian, Fedora, Arch, MacPorts) enable this in
their zstd package, and it would be nice to get the same `zstd` whether
you installed it with `apt` or with `brew`.

Also, it's a huge QOL improvement to just be able to do
```
zstd -d foo.{gz,lz4,lzma,xz,zst}
```
instead of having to work out which decompression utility to use
depending on the file format.

Let's also update the test to make sure that `zstd` can compress to and
decompress from the various applicable formats.
