### PR TITLE
jacoco-cli 0.8.8 (new formula)

### DIFF
--- a/Formula/jacoco-cli.rb
+++ b/Formula/jacoco-cli.rb
@@ -70,7 +70,7 @@ class JacocoCli < Formula
     system "gradle", "test"
 
     # Use jacoco-cli to generate xml coverage report
-    mkdir_p("#{testpath}/output")
+    (testpath/"output").mkpath
     system bin/"jacoco-cli", "report", testpath/"build/jacoco/test.exec", "--classfiles", testpath/"build/classes/",
       "--sourcefiles", testpath/"src/main/java/", "--xml", testpath/"output/unitTestCoverage.xml"
 

--- a/Formula/jacoco-cli.rb
+++ b/Formula/jacoco-cli.rb
@@ -71,8 +71,10 @@ class JacocoCli < Formula
 
     # Use jacoco-cli to generate xml coverage report
     (testpath/"output").mkpath
-    system bin/"jacoco-cli", "report", testpath/"build/jacoco/test.exec", "--classfiles", testpath/"build/classes/",
-      "--sourcefiles", testpath/"src/main/java/", "--xml", testpath/"output/unitTestCoverage.xml"
+    system bin/"jacoco-cli", "report", testpath/"build/jacoco/test.exec",
+                             "--classfiles", testpath/"build/classes/",
+                             "--sourcefiles", testpath/"src/main/java/",
+                             "--xml", testpath/"output/unitTestCoverage.xml"
 
     # Compare key node in generated xml coverage report with expected value
     assert_match "covered=\"2\"",

--- a/Formula/jacoco-cli.rb
+++ b/Formula/jacoco-cli.rb
@@ -77,9 +77,10 @@ class JacocoCli < Formula
                              "--xml", testpath/"output/unitTestCoverage.xml"
 
     # Compare key node in generated xml coverage report with expected value
-    assert_match "covered=\"2\"",
-      shell_output("xmllint --xpath \
-        '/report/package/sourcefile[@name=\"SimpleAddition.java\"]/counter[@type=\"LINE\"]/@covered' \
-         #{testpath}/output/unitTestCoverage.xml")
+    args = %W[
+      --xpath /report/package/sourcefile[@name="SimpleAddition.java"]/counter[@type="LINE"]/@covered
+      #{testpath}/output/unitTestCoverage.xml
+    ]
+    assert_match 'covered="2"', shell_output("xmllint #{args.join(" ")}")
   end
 end

--- a/Formula/jacoco-cli.rb
+++ b/Formula/jacoco-cli.rb
@@ -1,0 +1,18 @@
+class JacocoCli < Formula
+  desc "JaCoCo Java Code Coverage Library Command-line"
+  homepage "https://github.com/jacoco/jacoco"
+  url "https://search.maven.org/remotecontent?filepath=org/jacoco/org.jacoco.cli/0.8.7/org.jacoco.cli-0.8.7-nodeps.jar"
+  sha256 "11b549a9ef14d8454534f914ca1051fb9bcacab7f501e9f1c018eacfc5e77e8d"
+  license "EPL-2.0"
+
+  depends_on "openjdk@11"
+
+  def install
+    libexec.install "org.jacoco.cli-0.8.7-nodeps.jar"
+    bin.write_jar_script libexec/"org.jacoco.cli-0.8.7-nodeps.jar", "jacoco-cli"
+  end
+
+  test do
+    assert_match "0.8.7.202105040129", shell_output("#{bin}/jacoco-cli version")
+  end
+end

--- a/Formula/jacoco-cli.rb
+++ b/Formula/jacoco-cli.rb
@@ -1,18 +1,83 @@
 class JacocoCli < Formula
   desc "JaCoCo Java Code Coverage Library Command-line"
   homepage "https://github.com/jacoco/jacoco"
-  url "https://search.maven.org/remotecontent?filepath=org/jacoco/org.jacoco.cli/0.8.7/org.jacoco.cli-0.8.7-nodeps.jar"
-  sha256 "11b549a9ef14d8454534f914ca1051fb9bcacab7f501e9f1c018eacfc5e77e8d"
+  url "https://search.maven.org/remotecontent?filepath=org/jacoco/org.jacoco.cli/0.8.8/org.jacoco.cli-0.8.8-nodeps.jar"
+  sha256 "c449591174982bbc003d1290003fcbc7b939215436922d2f0f25239d110d531a"
   license "EPL-2.0"
 
-  depends_on "openjdk@11"
+  depends_on "gradle" => :test
+  depends_on "openjdk"
 
   def install
-    libexec.install "org.jacoco.cli-0.8.7-nodeps.jar"
-    bin.write_jar_script libexec/"org.jacoco.cli-0.8.7-nodeps.jar", "jacoco-cli"
+    libexec.install "org.jacoco.cli-#{version}-nodeps.jar"
+    bin.write_jar_script libexec/"org.jacoco.cli-#{version}-nodeps.jar", "jacoco-cli"
   end
 
   test do
-    assert_match "0.8.7.202105040129", shell_output("#{bin}/jacoco-cli version")
+    # Setup build script, including JUnit and JaCoCo Gradle Plugin
+    (testpath/"build.gradle").write <<~EOS
+      plugins {
+          id 'java'
+          id 'jacoco'
+      }
+
+      group 'org.example'
+      version '1.0-SNAPSHOT'
+
+      repositories {
+          mavenCentral()
+      }
+
+      dependencies {
+          testImplementation 'junit:junit:4.13.1'
+      }
+      java {
+          sourceCompatibility = JavaVersion.VERSION_18
+          sourceCompatibility = JavaVersion.VERSION_18
+      }
+      test {
+          finalizedBy jacocoTestReport
+      }
+      jacocoTestReport {
+          dependsOn test
+      }
+      jacoco {
+          toolVersion = "#{version}"
+      }
+    EOS
+    # Setup one Java class and one Java test class
+    (testpath/"src/main/java/org/example/SimpleAddition.java").write <<~EOS
+      package org.example;
+      public class SimpleAddition {
+          public int add(int a, int b) {
+              return a + b;
+          }
+      }
+    EOS
+    (testpath/"src/test/java/org/example/SimpleAdditionTest.java").write <<~EOS
+      package org.example;
+      import org.junit.Assert;
+      import org.junit.Test;
+      public class SimpleAdditionTest {
+          @Test
+          public void testAdd() {
+              Assert.assertEquals(3, new SimpleAddition().add(1, 2));
+          }
+      }
+    EOS
+
+    # Run unit test with coverage using Gradle
+    system "gradle", "test"
+
+    # Use jacoco-cli to generate xml coverage report
+    mkdir_p("#{testpath}/output")
+    system bin/"jacoco-cli", "report", testpath/"build/jacoco/test.exec", "--classfiles", testpath/"build/classes/",
+      "--sourcefiles", testpath/"src/main/java/", "--xml", testpath/"output/unitTestCoverage.xml"
+
+    # Compare key node in generated xml coverage report with expected value
+    assert_match "covered=\"2\"",
+      shell_output("xmllint --xpath \
+        '/report/package/sourcefile[@name=\"SimpleAddition.java\"]/counter[@type=\"LINE\"]/@covered' \
+         #{testpath}/output/unitTestCoverage.xml")
   end
 end


### PR DESCRIPTION
This formula adds the command line tools for JaCoCo (Java Code Coverage).

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
