### PR TITLE
git-when-merged: use Python from macOS

### DIFF
--- a/Formula/git-when-merged.rb
+++ b/Formula/git-when-merged.rb
@@ -6,16 +6,22 @@ class GitWhenMerged < Formula
   url "https://github.com/mhagger/git-when-merged/archive/v1.2.1.tar.gz"
   sha256 "46ba5076981862ac2ad0fa0a94b9a5401ef6b5c5b0506c6e306b76e5798e1f58"
   license "GPL-2.0-only"
+  head "https://github.com/mhagger/git-when-merged.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "cef2e377082bfa5b6457f6b6d19066fd7a74312860533b85fb62d6e16c0986b7"
   end
 
-  depends_on "python@3.10"
+  # TODO: Update this to whichever python has `bin/python3`.
+  depends_on "python@3.10" => :test
+  uses_from_macos "python"
 
   def install
-    rewrite_shebang detected_python_shebang, "bin/git-when-merged"
-    bin.install "bin/git-when-merged"
+    bin.install "src/git_when_merged.py" => "git-when-merged"
+
+    if !OS.mac? || MacOS.version >= :catalina
+      rewrite_shebang detected_python_shebang(use_python_from_path: true), bin/"git-when-merged"
+    end
   end
 
   test do
@@ -34,6 +40,11 @@ class GitWhenMerged < Formula
     touch "baz"
     system "git", "add", "baz"
     system "git", "commit", "-m", "baz"
-    system "#{bin}/git-when-merged", "bar"
+    system bin/"git-when-merged", "bar"
+
+    # Test with both Homebrew Python3 and system Python3 to validate our shebang.
+    which_all("python3").each do |python|
+      system python, bin/"git-when-merged", "bar"
+    end
   end
 end


### PR DESCRIPTION
This formula doesn't require a specific version of Python, so let's use
whichever `python3` is in the user's `PATH` by using a `/usr/bin/env python3`
shebang.

We add a test dependency on `python@3.10` to make sure this works if the
user has Homebrew `python3` in their `PATH`.

Closes #107876.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
