### PR TITLE
libxcrpyt: overwrite conflicts with `glibc`

### DIFF
--- a/Formula/libxcrypt.rb
+++ b/Formula/libxcrypt.rb
@@ -16,6 +16,9 @@ class Libxcrypt < Formula
 
   keg_only :provided_by_macos
 
+  link_overwrite "include/crypt.h"
+  link_overwrite "lib/libcrypt.so"
+
   # Fix -flat_namespace being used on Big Sur and later.
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- glibc: conflict with `libxcrypt`
- libxcrypt: conflict with `glibc`

These two formulae conflict with each other. Seen in #106680.

We probably want a better solution than this. While we don't have one yet, we should add the conflict to prevent users from trying to install both at the same time.
