### PR TITLE
nagios: revision bump for indirect `jpeg-turbo`

### DIFF
--- a/Formula/nagios.rb
+++ b/Formula/nagios.rb
@@ -4,6 +4,7 @@ class Nagios < Formula
   url "https://downloads.sourceforge.net/project/nagios/nagios-4.x/nagios-4.4.7/nagios-4.4.7.tar.gz"
   sha256 "6429d93cc7db688bc529519a020cad648dc55b5eff7e258994f21c83fbf16c4d"
   license "GPL-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -51,7 +52,7 @@ class Nagios < Formula
   end
 
   def install
-    args = std_configure_args + [
+    args = [
       "--sbindir=#{nagios_sbin}",
       "--sysconfdir=#{nagios_etc}",
       "--localstatedir=#{nagios_var}",
@@ -68,7 +69,7 @@ class Nagios < Formula
     ]
     args << "--with-command-group=_www" if OS.mac?
 
-    system "./configure", *args
+    system "./configure", *std_configure_args, *args
     system "make", "all"
     system "make", "install"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fix broken linkage after #107130.
Indirectly linked to libjpeg via `gd` 