### PR TITLE
nmrpflash 0.9.17 (new formula)

### DIFF
--- a/Formula/nmrpflash.rb
+++ b/Formula/nmrpflash.rb
@@ -7,6 +7,9 @@ class Nmrpflash < Formula
 
   uses_from_macos "libpcap"
 
+  # for now
+  depends_on :macos
+
   def install
     system "make", "VERSION=#{version}"
     # "make install" is currently broken

--- a/Formula/nmrpflash.rb
+++ b/Formula/nmrpflash.rb
@@ -13,8 +13,7 @@ class Nmrpflash < Formula
   end
 
   def install
-    system "make", "VERSION=#{version}"
-    system "make", "install", "PREFIX=#{prefix}"
+    system "make", "install", "PREFIX=#{prefix}", "VERSION=#{version}"
   end
 
   test do

--- a/Formula/nmrpflash.rb
+++ b/Formula/nmrpflash.rb
@@ -1,8 +1,8 @@
 class Nmrpflash < Formula
   desc "Netgear Unbrick Utility"
   homepage "https://github.com/jclehner/nmrpflash"
-  url "https://github.com/jclehner/nmrpflash/archive/refs/tags/v0.9.17.tar.gz"
-  sha256 "fd3193c8c3a10bc50eb01da655570fd7d4fa191f6f489d517f86a85a4fc14681"
+  url "https://github.com/jclehner/nmrpflash/archive/refs/tags/v0.9.18.tar.gz"
+  sha256 "e1bc46445ab302d76fc4d9a99885f5df404b77a7c836bf2ef9f08fd73390db38"
   license "GPL-3.0-or-later"
 
   uses_from_macos "libpcap"

--- a/Formula/nmrpflash.rb
+++ b/Formula/nmrpflash.rb
@@ -1,0 +1,19 @@
+class Nmrpflash < Formula
+  desc "Netgear Unbrick Utility"
+  homepage "https://github.com/jclehner/nmrpflash"
+  url "https://github.com/jclehner/nmrpflash/archive/refs/tags/v0.9.17.tar.gz"
+  sha256 "fd3193c8c3a10bc50eb01da655570fd7d4fa191f6f489d517f86a85a4fc14681"
+  license "GPL-3.0-or-later"
+
+  uses_from_macos "libpcap"
+
+  def install
+    system "make", "VERSION=#{version}"
+    # "make install" is currently broken
+    bin.install "nmrpflash"
+  end
+
+  test do
+    system "#{bin}/nmrpflash", "-L"
+  end
+end

--- a/Formula/nmrpflash.rb
+++ b/Formula/nmrpflash.rb
@@ -7,8 +7,10 @@ class Nmrpflash < Formula
 
   uses_from_macos "libpcap"
 
-  # for now
-  depends_on :macos
+  on_linux do
+    depends_on "pkg-config" => :build
+    depends_on "libnl"
+  end
 
   def install
     system "make", "VERSION=#{version}"
@@ -16,6 +18,6 @@ class Nmrpflash < Formula
   end
 
   test do
-    system "#{bin}/nmrpflash", "-L"
+    system bin/"nmrpflash", "-L"
   end
 end

--- a/Formula/nmrpflash.rb
+++ b/Formula/nmrpflash.rb
@@ -1,8 +1,8 @@
 class Nmrpflash < Formula
   desc "Netgear Unbrick Utility"
   homepage "https://github.com/jclehner/nmrpflash"
-  url "https://github.com/jclehner/nmrpflash/archive/refs/tags/v0.9.18.tar.gz"
-  sha256 "e1bc46445ab302d76fc4d9a99885f5df404b77a7c836bf2ef9f08fd73390db38"
+  url "https://github.com/jclehner/nmrpflash/archive/refs/tags/v0.9.18.1.tar.gz"
+  sha256 "24a61283f73e05abaa526dfeb68cb325bae56222a3d97a52cc63056e75783332"
   license "GPL-3.0-or-later"
 
   uses_from_macos "libpcap"
@@ -12,8 +12,7 @@ class Nmrpflash < Formula
 
   def install
     system "make", "VERSION=#{version}"
-    # "make install" is currently broken
-    bin.install "nmrpflash"
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do


### PR DESCRIPTION
`nmrpflash` is a utility that can be used to flash the firmware of various Netgear-branded routers

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
