### PR TITLE
solarus: migrate to `luajit`

### DIFF
--- a/Formula/solarus.rb
+++ b/Formula/solarus.rb
@@ -5,7 +5,7 @@ class Solarus < Formula
       tag:      "v1.6.5",
       revision: "3aec70b0556a8d7aed7903d1a3e4d9a18c5d1649"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1
@@ -22,7 +22,7 @@ class Solarus < Formula
   depends_on "libmodplug"
   depends_on "libogg"
   depends_on "libvorbis"
-  depends_on "luajit-openresty"
+  depends_on "luajit"
   depends_on "physfs"
   depends_on "sdl2"
   depends_on "sdl2_image"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Side note that existing Linux bottle will link to `luajit` (if installed) due to old RPATH-prioritization of `$HOMEBREW_PREFIX/lib`.
```
==>brew linkage --cached --test --strict solarus
==>FAILED
Full linkage --cached --test --strict solarus output
  Undeclared dependencies with linkage:
    luajit
```

Since we already moved `neovim` back to `luajit`, may as well move everything back to `luajit`.