### PR TITLE
libxml2: fix installation of Python bindings

### DIFF
--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -93,11 +93,9 @@ class Libxml2 < Formula
       inreplace "setup.py", "includes_dir = [",
                             "includes_dir = [#{includes}"
 
-      system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(prefix)
-
-      site_packages_310 = Language::Python.site_packages(Formula["python@3.10"].opt_bin/"python3")
-      system Formula["python@3.10"].opt_bin/"python3", *Language::Python.setup_install_args(prefix),
-                                                       "--install-lib=#{prefix/site_packages_310}"
+      ["3.9", "3.10"].each do |xy|
+        system "python#{xy}", *Language::Python.setup_install_args(prefix, "python#{xy}")
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We now pass `--install-lib` by default in `#setup_install_args`, but now
we need to be more specific about which Python to use when building.

See Homebrew/brew#13533 and #98809.
