### PR TITLE
gspell, tepl, tracker, vte3: depends on `glib-utils` to build

### DIFF
--- a/Formula/gspell.rb
+++ b/Formula/gspell.rb
@@ -16,6 +16,7 @@ class Gspell < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "glib-utils" => :build
   depends_on "gtk-doc" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
@@ -33,10 +34,8 @@ class Gspell < Formula
   patch :DATA
 
   def install
-    system "autoreconf", "-if"
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    system "autoreconf", "--force", "--install", "--verbose"
+    system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install"
   end
 

--- a/Formula/tepl.rb
+++ b/Formula/tepl.rb
@@ -15,6 +15,7 @@ class Tepl < Formula
     sha256 x86_64_linux:   "869fd24987a560c0ccb3bf06535cbdadcd921fc4905eaa3fd1b9d8586c7b65a9"
   end
 
+  depends_on "glib-utils" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
@@ -25,11 +26,9 @@ class Tepl < Formula
   depends_on "uchardet"
 
   def install
-    mkdir "build" do
-      system "meson", *std_meson_args, "-Dgtk_doc=false", ".."
-      system "ninja", "-v"
-      system "ninja", "install", "-v"
-    end
+    system "meson", *std_meson_args, "build", "-Dgtk_doc=false"
+    system "meson", "compile", "-C", "build", "-v"
+    system "meson", "install", "-C", "build"
   end
 
   test do

--- a/Formula/tracker.rb
+++ b/Formula/tracker.rb
@@ -20,6 +20,7 @@ class Tracker < Formula
     sha256 x86_64_linux:   "2b4c9a6c6afffba09852f9b003622ed275d1739455e515c507d73ce7b29a8fd1"
   end
 
+  depends_on "glib-utils" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
@@ -33,6 +34,7 @@ class Tracker < Formula
   depends_on "libsoup"
   depends_on "sqlite"
 
+  uses_from_macos "python" => :build, since: :catalina
   uses_from_macos "libxml2"
 
   def install

--- a/Formula/vte3.rb
+++ b/Formula/vte3.rb
@@ -14,6 +14,7 @@ class Vte3 < Formula
     sha256 x86_64_linux:   "7fcab5f5558274cf130242c4eaa520a57465787b81e25a6b619967165d34c0a8"
   end
 
+  depends_on "glib-utils" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Failures seen in #98809