### PR TITLE
Misc formulae: switch to go@1.18

### DIFF
--- a/Formula/brev.rb
+++ b/Formula/brev.rb
@@ -19,7 +19,9 @@ class Brev < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1903f0f640b60a813d92ae1de93f7c42c55a613fd71f1d5c6762e6fd583fcac7"
   end
 
-  depends_on "go" => :build
+  # Required latest gvisor.dev/gvisor/pkg/gohacks instead of inet.af/netstack/gohacks
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   def install
     ldflags = "-X github.com/brevdev/brev-cli/pkg/cmd/version.Version=v#{version}"

--- a/Formula/cloudflared.rb
+++ b/Formula/cloudflared.rb
@@ -15,7 +15,9 @@ class Cloudflared < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e271b7e7ed6c87b05fa07bc52f584f27b44192bec7b02a63c3cc62f5a5cac8c9"
   end
 
-  depends_on "go" => :build
+  # Required lucas-clemente/quic-go >= 0.28
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   def install
     system "make", "install",

--- a/Formula/colima.rb
+++ b/Formula/colima.rb
@@ -21,7 +21,9 @@ class Colima < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "16a92215d353ae0e2550ec2272edbb68bde22dc1d2e35d15b3c0bb12efabc328"
   end
 
-  depends_on "go" => :build
+  # Required latest gvisor.dev/gvisor/pkg/gohacks
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
   depends_on "lima"
 
   def install

--- a/Formula/doggo.rb
+++ b/Formula/doggo.rb
@@ -15,7 +15,9 @@ class Doggo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "656758ccedb107018e5cba479e134d17295fa939771162d8d2e001738dec89eb"
   end
 
-  depends_on "go" => :build
+  # Required lucas-clemente/quic-go >= 0.28
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   def install
     ldflags = %W[

--- a/Formula/flyctl.rb
+++ b/Formula/flyctl.rb
@@ -21,7 +21,9 @@ class Flyctl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5dfe7068fda69d4f5aa1199c808960df56815d270c69c97ef1da7ab9c1a825a4"
   end
 
-  depends_on "go" => :build
+  # Required latest gvisor.dev/gvisor/pkg/gohacks
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   def install
     ENV["CGO_ENABLED"] = "0"

--- a/Formula/grafana-agent.rb
+++ b/Formula/grafana-agent.rb
@@ -14,7 +14,9 @@ class GrafanaAgent < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "87371dd011f148c37d32d2113277d74e82da8dc37f25b263015b279a034dd0d8"
   end
 
-  depends_on "go" => :build
+  # Required latest https://pkg.go.dev/go4.org/unsafe/assume-no-moving-gc
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   on_linux do
     depends_on "systemd" => :build

--- a/Formula/ipfs.rb
+++ b/Formula/ipfs.rb
@@ -24,7 +24,9 @@ class Ipfs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "edebe83ebb656162416c90f41ef5e5fb7152409f58610b0b8b654990f6bb165c"
   end
 
-  depends_on "go" => :build
+  # Required lucas-clemente/quic-go >= 0.28
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   def install
     system "make", "build"

--- a/Formula/k3d.rb
+++ b/Formula/k3d.rb
@@ -20,7 +20,9 @@ class K3d < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "61a22fa1f5be965e2fdff4f40b9617f10dd00f57ebd1a20d45f581aab977f269"
   end
 
-  depends_on "go" => :build
+  # Required latest https://pkg.go.dev/go4.org/unsafe/assume-no-moving-gc
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   def install
     require "net/http"

--- a/Formula/logcli.rb
+++ b/Formula/logcli.rb
@@ -19,7 +19,9 @@ class Logcli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3c745400ce81042f0445ff608af40939b2207ecc0c8ae78b33f3d845d4f5c128"
   end
 
-  depends_on "go" => :build
+  # Required latest https://pkg.go.dev/go4.org/unsafe/assume-no-moving-gc
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
   depends_on "loki" => :test
 
   resource "testdata" do

--- a/Formula/loki.rb
+++ b/Formula/loki.rb
@@ -15,7 +15,9 @@ class Loki < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e5f881ba846aa8cde80623002319f31016006836ba5f010ee94febc07e7e4a6d"
   end
 
-  depends_on "go" => :build
+  # Required latest https://pkg.go.dev/go4.org/unsafe/assume-no-moving-gc
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   def install
     cd "cmd/loki" do

--- a/Formula/ooniprobe.rb
+++ b/Formula/ooniprobe.rb
@@ -19,7 +19,9 @@ class Ooniprobe < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a56081097f07522f166118bf95f8e270ecd2fb7295470deab5a08e8666cde081"
   end
 
-  depends_on "go" => :build
+  # Required lucas-clemente/quic-go >= 0.28
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
   depends_on "tor"
 
   def install

--- a/Formula/podman.rb
+++ b/Formula/podman.rb
@@ -29,8 +29,10 @@ class Podman < Formula
     end
   end
 
-  depends_on "go" => :build
   depends_on "go-md2man" => :build
+  # Required latest gvisor.dev/gvisor/pkg/gohacks
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
   depends_on "qemu"
 
   # Fixes compatability with qemu 7.0.0. Can be removed next release.

--- a/Formula/promtail.rb
+++ b/Formula/promtail.rb
@@ -19,7 +19,9 @@ class Promtail < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d04c1fb084e997340dd03a306343b114c9b59ab16e7526a2468e6c3ddeb3f7cc"
   end
 
-  depends_on "go" => :build
+  # Required latest https://pkg.go.dev/go4.org/unsafe/assume-no-moving-gc
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   on_linux do
     depends_on "systemd"

--- a/Formula/storj-uplink.rb
+++ b/Formula/storj-uplink.rb
@@ -19,7 +19,9 @@ class StorjUplink < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d18eaa70c6be0158071626fc5ac3575ab27fde84d2d9cbd52641fc715d1ea336"
   end
 
-  depends_on "go" => :build
+  # Required lucas-clemente/quic-go >= 0.28
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args, "-o", bin/"uplink", "./cmd/uplink"

--- a/Formula/syncthing.rb
+++ b/Formula/syncthing.rb
@@ -20,7 +20,9 @@ class Syncthing < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "13d8b93233ba1ed97f2c5e0c66d3915ff3c736573c2a9fc80db81a40fe1d427e"
   end
 
-  depends_on "go" => :build
+  # Required lucas-clemente/quic-go >= 0.28
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   def install
     build_version = build.head? ? "v0.0.0-#{version}" : "v#{version}"

--- a/Formula/traefik.rb
+++ b/Formula/traefik.rb
@@ -15,8 +15,10 @@ class Traefik < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "417dfc79bd3b7e669213859114a578405120306139a5b4e36bf781b0112a5393"
   end
 
-  depends_on "go" => :build
   depends_on "go-bindata" => :build
+  # Required lucas-clemente/quic-go >= 0.28
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   def install
     ldflags = %W[

--- a/Formula/vitess.rb
+++ b/Formula/vitess.rb
@@ -14,7 +14,8 @@ class Vitess < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "54cc14edcbf055ecede0cb9743143ceaf6b89fa0e005cfa415e43d0ff4441d11"
   end
 
-  depends_on "go" => :build
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
   depends_on "etcd"
 
   def install

--- a/Formula/xray.rb
+++ b/Formula/xray.rb
@@ -20,7 +20,9 @@ class Xray < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7245e312db9a34b636df22f8ab02c1f72e27db34e7a5f8360b709f9f70a81064"
   end
 
-  depends_on "go" => :build
+  # Required lucas-clemente/quic-go >= 0.28
+  # Try to switch to the latest go on the next release
+  depends_on "go@1.18" => :build
 
   resource "geoip" do
     url "https://github.com/v2fly/geoip/releases/download/202204280105/geoip.dat"

--- a/Formula/yorkie.rb
+++ b/Formula/yorkie.rb
@@ -16,7 +16,9 @@ class Yorkie < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9a2488fedc8d33e5cd7fffd222b3714b204487b9cfc3d0f148ccbd2510b43ef9"
   end
 
-  depends_on "go" => :build
+  # Doesn't build with latest go
+  # See https://github.com/yorkie-team/yorkie/issues/378
+  depends_on "go@1.18" => :build
 
   def install
     system "make", "build"


### PR DESCRIPTION
Extracted from https://github.com/Homebrew/homebrew-core/pull/107165, should be rebased after `go` 1.19 is merged.

These formulae don't work with `go` 1.19, so let's switch them to `go@1.18`.