### PR TITLE
Reorganize `patch` and `resource` blocks

### DIFF
--- a/Formula/cdparanoia.rb
+++ b/Formula/cdparanoia.rb
@@ -28,15 +28,15 @@ class Cdparanoia < Formula
   depends_on "automake" => :build
 
   # Patches via MacPorts
-  on_macos do
-    patch do
+  patch do
+    on_macos do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/2a22152/cdparanoia/osx_interface.patch"
       sha256 "3eca8ff34d2617c460056f97457b5ac62db1983517525e5c73886a2dea9f06d9"
     end
   end
 
-  on_linux do
-    patch do
+  patch do
+    on_linux do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/bfad134/cdparanoia/linux_fpic.patch"
       sha256 "496f53d21dde7e23f4c9cf1cc28219efcbb5464fe2abbd5a073635279281c9c4"
     end

--- a/Formula/dbus.rb
+++ b/Formula/dbus.rb
@@ -35,10 +35,10 @@ class Dbus < Formula
 
   uses_from_macos "expat"
 
-  on_macos do
-    # Patch applies the config templating fixed in https://bugs.freedesktop.org/show_bug.cgi?id=94494
-    # Homebrew pr/issue: 50219
-    patch do
+  # Patch applies the config templating fixed in https://bugs.freedesktop.org/show_bug.cgi?id=94494
+  # Homebrew pr/issue: 50219
+  patch do
+    on_macos do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/0a8a55872e/d-bus/org.freedesktop.dbus-session.plist.osx.diff"
       sha256 "a8aa6fe3f2d8f873ad3f683013491f5362d551bf5d4c3b469f1efbc5459a20dc"
     end

--- a/Formula/dieharder.rb
+++ b/Formula/dieharder.rb
@@ -31,8 +31,8 @@ class Dieharder < Formula
 
   depends_on "gsl"
 
-  on_linux do
-    patch do
+  patch do
+    on_linux do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/b5dfa6f2b9c5d44cb4bab93ace2e0d7d58465fb0/dieharder/dieharder-linux.patch"
       sha256 "8c0ab2425c8a315471f809d5ecaebd061985f24019886cba7f856e5aaf72112b"
     end

--- a/Formula/fdroidserver.rb
+++ b/Formula/fdroidserver.rb
@@ -28,8 +28,8 @@ class Fdroidserver < Formula
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
 
-  on_macos do
-    resource "appnope" do
+  resource "appnope" do
+    on_macos do
       url "https://files.pythonhosted.org/packages/6a/cd/355842c0db33192ac0fc822e2dcae835669ef317fe56c795fb55fcddb26f/appnope-0.1.3.tar.gz"
       sha256 "02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"
     end

--- a/Formula/flann.rb
+++ b/Formula/flann.rb
@@ -18,18 +18,18 @@ class Flann < Formula
   depends_on "cmake" => :build
   depends_on "hdf5"
 
-  on_linux do
-    # Fix for Linux build: https://bugs.gentoo.org/652594
-    # Not yet fixed upstream: https://github.com/mariusmuja/flann/issues/369
-    patch do
-      url "https://raw.githubusercontent.com/buildroot/buildroot/0c469478f64d0ddaf72c0622a1830d855306d51c/package/flann/0001-src-cpp-fix-cmake-3.11-build.patch"
-      sha256 "aa181d0731d4e9a266f7fcaf5423e7a6b783f400cc040a3ef0fef77930ecf680"
-    end
-  end
-
   resource("dataset") do
     url "https://github.com/flann-lib/flann/files/6518483/dataset.zip"
     sha256 "169442be3e9d8c862eb6ae4566306c31ff18406303d87b4d101f367bc5d17afa"
+  end
+
+  # Fix for Linux build: https://bugs.gentoo.org/652594
+  # Not yet fixed upstream: https://github.com/mariusmuja/flann/issues/369
+  patch do
+    on_linux do
+      url "https://raw.githubusercontent.com/buildroot/buildroot/0c469478f64d0ddaf72c0622a1830d855306d51c/package/flann/0001-src-cpp-fix-cmake-3.11-build.patch"
+      sha256 "aa181d0731d4e9a266f7fcaf5423e7a6b783f400cc040a3ef0fef77930ecf680"
+    end
   end
 
   def install

--- a/Formula/fpc.rb
+++ b/Formula/fpc.rb
@@ -24,18 +24,18 @@ class Fpc < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3491933cdf5782d3c4b9b1188757cb3846b5d823a6db75c8fb56f13b23bc6747"
   end
 
-  on_macos do
-    resource "bootstrap" do
+  # mesa is needed to test GL unit
+  on_linux do
+    depends_on "mesa" => :test
+  end
+
+  resource "bootstrap" do
+    on_macos do
       url "https://downloads.sourceforge.net/project/freepascal/Mac%20OS%20X/3.2.2/fpc-3.2.2.intelarm64-macosx.dmg"
       sha256 "05d4510c8c887e3c68de20272abf62171aa5b2ef1eba6bce25e4c0bc41ba8b7d"
     end
-  end
 
-  on_linux do
-    # mesa is needed to test GL unit
-    depends_on "mesa" => :test
-
-    resource "bootstrap" do
+    on_linux do
       url "https://downloads.sourceforge.net/project/freepascal/Linux/3.2.2/fpc-3.2.2.x86_64-linux.tar"
       sha256 "5adac308a5534b6a76446d8311fc340747cbb7edeaacfe6b651493ff3fe31e83"
     end

--- a/Formula/ghc@8.6.rb
+++ b/Formula/ghc@8.6.rb
@@ -26,17 +26,17 @@ class GhcAT86 < Formula
   uses_from_macos "m4" => :build
   uses_from_macos "ncurses"
 
-  on_macos do
-    resource "gmp" do
+  on_linux do
+    depends_on "gmp" => :build
+  end
+
+  resource "gmp" do
+    on_macos do
       url "https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz"
       mirror "https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz"
       mirror "https://ftpmirror.gnu.org/gmp/gmp-6.1.2.tar.xz"
       sha256 "87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912"
     end
-  end
-
-  on_linux do
-    depends_on "gmp" => :build
   end
 
   # https://www.haskell.org/ghc/download_ghc_8_6_5#macosx_x86_64

--- a/Formula/ghc@8.8.rb
+++ b/Formula/ghc@8.8.rb
@@ -26,17 +26,17 @@ class GhcAT88 < Formula
   uses_from_macos "m4" => :build
   uses_from_macos "ncurses"
 
-  on_macos do
-    resource "gmp" do
+  on_linux do
+    depends_on "gmp" => :build
+  end
+
+  resource "gmp" do
+    on_macos do
       url "https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz"
       mirror "https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz"
       mirror "https://ftpmirror.gnu.org/gmp/gmp-6.1.2.tar.xz"
       sha256 "87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912"
     end
-  end
-
-  on_linux do
-    depends_on "gmp" => :build
   end
 
   # https://www.haskell.org/ghc/download_ghc_8_8_3.html#macosx_x86_64

--- a/Formula/hspell.rb
+++ b/Formula/hspell.rb
@@ -25,10 +25,10 @@ class Hspell < Formula
 
   uses_from_macos "zlib"
 
-  on_macos do
-    # hspell was built for linux and compiles a .so shared library, to comply with macOS
-    # standards this patch creates a .dylib instead
-    patch :p0 do
+  # hspell was built for linux and compiles a .so shared library, to comply with macOS
+  # standards this patch creates a .dylib instead
+  patch :p0 do
+    on_macos do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/85fa66a9/hspell/1.3.patch"
       sha256 "63cc1bc753b1062d1144dcdd959a0a8f712b8872dce89e54ddff2d24f2ca2065"
     end

--- a/Formula/jigdo.rb
+++ b/Formula/jigdo.rb
@@ -30,17 +30,17 @@ class Jigdo < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
-  on_macos do
-    # Use MacPorts patch for compilation on 10.9. Remove when updating to 0.8+.
-    patch :p0 do
+  # Use MacPorts patch for compilation on 10.9. Remove when updating to 0.8+.
+  patch :p0 do
+    on_macos do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/e101570/jigdo/patch-src-compat.hh.diff"
       sha256 "a21aa8bcc5a03a6daf47e0ab4e04f16e611e787a7ada7a6a87c8def738585646"
     end
   end
 
-  on_linux do
-    # Use Fedora patch for compilation with GCC. Remove when updating to 0.8+.
-    patch do
+  # Use Fedora patch for compilation with GCC. Remove when updating to 0.8+.
+  patch do
+    on_linux do
       url "https://src.fedoraproject.org/rpms/jigdo/raw/27c01e27168b62157e98c7ffad1aa0b4aad405e9/f/jigdo-0.7.3-gcc43.patch"
       sha256 "57e13ca6c283cb086d1c5ceb5ed3562fab548fa19e1d14ecc045c3a23fa7d44a"
     end

--- a/Formula/jpegrescan.rb
+++ b/Formula/jpegrescan.rb
@@ -20,8 +20,8 @@ class Jpegrescan < Formula
 
   uses_from_macos "perl"
 
-  on_linux do
-    resource "File::Slurp" do
+  resource "File::Slurp" do
+    on_linux do
       url "https://cpan.metacpan.org/authors/id/C/CA/CAPOEIRAB/File-Slurp-9999.32.tar.gz"
       sha256 "4c3c21992a9d42be3a79dd74a3c83d27d38057269d65509a2f555ea0fb2bc5b0"
     end

--- a/Formula/kpcli.rb
+++ b/Formula/kpcli.rb
@@ -27,20 +27,22 @@ class Kpcli < Formula
 
   uses_from_macos "perl"
 
-  on_macos do
-    resource "Mac::Pasteboard" do
+  resource "Mac::Pasteboard" do
+    on_macos do
       url "https://cpan.metacpan.org/authors/id/W/WY/WYANT/Mac-Pasteboard-0.103.tar.gz"
       sha256 "2f5e8dd2db0d6445558484ca6d42d839c5a97ee8aa1b250e694d67d5b7f6634c"
     end
   end
 
-  on_linux do
-    resource "Clone" do
+  resource "Clone" do
+    on_linux do
       url "https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/Clone-0.45.tar.gz"
       sha256 "cbb6ee348afa95432e4878893b46752549e70dc68fe6d9e430d1d2e99079a9e6"
     end
+  end
 
-    resource "TermReadKey" do
+  resource "TermReadKey" do
+    on_linux do
       url "https://cpan.metacpan.org/authors/id/J/JS/JSTOWE/TermReadKey-2.38.tar.gz"
       sha256 "5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290"
     end

--- a/Formula/lanraragi.rb
+++ b/Formula/lanraragi.rb
@@ -33,8 +33,8 @@ class Lanraragi < Formula
 
   uses_from_macos "libarchive"
 
-  on_macos do
-    resource "libarchive-headers" do
+  resource "libarchive-headers" do
+    on_macos do
       url "https://opensource.apple.com/tarballs/libarchive/libarchive-83.100.2.tar.gz"
       sha256 "e54049be1b1d4f674f33488fdbcf5bb9f9390db5cc17a5b34cbeeb5f752b207a"
     end

--- a/Formula/latexindent.rb
+++ b/Formula/latexindent.rb
@@ -16,8 +16,8 @@ class Latexindent < Formula
 
   depends_on "perl"
 
-  on_macos do
-    resource "Mac::SystemDirectory" do
+  resource "Mac::SystemDirectory" do
+    on_macos do
       url "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Mac-SystemDirectory-0.14.tar.gz"
       sha256 "b3c336fe20850042d30e1db1e8d191d3c056cc1072a472eb4e5bd7229056dee1"
     end

--- a/Formula/libgccjit.rb
+++ b/Formula/libgccjit.rb
@@ -34,17 +34,17 @@ class Libgccjit < Formula
 
   uses_from_macos "zlib"
 
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
   # Branch from the Darwin maintainer of GCC, with a few generic fixes and
   # Apple Silicon support, located at https://github.com/iains/gcc-11-branch
-  on_arm do
-    patch do
+  patch do
+    on_arm do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/07e71538/gcc/gcc-11.3.0-arm.diff"
       sha256 "857390a7f32dbfc4c7e6163a3b3b9d5e1d392e5d9c74c3ebb98701c1d0629565"
     end
   end
-
-  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
-  cxxstdlib_check :skip
 
   def install
     # GCC will suffer build errors if forced to use a particular linker.

--- a/Formula/libnids.rb
+++ b/Formula/libnids.rb
@@ -27,8 +27,8 @@ class Libnids < Formula
   uses_from_macos "libpcap"
 
   # Patch fixes -soname and .so shared library issues. Unreported.
-  on_macos do
-    patch do
+  patch do
+    on_macos do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/85fa66a9dc80757ba32bf5d818d70fc26bb24b6f/libnids/1.24.patch"
       sha256 "d9339c16f89915a02025f10f26aab5bb77c2af85926d2d9ff52e9c7bf2092215"
     end

--- a/Formula/llnode.rb
+++ b/Formula/llnode.rb
@@ -22,8 +22,8 @@ class Llnode < Formula
 
   uses_from_macos "llvm"
 
-  on_macos do
-    resource "lldb" do
+  resource "lldb" do
+    on_macos do
       if DevelopmentTools.clang_build_version >= 1000
         # lldb release_60 branch tip of tree commit from 10 Apr 2018
         url "https://github.com/llvm-mirror/lldb.git",
@@ -49,8 +49,8 @@ class Llnode < Formula
     end
   end
 
-  on_linux do
-    resource "lldb" do
+  resource "lldb" do
+    on_linux do
       # lldb release_60 branch tip of tree commit from 10 Apr 2018
       url "https://github.com/llvm-mirror/lldb.git",
           revision: "b6df24ff1b258b18041161b8f32ac316a3b5d8d9"

--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -22,21 +22,21 @@ class Lua < Formula
 
   uses_from_macos "unzip" => :build
 
-  on_macos do
-    # Be sure to build a dylib, or else runtime modules will pull in another static copy of liblua = crashy
-    # See: https://github.com/Homebrew/legacy-homebrew/pull/5043
-    patch do
+  on_linux do
+    depends_on "readline"
+  end
+
+  # Be sure to build a dylib, or else runtime modules will pull in another static copy of liblua = crashy
+  # See: https://github.com/Homebrew/legacy-homebrew/pull/5043
+  patch do
+    on_macos do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/11c8360432f471f74a9b2d76e012e3b36f30b871/lua/lua-dylib.patch"
       sha256 "a39e2ae1066f680e5c8bf1749fe09b0e33a0215c31972b133a73d43b00bf29dc"
     end
-  end
-
-  on_linux do
-    depends_on "readline"
 
     # Add shared library for linux. Equivalent to the mac patch above.
     # Inspired from https://www.linuxfromscratch.org/blfs/view/cvs/general/lua.html
-    patch do
+    on_linux do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/0dcd11880c7d63eb395105a5cdddc1ca05b40f4a/lua/lua-so.patch"
       sha256 "522dc63a0c1d87bf127c992dfdf73a9267890fd01a5a17e2bcf06f7eb2782942"
     end

--- a/Formula/monkeysphere.rb
+++ b/Formula/monkeysphere.rb
@@ -30,8 +30,8 @@ class Monkeysphere < Formula
 
   uses_from_macos "perl"
 
-  on_linux do
-    resource "Crypt::OpenSSL::Guess" do
+  resource "Crypt::OpenSSL::Guess" do
+    on_linux do
       url "https://cpan.metacpan.org/authors/id/A/AK/AKIYM/Crypt-OpenSSL-Guess-0.13.tar.gz"
       sha256 "87c1dd7f0f80fcd3d1396bce9fd9962e7791e748dc0584802f8d10cc9585e743"
     end

--- a/Formula/mytop.rb
+++ b/Formula/mytop.rb
@@ -25,14 +25,14 @@ class Mytop < Formula
 
   uses_from_macos "perl"
 
-  on_linux do
-    resource "Term::ReadKey" do
+  conflicts_with "mariadb", because: "both install `mytop` binaries"
+
+  resource "Term::ReadKey" do
+    on_linux do
       url "https://cpan.metacpan.org/authors/id/J/JS/JSTOWE/TermReadKey-2.38.tar.gz"
       sha256 "5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290"
     end
   end
-
-  conflicts_with "mariadb", because: "both install `mytop` binaries"
 
   resource "List::Util" do
     url "https://cpan.metacpan.org/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.46.tar.gz"

--- a/Formula/nbdime.rb
+++ b/Formula/nbdime.rb
@@ -19,8 +19,8 @@ class Nbdime < Formula
   depends_on "python@3.10"
   depends_on "six"
 
-  on_macos do
-    resource "appnope" do
+  resource "appnope" do
+    on_macos do
       url "https://files.pythonhosted.org/packages/e9/bc/2d2c567fe5ac1924f35df879dbf529dd7e7cabd94745dc9d89024a934e76/appnope-0.1.2.tar.gz"
       sha256 "dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a"
     end

--- a/Formula/nethacked.rb
+++ b/Formula/nethacked.rb
@@ -47,15 +47,15 @@ class Nethacked < Formula
   uses_from_macos "flex" => :build
   uses_from_macos "ncurses"
 
-  on_macos do
-    patch do
+  # Don't remove save folder
+  skip_clean "libexec/save"
+
+  patch do
+    on_macos do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/b40e459/nethacked/1.0.patch"
       sha256 "d32bed5e7b4500515135270d72077bab49534abbdc60d8d040473fbee630f90f"
     end
   end
-
-  # Don't remove save folder
-  skip_clean "libexec/save"
 
   def install
     # Build everything in-order; no multi builds.

--- a/Formula/nghttp2.rb
+++ b/Formula/nghttp2.rb
@@ -32,11 +32,11 @@ class Nghttp2 < Formula
   uses_from_macos "libxml2"
   uses_from_macos "zlib"
 
-  on_linux do
-    # Fix: shrpx_api_downstream_connection.cc:57:3: error:
-    # array must be initialized with a brace-enclosed initializer
-    # https://github.com/nghttp2/nghttp2/pull/1269
-    patch do
+  # Fix: shrpx_api_downstream_connection.cc:57:3: error:
+  # array must be initialized with a brace-enclosed initializer
+  # https://github.com/nghttp2/nghttp2/pull/1269
+  patch do
+    on_linux do
       url "https://github.com/nghttp2/nghttp2/commit/829258e7038fe7eff849677f1ccaeca3e704eb67.patch?full_index=1"
       sha256 "c4bcf5cf73d5305fc479206676027533bb06d4ff2840eb672f6265ba3239031e"
     end

--- a/Formula/otf2bdf.rb
+++ b/Formula/otf2bdf.rb
@@ -23,8 +23,8 @@ class Otf2bdf < Formula
 
   depends_on "freetype"
 
-  on_linux do
-    resource "test-font" do
+  resource "test-font" do
+    on_linux do
       url "https://raw.githubusercontent.com/paddykontschak/finder/master/fonts/LucidaGrande.ttc"
       sha256 "e188b3f32f5b2d15dbf01e9b4480fed899605e287516d7c0de6809d8e7368934"
     end

--- a/Formula/pacvim.rb
+++ b/Formula/pacvim.rb
@@ -20,10 +20,10 @@ class Pacvim < Formula
 
   uses_from_macos "ncurses"
 
-  on_linux do
-    # Use ncurses.h instead of cursesw.h which is not installed by brew
-    # https://github.com/jmoon018/PacVim/pull/31
-    patch do
+  # Use ncurses.h instead of cursesw.h which is not installed by brew
+  # https://github.com/jmoon018/PacVim/pull/31
+  patch do
+    on_linux do
       url "https://github.com/jmoon018/PacVim/commit/2f95ef4d312d760b8a3aae463e959646b27e774a.patch?full_index=1"
       sha256 "e5b753de87937c0853a1adbab31eb1ec938add4ceb0df26eafef5b4f613bc3e6"
     end

--- a/Formula/prodigal.rb
+++ b/Formula/prodigal.rb
@@ -28,8 +28,8 @@ class Prodigal < Formula
   # https://github.com/hyattpd/Prodigal/issues/34
   # https://github.com/hyattpd/Prodigal/issues/41
   # https://github.com/hyattpd/Prodigal/pull/35
-  on_linux do
-    patch do
+  patch do
+    on_linux do
       url "https://github.com/hyattpd/Prodigal/commit/cbbb5db21d120f100724b69d5212cf1275ab3759.patch?full_index=1"
       sha256 "fd292c0a98412a7f2ed06d86e0e3f96a9ad698f6772990321ad56985323b99a6"
     end

--- a/Formula/snappy.rb
+++ b/Formula/snappy.rb
@@ -24,17 +24,17 @@ class Snappy < Formula
     depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
   end
 
-  on_linux do
-    # Fix for build failure. Remove with next release.
-    patch do
-      url "https://github.com/google/snappy/commit/0c716d435abe65250100c2caea0e5126ac4e14bd.patch?full_index=1"
-      sha256 "12ff7d1182a35298de3287db32ef8581b8ef600efd6d9509fcc894d3d2056c80"
-    end
-  end
-
   fails_with :clang do
     build 1100
     cause "error: invalid output constraint '=@ccz' in asm"
+  end
+
+  # Fix for build failure. Remove with next release.
+  patch do
+    on_linux do
+      url "https://github.com/google/snappy/commit/0c716d435abe65250100c2caea0e5126ac4e14bd.patch?full_index=1"
+      sha256 "12ff7d1182a35298de3287db32ef8581b8ef600efd6d9509fcc894d3d2056c80"
+    end
   end
 
   # Fix issue where `snappy` setting -fno-rtti causes build issues on `folly`

--- a/Formula/srecord.rb
+++ b/Formula/srecord.rb
@@ -24,16 +24,16 @@ class Srecord < Formula
 
   uses_from_macos "groff" => :build
 
+  on_linux do
+    depends_on "ghostscript" => :build # for ps2pdf
+  end
+
   # Use macOS's pstopdf
-  on_macos do
-    patch do
+  patch do
+    on_macos do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/85fa66a9/srecord/1.64.patch"
       sha256 "140e032d0ffe921c94b19145e5904538233423ab7dc03a9c3c90bf434de4dd03"
     end
-  end
-
-  on_linux do
-    depends_on "ghostscript" => :build # for ps2pdf
   end
 
   def install

--- a/Formula/web100clt.rb
+++ b/Formula/web100clt.rb
@@ -32,8 +32,8 @@ class Web100clt < Formula
 
   # fixes issue with new default secure strlcpy/strlcat functions in 10.9
   # https://github.com/ndt-project/ndt/issues/106
-  on_macos do
-    patch do
+  patch do
+    on_macos do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/37aa64888341/web100clt/ndt-3.6.5.2-osx-10.9.patch"
       sha256 "86d2399e3d139c02108ce2afb45193d8c1f5782996714743ec673c7921095e8e"
     end

--- a/Formula/xmltoman.rb
+++ b/Formula/xmltoman.rb
@@ -24,8 +24,8 @@ class Xmltoman < Formula
 
   uses_from_macos "perl"
 
-  on_linux do
-    resource "XML::Parser" do
+  resource "XML::Parser" do
+    on_linux do
       url "https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.44.tar.gz"
       sha256 "1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216"
     end


### PR DESCRIPTION
Sorry, another large PR. However, this one should be simpler and hopefully the last one.

This PR re-organizes the `patch` and `resource` blocks so that the `on_{system}` blocks are nested inside the `patch` and `resource` blocks. This allows these blocks to be placed in the correct places, instead of needing to be where the `on_{system}` blocks are. This will be enforced by rubocops once this is merged (see https://github.com/Homebrew/brew/pull/13539)
