### PR TITLE
crytic-compile 0.2.3 (new formula)

### DIFF
--- a/Formula/crytic-compile.rb
+++ b/Formula/crytic-compile.rb
@@ -1,0 +1,40 @@
+class CryticCompile < Formula
+  include Language::Python::Virtualenv
+
+  desc "Abstraction layer for smart contract build systems"
+  homepage "https://github.com/crytic/crytic-compile"
+  url "https://github.com/crytic/crytic-compile/archive/refs/tags/0.2.3.tar.gz"
+  sha256 "b41cc3ca6e43b70c2257dba5c1e794ca0881577f908acee9bc5bdfb132792e30"
+  license "AGPL-3.0-only"
+  head "https://github.com/crytic/crytic-compile.git", branch: "master"
+
+  depends_on "python@3.10"
+  depends_on "solc-select"
+
+  resource "pysha3" do
+    url "https://files.pythonhosted.org/packages/73/bf/978d424ac6c9076d73b8fdc8ab8ad46f98af0c34669d736b1d83c758afee/pysha3-1.0.2.tar.gz"
+    sha256 "fe988e73f2ce6d947220624f04d467faf05f1bbdbc64b0a201296bb3af92739e"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    (testpath/"test.sol").write <<~EOS
+      pragma solidity ^0.8.0;
+      contract Test {
+        function f() public pure returns (bool) {
+          return false;
+        }
+      }
+    EOS
+
+    system "solc-select", "install", "0.8.0"
+    with_env(SOLC_VERSION: "0.8.0") do
+      system bin/"crytic-compile", testpath/"test.sol", "--export-format=solc", "--export-dir=#{testpath}/export"
+    end
+
+    assert_predicate testpath/"export/combined_solc.json", :exist?
+  end
+end


### PR DESCRIPTION
crytic-compile is a tool that abstracts the compilation process of a smart contract project into a consistent interface. It can be used to compile and generate artifacts for projects using several different compilation frameworks, such as Hardhat, Brownie, or Foundry, among others. This simplifies supporting different kinds of smart contract projects on static analysis and fuzzing tools such as Slither and Echidna.

Full disclosure: I work at @trailofbits and contribute to crytic-compile and other open-source company tools.

-----

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
