### PR TITLE
idris: remove `libffi` dependency.

### DIFF
--- a/Formula/idris.rb
+++ b/Formula/idris.rb
@@ -16,7 +16,6 @@ class Idris < Formula
   depends_on "cabal-install" => :build
   depends_on "pkg-config" => :build
   depends_on "ghc@8.8"
-  depends_on "libffi"
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"


### PR DESCRIPTION
There is no linkage, and the build seems to succeed without it.