### PR TITLE
glibc: add runtime dependency on linux-headers@4.4

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -95,11 +95,11 @@ class Glibc < Formula
 
   depends_on "binutils" => :build
   depends_on GawkRequirement => :build
-  depends_on "linux-headers@4.4" => :build
   depends_on MakeRequirement => :build
   depends_on SedRequirement => :build
   depends_on BrewedGlibcNotOlderRequirement
   depends_on :linux
+  depends_on "linux-headers@4.4"
   depends_on LinuxKernelRequirement
 
   # GCC 4.7 or later is required.


### PR DESCRIPTION
Per suggestion of @SMillerDev & @danielnachun in https://github.com/orgs/Homebrew/discussions/3462
"users who need brewed glibc are very likely to also need newer Linux headers"

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
