### PR TITLE
pike: uses `krb5`

### DIFF
--- a/Formula/pike.rb
+++ b/Formula/pike.rb
@@ -30,6 +30,7 @@ class Pike < Formula
   depends_on "pcre"
   depends_on "webp"
 
+  uses_from_macos "krb5"
   uses_from_macos "libxcrypt"
 
   on_macos do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`krb5` was linked in #106531
```
`brew linkage --cached --test --strict pike` failed on Linux!
Undeclared dependencies with linkage:
  krb5
```