### PR TITLE
libwmf: fix inclusion of jpeg

### DIFF
--- a/Formula/libwmf.rb
+++ b/Formula/libwmf.rb
@@ -3,6 +3,7 @@ class Libwmf < Formula
   homepage "https://wvware.sourceforge.io/libwmf.html"
   url "https://downloads.sourceforge.net/project/wvware/libwmf/0.2.8.4/libwmf-0.2.8.4.tar.gz"
   sha256 "5b345c69220545d003ad52bfd035d5d6f4f075e65204114a9e875e84895a7cf8"
+  license "LGPL-2.1-only" # http://wvware.sourceforge.net/libwmf.html#download
   revision 2
 
   livecheck do
@@ -33,7 +34,8 @@ class Libwmf < Formula
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-png=#{Formula["libpng"].opt_prefix}",
-                          "--with-freetype=#{Formula["freetype"].opt_prefix}"
+                          "--with-freetype=#{Formula["freetype"].opt_prefix}",
+                          "--with-jpeg=#{Formula["jpeg"].opt_prefix}"
     system "make"
     ENV.deparallelize # yet another rubbish Makefile
     system "make", "install"


### PR DESCRIPTION
libwmf includes jpeg regardless of the `--with-jpeg` flag. This change ensures that programs that link
with libwmf are able to process correctly.

```sh
$ libwmf-config --libs
-L/Users/user/homebrew/Cellar/libwmf/0.2.8.4_2/lib -lwmf -lwmflite -L/Users/user/homebrew/opt/freetype/lib -lfreetype -lexpat -L/Users/user/homebrew/opt/jpeg/lib -ljpeg -L/Users/user/homebrew/opt/libpng/lib -lpng -lz -lm
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

`brew audit --strict` fails due to lack of test.

-----
