### PR TITLE
po4a: fix dependencies for v0.67

### DIFF
--- a/Formula/po4a.rb
+++ b/Formula/po4a.rb
@@ -8,6 +8,7 @@ class Po4a < Formula
   url "https://github.com/mquinson/po4a/releases/download/v0.67/po4a-0.67.tar.gz"
   sha256 "4a4166a480d9b5bcc80b688604501b5545f1c9f67067e8f5494846de167a18a7"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/mquinson/po4a.git", branch: "master"
 
   bottle do
@@ -65,14 +66,35 @@ class Po4a < Formula
     sha256 "bc315fa12e8f1e3ee5e2f430d90b708a5dc7e47c867dba8dce3a6b8fbe257744"
   end
 
+  resource "ExtUtils::CChecker" do
+    url "https://cpan.metacpan.org/authors/id/P/PE/PEVANS/ExtUtils-CChecker-0.11.tar.gz"
+    sha256 "117736677e37fc611f5b76374d7f952e1970eb80e1f6ad5150d516e7ae531bf5"
+  end
+
+  resource "XS::Parse::Keyword::Builder" do
+    url "https://cpan.metacpan.org/authors/id/P/PE/PEVANS/XS-Parse-Keyword-0.25.tar.gz"
+    sha256 "f5edb30cf7c7f220d0c6c31dc1eb554032840a99c7c298314f5cc3fef66c72c7"
+  end
+
+  resource "Syntax::Keyword::Try" do
+    url "https://cpan.metacpan.org/authors/id/P/PE/PEVANS/Syntax-Keyword-Try-0.27.tar.gz"
+    sha256 "246e1b033e3ff22fd5420550d4b6e0d56b438cdcbb9d35cbe8b1b5ba1574de23"
+  end
+
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
     ENV.prepend_path "PERL5LIB", libexec/"lib"
 
     resources.each do |r|
       r.stage do
-        system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}", "NO_MYMETA=1"
-        system "make", "install"
+        if File.exist?("Makefile.PL")
+          system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}", "NO_MYMETA=1"
+          system "make", "install"
+        else
+          system "perl", "Build.PL", "--install_base", libexec
+          system "./Build"
+          system "./Build", "install"
+        end
       end
     end
 
@@ -97,6 +119,8 @@ class Po4a < Formula
   end
 
   test do
+    # LaTeX
+
     (testpath/"en.tex").write <<~EOS
       \\documentclass[a4paper]{article}
       \\begin{document}
@@ -104,7 +128,13 @@ class Po4a < Formula
       \\end{document}
     EOS
 
-    system bin/"po4a-gettextize", "-f", "asciidoc", "-m", "en.tex", "-p", "out.pot"
-    assert_match "Hello from Homebrew!", (testpath/"out.pot").read
+    system bin/"po4a-gettextize", "-f", "latex", "-m", "en.tex", "-p", "latex.pot"
+    assert_match "Hello from Homebrew!", (testpath/"latex.pot").read
+
+    # Markdown
+
+    (testpath/"en.md").write("Hello from Homebrew!")
+    system bin/"po4a-gettextize", "-f", "text", "-m", "en.md", "-p", "text.pot"
+    assert_match "Hello from Homebrew!", (testpath/"text.pot").read
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This change fixes a runtime error in po4a v0.67 when "text" is specified as the format.

Prior to this change, the following error would occur, for example:

> ```shell-session
> $ po4a-gettextize -f text -m en.md -p out.pot
> 
> Unknown format type: text.
> po4a::chooser: Module loading error: Can't locate Syntax/Keyword/Try.pm in @INC (you may need to install the Syntax::Keyword::Try module) (@INC contains: /usr/local/Cellar/po4a/0.67/libexec/lib /usr/local/Cellar/po4a/0.67/libexec/lib/perl5/darwin-thread-multi-2level /usr/local/Cellar/po4a/0.67/libexec/lib/perl5 /usr/local/Cellar/perl/5.34.0/lib/perl5/site_perl/5.34.0/darwin-thread-multi-2level /usr/local/Cellar/perl/5.34.0/lib/perl5/site_perl/5.34.0 /usr/local/Cellar/perl/5.34.0/lib/perl5/5.34.0/darwin-thread-multi-2level /usr/local/Cellar/perl/5.34.0/lib/perl5/5.34.0 /usr/local/lib/perl5/site_perl/5.34.0/darwin-thread-multi-2level /usr/local/lib/perl5/site_perl/5.34.0) at /usr/local/Cellar/po4a/0.67/libexec/lib/perl5/Locale/Po4a/Text.pm line 61.
> BEGIN failed--compilation aborted at /usr/local/Cellar/po4a/0.67/libexec/lib/perl5/Locale/Po4a/Text.pm line 61.
> Compilation failed in require at (eval 33) line 1.
> BEGIN failed--compilation aborted at (eval 33) line 1.
> 
> List of valid formats:
>   - asciidoc: AsciiDoc format.
>   - dia: uncompressed Dia diagrams.
>   - docbook: DocBook XML.
>   - guide: Gentoo Linux's XML documentation format.
>   - ini: INI format.
>   - kernelhelp: Help messages of each kernel compilation option.
>   - latex: LaTeX format.
>   - man: Good old manual page format.
>   - pod: Perl Online Documentation format.
>   - rubydoc: Ruby Documentation (RD) format.
>   - sgml: either DebianDoc or DocBook DTD.
>   - texinfo: The info page format.
>   - tex: generic TeX documents (see also latex).
>   - text: simple text document.
>   - wml: WML documents.
>   - xhtml: XHTML documents.
>   - xml: generic XML documents (see also docbook).
>   - yaml: YAML documents.
> ```

The reason is that [po4a added a dependency on `Syntax::Keyword::Try` in v0.67](https://github.com/mquinson/po4a/blob/6993e159f4138783e9d0f307d363da83c5f244ae/NEWS#L62).

This change also corrected a small issue of formatting inconsistencies in the existing test (`asciidoc` to `latex`).