### PR TITLE
zopfli: build shared libs, pigz: use Homebrew zopfli

### DIFF
--- a/Formula/pigz.rb
+++ b/Formula/pigz.rb
@@ -4,6 +4,7 @@ class Pigz < Formula
   url "https://zlib.net/pigz/pigz-2.7.tar.gz"
   sha256 "b4c9e60344a08d5db37ca7ad00a5b2c76ccb9556354b722d56d55ca7e8b1c707"
   license "Zlib"
+  revision 1
 
   livecheck do
     url :homepage
@@ -19,10 +20,12 @@ class Pigz < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0a6ba53a70f69c7db90ab0f69af67ae3abfa95058cdb1ac319b3bfffbdbc6847"
   end
 
+  depends_on "zopfli"
   uses_from_macos "zlib"
 
   def install
-    system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"
+    libzopfli = Formula["zopfli"].opt_lib/shared_library("libzopfli")
+    system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}", "ZOP=#{libzopfli}"
     bin.install "pigz", "unpigz"
     man1.install "pigz.1"
     man1.install_symlink "pigz.1" => "unpigz.1"

--- a/Formula/zopfli.rb
+++ b/Formula/zopfli.rb
@@ -4,6 +4,7 @@ class Zopfli < Formula
   url "https://github.com/google/zopfli/archive/zopfli-1.0.3.tar.gz"
   sha256 "e955a7739f71af37ef3349c4fa141c648e8775bceb2195be07e86f8e638814bd"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/google/zopfli.git", branch: "master"
 
   bottle do
@@ -17,9 +18,12 @@ class Zopfli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5730bbf490205ab8daadcc298b3f4343d4fdd7d146a6789cc136b1da76d959ac"
   end
 
+  depends_on "cmake" => :build
+
   def install
-    system "make", "zopfli", "zopflipng"
-    bin.install "zopfli", "zopflipng"
+    system "cmake", "-S", ".", "-B", "build", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

### zopfli: build shared library

This allows us to use the shared library in `pigz`. We need to use CMake to build the shared libraries, since the `Makefile` supports building the shared library only on Linux.

### pigz: use Homebrew `zopfli`

This will use vendored `zopfli` sources if not pointed to a pre-build `libzopfli`.
