### PR TITLE
watchman: switch to `pcre2`

### DIFF
--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -2,6 +2,7 @@ class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
   license "MIT"
+  revision 1
 
   stable do
     url "https://github.com/facebook/watchman/archive/v2022.08.08.00.tar.gz"
@@ -50,7 +51,7 @@ class Watchman < Formula
   depends_on "glog"
   depends_on "libevent"
   depends_on "openssl@1.1"
-  depends_on "pcre"
+  depends_on "pcre2"
   depends_on "python@3.10"
 
   on_linux do


### PR DESCRIPTION
This no longer uses `pcre`. See https://github.com/facebook/watchman/commit/3ce6c9baa08c240d90937c85dae2afc6ad010bc8.

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
