### PR TITLE
nodeenv, ski, httpstat: use any python3 on Linux

### DIFF
--- a/Formula/httpstat.rb
+++ b/Formula/httpstat.rb
@@ -6,7 +6,7 @@ class Httpstat < Formula
   url "https://github.com/reorx/httpstat/archive/1.3.1.tar.gz"
   sha256 "7bfaa0428fe806ad4a68fc2db0aedf378f2e259d53f879372835af4ef14a6d41"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "8d9ac6f7d7da555221bffc4f49b59f60bcc9405439e5d418a49f15a547026dd5"
@@ -21,8 +21,10 @@ class Httpstat < Formula
   uses_from_macos "python"
 
   def install
-    rw_info = OS.mac? ? python_shebang_rewrite_info("/usr/bin/env python3") : detected_python_shebang
-    rewrite_shebang rw_info, "httpstat.py"
+    if OS.linux? || MacOS.version >= :catalina
+      rw_info = python_shebang_rewrite_info("/usr/bin/env python3")
+      rewrite_shebang rw_info, "httpstat.py"
+    end
     bin.install "httpstat.py" => "httpstat"
   end
 

--- a/Formula/nodeenv.rb
+++ b/Formula/nodeenv.rb
@@ -6,6 +6,7 @@ class Nodeenv < Formula
   url "https://github.com/ekalinin/nodeenv/archive/1.7.0.tar.gz"
   sha256 "a9e9e36e1be6439e877c53e7f27ce068f75b82cc08201f2c68471687199cfd7b"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "b62820fdf34eb99d433736cc707c41a506f404ff2043418b62a4ab47a46fe99d"
@@ -19,8 +20,10 @@ class Nodeenv < Formula
   uses_from_macos "python"
 
   def install
-    rw_info = OS.mac? ? python_shebang_rewrite_info("/usr/bin/env python3") : detected_python_shebang
-    rewrite_shebang rw_info, "nodeenv.py"
+    if OS.linux? || MacOS.version >= :catalina
+      rw_info = python_shebang_rewrite_info("/usr/bin/env python3")
+      rewrite_shebang rw_info, "nodeenv.py"
+    end
     bin.install "nodeenv.py" => "nodeenv"
   end
 

--- a/Formula/ski.rb
+++ b/Formula/ski.rb
@@ -4,6 +4,7 @@ class Ski < Formula
   desc "Evade the deadly Yeti on your jet-powered skis"
   homepage "http://catb.org/~esr/ski/"
   license "BSD-2-Clause"
+  revision 1
 
   stable do
     url "http://www.catb.org/~esr/ski/ski-6.13.tar.gz"
@@ -36,8 +37,8 @@ class Ski < Formula
       ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
       system "make"
     end
-    if MacOS.version <= :mojave
-      rw_info = OS.mac? ? python_shebang_rewrite_info("/usr/bin/env python") : detected_python_shebang
+    if OS.mac? && MacOS.version <= :mojave
+      rw_info = python_shebang_rewrite_info("/usr/bin/env python")
       rewrite_shebang rw_info, "ski"
     end
     bin.install "ski"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These formulae have Linux bottles that will break when we try to migrate aliases from `python@3.9 -> 3.10` and will force unneeded revision bumps in future (`3.10 -> 3.11 -> 3.12 -> ...`).