### PR TITLE
libkrunfw 3.1.0 (new formula)

### DIFF
--- a/Formula/libkrunfw.rb
+++ b/Formula/libkrunfw.rb
@@ -1,0 +1,27 @@
+class Libkrunfw < Formula
+  desc "Dynamic library bundling a Linux kernel in a convenient storage format"
+  homepage "https://github.com/slp/libkrunfw"
+  url "https://github.com/containers/libkrunfw/releases/download/v3.1.0/v3.1.0-with_macos_prebuilts.tar.gz"
+  sha256 "e93299160d6a0660c8cfaa2f338d85467b596adc559c2568925d851fa064bdb8"
+  license all_of: ["GPL-2.0-only", "LGPL-2.1-only"]
+
+  # libkrun, our only consumer, only supports Hypervisor.framework on arm64
+  depends_on arch: :arm64
+
+  def install
+    system "make", "PREFIX=#{prefix}", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      int krunfw_get_version();
+      int main()
+      {
+         int v = krunfw_get_version();
+         return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lkrunfw", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----
```
* 4: col 3: https://github.com/containers/libkrunfw/releases/download/v3.1.0/v3.1.0-with_macos_prebuilts.tar.gz looks like a binary package, not a source archive; homebrew/core is source-only.
```
[libkrunfw](https://github.com/containers/libkrunfw) bundles a specialized Linux kernel inside a dynamic library. Cross-compiling a Linux kernel from macOS is a complex and often unreliable task, so for each release we create a source tarball for macOS including a prebuilt Linux kernel. Everything is open source, there are no binary-only components.

For users wanting to build their own kernel, the project contains a `build_on_krunvm.sh` that allows them to easily accomplish this task from macOS as long they have [krunvm](https://github.com/containers/krunvm) installed.  `krunvm` is a tool that allows users to easily create and run microVMs from OCI images. `krunvm` requires `libkrun`, which in turn requites `libkrunfw`, so using this strategy to build the Linux kernel on macOS for Homebrew would pose a chicken <-> egg problem (and `krunvm` is not compatible with `brew` sandboxing anyway).

```
GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
```
`libkrunfw` does not meet the notability requirements, most likely because it's indirectly consumed via [libkrun](https://github.com/containers/libkrun) and [krunvm](https://github.com/containers/krunvm). We can't create the formulae for `libkrun` and `krunvm`, which do meet the notability requirements, unless we get `libkrunfw` packaged first. I don't see this one listed among the reasons granting an exception, but it seems like a reasonable one to me.

Or perhaps I should create a PR for `libkrun` (which does meet the notability criteria) that includes both `libkrun` and `libkrunfw`? This is my first time contributing to Homebrew, so any guidance would be appreciated here. Thanks!