### PR TITLE
bitcoin: add sqlite dependency on linux

### DIFF
--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -4,7 +4,7 @@ class Bitcoin < Formula
   url "https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0.tar.gz"
   sha256 "26748bf49d6d6b4014d0fedccac46bf2bcca42e9d34b3acfd9e3467c415acc05"
   license "MIT"
-  revision 2
+  revision 3
   head "https://github.com/bitcoin/bitcoin.git", branch: "master"
 
   livecheck do
@@ -31,6 +31,8 @@ class Bitcoin < Formula
   depends_on macos: :catalina
   depends_on "miniupnpc"
   depends_on "zeromq"
+
+  uses_from_macos "sqlite"
 
   on_linux do
     depends_on "util-linux" => :build # for `hexdump`


### PR DESCRIPTION
Add sqlite as a dependency of bitcoin. Required on Linux distros without
sqlite to enable descriptor wallet support. Not required on MacOS, as
MacOS ships with sqlite.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?