### PR TITLE
autobump: remove `pocsuite3`

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -601,7 +601,6 @@ env:
     pmd
     pngquant
     pnpm
-    pocsuite3
     podman
     postgis
     powerman


### PR DESCRIPTION
Upstream have their own automation for bumping this formula. See:
- https://github.com/knownsec/pocsuite3/blob/9ec593f284ad91d203e7977e60033e80fb9ee7e9/.github/workflows/release.yml#L30-L39
- https://github.com/Homebrew/homebrew-core/pull/107433

Keeping this in the autobump list causes issues with publishing the
bottles. See https://github.com/Homebrew/homebrew-core/pull/107453.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
