### PR TITLE
Change various depends_on to uses_from_macos

### DIFF
--- a/Formula/autopsy.rb
+++ b/Formula/autopsy.rb
@@ -22,10 +22,10 @@ class Autopsy < Formula
 
   depends_on "sleuthkit"
 
+  uses_from_macos "file-formula"
   uses_from_macos "perl"
 
   on_linux do
-    depends_on "file-formula"
     depends_on "grep"
     depends_on "md5sha1sum"
   end

--- a/Formula/cvs.rb
+++ b/Formula/cvs.rb
@@ -29,11 +29,11 @@ class Cvs < Formula
   depends_on "automake" => :build
   depends_on "gettext"
 
+  uses_from_macos "vim" => :build # a text editor must be detected by the configure script
   uses_from_macos "libxcrypt"
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "vim" => :build # a text editor must be detected by the configure script
     depends_on "linux-pam"
   end
 

--- a/Formula/dxpy.rb
+++ b/Formula/dxpy.rb
@@ -20,13 +20,14 @@ class Dxpy < Formula
   depends_on "python@3.10"
   depends_on "six"
 
+  uses_from_macos "libffi"
+
   on_macos do
     depends_on "readline"
   end
 
   on_linux do
     depends_on "pkg-config" => :build
-    depends_on "libffi"
   end
 
   resource "argcomplete" do

--- a/Formula/fastnetmon.rb
+++ b/Formula/fastnetmon.rb
@@ -25,11 +25,12 @@ class Fastnetmon < Formula
   depends_on macos: :big_sur # We need C++ 20 available for build which is available from Big Sur
   depends_on "mongo-c-driver"
   depends_on "openssl@1.1"
+
+  uses_from_macos "libpcap"
   uses_from_macos "ncurses"
 
   on_linux do
     depends_on "gcc"
-    depends_on "libpcap"
   end
 
   fails_with gcc: "5"

--- a/Formula/gnumeric.rb
+++ b/Formula/gnumeric.rb
@@ -24,11 +24,10 @@ class Gnumeric < Formula
   depends_on "rarian"
 
   uses_from_macos "bison"
+  uses_from_macos "perl"
 
-  on_linux do
-    depends_on "perl"
-
-    resource "XML::Parser" do
+  resource "XML::Parser" do
+    on_linux do
       url "https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.44.tar.gz"
       sha256 "1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216"
     end

--- a/Formula/handbrake.rb
+++ b/Formula/handbrake.rb
@@ -31,6 +31,7 @@ class Handbrake < Formula
   uses_from_macos "m4" => :build
   uses_from_macos "bzip2"
   uses_from_macos "libxml2"
+  uses_from_macos "xz"
   uses_from_macos "zlib"
 
   on_linux do
@@ -45,7 +46,6 @@ class Handbrake < Formula
     depends_on "speex"
     depends_on "theora"
     depends_on "x264"
-    depends_on "xz"
   end
 
   def install

--- a/Formula/icecream.rb
+++ b/Formula/icecream.rb
@@ -23,8 +23,9 @@ class Icecream < Formula
   depends_on "lzo"
   depends_on "zstd"
 
+  uses_from_macos "llvm" => :test
+
   on_linux do
-    depends_on "llvm" => :test
     depends_on "libcap-ng"
   end
 

--- a/Formula/intltool.rb
+++ b/Formula/intltool.rb
@@ -18,11 +18,11 @@ class Intltool < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9506dfd59eb01b9cd5735dde05523feded67cc2fc039053704dbbd46e02a49f8"
   end
 
-  on_linux do
-    depends_on "expat"
-    depends_on "perl"
+  uses_from_macos "expat"
+  uses_from_macos "perl"
 
-    resource "XML::Parser" do
+  resource "XML::Parser" do
+    on_linux do
       url "https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.44.tar.gz"
       sha256 "1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216"
     end

--- a/Formula/libsigc++.rb
+++ b/Formula/libsigc++.rb
@@ -18,8 +18,9 @@ class Libsigcxx < Formula
   depends_on "ninja" => :build
   depends_on macos: :high_sierra # needs C++17
 
+  uses_from_macos "m4" => :build
+
   on_linux do
-    depends_on "m4" => :build
     depends_on "gcc"
   end
 

--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -40,6 +40,7 @@ class Mesa < Formula
   depends_on "libxext"
 
   uses_from_macos "flex" => :build
+  uses_from_macos "gzip"
   uses_from_macos "llvm"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
@@ -47,7 +48,6 @@ class Mesa < Formula
   on_linux do
     depends_on "elfutils"
     depends_on "gcc"
-    depends_on "gzip"
     depends_on "libdrm"
     depends_on "libva"
     depends_on "libvdpau"

--- a/Formula/mycli.rb
+++ b/Formula/mycli.rb
@@ -22,9 +22,10 @@ class Mycli < Formula
   depends_on "openssl@1.1"
   depends_on "python@3.10"
 
+  uses_from_macos "libffi"
+
   on_linux do
     depends_on "pkg-config" => :build
-    depends_on "libffi"
   end
 
   resource "cffi" do

--- a/Formula/neko.rb
+++ b/Formula/neko.rb
@@ -24,11 +24,11 @@ class Neko < Formula
   depends_on "openssl@1.1"
   depends_on "pcre"
 
+  uses_from_macos "apr"
   uses_from_macos "sqlite"
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "apr"
     depends_on "apr-util"
     depends_on "gtk+" # On mac, neko uses carbon. On Linux it uses gtk2
     depends_on "httpd"

--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -25,10 +25,13 @@ class Openjdk < Formula
   depends_on xcode: :build
   depends_on macos: :catalina
 
+  uses_from_macos "cups"
+  uses_from_macos "unzip"
+  uses_from_macos "zip"
+
   on_linux do
     depends_on "pkg-config" => :build
     depends_on "alsa-lib"
-    depends_on "cups"
     depends_on "fontconfig"
     depends_on "gcc"
     depends_on "libx11"
@@ -37,8 +40,6 @@ class Openjdk < Formula
     depends_on "libxrender"
     depends_on "libxt"
     depends_on "libxtst"
-    depends_on "unzip"
-    depends_on "zip"
 
     ignore_missing_libraries "libjvm.so"
   end

--- a/Formula/openjdk@11.rb
+++ b/Formula/openjdk@11.rb
@@ -23,10 +23,13 @@ class OpenjdkAT11 < Formula
 
   depends_on "autoconf" => :build
 
+  uses_from_macos "cups"
+  uses_from_macos "unzip"
+  uses_from_macos "zip"
+
   on_linux do
     depends_on "pkg-config" => :build
     depends_on "alsa-lib"
-    depends_on "cups"
     depends_on "fontconfig"
     depends_on "libx11"
     depends_on "libxext"
@@ -34,8 +37,6 @@ class OpenjdkAT11 < Formula
     depends_on "libxrender"
     depends_on "libxt"
     depends_on "libxtst"
-    depends_on "unzip"
-    depends_on "zip"
 
     ignore_missing_libraries "libjvm.so"
   end

--- a/Formula/openjdk@17.rb
+++ b/Formula/openjdk@17.rb
@@ -24,10 +24,13 @@ class OpenjdkAT17 < Formula
   depends_on "autoconf" => :build
   depends_on xcode: :build
 
+  uses_from_macos "cups"
+  uses_from_macos "unzip"
+  uses_from_macos "zip"
+
   on_linux do
     depends_on "pkg-config" => :build
     depends_on "alsa-lib"
-    depends_on "cups"
     depends_on "fontconfig"
     depends_on "gcc"
     depends_on "libx11"
@@ -36,8 +39,6 @@ class OpenjdkAT17 < Formula
     depends_on "libxrender"
     depends_on "libxt"
     depends_on "libxtst"
-    depends_on "unzip"
-    depends_on "zip"
 
     ignore_missing_libraries "libjvm.so"
   end

--- a/Formula/openjdk@8.rb
+++ b/Formula/openjdk@8.rb
@@ -19,13 +19,16 @@ class OpenjdkAT8 < Formula
   depends_on "pkg-config" => :build
   depends_on "freetype"
 
+  uses_from_macos "cups"
+  uses_from_macos "unzip"
+  uses_from_macos "zip"
+
   on_monterey :or_newer do
     depends_on "gawk" => :build
   end
 
   on_linux do
     depends_on "alsa-lib"
-    depends_on "cups"
     depends_on "fontconfig"
     depends_on "libx11"
     depends_on "libxext"
@@ -33,8 +36,6 @@ class OpenjdkAT8 < Formula
     depends_on "libxrender"
     depends_on "libxt"
     depends_on "libxtst"
-    depends_on "unzip"
-    depends_on "zip"
 
     ignore_missing_libraries %w[libjvm.so libawt_xawt.so]
   end

--- a/Formula/openrct2.rb
+++ b/Formula/openrct2.rb
@@ -32,8 +32,9 @@ class Openrct2 < Formula
   depends_on "sdl2"
   depends_on "speexdsp"
 
+  uses_from_macos "curl"
+
   on_linux do
-    depends_on "curl"
     depends_on "fontconfig"
     depends_on "mesa"
   end

--- a/Formula/qt@5.rb
+++ b/Formula/qt@5.rb
@@ -36,6 +36,7 @@ class QtAT5 < Formula
   uses_from_macos "gperf" => :build
   uses_from_macos "bison"
   uses_from_macos "flex"
+  uses_from_macos "icu4c"
   uses_from_macos "krb5"
   uses_from_macos "libxslt"
   uses_from_macos "sqlite"
@@ -46,7 +47,6 @@ class QtAT5 < Formula
     depends_on "fontconfig"
     depends_on "gcc"
     depends_on "harfbuzz"
-    depends_on "icu4c"
     depends_on "libdrm"
     depends_on "libevent"
     depends_on "libice"

--- a/Formula/tremor-runtime.rb
+++ b/Formula/tremor-runtime.rb
@@ -18,10 +18,11 @@ class TremorRuntime < Formula
   depends_on "cmake" => :build
   depends_on "rust" => :build
 
+  uses_from_macos "llvm"
+
   on_linux do
     depends_on "pkg-config" => :build
     depends_on "gcc"
-    depends_on "llvm"
     depends_on "openssl@1.1"
   end
 

--- a/Formula/vtk@8.2.rb
+++ b/Formula/vtk@8.2.rb
@@ -33,6 +33,7 @@ class VtkAT82 < Formula
   depends_on "qt@5"
 
   uses_from_macos "expat"
+  uses_from_macos "icu4c"
   uses_from_macos "libxml2"
   uses_from_macos "tcl-tk"
   uses_from_macos "zlib"
@@ -43,7 +44,6 @@ class VtkAT82 < Formula
 
   on_linux do
     depends_on "gcc"
-    depends_on "icu4c"
     depends_on "libaec"
     depends_on "libxt"
     depends_on "mesa-glu"

--- a/Formula/ykman.rb
+++ b/Formula/ykman.rb
@@ -23,10 +23,10 @@ class Ykman < Formula
   depends_on "python@3.10"
 
   uses_from_macos "libffi"
+  uses_from_macos "pcsc-lite"
 
   on_linux do
     depends_on "pkg-config" => :build
-    depends_on "pcsc-lite"
   end
 
   resource "cffi" do

--- a/audit_exceptions/provided_by_macos_depends_on_allowlist.json
+++ b/audit_exceptions/provided_by_macos_depends_on_allowlist.json
@@ -5,5 +5,6 @@
   "llvm",
   "openblas",
   "openssl@1.1",
-  "openssl@3"
+  "openssl@3",
+  "swift"
 ]


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Working on a new audit that checks if `depends_on` inside `on_linux` can be `uses_from_macos`