### PR TITLE
jack, moc: use berkeley-db@5

### DIFF
--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -4,6 +4,7 @@ class Jack < Formula
   url "https://github.com/jackaudio/jack2/archive/v1.9.21.tar.gz"
   sha256 "8b044a40ba5393b47605a920ba30744fdf8bf77d210eca90d39c8637fe6bc65d"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -24,7 +25,7 @@ class Jack < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.10" => :build
-  depends_on "berkeley-db"
+  depends_on "berkeley-db@5" # berkeley-db > 5 is AGPL, so keep it at version 5 to avoid relicense
   depends_on "libsamplerate"
   depends_on "libsndfile"
   depends_on "readline"

--- a/Formula/moc.rb
+++ b/Formula/moc.rb
@@ -2,7 +2,7 @@ class Moc < Formula
   desc "Terminal-based music player"
   homepage "https://moc.daper.net/"
   license "GPL-2.0-or-later"
-  revision 6
+  revision 7
 
   stable do
     url "http://ftp.daper.net/pub/soft/moc/stable/moc-2.5.2.tar.bz2"
@@ -62,7 +62,7 @@ class Moc < Formula
   depends_on "automake" => :build
   depends_on "gettext" => :build
   depends_on "pkg-config" => :build
-  depends_on "berkeley-db"
+  depends_on "berkeley-db@5" # berkeley-db > 5 is AGPL, so keep it at version 5 to avoid relicense
   depends_on "ffmpeg@4"
   depends_on "jack"
   depends_on "libtool"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See #100796.

Required because `jack` is migrated to `berkeley-db@5` too in previous commit. I could disable `moc`'s cache feature (which requires libdb) and remove the `berkeley-db@5` dependency from `moc`, but since `jack` depends on `berkeley-db@5` anyway, I thought I'd keep the cache enabled.