### PR TITLE
sile 0.14.2

### DIFF
--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -1,8 +1,8 @@
 class Sile < Formula
   desc "Modern typesetting system inspired by TeX"
   homepage "https://sile-typesetter.org"
-  url "https://github.com/sile-typesetter/sile/releases/download/v0.14.1/sile-0.14.1.tar.xz"
-  sha256 "a6a86e59a6001b6bfac4448f6d2acaeedacf006ab6f9ccea17b6d9cb73a10cd0"
+  url "https://github.com/sile-typesetter/sile/releases/download/v0.14.2/sile-0.14.2.tar.xz"
+  sha256 "a3de247d9c21a3b26e9bef10865dc04ccf72021285aa1197365519a36f5062e0"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
Minor patch release with no changes relevant to Homebrew build. See [upstream release notes](https://github.com/sile-typesetter/sile/releases/tag/v0.14.2).