### PR TITLE
restund: update livecheck

### DIFF
--- a/Formula/restund.rb
+++ b/Formula/restund.rb
@@ -5,9 +5,13 @@ class Restund < Formula
   sha256 "3170441dc882352ab0275556b6fc889b38b14203d936071b5fa12f39a5c86d47"
   revision 3
 
+  # The sources.openwrt.org directory listing page is 2+ MB in size and
+  # growing. This alternative check is less ideal but only a few KB. Versions
+  # on the package page can use a format like 1.2.3-4, so we omit any trailing
+  # suffix to match the tarball version.
   livecheck do
-    url "https://sources.openwrt.org/"
-    regex(/href=.*?restund[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://openwrt.org/packages/pkgdata/restund"
+    regex(/<dd [^>]*?class="version"[^>]*?>\s*?v?(\d+(?:\.\d+)+)/im)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `restund` checks sources.openwrt.org, which is a directory listing page that contains ~15,000 entries (and growing). This page is currently around 2 MB in size (this server doesn't appear to have compression enabled) and will increase as more files are added in the future.

This PR addresses the situation by updating the `livecheck` block to check the package page for `restund` on openwrt.org, as this page is only ~10 KB. The version on the package page is listed as `0.4.12-9` and I've crafted the regex to only capture the version before the trailing suffix (to align with the tarball version).

As always, we can always revisit this if we run into issues in the future (e.g., if the package page is notably slower to update in comparison to the directory listing page, etc.).