### PR TITLE
creduce: point to the right `clang-format` for `HEAD`

### DIFF
--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -70,8 +70,10 @@ class Creduce < Formula
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
+    llvm = deps.find { |dep| dep.name.match?(/^llvm(@\d+)?$/) }
+               .to_formula
     # Avoid ending up with llvm's Cellar path hard coded.
-    ENV["CLANG_FORMAT"] = Formula["llvm@9"].opt_bin/"clang-format"
+    ENV["CLANG_FORMAT"] = llvm.opt_bin/"clang-format"
 
     resources.each do |r|
       r.stage do
@@ -81,8 +83,6 @@ class Creduce < Formula
       end
     end
 
-    llvm = deps.find { |dep| dep.name.match?(/^llvm(@\d+)?$/) }
-               .to_formula
     # Work around build failure seen on Apple Clang 13.1.6 by using LLVM Clang
     # Undefined symbols for architecture x86_64:
     #   "std::__1::basic_stringbuf<char, std::__1::char_traits<char>, ...


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should lead to a working `creduce` on ARM when installed from
`HEAD`.
