### PR TITLE
ppsspp: depend on `libpng` only on Intel

### DIFF
--- a/Formula/ppsspp.rb
+++ b/Formula/ppsspp.rb
@@ -20,7 +20,6 @@ class Ppsspp < Formula
   depends_on "nasm" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.10" => :build
-  depends_on "libpng"
   depends_on "libzip"
   depends_on "miniupnpc"
   depends_on "sdl2"
@@ -35,6 +34,12 @@ class Ppsspp < Formula
 
   on_linux do
     depends_on "glew"
+  end
+
+  on_intel do
+    # ARM uses a bundled, unreleased libpng.
+    # Make unconditional when we have libpng 1.7.
+    depends_on "libpng"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula has no linkage with `libpng`. Also, the build uses only [the `libpng` headers](https://github.com/hrydgard/ppsspp/blob/52fd81129971def1b30df1533ebe8d42e16346cf/CMakeLists.txt#L985-L989).
