### PR TITLE
moar 1.9.6 + man page

### DIFF
--- a/Formula/moar.rb
+++ b/Formula/moar.rb
@@ -1,8 +1,8 @@
 class Moar < Formula
   desc "Nice to use pager for humans"
   homepage "https://github.com/walles/moar"
-  url "https://github.com/walles/moar/archive/refs/tags/v1.9.5.tar.gz"
-  sha256 "e412a768c6f5774713486c1d663a4ec60b72a3ba09b03d47525cbc563267bf3a"
+  url "https://github.com/walles/moar/archive/refs/tags/v1.9.6.tar.gz"
+  sha256 "6345b1afd6c32adb296956c10553b93f23aab0571bd149345d415dbaaa53ea28"
   license "BSD-2-Clause"
 
   bottle do
@@ -19,6 +19,7 @@ class Moar < Formula
   def install
     ldflags = "-s -w -X main.versionString=v#{version}"
     system "go", "build", *std_go_args(ldflags: ldflags)
+    man1.install "moar.1"
   end
 
   test do


### PR DESCRIPTION
Created manually since I wanted to add the `man1.install "moar.1"` line to `moar.rb`.

Fixes <https://github.com/walles/moar/issues/87>.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
