### PR TITLE
Allow terragrunt formula to optionally depend on tfenv

### DIFF
--- a/Formula/terragrunt.rb
+++ b/Formula/terragrunt.rb
@@ -29,6 +29,6 @@ class Terragrunt < Formula
     # Generate an empty plan just to ensure Terraform works
     touch "#{testpath}/terragrunt.hcl"
     touch "#{testpath}/main.tf"
-    system "#{bin}/terragrunt plan"
+    assert_match "Terraform has been successfully initialized!", Utils.safe_popen_read(bin/"terragrunt", "plan")
   end
 end

--- a/Formula/terragrunt.rb
+++ b/Formula/terragrunt.rb
@@ -14,8 +14,11 @@ class Terragrunt < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "aebfaa647705da82ac376d8598a2522aeee3de7d8b60913a3fca65a25f9230d7"
   end
 
+  option "with-tfenv", "Depend on tfenv instead of terraform"
+
   depends_on "go" => :build
-  depends_on "terraform"
+  depends_on "terraform" => :optional unless build.with?("tfenv")
+  depends_on "tfenv" => :optional if build.with?("tfenv")
 
   conflicts_with "tgenv", because: "tgenv symlinks terragrunt binaries"
 

--- a/Formula/terragrunt.rb
+++ b/Formula/terragrunt.rb
@@ -14,11 +14,8 @@ class Terragrunt < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "aebfaa647705da82ac376d8598a2522aeee3de7d8b60913a3fca65a25f9230d7"
   end
 
-  option "with-tfenv", "Depend on tfenv instead of terraform"
-
   depends_on "go" => :build
-  depends_on "terraform" => :optional unless build.with?("tfenv")
-  depends_on "tfenv" => :optional if build.with?("tfenv")
+  depends_on "terraform" => :test
 
   conflicts_with "tgenv", because: "tgenv symlinks terragrunt binaries"
 
@@ -28,5 +25,10 @@ class Terragrunt < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/terragrunt --version")
+
+    # Generate an empty plan just to ensure Terraform works
+    touch "#{testpath}/terragrunt.hcl"
+    touch "#{testpath}/main.tf"
+    system "#{bin}/terragrunt plan"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This attempts to resolve the dependency conflicts between `tfenv` and `terraform` for this formula, already discussed in

* #41202
* #73326
* #75836

I saw the comment in the first PR that "options are not allowed in homebrew-core" ... I was wondering if there was any flexibility around this?  The supplied patch is a really clean fix for all the users that need tfenv, and has zero impact for anyone who doesn't supply the `--with-tfenv` flag. So it works for naive users (reason for declining two of the PRs)

Here's the audit-strict output which confirms that this is not ideal. I'm appealing to the safety and consistency of this approach.

```shell
$ brew audit --strict terragrunt
terragrunt:
  * Formulae in homebrew/core should not have optional or recommended dependencies
  * 17: col 3: Formulae in homebrew/core should not use `option`.
  * 20: col 46: Formulae in homebrew/core should not use `build.with?`.
  * 21: col 38: Formulae in homebrew/core should not use `build.with?`.
Error: 4 problems in 1 formula detected
```

fixes gruntwork-io/terragrunt#580