### PR TITLE
gegl: fix since glib-utils

### DIFF
--- a/Formula/gegl.rb
+++ b/Formula/gegl.rb
@@ -20,7 +20,7 @@ class Gegl < Formula
     sha256 x86_64_linux:   "9d82f54188b03437bf8db9c8cdf8be55fde5cdac6cc358e3ea9245212e7933a6"
   end
 
-  depends_on "glib" => :build
+  depends_on "glib-utils" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build


### PR DESCRIPTION
After the refactor of  `glib` and `glib-utils` a number of formulas no longer build. This fixes gegl.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
