### PR TITLE
libxcb: set `libpthread-stubs` as build dependency

### DIFF
--- a/Formula/libxcb.rb
+++ b/Formula/libxcb.rb
@@ -14,10 +14,10 @@ class Libxcb < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "993d37bb436fab0157ed5f3c031f9a18168053439e93edb4bdce9abe6e99373d"
   end
 
+  depends_on "libpthread-stubs" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.10" => :build
   depends_on "xcb-proto" => :build
-  depends_on "libpthread-stubs"
   depends_on "libxau"
   depends_on "libxdmcp"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`libpthread-stubs` depends on`pkg-config`, so `pkg-config` is no longer build dependency in some formulae that only need `pkg-config` in build time, e.g. `cairo`,`libxext` and some X related formulae.