### PR TITLE
python-tabulate: migrate to `python@3.10`

### DIFF
--- a/Formula/python-tabulate.rb
+++ b/Formula/python-tabulate.rb
@@ -4,13 +4,14 @@ class PythonTabulate < Formula
   url "https://files.pythonhosted.org/packages/7a/53/afac341569b3fd558bf2b5428e925e2eb8753ad9627c1f9188104c6e0c4a/tabulate-0.8.10.tar.gz"
   sha256 "6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "96aade7fd67304139f7c2ba7e3585393348fff2b7c9cc2067269cecccfdd9aec"
   end
 
   depends_on "libpython-tabulate"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
     # Install the binary only, the lib part is provided by libpython-tabulate


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
