### PR TITLE
lighthouse: make `protobuf` a build dependency

### DIFF
--- a/Formula/lighthouse.rb
+++ b/Formula/lighthouse.rb
@@ -15,8 +15,8 @@ class Lighthouse < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "protobuf" => :build
   depends_on "rust" => :build
-  depends_on "protobuf"
 
   uses_from_macos "llvm" => :build
   uses_from_macos "zlib"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This only seems to need the `protoc` compiler at build-time, so there's
no need to install it at run-time.

CC @terorie in case I'm mistaken here.
