### PR TITLE
bazaar: deprecate

### DIFF
--- a/Formula/bazaar.rb
+++ b/Formula/bazaar.rb
@@ -16,8 +16,7 @@ class Bazaar < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:    "cb1c0c8b5f19abef4043195d8cbd19f363a78581596de1ddcc763621964335b3"
   end
 
-  # This formula is currently needed when downloading with `using: :bzr`.
-  # deprecate! date: "2021-08-19", because: "is not supported. Check out `breezy` instead"
+  disable! date: "2022-10-18", because: "is not supported. Check out `breezy` instead"
 
   depends_on :macos # Due to Python 2
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also, I've set a future disable date for one year after it was
deprecated in Homebrew/core.

Should probably wait until Homebrew/brew#13617 lands in a release tag to merge.
