### PR TITLE
*magick/ffmpeg/qt dependency trees: migrate `jpeg` to `jpeg-turbo`

### DIFF
--- a/Formula/chafa.rb
+++ b/Formula/chafa.rb
@@ -4,6 +4,7 @@ class Chafa < Formula
   url "https://hpjansson.org/chafa/releases/chafa-1.12.3.tar.xz"
   sha256 "2456a0b6c1150e25b64cd6a92810d59bed3f061f8b86f91aba5a77bc7cc76cfa"
   license "LGPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://hpjansson.org/chafa/releases/?C=M&O=D"
@@ -20,17 +21,17 @@ class Chafa < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "freetype"
   depends_on "glib"
-  depends_on "imagemagick"
-
-  on_linux do
-    depends_on "gcc"
-  end
-
-  fails_with gcc: "5" # imagemagick is built with GCC
+  depends_on "jpeg-turbo"
+  depends_on "librsvg"
+  depends_on "libtiff"
+  depends_on "webp"
 
   def install
-    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "./configure", *std_configure_args,
+                          "--disable-silent-rules",
+                          "--without-imagemagick" # deprecated in 1.12.0 and planned for removal
     system "make", "install"
     man1.install "docs/chafa.1"
   end
@@ -38,5 +39,7 @@ class Chafa < Formula
   test do
     output = shell_output("#{bin}/chafa #{test_fixtures("test.png")}")
     assert_equal 2, output.lines.count
+    output = shell_output("#{bin}/chafa --version")
+    assert_match(/Loaders:.* JPEG.* SVG.* TIFF.* WebP/, output)
   end
 end

--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -1,6 +1,7 @@
 class Dcmtk < Formula
   desc "OFFIS DICOM toolkit command-line utilities"
   homepage "https://dicom.offis.de/dcmtk.php.en"
+  revision 1
   head "https://git.dcmtk.org/dcmtk.git", branch: "master"
 
   stable do
@@ -12,7 +13,7 @@ class Dcmtk < Formula
     # TODO: Remove in the next release along with stable block
     patch do
       url "https://git.dcmtk.org/?p=dcmtk.git;a=patch;h=5fba853b6f7c13b02bed28bd9f7d3f450e4c72bb"
-      sha256 "40ca9e6f377951e2d24a509a6c95b9e572224d74d694f0d648b8b33e4d67e285"
+      sha256 "533cfe46414f6c76dcdf56fd9633a399f813707a0cb8fe2630126cbd747134c8"
     end
   end
 

--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -4,6 +4,7 @@ class Ghostscript < Formula
   url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9561/ghostpdl-9.56.1.tar.xz"
   sha256 "05e64c19853e475290fd608a415289dc21892c4d08ee9086138284b6addcb299"
   license "AGPL-3.0-or-later"
+  revision 1
 
   # We check the tags from the `head` repository because the GitHub tags are
   # formatted ambiguously, like `gs9533` (corresponding to version 9.53.3).
@@ -35,7 +36,7 @@ class Ghostscript < Formula
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "jbig2dec"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libidn"
   depends_on "libpng"
   depends_on "libtiff"

--- a/Formula/graphicsmagick.rb
+++ b/Formula/graphicsmagick.rb
@@ -4,6 +4,7 @@ class Graphicsmagick < Formula
   url "https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.38/GraphicsMagick-1.3.38.tar.xz"
   sha256 "d60cd9db59351d2b9cb19beb443170acaa28f073d13d258f67b3627635e32675"
   license "MIT"
+  revision 1
   head "http://hg.code.sf.net/p/graphicsmagick/code", using: :hg
 
   livecheck do
@@ -22,7 +23,7 @@ class Graphicsmagick < Formula
   depends_on "pkg-config" => :build
   depends_on "freetype"
   depends_on "jasper"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "libtool"

--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -4,6 +4,7 @@ class Imagemagick < Formula
   url "https://imagemagick.org/archive/releases/ImageMagick-7.1.0-44.tar.xz"
   sha256 "c937c29c31ddd37ad441c13ce45e569ec911d3bb427dfaad6aa8450e5eef09a6"
   license "ImageMagick"
+  revision 1
   head "https://github.com/ImageMagick/ImageMagick.git", branch: "main"
 
   livecheck do
@@ -23,7 +24,7 @@ class Imagemagick < Formula
   depends_on "pkg-config" => :build
   depends_on "freetype"
   depends_on "ghostscript"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libheif"
   depends_on "liblqr"
   depends_on "libpng"

--- a/Formula/jasper.rb
+++ b/Formula/jasper.rb
@@ -4,7 +4,7 @@ class Jasper < Formula
   url "https://github.com/jasper-software/jasper/releases/download/version-3.0.6/jasper-3.0.6.tar.gz"
   sha256 "169be004d91f6940c649a4f854ada2755d4f35f62b0555ce9e1219c778cffc09"
   license "JasPer-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -21,7 +21,7 @@ class Jasper < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
 
   def install
     mkdir "tmp_cmake" do

--- a/Formula/jbig2enc.rb
+++ b/Formula/jbig2enc.rb
@@ -4,6 +4,7 @@ class Jbig2enc < Formula
   url "https://github.com/agl/jbig2enc/archive/0.29.tar.gz"
   sha256 "bfcf0d0448ee36046af6c776c7271cd5a644855723f0a832d1c0db4de3c21280"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/agl/jbig2enc.git", branch: "master"
 
   bottle do

--- a/Formula/jpeg-xl.rb
+++ b/Formula/jpeg-xl.rb
@@ -4,6 +4,7 @@ class JpegXl < Formula
   url "https://github.com/libjxl/libjxl/archive/v0.6.1.tar.gz"
   sha256 "ccbd5a729d730152303be399f033b905e608309d5802d77a61a95faa092592c5"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "299002d5c10f0009bcdf7b2f5c4d544e4b84fc36dd109a0b3dd5eee780dbb5f7"
@@ -19,7 +20,7 @@ class JpegXl < Formula
   depends_on "brotli"
   depends_on "giflib"
   depends_on "imath"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "openexr"
   depends_on "webp"

--- a/Formula/leptonica.rb
+++ b/Formula/leptonica.rb
@@ -4,6 +4,7 @@ class Leptonica < Formula
   url "http://www.leptonica.org/source/leptonica-1.82.0.tar.gz"
   sha256 "155302ee914668c27b6fe3ca9ff2da63b245f6d62f3061c8f27563774b8ae2d6"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     url "http://www.leptonica.org/download.html"
@@ -22,21 +23,16 @@ class Leptonica < Formula
 
   depends_on "pkg-config" => :build
   depends_on "giflib"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "openjpeg"
   depends_on "webp"
 
   def install
-    args = %W[
-      --disable-dependency-tracking
-      --prefix=#{prefix}
-      --with-libwebp
-      --with-libopenjpeg
-    ]
-
-    system "./configure", *args
+    system "./configure", *std_configure_args,
+                          "--with-libwebp",
+                          "--with-libopenjpeg"
     system "make", "install"
   end
 

--- a/Formula/libheif.rb
+++ b/Formula/libheif.rb
@@ -4,7 +4,7 @@ class Libheif < Formula
   url "https://github.com/strukturag/libheif/releases/download/v1.12.0/libheif-1.12.0.tar.gz"
   sha256 "e1ac2abb354fdc8ccdca71363ebad7503ad731c84022cf460837f0839e171718"
   license "LGPL-3.0-only"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "6285488bd07d49e996a1be0dfe7296051ade71cc2078ecbaa2243afd05afe560"
@@ -17,7 +17,7 @@ class Libheif < Formula
 
   depends_on "pkg-config" => :build
   depends_on "aom"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libde265"
   depends_on "libpng"
   depends_on "shared-mime-info"
@@ -30,9 +30,7 @@ class Libheif < Formula
   end
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install"
     pkgshare.install "examples/example.heic"
     pkgshare.install "examples/example.avif"

--- a/Formula/libmng.rb
+++ b/Formula/libmng.rb
@@ -1,9 +1,13 @@
 class Libmng < Formula
   desc "MNG/JNG reference library"
+  # Use Homebrew curl to work around audit failure from TLS 1.3-only homepage.
+  # TODO: The `using: :homebrew_curl` can be removed once default curl on all
+  # CI runners support TLS 1.3 or if there is a way to skip homepage audit in CI.
   homepage "https://libmng.com/"
-  url "https://downloads.sourceforge.net/project/libmng/libmng-devel/2.0.3/libmng-2.0.3.tar.gz"
+  url "https://downloads.sourceforge.net/project/libmng/libmng-devel/2.0.3/libmng-2.0.3.tar.gz", using: :homebrew_curl
   sha256 "cf112a1fb02f5b1c0fce5cab11ea8243852c139e669c44014125874b14b7dfaa"
   license "Zlib"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "c446fd993909b3334b8df2eaacf0af44be6da33c03899c85bc966b8659858648"
@@ -15,7 +19,7 @@ class Libmng < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "76a41e2666007dabb0bce0da17d0a55ca7694168e74f31ec6136cb9632642eea"
   end
 
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "little-cms2"
 
   uses_from_macos "zlib"
@@ -42,6 +46,7 @@ class Libmng < Formula
 
   test do
     system ENV.cc, pkgshare/"mngtree.c", "-DMNG_USE_SO",
+           "-I#{Formula["jpeg-turbo"].opt_include}",
            "-I#{include}", "-L#{lib}", "-lmng", "-o", "mngtree"
 
     resource("sample").stage do

--- a/Formula/libraw.rb
+++ b/Formula/libraw.rb
@@ -4,7 +4,7 @@ class Libraw < Formula
   url "https://www.libraw.org/data/LibRaw-0.20.2.tar.gz"
   sha256 "dc1b486c2003435733043e4e05273477326e51c3ea554c6864a4eafaff1004a6"
   license any_of: ["LGPL-2.1-only", "CDDL-1.0"]
-  revision 2
+  revision 3
 
   livecheck do
     url "https://www.libraw.org/download/"
@@ -25,7 +25,7 @@ class Libraw < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "jasper"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "little-cms2"
 
   uses_from_macos "zlib"

--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -5,6 +5,7 @@ class Libtiff < Formula
   mirror "https://fossies.org/linux/misc/tiff-4.4.0.tar.gz"
   sha256 "917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed"
   license "libtiff"
+  revision 1
 
   livecheck do
     url "https://download.osgeo.org/libtiff/"
@@ -20,7 +21,7 @@ class Libtiff < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "fa756f41864cae38e3c74b29b857f7c2f081a3b9eabd1c551cd6e39e12fd17bf"
   end
 
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
 
   uses_from_macos "zlib"
 
@@ -31,8 +32,8 @@ class Libtiff < Formula
       --disable-lzma
       --disable-webp
       --disable-zstd
-      --with-jpeg-include-dir=#{Formula["jpeg"].opt_include}
-      --with-jpeg-lib-dir=#{Formula["jpeg"].opt_lib}
+      --with-jpeg-include-dir=#{Formula["jpeg-turbo"].opt_include}
+      --with-jpeg-lib-dir=#{Formula["jpeg-turbo"].opt_lib}
       --without-x
     ]
     system "./configure", *args

--- a/Formula/little-cms2.rb
+++ b/Formula/little-cms2.rb
@@ -6,6 +6,7 @@ class LittleCms2 < Formula
   url "https://downloads.sourceforge.net/project/lcms/lcms/2.13/lcms2-2.13.1.tar.gz"
   sha256 "d473e796e7b27c5af01bd6d1552d42b45b43457e7182ce9903f38bb748203b88"
   license "MIT"
+  revision 1
   version_scheme 1
 
   # The Little CMS website has been redesigned and there's no longer a
@@ -26,13 +27,11 @@ class LittleCms2 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "021649a443c169b8b18dd404f99d367ef79e5a6f650d8912b552a1b887e85ffe"
   end
 
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libtiff"
 
   def install
-    args = %W[--disable-dependency-tracking --prefix=#{prefix}]
-
-    system "./configure", *args
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/pike.rb
+++ b/Formula/pike.rb
@@ -6,6 +6,7 @@ class Pike < Formula
   # Homepage has an expired SSL cert as of 16/12/2020, so we add a Debian mirror
   sha256 "1033bc90621896ef6145df448b48fdfa342dbdf01b48fd9ae8acf64f6a31b92a"
   license any_of: ["GPL-2.0-only", "LGPL-2.1-only", "MPL-1.1"]
+  revision 1
 
   livecheck do
     url "https://pike.lysator.liu.se/download/pub/pike/latest-stable/"
@@ -21,19 +22,18 @@ class Pike < Formula
     sha256 x86_64_linux:   "d1b09df6210744180a51992d93ba0d4344fea5fff256b6434486f909f0457a94"
   end
 
+  depends_on "gettext"
   depends_on "gmp"
+  depends_on "jpeg-turbo"
   depends_on "libtiff"
   depends_on "nettle"
   depends_on "pcre"
+  depends_on "webp"
 
   uses_from_macos "libxcrypt"
 
   on_macos do
     depends_on "gnu-sed" => :build
-  end
-
-  on_linux do
-    depends_on "jpeg"
   end
 
   def install

--- a/Formula/spandsp.rb
+++ b/Formula/spandsp.rb
@@ -1,14 +1,9 @@
 class Spandsp < Formula
   desc "DSP functions library for telephony"
-  homepage "https://www.soft-switch.org/"
-  url "https://www.soft-switch.org/downloads/spandsp/spandsp-0.0.6.tar.gz"
+  homepage "https://web.archive.org/web/20220504064130/https://www.soft-switch.org/"
+  url "https://web.archive.org/web/20220329161120/https://www.soft-switch.org/downloads/spandsp/spandsp-0.0.6.tar.gz"
   sha256 "cc053ac67e8ac4bb992f258fd94f275a7872df959f6a87763965feabfdcc9465"
-  revision 1
-
-  livecheck do
-    url "https://www.soft-switch.org/downloads/spandsp/?C=M&O=D"
-    regex(/href=.*?spandsp[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "126dae630e017d020ecdb42a862a1d25cf4cf0d45a9b8572a952939ab19a9a77"
@@ -33,10 +28,7 @@ class Spandsp < Formula
 
   def install
     ENV.deparallelize
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make"
     system "make", "install"
   end

--- a/Formula/webp.rb
+++ b/Formula/webp.rb
@@ -4,6 +4,7 @@ class Webp < Formula
   url "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.2.3.tar.gz"
   sha256 "f5d7ab2390b06b8a934a4fc35784291b3885b557780d099bd32f09241f9d83f9"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "dd0682d7262da6160c7306d8a2e32c9d30ea4f7431e5d17f32c5179e60607f62"
@@ -15,14 +16,14 @@ class Webp < Formula
   end
 
   head do
-    url "https://chromium.googlesource.com/webm/libwebp.git"
+    url "https://chromium.googlesource.com/webm/libwebp.git", branch: "main"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
   depends_on "giflib"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "libtiff"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying a smaller set of formulae from #103436 to reduce chances of merge conflicts and avoid having to migrate `texlive` at same time (indirectly linked to `jpeg`).

Focusing on dependency trees of 
- `imagemagick` and `ffmpeg` (in the top 20 install-on-request formulae)
- `graphicsmagick` (fork of `imagemagick`)
- `qt` (base formula already migrated). 

Modified formulae are mostly from `imagemagick` dependency tree excluding:
- `graphicsmagick` - fork of `imagemagick` so might as well migrate at same time
- `libmng` - Part of `qt` dependency tree.
- `leptonica` - Part of `ffmpeg` dependency tree. 