### PR TITLE
bitcoin: use Boost 1.79.0

### DIFF
--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -4,6 +4,7 @@ class Bitcoin < Formula
   url "https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0.tar.gz"
   sha256 "26748bf49d6d6b4014d0fedccac46bf2bcca42e9d34b3acfd9e3467c415acc05"
   license "MIT"
+  revision 1
   head "https://github.com/bitcoin/bitcoin.git", branch: "master"
 
   livecheck do
@@ -25,7 +26,7 @@ class Bitcoin < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "berkeley-db@4"
-  depends_on "boost@1.76"
+  depends_on "boost"
   depends_on "libevent"
   depends_on macos: :catalina
   depends_on "miniupnpc"
@@ -42,7 +43,7 @@ class Bitcoin < Formula
     system "./autogen.sh"
     system "./configure", *std_configure_args,
                           "--disable-silent-rules",
-                          "--with-boost-libdir=#{Formula["boost@1.76"].opt_lib}"
+                          "--with-boost-libdir=#{Formula["boost"].opt_lib}"
     system "make", "install"
     pkgshare.install "share/rpcauth"
   end


### PR DESCRIPTION
Bitcoin Core 23.0 compiles fine with Boost 1.79.0, so there doesn't seem to be a reason to stay pinned to Boost 1.76.0. Looks like this is a holdover from the [1.76.0 -> 1.78.0 migration](https://github.com/fanquake/homebrew-core/commit/1d0224e885fabc8e5dfc0bf547677d84e782f445), when 22.0 may have failed to compile with 1.78.0.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
