### PR TITLE
octant: add service and use free_port in test

### DIFF
--- a/Formula/octant.rb
+++ b/Formula/octant.rb
@@ -48,13 +48,24 @@ class Octant < Formula
            "-tags", tags, "-v", "./cmd/octant"
   end
 
+  service do
+    run [opt_bin/"octant", "--disable-open-browser"]
+    keep_alive true
+    working_dir var
+    log_path var/"log/octant.log"
+    error_log_path var/"log/octant.log"
+  end
+
   test do
+    port = free_port
+
     fork do
-      exec bin/"octant", "--kubeconfig", testpath/"config", "--disable-open-browser"
+      exec bin/"octant", "--kubeconfig", testpath/"config",
+           "--disable-open-browser", "--listener-addr=localhost:#{port}"
     end
     sleep 5
 
-    output = shell_output("curl -s http://localhost:7777")
+    output = shell_output("curl -s http://localhost:#{port}")
     assert_match "<title>Octant</title>", output, "Octant did not start"
     assert_match version.to_s, shell_output("#{bin}/octant version")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
We pass `--disable-open-browser` in the service since it will be running in the background and we probably don't want the user's web browser to pop open on every login/boot for this (or possibly just randomly if the application crashes and is restarted).

Use `free_port` to avoid potential port conflicts in the test.

Added `CI-no-bottles` because my understanding is that the service + test block are contained within the formula itself and should work fine with existing bottle.