### PR TITLE
dcmtk: fix Linux build with C++11 icu4c

### DIFF
--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -38,6 +38,7 @@ class Dcmtk < Formula
   uses_from_macos "libxml2"
 
   def install
+    ENV.cxx11 if OS.linux? # due to `icu4c` dependency in `libxml2`
     system "cmake", "-S", ".", "-B", "build/shared", *std_cmake_args,
                     "-DBUILD_SHARED_LIBS=ON",
                     "-DCMAKE_INSTALL_RPATH=#{rpath}"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Linux failure from #106531.
```
In file included from /home/linuxbrew/.linuxbrew/include/unicode/uenum.h:25:0,
                   from /home/linuxbrew/.linuxbrew/include/unicode/ucnv.h:52,
                   from /tmp/dcmtk-20220727-158847-lq8evp/dcmtk-3.6.6/ofstd/libsrc/ofchrenc.cc:67:
  /home/linuxbrew/.linuxbrew/include/unicode/localpointer.h:224:34: error: expected ‘,’ or ‘...’ before ‘&&’ token
       LocalPointer(LocalPointer<T> &&src) U_NOEXCEPT : LocalPointerBase<T>(src.ptr) {
                                    ^
```
