### PR TITLE
qt: depends on `openssl@1.1`

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -48,6 +48,7 @@ class Qt < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "md4c"
+  depends_on "openssl@1.1"
   depends_on "pcre2"
   depends_on "sqlite"
   depends_on "webp"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Broken linkage seen in some dependent testing probably from `glib` losing `python --> openssl@1.1` dependency:
```
==>brew linkage --cached --test --strict qt
==>FAILED
Full linkage --cached --test --strict qt output
  Undeclared dependencies with linkage:
    openssl@1.1
```