### PR TITLE
xgboost: remove `numpy` and `scipy`

### DIFF
--- a/Formula/xgboost.rb
+++ b/Formula/xgboost.rb
@@ -16,8 +16,6 @@ class Xgboost < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "numpy"
-  depends_on "scipy"
 
   on_macos do
     depends_on "libomp"
@@ -47,11 +45,9 @@ class Xgboost < Formula
     ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
 
-    mkdir "build" do
-      system "cmake", *std_cmake_args, ".."
-      system "make"
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
     pkgshare.install "demo"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These were added in 63a51f9d but the associated PR (#60246) gives no
indication of why.

I think these are needed to build they Python bindings, but we don't do
that. Let's try removing them.
