### PR TITLE
mpich: make python3 available at build-time

### DIFF
--- a/Formula/mpich.rb
+++ b/Formula/mpich.rb
@@ -30,6 +30,7 @@ class Mpich < Formula
 
   depends_on "gcc" # for gfortran
   depends_on "hwloc"
+  uses_from_macos "python" => :build
 
   on_macos do
     conflicts_with "libfabric", because: "both install `fabric.h`"


### PR DESCRIPTION
This fails to build when Python3 is not available. See #106755.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
