### PR TITLE
tarsnap-gui: use `qt@5`, fix build, and do not bundle Qt

### DIFF
--- a/Formula/tarsnap-gui.rb
+++ b/Formula/tarsnap-gui.rb
@@ -4,6 +4,7 @@ class TarsnapGui < Formula
   url "https://github.com/Tarsnap/tarsnap-gui/archive/v1.0.2.tar.gz"
   sha256 "3b271f474abc0bbeb3d5d62ee76b82785c7d64145e6e8b51fa7907b724c83eae"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/Tarsnap/tarsnap-gui.git", branch: "master"
 
   bottle do
@@ -13,17 +14,49 @@ class TarsnapGui < Formula
     sha256 cellar: :any, high_sierra: "d3e5e2aeee094f0e5944d68765965f2b9261cce026bafe45482a2b1e9abb1273"
   end
 
-  depends_on "qt"
+  depends_on "qt@5"
   depends_on "tarsnap"
+
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5" # qt@5 is built with GCC
+
+  # Work around build error: Set: Entry, ":CFBundleGetInfoString", Does Not Exist
+  # Issue ref: https://github.com/Tarsnap/tarsnap-gui/issues/557
+  patch :DATA
 
   def install
     system "qmake"
     system "make"
-    system "macdeployqt", "Tarsnap.app"
-    prefix.install "Tarsnap.app"
+    if OS.mac?
+      prefix.install "Tarsnap.app"
+      bin.install_symlink prefix/"Tarsnap.app/Contents/MacOS/Tarsnap" => "tarsnap-gui"
+    else
+      bin.install "tarsnap-gui"
+    end
   end
 
   test do
-    system "#{opt_prefix}/Tarsnap.app/Contents/MacOS/Tarsnap", "--version"
+    # Set QT_QPA_PLATFORM to minimal to avoid error "could not connect to display"
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+    system bin/"tarsnap-gui", "--version"
   end
 end
+
+__END__
+diff --git a/Tarsnap.pro b/Tarsnap.pro
+index 9954fc5c..560621b1 100644
+--- a/Tarsnap.pro
++++ b/Tarsnap.pro
+@@ -131,5 +131,8 @@ osx {
+ 
+     # Add VERSION to the app bundle.  (Why doesn't qmake do this?)
+     INFO_PLIST_PATH = $$shell_quote($${OUT_PWD}/$${TARGET}.app/Contents/Info.plist)
+-    QMAKE_POST_LINK += /usr/libexec/PlistBuddy -c \"Set :CFBundleGetInfoString $${VERSION}\" $${INFO_PLIST_PATH} ;
++    QMAKE_POST_LINK += /usr/libexec/PlistBuddy \
++                            -c \"Add :CFBundleVersionString string $${VERSION}\" \
++                            -c \"Add :CFBundleShortVersionString string $${VERSION}\" \
++                            $${INFO_PLIST_PATH} ;
+ }


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Relates to Monterey bottling #94212