### PR TITLE
cargo-crev 0.23.2 (new formula)

### DIFF
--- a/Formula/cargo-crev.rb
+++ b/Formula/cargo-crev.rb
@@ -1,0 +1,19 @@
+class CargoCrev < Formula
+  desc "Code review system for the cargo package manager"
+  homepage "https://web.crev.dev/rust-reviews/"
+  url "https://github.com/crev-dev/cargo-crev/archive/refs/tags/v0.23.2.tar.gz"
+  sha256 "b37ca10e252bcd352634aed7ea366dfa84900446dbd74888f3178c0c10068d10"
+  license "Apache-2.0"
+
+  depends_on "rust" => [:build, :test]
+
+  uses_from_macos "zlib"
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "./cargo-crev")
+  end
+
+  test do
+    system "cargo", "crev", "config", "dir"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/crev-dev/cargo-crev is a verifiable code review system for the Rust cargo package manager.

This formula installs a Rust crate extending cargo with the crev command.
Although this tool extends `cargo`, it doesn't actually depend on the `rust` package.
Due to the nature of this tool, the package test is only minimal, unfortunately.