### PR TITLE
mypy: fix bottle block

### DIFF
--- a/Formula/mypy.rb
+++ b/Formula/mypy.rb
@@ -9,12 +9,12 @@ class Mypy < Formula
   head "https://github.com/python/mypy.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8ec5c465d02d722400fd0dfd93171d73791b3f8a77f401f292bf81e469898485"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "84284f1fe87f53b61ba8bd86612a39383e4afb3d1824bf59125cc42526e87541"
-    sha256 cellar: :any_skip_relocation, monterey:       "7f8a26a4e41c869d62fa610ce88286563b420c7a9fa1220b2bda6e5f2708a8a7"
-    sha256 cellar: :any_skip_relocation, big_sur:        "b767e87cfcff8aec87e33cb448091782b087feada1b550475c8702c300a44b5e"
-    sha256 cellar: :any_skip_relocation, catalina:       "f680196f5053f3c8ad890cf04b0b00a687c988e7f61650082c05e1a06c83ac84"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ff434936c81ecf8e686cec19028255bbef70abb5205301a32b72b217950b05d0"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "6dcbe72ea5174cc777963832ef99822fd328e0413455fd19c36aeae44ac9ab3c"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "6390f03afbe6d37d83d83c7f57f45adaba298ee3eb3fff2ad4193105f49c259a"
+    sha256 cellar: :any_skip_relocation, monterey:       "1e412e8f75e14656b22b5b6888d369a4cec1e8649ac6e995ac3248b50aaa541d"
+    sha256 cellar: :any_skip_relocation, big_sur:        "5efc778549cf11b668874e280b750801e5710de3e19a9f42536dc80aa2fd4560"
+    sha256 cellar: :any_skip_relocation, catalina:       "677e72f9fb3c62959e0aa6b6e1b57bcaff8a9115dfb4eefd1aee9fe14f7d01a2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "82b25ddf6ec246b7fdc070d9383148d7b04dc37fec0c541c012863f2a23631b4"
   end
 
   depends_on "python@3.10"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seems a race condition has caused a faulty bottle block, breaking installs with `Error: Couldn't find manifest matching bottle checksum.`.

Both #106145 and #106148 bumped `mypy` and merges were triggered at the same time. The former's bottles were [uploaded and merged first](https://github.com/Homebrew/homebrew-core/runs/7416994682?check_suite_focus=true#step:10:178) yet was [overwritten in ghcr.io seconds later](https://github.com/Homebrew/homebrew-core/runs/7416994466?check_suite_focus=true#step:10:178) by the latter.
