### PR TITLE
janet: update jpm to 1.1.0

### DIFF
--- a/Formula/janet.rb
+++ b/Formula/janet.rb
@@ -19,8 +19,8 @@ class Janet < Formula
   depends_on "ninja" => :build
 
   resource "jpm" do
-    url "https://github.com/janet-lang/jpm/archive/refs/tags/v1.0.0.tar.gz"
-    sha256 "858d4ef2f6ac78222c53154dd91f8fb5994e3c3cbe253c9b0d3b9d52557eeb9b"
+    url "https://github.com/janet-lang/jpm/archive/refs/tags/v1.1.0.tar.gz"
+    sha256 "337c40d9b8c087b920202287b375c2962447218e8e127ce3a5a12e6e47ac6f16"
   end
 
   def install

--- a/Formula/janet.rb
+++ b/Formula/janet.rb
@@ -4,6 +4,7 @@ class Janet < Formula
   url "https://github.com/janet-lang/janet/archive/v1.23.0.tar.gz"
   sha256 "0b4d5d3632e0d376d9512ea8ea262f31f75c132b488dd7870f472acae709a865"
   license "MIT"
+  revision 1
   head "https://github.com/janet-lang/janet.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
    - As closely as possible, but exceptions are noted below.
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
    - No; I can't build this from source on my computer. But this is true before my changes as well.
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
    - No. Attempting to run any tests fails with hundreds of error messages from Bundler.
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
    - n/a, because I cannot brew install from source.

-----

Updates jpm to the latest release, to fix a bug where native modules don't install to the correct path. I cannot test these changes myself due to my computer being too old to build janet from source (Homebrew requires installing a 30GB subset of XCode in order to use gcc, apparently, which is not possible on my machine.)