### PR TITLE
hadoop: depends_on "openjdk@11"

### DIFF
--- a/Formula/flume.rb
+++ b/Formula/flume.rb
@@ -11,15 +11,16 @@ class Flume < Formula
   end
 
   depends_on "hadoop"
-  depends_on "openjdk"
+  depends_on "openjdk@11"
 
   def install
     rm_f Dir["bin/*.cmd", "bin/*.ps1"]
     libexec.install %w[conf docs lib tools]
-    bin.install Dir["bin/*"]
-    bin.env_script_all_files libexec/"bin",
-                             JAVA_HOME:  Formula["openjdk"].opt_prefix,
-                             FLUME_HOME: libexec
+    prefix.install "bin"
+
+    flume_env = Language::Java.java_home_env("11")
+    flume_env[:FLUME_HOME] = libexec
+    bin.env_script_all_files libexec/"bin", flume_env
   end
 
   test do

--- a/Formula/hadoop.rb
+++ b/Formula/hadoop.rb
@@ -15,27 +15,62 @@ class Hadoop < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "92cb92589ac48035f2482eca9321cebe31dfd3873272da601e24f30cc758cb5e"
   end
 
-  depends_on "openjdk"
+  # WARNING: Check https://cwiki.apache.org/confluence/display/HADOOP/Hadoop+Java+Versions before updating JDK version
+  depends_on "openjdk@11"
 
   conflicts_with "yarn", because: "both install `yarn` binaries"
 
   def install
     rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]
     libexec.install %w[bin sbin libexec share etc]
-    Dir["#{libexec}/bin/*"].each do |path|
-      (bin/File.basename(path)).write_env_script path, JAVA_HOME: Formula["openjdk"].opt_prefix
+
+    hadoop_env = Language::Java.java_home_env("11")
+    hadoop_env[:HADOOP_LOG_DIR] = var/"hadoop"
+
+    (libexec/"bin").each_child do |path|
+      (bin/File.basename(path)).write_env_script path, hadoop_env
     end
-    Dir["#{libexec}/sbin/*"].each do |path|
-      (sbin/File.basename(path)).write_env_script path, JAVA_HOME: Formula["openjdk"].opt_prefix
+    (libexec/"sbin").each_child do |path|
+      (sbin/File.basename(path)).write_env_script path, hadoop_env
     end
-    Dir["#{libexec}/libexec/*.sh"].each do |path|
-      (libexec/File.basename(path)).write_env_script path, JAVA_HOME: Formula["openjdk"].opt_prefix
+    libexec.glob("libexec/*.sh").each do |path|
+      (libexec/File.basename(path)).write_env_script path, hadoop_env
     end
+
     # Temporary fix until https://github.com/Homebrew/brew/pull/4512 is fixed
-    chmod 0755, Dir["#{libexec}/*.sh"]
+    chmod 0755, libexec.glob("*.sh")
   end
 
   test do
     system bin/"hadoop", "fs", "-ls"
+
+    # Test if resource manager can start successfully
+    port = free_port
+    classpaths = %w[
+      etc/hadoop
+      share/hadoop/common/lib/*
+      share/hadoop/common/*
+      share/hadoop/hdfs
+      share/hadoop/hdfs/lib/*
+      share/hadoop/hdfs/*
+      share/hadoop/mapreduce/*
+      share/hadoop/yarn
+      share/hadoop/yarn/lib/*
+      share/hadoop/yarn/*
+      share/hadoop/yarn/timelineservice/*
+      share/hadoop/yarn/timelineservice/lib/*
+    ].map { |path| libexec/path }
+
+    pid = Process.spawn({
+      "JAVA_HOME" => Language::Java.java_home("11"),
+      "CLASSPATH" => classpaths.join(":"),
+    }, Formula["openjdk@11"].opt_bin/"java", "org.apache.hadoop.yarn.server.resourcemanager.ResourceManager",
+                                             "-Dyarn.resourcemanager.webapp.address=127.0.0.1:#{port}")
+    sleep 8
+
+    Process.getpgid pid
+    system "curl", "http://127.0.0.1:#{port}"
+  ensure
+    Process.kill "TERM", pid
   end
 end

--- a/Formula/mahout.rb
+++ b/Formula/mahout.rb
@@ -17,10 +17,10 @@ class Mahout < Formula
   end
 
   depends_on "hadoop"
-  depends_on "openjdk"
+  depends_on "openjdk@11"
 
   def install
-    ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
+    ENV["JAVA_HOME"] = Language::Java.java_home("11")
 
     if build.head?
       chmod 755, "./bin"


### PR DESCRIPTION
According to https://cwiki.apache.org/confluence/display/HADOOP/Hadoop+Java+Versions, hadoop only supports java runtime 11 at most.
- Switched dependency from "openjdk" to "openjdk@11" for flume, hadoop and mahout
- Added a test case to check if resource manager server can start successfully with the JDK
- Appended HADOOP_LOG_DIR to env scripts
- Minor refactoring

Closes #107166

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?