### PR TITLE
xz: add HTTP mirror

### DIFF
--- a/Formula/xz.rb
+++ b/Formula/xz.rb
@@ -1,10 +1,13 @@
 # Upstream project has requested we use a mirror as the main URL
-# https://github.com/Homebrew/homebrew/pull/21419
+# https://github.com/Homebrew/legacy-homebrew/pull/21419
 class Xz < Formula
   desc "General-purpose data compression with high compression ratio"
   homepage "https://tukaani.org/xz/"
   url "https://downloads.sourceforge.net/project/lzmautils/xz-5.2.5.tar.gz"
   mirror "https://tukaani.org/xz/xz-5.2.5.tar.gz"
+  # This mirror needs to be manually created at `archive.org`.
+  mirror "https://archive.org/download/xz-5.2.5.tar.gz/xz-5.2.5.tar.gz"
+  mirror "http://archive.org/download/xz-5.2.5.tar.gz/xz-5.2.5.tar.gz"
   sha256 "f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"
   license all_of: [
     :public_domain,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Needed for #106098.

Admittedly, having to create a mirror manually isn't ideal. However,
`xz` is updated very [infrequently](https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+in%3Atitle+xz), so it doesn't hurt too much.
