### PR TITLE
teleport: enable libfido2 features

### DIFF
--- a/Formula/teleport.rb
+++ b/Formula/teleport.rb
@@ -25,6 +25,7 @@ class Teleport < Formula
   end
 
   depends_on "go" => :build
+  depends_on "libfido2"
 
   uses_from_macos "curl" => :test
   uses_from_macos "netcat" => :test
@@ -40,7 +41,7 @@ class Teleport < Formula
 
   def install
     (buildpath/"webassets").install resource("webassets")
-    ENV.deparallelize { system "make", "full" }
+    ENV.deparallelize { system "make", "full", "FIDO2=dynamic" }
     bin.install Dir["build/*"]
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Teleport v10 added support for passwordless, which requires the `tsh`
binary to link against libfido2. This change adds the libfido2
dependency to the formula and the necessary make switch to enable
dynamic linking against it.

The make switch is a noop for versions <= v10.0.2, but ready to land on
v10.0.3 or v10.1.0 (whatever releases first). Because of that, it's not
necessary to bump the revision or rebuild the bottles.