### PR TITLE
luajit: remove `inreplace` for `LUA_ROOT`

### DIFF
--- a/Formula/luajit.rb
+++ b/Formula/luajit.rb
@@ -52,12 +52,9 @@ class Luajit < Formula
     # 1 - Override the hardcoded gcc.
     # 2 - Remove the "-march=i686" so we can set the march in cflags.
     # Both changes should persist and were discussed upstream.
-    # Also: Set `LUA_ROOT` to `HOMEBREW_PREFIX` so that Luajit can find modules outside its own keg.
-    # This should avoid the need for writing env scripts that specify `LUA_PATH` or `LUA_CPATH`.
     inreplace "src/Makefile" do |f|
       f.change_make_var! "CC", ENV.cc
       f.gsub!(/-march=\w+\s?/, "")
-      f.gsub!(/^(  TARGET_XCFLAGS\+= -DLUA_ROOT=)\\"\$\(PREFIX\)\\"$/, "\\1\\\"#{HOMEBREW_PREFIX}\\\"")
     end
 
     # Per https://luajit.org/install.html: If MACOSX_DEPLOYMENT_TARGET
@@ -65,9 +62,13 @@ class Luajit < Formula
     ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
 
     # Pass `Q= E=@:` to build verbosely.
-    args = %W[PREFIX=#{prefix} Q= E=@:]
-    system "make", "amalg", *args
-    system "make", "install", *args
+    verbose_args = %w[Q= E=@:]
+
+    # Build with PREFIX=$HOMEBREW_PREFIX so that luajit can find modules outside its own keg.
+    # This allows us to avoid having to set `LUA_PATH` and `LUA_CPATH` for non-vendored modules.
+    system "make", "amalg", "PREFIX=#{HOMEBREW_PREFIX}", *verbose_args
+    system "make", "install", "PREFIX=#{prefix}", *verbose_args
+    doc.install (buildpath/"doc").children
 
     # We need `stable.version` here to avoid breaking symlink generation for HEAD.
     upstream_version = stable.version.to_s.sub(/-\d+\.\d+$/, "")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We can achieve the same effect of the `inreplace` without actually using
an `inreplace` by building luajit with `PREFIX=$HOMEBREW_PREFIX`. We
make sure it's installed to the right place by passing the real prefix
when we do `make install`.

This allows us to stop relying on a complicated and fragile `inreplace`.

Additionally, install the docs provided with the source tarball to avoid
any mismatches between the online documentation and the version we
actually install.
