### PR TITLE
ksh: deprecate

### DIFF
--- a/Formula/ksh.rb
+++ b/Formula/ksh.rb
@@ -16,6 +16,8 @@ class Ksh < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8a6f8d5a96eaf9d91da32c58e453d7aacc4f47acea57f6a2b3db7cc108bbcd1f"
   end
 
+  deprecate! date: "2020-05-01", because: "abandoned, unmaintained, no releases since 2020; consider ksh93 instead"
+
   depends_on "meson" => :build
   depends_on "ninja" => :build
 

--- a/Formula/ksh.rb
+++ b/Formula/ksh.rb
@@ -16,7 +16,7 @@ class Ksh < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8a6f8d5a96eaf9d91da32c58e453d7aacc4f47acea57f6a2b3db7cc108bbcd1f"
   end
 
-  deprecate! date: "2020-05-01", because: "abandoned, unmaintained, no releases since 2020; consider ksh93 instead"
+  deprecate! date: "2020-05-01", because: "abandoned, unmaintained, no releases since 2019; consider ksh93 instead"
 
   depends_on "meson" => :build
   depends_on "ninja" => :build


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Deprecate `ksh` (which is actually [ksh2020](https://github.com/ksh2020/ksh)).

This project is no longer maintained and abandoned - a fork of the the unstable [ksh93v-](https://github.com/att/ast/tree/ksh93v). AT&T [no longer maintains](https://github.com/att/ast#readme) *any* version of [ksh](https://en.wikipedia.org/wiki/KornShell).  The *only* maintained ksh93 shell now is [ksh93u+m](https://github.com/ksh93/ksh/releases), and will be provided by a new `ksh93` formula.

The `ksh` formula switched from installing `ksh93u` to installing `ksh2020` in 2019.  `ksh2020` was an unsuccessful attempt to fork `ksh93` and breathe new life into the KornShell by extensively refactoring the unstable AST beta version. As that project has ceased all activity (approximately three years ago) this `ksh` formula will never receive any bug-fixes, security fixes, or other any other updates and must (eventually) be removed from Homebrew. 

Users should install the up-to-date and maintained ksh93u+m shell via the `ksh93` formula (and not `ksh`.)