### PR TITLE
mono-libgdiplus: migrate `jpeg` to `jpeg-turbo`

### DIFF
--- a/Formula/mono-libgdiplus.rb
+++ b/Formula/mono-libgdiplus.rb
@@ -4,6 +4,7 @@ class MonoLibgdiplus < Formula
   url "https://download.mono-project.com/sources/libgdiplus/libgdiplus-6.1.tar.gz"
   sha256 "97d5a83d6d6d8f96c27fb7626f4ae11d3b38bc88a1726b4466aeb91451f3255b"
   license "MIT"
+  revision 1
 
   livecheck do
     url "https://download.mono-project.com/sources/libgdiplus/"
@@ -26,7 +27,7 @@ class MonoLibgdiplus < Formula
   depends_on "gettext"
   depends_on "giflib"
   depends_on "glib"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libexif"
   depends_on "libpng"
   depends_on "libtiff"
@@ -39,12 +40,10 @@ class MonoLibgdiplus < Formula
   end
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
+    system "./configure", *std_configure_args,
                           "--disable-silent-rules",
-                          "--without-x11",
                           "--disable-tests",
-                          "--prefix=#{prefix}"
+                          "--without-x11"
     system "make"
     cd "tests" do
       system "make", "testbits"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
