### PR TITLE
augustus: deprecate

### DIFF
--- a/Formula/augustus.rb
+++ b/Formula/augustus.rb
@@ -22,6 +22,11 @@ class Augustus < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8271784fc43729dd82e83e031ef63bb278771c6ba271ff7c7bc17908abc56646"
   end
 
+  # Fails to build with GCC 12
+  # https://github.com/Homebrew/homebrew-core/pull/106755
+  # https://github.com/Homebrew/homebrew-core/pull/40220
+  deprecate! date: "2022-08-03", because: :does_not_build
+
   depends_on "boost" => :build
   depends_on "bamtools"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is going to break when GCC 12 is merged (#106755), so we may as
well start showing users deprecation warnings.

It also relies on a bit of a hack to be able to build. This was [reported](https://github.com/Gaius-Augustus/Augustus/issues/64)
upstream in 2019, but there's not been a response.
