### PR TITLE
e2fsprogs 1.46.5

### DIFF
--- a/Formula/e2fsprogs.rb
+++ b/Formula/e2fsprogs.rb
@@ -1,8 +1,8 @@
 class E2fsprogs < Formula
   desc "Utilities for the ext2, ext3, and ext4 file systems"
   homepage "https://e2fsprogs.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/e2fsprogs/e2fsprogs/v1.46.4/e2fsprogs-1.46.4.tar.gz"
-  sha256 "7524520b291e901431ce59ea085955b601126de371bf3cfc0f5e4fad78684265"
+  url "https://downloads.sourceforge.net/project/e2fsprogs/e2fsprogs/v1.46.5/e2fsprogs-1.46.5.tar.gz"
+  sha256 "b7430d1e6b7b5817ce8e36d7c8c7c3249b3051d0808a96ffd6e5c398e4e2fbb9"
   license all_of: [
     "GPL-2.0-or-later",
     "LGPL-2.0-or-later", # lib/ex2fs
@@ -32,6 +32,10 @@ class E2fsprogs < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
 
+  # Remove `-flat_namespace` flag and fix M1 shared library build.
+  # Sent via email to theodore.tso@gmail.com
+  patch :DATA
+
   def install
     # Fix "unknown type name 'loff_t'" issue
     inreplace "lib/ext2fs/imager.c", "loff_t", "off_t"
@@ -47,7 +51,7 @@ class E2fsprogs < Formula
     ]
     args << if OS.linux?
       "--enable-elf-shlibs"
-    elsif !Hardware::CPU.arm?
+    else
       "--enable-bsd-shlibs"
     end
 
@@ -67,3 +71,19 @@ class E2fsprogs < Formula
     system bin/"lsattr", "-al"
   end
 end
+
+__END__
+diff --git a/lib/Makefile.darwin-lib b/lib/Makefile.darwin-lib
+index 95cdd4b..95e8ee0 100644
+--- a/lib/Makefile.darwin-lib
++++ b/lib/Makefile.darwin-lib
+@@ -24,7 +24,8 @@ image:		$(BSD_LIB)
+ $(BSD_LIB): $(OBJS)
+ 	$(E) "	GEN_BSD_SOLIB $(BSD_LIB)"
+ 	$(Q) (cd pic; $(CC) -dynamiclib -compatibility_version 1.0 -current_version $(BSDLIB_VERSION) \
+-		-flat_namespace -undefined warning -o $(BSD_LIB) $(OBJS))
++		-install_name $(BSDLIB_INSTALL_DIR)/$(BSD_LIB) \
++		-undefined dynamic_lookup -o $(BSD_LIB) $(OBJS))
+ 	$(Q) $(MV) pic/$(BSD_LIB) .
+ 	$(Q) $(RM) -f ../$(BSD_LIB)
+ 	$(Q) (cd ..; $(LN) $(LINK_BUILD_FLAGS) \


### PR DESCRIPTION
Also, apply a patch to fix the `-flat_namespace` flag and shared library
build on M1.

The patch was emailed to the author at theodore.tso@gmail.com, the email
address linked at http://e2fsprogs.sourceforge.net.
