### PR TITLE
winexe: deprecate

### DIFF
--- a/Formula/winexe.rb
+++ b/Formula/winexe.rb
@@ -13,6 +13,8 @@ class Winexe < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:  "58080b3729c9b261a65c7db2072ec867176bfd6a802c23f9b343feb44592789a"
   end
 
+  deprecate! date: "2022-07-26", because: "depends on Python 2 to build"
+
   depends_on "autoconf" => :build
   depends_on "pkg-config" => :build
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Listed on Monterey PR #94212 but Python 2 dependency is blocker. May be able to bottle on Big Sur with older `autoconf@2.69`, but will need to check CI output.
