### PR TITLE
libcython: use Python's `libexec/"bin"` directory

### DIFF
--- a/Formula/libcython.rb
+++ b/Formula/libcython.rb
@@ -28,16 +28,14 @@ class Libcython < Formula
 
   def pythons
     deps.map(&:to_formula)
-        .select { |f| f.name.match?(/python@\d\.\d+/) }
-        .map(&:opt_bin)
-        .map { |bin| bin/"python3" }
+        .select { |f| f.name.match?(/^python@\d\.\d+$/) }
+        .map { |f| f.opt_libexec/"bin/python" }
   end
 
   def install
     pythons.each do |python|
       ENV.prepend_create_path "PYTHONPATH", libexec/Language::Python.site_packages(python)
-      system python, *Language::Python.setup_install_args(libexec),
-             "--install-lib=#{libexec/Language::Python.site_packages(python)}"
+      system python, *Language::Python.setup_install_args(libexec, python)
     end
   end
 


### PR DESCRIPTION
Needed for #107517.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
