### PR TITLE
libsigrok{,decode}: migrate to `python@3.10`

### DIFF
--- a/Formula/libsigrokdecode.rb
+++ b/Formula/libsigrokdecode.rb
@@ -4,6 +4,7 @@ class Libsigrokdecode < Formula
   url "https://sigrok.org/download/source/libsigrokdecode/libsigrokdecode-0.5.3.tar.gz"
   sha256 "c50814aa6743cd8c4e88c84a0cdd8889d883c3be122289be90c63d7d67883fc0"
   license "GPL-3.0-or-later"
+  revision 1
   head "git://sigrok.org/libsigrokdecode", branch: "master"
 
   livecheck do
@@ -27,10 +28,12 @@ class Libsigrokdecode < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => [:build, :test]
   depends_on "glib"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   def install
-    py_version = Formula["python@3.9"].version.major_minor
+    # While this doesn't appear much better than hardcoding `3.10`, this allows
+    # `brew audit` to catch mismatches between this line and the dependencies.
+    py_version = Formula["python@3.10"].version.major_minor
 
     inreplace "configure.ac" do |s|
       # Force the build system to pick up the right Python 3
@@ -67,6 +70,8 @@ class Libsigrokdecode < Formula
         return 0;
       }
     EOS
+    # Needed since `python@3.10` is keg-only.
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["python@3.10"].opt_lib/"pkgconfig"
     flags = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs libsigrokdecode").strip.split
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"

--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -7,7 +7,9 @@
   "jupyterlab",
   "libgaiagraphics",
   "librasterlite",
+  "libsigrok",
   "predictionio",
+  "sigrok-cli",
   "sqoop",
   "swtpm"
 ]


### PR DESCRIPTION
Also, explicitly specify `python3.10` for #107517.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
