### PR TITLE
molten-vk: add HEAD support

### DIFF
--- a/Formula/molten-vk.rb
+++ b/Formula/molten-vk.rb
@@ -1,10 +1,58 @@
 class MoltenVk < Formula
   desc "Implementation of the Vulkan graphics and compute API on top of Metal"
   homepage "https://github.com/KhronosGroup/MoltenVK"
-  url "https://github.com/KhronosGroup/MoltenVK/archive/v1.1.10.tar.gz"
-  sha256 "fac11c2501195c9ce042103685c7778e35484562e6c084963a22072dd0a602e0"
   license "Apache-2.0"
   revision 1
+
+  stable do
+    url "https://github.com/KhronosGroup/MoltenVK/archive/v1.1.10.tar.gz"
+    sha256 "fac11c2501195c9ce042103685c7778e35484562e6c084963a22072dd0a602e0"
+
+    # MoltenVK depends on very specific revisions of its dependencies.
+    # For each resource the path to the file describing the expected
+    # revision is listed.
+    resource "cereal" do
+      # ExternalRevisions/cereal_repo_revision
+      url "https://github.com/USCiLab/cereal.git",
+          revision: "51cbda5f30e56c801c07fe3d3aba5d7fb9e6cca4"
+    end
+
+    resource "Vulkan-Headers" do
+      # ExternalRevisions/Vulkan-Headers_repo_revision
+      url "https://github.com/KhronosGroup/Vulkan-Headers.git",
+          revision: "3ef4c97fd6ea001d75a8e9da408ee473c180e456"
+    end
+
+    resource "SPIRV-Cross" do
+      # ExternalRevisions/SPIRV-Cross_repo_revision
+      url "https://github.com/KhronosGroup/SPIRV-Cross.git",
+          revision: "50b4d5389b6a06f86fb63a2848e1a7da6d9755ca"
+    end
+
+    resource "glslang" do
+      # ExternalRevisions/glslang_repo_revision
+      url "https://github.com/KhronosGroup/glslang.git",
+          revision: "adbf0d3106b26daa237b10b9bf72b1af7c31092d"
+    end
+
+    resource "SPIRV-Tools" do
+      # known_good.json in the glslang repository
+      url "https://github.com/KhronosGroup/SPIRV-Tools.git",
+          revision: "b930e734ea198b7aabbbf04ee1562cf6f57962f0"
+    end
+
+    resource "SPIRV-Headers" do
+      # known_good.json in the glslang repository
+      url "https://github.com/KhronosGroup/SPIRV-Headers.git",
+          revision: "5a121866927a16ab9d49bed4788b532c7fcea766"
+    end
+
+    resource "Vulkan-Tools" do
+      # ExternalRevisions/Vulkan-Tools_repo_revision
+      url "https://github.com/KhronosGroup/Vulkan-Tools.git",
+          revision: "ef9db7a8ec52f6c56158d83f5d57ef388c1abec1"
+    end
+  end
 
   bottle do
     sha256 cellar: :any, arm64_monterey: "db4bd2f19ea7d78b956d802fb1c56891c14ee3789351496d8caeb6b200e97ac3"
@@ -14,57 +62,51 @@ class MoltenVk < Formula
     sha256 cellar: :any, catalina:       "cbbf37ddeecf29e9e6b562436c995c14e022253a0ae545a507587cbd815a3898"
   end
 
+  head do
+    url "https://github.com/KhronosGroup/MoltenVK.git", branch: "master"
+
+    resource "cereal" do
+      url "https://github.com/USCiLab/cereal.git",
+          branch:   "master"
+    end
+
+    resource "Vulkan-Headers" do
+      url "https://github.com/KhronosGroup/Vulkan-Headers.git",
+          branch:   "main"
+    end
+
+    resource "SPIRV-Cross" do
+      url "https://github.com/KhronosGroup/SPIRV-Cross.git",
+          branch:   "master"
+    end
+
+    resource "glslang" do
+      url "https://github.com/KhronosGroup/glslang.git",
+          branch:   "master"
+    end
+
+    resource "SPIRV-Tools" do
+      url "https://github.com/KhronosGroup/SPIRV-Tools.git",
+          branch:   "master"
+    end
+
+    resource "SPIRV-Headers" do
+      url "https://github.com/KhronosGroup/SPIRV-Headers.git",
+          branch:   "master"
+    end
+
+    resource "Vulkan-Tools" do
+      url "https://github.com/KhronosGroup/Vulkan-Tools.git",
+          branch:   "master"
+    end
+  end
+
   depends_on "cmake" => :build
   depends_on "python@3.10" => :build
   depends_on xcode: ["11.7", :build]
   # Requires IOSurface/IOSurfaceRef.h.
   depends_on macos: :sierra
   depends_on :macos # Linux does not have a Metal implementation. Not implied by the line above.
-
-  # MoltenVK depends on very specific revisions of its dependencies.
-  # For each resource the path to the file describing the expected
-  # revision is listed.
-  resource "cereal" do
-    # ExternalRevisions/cereal_repo_revision
-    url "https://github.com/USCiLab/cereal.git",
-        revision: "51cbda5f30e56c801c07fe3d3aba5d7fb9e6cca4"
-  end
-
-  resource "Vulkan-Headers" do
-    # ExternalRevisions/Vulkan-Headers_repo_revision
-    url "https://github.com/KhronosGroup/Vulkan-Headers.git",
-        revision: "3ef4c97fd6ea001d75a8e9da408ee473c180e456"
-  end
-
-  resource "SPIRV-Cross" do
-    # ExternalRevisions/SPIRV-Cross_repo_revision
-    url "https://github.com/KhronosGroup/SPIRV-Cross.git",
-        revision: "50b4d5389b6a06f86fb63a2848e1a7da6d9755ca"
-  end
-
-  resource "glslang" do
-    # ExternalRevisions/glslang_repo_revision
-    url "https://github.com/KhronosGroup/glslang.git",
-        revision: "adbf0d3106b26daa237b10b9bf72b1af7c31092d"
-  end
-
-  resource "SPIRV-Tools" do
-    # known_good.json in the glslang repository
-    url "https://github.com/KhronosGroup/SPIRV-Tools.git",
-        revision: "b930e734ea198b7aabbbf04ee1562cf6f57962f0"
-  end
-
-  resource "SPIRV-Headers" do
-    # known_good.json in the glslang repository
-    url "https://github.com/KhronosGroup/SPIRV-Headers.git",
-        revision: "5a121866927a16ab9d49bed4788b532c7fcea766"
-  end
-
-  resource "Vulkan-Tools" do
-    # ExternalRevisions/Vulkan-Tools_repo_revision
-    url "https://github.com/KhronosGroup/Vulkan-Tools.git",
-        revision: "ef9db7a8ec52f6c56158d83f5d57ef388c1abec1"
-  end
 
   def install
     resources.each do |res|
@@ -95,23 +137,25 @@ class MoltenVk < Formula
                "SYMROOT=External/build", "OBJROOT=External/build",
                "build"
 
-    # Create SPIRVCross.xcframework
-    xcodebuild "-quiet", "-create-xcframework",
-               "-output", "External/build/Latest/SPIRVCross.xcframework",
-               "-library", "External/build/Intermediates/XCFrameworkStaging/" \
-                           "Release/Platform/libSPIRVCross.a"
+    if build.stable?
+      # Create SPIRVCross.xcframework
+      xcodebuild "-quiet", "-create-xcframework",
+                 "-output", "External/build/Latest/SPIRVCross.xcframework",
+                 "-library", "External/build/Intermediates/XCFrameworkStaging/" \
+                             "Release/Platform/libSPIRVCross.a"
 
-    # Create SPIRVTools.xcframework
-    xcodebuild "-quiet", "-create-xcframework",
-               "-output", "External/build/Latest/SPIRVTools.xcframework",
-               "-library", "External/build/Intermediates/XCFrameworkStaging/" \
-                           "Release/Platform/libSPIRVTools.a"
+      # Create SPIRVTools.xcframework
+      xcodebuild "-quiet", "-create-xcframework",
+                 "-output", "External/build/Latest/SPIRVTools.xcframework",
+                 "-library", "External/build/Intermediates/XCFrameworkStaging/" \
+                             "Release/Platform/libSPIRVTools.a"
 
-    # Created glslang.xcframework
-    xcodebuild "-quiet", "-create-xcframework",
-               "-output", "External/build/Latest/glslang.xcframework",
-               "-library", "External/build/Intermediates/XCFrameworkStaging/" \
-                           "Release/Platform/libglslang.a"
+      # Created glslang.xcframework
+      xcodebuild "-quiet", "-create-xcframework",
+                 "-output", "External/build/Latest/glslang.xcframework",
+                 "-library", "External/build/Intermediates/XCFrameworkStaging/" \
+                             "Release/Platform/libglslang.a"
+    end
 
     # Build MoltenVK Package
     xcodebuild "ARCHS=#{Hardware::CPU.arch}", "ONLY_ACTIVE_ARCH=YES",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Bump resources, required for latest HEAD (it depends on some newer Vulkan APIs)
- Make a couple build steps stable-only (likely to be removed altogether with some future stable release)
- Add `head`

This is particularly useful at the moment, since upstream master has some newly-standardized functionality allowing callers to map Metal objects to Vulkan ones (and vice versa).