### PR TITLE
svt-av1 1.1.0 (new formula)

### DIFF
--- a/Formula/svt-av1.rb
+++ b/Formula/svt-av1.rb
@@ -1,0 +1,29 @@
+class SvtAv1 < Formula
+  desc "AV1 encoder"
+  homepage "https://gitlab.com/AOMediaCodec/SVT-AV1"
+  url "https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v1.1.0/SVT-AV1-v1.1.0.tar.gz"
+  sha256 "1c211b944ac83ef013fe91aee96c01289da4e3762c1e2f265449f3a964f8e4bc"
+  license "BSD-3-Clause"
+  head "https://gitlab.com/AOMediaCodec/SVT-AV1.git", branch: "master"
+
+  depends_on "cmake" => :build
+  depends_on "make" => :build
+  depends_on "yasm" => :build
+
+  resource("homebrew-testvideo") do
+    url "https://github.com/grusell/svt-av1-homebrew-testdata/raw/main/video_64x64_yuv420p_25frames.yuv"
+    sha256 "0c5cc90b079d0d9c1ded1376357d23a9782a704a83e01731f50ccd162e246492"
+  end
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_INSTALL_RPATH=#{rpath}", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    testpath.install resource("homebrew-testvideo")
+    system "#{bin}/SvtAv1EncApp", "-w", "64", "-h", "64", "-i", "video_64x64_yuv420p_25frames.yuv", "-b", "output.ivf"
+    assert_predicate testpath/"output.ivf", :exist?
+  end
+end


### PR DESCRIPTION
Add formula for SVT-AV1 video codec, see also https://gitlab.com/AOMediaCodec/SVT-AV1 .

Signed-off-by: Gustav Grusell <gustav.grusell@svt.se>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
