### PR TITLE
coccinelle: set correct libdir

### DIFF
--- a/Formula/coccinelle.rb
+++ b/Formula/coccinelle.rb
@@ -5,6 +5,7 @@ class Coccinelle < Formula
       tag:      "1.1.1",
       revision: "5444e14106ff17404e63d7824b9eba3c0e7139ba"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/coccinelle/coccinelle.git", branch: "master"
 
   livecheck do
@@ -60,7 +61,8 @@ class Coccinelle < Formula
                             "--enable-ocaml",
                             "--enable-opt",
                             "--with-pdflatex=no",
-                            "--prefix=#{prefix}"
+                            "--prefix=#{prefix}",
+                            "--libdir=#{lib}"
       ENV.deparallelize
       system "opam", "config", "exec", "--", "make"
       system "make", "install"


### PR DESCRIPTION
This fixes wrong default paths for `standard.iso` and `standard.h` files, which cause `spatch` to produce runtime warnings:

```
spatch --sp-file simple.cocci simple.c
warning: Can't find macro file: /usr/local/bin/../Cellar/coccinelle/1.1.1/bin/lib/coccinelle/standard.h
warning: Can't find default iso file: /usr/local/bin/../Cellar/coccinelle/1.1.1/bin/lib/coccinelle/standard.iso
...
```

The same problem was reported in [this issue](https://github.com/coccinelle/coccinelle/issues/263). opam package for `coccinelle 1.1.1` also [explicitly specifies](https://github.com/ocaml/opam-repository/blob/master/packages/coccinelle/coccinelle.1.1.1/opam#L10) libdir path.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
