### PR TITLE
ledger: uses `libedit`

### DIFF
--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -28,6 +28,7 @@ class Ledger < Formula
   depends_on "python@3.10"
 
   uses_from_macos "groff"
+  uses_from_macos "libedit"
 
   # Compatibility with Boost 1.76
   # https://github.com/ledger/ledger/issues/2030


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Current Linux bottle links to `libedit` as seen in #106686
```
`brew linkage --cached --test --strict ledger` failed on Linux!
Undeclared dependencies with linkage:
  libedit
```