### PR TITLE
finatra: deprecate

### DIFF
--- a/Formula/finatra.rb
+++ b/Formula/finatra.rb
@@ -9,6 +9,8 @@ class Finatra < Formula
     sha256 cellar: :any_skip_relocation, all: "4647f53656631f55bef9d4a4c3ef66adafa598c3e48a65be4199a1cdc33bf5dc"
   end
 
+  deprecate! date: "2022-07-29", because: "not maintained in Homebrew"
+
   def install
     libexec.install Dir["*"]
     bin.install_symlink libexec/"finatra"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The formula has not received any version bumps since it was added back in October 2014. In addition, the formula only has 7 installs in the last 365 days (at least one of those is probably me, hehe).

If the formula being effectively unmaintained is not grounds for deprecating it, please let me know and I'll close this PR. Also, is deprecating the formula the appropriate action here instead of disabling it?
