### PR TITLE
openjpeg: set `CMAKE_INSTALL_RPATH`

### DIFF
--- a/Formula/openjpeg.rb
+++ b/Formula/openjpeg.rb
@@ -22,8 +22,11 @@ class Openjpeg < Formula
   depends_on "little-cms2"
 
   def install
-    system "cmake", ".", *std_cmake_args, "-DBUILD_DOC=ON"
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args,
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    "-DBUILD_DOC=ON"
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in #106531
```
Files with missing rpath:
  /opt/homebrew/Cellar/openjpeg/2.5.0/bin/opj_compress
  /opt/homebrew/Cellar/openjpeg/2.5.0/bin/opj_decompress
  /opt/homebrew/Cellar/openjpeg/2.5.0/bin/opj_dump
```
