### PR TITLE
vcpkg: fix test

### DIFF
--- a/Formula/vcpkg.rb
+++ b/Formula/vcpkg.rb
@@ -59,7 +59,8 @@ class Vcpkg < Formula
   end
 
   test do
-    message = "error: Could not detect vcpkg-root."
+    # DO NOT CHANGE. If the test breaks then the `inreplace` needs fixing.
+    message = "error: Could not detect vcpkg-root. You must define the VCPKG_ROOT environment variable"
     assert_match message, shell_output("#{bin}/vcpkg search sqlite", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's return the test assertion from 8c24a73d7e10ab0e45bb21e8fb13ff3047b75d53
to check for a broken `inreplace`.

The test was then broken by 51d30de079cfab8ba31ac40a5f295cf79a4364eb, so
let's leave a comment documenting that the `inreplace` also needs fixing
whenever the test does.
