### PR TITLE
deprecate elinks

### DIFF
--- a/Formula/elinks.rb
+++ b/Formula/elinks.rb
@@ -3,6 +3,7 @@ class Elinks < Formula
   homepage "http://elinks.or.cz/"
   url "http://elinks.or.cz/download/elinks-0.11.7.tar.bz2"
   sha256 "456db6f704c591b1298b0cd80105f459ff8a1fc07a0ec1156a36c4da6f898979"
+  license "GPL-2.0-only"
   revision 3
 
   livecheck do

--- a/Formula/elinks.rb
+++ b/Formula/elinks.rb
@@ -28,6 +28,9 @@ class Elinks < Formula
     depends_on "libtool" => :build
   end
 
+  # Warning: No elinks releases in the last 10 years, recommend using the actively maintained felinks instead
+  deprecate! date: "2022-07-25", because: "No releases since 2012; consider using the maintained felinks instead"
+
   depends_on "openssl@1.1"
 
   uses_from_macos "zlib"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

No elinks releases in the last 10 years, recommend users the actively maintained felinks.