### PR TITLE
postgresql@14: rename from postgresql, make versioned.

### DIFF
--- a/Aliases/postgres
+++ b/Aliases/postgres
@@ -1,1 +1,0 @@
-../Formula/postgresql.rb

--- a/Aliases/postgresql@14
+++ b/Aliases/postgresql@14
@@ -1,1 +1,0 @@
-../Formula/postgresql.rb

--- a/Formula/citus.rb
+++ b/Formula/citus.rb
@@ -4,6 +4,7 @@ class Citus < Formula
   url "https://github.com/citusdata/citus/archive/v11.0.6.tar.gz"
   sha256 "f3f2deb3e7f31844f4cc3bb0a311b52a4179cabe08c72b409819fa6f6e72f5f4"
   license "AGPL-3.0-only"
+  revision 1
   head "https://github.com/citusdata/citus.git", branch: "master"
 
   bottle do
@@ -16,28 +17,52 @@ class Citus < Formula
   end
 
   depends_on "lz4"
-  depends_on "postgresql"
+  depends_on "postgresql@14"
   depends_on "readline"
   depends_on "zstd"
 
   uses_from_macos "curl"
 
+  def postgresql
+    Formula["postgresql@14"]
+  end
+
   def install
-    ENV["PG_CONFIG"] = Formula["postgresql"].opt_bin/"pg_config"
+    ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
 
     system "./configure"
-
     # workaround for https://github.com/Homebrew/legacy-homebrew/issues/49948
-    system "make", "libpq=-L#{Formula["postgresql"].opt_lib} -lpq"
+    system "make", "libpq=-L#{postgresql.opt_lib} -lpq"
 
     # Use stage directory to prevent installing to pg_config-defined dirs,
     # which would not be within this package's Cellar.
     mkdir "stage"
     system "make", "install", "DESTDIR=#{buildpath}/stage"
 
-    path = File.join("stage", HOMEBREW_PREFIX)
-    lib.install (buildpath/path/"lib").children
-    include.install (buildpath/path/"include").children
-    (share/"postgresql/extension").install (buildpath/path/"share/postgresql/extension").children
+    stage_path = File.join("stage", HOMEBREW_PREFIX)
+    lib.install (buildpath/stage_path/"lib").children
+    include.install (buildpath/stage_path/"include").children
+    share.install (buildpath/stage_path/"share").children
+
+    bin.install (buildpath/File.join("stage", postgresql.bin.realpath)).children
+  end
+
+  test do
+    pg_ctl = postgresql.opt_bin/"pg_ctl"
+    psql = postgresql.opt_bin/"psql"
+    port = free_port
+
+    system pg_ctl, "initdb", "-D", testpath/"test"
+    (testpath/"test/postgresql.conf").write <<~EOS, mode: "a+"
+
+      shared_preload_libraries = 'citus'
+      port = #{port}
+    EOS
+    system pg_ctl, "start", "-D", testpath/"test", "-l", testpath/"log"
+    begin
+      system psql, "-p", port.to_s, "-c", "CREATE EXTENSION \"citus\";", "postgres"
+    ensure
+      system pg_ctl, "stop", "-D", testpath/"test"
+    end
   end
 end

--- a/Formula/libpq.rb
+++ b/Formula/libpq.rb
@@ -6,7 +6,8 @@ class Libpq < Formula
   license "PostgreSQL"
 
   livecheck do
-    formula "postgresql"
+    url "https://ftp.postgresql.org/pub/source/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do

--- a/Formula/pg_partman.rb
+++ b/Formula/pg_partman.rb
@@ -4,6 +4,7 @@ class PgPartman < Formula
   url "https://github.com/pgpartman/pg_partman/archive/refs/tags/v4.7.0.tar.gz"
   sha256 "c5d2653a705c98e544819ed48b04c84a18953b73aa1c45a2300d00f8c6506436"
   license "PostgreSQL"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "d30c2f67029fef09fc8a7c50d518a1cef89a62b42de03e5a95a832e2a724dde2"
@@ -14,34 +15,38 @@ class PgPartman < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ba38a04262870382a5bb6e986852beac780a922def9857456eafa92b43b98aa1"
   end
 
-  depends_on "postgresql"
+  depends_on "postgresql@14"
+
+  def postgresql
+    Formula["postgresql@14"]
+  end
 
   def install
+    ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
+
     system "make"
-    (prefix/"lib/postgresql").install "src/pg_partman_bgw.so"
-    (prefix/"share/postgresql/extension").install "pg_partman.control"
-    (prefix/"share/postgresql/extension").install Dir["sql/pg_partman--*.sql"]
-    (prefix/"share/postgresql/extension").install Dir["updates/pg_partman--*.sql"]
+    (lib/postgresql.name).install "src/pg_partman_bgw.so"
+    (share/postgresql.name/"extension").install "pg_partman.control"
+    (share/postgresql.name/"extension").install Dir["sql/pg_partman--*.sql"]
+    (share/postgresql.name/"extension").install Dir["updates/pg_partman--*.sql"]
   end
 
   test do
-    # Testing steps:
-    # - create new temporary postgres database
-    system "pg_ctl", "initdb", "-D", testpath/"test"
-
+    pg_ctl = postgresql.opt_bin/"pg_ctl"
+    psql = postgresql.opt_bin/"psql"
     port = free_port
-    # - enable pg_partman in temporary database
-    (testpath/"test/postgresql.conf").write("\nshared_preload_libraries = 'pg_partman_bgw'\n", mode: "a+")
-    (testpath/"test/postgresql.conf").write("\nport = #{port}\n", mode: "a+")
 
-    # - restart temporary postgres
-    system "pg_ctl", "start", "-D", testpath/"test", "-l", testpath/"log"
+    system pg_ctl, "initdb", "-D", testpath/"test"
+    (testpath/"test/postgresql.conf").write <<~EOS, mode: "a+"
 
-    # - create extension in temp database
-    system "psql", "-p", port.to_s,
-           "-c", "CREATE SCHEMA partman; CREATE EXTENSION pg_partman SCHEMA partman;", "postgres"
-
-    # - shutdown temp postgres
-    system "pg_ctl", "stop", "-D", testpath/"test"
+      shared_preload_libraries = 'pg_partman_bgw'
+      port = #{port}
+    EOS
+    system pg_ctl, "start", "-D", testpath/"test", "-l", testpath/"log"
+    begin
+      system psql, "-p", port.to_s, "-c", "CREATE EXTENSION \"pg_partman\";", "postgres"
+    ensure
+      system pg_ctl, "stop", "-D", testpath/"test"
+    end
   end
 end

--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -4,6 +4,7 @@ class Postgis < Formula
   url "https://download.osgeo.org/postgis/source/postgis-3.2.3.tar.gz"
   sha256 "1b4d8b5c756e5aba59efbc1833b22efe4d6562778eeca56fa497feb2eb13668c"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://download.osgeo.org/postgis/source/"
@@ -33,7 +34,7 @@ class Postgis < Formula
   depends_on "geos"
   depends_on "json-c" # for GeoJSON and raster handling
   depends_on "pcre2"
-  depends_on "postgresql"
+  depends_on "postgresql@14"
   depends_on "proj"
   depends_on "protobuf-c" # for MVT (map vector tiles) support
   depends_on "sfcgal" # for advanced 2D/3D functions
@@ -44,13 +45,19 @@ class Postgis < Formula
 
   fails_with gcc: "5"
 
+  def postgresql
+    Formula["postgresql@14"]
+  end
+
   def install
     ENV.deparallelize
+
+    ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
 
     args = [
       "--with-projdir=#{Formula["proj"].opt_prefix}",
       "--with-jsondir=#{Formula["json-c"].opt_prefix}",
-      "--with-pgconfig=#{Formula["postgresql"].opt_bin}/pg_config",
+      "--with-pgconfig=#{postgresql.opt_bin}/pg_config",
       "--with-protobufdir=#{Formula["protobuf-c"].opt_bin}",
       # Unfortunately, NLS support causes all kinds of headaches because
       # PostGIS gets all of its compiler flags from the PGXS makefiles. This
@@ -72,7 +79,7 @@ class Postgis < Formula
     # the version of postgresql used to build postgis.  Since we copy these
     # files into the postgis keg and symlink them to HOMEBREW_PREFIX, postgis
     # only needs to be rebuilt when there is a new major version of postgresql.
-    postgresql_prefix = Formula["postgresql"].prefix.realpath
+    postgresql_prefix = postgresql.prefix.realpath
     postgresql_stage_path = File.join("stage", postgresql_prefix)
     bin.install (buildpath/postgresql_stage_path/"bin").children
     doc.install (buildpath/postgresql_stage_path/"share/doc").children
@@ -95,10 +102,10 @@ class Postgis < Formula
   end
 
   test do
-    pg_version = Formula["postgresql"].version.major
+    pg_version = postgresql.version.major
     expected = /'PostGIS built for PostgreSQL % cannot be loaded in PostgreSQL %',\s+#{pg_version}\.\d,/
     postgis_version = Formula["postgis"].version.major_minor
-    assert_match expected, (share/"postgresql/contrib/postgis-#{postgis_version}/postgis.sql").read
+    assert_match expected, (share/postgresql.name/"contrib/postgis-#{postgis_version}/postgis.sql").read
 
     require "base64"
     (testpath/"brew.shp").write ::Base64.decode64 <<~EOS
@@ -135,5 +142,19 @@ class Postgis < Formula
     result = shell_output("#{bin}/shp2pgsql #{testpath}/brew.shp")
     assert_match "Point", result
     assert_match "AddGeometryColumn", result
+
+    pg_ctl = postgresql.opt_bin/"pg_ctl"
+    psql = postgresql.opt_bin/"psql"
+    port = free_port
+
+    system pg_ctl, "initdb", "-D", testpath/"test"
+    (testpath/"test/postgresql.conf").write <<~EOS, mode: "a+"
+
+      shared_preload_libraries = 'postgis-3'
+      port = #{port}
+    EOS
+    system pg_ctl, "start", "-D", testpath/"test", "-l", testpath/"log"
+    system psql, "-p", port.to_s, "-c", "CREATE EXTENSION \"postgis\";", "postgres"
+    system pg_ctl, "stop", "-D", testpath/"test"
   end
 end

--- a/Formula/postgraphile.rb
+++ b/Formula/postgraphile.rb
@@ -18,7 +18,7 @@ class Postgraphile < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "fb2b7fc86011d7f6262bb40919faff5180008ffd80b908f22c969bd828df7849"
   end
 
-  depends_on "postgresql" => :test
+  depends_on "postgresql@14" => :test
   depends_on "node"
 
   def install
@@ -29,7 +29,7 @@ class Postgraphile < Formula
   test do
     assert_match "postgraphile", shell_output("#{bin}/postgraphile --help")
 
-    pg_bin = Formula["postgresql"].opt_bin
+    pg_bin = Formula["postgresql@14"].opt_bin
     system "#{pg_bin}/initdb", "-D", testpath/"test"
     pid = fork do
       exec("#{pg_bin}/postgres", "-D", testpath/"test")

--- a/Formula/postgresql@11.rb
+++ b/Formula/postgresql@11.rb
@@ -123,10 +123,10 @@ class PostgresqlAT11 < Formula
   end
 
   service do
-    run [opt_bin/"postgres", "-D", var/"postgresql@11"]
+    run [opt_bin/"postgres", "-D", f.postgresql_datadir]
     keep_alive true
-    log_path var/"log/postgresql@11.log"
-    error_log_path var/"log/postgresql@11.log"
+    log_path f.postgresql_log_path
+    error_log_path f.postgresql_log_path
     working_dir HOMEBREW_PREFIX
   end
 

--- a/Formula/postgresql@12.rb
+++ b/Formula/postgresql@12.rb
@@ -127,10 +127,6 @@ class PostgresqlAT12 < Formula
     var/"postgres"
   end
 
-  def postgresql_formula_present?
-    Formula["postgresql"].any_version_installed?
-  end
-
   # Figure out what version of PostgreSQL the old data dir is
   # using
   def old_postgresql_datadir_version
@@ -142,36 +138,19 @@ class PostgresqlAT12 < Formula
     caveats = ""
 
     # Extract the version from the formula name
-    pg_formula_version = name.split("@", 2).last
+    pg_formula_version = version.major.to_s
     # ... and check it against the old data dir postgres version number
     # to see if we need to print a warning re: data dir
     if old_postgresql_datadir_version == pg_formula_version
-      caveats += if postgresql_formula_present?
-        # Both PostgreSQL and PostgreSQL@12 are installed
-        <<~EOS
-          Previous versions of this formula used the same data directory as
-          the regular PostgreSQL formula. This causes a conflict if you
-          try to use both at the same time.
+      caveats += <<~EOS
+        Previous versions of postgresql shared the same data directory.
 
-          In order to avoid this conflict, you should make sure that the
-          #{name} data directory is located at:
-            #{postgresql_datadir}
+        You can migrate to a versioned data directory by running:
+          mv -v "#{old_postgres_data_dir}" "#{postgresql_datadir}"
 
-        EOS
-      else
-        # Only PostgreSQL@12 is installed, not PostgreSQL
-        <<~EOS
-          Previous versions of #{name} used the same data directory as
-          the postgresql formula. This will cause a conflict if you
-          try to use both at the same time.
+        (Make sure PostgreSQL is stopped before executing this command)
 
-          You can migrate to a versioned data directory by running:
-            mv -v "#{old_postgres_data_dir}" "#{postgresql_datadir}"
-
-          (Make sure PostgreSQL is stopped before executing this command)
-
-        EOS
-      end
+      EOS
     end
 
     caveats += <<~EOS
@@ -185,10 +164,10 @@ class PostgresqlAT12 < Formula
   end
 
   service do
-    run [opt_bin/"postgres", "-D", var/"postgresql@12"]
+    run [opt_bin/"postgres", "-D", f.postgresql_datadir]
     keep_alive true
-    log_path var/"log/postgresql@12.log"
-    error_log_path var/"log/postgresql@12.log"
+    log_path f.postgresql_log_path
+    error_log_path f.postgresql_log_path
     working_dir HOMEBREW_PREFIX
   end
 

--- a/Formula/postgresql@13.rb
+++ b/Formula/postgresql@13.rb
@@ -22,7 +22,7 @@ class PostgresqlAT13 < Formula
   keg_only :versioned_formula
 
   # https://www.postgresql.org/support/versioning/
-  deprecate! date: "2024-11-13", because: :unsupported
+  deprecate! date: "2025-11-13", because: :unsupported
 
   depends_on "pkg-config" => :build
   depends_on "icu4c"
@@ -142,36 +142,19 @@ class PostgresqlAT13 < Formula
     caveats = ""
 
     # Extract the version from the formula name
-    pg_formula_version = name.split("@", 2).last
+    pg_formula_version = version.major.to_s
     # ... and check it against the old data dir postgres version number
     # to see if we need to print a warning re: data dir
     if old_postgresql_datadir_version == pg_formula_version
-      caveats += if postgresql_formula_present?
-        # Both PostgreSQL and PostgreSQL@13 are installed
-        <<~EOS
-          Previous versions of this formula used the same data directory as
-          the regular PostgreSQL formula. This causes a conflict if you
-          try to use both at the same time.
+      caveats += <<~EOS
+        Previous versions of postgresql shared the same data directory.
 
-          In order to avoid this conflict, you should make sure that the
-          #{name} data directory is located at:
-            #{postgresql_datadir}
+        You can migrate to a versioned data directory by running:
+          mv -v "#{old_postgres_data_dir}" "#{postgresql_datadir}"
 
-        EOS
-      else
-        # Only PostgreSQL@13 is installed, not PostgreSQL
-        <<~EOS
-          Previous versions of #{name} used the same data directory as
-          the postgresql formula. This will cause a conflict if you
-          try to use both at the same time.
+        (Make sure PostgreSQL is stopped before executing this command)
 
-          You can migrate to a versioned data directory by running:
-            mv -v "#{old_postgres_data_dir}" "#{postgresql_datadir}"
-
-          (Make sure PostgreSQL is stopped before executing this command)
-
-        EOS
-      end
+      EOS
     end
 
     caveats += <<~EOS
@@ -185,10 +168,10 @@ class PostgresqlAT13 < Formula
   end
 
   service do
-    run [opt_bin/"postgres", "-D", var/"postgresql@13"]
+    run [opt_bin/"postgres", "-D", f.postgresql_datadir]
     keep_alive true
-    log_path var/"log/postgresql@13.log"
-    error_log_path var/"log/postgresql@13.log"
+    log_path f.postgresql_log_path
+    error_log_path f.postgresql_log_path
     working_dir HOMEBREW_PREFIX
   end
 

--- a/Formula/wal2json.rb
+++ b/Formula/wal2json.rb
@@ -4,6 +4,7 @@ class Wal2json < Formula
   url "https://github.com/eulerto/wal2json/archive/wal2json_2_4.tar.gz"
   sha256 "87e627cac2d86f7203b1580a78b51e1da8aa61bb0af9ebfa14435370f3878237"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,11 +22,33 @@ class Wal2json < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e390370160cf6213efc8b3436d544a2c48d82c47404a243ed7a384940ce53ea6"
   end
 
-  depends_on "postgresql"
+  depends_on "postgresql@14"
+
+  def postgresql
+    Formula["postgresql@14"]
+  end
 
   def install
+    ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
+
     mkdir "stage"
     system "make", "install", "USE_PGXS=1", "DESTDIR=#{buildpath}/stage"
-    lib.install Dir["stage/#{HOMEBREW_PREFIX}/lib/*"]
+
+    stage_path = File.join("stage", HOMEBREW_PREFIX)
+    lib.install (buildpath/stage_path/"lib").children
+  end
+
+  test do
+    pg_ctl = postgresql.opt_bin/"pg_ctl"
+    port = free_port
+
+    system pg_ctl, "initdb", "-D", testpath/"test"
+    (testpath/"test/postgresql.conf").write <<~EOS, mode: "a+"
+
+      shared_preload_libraries = 'wal2json'
+      port = #{port}
+    EOS
+    system pg_ctl, "start", "-D", testpath/"test", "-l", testpath/"log"
+    system pg_ctl, "stop", "-D", testpath/"test"
   end
 end

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -24,6 +24,7 @@
   "openssl@1.1",
   "openssl@3",
   "pangomm@2.46",
+  "postgresql@14",
   "pyqt@5",
   "python@3.7",
   "python@3.8",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -117,6 +117,7 @@
   "polarssl": "mbedtls",
   "postgresql94": "postgresql@9.4",
   "postgresql95": "postgresql@9.5",
+  "postgresql": "postgresql@14",
   "prest": "prestd",
   "presto": "prestodb",
   "prestosql": "trino",

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -34,7 +34,6 @@
   ["libnetworkit", "networkit"],
   ["libnghttp2", "nghttp2"],
   ["libngspice", "ngspice"],
-  ["libpq", "postgresql"],
   ["libqalculate", "qalculate-gtk"],
   ["libvnc", "libvncserver"],
   ["logcli", "loki", "promtail"],


### PR DESCRIPTION
PostgreSQL makes more sense to only be a versioned formula. It breaks on every major version upgrade until people run a tool we provide for them which is not 100% bug-free.

While we're here, fix up the existing versioned `postgresql` formulae a bit.

Companion PR: https://github.com/Homebrew/brew/pull/13676

Note: don't merge until https://github.com/Homebrew/brew/pull/13705 is tagged