### PR TITLE
Undeprecate formulae with dependents

### DIFF
--- a/Formula/bazaar.rb
+++ b/Formula/bazaar.rb
@@ -16,7 +16,8 @@ class Bazaar < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:    "cb1c0c8b5f19abef4043195d8cbd19f363a78581596de1ddcc763621964335b3"
   end
 
-  deprecate! date: "2021-08-19", because: "is not supported. Check out `breezy` instead"
+  # This formula is currently needed when downloading with `using: :bzr`.
+  # deprecate! date: "2021-08-19", because: "is not supported. Check out `breezy` instead"
 
   depends_on :macos # Due to Python 2
 
@@ -45,6 +46,13 @@ class Bazaar < Formula
     libexec.install "bzr", "bzrlib"
 
     (bin/"bzr").write_env_script(libexec/"bzr", BZR_PLUGIN_PATH: "+user:#{HOMEBREW_PREFIX}/share/bazaar/plugins")
+  end
+
+  def caveats
+    <<~EOS
+      This software is no longer maintained. Try `breezy` instead:
+        brew install breezy
+    EOS
   end
 
   test do

--- a/Formula/cmu-sphinxbase.rb
+++ b/Formula/cmu-sphinxbase.rb
@@ -36,7 +36,8 @@ class CmuSphinxbase < Formula
     depends_on "swig" => :build
   end
 
-  deprecate! date: "2022-06-12", because: :repo_archived
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2022-06-12", because: :repo_archived
 
   depends_on "pkg-config" => :build
   # If these are found, they will be linked against and there is no configure

--- a/Formula/dep.rb
+++ b/Formula/dep.rb
@@ -18,7 +18,8 @@ class Dep < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d7917c664bc0a540e065deb1e14671a5a818823672ec7a5a5caee34eb8feb664"
   end
 
-  deprecate! date: "2020-11-25", because: :repo_archived
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2020-11-25", because: :repo_archived
 
   depends_on "go"
 

--- a/Formula/docker-machine.rb
+++ b/Formula/docker-machine.rb
@@ -17,7 +17,8 @@ class DockerMachine < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f08e7ba29eb793a79b8126631485ee4100cf07b9e1e5654a7c4db8c2d229d5af"
   end
 
-  deprecate! date: "2021-09-30", because: :repo_archived
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2021-09-30", because: :repo_archived
 
   depends_on "automake" => :build
   depends_on "go" => :build

--- a/Formula/glide.rb
+++ b/Formula/glide.rb
@@ -18,7 +18,8 @@ class Glide < Formula
   end
 
   # See: https://github.com/Masterminds/glide/commit/c64b14592409a83052f7735a01d203ff1bab0983
-  deprecate! date: "2021-01-02", because: :deprecated_upstream
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2021-01-02", because: :deprecated_upstream
 
   depends_on "go"
 

--- a/Formula/go@1.16.rb
+++ b/Formula/go@1.16.rb
@@ -17,7 +17,9 @@ class GoAT116 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2022-03-15", because: :unsupported
+  # Original date: 2022-03-15
+  # The date below was adjusted to match `kubernetes-cli@1.22`.
+  deprecate! date: "2022-08-28", because: :unsupported
 
   depends_on "go" => :build
 

--- a/Formula/govendor.rb
+++ b/Formula/govendor.rb
@@ -17,7 +17,8 @@ class Govendor < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "24497503629e520a1fe718029ab520b05c012677df065c9fd104afe4d898b8b8"
   end
 
-  deprecate! date: "2020-03-02", because: :repo_archived
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2020-03-02", because: :repo_archived
 
   depends_on "go"
 

--- a/Formula/guile@2.rb
+++ b/Formula/guile@2.rb
@@ -18,7 +18,8 @@ class GuileAT2 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-04-07", because: :versioned_formula
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2020-04-07", because: :versioned_formula
 
   depends_on "gnu-sed" => :build
   depends_on "bdw-gc"

--- a/Formula/ilmbase.rb
+++ b/Formula/ilmbase.rb
@@ -18,7 +18,8 @@ class Ilmbase < Formula
   keg_only "ilmbase conflicts with `openexr` and `imath`"
 
   # https://github.com/AcademySoftwareFoundation/openexr/pull/929
-  deprecate! date: "2021-04-05", because: :unsupported
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2021-04-05", because: :unsupported
 
   depends_on "cmake" => :build
 

--- a/Formula/isl@0.18.rb
+++ b/Formula/isl@0.18.rb
@@ -25,7 +25,8 @@ class IslAT018 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-11-05", because: :versioned_formula
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2020-11-05", because: :versioned_formula
 
   depends_on "gmp"
 

--- a/Formula/jam.rb
+++ b/Formula/jam.rb
@@ -20,7 +20,8 @@ class Jam < Formula
   # The last Perforce release of Jam was version 2.6 in August of 2014. We will
   # keep the Perforce-controlled links and information posted here available
   # until further notice."
-  deprecate! date: "2021-07-10", because: :unmaintained
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2021-07-10", because: :unmaintained
 
   conflicts_with "ftjam", because: "both install a `jam` binary"
 

--- a/Formula/lua@5.1.rb
+++ b/Formula/lua@5.1.rb
@@ -21,7 +21,8 @@ class LuaAT51 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4b5ebc378db8f01127fdec3922b58252ede872cd6b70cbbde2adde311f1f699a"
   end
 
-  deprecate! date: "2012-02-17", because: :unsupported
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2012-02-17", because: :unsupported
 
   uses_from_macos "unzip"
 

--- a/Formula/mpfi.rb
+++ b/Formula/mpfi.rb
@@ -18,7 +18,8 @@ class Mpfi < Formula
 
   # Formula does not build, https://gforge.inria.fr/tracker/index.php?func=detail&aid=21721&group_id=157&atid=709
   # and upstream is not actively maintaining (last commit was on 2019-08-01)
-  deprecate! date: "2021-08-15", because: :unmaintained
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2021-08-15", because: :unmaintained
 
   depends_on "gmp"
   depends_on "mpfr"

--- a/Formula/openexr@2.rb
+++ b/Formula/openexr@2.rb
@@ -17,7 +17,8 @@ class OpenexrAT2 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2021-04-01", because: :unsupported
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2021-04-01", because: :unsupported
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/sdl.rb
+++ b/Formula/sdl.rb
@@ -65,7 +65,8 @@ class Sdl < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  deprecate! date: "2013-08-17", because: :deprecated_upstream
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   conflicts_with "sdl12-compat", because: "sdl12-compat is a drop-in replacement for sdl"
 

--- a/Formula/sdl_image.rb
+++ b/Formula/sdl_image.rb
@@ -39,7 +39,8 @@ class SdlImage < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  deprecate! date: "2013-08-17", because: :deprecated_upstream
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "jpeg"

--- a/Formula/sdl_mixer.rb
+++ b/Formula/sdl_mixer.rb
@@ -26,7 +26,8 @@ class SdlMixer < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  deprecate! date: "2013-08-17", because: :deprecated_upstream
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "flac"

--- a/Formula/sdl_net.rb
+++ b/Formula/sdl_net.rb
@@ -26,7 +26,8 @@ class SdlNet < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  deprecate! date: "2013-08-17", because: :deprecated_upstream
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "sdl"

--- a/Formula/sdl_sound.rb
+++ b/Formula/sdl_sound.rb
@@ -28,7 +28,8 @@ class SdlSound < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  deprecate! date: "2013-08-17", because: :deprecated_upstream
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "libogg"

--- a/Formula/sdl_ttf.rb
+++ b/Formula/sdl_ttf.rb
@@ -37,7 +37,8 @@ class SdlTtf < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  deprecate! date: "2013-08-17", because: :deprecated_upstream
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2013-08-17", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "freetype"

--- a/Formula/tbb@2020.rb
+++ b/Formula/tbb@2020.rb
@@ -18,7 +18,8 @@ class TbbAT2020 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-04-02", because: :unsupported
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2020-04-02", because: :unsupported
 
   depends_on "cmake" => :build
   depends_on "swig" => :build

--- a/Formula/vtk@8.2.rb
+++ b/Formula/vtk@8.2.rb
@@ -17,7 +17,8 @@ class VtkAT82 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-05-14", because: :versioned_formula
+  # Commented out while this formula still has dependents.
+  # deprecate! date: "2020-05-14", because: :versioned_formula
 
   depends_on "cmake" => [:build, :test]
   depends_on "boost"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Needed for Homebrew/brew#12770. I've left the existing deprecation lines in a comment to make it easier to find them without digging up Git logs, so they're easier to action later on.

These formulae being deprecated also violate our policy about formulae with dependents not being deprecated (unless the dependents themselves are deprecated). We can uncomment the deprecation lines when we're able to sort out the dependents.

This should help make sure we're not disabling formulae with dependents in Homebrew/homebrew-core#103904.

See also:
- Homebrew/brew#12748
- Homebrew/brew#12727
- Homebrew/homebrew-core#91368
