### PR TITLE
libdatrie 0.2.13 (new formula)

### DIFF
--- a/Formula/libdatrie.rb
+++ b/Formula/libdatrie.rb
@@ -1,0 +1,38 @@
+class Libdatrie < Formula
+  desc "Double-Array Trie Library"
+  homepage "https://linux.thai.net/~thep/datrie/datrie.html"
+  url "https://github.com/tlwg/libdatrie/releases/download/v0.2.13/libdatrie-0.2.13.tar.xz"
+  sha256 "12231bb2be2581a7f0fb9904092d24b0ed2a271a16835071ed97bed65267f4be"
+  license "LGPL-2.1-or-later"
+
+  def install
+    # 'make install' fails in parallel mode
+    ENV.deparallelize
+
+    args = std_configure_args
+    args.delete("--disable-debug")
+
+    # upstream ./configure does not support --disable-debug
+    system "./configure", *args, "--disable-silent-rules"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <datrie/trie.h>
+      int main() {
+        AlphaMap *map = alpha_map_new();
+        if (!map) {
+          return 1;
+        }
+        Trie *test_trie = trie_new(map);
+        if (!test_trie) {
+          return 1;
+        }
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-ldatrie", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Add a formula for libdatrie, a C implementation of a double-array trie
data structure.[1] Although the library and its repository in itself
appears to not hit the popularity thresholds used by homebrew in terms
of number of watchers, forks etc., this library is used by libthai, a
Thai language support library[2] and accordingly packaged by Debian and
derivatives, so its inclusion in homebrew should be warranted.

---
[1] https://linux.thai.net/~thep/datrie/datrie.html
[2] https://github.com/tlwg/libthai/blob/9abae820b8369774f9fec0e79975be63c585940a/INSTALL#L6