### PR TITLE
glib needs dbus on older Linux systems.

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -16,7 +16,6 @@ class Glib < Formula
     sha256 x86_64_linux:   "6bf1b47d083b90834e59c72f3ba6d6a8edc7637bcecba7d3ff769eff8d66a946"
   end
 
-  depends_on "dbus" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
@@ -26,6 +25,7 @@ class Glib < Formula
   depends_on "pcre"
 
   on_linux do
+    depends_on "dbus" => :build
     depends_on "util-linux"
   end
 

--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -16,6 +16,7 @@ class Glib < Formula
     sha256 x86_64_linux:   "6bf1b47d083b90834e59c72f3ba6d6a8edc7637bcecba7d3ff769eff8d66a946"
   end
 
+  depends_on "dbus" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Seems more correct to always use the brew version.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
