### PR TITLE
return of the linux bottles

### DIFF
--- a/Formula/abseil.rb
+++ b/Formula/abseil.rb
@@ -6,16 +6,20 @@ class Abseil < Formula
   license "Apache-2.0"
   head "https://github.com/abseil/abseil-cpp.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "0055d33f047cc5b840cecc5a914fbeaa2b9ab88bd17d8d37bc4fd6e0ff2ccf27"
     sha256 cellar: :any,                 arm64_big_sur:  "131fc67a76243ecd760cf20457de8952649677e4eedf44f20fe5ae613120c18e"
     sha256 cellar: :any,                 monterey:       "24bfd83bbae83e0562e3798e8b86a98f274acfbd456b8836bfb9d2e4b75dfdec"
     sha256 cellar: :any,                 big_sur:        "d694723ee65f04c8727035f49c36ecf1f7fcbe36e5833fd27f5d7d88594a445b"
     sha256 cellar: :any,                 catalina:       "9b5cf436cb57b35260fc2a0d7182259fa9351893be591ee570731d1600d4678b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "84a1f15dd86c0ac02ceb06eca0a01fceeaab04c731a31c925b2d40d5d7b2031f"
   end
 
   depends_on "cmake" => :build
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # C++17
 

--- a/Formula/allegro.rb
+++ b/Formula/allegro.rb
@@ -12,13 +12,13 @@ class Allegro < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "d837a297e5b7a4b135831b2549a9388250de130fb86201c9c160c1211f1ff773"
     sha256 cellar: :any,                 arm64_big_sur:  "674a59e675e01fb444a806ec712cef6de9d42be7ff07a35811a80bc4259c3bdc"
     sha256 cellar: :any,                 monterey:       "0f8f973ab20f49f58f84d61aa5238c83c46ea7ced40cc426c55efc5a5dbfc4be"
     sha256 cellar: :any,                 big_sur:        "42a27ed5656e9ddb3a4cc8b84e1684063cdd87229c3979f0efad7a5cf30077a3"
     sha256 cellar: :any,                 catalina:       "8e271ed2ef392df9cf6bf0d491be1ec8a303099ffe6634000407869969c2d85c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b0c3f329f2a98021d677a6eaf3812e5d198f27417d52da22df7e1854f6afafa0"
   end
 
   depends_on "cmake" => :build
@@ -33,6 +33,7 @@ class Allegro < Formula
   depends_on "webp"
 
   on_linux do
+    depends_on "gcc"
     depends_on "jpeg-turbo"
     depends_on "libpng"
     depends_on "libx11"

--- a/Formula/antlr4-cpp-runtime.rb
+++ b/Formula/antlr4-cpp-runtime.rb
@@ -10,7 +10,6 @@ class Antlr4CppRuntime < Formula
     regex(/href=.*?antlr4-cpp-runtime[._-]v?(\d+(?:\.\d+)+)-source\.zip/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "c513a0222e04b43c0013ac15a77d2acef6890f2e7fbbdb42a264e4143ecaa5a1"
@@ -18,9 +17,16 @@ class Antlr4CppRuntime < Formula
     sha256 cellar: :any,                 monterey:       "d06a0114f1d079d7b5f29ae64ebdf1868eb7b9f04410e049161226a2a1e76d6c"
     sha256 cellar: :any,                 big_sur:        "024707eebab37c6f5504ca3a4f2e81d4869e084208c6733bc14c8b6341472515"
     sha256 cellar: :any,                 catalina:       "2fd4f6cb6c5d2580e32d177ae6ef8c8e67be0e23768b19cc27f5796b0cba25f9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "54f86b03137aad378c8640cc49c7f07bb1634e735784183e6fa593f76c50a3ee"
   end
 
   depends_on "cmake" => :build
+
+  on_linux do
+    depends_on "pkg-config" => :build
+    depends_on "gcc"
+    depends_on "util-linux"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/apache-arrow-glib.rb
+++ b/Formula/apache-arrow-glib.rb
@@ -11,13 +11,13 @@ class ApacheArrowGlib < Formula
     formula "apache-arrow"
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "2b85faa106edf308595c12af9a62a7f05e100cfaba6b337600ec832dba09aa71"
     sha256 cellar: :any, arm64_big_sur:  "9a1924c7eb7853e71ea0dee8a9e062a657849ae2a25343a37b344c684e8470a3"
     sha256 cellar: :any, monterey:       "15f68c3d3eff600ae62bd362e3dc32ea0e97cfd45155f747fa4a73db1624ba4c"
     sha256 cellar: :any, big_sur:        "92e1eb8ccab434bb9d5234ebf620ef4f26e93984778b9864404ceff06af377f0"
     sha256 cellar: :any, catalina:       "249dff425624bda77f3d26f3f60b3c50a11479e8e11234281b039c4d641535f3"
+    sha256               x86_64_linux:   "570d7b532ae126ead199b182cac3eb3de4ccc01fc5b75adf6bd3dd63d8085ca7"
   end
 
   depends_on "glib-utils" => :build
@@ -27,6 +27,10 @@ class ApacheArrowGlib < Formula
   depends_on "pkg-config" => :build
   depends_on "apache-arrow"
   depends_on "glib"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -7,13 +7,13 @@ class ApacheArrow < Formula
   license "Apache-2.0"
   head "https://github.com/apache/arrow.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "236f3e3d792c5450549703d4baaffb4c272c10495ab5e28e00745e33dd5c8b9f"
     sha256 cellar: :any,                 arm64_big_sur:  "4f410eb8437deb23972cc7c1afee02f589debed45c0e2cd70b5f30735a45a94a"
     sha256 cellar: :any,                 monterey:       "b523d867a39dcd7bb1e6184bf542a7dbe2dcecdf4ce987413e0a4beaa86dcd67"
     sha256 cellar: :any,                 big_sur:        "6c94f65c8985387ff46b26b2d0e6a2a3cf6ce2c34d264d2353580ba73c0fdc7e"
     sha256 cellar: :any,                 catalina:       "1bb210d9cb9bbd851c1d0d51ad88ffc2516f35d87f4b3771b4d4313e65576a68"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "34c6809c6ecf836b59924fc4ea0f5677bdf17b0fd3cecbeba2cbd8e4f599fbbb"
   end
 
   depends_on "boost" => :build
@@ -34,6 +34,10 @@ class ApacheArrow < Formula
   depends_on "thrift"
   depends_on "utf8proc"
   depends_on "zstd"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/apngasm.rb
+++ b/Formula/apngasm.rb
@@ -7,13 +7,13 @@ class Apngasm < Formula
   revision 1
   head "https://github.com/apngasm/apngasm.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "80b90951415a88eff1da221b4826a2f1511fa5322ba04c449f3aeec393e0999b"
     sha256 cellar: :any,                 arm64_big_sur:  "d4bbbe2f3dce2bf221ee011f7f192ca1b5c2e1440214bc0105d09a0c0be356bd"
     sha256 cellar: :any,                 monterey:       "2cfe286cfa16d59d200bb5b1b5f37afa66d01e270c976cc179f82dc70e6e1fe5"
     sha256 cellar: :any,                 big_sur:        "4b7399bdb7991330dee6a26a00ee1ec58e6074895b026fda608950b0372525d7"
     sha256 cellar: :any,                 catalina:       "bcba805553ae564c117609755b2f4c3e06f1c23579430505fa89fda8c126c06c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "428941624e3fc27d7ac937ac7eaa016724abafa63119969b01bfd4159421cbba"
   end
 
   depends_on "cmake" => :build
@@ -22,6 +22,10 @@ class Apngasm < Formula
   depends_on "libpng"
   depends_on "lzlib"
   depends_on macos: :catalina
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with :gcc do
     version "7"

--- a/Formula/arangodb.rb
+++ b/Formula/arangodb.rb
@@ -11,11 +11,11 @@ class Arangodb < Formula
     regex(/href=.*?ArangoDB[._-]v?(\d+(?:\.\d+)+)(-\d+)?\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 monterey:     "6ce88863c3d64b6e0f80157b81ccada705ba6a364ee8ff827e46f63df16b3b10"
     sha256 big_sur:      "e38065e33bd2ee3eee533bcde177f1ce0c3dfd7c8857f678fe73d4e2e8fcec75"
     sha256 catalina:     "5420623e77cc3c4dd8c272a791ce8d102d46fdceeea983104f2443a6b2cb95c8"
+    sha256 x86_64_linux: "8c311faac036bab8fc2acee10adf136275ccbf5c976795fadae2b08adaefffaf"
   end
 
   depends_on "ccache" => :build
@@ -24,6 +24,10 @@ class Arangodb < Formula
   depends_on "python@3.10" => :build
   depends_on macos: :mojave
   depends_on "openssl@1.1"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/arcade-learning-environment.rb
+++ b/Formula/arcade-learning-environment.rb
@@ -9,13 +9,13 @@ class ArcadeLearningEnvironment < Formula
   license "GPL-2.0-only"
   head "https://github.com/mgbellemare/Arcade-Learning-Environment.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "69b3c918b471d86a15ddc33ca7d8788b7df97cdb37c24b0f9bf278acea044a92"
     sha256 cellar: :any,                 arm64_big_sur:  "b91365dd433a5aaa6c63e1930fa485a0c7d8f30aee4709f77d47a1c227aad39c"
     sha256 cellar: :any,                 monterey:       "928deddbfd6b71a6683d9baabb34e95e42b2426e306d050cf785e5aa0ea45c07"
     sha256 cellar: :any,                 big_sur:        "385f3c78c9926ea3cf5fb5ea44d0ef363d3c097058e039e822a127d3f7f031f1"
     sha256 cellar: :any,                 catalina:       "6b4982ba66a1dae92d8894c64d10413eefe553bcb3e368770d49a4ea66b6af3b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "11739052d50db05aac650a0d23c46aeb04535b9ff97b982c3687bb5baac0fbbc"
   end
 
   depends_on "cmake" => :build
@@ -25,6 +25,10 @@ class ArcadeLearningEnvironment < Formula
   depends_on "sdl2"
 
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc" # for C++17
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/arrayfire.rb
+++ b/Formula/arrayfire.rb
@@ -5,13 +5,13 @@ class Arrayfire < Formula
   sha256 "13edaeb329826e7ca51b5db2d39b8dbdb9edffb6f5b88aef375e115443155668"
   license "BSD-3-Clause"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "c91188803bdb170202adc8fcc0b26294057e119e0bdefa1843ab158602ddd0b9"
     sha256 cellar: :any,                 arm64_big_sur:  "3b7d5567de48d187d18c4e5a12d7a292d0c4dfebb9e181222ef4030a9b7115fc"
     sha256 cellar: :any,                 monterey:       "2e28ca14205729d079b08b01eeb91d6c090d9c50caa7321a2fb7fa55a8bfd376"
     sha256 cellar: :any,                 big_sur:        "4b59cd0db04eaf807b459f872b4fe2e6401cc5c9ae3675bdafb7af52f742ca3e"
     sha256 cellar: :any,                 catalina:       "81f15373fb946ee09ed96d57731a07c06d85a522db953ed131b2de747f18fe0f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a34242e438745f4309147b5b0adbc2440ee9d1292dbadc2b7dff2707eb61a217"
   end
 
   depends_on "boost" => :build
@@ -20,6 +20,10 @@ class Arrayfire < Formula
   depends_on "fftw"
   depends_on "freeimage"
   depends_on "openblas"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/assimp.rb
+++ b/Formula/assimp.rb
@@ -6,19 +6,23 @@ class Assimp < Formula
   license :cannot_represent
   head "https://github.com/assimp/assimp.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "67d6e7b43419f11e105b6ac7e4a147ce07aef50b933c41fbfdf02382508abff5"
     sha256 cellar: :any,                 arm64_big_sur:  "7caf721e862862f3c4dbcaba048fe8707368a9ec148b7ec578ee34cebaaa3455"
     sha256 cellar: :any,                 monterey:       "f5fdb9347de7b36866ac711c002366412971219d02c365af91fd7a620f9ab88f"
     sha256 cellar: :any,                 big_sur:        "b9402a7cc394876768c95b76e4e9893ac32a2c0dcd7c4ce893e77ba6582d91cf"
     sha256 cellar: :any,                 catalina:       "f0b432d116da9f388c812fdc39c05dfe8bab467f285b4046f29023a3bee2f073"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f3489f9eba0842af02276b74aec5da76188f48b5d13366c9cb0a69e36135a27f"
   end
 
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/asymptote.rb
+++ b/Formula/asymptote.rb
@@ -11,13 +11,13 @@ class Asymptote < Formula
     regex(%r{url=.*?/asymptote[._-]v?(\d+(?:\.\d+)+)\.src\.t}i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "24dafab10c9cb3ce25a5cd58d535b9d483ec1844204f6c6073d1a7e530f2ff82"
     sha256 arm64_big_sur:  "ccd8fb43d61926ddc356291e90bdce81b0a11f7dd97a522f340a647644082280"
     sha256 monterey:       "09bb8447e714ecfc704289df1a3fcbe30623dcafca4f3539f15685c3da0c9a0c"
     sha256 big_sur:        "37f8f552883033592490b83f02da1177356ecddadd0cefdb2e5efc0ac1761ccd"
     sha256 catalina:       "872c509ade405f97b9c35c278118548203ac6a4b6ca9f5ba62460a5efc24ae54"
+    sha256 x86_64_linux:   "7ffa5e3c133c0f8c5be864053fbc94a073299371e2562a4b0e3938eb6368b55b"
   end
 
   depends_on "glm" => :build

--- a/Formula/atkmm.rb
+++ b/Formula/atkmm.rb
@@ -5,13 +5,13 @@ class Atkmm < Formula
   sha256 "6f62dd99f746985e573605937577ccfc944368f606a71ca46342d70e1cdae079"
   license "LGPL-2.1-or-later"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "060aaa8eff1cde559d778477b5d3b0b707de855a590a13a9ff9b416ce7a4d2ee"
     sha256 cellar: :any, arm64_big_sur:  "664288c4e6fb17a1d7b496e77ed85ca6f1133aeb56f96ba643cd0d1878544935"
     sha256 cellar: :any, monterey:       "59d500b3a99b28004129b67bdd0e7b01e380641775c3a8f419c8ef946ebfb885"
     sha256 cellar: :any, big_sur:        "6faaf66dbd24fd9a6653cd123c5ea7e3d859f6271889315ebdf53a1c66548ea3"
     sha256 cellar: :any, catalina:       "b90948dbd7c51cc8a6a1cddadb90942b8edec8e682b37f168be4fd5eca3c6cee"
+    sha256               x86_64_linux:   "1d659fec4e9807cd89ff4dfb30ccebcde19856021ff78bc15a85107eded62152"
   end
 
   depends_on "meson" => :build
@@ -19,6 +19,10 @@ class Atkmm < Formula
   depends_on "pkg-config" => :build
   depends_on "atk"
   depends_on "glibmm"
+
+  on_linux do
+    depends_on "gcc" => :build
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -18,13 +18,13 @@ class Audacious < Formula
     regex(/href=.*?audacious[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "c35e7535ae9705ac9d9a7e28b760081d86c1abdae99c5e722e0cdb7ed5707987"
     sha256 arm64_big_sur:  "aff5aaeab24180aff1ae91da6421edf7d58d81af57c1f5c6a049db247316fbd2"
     sha256 monterey:       "7893f401cc6bc9e7a4f8d22cf18b551ef3ea152711887f3c6037b55f446e351b"
     sha256 big_sur:        "22a2be0cacb4ae5d259e494bd08cb59cb5b38e28e2de8b492ae7d27bd676b12c"
     sha256 catalina:       "853a11fdf1db841cb70cd9af5ef80109356ef398cea6b44a39119bae18f31815"
+    sha256 x86_64_linux:   "2fc678cf70ed5f060c0dc24be179a95f314b3a859491f5403b74fe3462744d7f"
   end
 
   head do
@@ -58,6 +58,10 @@ class Audacious < Formula
   depends_on "qt@5"
   depends_on "sdl2"
   depends_on "wavpack"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -8,7 +8,6 @@ class AwsSdkCpp < Formula
   license "Apache-2.0"
   head "https://github.com/aws/aws-sdk-cpp.git", branch: "main"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "81b56d05e77548564afa0e93603379ce26cd64acb5e9e8d615d5ab9744288086"
     sha256 cellar: :any,                 arm64_big_sur:  "045caa0074c04b231ef27e27e42ed8206f9510311dbf977e36bdf09b45a49e7b"
@@ -21,6 +20,10 @@ class AwsSdkCpp < Formula
   depends_on "cmake" => :build
 
   uses_from_macos "curl"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/bcpp.rb
+++ b/Formula/bcpp.rb
@@ -10,7 +10,6 @@ class Bcpp < Formula
     regex(/id=.*?t(\d{6,8})["' >]/im)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "1ef362f6583a9a5779f8fb0a5237cc554615161d4f7f9fd5b054e0a59b51d917"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "1c7332e45d68c7c34e04b36935495e8e189944442650379f2c920757f2b210b7"
@@ -18,10 +17,15 @@ class Bcpp < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "447070d7c227cdb2e5c8df360c8ea31c8f9fa89b39e2092a3a888a40caedb523"
     sha256 cellar: :any_skip_relocation, catalina:       "1f2a9da46190bde2855e3bdc5d430302c831e3ff0eb3e3c34f8754bbe73744da"
     sha256 cellar: :any_skip_relocation, mojave:         "1872e08cd8d7addb8459865d451622d05ed4f4fc2f91e3a6f144ba1fe483b27a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ec23404179ff7f080c3af852e5df992e01126b5a7d22b34ff509c20c863f7e18"
   end
 
-  # Build succeeds with gcc 5 but seems to segfault at runtime.
+  # Build succeeds with system gcc (5.4.0) but seems to segfault at runtime.
   # Unclear whether this is an issue with the compiler itself or the libc++ runtime.
+  on_linux do
+    depends_on "gcc"
+  end
+
   fails_with gcc: "5"
 
   def install

--- a/Formula/bear.rb
+++ b/Formula/bear.rb
@@ -6,13 +6,13 @@ class Bear < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/rizsotto/Bear.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "0771405df1deec6b060a4f3c99439cd49c40a8749d8a7c192b045232e285165f"
     sha256 arm64_big_sur:  "e7c5589671130966af58a5040bc85e58a03e7bf1e58cf24b88a00960a40ce40d"
     sha256 monterey:       "24fa77c3b3d432bd5dafb11cfe17c54ba12140fe187e70050ad9281f438e84d9"
     sha256 big_sur:        "16074e6c469f2ef05ab4cec5806b77fbf3433ec4d81f80c25c7f4188ccf6b3dc"
     sha256 catalina:       "3ca416dc7635e808b58b0e94216d4037bc0c1f2338b6cfaa5f4e39ad527374be"
+    sha256 x86_64_linux:   "1b3443070cb27bb411cbebcbeb4c7d23daecf2ad444b5a7990c59090df53d98a"
   end
 
   depends_on "cmake" => :build
@@ -26,6 +26,10 @@ class Bear < Formula
 
   on_macos do
     depends_on "llvm" if DevelopmentTools.clang_build_version <= 1100
+  end
+
+  on_linux do
+    depends_on "gcc"
   end
 
   fails_with gcc: "5" # needs C++17

--- a/Formula/binaryen.rb
+++ b/Formula/binaryen.rb
@@ -6,17 +6,21 @@ class Binaryen < Formula
   license "Apache-2.0"
   head "https://github.com/WebAssembly/binaryen.git", branch: "main"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "af46ba9d11c1ca19483641276f8d6dd7c983fa4e4e0e27e833591034cd62a2cb"
     sha256 cellar: :any,                 arm64_big_sur:  "08765a7a1de7e5233a47c7a54abd63ec64b2f28f179d2390506d764443dc32fd"
     sha256 cellar: :any,                 monterey:       "3e8cd5e87750296858387afdac008452ce32f9efe449915b4e96c9e46f2949ee"
     sha256 cellar: :any,                 big_sur:        "c8060eff6afec83c9636a79329b67a67f5bd259e2a999b7e22408a82604a4b2c"
     sha256 cellar: :any,                 catalina:       "f2afc26acfb849e9843586e61087504736ebe5b444289e67b49bc60fff7dcbf7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b9b1b9f7882c1048b6a61fc9736b4ac05201198a12c3aa84b836ec8371d58d54"
   end
 
   depends_on "cmake" => :build
   depends_on "python@3.10" => :build
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -12,13 +12,13 @@ class Bitcoin < Formula
     regex(/latest version.*?v?(\d+(?:\.\d+)+)/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "c084959d808330eb564cf27b7ea51c62497a8008c2d584640466c6019bdc55b9"
     sha256 cellar: :any,                 arm64_big_sur:  "0bbf8b60af0394b210c88202c7319b785eff65635f8cbb55682793a9c674b73a"
     sha256 cellar: :any,                 monterey:       "de3f8d260583f8b12f2159358deaec0c71408cf745c250e72cc43a208c96e5a3"
     sha256 cellar: :any,                 big_sur:        "ee59dc2285d421fac229272894a9297dd97f7538995cc651839494fa184f4cdd"
     sha256 cellar: :any,                 catalina:       "225a9045c66625bb715fc92d4971f4f847ae459e22cb9e93910048f2576fe23e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d6565228ccfa1b5c59aa14fde06a7ac901261c89d0d1099bcb78791265d783ae"
   end
 
   depends_on "autoconf" => :build
@@ -31,6 +31,11 @@ class Bitcoin < Formula
   depends_on macos: :catalina
   depends_on "miniupnpc"
   depends_on "zeromq"
+
+  on_linux do
+    depends_on "util-linux" => :build # for `hexdump`
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/blast.rb
+++ b/Formula/blast.rb
@@ -11,12 +11,12 @@ class Blast < Formula
     regex(/v?(\d+(?:\.\d+)+)/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_big_sur: "2bf18560fdbeeba904b1c064de2d7485f5f478ed8608124ba034889b8372518a"
     sha256 monterey:      "8b52442d8fccc8f099cf06b3f5c047eedbb3823326d0ea1a4e61cae535231295"
     sha256 big_sur:       "ee3a1af3ae297a89e2c9faadbf0e9f677d06540777fefa72503fe7d9cde69d56"
     sha256 catalina:      "2a649294c81ba2449ed122c981359b05273bfd51d200c0cd56a0819458808b1f"
+    sha256 x86_64_linux:  "5ed46b12d1329eac692b299b62d19b1785154ea56df348da9592840f73da8880"
   end
 
   depends_on "lmdb"
@@ -27,6 +27,10 @@ class Blast < Formula
 
   on_macos do
     depends_on "libomp"
+  end
+
+  on_linux do
+    depends_on "gcc"
   end
 
   conflicts_with "proj", because: "both install a `libproj.a` library"

--- a/Formula/botan.rb
+++ b/Formula/botan.rb
@@ -11,13 +11,13 @@ class Botan < Formula
     regex(/href=.*?Botan[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "d915afe43b2437fe42e94a3392a5855b258b6ed6b5511ead2a0fbf9886a0461b"
     sha256 arm64_big_sur:  "87689319c0f9a4a1c007c3609f780490f9f7120652220a63828e0316f6d14cee"
     sha256 monterey:       "e173868c663e129ce4af972cd7efc567f25e623c6e9ee956b8230719b74a943c"
     sha256 big_sur:        "1f25905970becbcc4b508dfcf5c48a2e018692ed3267f08c5061133b4e3ac60c"
     sha256 catalina:       "bb925ad7521c9f2d966b452de0763517cf2b1e65700aae1c9cbcc6a01334e9f1"
+    sha256 x86_64_linux:   "3c27ab2df31d5c3e583bccbfb45767515104826e7c031ca996e6114a2cdbfa99"
   end
 
   depends_on "pkg-config" => :build
@@ -26,6 +26,10 @@ class Botan < Formula
 
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/c2rust.rb
+++ b/Formula/c2rust.rb
@@ -5,7 +5,6 @@ class C2rust < Formula
   sha256 "9ed1720672afb503db91b30cec1dedcf878841f57eaea4c7046839890990d8cd"
   license "BSD-3-Clause"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "ed7fd65c5dab2ba23a06bb8eaf26900c6c88001adcf981609807875fcb2421da"
@@ -13,11 +12,16 @@ class C2rust < Formula
     sha256 cellar: :any,                 monterey:       "e731c18631ef35b1fbc5a47210b486d6fc09689572e9ed16e99369ae87759086"
     sha256 cellar: :any,                 big_sur:        "5ef83273bd576ccfbc9a8f94a882f6a473e6675030bc770db125bc3432d815e5"
     sha256 cellar: :any,                 catalina:       "fda784d7984de0032064041302d4027aa87046fdba7f54a9e7d11ab4b8ad3570"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2f79604e99383d4a8966b748483469189c06733b581487a86de2070a8b630e55"
   end
 
   depends_on "cmake" => [:build, :test]
   depends_on "rust" => :build
   depends_on "llvm"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/caf.rb
+++ b/Formula/caf.rb
@@ -7,7 +7,6 @@ class Caf < Formula
   license "BSD-3-Clause"
   head "https://github.com/actor-framework/actor-framework.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "1313480b89b8ab7151ec4c585b2c7470b756a9b281f8944dbf85eb5ee16b82d7"
@@ -15,10 +14,15 @@ class Caf < Formula
     sha256 cellar: :any,                 monterey:       "d34c094aa418f1fa3b17e0dabc9d31f78b1e33a7e83bbba6e6eb00998cdd3320"
     sha256 cellar: :any,                 big_sur:        "fd895f94627410078a14281a8cf201d8ea0399f3393b55c4c6742da8922f2e90"
     sha256 cellar: :any,                 catalina:       "4e4f922feb8b8da760941ca4dfc3c050536938edaef0b7f3ea3c328b4d23c038"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0604ff641db3478a78639cac72937792e4efe4593a22f2ad027c09cf793f9f5d"
   end
 
   depends_on "cmake" => :build
   depends_on "openssl@1.1"
+
+  on_linux do
+    depends_on "gcc" # For C++17
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/caffe.rb
+++ b/Formula/caffe.rb
@@ -11,13 +11,13 @@ class Caffe < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "7f5a96c8328e6138829acf81276427238d869cf19f1c71e24022dc2d5b5d420a"
     sha256 cellar: :any,                 arm64_big_sur:  "b8f034785b485867f7886103c4bd3fd4bd4f540b7bb0a5b7cde01714c4b9e945"
     sha256 cellar: :any,                 monterey:       "cd851e5cba512ad56c70ddf31adcb0961e2598a540d56196bfaf3b39d4c0c904"
     sha256 cellar: :any,                 big_sur:        "a94881877f3695dbf486e63e149e0a94cfead9ae0e9bb8f7e56dacad6aa29ee9"
     sha256 cellar: :any,                 catalina:       "e080ed2516787bd3a43e627488e2ada20d60aa166b3919dc87e83cefe9fd35e1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b1717e247dc12a01921efc4dacc4507bd9e7ed645ad2f154359fdf90b2c1f106"
   end
 
   depends_on "cmake" => :build
@@ -31,6 +31,11 @@ class Caffe < Formula
   depends_on "opencv"
   depends_on "protobuf"
   depends_on "snappy"
+
+  on_linux do
+    depends_on "gcc"
+    depends_on "openblas"
+  end
 
   fails_with gcc: "5" # opencv is compiled with GCC
 
@@ -70,6 +75,7 @@ class Caffe < Formula
       -DUSE_OPENCV=ON
       -DUSE_OPENMP=OFF
     ]
+    args << "-DBLAS=Open" if OS.linux?
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/cairomm.rb
+++ b/Formula/cairomm.rb
@@ -10,7 +10,6 @@ class Cairomm < Formula
     regex(/href=.*?cairomm[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "d285d418a00fa705e40e1216d4949b0c80a7f12580c0f7021edf4c8083b833f9"
     sha256 cellar: :any, arm64_big_sur:  "70e65e43376e9f2159955ee6ec8db9f4c440c24df8dfebdc06fa10953604eba9"
@@ -18,6 +17,7 @@ class Cairomm < Formula
     sha256 cellar: :any, big_sur:        "6b0e30e7ed71aed6bf7dfb862eba5d2c62dd0abc7a6d13684448ac6f5430f045"
     sha256 cellar: :any, catalina:       "e02d87fa8a812686d9a2bf9ccfbe56e2937156e75488ee0795fb061d087cc171"
     sha256 cellar: :any, mojave:         "53433da3d97a46f2878505f42882162eda2b145e7fbc3380034c79c9626120af"
+    sha256               x86_64_linux:   "ccbec4be03fed226dc702b2b03cd55e64a35aa4b2e3fdbf9b11c2c27c3e61fdc"
   end
 
   depends_on "meson" => :build
@@ -26,6 +26,10 @@ class Cairomm < Formula
   depends_on "cairo"
   depends_on "libpng"
   depends_on "libsigc++"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/carla.rb
+++ b/Formula/carla.rb
@@ -19,13 +19,13 @@ class Carla < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "8c246cbd73e6e440d7b6214b8be4f956894ab606b5ba423f221646e2441d6bea"
     sha256 cellar: :any,                 arm64_big_sur:  "1640e2ca5e75448074727b3bc28f01057676877712fbf4b3cfdbeac9a6a6d2e8"
     sha256 cellar: :any,                 monterey:       "655ba99cf6c55eab1d499224684ca82e40d26b9eccbb03068141e8771165e561"
     sha256 cellar: :any,                 big_sur:        "2f38b8ec4582c16d3c19b61c10dd1bbb6668bef05284edda5c18e6defbb4a07b"
     sha256 cellar: :any,                 catalina:       "ef913d5eaaba882d6e0911524755c4fc3684be537bb224267dbd8a8c2f1d3efa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "348ca755162c5d4e1ae23c2e6afed1cc81fc17b24ab80335a2cf6f3c442f7b0d"
   end
 
   depends_on "pkg-config" => :build
@@ -34,6 +34,10 @@ class Carla < Formula
   depends_on "libmagic"
   depends_on "pyqt@5"
   depends_on "python@3.9"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/castxml.rb
+++ b/Formula/castxml.rb
@@ -12,17 +12,21 @@ class Castxml < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "7710e2667427b667c27907905a50084a3ff9466e308dd12f4825983ebd3eb0a6"
     sha256 cellar: :any,                 arm64_big_sur:  "6e21cb15925d1398805313b022281cdf61bac37d06b17768dbb736952c213813"
     sha256 cellar: :any,                 monterey:       "c12e6bf4714e1f208d6c2467ecc48c2931dd7fa2b7b74971a487ab328ce72c94"
     sha256 cellar: :any,                 big_sur:        "60dfbc11e9850fe6df0f13925173db6b6d8a349eac98c997ea70bfd28d888e33"
     sha256 cellar: :any,                 catalina:       "d46e70cbcd7bdd674c3f0595f4eace13286bdca0167a5dc11e92a8587077faef"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "89162f0cf120b5d29671c08176e408a0a7e6f62862ad7b56b8a782f2710228e0"
   end
 
   depends_on "cmake" => :build
   depends_on "llvm"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -6,13 +6,13 @@ class Cbmc < Formula
       revision: "64034e0d47f5d79b67fb22310a0e785469d24f01"
   license "BSD-4-Clause"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "0a786a1eaefab7a9b0331a27a58287dd0fdcc04249738dc578e9cc547151db41"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "3e8056ffd13c5919664209058ad2507783ff36d179f5b89aa7f3f0672604a654"
     sha256 cellar: :any_skip_relocation, monterey:       "044e86d04e53ce090d3d9c9142b1cb5bfe6891f6f2294690416a169b2da22aa0"
     sha256 cellar: :any_skip_relocation, big_sur:        "28107ea839525f15986c3c69cfe8fbeb481f93298d6d25e9825458370d38924e"
     sha256 cellar: :any_skip_relocation, catalina:       "098319a8cbb6a295d8a6db00e2ac3f4957828dedb4bdb737025c72055eea865e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bd6ac1f0e18386248a6a2621fafb7bf6bceb26492f1c9586a258b565e3ff20b7"
   end
 
   depends_on "cmake" => :build
@@ -21,6 +21,10 @@ class Cbmc < Formula
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/ccache.rb
+++ b/Formula/ccache.rb
@@ -7,7 +7,6 @@ class Ccache < Formula
   revision 1
   head "https://github.com/ccache/ccache.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "6c7df26513e64e81bd1c34bdecd3c0f244584de42861edc1a10eb47080a2f36e"
@@ -15,6 +14,7 @@ class Ccache < Formula
     sha256 cellar: :any,                 monterey:       "a850bea227e005e5eeb4a06854c3dd409939f0a05921b493c78b0c3a6a4f3179"
     sha256 cellar: :any,                 big_sur:        "fc86f696e7533bbb5c5cb10e72d508667cd0013ed42a3082eceb5608005b4906"
     sha256 cellar: :any,                 catalina:       "0f1e9ffd25cdfc59a40b4ff0d4958aebd4ef6a63ec6adf2e59c2dc741a3a5416"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5339cf0bd2c396f3aa646c0bb853b90276255d14a613c8173e888c7f630bf775"
   end
 
   depends_on "asciidoctor" => :build
@@ -23,6 +23,10 @@ class Ccache < Formula
 
   depends_on "hiredis"
   depends_on "zstd"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/ccls.rb
+++ b/Formula/ccls.rb
@@ -6,7 +6,6 @@ class Ccls < Formula
   license "Apache-2.0"
   head "https://github.com/MaskRay/ccls.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256                               arm64_monterey: "b8c13816cd75809e6ea41113e55f37c547aeba195c648c47af3863921ac85115"
     sha256                               arm64_big_sur:  "11204e506ee765088067057072547cb7b190fb466ff719d8a1de0fd0b4116a7f"
@@ -20,6 +19,10 @@ class Ccls < Formula
   depends_on "rapidjson" => :build
   depends_on "llvm"
   depends_on macos: :high_sierra # C++ 17 is required
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/ceres-solver.rb
+++ b/Formula/ceres-solver.rb
@@ -12,13 +12,13 @@ class CeresSolver < Formula
     regex(/href=.*?ceres-solver[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "c727ac20864b6d83a0ca462b57d7aa4f36119eba132565faa9c4a21eec1bf0cb"
     sha256 cellar: :any,                 arm64_big_sur:  "3319708adf812ed908c95dba4984a51f39d49f57d08e71ad2e5b2c124c433348"
     sha256 cellar: :any,                 monterey:       "ab39d83b1ae0299e88f3fc9d5b23f19c98903d6452e21b6d363966ef5f4817d0"
     sha256 cellar: :any,                 big_sur:        "d1918fe281cb00dbb2d773c03252a0d50384688c32cb1ad92510f55c37276dca"
     sha256 cellar: :any,                 catalina:       "d6a945ae9d978b449228a795cfab9ab0061920f6c73f9cb93bb0a72946f4b206"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5f095246dbff97818863a99864400c25278c6c23ee5bf42546eca75ae04f7de1"
   end
 
   depends_on "cmake" => [:build, :test]
@@ -29,6 +29,10 @@ class CeresSolver < Formula
   depends_on "openblas"
   depends_on "suite-sparse"
   depends_on "tbb"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # C++17
 

--- a/Formula/chromaprint.rb
+++ b/Formula/chromaprint.rb
@@ -6,13 +6,13 @@ class Chromaprint < Formula
   license "LGPL-2.1-or-later"
   revision 1
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "d4479962c7c30dbc07c8d4639639198e8de0015f35ce7e3ac47c5e87e492333f"
     sha256 cellar: :any,                 arm64_big_sur:  "8ce15ae4efe13275af05b62e83fbcde65644d7baee3dd4ae37fae7007396b80c"
     sha256 cellar: :any,                 monterey:       "86d59168bfd57c19029084ea626953a99976361f4d0aadcdc6d51fbda8b8ca6b"
     sha256 cellar: :any,                 big_sur:        "f9df429a357d408b65f6e1e5effc720005bb75bc10e069891acbba25430b755d"
     sha256 cellar: :any,                 catalina:       "935e7dbb82458a6dd276b3265d8df41390c6aa236cbdf4ef4287662961f5d97d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "aecf570ed20d986f95f0071c52c0cca65eb96ef6d308a60d83529b1f16984682"
   end
 
   depends_on "cmake" => :build

--- a/Formula/clazy.rb
+++ b/Formula/clazy.rb
@@ -12,13 +12,13 @@ class Clazy < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "aaaa160995aa8134003713a92fa61ccf94a2ef918b5f20cd01e646e12537f57a"
     sha256 cellar: :any,                 arm64_big_sur:  "9fbf9d700955ad17fa061447e4d4665781c4e7110f0c7214e5944710f927ce7e"
     sha256 cellar: :any,                 monterey:       "a96fce75ba8454e0fea0b4c7925e9f3c64ecd4f6332ffdc4ddc7a9fcd7c16e2b"
     sha256 cellar: :any,                 big_sur:        "d0130eecf3cffb4ecb14168f7fad810c7f11264bfd9163d67f7bdd8d2dd11aee"
     sha256 cellar: :any,                 catalina:       "b4e73e0bdaf4fd050513f2697b11bac66c8bf4d24ba6a33ec116b3447d296639"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0fdc8926cc35d4ca571c707289b6051055e625bb829b57765b880df0e84a18ff"
   end
 
   depends_on "cmake"   => [:build, :test]
@@ -29,6 +29,10 @@ class Clazy < Formula
   uses_from_macos "libxml2"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # C++17
 

--- a/Formula/corsixth.rb
+++ b/Formula/corsixth.rb
@@ -7,13 +7,13 @@ class Corsixth < Formula
   revision 1
   head "https://github.com/CorsixTH/CorsixTH.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "f4d14eb421f532a4a488e679132d306eaf9bf1ebd1b39c2e02e63fbb04bdad4b"
     sha256 arm64_big_sur:  "5beb15c7c0b6ed9f546005d5acbe37517a508e877e96321c9bf6523b3c80d367"
     sha256 monterey:       "e924cb36de87cb61b5eb08d6eaeb28b8be0c9b905cd78f78b39d5ff8a4bcb7cd"
     sha256 big_sur:        "478d7f02be8a3b833146a89f1328323c5278bed101b09e8bb8a1c3381cba07d3"
     sha256 catalina:       "38f468fe76921a98c93b6c136bfeee177abb3e5d17aaf8d0f1e885191661d065"
+    sha256 x86_64_linux:   "3adb8207f243c96478315ccee89c7869a8d9daeb6dc8e41d4fc81b5acc4d0fa7"
   end
 
   depends_on "cmake" => :build
@@ -26,6 +26,7 @@ class Corsixth < Formula
   depends_on "sdl2_mixer"
 
   on_linux do
+    depends_on "gcc"
     depends_on "mesa"
   end
 

--- a/Formula/csound.rb
+++ b/Formula/csound.rb
@@ -13,13 +13,13 @@ class Csound < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "1175c3fceb71974686a1ca92dd0ba221cbe77bcd46ea114b872b5fbf545d51e9"
     sha256 arm64_big_sur:  "08207e1b01164ee73f5570933b4522943319277074ba1f4836bbab741bf96a3a"
     sha256 monterey:       "78443a71a60eebea86219a5bfd612dc2b9fb6d4c70621b4ae83fc192e42b462a"
     sha256 big_sur:        "8b5d329857d11f3cd4fb193c212d112d16dd328433ae6dd4c7a0218822b06ec3"
     sha256 catalina:       "0b953aee205007ead4e9e69a2bbcb572b5f2d3fbf1b22e8539ca007c8628dab1"
+    sha256 x86_64_linux:   "d4bd60ac72dd39fbe4c20833d2455aeda2ef701d7fe82c4acda7dec079ee1aa5"
   end
 
   depends_on "asio" => :build
@@ -52,6 +52,10 @@ class Csound < Formula
 
   on_macos do
     depends_on "wiiuse"
+  end
+
+  on_linux do
+    depends_on "gcc"
   end
 
   conflicts_with "libextractor", because: "both install `extract` binaries"

--- a/Formula/enzyme.rb
+++ b/Formula/enzyme.rb
@@ -6,17 +6,21 @@ class Enzyme < Formula
   license "Apache-2.0" => { with: "LLVM-exception" }
   head "https://github.com/EnzymeAD/Enzyme.git", branch: "main"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "aa7aa7c7e4ff4cca33614cb03e0db9e4ab7cf1e91c0b949f1201ae10c212e401"
     sha256 cellar: :any,                 arm64_big_sur:  "2033f7f9ded57262fa9c75c320d3769024dca502b21bdcb316f58b0f50fc2ca8"
     sha256 cellar: :any,                 monterey:       "cc0790ae94df0016b810320b5d8f23c75282ad4059ea1a5cefaed6a8db5f7122"
     sha256 cellar: :any,                 big_sur:        "02b0797a44f4b369a57eb848f7d4b45676efbef344a6ec9f5eedf6fa7c371af3"
     sha256 cellar: :any,                 catalina:       "012c5cc52c4c2632b6ecac144d772c5b96d61fed28a5dc514c57c2a9aa1db2b1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e87bc8ec983abb41659e89a73b2769c03c584a9c8b3903c7b318924e434f208f"
   end
 
   depends_on "cmake" => :build
   depends_on "llvm"
+
+  on_linux do
+    depends_on "gcc" => :build
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/fauna-shell.rb
+++ b/Formula/fauna-shell.rb
@@ -7,13 +7,13 @@ class FaunaShell < Formula
   sha256 "ac7339ae28b4815958e19079221c18af0704825243b6cbdd23c5e1120df955c6"
   license "MPL-2.0"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "d33aaad33a615822bba12c72a579c4864e07e6445909495c2e80221440055b7e"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "d33aaad33a615822bba12c72a579c4864e07e6445909495c2e80221440055b7e"
     sha256 cellar: :any_skip_relocation, monterey:       "21eb180f13feb537c213825d3882642e0ede1ab87b3940fc278fc693569adf2e"
     sha256 cellar: :any_skip_relocation, big_sur:        "21eb180f13feb537c213825d3882642e0ede1ab87b3940fc278fc693569adf2e"
     sha256 cellar: :any_skip_relocation, catalina:       "21eb180f13feb537c213825d3882642e0ede1ab87b3940fc278fc693569adf2e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d33aaad33a615822bba12c72a579c4864e07e6445909495c2e80221440055b7e"
   end
 
   depends_on "node"

--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -5,13 +5,13 @@ class Faust < Formula
   sha256 "0a8170ee8e037ee62f92d71ad8a5c3c4a9bfee5a995adfc1be9785f66727e818"
   license "GPL-2.0-or-later"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "5c600c392f411bef5e594fc049fc2e900af6793f575c775d7b59fce8263b7809"
     sha256 cellar: :any,                 arm64_big_sur:  "bcd8e1b348b25fd5d86a958d4318f6fa85cb833dbe070ca624351545b431f367"
     sha256 cellar: :any,                 monterey:       "7e0ab1a5d14045a88dcf9e94732b71947e2edb3c008594e9b5bf505907354322"
     sha256 cellar: :any,                 big_sur:        "f43967cc5667cc7d6f0fd32b8c061aced93eed49b65c5350d7ab9b3be9f27833"
     sha256 cellar: :any,                 catalina:       "2fdb52829b14fb18ae8050dd595bf93841b98b82bdd40a61146f11bdc4d4021c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cc27866b889915dc0e345a0e86a637bc8ef4f3e6f270269ee2f770372cbef5e3"
   end
 
   depends_on "cmake" => :build
@@ -19,6 +19,10 @@ class Faust < Formula
   depends_on "libmicrohttpd"
   depends_on "libsndfile"
   depends_on "llvm@12"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/fbthrift.rb
+++ b/Formula/fbthrift.rb
@@ -6,13 +6,13 @@ class Fbthrift < Formula
   license "Apache-2.0"
   head "https://github.com/facebook/fbthrift.git", branch: "main"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "81a2529451702e153f85a85d4051389db175843421cef5b9622eeb03721634e9"
     sha256 cellar: :any,                 arm64_big_sur:  "3094356a0f438c1bd9ddd03543a92cde821e39eafd5ad0355fc538dd79e42ea2"
     sha256 cellar: :any,                 monterey:       "e673bed28d433e918dc372d41465284470e8cdaae5ae9d825c4f86011f53474f"
     sha256 cellar: :any,                 big_sur:        "39ebb577f1a842570337d176bf693ab2801530a5a613a1e9b4cba57fb2e9797b"
     sha256 cellar: :any,                 catalina:       "c0329e2f2bbcfbe65d6a26ea63a668fe81776a56e28796702b3c6c6a0d49c577"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "26c88cd29215c2434c0b27f266c646dd9212c985c1e907cab109c7605bf63055"
   end
 
   depends_on "bison" => :build # Needs Bison 3.1+
@@ -32,6 +32,10 @@ class Fbthrift < Formula
 
   on_macos do
     depends_on "llvm" if DevelopmentTools.clang_build_version <= 1100
+  end
+
+  on_linux do
+    depends_on "gcc"
   end
 
   fails_with :clang do

--- a/Formula/fceux.rb
+++ b/Formula/fceux.rb
@@ -8,13 +8,13 @@ class Fceux < Formula
   revision 2
   head "https://github.com/TASEmulators/fceux.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "014868c8f0454c13fb6ad090a4335c8348fc630bc95f7382b811498cf8991bac"
     sha256 cellar: :any,                 arm64_big_sur:  "530a4dd105ea8da50b1bcddc1a729b3788af6a817f8864a7af7c9bc3c1376f01"
     sha256 cellar: :any,                 monterey:       "4c5b724f4e3466dd522f875a5419a57353e9c8dd493562dc7ae35d4ff2f976df"
     sha256 cellar: :any,                 big_sur:        "e131aa7191a0a861b2b6c667bd0b42a2bb9e763e96a8e5ef6083d7083ebce88d"
     sha256 cellar: :any,                 catalina:       "7e3b7db25b0357708a66d3c8fa64599cbf0128bc4cb198842958796cce9a4e45"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d417b558825996c6281881206d0493d6ee914f38b51bedfdf7fc9dd3b66436e6"
   end
 
   depends_on "cmake" => :build
@@ -26,6 +26,7 @@ class Fceux < Formula
   depends_on "x264"
 
   on_linux do
+    depends_on "gcc"
     depends_on "mesa-glu"
   end
 

--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -13,13 +13,13 @@ class Ffmpeg < Formula
     regex(/href=.*?ffmpeg[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "d53118e4fe9d577571267572b9e383cdf5a839bb9729fbaa660cb1c84f4ee972"
     sha256 arm64_big_sur:  "2dceaa058c49ac69c70aa31f19518d3031ef8025a10d5ee29372321a37faf6ed"
     sha256 monterey:       "0248146170adb0890a1d9c131e942df5251049a46c9d8a2705712257b04df9e1"
     sha256 big_sur:        "75bf30d8436dc4469d4963126e1e765cb75257e9868f44f715a72b75785ee35e"
     sha256 catalina:       "563cfc90a7091053eff372a1504795a67c08af265ddc43b67f339b72eff3b42f"
+    sha256 x86_64_linux:   "e0088387de558b90d7f9e4953238881b1269b2953b14209f6c2f18b467b108f3"
   end
 
   depends_on "nasm" => :build
@@ -64,6 +64,7 @@ class Ffmpeg < Formula
 
   on_linux do
     depends_on "alsa-lib"
+    depends_on "gcc" # because rubberband is compiled with gcc
     depends_on "libxv"
   end
 

--- a/Formula/ffmpeg2theora.rb
+++ b/Formula/ffmpeg2theora.rb
@@ -11,13 +11,13 @@ class Ffmpeg2theora < Formula
     regex(/href=.*?ffmpeg2theora[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "fda3d3ece47a930bb675a3bfcf9bb9f9565ee64ffb8249ec1b282dc52d886b15"
     sha256 cellar: :any,                 arm64_big_sur:  "821bc4ec0b0900b41bc8236edfba9087b0637ddccbb58b60bf393f96177d6858"
     sha256 cellar: :any,                 monterey:       "c1da252c4ada9b2dc39ae83a1af5d1d2a449191173a35a2fb05c1667224fada9"
     sha256 cellar: :any,                 big_sur:        "83c525d0923c3b2b550e00b78dd6257dc4ff4ed9639464e6d360ed6784b9d09e"
     sha256 cellar: :any,                 catalina:       "33be387b709b49ebd87f07c95f396b24aabbe09dc4ee74d71067b08ae13978a9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e1e1607b67fd2b486a89e6eff86cea8f05f5715b93baef49aa839ab844f71c43"
   end
 
   depends_on "pkg-config" => :build
@@ -27,6 +27,10 @@ class Ffmpeg2theora < Formula
   depends_on "libogg"
   depends_on "libvorbis"
   depends_on "theora"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # ffmpeg is compiled with GCC
 

--- a/Formula/ffmpeg@4.rb
+++ b/Formula/ffmpeg@4.rb
@@ -13,13 +13,13 @@ class FfmpegAT4 < Formula
     regex(/href=.*?ffmpeg[._-]v?(4(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "45fe3d6bcbed4a82661897100313edef0985cbbfd31c8a26e3d0e8d0cff4ae80"
     sha256 arm64_big_sur:  "6be8e7871edbbdc8ac4ed06c30aaf0b2ce885a06d228f25b212e8133ae251034"
     sha256 monterey:       "97d4a31d4b3273635c38fd06d3dcf6476564517c8b8d25e172d97823ceb08cea"
     sha256 big_sur:        "48bd7a081bda5fa6fa355611e3a2ca7e1b58c34296df821fcaad79bd2068ecf4"
     sha256 catalina:       "1249b1db3fd4bb13354a11db67c3546f81ef74eafc0b13b671be3828a51ff903"
+    sha256 x86_64_linux:   "d7a6a6e7ed2ce7ad954f05ecd16324c79ffa6cdb7d8a1699c3b8afa6837b675f"
   end
 
   keg_only :versioned_formula
@@ -66,6 +66,7 @@ class FfmpegAT4 < Formula
 
   on_linux do
     depends_on "alsa-lib"
+    depends_on "gcc" # because rubberband is compiled with gcc
     depends_on "libxv"
   end
 

--- a/Formula/ffmpegthumbnailer.rb
+++ b/Formula/ffmpegthumbnailer.rb
@@ -7,7 +7,6 @@ class Ffmpegthumbnailer < Formula
   revision 8
   head "https://github.com/dirkvdb/ffmpegthumbnailer.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "ad656e321013d04bc23f49160bb4476411005e989921c8d2f941644ca735ed7a"
     sha256 cellar: :any, arm64_big_sur:  "469d3f0045c47ab3018a13edc8b7d2c2491e813cd91cdd471679dbf6432dd03b"
@@ -21,6 +20,10 @@ class Ffmpegthumbnailer < Formula
   depends_on "ffmpeg@4"
   depends_on "jpeg-turbo"
   depends_on "libpng"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # rubberband is built with GCC
 

--- a/Formula/fheroes2.rb
+++ b/Formula/fheroes2.rb
@@ -11,13 +11,13 @@ class Fheroes2 < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "47f4a8336778e11c7f6eb11ec2251a661d739d4d3d4ca00153942b7fd82bbe3b"
     sha256 arm64_big_sur:  "62d964a871ed55bcf12f933754bab754fe39d3af209d3740fc6a3cc40ec5cb07"
     sha256 monterey:       "a7f757ac4c2468bbab0e87359fe0116e9b15a928ec1af8117c6931a6d56af585"
     sha256 big_sur:        "5a56a45450fa2ead28aeb3e7e3d96cfb8007e326cbd25597079265a56453daa3"
     sha256 catalina:       "3585707b2f70fc524f4714362928b4ff8d90d6c9f3038faa12cfabef1fc109ef"
+    sha256 x86_64_linux:   "7b72498452c57834bdc3afe97b39f6b00b35da4d720a4faabd8afd25336f20f9"
   end
 
   depends_on "cmake" => :build
@@ -29,6 +29,10 @@ class Fheroes2 < Formula
   depends_on "sdl2_mixer"
 
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/fibjs.rb
+++ b/Formula/fibjs.rb
@@ -6,12 +6,12 @@ class Fibjs < Formula
   license "GPL-3.0-only"
   head "https://github.com/fibjs/fibjs.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, monterey:     "71a047b154c8833d08c7f1d56f148bb4123a14a03786c8e98217c49ed56da038"
     sha256 cellar: :any_skip_relocation, big_sur:      "5b94c5a2291ada6c8987b23357ea3c0be4306d2ead6caca2b236a73643947d7f"
     sha256 cellar: :any_skip_relocation, catalina:     "74a446f80b494dee49981e4fa0dc68fc1653d81ba09dbf316e5bde3100360030"
     sha256 cellar: :any_skip_relocation, mojave:       "0489b047454da54566d071fddfc011c91ca8c44620631a1aebe359c887fb65fb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "7992458fb9fc9ab2aab41cdf12f7f68896c21202c9499d9a0900b32d1dfc7dd0"
   end
 
   depends_on "cmake" => :build

--- a/Formula/gifski.rb
+++ b/Formula/gifski.rb
@@ -5,13 +5,13 @@ class Gifski < Formula
   sha256 "f9d66778d763f2391fa626261d24815799f1dfe61ce9ee0cc5637692172db29d"
   license "AGPL-3.0-only"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "ff9a703f6f1ccad514c4eed9b1f2fb54e02f245b6e765b551e1bad28fbecf870"
     sha256 cellar: :any,                 arm64_big_sur:  "7f8fb7a008f173ed43074a3c2c7aa5c48f809e92ffd88096926625ce7b8fab66"
     sha256 cellar: :any,                 monterey:       "704e3011b96b4cb7865c3fe77adaa27d849acb3ee0cf638e08817e97d34aca0a"
     sha256 cellar: :any,                 big_sur:        "b5ddc35b04a75f1e553a97c90e09a2671146ead4511e69324b4fc82c6ede8d5d"
     sha256 cellar: :any,                 catalina:       "eb5d6832ad98307405113d443144dc7632aeddb77fdb788ef5bf6c977f5bffdf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d3fd4fb52b0eb0131eb866949f7dbe3f9dd63cd23d0d04cbb4e46a424447b056"
   end
 
   depends_on "pkg-config" => :build
@@ -19,6 +19,10 @@ class Gifski < Formula
   depends_on "ffmpeg@4"
 
   uses_from_macos "llvm" => :build
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # rubberband is built with GCC
 

--- a/Formula/gmt.rb
+++ b/Formula/gmt.rb
@@ -7,13 +7,13 @@ class Gmt < Formula
   license "LGPL-3.0-or-later"
   head "https://github.com/GenericMappingTools/gmt.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "049f3bbd857920614205a7680206e97fe757e2d3ee3f69e3a84c833abc7b6a7a"
     sha256 arm64_big_sur:  "4034c75ff52c4b2c539339a2e2129f80a4b841aa65169831d24b6de81747272e"
     sha256 monterey:       "fcd2a33c09b6c4f30b208f658ec5edf9036f54c7dc7ef5fb0ea9d68610930660"
     sha256 big_sur:        "b0187d3a3888c19665c0747a1e2d0dc3fafdc3600ac5a0b5b82d3e57c5907821"
     sha256 catalina:       "49b528a8402984592297ba31dbbf3c6c2a2fb214d18f67cfbb464aee5a963025"
+    sha256 x86_64_linux:   "1dedbccfceb6e6e01a68f9725360cb5cd0d368ae02759ee06392e26991f1980b"
   end
 
   depends_on "cmake" => :build

--- a/Formula/gnuradio.rb
+++ b/Formula/gnuradio.rb
@@ -13,13 +13,13 @@ class Gnuradio < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "301fbc8b1f8b95c2097e5797d1b58677c5eb8fd6b332568cfac2a3e2e3f56561"
     sha256 cellar: :any,                 arm64_big_sur:  "f24da651f3c3dafd954b7ff78ebe013c147f2ea3e494f205e9ea22afc7a194ed"
     sha256 cellar: :any,                 monterey:       "8fb7e72f3591148a11751896eea5f52289d2101f59bcd635c2b4a74c9269437a"
     sha256 cellar: :any,                 big_sur:        "38b9564c51a22ac784cffc0ccf321187af550757575f95e64d79a9b0cb5341bb"
     sha256 cellar: :any,                 catalina:       "4756f550760246261db3dd9933d2201c75417fdfff15d9fedefabb2c9e4c76b2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "003a6f6e6cd01fd4e1d169d01695d03f2080d9197dc45ff3e6ca21616d8dbe4a"
   end
 
   depends_on "cmake" => :build
@@ -49,6 +49,10 @@ class Gnuradio < Formula
   depends_on "uhd"
   depends_on "volk"
   depends_on "zeromq"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/graph-tool.rb
+++ b/Formula/graph-tool.rb
@@ -13,13 +13,13 @@ class GraphTool < Formula
     regex(/href=.*?graph-tool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256                               arm64_monterey: "c90658944301e77bfeb51664141b52a8bc6195eebfc4806b0cca019d3b04c6c7"
     sha256                               arm64_big_sur:  "c2ea288670c08046aaf54d8b705ae7110ece6b6c77281eea710a537273e5738b"
     sha256                               monterey:       "236e817aab65a6f4c796bcf943789aa193e46e7ec4f423f938b4cbb477507886"
     sha256                               big_sur:        "cae1f9f5656e605bc5b27158416e8bb4c07a9c16edb3242b5dd4a4bb9a965f4b"
     sha256                               catalina:       "9f9c6524eb7446691924c7abe51d1144125929549723839f0ebb153d110f84c9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "58bda14067b62c15b3f62488b2532604305bf20478addd5dc3410353f92b076e"
   end
 
   depends_on "autoconf" => :build
@@ -42,6 +42,10 @@ class GraphTool < Formula
   depends_on "six"
 
   uses_from_macos "expat" => :build
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/graphql-cli.rb
+++ b/Formula/graphql-cli.rb
@@ -15,7 +15,6 @@ class GraphqlCli < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "f0032a97995c66d8f090765b11c3fc85af23a7ca389cce6f2e183508721e4039"
     sha256                               arm64_big_sur:  "2da205bbd5c76588be334a84b52dacfac9062045d605ed3f8298b7cb7b9b84a7"
@@ -24,6 +23,7 @@ class GraphqlCli < Formula
     sha256                               catalina:       "5060d007d13a695709ff9afaa16a1492d8645e17ab78ec2b14650e0c7a305e55"
     sha256                               mojave:         "212bf2d20997a930838775736ca468dc25cbd3c3978c0189f8a435873a029286"
     sha256                               high_sierra:    "d8f266f129027b1fe731c12264f7b8679c271ecdb6418cef72dba0a730e99771"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "48fc095743bddaa241e8ec367b80d06f4b742c6f5e3327c2d2f07ed941514adb"
   end
 
   depends_on "node"

--- a/Formula/graphqurl.rb
+++ b/Formula/graphqurl.rb
@@ -7,7 +7,6 @@ class Graphqurl < Formula
   sha256 "c6dfb4106d5b8b0860c0df5dffd0cc75095d280ad4841bda25a6ef0b9a75e199"
   license "Apache-2.0"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "d8f189f4e958a6f06e820be1734fcdacf427b7ae67d7230347ee05a067ac5035"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "138b68d4fffc64cd4ce86e07b618ccfa561aa15a700e8c08c66b20b65797ba70"
@@ -15,6 +14,7 @@ class Graphqurl < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "5300156ac1794e98e8e9e8f261f469ae7a6749631dfd55c8374054f425e83cb4"
     sha256 cellar: :any_skip_relocation, catalina:       "5300156ac1794e98e8e9e8f261f469ae7a6749631dfd55c8374054f425e83cb4"
     sha256 cellar: :any_skip_relocation, mojave:         "5300156ac1794e98e8e9e8f261f469ae7a6749631dfd55c8374054f425e83cb4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c0c19d5f82887b811d0b9f5cdaad5efcfb8da33e970c253af8af63faae597f02"
   end
 
   depends_on "node"

--- a/Formula/groestlcoin.rb
+++ b/Formula/groestlcoin.rb
@@ -6,13 +6,13 @@ class Groestlcoin < Formula
   license "MIT"
   head "https://github.com/groestlcoin/groestlcoin.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "8bccdc0813d7919a5234933088b4bba0905444d3e01c61edea1cd8da300698d3"
     sha256 cellar: :any,                 arm64_big_sur:  "2a3beec995b7397d1bdae6c85c84d04cd3a6073d4513d1e3d75e65b882301fc5"
     sha256 cellar: :any,                 monterey:       "c4833ca54a9cfc86b354ad5d9ebe4e0222b08270b629da53fe3f181690562e40"
     sha256 cellar: :any,                 big_sur:        "bc3d72136cdc501ebb45737c857a5846f2810001fdfbeecec8f6f46c96c31e8c"
     sha256 cellar: :any,                 catalina:       "45e2c1608558470482b260f7ee9dc8439dfacdbb98c6fd14d548ee139cbe698a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c9d90eedf379fc2c28e9dc89ef5f562630146dacd6a9017ee4c85278eff0c5d1"
   end
 
   depends_on "autoconf" => :build
@@ -28,6 +28,7 @@ class Groestlcoin < Formula
 
   on_linux do
     depends_on "util-linux" => :build # for `hexdump`
+    depends_on "gcc"
   end
 
   fails_with gcc: "5"

--- a/Formula/grokj2k.rb
+++ b/Formula/grokj2k.rb
@@ -11,13 +11,13 @@ class Grokj2k < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "170f081aa1ef55cdc4069a72a7bda2444c4de2613f74d8544984693336234558"
     sha256 cellar: :any,                 arm64_big_sur:  "a27907174c61509e3acbb630a3b477ca17ae718e35be464d64339a5b404c8235"
     sha256 cellar: :any,                 monterey:       "eac8d5c35074aa79606d23643dfce579e5ac817aeb55a5f8aa6e7e3f3ab54bec"
     sha256 cellar: :any,                 big_sur:        "6fcd4632599e9119d23d900a864d5f9065a797f2cd18e567d660aafc513dc014"
     sha256 cellar: :any,                 catalina:       "d60b4de529b9bb09b69e69be0b25ffde2d697dd42ba5ba09afb9ea9a06b505af"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "35b19ec573881184b88a8e165d4a693effcdaf6c5148a110debecbd2a4c2ae08"
   end
 
   depends_on "cmake" => :build
@@ -36,6 +36,10 @@ class Grokj2k < Formula
   on_macos do
     # HACK: this should not be a test dependency but is due to a limitation with fails_with
     depends_on "llvm" => [:build, :test] if DevelopmentTools.clang_build_version >= 1205
+  end
+
+  on_linux do
+    depends_on "gcc"
   end
 
   # https://github.com/GrokImageCompression/grok/blob/master/INSTALL.md#compilers

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -16,13 +16,13 @@ class Grpc < Formula
     strategy :page_match
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "411cb6fee11f213c11a70ee53df501c678ecaf0f6e6175c47a2bb96af6f3bb4d"
     sha256 cellar: :any,                 arm64_big_sur:  "155c7aa6a2e27a8ad7e0bb0fef2cac926aa813e7b72e9aaf52e5c302f4a8306c"
     sha256 cellar: :any,                 monterey:       "af1af10670b534d46aff09659eb027289663c023a20ae7d7c1bda5afa86c2d87"
     sha256 cellar: :any,                 big_sur:        "2253e27ef584c9f31b4c913da871332ea2e8492766c95d1aa1e11bc1cd9126d2"
     sha256 cellar: :any,                 catalina:       "987c9bb65a74af1dc4fe52dc3a9ef743cae482a8324d1c3c9978bf471c2ead12"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "00a0ab3614637d6573db1303d16bfe390f3ad69d7923d4b7fd53e1d86e6881a0"
   end
 
   depends_on "autoconf" => :build
@@ -42,6 +42,10 @@ class Grpc < Formula
     # This shouldn't be needed for `:test`, but there's a bug in `brew`:
     # CompilerSelectionError: pdnsrec cannot be built with any available compilers.
     depends_on "llvm" => [:build, :test] if DevelopmentTools.clang_build_version <= 1100
+  end
+
+  on_linux do
+    depends_on "gcc"
   end
 
   fails_with :clang do

--- a/Formula/grunt-cli.rb
+++ b/Formula/grunt-cli.rb
@@ -7,7 +7,6 @@ class GruntCli < Formula
   sha256 "c7ffc367ad7d019ef34e98913dfdbcf05dcf03f2e32dc88fba8f650b1dae83bd"
   license "MIT"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "38f67054b492a11847be41d443b32c017fdbb9b94265ce42299675ea8742ef99"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "8eafad607c94848c1bd74eca2a52b92533f399247c85d4de923ff12367ce2cda"
@@ -15,6 +14,7 @@ class GruntCli < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "e1be76f2bb72f2cc111627400cf586487b8515a0051b96c4d8138da773d1ac73"
     sha256 cellar: :any_skip_relocation, catalina:       "e1be76f2bb72f2cc111627400cf586487b8515a0051b96c4d8138da773d1ac73"
     sha256 cellar: :any_skip_relocation, mojave:         "e1be76f2bb72f2cc111627400cf586487b8515a0051b96c4d8138da773d1ac73"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b45f26c253f18a68abd0e318d4a5634d371cace863b5b086fc8187d05ee5f5f7"
   end
 
   depends_on "node"

--- a/Formula/gst-libav.rb
+++ b/Formula/gst-libav.rb
@@ -11,13 +11,13 @@ class GstLibav < Formula
     regex(/href=.*?gst-libav[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "fc2fb6970dcc2e153b11d6cd53bbb61216aeb19398de18727ca75ecae450313b"
     sha256 cellar: :any, arm64_big_sur:  "99c1537bd90d255df9e4e92a90037b24a57beeb51ab44daf590dfe3a45a1b801"
     sha256 cellar: :any, monterey:       "d09097cb0f504f0e6da37f125078bc171a1923de817261f16fd3ca086f3b557c"
     sha256 cellar: :any, big_sur:        "a016cd9ef794ed2c9281c1e30f8052a59d47d21641bd083721b0cfa88bbf1db6"
     sha256 cellar: :any, catalina:       "acf202daebcfd054d1f226797c562ec8dcb610b9e5794a1548df4cd4afa89357"
+    sha256               x86_64_linux:   "4b36f679caf58d93cd3434c7c517809ac57a3353571c2ee2e436d83bb76ef3d8"
   end
 
   depends_on "meson" => :build
@@ -27,6 +27,10 @@ class GstLibav < Formula
   depends_on "ffmpeg"
   depends_on "gst-plugins-base"
   depends_on "xz" # For LZMA
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # ffmpeg is compiled with GCC
 

--- a/Formula/gtop.rb
+++ b/Formula/gtop.rb
@@ -7,13 +7,13 @@ class Gtop < Formula
   sha256 "5bd04175c5d075b58448cf4fff3a2c6a760e28807e73f4a8f1ab0adf14d7c926"
   license "MIT"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "f7bfefab47efb569bebb4e3c5ee45159c8f26aaf6fda49b74015bdc665be8dcf"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f7bfefab47efb569bebb4e3c5ee45159c8f26aaf6fda49b74015bdc665be8dcf"
     sha256 cellar: :any_skip_relocation, monterey:       "bd9f489110a6841a2306afef5b77e160e34e650a1fc63978698d54a982358a8b"
     sha256 cellar: :any_skip_relocation, big_sur:        "bd9f489110a6841a2306afef5b77e160e34e650a1fc63978698d54a982358a8b"
     sha256 cellar: :any_skip_relocation, catalina:       "bd9f489110a6841a2306afef5b77e160e34e650a1fc63978698d54a982358a8b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b8a49fe170889400a5976142f6131b06f4f3d0f366a9c821beac1997f29be6f7"
   end
 
   depends_on "node"

--- a/Formula/gulp-cli.rb
+++ b/Formula/gulp-cli.rb
@@ -7,7 +7,6 @@ class GulpCli < Formula
   sha256 "0a5a76e5be9856edf019fb5be0ed8501a8d815da1beeb9c6effca07a93873ba4"
   license "MIT"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "8ea471114a8812cf87daaea09ea00dc61297ac35c4227372a9c68aaa04ed1901"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "fc2ba1fab80c6b58a6f916e317141e155369834a16526ce271758f46384813a5"
@@ -16,6 +15,7 @@ class GulpCli < Formula
     sha256 cellar: :any_skip_relocation, catalina:       "231b635ddf8a704a3be4a6ba34611248ece69ed1de04fb82adfa6a20ac83fddb"
     sha256 cellar: :any_skip_relocation, mojave:         "29ec2f9cf132be84c577ff6d6ea02845ee96d995e1affdea8961903f9fec616a"
     sha256 cellar: :any_skip_relocation, high_sierra:    "e4d363c9d5035fc814ca6a6820b9c8c35a320cd507067cad5eb0c0e6c337c36e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bdba5b8c37fcd4ade1460d72bc881e345b2eafbfaa0f84a57aeb19479abcaeba"
   end
 
   depends_on "node"

--- a/Formula/haxe.rb
+++ b/Formula/haxe.rb
@@ -21,13 +21,13 @@ class Haxe < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "ebb6b5472bc7408ce268e357651c2b123abaa2f614260f88838a149289423499"
     sha256 cellar: :any,                 arm64_big_sur:  "380f0f1f640c3f4919d272a4648b2d04fb3afd93820003cec19b9f54be1cba75"
     sha256 cellar: :any,                 monterey:       "8cdccc4df05e252d1094ecad90a97ea898659a5017b9c61c6a157629887e68ad"
     sha256 cellar: :any,                 big_sur:        "dcb8925b9b647939dbf5abbd2ba150f26f581a525fbf8e9c1ce369de58bb6adc"
     sha256 cellar: :any,                 catalina:       "21ddb930758328523200f2ef95d7639bfe32ca1a94a9861972a721b0c96ab968"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cce4723939b40c48dfb88f1ef06cf967aa5bb76a033a774eb207c72bb93abf12"
   end
 
   depends_on "cmake" => :build

--- a/Formula/highlight.rb
+++ b/Formula/highlight.rb
@@ -11,18 +11,22 @@ class Highlight < Formula
     regex(/href=.*?highlight[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "caf613faeea04598af9f40e33f0035584250cb690bd2747374b932a562f16f04"
     sha256 arm64_big_sur:  "4334f3d71cd6c4e5b452154f7b9d1386d921afc9805bcbafd18c4a945a88dbac"
     sha256 monterey:       "f9fd20137f1c3bba43234e0d1ef181ff37001e226f4887d1c168be726c989514"
     sha256 big_sur:        "2cf01ec552ef0d2367aa9aecd1606cbee37c17e009bd72e371f8375e416d2a3f"
     sha256 catalina:       "5bb748bd4cdc0211a157d2a846bb2921cda8c35a3c2508acb17290a376b66010"
+    sha256 x86_64_linux:   "e60a62a021aee25dd40cd2fed076a7700f8a943da70927a0d4fd934945b69245"
   end
 
   depends_on "boost" => :build
   depends_on "pkg-config" => :build
   depends_on "lua"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # needs C++17
 

--- a/Formula/icemon.rb
+++ b/Formula/icemon.rb
@@ -6,7 +6,6 @@ class Icemon < Formula
   license "GPL-2.0-or-later"
   revision 1
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "3bdc990f8c84ac25b6f68859b54423b26425d08d40b0b91d2dc034b248e8a73a"
     sha256 cellar: :any,                 arm64_big_sur:  "f310aad5e98a7cf3c6fca8a1ddcda9af425cb7b442512b5c540619de0312cb60"
@@ -14,6 +13,7 @@ class Icemon < Formula
     sha256 cellar: :any,                 big_sur:        "8db3861063efc1a5e53703b41993328968aa637ae4fed60112ac8ff4e364a422"
     sha256 cellar: :any,                 catalina:       "6a80f6cbc858fbc942c5845492ca6bfefdf2dd4f0746f97e28704301585f19aa"
     sha256 cellar: :any,                 mojave:         "34f8c691f2c2d23fc65bc84429f0282c96d47f88036ada6d6f44761287a88441"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8cf76a2e17950f37348b0f29c0f0ac228fa483c432c16240edb5b70b3002dc6d"
   end
 
   depends_on "cmake" => :build
@@ -23,6 +23,10 @@ class Icemon < Formula
   depends_on "icecream"
   depends_on "lzo"
   depends_on "qt@5"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/imagemagick.rb
+++ b/Formula/imagemagick.rb
@@ -11,7 +11,6 @@ class Imagemagick < Formula
     regex(/href=.*?ImageMagick[._-]v?(\d+(?:\.\d+)+-\d+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "59b175f274e796a0f426c09fd4bfbd6a2def28ed23e2c80c2dca36d16dd44d71"
     sha256 arm64_big_sur:  "ff67c8a22b12c2e9499981142fcbdd399ed6a49d86eb14b0cae8fb879551c590"
@@ -46,6 +45,7 @@ class Imagemagick < Formula
   end
 
   on_linux do
+    depends_on "gcc"
     depends_on "libx11"
   end
 

--- a/Formula/ispc.rb
+++ b/Formula/ispc.rb
@@ -6,13 +6,13 @@ class Ispc < Formula
   license "BSD-3-Clause"
   revision 2
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "5a5fc37bbdf6fcbb4fba27258c45375a26eea734edcbecae41715a990b989d99"
     sha256 cellar: :any,                 arm64_big_sur:  "f69fc55e33fd45a8bd12da6c97604f4f72c043e03cbca2f11095d0d46a638c16"
     sha256 cellar: :any,                 monterey:       "17bffc3892dd6cce820a77585f04f6b3edb3394ccd76104b7e0b5243c2e1c40a"
     sha256 cellar: :any,                 big_sur:        "25c32b978928b322c5742da89ce024016daefbba49e4b9fb63d70073756bd914"
     sha256 cellar: :any,                 catalina:       "8fce16395de7f76c88eae707da678b1bf63c39f6768e3404b87749ae081ab99e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "97be3aa73e6249c6b65a4352f37a2157fa660a027292ab57c2850432e82a8376"
   end
 
   depends_on "bison" => :build
@@ -20,6 +20,10 @@ class Ispc < Formula
   depends_on "flex" => :build
   depends_on "python@3.10" => :build
   depends_on "llvm" # Must be LLVM 13
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/jpeg-xl.rb
+++ b/Formula/jpeg-xl.rb
@@ -6,13 +6,13 @@ class JpegXl < Formula
   license "BSD-3-Clause"
   revision 1
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "a603bfaffbd444d11e882f8d72beaf3833cbf91473c4bb8c964c00bd94b07d65"
     sha256 cellar: :any,                 arm64_big_sur:  "d1ba28b49a63312dd1632bfe5a5fd2dfe91c5ca8f3d4c5961ea61a65f5c96834"
     sha256 cellar: :any,                 monterey:       "e310aca584c333e593054342050241e58b88676c408aedd5442a317f10597870"
     sha256 cellar: :any,                 big_sur:        "797bd4ddd8716f8feaf99d725c832b616273a49cb0ed779c10e90d8bebc359bf"
     sha256 cellar: :any,                 catalina:       "946101b747602ef79712852a3fdb0517cb0c6341c485639aa9b65dbae67649fb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "362eb1bd31e6f791f8e8ff44290932c87ed0652d941c71bc1f3fca3559a60538"
   end
 
   depends_on "cmake" => :build
@@ -27,6 +27,10 @@ class JpegXl < Formula
 
   uses_from_macos "libxml2" => :build
   uses_from_macos "libxslt" => :build # for xsltproc
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
   fails_with gcc: "6"

--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -11,13 +11,13 @@ class Kakoune < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "04ba0d6fed5371d8f5012cb0731be90a011cf05dabcffaa51b467117dcf62275"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "edc941221942a73d79767e254798319842b1849988706e0c41deaaa65c0f3407"
     sha256 cellar: :any_skip_relocation, monterey:       "6361db56b495a4be2855981c95bcfa0ed81ec0e63aace99b6fa06e9340d4ca28"
     sha256 cellar: :any_skip_relocation, big_sur:        "95949d504b4b3d6c87bd4e3cf0e391b3a346ee0166187cf8b43945dd3e6cb826"
     sha256 cellar: :any_skip_relocation, catalina:       "0bf1d69af4e88dd3e7c441c77bbc9ea5f211205883f9a02914b4590035f616e2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2fa06946316f28a0375d5d883b45c899775f9aacff98e13bc8bca7d4721d336e"
   end
 
   depends_on macos: :high_sierra # needs C++17
@@ -29,6 +29,7 @@ class Kakoune < Formula
     depends_on "binutils" => :build
     depends_on "linux-headers@4.4" => :build
     depends_on "pkg-config" => :build
+    depends_on "gcc"
   end
 
   fails_with gcc: "5"

--- a/Formula/kdoctools.rb
+++ b/Formula/kdoctools.rb
@@ -18,13 +18,13 @@ class Kdoctools < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "5a601f32bffe4dc8e216a93dd2f2b861e4b663770fc9868bf62a83d611d91143"
     sha256 cellar: :any,                 arm64_big_sur:  "155b77b3477dd88469faa9bf40b46216a97b7995ed914f9cf0ae896a961994e1"
     sha256 cellar: :any,                 monterey:       "def28a011b015afae3dc352fa8f48fb58eea76822bea22de7b47fa328773319b"
     sha256 cellar: :any,                 big_sur:        "17dab58fd1c185c2bb201d305e1f395a5e1dfd1d7f173d958fb0a186ca21e4d9"
     sha256 cellar: :any,                 catalina:       "936ca4a58e5cc12ff1ea0ae2d6ebaacd57902e40a5b07e248dc36bfa8dd54119"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a24f2f3cd23d1e603b1905372ac8158db06267cb0b011ab60b0e21e0a0357ee3"
   end
 
   depends_on "cmake" => [:build, :test]
@@ -39,6 +39,10 @@ class Kdoctools < Formula
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
   uses_from_macos "perl"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/kitchen-sync.rb
+++ b/Formula/kitchen-sync.rb
@@ -11,18 +11,22 @@ class KitchenSync < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "b090e8487ec4755755e726638f6d23e1146c63bab3abdca1abfd9eb5729a9c9b"
     sha256 cellar: :any,                 arm64_big_sur:  "b66ded8959d88193f30ed3bd7cb3dfbf81316f6cbef82e77fda85e227772cb40"
     sha256 cellar: :any,                 monterey:       "5106166e0e08e91b0703c38bce5e864cefd09ce016f91e989a895daa22c4796d"
     sha256 cellar: :any,                 big_sur:        "d02d2abaf4098fb1fa07bcf8a28193ebb762409a010d20be595706205d69a886"
     sha256 cellar: :any,                 catalina:       "d452e4f3e29836a4919108df9209af24a58562c77dadc46e47900fd63c78e840"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a073dc3cf0f4db1a641de2931020ef4f27a4db5416e907ed53233ddd937a5f37"
   end
 
   depends_on "cmake" => :build
   depends_on "libpq"
   depends_on "mysql-client"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/klee.rb
+++ b/Formula/klee.rb
@@ -18,13 +18,13 @@ class Klee < Formula
     end
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "6a31c472578a5aa4b679654b8df2da201e27089fa22a26e41bc159db3a2cbc78"
     sha256 arm64_big_sur:  "523865bd65c97e2b4a82dea38d394b32fef36bfce275b156357b092c78fdaa44"
     sha256 monterey:       "dcee52e30664b74d8be8b6a6c5916b8e617af263f4b17a16185490e550459adf"
     sha256 big_sur:        "5faee0cd2b6385f27c247ddda8909f210cb33c1aba4a88fb5c538e13e1a0f71c"
     sha256 catalina:       "a5390272bbd5454688b7014cc422b48dbbc38333d7592a76a3defd45403d5448"
+    sha256 x86_64_linux:   "03e64c52ceb8a2a660d2c01b78ecbcab730b7cfe9da438c28d83f917937a6095"
   end
 
   depends_on "cmake" => :build
@@ -39,6 +39,10 @@ class Klee < Formula
   depends_on "z3"
 
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/lanraragi.rb
+++ b/Formula/lanraragi.rb
@@ -8,13 +8,13 @@ class Lanraragi < Formula
   license "MIT"
   head "https://github.com/Difegue/LANraragi.git", branch: "dev"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "5aa823c1f1838e971751b56f2a3cd42bd815c9513b13d327e432e9017570b970"
     sha256 cellar: :any,                 arm64_big_sur:  "2e1ef247998188562bc78cfef1689cbee1134cd834280fd243a0c1452b1a28aa"
     sha256 cellar: :any,                 monterey:       "aa53aeb1ec9499a301c79f7011e3b228655ebe4c03e19de3f935478da467d969"
     sha256 cellar: :any,                 big_sur:        "879f9384947c8453d3c803edf591f2c61decab4a5d39d4205c3db799d2ce2d23"
     sha256 cellar: :any,                 catalina:       "44bb28ad1890524464db94ca26c07c838bf287c6ba784d6d60ddef7645552b16"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2a80e239000c32a4f07b7aebc708bca123526653e5e995841eee6de002b4ffd9"
   end
 
   depends_on "nettle" => :build

--- a/Formula/lc0.rb
+++ b/Formula/lc0.rb
@@ -7,13 +7,13 @@ class Lc0 < Formula
   license "GPL-3.0-or-later"
   revision 2
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "2d8bfca5ebff386f71840281f15ec3c04e2436f1fcb3529ce1eb5d10facbc9db"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "bdc7f840a570db9c0f54a5055091fd16ab04399b68381d05e75071d5c61fd8e9"
     sha256 cellar: :any_skip_relocation, monterey:       "97af5c15368b7ccc506055dd37a7dabefb3fa437eafe3326b7c9a094ae6583f1"
     sha256 cellar: :any_skip_relocation, big_sur:        "981faff9f38f2d4d40ea716e837f8ba45ea63dc627f80078af043110074204b0"
     sha256 cellar: :any_skip_relocation, catalina:       "bb01f65bcf9aa37e511b8235ffd2108dcc9176a4a6ab1c20eca909eb0f8146bd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fbe3c6e9c3e92df13902470ddae27d1cc2cebc26d395b5be01a82465ec940575"
   end
 
   depends_on "cmake" => :build
@@ -26,6 +26,7 @@ class Lc0 < Formula
   uses_from_macos "zlib"
 
   on_linux do
+    depends_on "gcc" # for C++17
     depends_on "openblas"
   end
 

--- a/Formula/ldc.rb
+++ b/Formula/ldc.rb
@@ -11,13 +11,13 @@ class Ldc < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "703a1b7cc6dea61112183cbc21cd77faf686a7527b105bb61db7e3d92c0bd6a6"
     sha256 arm64_big_sur:  "660bc67a5e12896a19427be2f39d58fad9f2c78d3f5948792706d20e80f351db"
     sha256 monterey:       "c2b1c19deb39e815c8f1ddf0f8f1fdab63e849e6777c7e3e092399f3891110b1"
     sha256 big_sur:        "c3fbdc34a89752a66e633ace1416e4f31eec1e4067f37d2cd12855323a068e15"
     sha256 catalina:       "574931fec5e3746c83d7fb67a25af715d8c51efde11f70a48d037abecf2824ea"
+    sha256 x86_64_linux:   "7e532a02f6949cfc57355eb5c35b0f438e955db551dd5a98833d621be58a51fd"
   end
 
   depends_on "cmake" => :build

--- a/Formula/leapp-cli.rb
+++ b/Formula/leapp-cli.rb
@@ -7,13 +7,13 @@ class LeappCli < Formula
   sha256 "408d06dfbf5291f6eda330dcfb6ab6c1f5e4f069f46a22aa3f5bab5808b4daea"
   license "MPL-2.0"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256                               arm64_monterey: "fa76e24aed7da3f084585c75eefd0f8a0bed353af3fe33132f780bdfb11a5690"
     sha256                               arm64_big_sur:  "b88501ffd2707219fb17ad2b2b6a85aadb9704f668449fa90eb6e051803e65fd"
     sha256                               monterey:       "88e4b93484bfc687d1a39dd1df019d9d83147a611f76e1ca1bb17346a45e609d"
     sha256                               big_sur:        "272674d4d72f9cccb475660f4eb86284bc2a8979dfb2ebe22b21406e31ef20a4"
     sha256                               catalina:       "0f5ac650baca5b1719aea5b4b1c45e45866b5870ebae34a39b62edcc5e5dff1e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e128d28688834ccea232695b4d748a55c46dc1d0bb4bb66871f09210fce7a79f"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/lerna.rb
+++ b/Formula/lerna.rb
@@ -7,13 +7,13 @@ class Lerna < Formula
   sha256 "96a2982e085ac6aa6966a71a615143f37ca923b80eb79c232cafcfe2594f8b2e"
   license "MIT"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "3c83fd1b45bedae4abee157231b5fe78331ac14948e3e99c183a71eda10ce4d0"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "3c83fd1b45bedae4abee157231b5fe78331ac14948e3e99c183a71eda10ce4d0"
     sha256 cellar: :any_skip_relocation, monterey:       "a6c8f333fd0d643184f63379826daf456f29566fd754393fd3330837abf93d6a"
     sha256 cellar: :any_skip_relocation, big_sur:        "a6c8f333fd0d643184f63379826daf456f29566fd754393fd3330837abf93d6a"
     sha256 cellar: :any_skip_relocation, catalina:       "a6c8f333fd0d643184f63379826daf456f29566fd754393fd3330837abf93d6a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3c83fd1b45bedae4abee157231b5fe78331ac14948e3e99c183a71eda10ce4d0"
   end
 
   depends_on "node"

--- a/Formula/libmwaw.rb
+++ b/Formula/libmwaw.rb
@@ -5,17 +5,21 @@ class Libmwaw < Formula
   sha256 "e8750123a78d61b943cef78b7736c8a7f20bb0a649aa112402124fba794fc21c"
   license any_of: ["LGPL-2.1-or-later", "MPL-2.0"]
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "8e8b9c289bfacec49f6698fb9b3024c92b86e89d6712069112faf4e777616b45"
     sha256 cellar: :any,                 arm64_big_sur:  "6079d619891c7379f984bb8e9c50f090183ee97fc291bbbcf354b7e73cf334ab"
     sha256 cellar: :any,                 monterey:       "ec17c3a3d8014901bb3dedca4c2d532c8f343c28f39130d49ac29c88b5dd47e6"
     sha256 cellar: :any,                 big_sur:        "81fab7be2a6f5352ab9757cfa5a93827debc0a0469897a4b28922ca31a53fba5"
     sha256 cellar: :any,                 catalina:       "98c7ef307cac9580e285a6c871b392cc7e67036906ff8565d55bbb5c6498850a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8853b2f34f3f561be4cef972c911697afd90e1404207f73f782cb113cb0e4ec9"
   end
 
   depends_on "pkg-config" => :build
   depends_on "librevenge"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/libopenmpt.rb
+++ b/Formula/libopenmpt.rb
@@ -11,13 +11,13 @@ class Libopenmpt < Formula
     regex(/href=.*?libopenmpt[._-]v?(\d+(?:\.\d+)+)\+release\.autotools\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "ae0ff7a657ec01c58021a43af5b329c475f0aca41a3fbd7732a9f796321a85b8"
     sha256 cellar: :any,                 arm64_big_sur:  "87abd6b76d93a0ba472036c8c1f28635ea3d24b7976ca6a9920cfb2011167dfa"
     sha256 cellar: :any,                 monterey:       "4838e76c64ca27cdf6cdc81ca9e9a5250605f2dfe7bd79a027e985429462a6d6"
     sha256 cellar: :any,                 big_sur:        "793c68af688bf11d6d9fd8657cdcc8ac91da8023112187b6e83a271c78c91dc4"
     sha256 cellar: :any,                 catalina:       "8eae0f6145e36a73818c516a9ed0099428e467057f3224623b03df47b9c759d4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "446de3b35d25cf8a71bcac2b8466c1ad96f9a41c5b641e2b1921e7ceb6337e5b"
   end
 
   depends_on "pkg-config" => :build
@@ -32,6 +32,7 @@ class Libopenmpt < Formula
   uses_from_macos "zlib"
 
   on_linux do
+    depends_on "gcc"
     depends_on "pulseaudio"
   end
 

--- a/Formula/libsigrok.rb
+++ b/Formula/libsigrok.rb
@@ -26,13 +26,13 @@ class Libsigrok < Formula
     regex(/href=.*?libsigrok[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "ddd492d738a66664c99658808dbd0770369a86498ad4c084967bd3d9c07ea009"
     sha256 arm64_big_sur:  "a1632041336ea122f3b66426e1fb7ec38acb0f5fefa974afe11bce598fd5f271"
     sha256 monterey:       "58f1ac6b7e1ac50257660ddcc1b879d75390b2de4b6c38f12496914f42a57348"
     sha256 big_sur:        "85145a60cbb7282c1338d9214d91489ef58a409d6884ec9ed55e854634e2dde4"
     sha256 catalina:       "690126f07d977fe9ae4beb754073405279f35fdcb874b4a10cf7c087a1e9ac01"
+    sha256 x86_64_linux:   "255ef573fec2d17e6a693711db00744e0a0440a060b1db430b00fa638b993bc5"
   end
 
   head do

--- a/Formula/libspectre.rb
+++ b/Formula/libspectre.rb
@@ -11,13 +11,13 @@ class Libspectre < Formula
     regex(/href=.*?libspectre[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "de303c8dc164622e39d9091dbe666b508616d85701a1f41382e80cb0f7ee3092"
     sha256 cellar: :any,                 arm64_big_sur:  "e94302c8cda17fbcdc68e912d5ed673572f6c08812b582db9bebdbc3fc837945"
     sha256 cellar: :any,                 monterey:       "cc40497e1a32f03ef88145402e4b1c8c4ffb0c6686ca1c6777819be09e4065e8"
     sha256 cellar: :any,                 big_sur:        "27e180a019179942a0131eac3f8a52422194af080313ea730390624a8ab83e28"
     sha256 cellar: :any,                 catalina:       "125aaff11e8e92efdd6159d21133689ba8af9d3f13208994850ce4f8a7e7a9dd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5ec70453fc82893b76d4e4c57585d582b99fde8b8f3340df02c580a04f494192"
   end
 
   depends_on "ghostscript"

--- a/Formula/libzdb.rb
+++ b/Formula/libzdb.rb
@@ -11,13 +11,13 @@ class Libzdb < Formula
     regex(%r{href=.*?dist/libzdb[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "a984ed34d47824121c308a122c397e06429fa80db31c5511de5dbd38a5a12ed7"
     sha256 cellar: :any,                 arm64_big_sur:  "82e9b70755a848d0d9386c42ff2e771a2acdad6d2497251d6dd9d0b96a26edf9"
     sha256 cellar: :any,                 monterey:       "406b423b65940127d9d6ba6c7d20c5926be12a1445539e40e376e746e19323e5"
     sha256 cellar: :any,                 big_sur:        "75c8ff67e93358dc8733bc0505b7a2a7f18be1da23bdbf1c19e97de60c03cf08"
     sha256 cellar: :any,                 catalina:       "4ae11691a08964b1c88aaded3dc7d9c7b5ac47cf2389fa790e76aa48c874497e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "abb34c1e09a5fbac337d3eaa3b722bf51824ae2a811712e29b2f2dfc01444f52"
   end
 
   depends_on macos: :high_sierra # C++ 17 is required
@@ -25,6 +25,10 @@ class Libzdb < Formula
   depends_on "openssl@1.1"
   depends_on "postgresql"
   depends_on "sqlite"
+
+  on_linux do
+    depends_on "gcc" # C++ 17 is required
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/llvm@13.rb
+++ b/Formula/llvm@13.rb
@@ -14,13 +14,13 @@ class LlvmAT13 < Formula
     regex(/^llvmorg[._-]v?(13(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "0871109ada8b7b50a210dabb9f354e922ea73b087678cd06849268f1f5cfee71"
     sha256 cellar: :any,                 arm64_big_sur:  "f7231cd86d1ec1f3bfebc586d793565b395fea673287cd62de05212b03972e7d"
     sha256 cellar: :any,                 monterey:       "60ac0ca7260352e807e08591b29423c915971f0e7f1e8532af25b8986848466f"
     sha256 cellar: :any,                 big_sur:        "6089883fc0032bef65d597648758f12c7497e62400f66cecb363be2eb93407a1"
     sha256 cellar: :any,                 catalina:       "bfae7889794444e19c8cca3d1da40a6461c86a0defa8c3378f87932a05fc72bb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "139453f124f5e88c575bfc0fdf9c3582ccbc074e5ffb8750d07b34f1492b98b3"
   end
 
   # Clang cannot find system headers if Xcode CLT is not installed
@@ -46,6 +46,7 @@ class LlvmAT13 < Formula
     depends_on "pkg-config" => :build
     depends_on "binutils" # needed for gold
     depends_on "elfutils" # openmp requires <gelf.h>
+    depends_on "gcc"
   end
 
   # Fails at building LLDB

--- a/Formula/lnav.rb
+++ b/Formula/lnav.rb
@@ -10,13 +10,13 @@ class Lnav < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "19feba2a42503e1bddbc247e2d6c72e59ccf4cdb25f8ef18fef050e054d4eb89"
     sha256 cellar: :any,                 arm64_big_sur:  "d162151f7043144d24b47c6ae23b61cdbb71959b5c77bba016e0f3d538dc432b"
     sha256 cellar: :any,                 monterey:       "eab9bc062c791cf77864916cc055b281b593d153c5afd165171fb554203ecd67"
     sha256 cellar: :any,                 big_sur:        "57dcbc897e03444f03e78e2fbeaf9c20c65b8b4ba93c759da5118b206007fe04"
     sha256 cellar: :any,                 catalina:       "c137529abc15c63b8e4d865f433712355b5f6fc750ac76c177f805cb7813dd44"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bd04107f50f8d01f00f476ad87ae8228416f81a3124e0a3d64948d7fd2d695fc"
   end
 
   head do
@@ -31,6 +31,10 @@ class Lnav < Formula
   depends_on "pcre"
   depends_on "readline"
   depends_on "sqlite"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/luau.rb
+++ b/Formula/luau.rb
@@ -6,16 +6,20 @@ class Luau < Formula
   license "MIT"
   head "https://github.com/Roblox/luau.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "a8929ad274e7e292afe92af6d448d705014b57751b49a0d9adc09a79147d5993"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ffa1b7e0bd5950a4b1bbf517504ad2abf51e391c33c3fcb7c00f5512bd74414c"
     sha256 cellar: :any_skip_relocation, monterey:       "b41e5884b3e79b93393cd273cc979446c5601b67b6240763f18e24583ad2bf58"
     sha256 cellar: :any_skip_relocation, big_sur:        "0d628a2a984d3fbf4e3e1052197c10ddd2d7c64f6c2d5b52e50b87b620e02f55"
     sha256 cellar: :any_skip_relocation, catalina:       "ba017f42bc41e4aed5a0f162e28cf7a61cdd4b62ff0eeef6068124837088d87a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "eb9a6efef8f413eeb62656ac510c9dcd0644012ac7c3557010a4057b7c987599"
   end
 
   depends_on "cmake" => :build
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/mame.rb
+++ b/Formula/mame.rb
@@ -17,7 +17,6 @@ class Mame < Formula
     regex(/>\s*MAME v?(\d+(?:\.\d+)+)/im)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "1f535fd38e2b1aaa0851d5a5172dfd05f0d28f2666c09f8ff8c110222967d69d"
     sha256 cellar: :any, arm64_big_sur:  "69b5929e7463eb31a3b73010e922587caa1f090f6858e59511b68107a303e7c6"
@@ -46,6 +45,7 @@ class Mame < Formula
   uses_from_macos "zlib"
 
   on_linux do
+    depends_on "gcc" # for C++17
     depends_on "pulseaudio"
     depends_on "qt@5"
     depends_on "sdl2_ttf"

--- a/Formula/mapserver.rb
+++ b/Formula/mapserver.rb
@@ -11,13 +11,13 @@ class Mapserver < Formula
     regex(/href=.*?mapserver[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "329b8b0d9171e1ddd78caccfa2181387a4a96fd6fa0d793d8e2df08e4d483e28"
     sha256 cellar: :any,                 arm64_big_sur:  "9e9f70c6e73ebf54c17e724c9258ebfe551154a6d136110db7a84dd8d9179b5d"
     sha256 cellar: :any,                 monterey:       "c54dfcf1ee80c006d2577a62b8d611b5deb1296e76eec74d9267ec26ccd13299"
     sha256 cellar: :any,                 big_sur:        "27208daf7f0f2d4c54a7acb06ac64534a073e7211e687ecc8764042f996cfa65"
     sha256 cellar: :any,                 catalina:       "47697fff3cfd46f892a42ec9ff649a72521aadf6dc8a2519966b5d24f3e19e0a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "80ad31e2bb0aaf61cb589cfe32b302179a5184aaa699bf51c4816575fff7a524"
   end
 
   depends_on "cmake" => :build
@@ -37,6 +37,10 @@ class Mapserver < Formula
   depends_on "python@3.9"
 
   uses_from_macos "curl"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/mariadb.rb
+++ b/Formula/mariadb.rb
@@ -20,13 +20,13 @@ class Mariadb < Formula
     end
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "44ff9ff617ada03c556166db35991f5f0a8ae98ad1db14fd215cc66255964a48"
     sha256 arm64_big_sur:  "f94078ba09153536cd665e50596d2b731bf8f766691c85f7cb01c13c2c6380ea"
     sha256 monterey:       "9708487080ced59452ff0f4b89124ee97f4c30428496d30150cd2e6f43514b52"
     sha256 big_sur:        "2bde55ad31b742ad68f5a23b4b645014d6b4232d0d198ae30a6389153aa61870"
     sha256 catalina:       "3b202fe1609080b8778832475766a869b488bd5c423b8354902690f56261d047"
+    sha256 x86_64_linux:   "d7fef80655269d2066859aa87d779fa7460ffff4d18a1d5a30800305de2dc999"
   end
 
   depends_on "bison" => :build
@@ -44,6 +44,7 @@ class Mariadb < Formula
   uses_from_macos "zlib"
 
   on_linux do
+    depends_on "gcc"
     depends_on "linux-pam"
     depends_on "readline" # uses libedit on macOS
   end

--- a/Formula/marp-cli.rb
+++ b/Formula/marp-cli.rb
@@ -7,13 +7,13 @@ class MarpCli < Formula
   sha256 "be653c39c57ee00d219742e0634301af2f1fb17254b8cec449903646bcf5429d"
   license "MIT"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "9abfc30732daa6c854115ced0ca662956a706a70e8682643f3aaeacf84d49c6d"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "9abfc30732daa6c854115ced0ca662956a706a70e8682643f3aaeacf84d49c6d"
     sha256 cellar: :any_skip_relocation, monterey:       "d0a8c71c0e36ee8e278bd3bbe839d6fd16c078a2f4edda6c12c89a5d7a91fc85"
     sha256 cellar: :any_skip_relocation, big_sur:        "d0a8c71c0e36ee8e278bd3bbe839d6fd16c078a2f4edda6c12c89a5d7a91fc85"
     sha256 cellar: :any_skip_relocation, catalina:       "d0a8c71c0e36ee8e278bd3bbe839d6fd16c078a2f4edda6c12c89a5d7a91fc85"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9c2e3e7e382d9897f6c8f5c801ad51a6e2a3d7a1d2aa9426cf04c66fe855ffaf"
   end
 
   depends_on "node"

--- a/Formula/mavsdk.rb
+++ b/Formula/mavsdk.rb
@@ -13,13 +13,13 @@ class Mavsdk < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "5aa08d40b5ef46b7216c436201f195cac1a0bad817cb54260623023e59f152d1"
     sha256 cellar: :any,                 arm64_big_sur:  "6c6377dfeefb7de5ff42b64b60a80a5855abadc893c38cc5071afc2f9051284c"
     sha256 cellar: :any,                 monterey:       "780f725ea8c022fd1b7536cc11a519711df390c6177b41241119fe0d3c9895dd"
     sha256 cellar: :any,                 big_sur:        "f86d329776bdb7c70a26d1ffdec2ae1c1b04131760d93b9025c485bf4fac0c08"
     sha256 cellar: :any,                 catalina:       "25a5f566b4729aa1e4e9b9e07f0c5d3c85bc1ec191d6393617cd9494e9b2d6c7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a3d62255c66092bc1d2ffbb9b50c4b076f04f1afd46e1463bcd4bc7cdac6430c"
   end
 
   depends_on "cmake" => :build
@@ -39,6 +39,10 @@ class Mavsdk < Formula
 
   on_macos do
     depends_on "llvm" if DevelopmentTools.clang_build_version <= 1100
+  end
+
+  on_linux do
+    depends_on "gcc"
   end
 
   fails_with :clang do

--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -16,7 +16,6 @@ class Mesa < Formula
     end
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "df0b44f3ab436ebee487b9ef7fd5fb8c7f55b39cf404fd7e412691caedb46971"
     sha256 arm64_big_sur:  "10fb7ce402bbdb407905023b73adf88bcd535cb52d76b0ffa1acc5af9158fb6d"
@@ -47,6 +46,7 @@ class Mesa < Formula
 
   on_linux do
     depends_on "elfutils"
+    depends_on "gcc"
     depends_on "gzip"
     depends_on "libdrm"
     depends_on "libva"

--- a/Formula/metaproxy.rb
+++ b/Formula/metaproxy.rb
@@ -13,18 +13,22 @@ class Metaproxy < Formula
     regex(/href=.*?metaproxy[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "8bd251c25b40cb964ac83fad38db949526ae6a4e460458a8c24c9d0dea937b2b"
     sha256 cellar: :any,                 arm64_big_sur:  "520ee4ee1c8f96cdd91ca31a6b77b49c3ee447273ad72c297bd687d3fe5c2aa9"
     sha256 cellar: :any,                 monterey:       "af5a2f792bfde97b3c303d6e59c518b189b75e9c44e18b8bfe9f656b80d93916"
     sha256 cellar: :any,                 big_sur:        "805b299b14498830c931071bb23e15125f8386046593947d92481b30c9dbb5e7"
     sha256 cellar: :any,                 catalina:       "bb29f5fb3c0e23ea29ab2d4a8104207711749d3e325116d758ecd0ebfc3bb3d2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2b0ccce6addc16649b74d4843e35f12372365eb34c9d83ac0c450c3e85ca2f10"
   end
 
   depends_on "pkg-config" => :build
   depends_on "boost"
   depends_on "yazpp"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/mgba.rb
+++ b/Formula/mgba.rb
@@ -12,13 +12,13 @@ class Mgba < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "34235cb6f1aaeca67d11e4b060bfd2d7adf462b61b115beb029fd81ec0adc563"
     sha256 cellar: :any, arm64_big_sur:  "0dc3200fa947b5872c48500c3c7b4841668edfc2143d2977226e850fa53db2dd"
     sha256 cellar: :any, monterey:       "8486c6db482c218845f22d3dfbc5402066d002c6712b1fc0faefa3ce88d186f0"
     sha256 cellar: :any, big_sur:        "575163b96818d53848c6b4a536fbccea185cce14487394974519b1655c3cb03f"
     sha256 cellar: :any, catalina:       "fe54e4803c93036beb054b6e649f722e21f1ae08fa4efb4c2808d9b5b875fd8f"
+    sha256               x86_64_linux:   "2e521f7ea91d0e5b77583d818c0eed31ece44389d4ac3235dd6ed52bfd6141ae"
   end
 
   depends_on "cmake" => :build
@@ -30,6 +30,10 @@ class Mgba < Formula
   depends_on "qt@5"
   depends_on "sdl2"
   depends_on "sqlite" # try to change to uses_from_macos after python is not a dependency
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # ffmpeg is compiled with GCC
 

--- a/Formula/minizinc.rb
+++ b/Formula/minizinc.rb
@@ -6,18 +6,22 @@ class Minizinc < Formula
   license "MPL-2.0"
   head "https://github.com/MiniZinc/libminizinc.git", branch: "develop"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "b0a513043c90cdaf37886e77e7e8fd5d26b669ae17a97285709ac2354a0f2412"
     sha256 cellar: :any,                 arm64_big_sur:  "d4848cac56d6ed4199cc562e8cb7d9f03b592481c49ebd7800d865a0c552db39"
     sha256 cellar: :any,                 monterey:       "aa9431c2cecc4b689aa2340fc55049ab389fbd3c3addc37f926c1a928e6068f6"
     sha256 cellar: :any,                 big_sur:        "040a9ba684acb1661952ec2742146d67c92d423a2628e9d19256c57353a62ab9"
     sha256 cellar: :any,                 catalina:       "e1330a26f4fe8c2b8615c7358d99a7f9a7b61abd86575012e51007c7b2a6569a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f01136a668aae3151fc5f25bab6f8d3e64c974abf59b57d4628c75834d3f49b0"
   end
 
   depends_on "cmake" => :build
   depends_on "cbc"
   depends_on "gecode"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/mkvtoolnix.rb
+++ b/Formula/mkvtoolnix.rb
@@ -11,13 +11,13 @@ class Mkvtoolnix < Formula
     regex(/href=.*?mkvtoolnix[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "c3fefc7f780138b7fd60e3acbd3051dc135060197a2e1969ad8363c020abe14e"
     sha256 cellar: :any, arm64_big_sur:  "952ae59439c970e29fd465b2389ead5acd858216d32298ce1a178be4eb041989"
     sha256 cellar: :any, monterey:       "5487b77b0100ef14889d7a32b495b297209071952b4b44e1a33e94d389d65bf1"
     sha256 cellar: :any, big_sur:        "291a34f9adead5f193dd2b3f53d3ec5808fc3cb6a43d47004b2e592f8fdea8c7"
     sha256 cellar: :any, catalina:       "636e4bb2d8233193d1f9c952ba2d46a4919bb5526964420c87f320c646421f59"
+    sha256               x86_64_linux:   "8ae23a2588b6d3b4a582a27e75c99a1d51bd76677195ea98d3ecb648fa0b994f"
   end
 
   head do
@@ -47,6 +47,10 @@ class Mkvtoolnix < Formula
 
   uses_from_macos "libxslt" => :build
   uses_from_macos "ruby" => :build
+
+  on_linux do
+    depends_on "gcc" => :build
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/mlt.rb
+++ b/Formula/mlt.rb
@@ -6,13 +6,13 @@ class Mlt < Formula
   license "LGPL-2.1-only"
   head "https://github.com/mltframework/mlt.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "dcaf9747d3aad9909d225e3b98864072103d2d2b93391678ef66732ee970e8eb"
     sha256 arm64_big_sur:  "b9b6b9540a4c478a0f64612f430c821c67b2652fa483cce1f22098cb04ac4851"
     sha256 monterey:       "b6e91b91d5640a87dbe02513c88f698ca4dd35e03d3e0ba5abb67a426d224039"
     sha256 big_sur:        "c552e946cad9bb2752889885296d9983f96ab13edd609371ba766577d1e0a1bf"
     sha256 catalina:       "561db9de0a8f913913d8190071dd3f08bfc7ad7b535cd83112c258a911392ca1"
+    sha256 x86_64_linux:   "59f7e0cb66e63fcd8961a22e578622f3086d5af31a6f633e370461d126ad0ba0"
   end
 
   depends_on "cmake" => :build
@@ -30,6 +30,10 @@ class Mlt < Formula
   depends_on "qt@5"
   depends_on "sdl2"
   depends_on "sox"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/mold.rb
+++ b/Formula/mold.rb
@@ -6,13 +6,13 @@ class Mold < Formula
   license "AGPL-3.0-only"
   head "https://github.com/rui314/mold.git", branch: "main"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "535645ac73281705d7bb5c3564c2864cc895d7bfc1e38729e2bd66c3cf109088"
     sha256 cellar: :any, arm64_big_sur:  "e51450fdc1d490b94da64c6a3312e406d3d9d9e0a994e42c75c9f1008c06c54e"
     sha256 cellar: :any, monterey:       "98e4fe39d91c35df6f5c42e0b6e49d8d3bc6378f835e9b4e03706d53155d3adb"
     sha256 cellar: :any, big_sur:        "a886cc4ef4785564ce08908b0bb8dee415b3eb5ce1a2b742e0ca44ae5d3fdbb1"
     sha256 cellar: :any, catalina:       "da3549514abf8a29e94939a79ffa3eba4d13677032bd3cce1f8c73fa5376faf4"
+    sha256               x86_64_linux:   "294c9348f55e8661bb25f5f4824857ab4a1d5755381a42759430e5f7b08e533c"
   end
 
   depends_on "tbb"
@@ -23,6 +23,7 @@ class Mold < Formula
   end
 
   on_linux do
+    depends_on "gcc"
     depends_on "mimalloc"
     depends_on "openssl@1.1" # Uses CommonCrypto on macOS
   end

--- a/Formula/mongosh.rb
+++ b/Formula/mongosh.rb
@@ -7,13 +7,13 @@ class Mongosh < Formula
   sha256 "b2163fbf1decf33f19a75c888f6a1365be26edcf21ee2e2181a700f70475af28"
   license "Apache-2.0"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
-    sha256 arm64_monterey: "afd60961e76713fcd598cf7241a94006057e527ce0ec254746c3e26103d8e644"
-    sha256 arm64_big_sur:  "bab14dc4f97a33337d77aeb1d7a1eedcbd00d1842e4451b35c666658d1daf996"
-    sha256 monterey:       "b618e101c7591f80c4138074da22cf956a4d9ab7e37834840ceab6b7f4bc3c4c"
-    sha256 big_sur:        "593e89a8fda1465886b55776d840c55bbd490e3a32caedfffe3e093ce099b137"
-    sha256 catalina:       "525cf115b605f561e3eb9ff507d6573826dabd1565e6cd94da887b7e92d47d9f"
+    sha256                               arm64_monterey: "afd60961e76713fcd598cf7241a94006057e527ce0ec254746c3e26103d8e644"
+    sha256                               arm64_big_sur:  "bab14dc4f97a33337d77aeb1d7a1eedcbd00d1842e4451b35c666658d1daf996"
+    sha256                               monterey:       "b618e101c7591f80c4138074da22cf956a4d9ab7e37834840ceab6b7f4bc3c4c"
+    sha256                               big_sur:        "593e89a8fda1465886b55776d840c55bbd490e3a32caedfffe3e093ce099b137"
+    sha256                               catalina:       "525cf115b605f561e3eb9ff507d6573826dabd1565e6cd94da887b7e92d47d9f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e5305f51dca712d4b7913752e6d24d671ba5fa631c5c91026348020ebdbfc4a2"
   end
 
   depends_on "node@16"

--- a/Formula/monika.rb
+++ b/Formula/monika.rb
@@ -7,13 +7,13 @@ class Monika < Formula
   sha256 "e8ff67bda45653944e772e4912998640bbb5268408bc3c29dfa1085677c3b62f"
   license "MIT"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "7ea49ed3a6e291e1253a800e63527254717b68f3ab1f8237468e976529013a14"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "87ac0d429541ad0645203b57858e970aee169148297dbe66aa0599cdf49af51f"
     sha256 cellar: :any_skip_relocation, monterey:       "ffafad74fa6b66e440179ad8a85f6470b40be61ee78b0d290d05a9b2f92ad5b3"
     sha256 cellar: :any_skip_relocation, big_sur:        "f41b2826a2ec61d682bd25b6a3cd875879777c98e381554420c0b7bb2ce682dc"
     sha256 cellar: :any_skip_relocation, catalina:       "4fc0ce0171e815f85d145764e523808ab34205a09d41bb7c11796a097b3b2011"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "01fab64a2d960164ad124b6ac0167f060b655f6aced6ce0c36eb1128303aa3b6"
   end
 
   depends_on "node"

--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -7,13 +7,13 @@ class Mpv < Formula
   revision 1
   head "https://github.com/mpv-player/mpv.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "09e223bc45b0968497077eacfe9eeb7e1143ecc782ccd18af454ef215b4c1483"
     sha256 arm64_big_sur:  "47c1c8f8cd49e071be6cda0f729aeaef829ac941e26c87f5ba266d41da423c12"
     sha256 monterey:       "60f51e9c67a707139b2cfa763a961c0778323eae81c1a5aec69c17840ce49e61"
     sha256 big_sur:        "3ee4dfdaea28f1b0c4ebabba8eb677949d1462af4133d4f6b94a60661ab615e7"
     sha256 catalina:       "aca6e4cfc8598dfbd88882622aaeb117f97f1f843c82b87a5308b3fe90740c68"
+    sha256 x86_64_linux:   "f61254f8629ce7d463d36db3bd0c5ad36a52ef3ac5989316756eb3703e86a300"
   end
 
   depends_on "docutils" => :build

--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -17,13 +17,13 @@ class Mu < Formula
     regex(/^v?(\d+\.\d*[02468](?:\.\d+)*)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "975f54e33a72351b6f7057076f810b9be94c4f9ee844036e6cf5c6d6b564a2cf"
     sha256 arm64_big_sur:  "3b7b1c9419df158ce507a9ac1a9350bb147ec14342f77b32ff30dbd865639a2a"
     sha256 monterey:       "f9523f30023b4fd09c8879890b7e6657bd893a32d29d3e9210cfe696ba68b944"
     sha256 big_sur:        "1334ad4bfa73d9c71ec880606b35fd14aef86621ad46f3450e0fcc666c8d39dd"
     sha256 catalina:       "3262a6fd56c0f0e690eab3613a901c8c8ee9cd1488b04d22bb30eacec12138c6"
+    sha256 x86_64_linux:   "99c7cccc67f0462743b51f53941b8aa62502daadf3faf95fa8622909db7c41a0"
   end
 
   depends_on "emacs" => :build
@@ -38,6 +38,10 @@ class Mu < Formula
   depends_on "xapian"
 
   uses_from_macos "texinfo" => :build
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   conflicts_with "mu-repo", because: "both install `mu` binaries"
 

--- a/Formula/mvtools.rb
+++ b/Formula/mvtools.rb
@@ -7,7 +7,6 @@ class Mvtools < Formula
   revision 1
   head "https://github.com/dubhater/vapoursynth-mvtools.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "103ac07596bd7b5e6142b3fbedabf5adffdc553381d8b9eb9e5832a1a8df8f3a"
     sha256 cellar: :any,                 arm64_big_sur:  "d532c9381d9c889e06a0ce330ed9f3a95d5552572981605f233efd28a052b34f"
@@ -16,6 +15,7 @@ class Mvtools < Formula
     sha256 cellar: :any,                 catalina:       "01785cf0cea2080cb2b875df545e027aaaf339fbbddeca53fd5dae8f39bf4726"
     sha256 cellar: :any,                 mojave:         "0809f0353e48e30d8628bbe2124cebfa0ebd1a6add77e2d27798ce968dadb84d"
     sha256 cellar: :any,                 high_sierra:    "0a1bab6b74375cb11959d2100e562bb2cc8124da7115b754975cd70c31e676b2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "915cd8e779a5143a86f77cecc9efae2029eda0194358b52e69c4e59811c20c6f"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/mydumper.rb
+++ b/Formula/mydumper.rb
@@ -5,13 +5,13 @@ class Mydumper < Formula
   sha256 "2fc5af9643a27eaca0a2ab37ba11ccac4d82f20bd8a9c14c886961453aafdf24"
   license "GPL-3.0-or-later"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "e5599dca1e1ab5f7f591c8f6e3e286561065925c8413df446c1a497c34e3fa31"
     sha256 cellar: :any,                 arm64_big_sur:  "02678d600f5e9f5b61c97f86257b17bd4ffeb16036b1f7018fbb14a09d506aee"
     sha256 cellar: :any,                 monterey:       "5abc3e7f947d591430d659bf00126e37e6ab10865e25102dc3e64d71814eaa5a"
     sha256 cellar: :any,                 big_sur:        "38c194f3ee2c16d038ad3f8d0201941d88ad31aa17b9003623b9e4a652fbcab3"
     sha256 cellar: :any,                 catalina:       "d596ebed1de4da2c66302bf26edfbafae0154bfd911b5909d142e12469f80eb5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f348f0a1ab90a7579da2ae42482b2013bdee1e859d7e690283216a7809ac62b7"
   end
 
   depends_on "cmake" => :build
@@ -23,6 +23,10 @@ class Mydumper < Formula
   depends_on "pcre"
 
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/mysql-client.rb
+++ b/Formula/mysql-client.rb
@@ -9,13 +9,13 @@ class MysqlClient < Formula
     formula "mysql"
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "abccc4fa9808274f5bd66a1b9d02eabc114340738f2b1425eaff658365dddf47"
     sha256 arm64_big_sur:  "2a7d242c0bd023dd331ac079cc467e7d3f77477b78ab5110cdae68cb7aab17f3"
     sha256 monterey:       "a8b71724eb655a359756740ca25c755efd927700396935ca641c89de3822187b"
     sha256 big_sur:        "d9bf8ae6fb0548ee9bb981a88a3f09b9a3efffebc63ab14303979811cb59fee4"
     sha256 catalina:       "2ff83a77f27bf45216c66002dac0e7da45d11626099324f381ff49b2f323992a"
+    sha256 x86_64_linux:   "6b0ae42f32c53f05cdf52c4fd1db04177e5a693dc748b8083d813a7eaf2a5875"
   end
 
   keg_only "it conflicts with mysql (which contains client libraries)"
@@ -31,6 +31,10 @@ class MysqlClient < Formula
   depends_on "zstd"
 
   uses_from_macos "libedit"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -10,13 +10,13 @@ class Mysql < Formula
     regex(/href=.*?mysql[._-](?:boost[._-])?v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "078d86da54cb87712d2d941c5faa7d7be29ae8c22bdbd92743425d872f2f198b"
     sha256 arm64_big_sur:  "4ab222921e74b31f81310e981ac6b63e164f7a71df561e7ea802409b189d202a"
     sha256 monterey:       "07e7117de00eb24eace602baeeea768b3579b2c2d10649cb7c32b82ff7ab22fd"
     sha256 big_sur:        "884bc510cd10e0fd1b3dcd5500d4bc56a3dc81d6bb9d92b741789e393ca839db"
     sha256 catalina:       "a85e24ef0836ad46de2d3ee755b7612cffb92d09056987c94b6fc7c780c69374"
+    sha256 x86_64_linux:   "30dd16248eb9744fad51a591d30b7e09f241e2dedeae972de7d29d5f06287942"
   end
 
   depends_on "cmake" => :build
@@ -36,6 +36,7 @@ class Mysql < Formula
 
   on_linux do
     depends_on "patchelf" => :build
+    depends_on "gcc" # for C++17
   end
 
   conflicts_with "mariadb", "percona-server",

--- a/Formula/ncmpc.rb
+++ b/Formula/ncmpc.rb
@@ -10,13 +10,13 @@ class Ncmpc < Formula
     regex(/href=.*?ncmpc[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "9c5a751cf1cdf763576b2a5af746ae5f0042cbc2eceb1fb2057ce8f0d4a7e3fc"
     sha256 cellar: :any, arm64_big_sur:  "59fb26a2c225c8f652a4bd075e3536677f435a804d5acf774f893759cf1e5ce5"
     sha256 cellar: :any, monterey:       "3c0eeb6d9f4de139daf1ed63d8f8e9fbe8f5ca41b47d93aae5b2d14dedff4888"
     sha256 cellar: :any, big_sur:        "630160a894df86a9f369740acde9e92880c36b7262fab5a75857123d67ea8aa8"
     sha256 cellar: :any, catalina:       "07e7f1e1a017591372496368045eda2e871a1d5d2a9bfcf57f5408b3608335c5"
+    sha256               x86_64_linux:   "69a523557e8f1de3e7d0b97501f0806c2f6f98fe838ad991aea423a8648b663e"
   end
 
   depends_on "boost" => :build
@@ -26,6 +26,10 @@ class Ncmpc < Formula
   depends_on "gettext"
   depends_on "libmpdclient"
   depends_on "pcre2"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/netlify-cli.rb
+++ b/Formula/netlify-cli.rb
@@ -8,7 +8,6 @@ class NetlifyCli < Formula
   license "MIT"
   head "https://github.com/netlify/cli.git", branch: "main"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "d50b2a69f20fa817985ec0ea32d634ae3a03f4d8cb2fec9f2083488924f970af"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "d50b2a69f20fa817985ec0ea32d634ae3a03f4d8cb2fec9f2083488924f970af"

--- a/Formula/newman.rb
+++ b/Formula/newman.rb
@@ -7,13 +7,13 @@ class Newman < Formula
   sha256 "02f4468076e38b8950281518839cc3869f4c5b7ad7cab34e9e600c1451e2fcd6"
   license "Apache-2.0"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "ffbd3ef5d1bf69b22eb175f6d72599c4d915d1b1fdea6dfd7a7f85fff4d4f6c9"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ffbd3ef5d1bf69b22eb175f6d72599c4d915d1b1fdea6dfd7a7f85fff4d4f6c9"
     sha256 cellar: :any_skip_relocation, monterey:       "f9458d98ebca55f9aac434fcb5e65d6ef5327d0de50f1da8945e165820d4f5f4"
     sha256 cellar: :any_skip_relocation, big_sur:        "af2c026502794cf7b25fcd468ee2b7769fc62c081c6946b6bb96a983f50dc978"
     sha256 cellar: :any_skip_relocation, catalina:       "af2c026502794cf7b25fcd468ee2b7769fc62c081c6946b6bb96a983f50dc978"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ffbd3ef5d1bf69b22eb175f6d72599c4d915d1b1fdea6dfd7a7f85fff4d4f6c9"
   end
 
   depends_on "node"

--- a/Formula/node-sass.rb
+++ b/Formula/node-sass.rb
@@ -7,13 +7,13 @@ class NodeSass < Formula
   sha256 "e47a1e370f78990f1f6f3047a86f166ea6184f3a4e37193b16df08f9950b555b"
   license "MIT"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "7c68a97888aad640d3fb00bc9f41b1d155870d5f06cdfad8f9e1e5b8643a23e6"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "7c68a97888aad640d3fb00bc9f41b1d155870d5f06cdfad8f9e1e5b8643a23e6"
     sha256 cellar: :any_skip_relocation, monterey:       "7c68a97888aad640d3fb00bc9f41b1d155870d5f06cdfad8f9e1e5b8643a23e6"
     sha256 cellar: :any_skip_relocation, big_sur:        "7c68a97888aad640d3fb00bc9f41b1d155870d5f06cdfad8f9e1e5b8643a23e6"
     sha256 cellar: :any_skip_relocation, catalina:       "7c68a97888aad640d3fb00bc9f41b1d155870d5f06cdfad8f9e1e5b8643a23e6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "52cc2831b05ad9829d1889418fc61835623fb0c1ecabc3310bf790bf088d8ca8"
   end
 
   depends_on "node"

--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -11,13 +11,13 @@ class Node < Formula
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "5bc3bbc7796679a30ef86748accee8170fad11bccea0fcc1fc129f2a51b4b6fa"
     sha256 cellar: :any,                 arm64_big_sur:  "e29c164c7303516f06817f5b5aeec5e857b53d2f35d20d0eaeb32081a97d3ca9"
     sha256 cellar: :any,                 monterey:       "cbcfe985fe9bdc27d487144feffd68e8ae0fdc247c312588ad3cf52e80e02183"
     sha256 cellar: :any,                 big_sur:        "ce4293b284db54f3a1144728a7b0c8226c9fe026847cda4aad50b7a52ca87c1e"
     sha256 cellar: :any,                 catalina:       "da43d1de42d234e2385bcbc97b12c63b7592aa7e5489ee02c97e6773487d7888"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "151dbd4c085946efe2da970d1fbd4859393a7ce72ba7ad68aa0a6b33572ccccf"
   end
 
   depends_on "pkg-config" => :build
@@ -34,6 +34,10 @@ class Node < Formula
 
   on_macos do
     depends_on "llvm" => [:build, :test] if DevelopmentTools.clang_build_version <= 1100
+  end
+
+  on_linux do
+    depends_on "gcc"
   end
 
   fails_with :clang do

--- a/Formula/node@16.rb
+++ b/Formula/node@16.rb
@@ -10,13 +10,13 @@ class NodeAT16 < Formula
     regex(%r{href=["']?v?(16(?:\.\d+)+)/?["' >]}i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "5c6ae1e595e060427f9bad74738707d2d20eb953c79a732d9394a4064488601c"
     sha256 cellar: :any,                 arm64_big_sur:  "992decc76b2647e59d8b24d0d8994eb8e2b02573c8aad97ef1697ff35be69fcc"
     sha256 cellar: :any,                 monterey:       "2ce0ecc46ad0015945f9a062af463917420a76eea32c6624e6cb9526cb7cbf91"
     sha256 cellar: :any,                 big_sur:        "8758ad0e68a656f5409e07f961718b682cad25016a6f7c8ca92cd31abdd0ea63"
     sha256 cellar: :any,                 catalina:       "9e3f1e7befb1692654166c6127f48640602ec8062bc122d6b139a75b2eb88601"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0f41eb233087c9c957accdf022702ba2b37f6a3e7d9eb3d3f77e5ebc20c2b715"
   end
 
   keg_only :versioned_formula
@@ -32,6 +32,10 @@ class NodeAT16 < Formula
 
   uses_from_macos "python", since: :catalina
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with :clang do
     build 1099

--- a/Formula/ns-3.rb
+++ b/Formula/ns-3.rb
@@ -6,13 +6,13 @@ class Ns3 < Formula
   license "GPL-2.0-only"
   revision 2
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "4f3d2a4df386be25087fa43898cfd7e5dc3f839ae8654720b5a6ae1453c33ba8"
     sha256 cellar: :any, arm64_big_sur:  "e08ff31e390431d96faa2676104a227d19028837428c2d2d5730fa9e88e436ea"
     sha256 cellar: :any, monterey:       "39baddc92860b4e43331b979ea23d53b05d6a1f60f83bbac23b8a07e7fa621ea"
     sha256 cellar: :any, big_sur:        "d0f2c1d3bd2b1b6eba5cd2d86d7a08ff83ecc0cb3116a8436c49eaa429161bcd"
     sha256 cellar: :any, catalina:       "fe65d59b1528b61d2e6acda4c634e2adf1721113caa0a6433127fffe864134d1"
+    sha256               x86_64_linux:   "c9c36b988db945172517f6563f9b33e93093c259cab21cf07fac8e8faffad99e"
   end
 
   depends_on "boost" => :build
@@ -21,6 +21,10 @@ class Ns3 < Formula
   uses_from_macos "libxcrypt"
   uses_from_macos "libxml2"
   uses_from_macos "sqlite"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   # `gcc version 5.4.0 older than minimum supported version 7.0.0`
   fails_with gcc: "5"

--- a/Formula/ntopng.rb
+++ b/Formula/ntopng.rb
@@ -10,13 +10,13 @@ class Ntopng < Formula
     depends_on "ndpi"
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "65efdae761d1ae845a48d304daf459af893cfeedc004ca598db3c39650c20fdf"
     sha256 arm64_big_sur:  "ad20989ce5163ffe940e954c6eaff38cabf2e5d0922c4aba4a7a86e4e592db30"
     sha256 monterey:       "a7523c2a2d83dc057f360a9656d1475d0cc73d3d5534beabcdd2307126c0a0e6"
     sha256 big_sur:        "bfbbc638a791fe1e2ab951396243faae914a8249441c900b1d8db877fae376bb"
     sha256 catalina:       "dfa4fa4fdaea595da3d102f08d5522737c931aa6a33b136480f7233bec934cbd"
+    sha256 x86_64_linux:   "420bdc0167bc229a009b030100ec612fdc57b19ca09de0896e70278081668a55"
   end
 
   head do
@@ -45,6 +45,10 @@ class Ntopng < Formula
 
   uses_from_macos "curl"
   uses_from_macos "libpcap"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/nu.rb
+++ b/Formula/nu.rb
@@ -5,13 +5,13 @@ class Nu < Formula
   sha256 "1a6839c1f45aff10797dd4ce5498edaf2f04c415b3c28cd06a7e0697d6133342"
   license "Apache-2.0"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 monterey:     "bceb7b3b986c2b6861645b7044dae295ee1d0cdeefe1af8990accff06bbac370"
     sha256 cellar: :any,                 big_sur:      "f99e9ccd7919c4e2058299e3c545c26ac2fca23a241550fd306afcee6c790d98"
     sha256 cellar: :any,                 catalina:     "d785730e9226dbfe78513a268657bfa50bacd5427b8779f838d00f1c312cc2a8"
     sha256 cellar: :any,                 mojave:       "a3e605c8fca139258b5b5d49f85ac4d57a781017ae0deac8096a74d491219121"
     sha256 cellar: :any,                 high_sierra:  "119f4f3eed1bf677c4e8d0248bd4d042d6c7333d21e6442b90440504bb2e276a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "3f11c4023a9a1b16f8528aeff1d0c40c627e6f7d1d6b0df8a229cd8f448538e8"
   end
 
   depends_on "pcre"

--- a/Formula/nvc.rb
+++ b/Formula/nvc.rb
@@ -6,13 +6,13 @@ class Nvc < Formula
   license "GPL-3.0-or-later"
   revision 1
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "a2b12eab1789c86431f2c2243e07f012f8bc23eb8bdc753cc460e2c548f80e63"
     sha256 arm64_big_sur:  "e2af86fea8247b02a6fae2a9dd6a197f180647950bcbda07a0e7a865054873c5"
     sha256 monterey:       "9c4dbeb21c316cef280370437fe31c6a2d8536ae66bd8f6f13de8303adf4f1fc"
     sha256 big_sur:        "41afd05b5d20c00d5f2051858bbaae4c46c200eed14e25a77916b7072341787c"
     sha256 catalina:       "806ec3dff942acf027597a0c712527ed90d04f732cf111be011bad506fbeb16a"
+    sha256 x86_64_linux:   "58200eb93611d5b1ea8efe69f1f7d26e117f8d184c09a39ab9445fef24b17b98"
   end
 
   head do

--- a/Formula/objfw.rb
+++ b/Formula/objfw.rb
@@ -10,7 +10,6 @@ class Objfw < Formula
     regex(/href=.*?objfw[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "83b505efb37df36fe0dba40337409835856293328b2977f28d0ef8868e1d250e"
     sha256 arm64_big_sur:  "59dd4798a6017b6062614f70004c87feb3bbf7aecb9ac2165b5b6f92353c6361"
@@ -20,6 +19,7 @@ class Objfw < Formula
     sha256 mojave:         "abc09195b6abf66d1d638af2999abe712a41cdcbb4bbf8d7ea422443150ae637"
     sha256 high_sierra:    "33c72d86bb5a56ff4a2c9607707edb31f7af21bf863c8d34d95f6c527d9ee483"
     sha256 sierra:         "2369c4233bafe95aeea87f678cc5e0f0b001d36b5aeff6a7b6512f766d77eb5e"
+    sha256 x86_64_linux:   "57dcb7565015413f1fb668f18b03af564e8b631b47e051c6b98dfb57d1530fa0"
   end
 
   head do

--- a/Formula/ocrmypdf.rb
+++ b/Formula/ocrmypdf.rb
@@ -7,7 +7,6 @@ class Ocrmypdf < Formula
   sha256 "45fa226f6753f6e0be1e6304d3363a6d8047bb4cb0cf0d25728c3b9c9a0bff40"
   license "MPL-2.0"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "fc0cdf1382e63980be844ab60dfa6c1a8fe56cb6bd2218249c5f76ccf5269066"
     sha256 cellar: :any, arm64_big_sur:  "d1f4a41cafafce247ce2961f75e79627568bde9defb0879647ab409569795211"
@@ -33,6 +32,10 @@ class Ocrmypdf < Formula
 
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/odin.rb
+++ b/Formula/odin.rb
@@ -8,7 +8,6 @@ class Odin < Formula
   license "BSD-3-Clause"
   head "https://github.com/odin-lang/Odin.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "05ecd553e5ee0bd46862767c710c1e3a1d86ea2f779d017a6b313df44065326c"
     sha256 cellar: :any,                 arm64_big_sur:  "e04e6af571209fc7ad4ce0742d566cd05429ece4854bdd948f9e6501238ef3aa"

--- a/Formula/openfst.rb
+++ b/Formula/openfst.rb
@@ -10,13 +10,17 @@ class Openfst < Formula
     regex(/href=.*?openfst[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "9c205f655815ece696db66cb6d951bc421187a7d5e564a5c9c147d5077ba7dba"
     sha256 cellar: :any,                 arm64_big_sur:  "677eca1e0c86c76cf78a05d193074065e96bd121b3000f5636e596d211ce4ad8"
     sha256 cellar: :any,                 monterey:       "35b01a7251c02f16c451a8dd961c3461bae8715289bb529f6580aaee90b0defd"
     sha256 cellar: :any,                 big_sur:        "61788460f5d24b7feb792e36158722880048512a56b67bd93a185c613944471b"
     sha256 cellar: :any,                 catalina:       "7a279be4687687d2aba95247292e72e9b51cdad00343478069f56d72360fde1d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d09e40d67f808e45549c67a15b4f8beca5e13dac9c30603411c3095ad07fa4e8"
+  end
+
+  on_linux do
+    depends_on "gcc" # for C++17
   end
 
   fails_with gcc: "5"

--- a/Formula/openmsx.rb
+++ b/Formula/openmsx.rb
@@ -12,7 +12,6 @@ class Openmsx < Formula
     regex(%r{href=.*?/tag/RELEASE[._-]v?(\d+(?:[._]\d+)+)["' >]}i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "f2adab2e188fe3359050eac24577a703a3ca28be607033525b44cee9bc8f48bc"
@@ -20,6 +19,7 @@ class Openmsx < Formula
     sha256 cellar: :any,                 monterey:       "4bb067ee6ba11fd48cbe4a97281835bd44df215d4e7b7473cadc6e0a698f4de2"
     sha256 cellar: :any,                 big_sur:        "0d2b0c7de2234c34935f11f952ea5ae8b4b818a4d87d83b5617bc28999956ab4"
     sha256 cellar: :any,                 catalina:       "39fc0cf97185508d3d107c73495f64cf6f44285f165b17852679e57caf8376b9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4a7ecec109af5105fe217ddcd1e43f40d4290431a3e075bb1587b17350c47adf"
   end
 
   depends_on "python@3.10" => :build
@@ -37,6 +37,7 @@ class Openmsx < Formula
 
   on_linux do
     depends_on "alsa-lib"
+    depends_on "gcc"
   end
 
   fails_with gcc: "5"

--- a/Formula/openrct2.rb
+++ b/Formula/openrct2.rb
@@ -7,13 +7,13 @@ class Openrct2 < Formula
   license "GPL-3.0-only"
   head "https://github.com/OpenRCT2/OpenRCT2.git", branch: "develop"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "34b63e6aa7fb8b17e61ed22f00608207ac2ad10d4d377add4a62454ef72979df"
     sha256 cellar: :any, arm64_big_sur:  "656093b37b8111629e51b979e2241b38bab957793faf4ee4ad3a22826a2f9f49"
     sha256 cellar: :any, monterey:       "a2e9541db7d546f36a54b849f40c21cf2092fe4ae41d3e247da0b521355499ed"
     sha256 cellar: :any, big_sur:        "f04d9cba1d66b55eb2dfc602a84fa3f4c522ac44951278d12149b6bec32c8d09"
     sha256 cellar: :any, catalina:       "937edd5b2c5d684df7efb91067e2c8808dbbe456457778dbb7e80a0a145a235c"
+    sha256               x86_64_linux:   "46a9886feb0ea9b18c3eb74b1fd0cb3640faef52031d66e268e796814d70cd60"
   end
 
   depends_on "cmake" => :build

--- a/Formula/openttd.rb
+++ b/Formula/openttd.rb
@@ -11,13 +11,13 @@ class Openttd < Formula
     regex(/Download stable \((\d+(\.\d+)+)\)/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "c8e7924e6b8f1d3fc32c777ab3ab4b2ab1bffbca6d599497560b13799a389661"
     sha256 cellar: :any, arm64_big_sur:  "c7772367d985f9981bee4069208a958a398aab61923d9fd02f03b2a0c2926705"
     sha256 cellar: :any, monterey:       "3331f8d0d63db46dac47418043e24f29c6431fa071f9da5a97103a1464a0787d"
     sha256 cellar: :any, big_sur:        "9f9ff69db98080b7ae62828f639055b5e2b7bbd750271fee2d037e2ac8fa5884"
     sha256 cellar: :any, catalina:       "7d90dc5a119ce92be9347385e872ce40befc6ba68ff0ddf5c7f22caed55e26b6"
+    sha256               x86_64_linux:   "3dfbf841157447caddfb874da41cd9ca806d3b96ce54380b16e085e910f2c74f"
   end
 
   depends_on "cmake" => :build
@@ -30,6 +30,7 @@ class Openttd < Formula
     depends_on "fluid-synth"
     depends_on "fontconfig"
     depends_on "freetype"
+    depends_on "gcc"
     depends_on "mesa"
     depends_on "mesa-glu"
     depends_on "sdl2"

--- a/Formula/openvdb.rb
+++ b/Formula/openvdb.rb
@@ -7,13 +7,13 @@ class Openvdb < Formula
   revision 1
   head "https://github.com/AcademySoftwareFoundation/openvdb.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "335cfb69a9e3b591eed64131c41822f00058a021b097359ab8f02100b5a79317"
     sha256 cellar: :any,                 arm64_big_sur:  "2a8919f3442922f0249c66006d0008416499bb3beba78e75100a507db3809c0d"
     sha256 cellar: :any,                 monterey:       "cec4679ecf428581b69615253c728de62678e3339b5d8e7fa8083ee508c40d57"
     sha256 cellar: :any,                 big_sur:        "6cc379c5eee390df9758d01d1ef4f9ceeed21427d76a5b1424b0446f797df437"
     sha256 cellar: :any,                 catalina:       "c1e459e1d5d7c510420030dbaee505d0db0444494cbd95a6eef9c207515a7a06"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b4b843e1c02948cefdbcfee809cdd4a5a67b896a98e7f73f93e672dde920b00c"
   end
 
   depends_on "cmake" => :build
@@ -23,6 +23,10 @@ class Openvdb < Formula
   depends_on "jemalloc"
   depends_on "openexr"
   depends_on "tbb"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/or-tools.rb
+++ b/Formula/or-tools.rb
@@ -22,13 +22,13 @@ class OrTools < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "70bc042453a171a4ddfc617431495877022c3c9b39cf20e6b36977758e8b11e4"
     sha256 cellar: :any,                 arm64_big_sur:  "d7051adeec3d981e66813c1041c60772f4de566e024964f383fe9c42b65daf61"
     sha256 cellar: :any,                 monterey:       "d76faae4705c9f29fe71cf0daf2d50157f8daf0dfb1800b03ff58c0b8ed9f62f"
     sha256 cellar: :any,                 big_sur:        "3a88edaf5a3fdb34afe1202790fac3157a45d9dfdde3b48f2256d195e58d3bc5"
     sha256 cellar: :any,                 catalina:       "3cbf768fb36c903c77c3d35f5f818fb9d87c00128dfa5a8dcc4b579845c496f3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "619a54c8667620263c8d35ed08fd1ac8104ca4abef13bfa08efb94a21a1fc327"
   end
 
   depends_on "cmake" => :build
@@ -45,6 +45,10 @@ class OrTools < Formula
   depends_on "re2"
 
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/pc6001vx.rb
+++ b/Formula/pc6001vx.rb
@@ -6,13 +6,13 @@ class Pc6001vx < Formula
   license "LGPL-2.1-or-later"
   head "https://github.com/eighttails/PC6001VX.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "1fd959ab3d6b3527a09659b2db4df78f8892714758b106a3e47b76fcb4f2dec0"
     sha256 cellar: :any,                 arm64_big_sur:  "76c031d32a5e08a6662aa4eb9fb608624132d40981928fe3123b4609abd8f9ef"
     sha256 cellar: :any,                 monterey:       "cd638bc927e069d8705fb94da9b09095b2e567b86d431370b03b0f3605f74a24"
     sha256 cellar: :any,                 big_sur:        "aae1f5343fcb87b2a21181db473beecba98fabb17bb64ee7189f89834137b6ea"
     sha256 cellar: :any,                 catalina:       "e7cec22ab3e5307aceb886347da8c66a519d46cfdf17a31841a1903ea2314a3e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "56f1db0284c4dc6393c2130f21cfd0da50dccd0d40fb0dca31019ec4d927913e"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/pdfsandwich.rb
+++ b/Formula/pdfsandwich.rb
@@ -6,7 +6,6 @@ class Pdfsandwich < Formula
   revision 4
   head "https://svn.code.sf.net/p/pdfsandwich/code/trunk/src"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "a6af2fc71eb56e9f121e035b6348a1fa984989096a7158b963a84d5f7b92cc44"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "9d03e5564d606b37f3b2aaa2dc68837ca023e87c455c9543836a854ec7728c4f"
@@ -14,6 +13,7 @@ class Pdfsandwich < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "eed36d608adf9c4c6a7bcfa2f8d51fc7d7db6b9625d8dd87420b0a49432ed099"
     sha256 cellar: :any_skip_relocation, catalina:       "e45ad2480a96ef2ff2ee1a0a561004510d3d3f2b61117fce51d2995b5a004b34"
     sha256 cellar: :any_skip_relocation, mojave:         "dd4a617ef7bb8bb83cb9da94556537624bcf188789846e978ccb25926fcd7027"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6f77d1aa373059a0b32d879bc45f075527a28c6a0a2068b8d38d634dfd2d7d60"
   end
 
   depends_on "gawk" => :build

--- a/Formula/pianod.rb
+++ b/Formula/pianod.rb
@@ -10,13 +10,13 @@ class Pianod < Formula
     regex(/href=.*?pianod2[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "e0f97c293764bc1d6ec7e9e9e2d18d554b39ad95071e295592e33e4087376064"
     sha256 arm64_big_sur:  "f2fa087fb17f1e2cfc9aa1fb33a2a2c8438a024e06d510c43f2c15c9bf0cc2b8"
     sha256 monterey:       "b9aa59f530b8a6663a6483ef9e5dc18d28f024aaada85113b5ddcca42481b3d0"
     sha256 big_sur:        "4f100221aa096f62ff4accc0e2797781c4df7c4dbc4496668f6e2615fbc084fa"
     sha256 catalina:       "ca896c858edd71e8ec1545c4f8c5a107a40bfafa23304b521d1a5ee1c5861d01"
+    sha256 x86_64_linux:   "f00f9a7fbdb2e6483a1ffa15b5d6841d312e742b8907b60321ebdb9fce067210"
   end
 
   depends_on "pkg-config" => :build
@@ -33,6 +33,7 @@ class Pianod < Formula
   on_linux do
     # pianod uses avfoundation on macOS, ffmpeg on Linux
     depends_on "ffmpeg@4"
+    depends_on "gcc"
     depends_on "gnutls"
     depends_on "libbsd"
   end

--- a/Formula/qcli.rb
+++ b/Formula/qcli.rb
@@ -6,13 +6,13 @@ class Qcli < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/bavc/qctools.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "c938fd599d5673faa37050128aee9a772b4839d06904f5590e58418236d12777"
     sha256 cellar: :any,                 arm64_big_sur:  "c21c3d3503c25df679252810f0fe02ce8804d2ca17beca67e4e8d664a40757d0"
     sha256 cellar: :any,                 monterey:       "0848ef18376ea60af79db5a6dacd3238057d3026d58301fb2a7005e88835627e"
     sha256 cellar: :any,                 big_sur:        "834aa115e6d3564ecd1b2ee6aa92bb614205c04f219b31ab3afa49394bc4823d"
     sha256 cellar: :any,                 catalina:       "c2bca545b18f596970d770bdcfdd8e8d28fbf8066da7ec1916e6ed8efdd6b45b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ec653e796249edd74fa133508baaf3577ed5acbcfead80fa040db92ce741275c"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/qmmp.rb
+++ b/Formula/qmmp.rb
@@ -10,13 +10,13 @@ class Qmmp < Formula
     regex(/href=.*?qmmp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "71a53acc1108adc9c918a979ef90d5af0800eb99d7c0293b7e967049f94125fb"
     sha256 arm64_big_sur:  "e60001ec427e59a06271e08259035db1f8035faede6072ecfe72fec2d93885ed"
     sha256 monterey:       "34bcff555cd200f2466183c88778a371b8e2336dfa34a99e946b0db97bd949d6"
     sha256 big_sur:        "4250889ad41fcd66a89c29b02d580b3f5c43d795784c9c184b79cecf12c6f4d1"
     sha256 catalina:       "b775a1c3af67e426845a72fca215bb66ea3fdfa07d5d492ec6528ce77f639a8e"
+    sha256 x86_64_linux:   "a7e875d93455467c6ab319f96281dd7af62407830596931bc5ebb96cd6aaffdf"
   end
 
   depends_on "cmake"      => :build
@@ -59,6 +59,10 @@ class Qmmp < Formula
     # musepack is not bottled on Linux
     # https://github.com/Homebrew/homebrew-core/pull/92041
     depends_on "musepack"
+  end
+
+  on_linux do
+    depends_on "gcc"
   end
 
   fails_with gcc: "5" # ffmpeg is compiled with GCC

--- a/Formula/rtags.rb
+++ b/Formula/rtags.rb
@@ -39,19 +39,23 @@ class Rtags < Formula
     end
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "67fde9c9fd4f1ccc4dd3150278f9323974e1a49193f157efb852cd49aa3e6858"
     sha256 cellar: :any, arm64_big_sur:  "271ed75ecc942d6577918b24b7002a5823c0387488d1cdc119858671906fc41d"
     sha256 cellar: :any, monterey:       "1fb01122c1387a7e94fa8a778bee77466b73ee3d4b3f843d06f6bd2d5d0a36e4"
     sha256 cellar: :any, big_sur:        "7d898020bd18e0a52f2e6295ce749c5bd26cbdfadc5b0dd4e03753c875a39e72"
     sha256 cellar: :any, catalina:       "a20866caac99a36a4310a3e157fe898e8dd0e6ed6e2f52e9b397e327060dc2a1"
+    sha256               x86_64_linux:   "de2a6f23bb6620c4790fc5c48c2e9306e82d60cfae5e31e48181b6033c98dcd9"
   end
 
   depends_on "cmake" => :build
   depends_on "emacs"
   depends_on "llvm"
   depends_on "openssl@1.1"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/rubberband.rb
+++ b/Formula/rubberband.rb
@@ -11,13 +11,13 @@ class Rubberband < Formula
     regex(/href=.*?rubberband[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any, arm64_monterey: "5e69d82b8ac49175b0d5f7ce7cd144cf5ad0a1a53256ec3d320a88e049f519d4"
     sha256 cellar: :any, arm64_big_sur:  "fe47590afe376f2f7e1b24a239a5e4947534d8425e97c42a3a34b30d343f3d02"
     sha256 cellar: :any, monterey:       "ff93a71a132ce14e836d9f3d80d430ef41c39470da40d4088d3d8d3e58cf827f"
     sha256 cellar: :any, big_sur:        "b02d05078216b43fe33e2b1354fd8a67fa5c3330f893480ccb3bc2b6bb9880f2"
     sha256 cellar: :any, catalina:       "b73a156422b447a2c5a9426abbc70e58e97b0bb644080849e796d8ddbbbab630"
+    sha256               x86_64_linux:   "2edf30d682c1aeebe61f194a30e8d06203baa8bf88a05a83a5465e4fa30496d3"
   end
 
   depends_on "meson" => :build
@@ -28,6 +28,7 @@ class Rubberband < Formula
 
   on_linux do
     depends_on "fftw"
+    depends_on "gcc"
     depends_on "ladspa-sdk"
     depends_on "vamp-plugin-sdk"
   end

--- a/Formula/scrcpy.rb
+++ b/Formula/scrcpy.rb
@@ -5,13 +5,13 @@ class Scrcpy < Formula
   sha256 "e3054ad453ac577b941f8df0eabc94e842affc6e1d10ba8d21cededfa2eacc73"
   license "Apache-2.0"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "91df79f4024fa176e181472704132910a6738581fa8332de47e52af4874eec75"
     sha256 arm64_big_sur:  "bef49af8e3698d505717df5e1b96c1fddba8ce60e6ec5abde1b49ed47a28dfd3"
     sha256 monterey:       "d78192eddd8e0a55086a8e72ab5e58ed04102edbcd4965cb2689991fa66b80f5"
     sha256 big_sur:        "79796e78b1caa76cd5b4015ff45809cf034589cdfd6fe82d2c3ba136f42db762"
     sha256 catalina:       "50ffe9ea62b01ac23ec09b618d1451bcdac8a81b7d7cd4eede2446997527af5b"
+    sha256 x86_64_linux:   "2230b214d82871edad106d8bfeae19ec53b5c9354f164111021162a4242e851b"
   end
 
   depends_on "meson" => :build
@@ -20,6 +20,10 @@ class Scrcpy < Formula
   depends_on "ffmpeg"
   depends_on "libusb"
   depends_on "sdl2"
+
+  on_linux do
+    depends_on "gcc" => :build
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/serverless.rb
+++ b/Formula/serverless.rb
@@ -8,13 +8,13 @@ class Serverless < Formula
   license "MIT"
   head "https://github.com/serverless/serverless.git", branch: "main"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "bbd2953055332c0a596e53d102e8f80f1c47f5b9c3d1566ef743c8cce4ac9871"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "bbd2953055332c0a596e53d102e8f80f1c47f5b9c3d1566ef743c8cce4ac9871"
     sha256 cellar: :any_skip_relocation, monterey:       "1e7a2e2409fb564f0596edc002e897e326737c9e868e3212466baffbc8b42895"
     sha256 cellar: :any_skip_relocation, big_sur:        "1e7a2e2409fb564f0596edc002e897e326737c9e868e3212466baffbc8b42895"
     sha256 cellar: :any_skip_relocation, catalina:       "1e7a2e2409fb564f0596edc002e897e326737c9e868e3212466baffbc8b42895"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "82efe8bad35c6f421da6d2aa201219fee02ac195584913f93a2dd37ad1fe8d74"
   end
 
   depends_on "node"

--- a/Formula/simple-tiles.rb
+++ b/Formula/simple-tiles.rb
@@ -7,13 +7,13 @@ class SimpleTiles < Formula
   revision 16
   head "https://github.com/propublica/simple-tiles.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "e1feae5d81d6053c7250b215f0479498e9b1c877a5fe9c4250912a4d68a4e24f"
     sha256 cellar: :any,                 arm64_big_sur:  "6a6fb456fa5ddbb46efd66c33f6146a8a690be8339d075900a71cb2822f8ca4f"
     sha256 cellar: :any,                 monterey:       "34c7b1151f1d76c0960fd51fe58be239c1f5500ce899a751f80f35324285f7c0"
     sha256 cellar: :any,                 big_sur:        "c0a0749749fcaff01e88bf679bad4fc6b592ddb6b01565b5e1a213a81ed840ab"
     sha256 cellar: :any,                 catalina:       "74bf35c12b55c9906e7ff0e07cd4f9b379f936735efe376267c41c57e49e276d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cecab0695264296890e13713b6ab3b890a93df255cfcf488a4e705a8d45e895b"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/simutrans.rb
+++ b/Formula/simutrans.rb
@@ -12,13 +12,13 @@ class Simutrans < Formula
     strategy :page_match
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "89c68007e13410b6d7fc4d675f0eabc4487393ad4d4768d2e0830a206ae5dae7"
     sha256 cellar: :any,                 arm64_big_sur:  "aa8073c151259b074563854c6ea63ffaab8a41b268b150e24d3dab93ab75231e"
     sha256 cellar: :any,                 monterey:       "339ac25e7eb60cbe2158c59feece111a66bdb587e23f4104c5045b820c861031"
     sha256 cellar: :any,                 big_sur:        "076b15195eb642b6e97eef391580c62d9333a52c68f8551aeb1812736e9967d1"
     sha256 cellar: :any,                 catalina:       "e618f3935018b641b10d70286fe3d60e366cfcd914125a634d6c51c8e33fad79"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2c2eb82d4b879f59e2201b78d11cea24a8f8f3fc7ba2859d5c6c3aa41a830355"
   end
 
   depends_on "autoconf" => :build
@@ -30,6 +30,10 @@ class Simutrans < Formula
 
   uses_from_macos "curl"
   uses_from_macos "unzip"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/siril.rb
+++ b/Formula/siril.rb
@@ -6,13 +6,13 @@ class Siril < Formula
   license "GPL-3.0-or-later"
   head "https://gitlab.com/free-astro/siril.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "6e2a517c7c7c697440ef5ca850bed738a117f88e55c4962766c9e7dca72d7d41"
     sha256 arm64_big_sur:  "a6ebd53726bc9d9d24ea3ca857507801ad45e1d99ff3c773bf8ac38ec459730b"
     sha256 monterey:       "cf1b0437f4c1abf99267ec82393cece1d3f44e8e5815de1c8d38b634adb3e802"
     sha256 big_sur:        "1c471f84f0e3635888a951d9addae170d61c1d3b54d15a26ca9f0f2c2450b1d3"
     sha256 catalina:       "ebc5dc9a3e151c417833782f22c48e4af5302ac927e004c99c8e8ca6e5ef0916"
+    sha256 x86_64_linux:   "e3e086e77f6fd437595f7d8e7ff8196d85a9c367aa31e1d6be1e9a599a0fdd8e"
   end
 
   depends_on "autoconf" => :build
@@ -43,6 +43,10 @@ class Siril < Formula
   on_macos do
     depends_on "gtk-mac-integration"
     depends_on "libomp"
+  end
+
+  on_linux do
+    depends_on "gcc"
   end
 
   fails_with gcc: "5" # ffmpeg is compiled with GCC

--- a/Formula/sloc.rb
+++ b/Formula/sloc.rb
@@ -7,7 +7,6 @@ class Sloc < Formula
   sha256 "fb56f1763b7dadfd0566f819665efc0725ba8dfbec13c75da3839edf309596e6"
   license "MIT"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "ebd1c159ad1f9f263528431a12b45bea9bffb4e0bf28393da414e9ccb62f9942"
     sha256 cellar: :any_skip_relocation, big_sur:       "28fb222768fc7ca90e6a9fa29c97d5f79f11bd9a928024ae84aabe8dfb8f0ff9"
@@ -15,6 +14,7 @@ class Sloc < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "f241a7bf03cb7bb97bb061f5f46442d7a40de893697a5335c821049d471e9466"
     sha256 cellar: :any_skip_relocation, high_sierra:   "345308d671b83edb390c143554c64958135cf37bc7cd365ce613011da682a8b7"
     sha256 cellar: :any_skip_relocation, sierra:        "1386a024efebe74829d85c8d75d07ae9f09f8c8a8104aa41424a5ea8c425fca5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "48646678b61d6a776462692734af1f5048d0c31faf8e2c6118e452ab48b553d4"
     sha256 cellar: :any_skip_relocation, all:           "bf12e86a52f11e012ab47f6ce03f690ecaf0e80b2250271378fcc3ef645ed7b6"
   end
 

--- a/Formula/snapcraft.rb
+++ b/Formula/snapcraft.rb
@@ -14,7 +14,6 @@ class Snapcraft < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "a6dcb83b7b49cf8d66d10fe8b07f618bd738be17f527aa27bb26c12463547463"
     sha256 cellar: :any,                 arm64_big_sur:  "bc26b770bd8c1ea649085e8a77d1b3ab3a29d1b996d796308d20eea851d814f7"
@@ -22,6 +21,7 @@ class Snapcraft < Formula
     sha256 cellar: :any,                 big_sur:        "b442a18012137247cf1822d0db825cca3c0e69bfdb244744de6672db76280e02"
     sha256 cellar: :any,                 catalina:       "a4b036213d992185bd3d61c00b7dc90b0e82dcbc2ec8ab842c1dfed298acd04e"
     sha256 cellar: :any,                 mojave:         "e4cc628cee8d1c5690296b4d60e4d306d92e5c8ad2a619540f4e833e63c54536"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ebfa2c4782334025436d67b2d2aec5b76e0429c9a245682c138f1d442e8ce5a3"
   end
 
   depends_on "rust" => :build # for cryptography
@@ -39,6 +39,7 @@ class Snapcraft < Formula
   on_linux do
     depends_on "intltool" => :build # for python-distutils-extra
     depends_on "apt"
+    depends_on "gcc"
 
     # Extra non-PyPI Python resources
 

--- a/Formula/snort.rb
+++ b/Formula/snort.rb
@@ -7,13 +7,13 @@ class Snort < Formula
   license "GPL-2.0-only"
   head "https://github.com/snort3/snort3.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "1b85e43d2913c2099bf61f6087cc6c2d43f52fe1d90b438c12cc42e81576e081"
     sha256 cellar: :any,                 arm64_big_sur:  "6255dad20d58f2546b8d14b95def79f75729ec7c78feb2193156f766fd34f6be"
     sha256 cellar: :any,                 monterey:       "298f12f999ca0d2de48429ace04d147af67885584f60c9f76fc1edcbc46b1096"
     sha256 cellar: :any,                 big_sur:        "f68e42f96390ef255c7751e428c7bff8e16e68d1baba019e53de32549ffa60ea"
     sha256 cellar: :any,                 catalina:       "a1e5cdd6f5d3d6da45536247b1c3e3d67b0b12e6c0e430f32ff60e2862808a0f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "87e0476624996b0cdfb710d67e0af751231de3b03571099e2897c49746cd37eb"
   end
 
   depends_on "cmake" => :build
@@ -33,6 +33,7 @@ class Snort < Formula
 
   on_linux do
     depends_on "libunwind"
+    depends_on "gcc"
   end
 
   # Hyperscan improves IPS performance, but is only available for x86_64 arch.

--- a/Formula/snowpack.rb
+++ b/Formula/snowpack.rb
@@ -7,7 +7,6 @@ class Snowpack < Formula
   sha256 "0cf99f86955b29c3e40332131e488ff38f64045ef23ba649d0a20c2a7cd2d29e"
   license "MIT"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256                               arm64_monterey: "a58108194a509b22ed1f173f6bd1d5debd8a877d5cd536f280d06df5d6f906c8"
     sha256                               arm64_big_sur:  "424c198450962b4be8cf4314d570ff7e8febc23308b22430a47b8aaf0d4f3531"
@@ -15,6 +14,7 @@ class Snowpack < Formula
     sha256                               big_sur:        "fb13d64f32a7d9bdc58cf4dfd6776bf1254b09029b2778c6b6ae8aa1f3af5897"
     sha256                               catalina:       "abed65f5debef77a9380822f5612b17933df211375766e800fb9e481f2829178"
     sha256                               mojave:         "76e0af8a4e5f7fbc2d2095e8c6524c80a8e03ac2c9f9cbc2b8b319fff3dd7056"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "78baacecc857f50f7a6fbe7643c4edad620c4e2c09a0f31e336fcfa52f0576e6"
   end
 
   depends_on "node"

--- a/Formula/solarus.rb
+++ b/Formula/solarus.rb
@@ -7,13 +7,13 @@ class Solarus < Formula
   license "GPL-3.0-or-later"
   revision 2
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "2ae97a8f18bee5115f7f801ec8a8b31d6ad6ba98491402084432b954406af8aa"
     sha256 cellar: :any,                 arm64_big_sur:  "f88cd9f0a9883baa813108017034bdb54dd4d5ae8c1c651fd2a0bb23076896d6"
     sha256 cellar: :any,                 monterey:       "979da74628804c8e2517ffd5ee1dd97331d8b88f9148ecb6943db3985a574bfe"
     sha256 cellar: :any,                 big_sur:        "e134a16e60f8b9c9aeedc4824acba770e01c70ca5ddbf623a87b112bd708757e"
     sha256 cellar: :any,                 catalina:       "2ca4689984b74144664fc5e620df94ac3b1bbece2ab8ad0a2641fad3aba07880"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "50e9579c71bd23cf4a0eb8f84ffba1be2f101f3278ec1df94fe2150100509909"
   end
 
   depends_on "cmake" => :build
@@ -28,6 +28,7 @@ class Solarus < Formula
   depends_on "sdl2_ttf"
 
   on_linux do
+    depends_on "gcc"
     depends_on "mesa"
     depends_on "openal-soft"
   end

--- a/Formula/solidity.rb
+++ b/Formula/solidity.rb
@@ -10,18 +10,22 @@ class Solidity < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "1f308618d79c708fc20dde86dd0290c0720b4d79d599c45723c43b74b0833540"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "5c0789479044279818c63e772322767222d793c539d795bf7537f832357306e3"
     sha256 cellar: :any_skip_relocation, monterey:       "831d68c60972e17dc8a4459dd216e5844adb5e3654537955820b2399dd5dbc77"
     sha256 cellar: :any_skip_relocation, big_sur:        "056b43bad2d0945934ba4390b1f728fd7ec11dff1583c3ec65bd9e9922a952c9"
     sha256 cellar: :any_skip_relocation, catalina:       "d56203923ac9975791993b359ce8e871488ff75feb92e08d1f6020d1a5fc0d3a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "16c200f3c86602d369154d911c67ad4e684afb6270237d5cbef8b2e3b84361f2"
   end
 
   depends_on "cmake" => :build
   depends_on xcode: ["11.0", :build]
   depends_on "boost"
+
+  on_linux do
+    depends_on "gcc" # For C++17
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/spirv-llvm-translator.rb
+++ b/Formula/spirv-llvm-translator.rb
@@ -5,17 +5,21 @@ class SpirvLlvmTranslator < Formula
   sha256 "1afc52bb4e39aeb9b5b69324a201c81bd986364f347b559995eff6fd6f013318"
   license "Apache-2.0" => { with: "LLVM-exception" }
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "624e78d249e32eadd7f878a1614f48d6221b7c003ca1320d1caf7a26e2ce17bd"
     sha256 cellar: :any,                 arm64_big_sur:  "77a011303bed9649122aaa2e8e525524009bbb37aeac323f01eebd7024466027"
     sha256 cellar: :any,                 monterey:       "a93b9293ec484e764a2b7d78a7e495408cdeb0f34e82f6f323e2dce2541b277c"
     sha256 cellar: :any,                 big_sur:        "b8b5cbdda3d0e86c9fce82a49e7b7c8b7d1ed1a7004071d4c391550e0cd8545d"
     sha256 cellar: :any,                 catalina:       "986f6173f32dff93e402476eb29107b4e191f2f2ee6af3e8190a02e184454e89"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8e595c8944ed32fa7a100a2091b1de0d23aa3530c0c728f9d4d9e1aa25353ade"
   end
 
   depends_on "cmake" => :build
   depends_on "llvm"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56480
   fails_with gcc: "5"

--- a/Formula/spot.rb
+++ b/Formula/spot.rb
@@ -10,16 +10,20 @@ class Spot < Formula
     regex(/href=.*?spot[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "b1430858b8bb86bf381ce7ce6bdf2ad6353eca969ff76967e5f307ad9e21032c"
     sha256 cellar: :any,                 arm64_big_sur:  "3446679a5ef8e565deff8aa7cb25b3da156056cd0e96f084e64a920cef428fce"
     sha256 cellar: :any,                 monterey:       "bedb932f538883e9fad2d64dc00b5185ecc49d44ef99b88ab65d6d0951c76827"
     sha256 cellar: :any,                 big_sur:        "62b1883615299ed12f9bda54f0b381ce5ffcc4badbc0ba0d8a59301f97d5e60d"
     sha256 cellar: :any,                 catalina:       "06eefd56dca1c57ddaa883ec4f0985db4b48ee119befa0e18ef7fe67221040e9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ea1d2f111bd18c6b35d808273777d5b3f1c58adb29e5c9d943114f50e67e5440"
   end
 
   depends_on "python@3.10" => :build
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # C++17
 

--- a/Formula/sql-lint.rb
+++ b/Formula/sql-lint.rb
@@ -7,13 +7,13 @@ class SqlLint < Formula
   sha256 "0ee3b71d812af3cc809829b663d9cd747996ec76e2b3e49fd3b7a5969398190e"
   license "MIT"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "c41585b38889006247a0d7a66278ba037138d2395321031d0ac899892fa19255"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "c41585b38889006247a0d7a66278ba037138d2395321031d0ac899892fa19255"
     sha256 cellar: :any_skip_relocation, monterey:       "56ec39a2f7cd18626231790aaeab98c6f4d7fa648dc6227cd65884dfdddd3d15"
     sha256 cellar: :any_skip_relocation, big_sur:        "56ec39a2f7cd18626231790aaeab98c6f4d7fa648dc6227cd65884dfdddd3d15"
     sha256 cellar: :any_skip_relocation, catalina:       "56ec39a2f7cd18626231790aaeab98c6f4d7fa648dc6227cd65884dfdddd3d15"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c41585b38889006247a0d7a66278ba037138d2395321031d0ac899892fa19255"
   end
 
   depends_on "node"

--- a/Formula/standardese.rb
+++ b/Formula/standardese.rb
@@ -9,13 +9,13 @@ class Standardese < Formula
   revision 6
   head "https://github.com/standardese/standardese.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256                               arm64_monterey: "20510779aff9169f62e4a59f6660754ec0d6922cd111c815bf69448fc2cb9332"
     sha256                               arm64_big_sur:  "d33f33d4eee420512ffabc9256224944ece9cd0fdcc6927baf3fa673b9ae89d4"
     sha256                               monterey:       "b0532208ae09b3dac683c18d82124889e487e771727a4e9d1435612b4a83368e"
     sha256                               big_sur:        "f20d482991377fd461a1e877d287faa4023a9d969883f782122ea224e6e767e3"
     sha256                               catalina:       "34d139092ee7b1e1792d4576c11e782e25c23214503f60dab7f4cafc1de85432"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bc974babb4114c8acf316df01d2ae24f9822fd31cb0e2e4d87f6fcc2521bf245"
   end
 
   depends_on "cmake" => :build

--- a/Formula/stella.rb
+++ b/Formula/stella.rb
@@ -6,13 +6,13 @@ class Stella < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/stella-emu/stella.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "77773fb03e92c01def740b7acba99c765ed509e04b0adf0372d59f11634fdc92"
     sha256 cellar: :any,                 arm64_big_sur:  "f1d2831b612ce334a42b340e15482f4abfea1095f2850904b87fb388f5b644e6"
     sha256 cellar: :any,                 monterey:       "93530cff4003a6155360f6a7683913d536a81856909672d1db4a750a9ccf87d9"
     sha256 cellar: :any,                 big_sur:        "6a982f58468560bdb62cec0d2235e56343b7373a93176a0af005c0f7ee5329e8"
     sha256 cellar: :any,                 catalina:       "9f01df79243f051af7f6634646b7398ba8d380fa9213233b0f01f6c4a13e9fb0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6aae8f6b0df12475faeafb6bcfb80c6009bdd68539e301a7bb945571be9e363e"
   end
 
   depends_on xcode: :build
@@ -20,6 +20,10 @@ class Stella < Formula
   depends_on "sdl2"
 
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/stellar-core.rb
+++ b/Formula/stellar-core.rb
@@ -7,13 +7,13 @@ class StellarCore < Formula
   license "Apache-2.0"
   head "https://github.com/stellar/stellar-core.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "1448e110ca53e698c17c8b03f9624b97cd27a5b850b873a68a2d431f768ee98e"
     sha256 cellar: :any,                 arm64_big_sur:  "3e2d3cb23a83a67588967e7fc6f469a53a6ae368b05c3295dfe7559dabb90306"
     sha256 cellar: :any,                 monterey:       "28bce77a35079c3da0c3553dec91bd0282f29f55a98f015a1e66b04dff37828c"
     sha256 cellar: :any,                 big_sur:        "243a2fcfe423ba6a6023b70df32d044095bfcb5545d571f3ccf63b9d3bfd2f87"
     sha256 cellar: :any,                 catalina:       "c2b043f20dbe8038906076e402cfab67b41f50a97236a60a4b5ab46f51f99721"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9abefc1c4abcd62475c622bc3f433a947d14f8aaf538153bb57cc5173d7ce0bd"
   end
 
   depends_on "autoconf" => :build
@@ -30,6 +30,7 @@ class StellarCore < Formula
   uses_from_macos "flex" => :build
 
   on_linux do
+    depends_on "gcc"
     depends_on "libunwind"
   end
 

--- a/Formula/stockfish.rb
+++ b/Formula/stockfish.rb
@@ -11,13 +11,17 @@ class Stockfish < Formula
     regex(/^sf[._-]v?(\d+(?:\.\d+)*)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "775aa929a7068fe8c55b17658a75a09a8b3191fe95339ec8366bf4b5caf48be5"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "1d584b40e695a1ed4eb19b4b6e1013c580b28e74f3ca2bdb25a15ce1b5473db4"
     sha256 cellar: :any_skip_relocation, monterey:       "6747b74d9cc107ab4d0e7b6f051a9f96a30f5dac53c2fbfbac49c0ba246326e4"
     sha256 cellar: :any_skip_relocation, big_sur:        "5336ae6cdc7d0ad712a527102209156c5a5b12ef8238606798f996b528e41d57"
     sha256 cellar: :any_skip_relocation, catalina:       "fb242d484c460218a677549600fd51a6d82f1cc47751283d2047ae8b5dbbaa4f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "87210cffd22b657169dfc10428a1ab92ebfd3029f5c051fdc5006e35cc61b5fb"
+  end
+
+  on_linux do
+    depends_on "gcc" # For C++17
   end
 
   fails_with gcc: "5"

--- a/Formula/stone-soup.rb
+++ b/Formula/stone-soup.rb
@@ -12,13 +12,13 @@ class StoneSoup < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "739eb63071963e6998243a03592a1c85dbb87b1ae39edbbbd5d4412f887ddcfb"
     sha256 arm64_big_sur:  "5c73e7b489f45806902d011973d91947c9d0af47aa2cea058e81fdfa9b2f15c0"
     sha256 monterey:       "00ebb829ffc8ad6b608e50528ec8b4692f2181efce13c071688c0ebd03012a16"
     sha256 big_sur:        "d68275933552ec851d6e1f06a8528d6d2f6eb3b683e21fa34beaf5f9c5e23c1d"
     sha256 catalina:       "0a5fed8750fcfda5f27efc2a8337e844911454fad521cad6d21e4585211b64a5"
+    sha256 x86_64_linux:   "7a6b21ce059ffeaca3fad2ffde77fccc2d030e1f2212f6cf23693a8afbe1ddcf"
   end
 
   depends_on "pkg-config" => :build
@@ -26,6 +26,10 @@ class StoneSoup < Formula
   depends_on "lua@5.1"
   depends_on "pcre"
   depends_on "sqlite"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/synergy-core.rb
+++ b/Formula/synergy-core.rb
@@ -34,13 +34,13 @@ class SynergyCore < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256                               arm64_monterey: "93130d9add2ff477b7ab848e0f4b4336031ca0ff50dddc2b67cfaef51040bd56"
     sha256                               arm64_big_sur:  "5d3fab34b90a58e079012cc8d2b7f441ad098214161d83894558177b356ed2ed"
     sha256                               monterey:       "2fcafb9115be3180db650acf09ba588ebfadb9c0f8c4a0ecde4d56f9df458206"
     sha256                               big_sur:        "ea0c6b24239d0e24a28cc5a8668cf85b956f3d4d2f43d0102c5a43742a07d49b"
     sha256                               catalina:       "f1666f47106ce89f7607d0e24ed2dd9d1d5d3ac0dce72357ff81c0f4b55612ec"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cbab7cd07ce0f831b70812149aba63de79a8ab7cf998396e44742065249082b6"
   end
 
   depends_on "cmake" => :build
@@ -50,6 +50,7 @@ class SynergyCore < Formula
 
   on_linux do
     depends_on "pkg-config" => :build
+    depends_on "gcc" # For C++17 support.
     depends_on "gdk-pixbuf"
     depends_on "glib"
     depends_on "libnotify"

--- a/Formula/sysbench.rb
+++ b/Formula/sysbench.rb
@@ -7,13 +7,13 @@ class Sysbench < Formula
   revision 2
   head "https://github.com/akopytov/sysbench.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "40f5fc3a27f285b45dd864fc58d86dbcb5323e85539986973675bd2bd8a62029"
     sha256 cellar: :any,                 arm64_big_sur:  "cd5ffec8e0c4467c339ea6da2017c160acc695afda9e0e7572092eb6a2bf5a13"
     sha256 cellar: :any,                 monterey:       "b1cd2a8cd2e4a116976d7082b3e4c38b3df986a2033fe6e81745e6e9da25efe9"
     sha256 cellar: :any,                 big_sur:        "a79024100f669f978e69d22869dcfef53f15a7d2760e0268f94888a354068299"
     sha256 cellar: :any,                 catalina:       "df79e63911a44aa9f6a4b3eb0f9c74a1dd8ca5810b5f6d1a70ae79b1a58f29d0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "66d8aad04cd69ea97d38693e07231aba70312c269bf4687cd47f3d5dd3c98b8c"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/sysdig.rb
+++ b/Formula/sysdig.rb
@@ -21,13 +21,13 @@ class Sysdig < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256                               arm64_monterey: "2d6f3f56bc296c1a61ebb845d21c306f0c221649ec4e9eef1dc960e1436eb7cd"
     sha256                               arm64_big_sur:  "2b94a4f8b946be161a4049e197d03f7d3c9b4d6515e84777c90de54fe8e6847d"
     sha256                               monterey:       "a036c52834863c81b36d9bc61f2e4beae91071e5a78dcdffcf7cff0c42ee50cb"
     sha256                               big_sur:        "d7f3d67ee95aab34dd69b2be6df866ac50968d83b3ba30d2ba32f6afeb1dfc49"
     sha256                               catalina:       "f2a6d211b2ae24f9223a90a5ca0a278a93ee8cee8f0dfe132f6cab0227bfde9b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b8b585f6db774e56c095f30b22807c509b41d5f9ecf8638eb2c7b352b7a5ee5f"
   end
 
   head do
@@ -54,6 +54,7 @@ class Sysdig < Formula
   on_linux do
     depends_on "libb64" => :build
     depends_on "elfutils"
+    depends_on "gcc"
     depends_on "grpc"
     depends_on "jq"
     depends_on "protobuf"

--- a/Formula/tarsnap-gui.rb
+++ b/Formula/tarsnap-gui.rb
@@ -7,17 +7,21 @@ class TarsnapGui < Formula
   revision 1
   head "https://github.com/Tarsnap/tarsnap-gui.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "f8f2504a74299c6fbcc41df3811498f6d4f8716ade39165f5fb8a2e611ae0aac"
     sha256 cellar: :any,                 arm64_big_sur:  "0e8def1a5aad31ebe64570260d5c622bd350880034c26d35c0d564b2bda46a98"
     sha256 cellar: :any,                 monterey:       "807c80d7626a0e7c1bb318e379e1e5fffe32d1f80bda8cf2cd09063434c0d447"
     sha256 cellar: :any,                 big_sur:        "caa57be13fe93093dfd6fd275d7648f181db9508064308267bd3d5883974d00c"
     sha256 cellar: :any,                 catalina:       "84c04aa45fbc4620b074386f5238731ad053e95b17309e27ce923c9e0439b3c0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "47b23d0ded49784f629d78b087dc9af73993c59aa0c00108fa41c18b9318843c"
   end
 
   depends_on "qt@5"
   depends_on "tarsnap"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # qt@5 is built with GCC
 

--- a/Formula/tasksh.rb
+++ b/Formula/tasksh.rb
@@ -12,7 +12,6 @@ class Tasksh < Formula
     regex(/href=.*?tasksh[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "6c6390a79e5f4645f2cf2507a1c29ad1b935a5f51d87387412e557343688a11d"
@@ -21,6 +20,7 @@ class Tasksh < Formula
     sha256 cellar: :any,                 big_sur:        "987789014e770fb3b4b1d4500321877c457ba2a1dde2fc9925762dfb0d7da541"
     sha256 cellar: :any,                 catalina:       "68a13aa8ea81fd1fe7c2c5e9eadd3850fe21265b34c4cf2f1cf7e7ede3caeaee"
     sha256 cellar: :any,                 mojave:         "a2178acd290abac6dc8c024b48304c05660616639c7de1c7b35eb166ae8345dc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e8a89402e614a9f93aa6716e6b4c442b44f2f0471c0d8534096ee8428565a149"
   end
 
   depends_on "cmake" => :build

--- a/Formula/terminalimageviewer.rb
+++ b/Formula/terminalimageviewer.rb
@@ -6,17 +6,21 @@ class Terminalimageviewer < Formula
   license "Apache-2.0"
   head "https://github.com/stefanhaustein/TerminalImageViewer.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "fbf2316ed0c4cc099c29b52dcf1970d78a90c3325ae89e3dff2e66c4faf1722d"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "d9d5d315e5ac576411e6bc71adc39566f1610d355b4d2f243568ee44b79228e7"
     sha256 cellar: :any_skip_relocation, monterey:       "f9939913e227575dcadd570ffce7325f338de0b32381a13a57548dc81874639f"
     sha256 cellar: :any_skip_relocation, big_sur:        "d37173ffc79b0f4e7bef0d9f24105209ddf1ea9c7283e6607b0b7549ecadcd6e"
     sha256 cellar: :any_skip_relocation, catalina:       "b0a77c46278852529506b8a6e4b0a377445005fa4ab32b003c12f0b87bddd01d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a612b37b5f01ee66ea80005c2a3d9dadbb5717512dcb890927ad1cba14e55db5"
   end
 
   depends_on "imagemagick"
   depends_on macos: :catalina
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/tesseract-lang.rb
+++ b/Formula/tesseract-lang.rb
@@ -5,12 +5,12 @@ class TesseractLang < Formula
   sha256 "d0e3bb6f3b4e75748680524a1d116f2bfb145618f8ceed55b279d15098a530f9"
   license "Apache-2.0"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "3ce8f09d799cc3483cfba6c3a238b10271507c9e309828521b1f86325a2f79b0"
     sha256 cellar: :any_skip_relocation, big_sur:       "7a4a2646cf813ffa6778f4b110d98666144d2b44dde177f66a663de313f781bb"
     sha256 cellar: :any_skip_relocation, catalina:      "93f7d390e6f209f2f452a181a832d0d88e21b7afc171515cf9eeb3a9ba500ffd"
     sha256 cellar: :any_skip_relocation, mojave:        "28d91c5d2a8efc9f33d5ccc4d8eb76bf0c6649f604d1f9a52e06c3b8e3a2daef"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "589b4e7851f76924cf8bd77155f53ffda95bb92cbb19327aed1766000a203760"
     sha256 cellar: :any_skip_relocation, all:           "589b4e7851f76924cf8bd77155f53ffda95bb92cbb19327aed1766000a203760"
   end
 

--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -11,13 +11,13 @@ class Tesseract < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "ad4c2c27f59f9c094d1ca9e81e731614491b785c8995f7dc505404bd8e35f34d"
     sha256 cellar: :any,                 arm64_big_sur:  "70fb8a3f055181efe94973fc4aa2a74460b99620b74b970713bc895666daa79b"
     sha256 cellar: :any,                 monterey:       "c0ea33e79f58f2e7dec3dd9c0f24a2d6e604ab8308d906f2804f0d4455ed9f3a"
     sha256 cellar: :any,                 big_sur:        "94e75d2c6e2ae832c88ed4806dd19e18ee2e8ab8acb2d41ab683f955b80a562e"
     sha256 cellar: :any,                 catalina:       "6a3b145ef65efa99373995eee83fe288f727490d759e56c22eb066bcc348825c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3ada571eade45d98869e2cb2de5e091dae975f8b48243217724944aa04f372dd"
   end
 
   depends_on "autoconf" => :build
@@ -26,6 +26,10 @@ class Tesseract < Formula
   depends_on "pkg-config" => :build
   depends_on "leptonica"
   depends_on "libarchive"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/thrax.rb
+++ b/Formula/thrax.rb
@@ -12,13 +12,13 @@ class Thrax < Formula
     regex(/href=.*?thrax[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "c13867026b97d86192e436f4da236b7dce271a44b21c1b0388cd4aec700adc99"
     sha256 cellar: :any,                 arm64_big_sur:  "fb098c0a6832a09efacef7252d8f472dddfc280c540b8190de18b1ae45b30fe6"
     sha256 cellar: :any,                 monterey:       "653c405ae61061f57f17457657da161ded1ddc39056712dbb7d7dd9643509824"
     sha256 cellar: :any,                 big_sur:        "4a09f5dcaccb60db82d0e034a8ab66b32e01756aa99f72c08531e0d5d3a98154"
     sha256 cellar: :any,                 catalina:       "722203944df85f4144814246f34a3eeaabdfe110b4fa80584ca28b76e4334596"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "17300c144318201c1ebeafe8cf01bf50ce47ded3a71b98096ae5a94ab98e585e"
   end
 
   # Regenerate `configure` to avoid `-flat_namespace` bug.
@@ -30,6 +30,7 @@ class Thrax < Formula
   depends_on "openfst"
 
   on_linux do
+    depends_on "gcc"
     depends_on "python@3.10"
   end
 

--- a/Formula/timewarrior.rb
+++ b/Formula/timewarrior.rb
@@ -7,7 +7,6 @@ class Timewarrior < Formula
   revision 1
   head "https://github.com/GothenburgBitFactory/timewarrior.git", branch: "dev"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "712cd5e3d2766ce2d32e87799c619547cb65084c9e0d23ffb2b2aa5136cb63b6"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "c237684f26cc8b20162ab44dc3fd1822317bcc7988004ebfaaae1b262706a9c0"
@@ -15,6 +14,7 @@ class Timewarrior < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "408828a1e987d46c028e984d205a05e08e9f1f1c22f2e06f63d83f1c4103abed"
     sha256 cellar: :any_skip_relocation, catalina:       "bfd843a753ea65204f5c2d125a6bfcb97034e5b0ca997c5c224338755e4a1b36"
     sha256 cellar: :any_skip_relocation, mojave:         "adcac7b2fe1e61a589a674b581ad77b2d0f6e6646454d12da192ceb8ff4d8dd1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a2639fbb7dc4ec4c629539f10ac0d0766bad0b01100c9a25a00f5d2bf9185267"
   end
 
   depends_on "asciidoctor" => :build
@@ -22,6 +22,7 @@ class Timewarrior < Formula
 
   on_linux do
     depends_on "man-db" => :test
+    depends_on "gcc"
   end
 
   fails_with gcc: "5"

--- a/Formula/timg.rb
+++ b/Formula/timg.rb
@@ -6,13 +6,13 @@ class Timg < Formula
   license "GPL-2.0-only"
   head "https://github.com/hzeller/timg.git", branch: "main"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "de4c65235281a2b9c5d62d28fa39053e21f30c4852ae3f6a0cb419a5ef4231d4"
     sha256 cellar: :any,                 arm64_big_sur:  "da8576af220bdd5052fcd031c0e2b0e1fb206d449c40354f72d10dfb5d9c6d7a"
     sha256 cellar: :any,                 monterey:       "f9f639aac4e106fb0c3ab2f4776acee6d6423f4f497491f334e43547e734ccea"
     sha256 cellar: :any,                 big_sur:        "0efbad0c7a082200d97ec158e1934362d82f5db03aa1130f8ea54088b73c478b"
     sha256 cellar: :any,                 catalina:       "5a2f9661a9e5ad1ada45486c2efb99a16f070f955d373cefdb63a6c9079e8b24"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c173cd55ef26536b606b64e5044777732fcf67b625d17f6c430947325e8f2ec1"
   end
 
   depends_on "cmake" => :build
@@ -23,6 +23,10 @@ class Timg < Formula
   depends_on "libpng"
   depends_on "openslide"
   depends_on "webp"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5" # rubberband is built with GCC
 

--- a/Formula/treefrog.rb
+++ b/Formula/treefrog.rb
@@ -11,18 +11,22 @@ class Treefrog < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "80a7272e904c060938ddaa19c090822240446e1cf66c2dad5d6ee68b1f451048"
     sha256 arm64_big_sur:  "c9afe4515ec107bf744805b7525faaee6a166f7c12b31d36dc8cd9f13d0b11cc"
     sha256 monterey:       "0f4080bde815c4a090e93e7945991f7e2edb36818243626cc65d45418402a826"
     sha256 big_sur:        "370e03b7c0de69daea6f7d3204d0d3bd07fdc4381134ea46e2991b678cdcedde"
     sha256 catalina:       "b558f6d8c06e8c592ee2a57a8bfa1fdb918b5bc3dc344276b81fb132ac4eec20"
+    sha256 x86_64_linux:   "02f14ab3da6f135ed0a214c8b8ddb0bb1ca49b7a8dd55c86f4abdcca9c2be6d3"
   end
 
   depends_on xcode: :build
   depends_on "mongo-c-driver"
   depends_on "qt"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/trimage.rb
+++ b/Formula/trimage.rb
@@ -6,7 +6,6 @@ class Trimage < Formula
   license "MIT"
   revision 2
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "06945f0b2785db7539c7c40b1ed21f88d263906b565a20282c87830d35ab56d4"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "1a6dca1721ee66b96bcc5f010fb96657024b17059eefc82db0e61c6e2ff12a21"
@@ -14,6 +13,7 @@ class Trimage < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "eb3768183ebb466b03e1134b498a0331e43f9aa19ca2f5fb3550f14bf28c1998"
     sha256 cellar: :any_skip_relocation, catalina:       "2174157bed654961ae8f5b1b60653c40a6a336aa4f26292ebe842d02652c62c5"
     sha256 cellar: :any_skip_relocation, mojave:         "638e2b76d476287fad690b99c20759798e1eab19bf3beadfad35c8f177bd59c8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "822f4cf83f95f708e32d3fe8befe189d4d621b87a70dcd285cca243b8ee879d0"
   end
 
   depends_on "advancecomp"

--- a/Formula/triton.rb
+++ b/Formula/triton.rb
@@ -7,13 +7,13 @@ class Triton < Formula
   sha256 "e325641d2ba183c484597e196ee74ecf67e6a0bcb459dd7ef49d23c509eec984"
   license "MPL-2.0"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "3b3585f7d4a99ecc32a89e885e32129b59ecddcc289d9bf69742e0dd801fa68e"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "b7a8608059c99cf8107c068151dd548aac3d15dd1f986f5786070980959d2a0e"
     sha256 cellar: :any_skip_relocation, monterey:       "7e592557b904ee529e3aa23dfff5778034957bde88153fea0c8d227548a009c9"
     sha256 cellar: :any_skip_relocation, big_sur:        "85d3dcacfcbfbdeea29c5fa480f4c9300f3571fde69a8267d9c52549a4c4784a"
     sha256 cellar: :any_skip_relocation, catalina:       "4e983929a1d92eb733d8bba821fb99caa3aa03dabc28df7965d4b8f307462411"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1a5fe6ca92a17edbeb1e1868ad99c9ce19db6110c188fc244a3746437d9518a7"
   end
 
   depends_on "node"

--- a/Formula/truffle.rb
+++ b/Formula/truffle.rb
@@ -7,11 +7,11 @@ class Truffle < Formula
   sha256 "d2062c5ba8ba177cd2768ab7c411310174b9ed504905f5c72b54089e39f22ebe"
   license "MIT"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256                               monterey:     "98002dbc9de2d94c8b9c8b5f52bc270c06b5f3f0a52e7bf9f2f4ea43538b2076"
     sha256                               big_sur:      "ae31bf9eb686e8a8bbaaf87d306dfeb7af93f03ade5381aa33ff7116d2740b88"
     sha256                               catalina:     "29415be18c64be31abfdd822482d05a9927f2bcb89d9eab91e4d0151de1109a6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "4d9131a259af1c1c59ca8a90ae9a64b6d5f7af57b9c7804dbc8a1dbeea735c90"
   end
 
   depends_on "node"

--- a/Formula/uhd.rb
+++ b/Formula/uhd.rb
@@ -13,7 +13,6 @@ class Uhd < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "bc85f64768e494482a19797e4fc2ed1c116a374ba6dd7f30b4a33fc7db13555b"
     sha256 arm64_big_sur:  "9d0863dd30ca3234df2cd754e7eeef970c9cc0d78ee87a03458e1cd88eb85357"
@@ -29,6 +28,10 @@ class Uhd < Formula
   depends_on "boost"
   depends_on "libusb"
   depends_on "python@3.9"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/urh.rb
+++ b/Formula/urh.rb
@@ -9,13 +9,13 @@ class Urh < Formula
   revision 2
   head "https://github.com/jopohl/urh.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "d88fd08049e3eb1fb74ad3adaca2e00a3a7f6bd38ce54cbd38a4ae5bc611f362"
     sha256 cellar: :any,                 arm64_big_sur:  "9424a7749801f6715bd090550243c8648476fd7a9341478601ecc97733479694"
     sha256 cellar: :any,                 monterey:       "de9494a90a16e95c9b56c8a8c6754a4bca1ec8877b80c4ea8fd74cbfa6c155ed"
     sha256 cellar: :any,                 big_sur:        "e9d8335313cd3438bb1f3f3cc15876e25550f6b9e9a06c190f53bd28c24f9e19"
     sha256 cellar: :any,                 catalina:       "8251c7319b097610a58503876afe9b72b6af903cd89e9f06cac863f4ca318c59"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bc49d62af0b2ddb9b6a3cca62f44cb734b5f49c3b99c10a88715f2af19dc2ef8"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/vapoursynth-sub.rb
+++ b/Formula/vapoursynth-sub.rb
@@ -8,13 +8,13 @@ class VapoursynthSub < Formula
 
   head "https://github.com/vapoursynth/subtext.git", branch: "master"
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "598c2f969d228c6aad738f79102fd549d47facea2ebfd8fd25b1f3d7e85edbd2"
     sha256 cellar: :any,                 arm64_big_sur:  "b279a50abb9df0e703a3ed9edbc2f65146e5ee2cedc0e49fd9d593a8001e1f42"
     sha256 cellar: :any,                 monterey:       "adeb08c0941dbfb5ade18eb806408659a450c1bc3f0a84501e2bb2e24023c190"
     sha256 cellar: :any,                 big_sur:        "022a82b6d201fbdf76b421695bd6338fe2c02710f5fae1e17b9d304a9ef228a3"
     sha256 cellar: :any,                 catalina:       "eaa0081cf6b8569686e3d6405267aa9825e2e1021e63a7128f37c269f4bd4fdc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f74fda462cb23aadfd9c57d0f98dd67980f5dfbd303015a864143def16ebf356"
   end
 
   depends_on "cmake" => :build

--- a/Formula/vapoursynth.rb
+++ b/Formula/vapoursynth.rb
@@ -12,13 +12,13 @@ class Vapoursynth < Formula
     regex(/^R(\d+(?:\.\d+)*?)$/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "8559b899be40688892a57aadfd4da4626048034cc4a11de8d63172d68c0bebff"
     sha256 cellar: :any,                 arm64_big_sur:  "640e82eaf761570b464d966b5fdfe3568c13404d06431653a6f27530b099200d"
     sha256 cellar: :any,                 monterey:       "be0fa0c82118b584b22ff7a55cd57f8a9984c7275dca8f922fbbbfbc8792ba05"
     sha256 cellar: :any,                 big_sur:        "b47f129bbc6475aeca840f688a3f948d19d74db278e4db182a2f5e5be5189d08"
     sha256 cellar: :any,                 catalina:       "8d372167dc396acf90c667b8c5250d7967ddb057558ecb17867b8d20293e3305"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a156dfffc5b2d4dce4432691c3e71f52a1508234583960164d1c7112b026e384"
   end
 
   depends_on "autoconf" => :build
@@ -29,6 +29,10 @@ class Vapoursynth < Formula
   depends_on "pkg-config" => :build
   depends_on "python@3.10"
   depends_on "zimg"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 

--- a/Formula/vcs.rb
+++ b/Formula/vcs.rb
@@ -10,7 +10,6 @@ class Vcs < Formula
     regex(/href=.*?vcs[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "032fbce3c72e8ea03c3b4fbcde03f391d7c9df149ae5b664618d7e5b2a265bce"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "5a12b2c51afec7626a44463cd9145bf47819e8561f05194f2f17ea8eec0459c9"
@@ -18,6 +17,7 @@ class Vcs < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "f13c9ce9291572d343bb3411e059601aa71fc4776138f13d33941653aab4dfb4"
     sha256 cellar: :any_skip_relocation, catalina:       "3ae09912577433e9aee40da787b21b278d2e4d625454e6a554a10dfd71a3cb82"
     sha256 cellar: :any_skip_relocation, mojave:         "2100a37453706602e0bd5941c7fb343cf64659493b27889957bad498934c6daf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "032fbce3c72e8ea03c3b4fbcde03f391d7c9df149ae5b664618d7e5b2a265bce"
   end
 
   depends_on "ffmpeg"

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -10,13 +10,13 @@ class Vips < Formula
     strategy :github_latest
   end
 
-  # Linux bottle removed for GCC 12 migration
   bottle do
     sha256 arm64_monterey: "bbf11a1d4492d79d56af32c725bb9944008ebb06fd7c0713e732808469b724c5"
     sha256 arm64_big_sur:  "718fbfdbc1b5cc74cbd94be9655925aa67724922df09ecc02c8c2535f1268ba8"
     sha256 monterey:       "4308057d78329ef549c8cc7ddd2309ff531331a4528adcd63ecba6b319745ad8"
     sha256 big_sur:        "b974dbf15eada9ddd3643e1df5cc5ae6f1dbbfe3ec1465f6e2329ac599b9aa2f"
     sha256 catalina:       "d2d9541bf5a5dd860a5f49c2be06499d7eb272cefef3624806fb7766b85c478b"
+    sha256 x86_64_linux:   "e7e6805890f686d446384a341b6c18d4d0927e5356126dbb0a5dfde0c7e9db7e"
   end
 
   depends_on "glib-utils" => :build
@@ -53,6 +53,10 @@ class Vips < Formula
 
   uses_from_macos "expat"
   uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "gcc"
+  end
 
   fails_with gcc: "5"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We now have a new strategy for handling the migration, which no longer requires the removal of bottles. See Homebrew/brew#13631.

Some of these bottles were lost due to changes from other PRs, but it looks like most of them should still be there.

I do still hope to get rid of all Linux-only GCC dependencies, but I think that's better done once we move to a new Ubuntu version.
