### PR TITLE
libvatek 3.04 (new formula)

### DIFF
--- a/Formula/libvatek.rb
+++ b/Formula/libvatek.rb
@@ -1,0 +1,43 @@
+class Libvatek < Formula
+  desc "User library to control VATek chips"
+  homepage "https://github.com/VisionAdvanceTechnologyInc/vatek_sdk_2"
+  url "https://github.com/VisionAdvanceTechnologyInc/vatek_sdk_2/archive/v3.04.tar.gz"
+  sha256 "a2a380fe653f83445153b2043cb00fa3ac63464499e467aa3d1633b715dec1ed"
+  license "BSD-2-Clause"
+  head "https://github.com/VisionAdvanceTechnologyInc/vatek_sdk_2.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "libusb"
+
+  def install
+    system "cmake", "-S", ".", "-B", "builddir",
+                    "-DSDK2_EN_QT=OFF", "-DSDK2_EN_APP=OFF", "-DSDK2_EN_SAMPLE=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "builddir"
+    system "cmake", "--install", "builddir"
+  end
+
+  test do
+    (testpath/"vatek_test.c").write <<~EOS
+      #include <vatek_sdk_device.h>
+      #include <stdio.h>
+      #include <stdlib.h>
+
+      int main()
+      {
+          hvatek_devices hdevices = NULL;
+          vatek_result devcount = vatek_device_list_enum(DEVICE_BUS_USB, service_transform, &hdevices);
+          if (is_vatek_success(devcount)) {
+              printf("passed\\n");
+              return EXIT_SUCCESS;
+          }
+          else {
+              printf("failed\\n");
+              return EXIT_FAILURE;
+          }
+      }
+    EOS
+    system ENV.cc, "vatek_test.c", "-I#{include}/vatek", "-L#{lib}", "-lvatek_core", "-o", "vatek_test"
+    assert_equal "passed", shell_output("./vatek_test").strip
+  end
+end


### PR DESCRIPTION
The Vatek C/C++ library is used by TV applications to control modulator
devices based on Vatek chips. Because these chips are supported on macOS,
this makes them the first (and currently only) TV modulators available
on macOS. Other existing modulators are available on Linux and Windows
only.

This is a new library which is provided as open source by Vatek, the
company which produces these chips.

This library will be used by the next version of TSDuck. This library
will be consequently required as a dependency for the tsduck formula
in its next version.

As a committer, I am not the owner of that library. However, the
development team of libvatek gave me the permission to initiate the
first commit into Homebrew with that name and version. They are not
yet familiar with Homebrew.

Please note that brew audit --new-formula libvatek reports this error:
 * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)

Please ignore this error and allow this formula into Homebrew. New libraries
must start somewhere. They become notable when they are used. And users
need packages to use a library. Additionally, not allowing this library
into Homebrew would block the next version of the tsduck formula.

Thanks.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
