### PR TITLE
conan: remove `libffi` dependency

### DIFF
--- a/Formula/conan.rb
+++ b/Formula/conan.rb
@@ -19,7 +19,6 @@ class Conan < Formula
 
   depends_on "pkg-config" => :build
   depends_on "cmake" => :test
-  depends_on "libffi"
   depends_on "openssl@1.1"
   depends_on "python@3.10"
   depends_on "six"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
