### PR TITLE
mat2: migrate to `python@3.10`

### DIFF
--- a/Formula/mat2.rb
+++ b/Formula/mat2.rb
@@ -4,6 +4,7 @@ class Mat2 < Formula
   url "https://0xacab.org/jvoisin/mat2/-/archive/0.13.0/mat2-0.13.0.tar.gz"
   sha256 "8f895b45247c701f311da52442de7d1117cce234f82936edf305d6e339c016b0"
   license "LGPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "cec2f81c1aa38406cda44a3e3abe40fc353f096d4b83938fe368e398ea980699"
@@ -16,7 +17,7 @@ class Mat2 < Formula
   depends_on "poppler"
   depends_on "py3cairo"
   depends_on "pygobject3"
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "mutagen" do
     url "https://files.pythonhosted.org/packages/f3/d9/2232a4cb9a98e2d2501f7e58d193bc49c956ef23756d7423ba1bd87e386d/mutagen-1.45.1.tar.gz"
@@ -24,24 +25,23 @@ class Mat2 < Formula
   end
 
   def install
-    version = Language::Python.major_minor_version Formula["python@3.9"].bin/"python3"
-    pygobject3 = Formula["pygobject3"]
-    ENV["PYTHONPATH"] = lib/"python#{version}/site-packages"
-    ENV.append_path "PYTHONPATH", pygobject3.opt_lib+"python#{version}/site-packages"
-    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python#{version}/site-packages"
+    python = "python3.10"
+
+    ENV.append_path "PYTHONPATH", prefix/Language::Python.site_packages(python)
+    ENV.append_path "PYTHONPATH", Formula["pygobject3"].opt_prefix/Language::Python.site_packages(python)
+    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor"/Language::Python.site_packages(python)
 
     resources.each do |r|
       r.stage do
-        system Formula["python@3.9"].bin/"python3", *Language::Python.setup_install_args(libexec/"vendor")
+        system python, *Language::Python.setup_install_args(libexec/"vendor", python)
       end
     end
 
-    system Formula["python@3.9"].bin/"python3", *Language::Python.setup_install_args(prefix)
-
+    system python, *Language::Python.setup_install_args(prefix, python)
     bin.env_script_all_files(libexec/"bin", PYTHONPATH: ENV["PYTHONPATH"])
   end
 
   test do
-    system "#{bin}/mat2", "-l"
+    system bin/"mat2", "-l"
   end
 end


### PR DESCRIPTION
Also, explicitly specify `python3.10` for #107517.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
