### PR TITLE
vulkan-loader: add /opt/homebrew/etc-based search paths

### DIFF
--- a/Formula/vulkan-loader.rb
+++ b/Formula/vulkan-loader.rb
@@ -4,6 +4,7 @@ class VulkanLoader < Formula
   url "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v1.3.220.tar.gz"
   sha256 "fe5b65e5d88febb1220ae59de363ed8b2794f8c861d6d74efb14aecefd464559"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/KhronosGroup/Vulkan-Loader.git", branch: "master"
 
   bottle do
@@ -31,6 +32,8 @@ class VulkanLoader < Formula
     system "cmake", "-S", ".", "-B", "build",
                     "-DVULKAN_HEADERS_INSTALL_DIR=#{Formula["vulkan-headers"].opt_prefix}",
                     "-DFALLBACK_DATA_DIRS=#{HOMEBREW_PREFIX}/share:/usr/local/share:/usr/share",
+                    "-DCMAKE_INSTALL_SYSCONFDIR=#{etc}",
+                    "-DFALLBACK_CONFIG_DIRS=#{etc}/xdg:/etc/xdg",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
Following up on discussion with @carlocab on #105567.

This means that /opt/homebrew/etc and /opt/homebrew/etc/xdg will be searched for drivers (in addition to /etc, /etc/xdg, and all the other non-/etc paths), and also that we won't try to search nonsensical paths like /etc/opt/homebrew/Cellar/vulkan-loader/1.3.220.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?