### PR TITLE
berkeley-db: fix livecheck

### DIFF
--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -9,7 +9,7 @@ class BerkeleyDb < Formula
 
   livecheck do
     url "https://www.oracle.com/database/technologies/related/berkeleydb-downloads.html"
-    regex(/h3>Berkeley\s*DB.*\(\s*(\d+(?:\.\d+)+)\s*\)/i)
+    regex(/Berkeley\s*DB[^(]*?\(\s*v?(\d+(?:\.\d+)+)\s*\)/i)
   end
 
   bottle do

--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -1,9 +1,8 @@
 class BerkeleyDb < Formula
   desc "High performance key/value database"
   homepage "https://www.oracle.com/database/technologies/related/berkeleydb.html"
-  url "https://download.oracle.com/berkeley-db/db-#{version}.tar.gz"
-  mirror "https://fossies.org/linux/misc/db-#{version}.tar.gz"
-  version "18.1.40"
+  url "https://download.oracle.com/berkeley-db/db-18.1.40.tar.gz"
+  mirror "https://fossies.org/linux/misc/db-18.1.40.tar.gz"
   sha256 "0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8"
   license "AGPL-3.0-only"
   revision 1

--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -1,8 +1,9 @@
 class BerkeleyDb < Formula
+  version "18.1.40"
   desc "High performance key/value database"
   homepage "https://www.oracle.com/database/technologies/related/berkeleydb.html"
-  url "https://download.oracle.com/berkeley-db/db-18.1.40.tar.gz"
-  mirror "https://fossies.org/linux/misc/db-18.1.40.tar.gz"
+  url "https://download.oracle.com/berkeley-db/db-#{version}.tar.gz"
+  mirror "https://fossies.org/linux/misc/db-#{version}.tar.gz"
   sha256 "0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8"
   license "AGPL-3.0-only"
   revision 1

--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -9,7 +9,7 @@ class BerkeleyDb < Formula
 
   livecheck do
     url "https://www.oracle.com/database/technologies/related/berkeleydb-downloads.html"
-    regex(%r{href=.*?/berkeley-db/db[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{h3>Berkeley\s*DB.*\(\s*(\d+(?:\.\d+)+)\s*\)}i)
   end
 
   bottle do

--- a/Formula/berkeley-db.rb
+++ b/Formula/berkeley-db.rb
@@ -1,16 +1,16 @@
 class BerkeleyDb < Formula
-  version "18.1.40"
   desc "High performance key/value database"
   homepage "https://www.oracle.com/database/technologies/related/berkeleydb.html"
   url "https://download.oracle.com/berkeley-db/db-#{version}.tar.gz"
   mirror "https://fossies.org/linux/misc/db-#{version}.tar.gz"
+  version "18.1.40"
   sha256 "0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8"
   license "AGPL-3.0-only"
   revision 1
 
   livecheck do
     url "https://www.oracle.com/database/technologies/related/berkeleydb-downloads.html"
-    regex(%r{h3>Berkeley\s*DB.*\(\s*(\d+(?:\.\d+)+)\s*\)}i)
+    regex(/h3>Berkeley\s*DB.*\(\s*(\d+(?:\.\d+)+)\s*\)/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Livecheck has been broken a while due to apparent changes to Oracle's site, so took a crack at fixing it.