### PR TITLE
sophus: use workaround for new fmt incompatibility

### DIFF
--- a/Formula/sophus.rb
+++ b/Formula/sophus.rb
@@ -11,9 +11,9 @@ class Sophus < Formula
   end
 
   depends_on "cmake" => [:build, :test]
+  depends_on "fmt" => :build
   depends_on "ceres-solver"
   depends_on "eigen"
-  depends_on "fmt"
 
   on_linux do
     depends_on "gcc"
@@ -34,6 +34,7 @@ class Sophus < Formula
     (testpath/"CMakeLists.txt").write <<~EOS
       cmake_minimum_required(VERSION 3.5)
       project(HelloSO3)
+      add_compile_definitions(SOPHUS_USE_BASIC_LOGGING)
       find_package(Sophus REQUIRED)
       add_executable(HelloSO3 HelloSO3.cpp)
       target_link_libraries(HelloSO3 Sophus::Sophus)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We might be able to avoid Sophus using `fmt` by setting
`SOPHUS_USE_BASIC_LOGGING`.

Needed for #105132.
