### PR TITLE
create-api 0.0.5 (new formula)

### DIFF
--- a/Formula/create-api.rb
+++ b/Formula/create-api.rb
@@ -1,0 +1,25 @@
+class CreateApi < Formula
+  desc "Delightful code generator for OpenAPI specs"
+  homepage "https://github.com/CreateAPI/CreateAPI"
+  url "https://github.com/CreateAPI/CreateAPI/archive/refs/tags/0.0.5.tar.gz"
+  sha256 "c250ff140af83e093d86fef0dd18b87363ae91a087c0804bedb40f9922989093"
+  license "MIT"
+  head "https://github.com/CreateAPI/CreateAPI.git", branch: "main"
+
+  depends_on xcode: "13.0"
+
+  uses_from_macos "swift"
+
+  def install
+    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    bin.install ".build/release/create-api"
+    pkgshare.install "Tests/CreateAPITests/Specs/cookpad.json" => "test-spec.json"
+  end
+
+  test do
+    system bin/"create-api", "generate", "--package", "TestPackage", "--output", ".", pkgshare/"test-spec.json"
+    cd "TestPackage" do
+      system "swift", "build", "--disable-sandbox"
+    end
+  end
+end


### PR DESCRIPTION
- https://github.com/CreateAPI/CreateAPI/issues/69

Introduce the 'CreateApi' formula for the Swift based OpenAPI code generator (https://github.com/CreateAPI/CreateAPI).

Added install and test actions. The test uses fixtures that are included as part of the released archive to ensure that generation works.

The tool supports both macOS and Linux.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
