### PR TITLE
quilt-installer 0.4.3 (new formula)

### DIFF
--- a/Formula/quilt-installer.rb
+++ b/Formula/quilt-installer.rb
@@ -6,8 +6,8 @@ class QuiltInstaller < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://meta.quiltmc.org/v3/versions/installer"
-    regex(/["']url["']:\s*["'][^"']*?quilt-installer[._-]v?(\d+(?:\.\d+)+)\.jar/i)
+    url "https://maven.quiltmc.org/repository/release/org/quiltmc/quilt-installer/maven-metadata.xml"
+    regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
   end
 
   depends_on "openjdk"

--- a/Formula/quilt-installer.rb
+++ b/Formula/quilt-installer.rb
@@ -1,0 +1,24 @@
+class QuiltInstaller < Formula
+  desc "Installer for Quilt for the vanilla launcher"
+  homepage "https://quiltmc.org/"
+  url "https://maven.quiltmc.org/repository/release/org/quiltmc/quilt-installer/0.4.3/quilt-installer-0.4.3.jar"
+  sha256 "045668265303d41dae13abc5eb000e988ad409b792431663e06b46ad0811f80a"
+  license "Apache-2.0"
+
+  livecheck do
+    url "https://meta.quiltmc.org/v3/versions/installer"
+    regex(/["']url["']:\s*["'][^"']*?quilt-installer[._-]v?(\d+(?:\.\d+)+)\.jar/i)
+  end
+
+  depends_on "openjdk"
+
+  def install
+    libexec.install "quilt-installer-#{version}.jar"
+    bin.write_jar_script libexec/"quilt-installer-#{version}.jar", "quilt-installer"
+  end
+
+  test do
+    system "#{bin}/quilt-installer", "install", "server", "1.19.2"
+    assert_predicate testpath/"server/quilt-server-launch.jar", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a notable fork of fabric-installer, so the manifests are basically the same. However, quilt-installer's install server argument doesn't recognize nothing or "latest" as the version argument for minecraft, so I just put in the latest version of minecraft.