### PR TITLE
jython: revision bump for Monterey bottle without Python 2

### DIFF
--- a/Formula/jython.rb
+++ b/Formula/jython.rb
@@ -4,7 +4,7 @@ class Jython < Formula
   url "https://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.2/jython-installer-2.7.2.jar"
   sha256 "36e40609567ce020a1de0aaffe45e0b68571c278c14116f52e58cc652fb71552"
   license "PSF-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://search.maven.org/remotecontent?filepath=org/python/jython-installer/"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Previous Monterey bottles were built on CI runners with Python 2, so they are now broken as seen in #106241

Rebuilding bottles in Monterey CI without Python 2 should drop the unwanted references.