### PR TITLE
Update Railway tap to support auto-updating

### DIFF
--- a/Formula/railway.rb
+++ b/Formula/railway.rb
@@ -1,11 +1,11 @@
-require "language/node"
-
 class Railway < Formula
   desc "Develop and deploy code with zero configuration"
   homepage "https://railway.app/"
-  url "https://registry.npmjs.org/@railway/cli/-/cli-1.8.4.tgz"
-  sha256 "b057db0b76df651e982f79928d9f1f8dd37c6fce91995e41c56bf8ea6559b11c"
+  url "https://github.com/railwayapp/cli.git",
+      tag:      "v2.0.5",
+      revision: "6f8f9a6e61fb1cba4a6c800128dffaaf28ed7963"
   license "MIT"
+  head "https://github.com/railwayapp/cli.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "1a4fa8e05f74aa696ee22ef23635a7830851faa96ac939faff170a5fe933cafe"
@@ -16,11 +16,8 @@ class Railway < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5f82ce3fe592056a356c7ce02806fd4ed8666b4ea78fa876079bf492ab4e1bf4"
   end
 
-  depends_on "node"
-
   def install
-    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    system "./install"
 
     # Install shell completions
     output = Utils.safe_popen_read(bin/"railway", "completion", "bash")

--- a/Formula/railway.rb
+++ b/Formula/railway.rb
@@ -17,7 +17,7 @@ class Railway < Formula
   end
 
   def install
-    system "./install"
+    system "./install.sh"
 
     # Install shell completions
     output = Utils.safe_popen_read(bin/"railway", "completion", "bash")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hello! It appears someone added a Railway tap, which is great!

I'm changing the tap to allow us to auto update the Railway tap when a new version is published to the CLI

I've tried to install it using the brew install --build-from-source option, however it seems to hang on the install.sh. Is there anything here I'm doing wrong? That script should handle the install based on the OS + other information

