### PR TITLE
pdfpc: fix `HEAD` build

### DIFF
--- a/Formula/pdfpc.rb
+++ b/Formula/pdfpc.rb
@@ -5,7 +5,6 @@ class Pdfpc < Formula
   sha256 "4adb42fd1844a7e2ab44709dd043ade618c87f2aaec03db64f7ed659e8d3ddad"
   license "GPL-3.0-or-later"
   revision 1
-  head "https://github.com/pdfpc/pdfpc.git", branch: "master"
 
   bottle do
     sha256 arm64_monterey: "69fcafdc5492f2c38753aac0d2e146c929eeecefe7f0e7091b3a90d2463cdb46"
@@ -17,6 +16,19 @@ class Pdfpc < Formula
     sha256 x86_64_linux:   "7f8c4bf4f879d5785c7c0832ca121e93742d82f7c03a67e3f1648028393a7d55"
   end
 
+  head do
+    url "https://github.com/pdfpc/pdfpc.git", branch: "master"
+
+    depends_on "discount"
+    depends_on "json-glib"
+    depends_on "libsoup@2"
+    depends_on "qrencode"
+
+    on_linux do
+      depends_on "webkitgtk"
+    end
+  end
+
   depends_on "cmake" => :build
   depends_on "vala" => :build
   depends_on "gst-plugins-good"
@@ -26,7 +38,12 @@ class Pdfpc < Formula
   depends_on "poppler"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DMOVIES=ON", "-DCMAKE_INSTALL_SYSCONFDIR=#{etc}"
+    # NOTE: You can avoid the `libsoup@2` dependency by passing `-DREST=OFF`.
+    # https://github.com/pdfpc/pdfpc/blob/3310efbf87b5457cbff49076447fcf5f822c2269/src/CMakeLists.txt#L38-L40
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args,
+                    "-DCMAKE_INSTALL_SYSCONFDIR=#{etc}",
+                    "-DMDVIEW=#{OS.linux?}", # Needs webkitgtk
+                    "-DMOVIES=ON"
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end
@@ -35,6 +52,6 @@ class Pdfpc < Formula
     # Gtk-WARNING **: 00:25:01.545: cannot open display
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"].present?
 
-    system "#{bin}/pdfpc", "--version"
+    system bin/"pdfpc", "--version"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The latest version of `pdfpc` (v4.5.0) does not build on macOS because
it requires `webkitgtk` [1, 2], which does not build on macOS [3, 4].

Conveniently, `webkitgtk` is now optional on `master` [5, 6]. However,
building `HEAD` also requires a few extra dependencies. Let's try to fix
that so that users who want the latest version can try to build from
`HEAD` (at least until the next time it breaks).

Inconveniently, this introduces a mixed version dependency, since
`pdfpc` requires `libsoup@2` and `gst-plugins-good`, which depends on
`libsoup`. But, for now, this just on `HEAD` so it's not something we
have to worry about. We can disable either the `MOVIES` feature
(requires `gst-plugins-good`) or the `REST` feature (requires
`libsoup@2`) in the event that we need to resolve the dependency
conflict.

Closes #106759.

[1] https://github.com/pdfpc/pdfpc/blob/0805bd3b2eb7a2f0d14ed045c81fbc298c4202d1/src/CMakeLists.txt#L7
[2] https://github.com/Homebrew/homebrew-core/pull/67319
[3] https://github.com/Homebrew/homebrew-core/pull/11243
[4] https://github.com/Homebrew/homebrew-core/pull/104779
[5] https://github.com/pdfpc/pdfpc/blob/3310efbf87b5457cbff49076447fcf5f822c2269/src/CMakeLists.txt#L32-L36
[6] https://github.com/pdfpc/pdfpc/issues/590
