### PR TITLE
hut: remove coreutils dependency

### DIFF
--- a/Formula/hut.rb
+++ b/Formula/hut.rb
@@ -15,13 +15,12 @@ class Hut < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "30c5343766e55c828b77d83a46faed7ee68881e21268005e0267ca00701372cc"
   end
 
-  depends_on "coreutils" => :build # Needed for GNU install in 0.1.0, remove in next release
   depends_on "go" => :build
   depends_on "scdoc" => :build
 
   def install
     system "make"
-    system "make", "install", "PREFIX=#{prefix}", "INSTALL=ginstall"
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

GNU coreutils is no longer required as of the 0.2.0 release.

