### PR TITLE
dsda-doom v0.24.3 (new formula)

### DIFF
--- a/Formula/dsda-doom.rb
+++ b/Formula/dsda-doom.rb
@@ -58,7 +58,7 @@ class DsdaDoom < Formula
   end
 
   test do
-    expected_output = "IdentifyVersion: IWAD not found"
+    expected_output = "dsda-doom v#{version.major_minor_patch}"
     assert_match expected_output, shell_output("#{bin}/dsda-doom -iwad invalid_wad 2>&1", 255)
   end
 end

--- a/Formula/dsda-doom.rb
+++ b/Formula/dsda-doom.rb
@@ -41,8 +41,8 @@ class DsdaDoom < Formula
                     "-DWITH_VORBISFILE=ON",
                     "-DWITH_ZLIB=ON",
                     *std_cmake_args
-    system "cmake", "--build", "build", "--config", "Release"
-    system "cmake", "--install", "build", "--config", "Release"
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
 
     # We need to move these elsewhere so we can symlink them to the right place in `postinstall`.
     pkgshare.install doomwaddir(prefix).children
@@ -55,6 +55,13 @@ class DsdaDoom < Formula
 
     # Make sure `dsda-doom` also checks the DOOMWADDIR in HOMEBREW_PREFIX.
     doomwaddir(prefix).parent.install_symlink doomwaddir(HOMEBREW_PREFIX)
+  end
+
+  def caveats
+    <<~EOS
+      For DSDA-Doom to find your WAD files, place them in:
+      #{doomwaddir(HOMEBREW_PREFIX)}
+    EOS
   end
 
   test do

--- a/Formula/dsda-doom.rb
+++ b/Formula/dsda-doom.rb
@@ -1,0 +1,47 @@
+class DsdaDoom < Formula
+  desc "Fork of prboom+ with a focus on speedrunning"
+  homepage "https://github.com/kraflab/dsda-doom"
+  url "https://github.com/kraflab/dsda-doom/archive/refs/tags/v0.24.3.tar.gz"
+  sha256 "d4cfc82eea029068329d6b6a2dcbe0b316b31a60af12e6dc5ad3e1d2c359d913"
+  license "GPL-2.0-only"
+  head "https://github.com/kraflab/dsda-doom.git", branch: "master"
+
+  depends_on "cmake" => :build
+  depends_on "fluid-synth"
+  depends_on "libvorbis"
+  depends_on "mad"
+  depends_on "pcre"
+  depends_on "portmidi"
+  depends_on "sdl2"
+  depends_on "sdl2_image"
+  depends_on "sdl2_mixer"
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "mesa-glu"
+  end
+
+  def install
+    # Patch for Linux builds until kraflab/dsda-doom#122 is merged and added to a release
+    inreplace "prboom2/src/d_deh.c", "uint64_t", "uint_64_t"
+
+    system "cmake", "-S", "prboom2", "-B", "build",
+                    "-DBUILD_GL=ON",
+                    "-DWITH_DUMB=OFF",
+                    "-DWITH_IMAGE=ON",
+                    "-DWITH_FLUIDSYNTH=ON",
+                    "-DWITH_MAD=ON",
+                    "-DWITH_PCRE=ON",
+                    "-DWITH_PORTMIDI=ON",
+                    "-DWITH_VORBISFILE=ON",
+                    "-DWITH_ZLIB=ON",
+                    *std_cmake_args
+    system "cmake", "--build", "build", "--config", "Release"
+    system "cmake", "--install", "build", "--config", "Release"
+  end
+
+  test do
+    expected_output = "IdentifyVersion: IWAD not found"
+    assert_match expected_output, shell_output("#{bin}/dsda-doom -iwad invalid_wad 2>&1", 255)
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hello, thank you for taking the time to review this PR!

Since #83236, DSDA-Doom has gained much more popularity, even for non-speedrunners.
It differs itself from current options (crispy/chocolate Doom and GZDoom) in several ways:
- It is "Boom compatible", making it compatible with the vast majority of popular custom maps.
- It is able to accurately reproduce the behaviour of the original Doom executables.
- It offers a wide variety of quality of life improvements, additional tools for speedrunners to record, play back and validate runs.

This PR would also address one notable issue DSDA-Doom currently suffers from, being the lack of binary release for Linux and macOS.