### PR TITLE
docker-machine-driver-vultr: deprecate

### DIFF
--- a/Formula/docker-machine-driver-vultr.rb
+++ b/Formula/docker-machine-driver-vultr.rb
@@ -21,7 +21,7 @@ class DockerMachineDriverVultr < Formula
   end
 
   # last commit was in 2017
-  deprecate! date: "20-07-29", because: :unmaintained
+  deprecate! date: "2022-07-29", because: :unmaintained
 
   depends_on "go" => :build
   depends_on "docker-machine"

--- a/Formula/docker-machine-driver-vultr.rb
+++ b/Formula/docker-machine-driver-vultr.rb
@@ -20,6 +20,9 @@ class DockerMachineDriverVultr < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "60610ec215e212a442adf660b34f651db0c97a75cfe7ca908e00c8d450ccd8f4"
   end
 
+  # last commit was in 2017
+  deprecate! date: "2017-08-11", because: :unmaintained
+
   depends_on "go" => :build
   depends_on "docker-machine"
 

--- a/Formula/docker-machine-driver-vultr.rb
+++ b/Formula/docker-machine-driver-vultr.rb
@@ -21,7 +21,7 @@ class DockerMachineDriverVultr < Formula
   end
 
   # last commit was in 2017
-  deprecate! date: "2017-08-11", because: :unmaintained
+  deprecate! date: "20-07-29", because: :unmaintained
 
   depends_on "go" => :build
   depends_on "docker-machine"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
