### PR TITLE
aptly: use go modules

### DIFF
--- a/Formula/aptly.rb
+++ b/Formula/aptly.rb
@@ -18,16 +18,11 @@ class Aptly < Formula
   depends_on "go" => :build
 
   def install
-    ENV["GOPATH"] = buildpath
-    ENV["GO111MODULE"] = "auto"
-    ENV["GOBIN"] = bin
-    (buildpath/"src/github.com/aptly-dev/aptly").install buildpath.children
-    cd "src/github.com/aptly-dev/aptly" do
-      system "make", "VERSION=#{version}", "install"
-      prefix.install_metafiles
-      bash_completion.install "completion.d/aptly"
-      zsh_completion.install "completion.d/_aptly"
-    end
+    system "go", "generate" if build.head?
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.Version=#{version}")
+
+    bash_completion.install "completion.d/aptly"
+    zsh_completion.install "completion.d/_aptly"
   end
 
   test do


### PR DESCRIPTION
This is my first attempt at this kind of thing, thank you in advance for your patience.

I tried using the existing `make` invocation but it didn't work for me.

Note that by the next release, building from the tarball may not work without patching. See https://github.com/aptly-dev/aptly/issues/1095. This issue affects the formula even without using `make` directly, as the aptly version is embedded in the program by calling `make`:

https://github.com/aptly-dev/aptly/blob/f0a85b2b6e746f6da90ca85187ec2bb658490740/main.go#L14

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
