### PR TITLE
mscgen: revision bump to drop indirect `jpeg` on Catalina

### DIFF
--- a/Formula/mscgen.rb
+++ b/Formula/mscgen.rb
@@ -4,7 +4,7 @@ class Mscgen < Formula
   url "https://www.mcternan.me.uk/mscgen/software/mscgen-src-0.20.tar.gz"
   sha256 "3c3481ae0599e1c2d30b7ed54ab45249127533ab2f20e768a0ae58d8551ddc23"
   license "GPL-2.0-or-later"
-  revision 3
+  revision 4
 
   livecheck do
     url :homepage
@@ -29,9 +29,7 @@ class Mscgen < Formula
   depends_on "gd"
 
   def install
-    system "./configure", "--prefix=#{prefix}",
-                          "--with-freetype",
-                          "--disable-dependency-tracking"
+    system "./configure", *std_configure_args, "--with-freetype"
     system "make", "install"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Only Catalina had broken linkage to `jpeg` after #107130. Need to check if it is still getting linked after CI run.