### PR TITLE
solc-select 0.2.1 (new formula)

### DIFF
--- a/Formula/solc-select.rb
+++ b/Formula/solc-select.rb
@@ -1,0 +1,32 @@
+class SolcSelect < Formula
+  include Language::Python::Virtualenv
+
+  desc "Manage multiple Solidity compiler versions"
+  homepage "https://github.com/crytic/solc-select"
+  url "https://files.pythonhosted.org/packages/48/d6/35f72b61b89c087e7b886ff6511deb6d3193db2ffacdcf03827373e5e312/solc-select-0.2.1.tar.gz"
+  sha256 "e956b04dc7df2209d1fb3b82e2bb62f8e730bb554c4d7f958a14ff2fb2f37212"
+  license "AGPL-3.0-only"
+  head "https://github.com/crytic/solc-select.git", branch: "dev"
+
+  depends_on "python@3.10"
+
+  resource "pysha3" do
+    url "https://files.pythonhosted.org/packages/73/bf/978d424ac6c9076d73b8fdc8ab8ad46f98af0c34669d736b1d83c758afee/pysha3-1.0.2.tar.gz"
+    sha256 "fe988e73f2ce6d947220624f04d467faf05f1bbdbc64b0a201296bb3af92739e"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    system bin/"solc-select", "install", "0.5.7"
+    system bin/"solc-select", "install", "0.8.0"
+    system bin/"solc-select", "use", "0.5.7"
+
+    assert_match("0.5.7", shell_output("#{bin}/solc --version"))
+    with_env(SOLC_VERSION: "0.8.0") do
+      assert_match("0.8.0", shell_output("#{bin}/solc --version"))
+    end
+  end
+end


### PR DESCRIPTION
`solc-select` is a tool that allows installing and managing different versions of the Solidity compiler, `solc`. As the tool's job revolves around installing and managing different compiler versions, the tests check that installation succeeds and the correct versions are reported.

Full disclosure: I work at @trailofbits and contribute to solc-select and other open-source company tools.

----

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
