### PR TITLE
netpbm + dependents: migrate `jpeg` to `jpeg-turbo`

### DIFF
--- a/Formula/astrometry-net.rb
+++ b/Formula/astrometry-net.rb
@@ -3,10 +3,9 @@ class AstrometryNet < Formula
 
   desc "Automatic identification of astronomical images"
   homepage "https://github.com/dstndstn/astrometry.net"
-  url "https://github.com/dstndstn/astrometry.net/releases/download/0.89/astrometry.net-0.89.tar.gz"
-  sha256 "98e955a6f747cde06904e461df8e09cd58fe14b1ecceb193e3619d0f5fc64acb"
+  url "https://github.com/dstndstn/astrometry.net/releases/download/0.91/astrometry.net-0.91.tar.gz"
+  sha256 "832b7613a2a2974be0fb85b055b395707d10c172846e5cf83573a4e759a83b8e"
   license "BSD-3-Clause"
-  revision 2
 
   livecheck do
     url :stable
@@ -37,23 +36,6 @@ class AstrometryNet < Formula
   resource "fitsio" do
     url "https://files.pythonhosted.org/packages/23/ec/280f91842d5aeaa1a95dc1d86d64d3fe57a5a37a98bb39b73a963f5dc91d/fitsio-1.1.6.tar.gz"
     sha256 "3e7e5d4fc025d8b6328ae330e72628b92784d4c2bb2f1f0caeb75e730b2f91a5"
-  end
-
-  # Three patches to fix building with numpy 1.23+
-  # https://github.com/dstndstn/astrometry.net/issues/262
-  patch do
-    url "https://github.com/dstndstn/astrometry.net/commit/ae47640f8abe0593a2a757c2654201e650460445.patch?full_index=1"
-    sha256 "41e245ef699cfd7f04199e678942071822eb5bea071b6d11e82013d4af703c1b"
-  end
-
-  patch do
-    url "https://github.com/dstndstn/astrometry.net/commit/816976ae7e15fd1b9c589312a7aadc802f6915fe.patch?full_index=1"
-    sha256 "02bfe7523791672896e7ec9a16e2c0968149d9f1dc79c37803748d60da123ac9"
-  end
-
-  patch do
-    url "https://github.com/dstndstn/astrometry.net/commit/943c61dc42fb9a57167fab4e4fd7a88f058ab3fc.patch?full_index=1"
-    sha256 "6034b689a172f27a95a7fb10c718005c862ad3d84c44a41ce191c9c82fee850d"
   end
 
   def install

--- a/Formula/gocr.rb
+++ b/Formula/gocr.rb
@@ -3,7 +3,7 @@ class Gocr < Formula
   homepage "https://wasd.urz.uni-magdeburg.de/jschulen/ocr/"
   url "https://wasd.urz.uni-magdeburg.de/jschulen/ocr/gocr-0.52.tar.gz"
   sha256 "df906463105f5f4273becc2404570f187d4ea52bd5769d33a7a8661a747b8686"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://wasd.urz.uni-magdeburg.de/jschulen/ocr/download.html"
@@ -21,7 +21,7 @@ class Gocr < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4fc5af66eb1d5e1345c1599d57da5a4695f7d37975ba96bfa97dd481ec3a7b1c"
   end
 
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "netpbm"
 
   # Edit makefile to install libs per developer documentation
@@ -31,9 +31,7 @@ class Gocr < Formula
   end
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", *std_configure_args
 
     # --mandir doesn't work correctly; fix broken Makefile
     inreplace "man/Makefile" do |s|
@@ -45,6 +43,6 @@ class Gocr < Formula
   end
 
   test do
-    system "#{bin}/gocr", "--help"
+    system bin/"gocr", "--help"
   end
 end

--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -6,6 +6,7 @@ class Netpbm < Formula
   url "https://svn.code.sf.net/p/netpbm/code/stable", revision: "4328"
   version "10.86.33"
   license "GPL-3.0-or-later"
+  revision 1
   version_scheme 1
   head "https://svn.code.sf.net/p/netpbm/code/trunk"
 
@@ -25,7 +26,7 @@ class Netpbm < Formula
   end
 
   depends_on "jasper"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "libtiff"
 
@@ -45,8 +46,8 @@ class Netpbm < Formula
       s.change_make_var! "PNGLIB", "-lpng"
       s.change_make_var! "ZLIB", "-lz"
       s.change_make_var! "JASPERLIB", "-ljasper"
-      s.change_make_var! "JASPERHDR_DIR", "#{Formula["jasper"].opt_include}/jasper"
-      s.gsub! "/usr/local/netpbm/rgb.txt", "#{prefix}/misc/rgb.txt"
+      s.change_make_var! "JASPERHDR_DIR", Formula["jasper"].opt_include/"jasper"
+      s.gsub! "/usr/local/netpbm/rgb.txt", prefix/"misc/rgb.txt"
 
       if OS.mac?
         s.change_make_var! "CFLAGS_SHLIB", "-fno-common"
@@ -70,7 +71,7 @@ class Netpbm < Formula
       end
 
       prefix.install %w[bin include lib misc]
-      lib.install Dir["staticlink/*.a"], Dir["sharedlink/#{shared_library("*")}"]
+      lib.install buildpath.glob("staticlink/*.a"), buildpath.glob("sharedlink/#{shared_library("*")}")
       (lib/"pkgconfig").install "pkgconfig_template" => "netpbm.pc"
     end
   end
@@ -78,7 +79,7 @@ class Netpbm < Formula
   test do
     fwrite = shell_output("#{bin}/pngtopam #{test_fixtures("test.png")} -alphapam")
     (testpath/"test.pam").write fwrite
-    system "#{bin}/pamdice", "test.pam", "-outstem", testpath/"testing"
+    system bin/"pamdice", "test.pam", "-outstem", testpath/"testing"
     assert_predicate testpath/"testing_0_0.pam", :exist?
     (testpath/"test.xpm").write <<~EOS
       /* XPM */

--- a/Formula/siril.rb
+++ b/Formula/siril.rb
@@ -4,6 +4,7 @@ class Siril < Formula
   url "https://free-astro.org/download/siril-1.0.3.tar.bz2"
   sha256 "2fefa7b7e1378f4ba277818c92ec7c4fca1fdcaa6df95bb65aed0163750be2c6"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://gitlab.com/free-astro/siril.git", branch: "master"
 
   bottle do
@@ -29,7 +30,7 @@ class Siril < Formula
   depends_on "gnuplot"
   depends_on "gsl"
   depends_on "gtk+3"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "json-glib"
   depends_on "libconfig"
   depends_on "libraw"

--- a/Formula/xfig.rb
+++ b/Formula/xfig.rb
@@ -4,7 +4,7 @@ class Xfig < Formula
   url "https://downloads.sourceforge.net/mcj/xfig-3.2.8b.tar.xz"
   sha256 "b2cc8181cfb356f6b75cc28771970447f69aba1d728a2dac0e0bcf1aea7acd3a"
   license "MIT"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -22,7 +22,7 @@ class Xfig < Formula
 
   depends_on "fig2dev"
   depends_on "ghostscript"
-  depends_on "jpeg"
+  depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "libx11"
@@ -32,17 +32,10 @@ class Xfig < Formula
   depends_on "libxt"
 
   def install
-    args = %W[
-      --prefix=#{prefix}
-      --disable-dependency-tracking
-      --disable-silent-rules
-      --with-appdefaultdir=#{etc}/X11/app-defaults
-    ]
-
-    system "./configure", *args
-    # "LDFLAGS" argument can be deleted the next release after 3.2.8a. See discussion at
-    # https://sourceforge.net/p/mcj/discussion/general/thread/36ff8854e8/#fa9d.
-    system "make", "LDFLAGS=-ltiff -ljpeg -lpng", "install-strip"
+    system "./configure", "--with-appdefaultdir=#{etc}/X11/app-defaults",
+                          "--disable-silent-rules",
+                          *std_configure_args
+    system "make", "install-strip"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- astrometry-net: migrate `jpeg` to `jpeg-turbo`
- gocr: migrate `jpeg` to `jpeg-turbo`
- netpbm: migrate `jpeg` to `jpeg-turbo`
- siril: migrate `jpeg` to `jpeg-turbo`
- xfig: migrate `jpeg` to `jpeg-turbo`

Still need to double-check linkage.
