### PR TITLE
lynx: install COPYHEADER and and fix license

### DIFF
--- a/Formula/lynx.rb
+++ b/Formula/lynx.rb
@@ -5,8 +5,8 @@ class Lynx < Formula
   mirror "https://fossies.org/linux/www/lynx2.8.9rel.1.tar.bz2"
   version "2.8.9rel.1"
   sha256 "387f193d7792f9cfada14c60b0e5c0bff18f227d9257a39483e14fa1aaf79595"
-  license "GPL-2.0"
-  revision 1
+  license "GPL-2.0-only"
+  revision 2
 
   livecheck do
     url "https://invisible-mirror.net/archives/lynx/tarballs/?C=M&O=D"
@@ -45,6 +45,8 @@ class Lynx < Formula
                           "--enable-externs",
                           "--disable-config-info"
     system "make", "install"
+
+    prefix.install "COPYHEADER", "COPYHEADER.asc"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I bumped the revision because the following is stated in `COPYHEADER`:

> This copyright notice must be included in all copies or substantial portions of Lynx.  It outlines rights and restrictions for Lynx which override the guidelines given in the COPYING file.

`COPYHEADER.asc` is installed, given that `COPYING.asc` is also installed.
