### PR TITLE
texlive: migrate to `python@3.10` and `luajit`

### DIFF
--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -8,6 +8,7 @@ class Texlive < Formula
   mirror "https://ftp.tu-chemnitz.de/pub/tug/historic/systems/texlive/2022/texlive-20220321-source.tar.xz"
   sha256 "5ffa3485e51eb2c4490496450fc69b9d7bd7cb9e53357d92db4bcd4fd6179b56"
   license :public_domain
+  revision 1
   head "https://github.com/TeX-Live/texlive-source.git", branch: "trunk"
 
   livecheck do
@@ -53,7 +54,7 @@ class Texlive < Formula
   depends_on "libpng"
   depends_on "libxft"
   depends_on "lua"
-  depends_on "luajit-openresty"
+  depends_on "luajit"
   depends_on "mpfr"
   depends_on "openjdk"
   depends_on "openssl@1.1"
@@ -61,7 +62,7 @@ class Texlive < Formula
   depends_on "pixman"
   depends_on "potrace"
   depends_on "pstoedit"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   uses_from_macos "icu4c"
   uses_from_macos "ncurses"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Checking on `python@3.10` since a couple indirect `python@3.9` were removed from dependency tree.

Currently need to migrate `texlive` & `gd` at same time for `jpeg-turbo` due to indirect linkage. Also added `libavif` as it is in dependency tree and uses `jpeg`.

May end up needing other revision bumps if other formulae are indirectly linked to `jpeg` via `gd`/`libavif`.