### PR TITLE
throttled_formulae: add testkube

### DIFF
--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -7,5 +7,6 @@
   "gatsby-cli": 10,
   "netlify-cli": 5,
   "quicktype": 10,
+  "testkube": 5,
   "vim": 50
 }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`testkube` gets several releases per day: https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+testkube+is%3Aclosed
Quite often, we have several open PRs with it. I suggest throttling it a little
