### PR TITLE
python@3.9: avoid shelling out to `brew`

### DIFF
--- a/Formula/python@3.9.rb
+++ b/Formula/python@3.9.rb
@@ -372,6 +372,13 @@ class PythonAT39 < Formula
       include_dirs=#{include_dirs.join ":"}
       library_dirs=#{library_dirs.join ":"}
     EOS
+
+    # setuptools 63.2.0+ breaks when used inside superenv.
+    # https://github.com/pypa/distutils/pull/155
+    # https://github.com/pypa/distutils/issues/158
+    inreplace site_packages/"setuptools/_distutils/command/_framework_compat.py",
+              /^(\s+homebrew_prefix\s+=\s+).*/,
+              "\\1'#{HOMEBREW_PREFIX}'"
   end
 
   def sitecustomize


### PR DESCRIPTION
This breaks builds inside superenv. See
- #107660
- #107662
- #107663
- #107664
- #107665
- https://github.com/pypa/distutils/pull/155
- https://github.com/pypa/distutils/issues/158

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
