### PR TITLE
elixir-ls: Use compiled builds

### DIFF
--- a/Formula/elixir-ls.rb
+++ b/Formula/elixir-ls.rb
@@ -1,31 +1,15 @@
 class ElixirLs < Formula
   desc "Language Server and Debugger for Elixir"
   homepage "https://elixir-lsp.github.io/elixir-ls"
-  url "https://github.com/elixir-lsp/elixir-ls/archive/refs/tags/v0.10.0.tar.gz"
-  sha256 "cba5b9afb46228c7472e2e2ecc5d7fd99a29e778ce3e726db1dd9f702a68bbbd"
+  url "https://github.com/elixir-lsp/elixir-ls/releases/download/v0.10.0/elixir-ls.zip"
+  sha256 "ebc6c0a1c86003ee627ef14520987df7ee517885dc1402c0a351d2cd39618c18"
   license "Apache-2.0"
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "2508f07c361fee37a62eff19b9ce0772564ed43467e927e25310cd47286fd59f"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "bde32d69852db52952aa55e71a9d0e000a3cbb70f9acc41fa0c21ed2556cea96"
-    sha256 cellar: :any_skip_relocation, monterey:       "2c6419dab00f7268c698a4ed55b8e0ecb8ee9cb64aa5b7d7c38d49897de1ecc9"
-    sha256 cellar: :any_skip_relocation, big_sur:        "9954971dd64118ec86bc464fdbfdce2793b9d50fbbd2881791894248deccf756"
-    sha256 cellar: :any_skip_relocation, catalina:       "65b16d8a3c5172c7aa9bb3faf189ec3e0e61e111996ef64139b7d23a71101918"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c1f6cd1e14c2937b657abec11f0d3e1cf5364a6c4fa73670f7d1cd68ab04b416"
-  end
-
-  depends_on "elixir"
+  depends_on "elixir" => :optional
 
   def install
-    ENV["MIX_ENV"] = "prod"
-
-    system "mix", "local.hex", "--force"
-    system "mix", "local.rebar", "--force"
-    system "mix", "deps.get"
-    system "mix", "compile"
-    system "mix", "elixir_ls.release", "-o", libexec
-
-    bin.install_symlink libexec/"language_server.sh" => "elixir-ls"
+    libexec.install Dir["*"]
+    bin.install_symlink lib/libexec/"language_server.sh" => "elixir-ls"
   end
 
   test do


### PR DESCRIPTION
DISCLAIMER: It's my first time editing/writing Homebrew formula, so I'm sure I missed some concept/requirement/etc.

### Issue
Right now `elixir-ls` build itself from source with `elixir` dependency installed from brew.

The problem is that it causes to use latest version of Erlang, build artifacts of which are not backward compatible (e.g. OTP-25 build won't run on anything but OTP-25).

Because of that, [it messes with `elixir-ls`' support of last 3 version of Elixir and Erlang](https://github.com/elixir-lsp/elixir-ls#supported-versions=) if you try to use it in projects that use different Elixir/Erlang version, e.g. via asdf (which `elixir-ls` explicitly supports).

This PR uses precompiled releases of `elixir-ls` built **with minimum versions of Erlang and Elixir supported** by the project, which makes it forward compatible with their newer releases.

- [X] (Kinda) Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
  - I think we can still provide option of building from source, but I'm don't know how to do that
  - Should we include bottles if we use precompiled binaries?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
  - Not really: it says that there should be no optional dependencies, but in this case it makes sense to mention `elixir` as optional dependency, since `elixir-ls` won't run without it, but `asdf` usage for that is **strongly advised**.

-----
