### PR TITLE
jpeg: make keg-only

### DIFF
--- a/Formula/jpeg.rb
+++ b/Formula/jpeg.rb
@@ -20,14 +20,14 @@ class Jpeg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5b15c19b1cfdee81b6c3ebb96b1a743157da600030f943c9e18cbbda0612924a"
   end
 
+  keg_only "it conflicts with `jpeg-turbo`"
+
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install"
   end
 
   test do
-    system "#{bin}/djpeg", test_fixtures("test.jpg")
+    system bin/"djpeg", test_fixtures("test.jpg")
   end
 end


### PR DESCRIPTION
Most formulae that need a `libjpeg` now depend on `jpeg-turbo`, so it
makes sense to link `jpeg-turbo` instead of `jpeg`.

We should consider adding an audit that makes sure formulae depend on
`jpeg-turbo` instead of `jpeg` (cf. `open-mpi` vs `mpich`).

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
