### PR TITLE
x264: remove unused `gcc` on Linux

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -1,15 +1,12 @@
 class X264 < Formula
   desc "H.264/AVC encoder"
   homepage "https://www.videolan.org/developers/x264.html"
+  # the latest commit on the stable branch
+  url "https://code.videolan.org/videolan/x264.git",
+      revision: "baee400fa9ced6f5481a728138fed6e867b0ff7f"
+  version "r3095"
   license "GPL-2.0-only"
   head "https://code.videolan.org/videolan/x264.git", branch: "master"
-
-  stable do
-    # the latest commit on the stable branch
-    url "https://code.videolan.org/videolan/x264.git",
-        revision: "baee400fa9ced6f5481a728138fed6e867b0ff7f"
-    version "r3095"
-  end
 
   # Cross-check the abbreviated commit hashes from the release filenames with
   # the latest commits in the `stable` Git branch:
@@ -52,11 +49,14 @@ class X264 < Formula
 
   depends_on "nasm" => :build
 
-  on_system :linux, macos: :high_sierra_or_older do
-    # Stack realignment requires newer Clang
-    # https://code.videolan.org/videolan/x264/-/commit/b5bc5d69c580429ff716bafcd43655e855c31b02
-    depends_on "gcc"
-    fails_with :clang
+  on_macos do
+    depends_on "gcc" if DevelopmentTools.clang_build_version <= 902
+  end
+
+  # https://code.videolan.org/videolan/x264/-/commit/b5bc5d69c580429ff716bafcd43655e855c31b02
+  fails_with :clang do
+    build 902
+    cause "Stack realignment requires newer Clang"
   end
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
