### PR TITLE
ns-3 3.36.1

### DIFF
--- a/Formula/ns-3.rb
+++ b/Formula/ns-3.rb
@@ -67,6 +67,7 @@ class Ns3 < Formula
     system "cmake", "--install", "build"
 
     # Starting 3.36, bindings are no longer installed
+    # https://gitlab.com/nsnam/ns-3-dev/-/merge_requests/1060
     site_packages = Language::Python.site_packages("python3.10")
     (prefix/site_packages).install (buildpath/"build/bindings/python").children
 

--- a/Formula/ns-3.rb
+++ b/Formula/ns-3.rb
@@ -16,13 +16,13 @@ class Ns3 < Formula
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
-  depends_on "gsl" => :build
   depends_on "ninja" => :build
-  depends_on "open-mpi" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on xcode: [:build, "11"]
 
-  uses_from_macos "libxcrypt"
+  depends_on "gsl"
+  depends_on "open-mpi"
+  depends_on "python@3.10"
+
   uses_from_macos "libxml2"
   uses_from_macos "sqlite"
 
@@ -30,6 +30,9 @@ class Ns3 < Formula
     depends_on "gcc"
   end
 
+  # Needs GCC 8 or above
+  fails_with gcc: "5"
+  fails_with gcc: "6"
   fails_with gcc: "7"
 
   resource "pybindgen" do
@@ -50,7 +53,8 @@ class Ns3 < Formula
     system "./ns3", "install"
 
     # Starting 3.36, bindings are no longer installed
-    (lib/"python3.10/site-packages").install Dir["build/bindings/python/*"]
+    site_packages = Language::Python.site_packages("python3.10")
+    (prefix/site_packages).install (buildpath/"build/bindings/python").children
 
     pkgshare.install "examples/tutorial/first.cc", "examples/tutorial/first.py"
   end
@@ -62,6 +66,6 @@ class Ns3 < Formula
            "-std=c++17", "-o", "test"
     system "./test"
 
-    system Formula["python@3.10"].opt_bin/"python3", pkgshare/"first.py"
+    system Formula["python@3.10"].opt_bin/"python3.10", pkgshare/"first.py"
   end
 end

--- a/Formula/ns-3.rb
+++ b/Formula/ns-3.rb
@@ -25,12 +25,6 @@ class Ns3 < Formula
   uses_from_macos "libxml2"
   uses_from_macos "sqlite"
 
-  # Clears the Python3_LIBRARIES variable. Removing `PRIVATE ${Python3_LIBRARIES}`
-  # in ns3-module-macros is not sufficient as it doesn't apply to visualizer.so.
-  on_macos do
-    patch :DATA
-  end
-
   on_linux do
     depends_on "gcc"
   end
@@ -46,22 +40,30 @@ class Ns3 < Formula
   end
 
   def install
-    resource("pybindgen").stage buildpath/"../pybindgen"
-    ENV.append "PYTHONPATH", "#{buildpath}/../pybindgen"
-
-    # Avoid explicit linkage with python
-    linker_flags = "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-undefined,dynamic_lookup"
+    resource("pybindgen").stage buildpath.parent/"pybindgen"
+    ENV.append "PYTHONPATH", buildpath.parent/"pybindgen"
 
     # Fix binding's rpath
-    linker_flags << " -Wl,-rpath,@loader_path" if OS.mac?
-    linker_flags << " -Wl,-rpath,$ORIGIN" if OS.linux?
+    linker_flags = if OS.mac?
+      "-Wl,-undefined,dynamic_lookup,-rpath,@loader_path"
+    else
+      "-Wl,-rpath,$ORIGIN"
+    end
+
+    if OS.mac?
+      # Clears the Python3_LIBRARIES variable. Removing `PRIVATE ${Python3_LIBRARIES}`
+      # in ns3-module-macros is not sufficient as it doesn't apply to visualizer.so.
+      inreplace "build-support/macros-and-definitions.cmake",
+                "set(Python3_FOUND TRUE)\n      if(APPLE)",
+                "set(Python3_FOUND TRUE)\nset(Python3_LIBRARIES \"\")\nif(FALSE)"
+    end
 
     system "cmake", "-S", ".", "-B", "build",
-                                 "-DNS3_GTK3=OFF",
-                                 "-DNS3_PYTHON_BINDINGS=ON",
-                                 "-DNS3_MPI=ON",
-                                 linker_flags,
-                                 *std_cmake_args
+                    "-DNS3_GTK3=OFF",
+                    "-DNS3_PYTHON_BINDINGS=ON",
+                    "-DNS3_MPI=ON",
+                    "-DCMAKE_SHARED_LINKER_FLAGS=#{linker_flags}",
+                    *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 
@@ -82,19 +84,3 @@ class Ns3 < Formula
     system Formula["python@3.10"].opt_bin/"python3.10", pkgshare/"first.py"
   end
 end
-
-__END__
-diff --git a/build-support/macros-and-definitions.cmake b/build-support/macros-and-definitions.cmake
-index 304ccdde7..64ae322c5 100644
---- a/build-support/macros-and-definitions.cmake
-+++ b/build-support/macros-and-definitions.cmake
-@@ -723,7 +723,8 @@ macro(process_options)
-   if(${Python3_Interpreter_FOUND})
-     if(${Python3_Development_FOUND})
-       set(Python3_FOUND TRUE)
--      if(APPLE)
-+      set(Python3_LIBRARIES "")
-+      if(FALSE)
-         # Apple is very weird and there could be a lot of conflicting python
-         # versions which can generate conflicting rpaths preventing the python
-         # bindings from working

--- a/Formula/ns-3.rb
+++ b/Formula/ns-3.rb
@@ -1,10 +1,9 @@
 class Ns3 < Formula
   desc "Discrete-event network simulator"
   homepage "https://www.nsnam.org/"
-  url "https://gitlab.com/nsnam/ns-3-dev/-/archive/ns-3.35/ns-3-dev-ns-3.35.tar.bz2"
-  sha256 "946abd1be8eeeb2b0f72a67f9d5fa3b9839bb6973297d4601c017a6c3a50fc10"
+  url "https://gitlab.com/nsnam/ns-3-dev/-/archive/ns-3.36.1/ns-3-dev-ns-3.36.1.tar.bz2"
+  sha256 "8826dbb35290412df9885d8a936ab0c3fe380dec4dd48c57889148c0a2c1a856"
   license "GPL-2.0-only"
-  revision 2
 
   bottle do
     sha256 cellar: :any, arm64_monterey: "4f3d2a4df386be25087fa43898cfd7e5dc3f839ae8654720b5a6ae1453c33ba8"
@@ -16,7 +15,12 @@ class Ns3 < Formula
   end
 
   depends_on "boost" => :build
+  depends_on "cmake" => :build
+  depends_on "gsl" => :build
+  depends_on "ninja" => :build
+  depends_on "open-mpi" => :build
   depends_on "python@3.10" => [:build, :test]
+  depends_on xcode: [:build, "11"]
 
   uses_from_macos "libxcrypt"
   uses_from_macos "libxml2"
@@ -26,41 +30,36 @@ class Ns3 < Formula
     depends_on "gcc"
   end
 
-  # `gcc version 5.4.0 older than minimum supported version 7.0.0`
-  fails_with gcc: "5"
+  fails_with gcc: "7"
 
   resource "pybindgen" do
     url "https://files.pythonhosted.org/packages/e0/8e/de441f26282eb869ac987c9a291af7e3773d93ffdb8e4add664b392ea439/PyBindGen-0.22.1.tar.gz"
     sha256 "8c7f22391a49a84518f5a2ad06e3a5b1e839d10e34da7631519c8a28fcba3764"
   end
 
-  # Fix ../src/lte/model/fdmt-ff-mac-scheduler.cc:1044:16: error:
-  # variable 'bytesTxed' set but not used [-Werror,-Wunused-but-set-variable]
-  # TODO: remove in the next release.
-  patch do
-    url "https://gitlab.com/nsnam/ns-3-dev/-/commit/dbd49741fcd5938edec17eddcde251b5dee25d05.diff"
-    sha256 "28e92297cfe058cfb587527dc3cfdb8ac66b51aba672be29539b6544591e2f1e"
-  end
-
   def install
-    resource("pybindgen").stage buildpath/"pybindgen"
+    resource("pybindgen").stage buildpath/"../pybindgen"
 
-    system "./waf", "configure", "--prefix=#{prefix}",
-                                 "--build-profile=release",
+    system "./ns3", "configure", "--prefix=#{prefix}",
+                                 "-d", "release",
                                  "--disable-gtk",
-                                 "--with-python=#{which("python3")}",
-                                 "--with-pybindgen=#{buildpath}/pybindgen"
-    system "./waf", "--jobs=#{ENV.make_jobs}"
-    system "./waf", "install"
+                                 "--enable-python-bindings",
+                                 "--enable-mpi",
+                                 "--", "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    system "./ns3", "build", "--jobs=#{ENV.make_jobs}"
+    system "./ns3", "install"
+
+    # Starting 3.36, bindings are no longer installed
+    (lib/"python3.10/site-packages").install Dir["build/bindings/python/*"]
 
     pkgshare.install "examples/tutorial/first.cc", "examples/tutorial/first.py"
   end
 
   test do
-    system ENV.cxx, pkgshare/"first.cc", "-I#{include}/ns#{version}", "-L#{lib}",
+    system ENV.cxx, pkgshare/"first.cc", "-I#{include}", "-L#{lib}",
            "-lns#{version}-core", "-lns#{version}-network", "-lns#{version}-internet",
            "-lns#{version}-point-to-point", "-lns#{version}-applications",
-           "-std=c++11", "-o", "test"
+           "-std=c++17", "-o", "test"
     system "./test"
 
     system Formula["python@3.10"].opt_bin/"python3", pkgshare/"first.py"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Starting version 3.36, ns-3 removed the WAF build tool in favour of CMake. 

Notable changes are:
- Bump to the minimum version of GCC to 8.
- Xcode is required for building, CLT systematically fails.
- Bindings need to be installed manually.

Current issues:
- `brew audit` reports that the bindings libraries are explicitly linked to a python library/framework and instead should be linked to `-undefined dynamic_lookup`. This does not seem to be achievable through setting CMake variables.
- Python bindings consists in shared libraries depending on one another (located in `#{lib}/python3.10/site-packages/ns`), this leads to broken rpath where, for example, a call to `dlopen` on `applications.so` fails due to being unable to find `internet.so`. Adding the bindings' path to `CMAKE_INSTALL_RPATH` does not fix this issue. Moreover, using the `--enable-monolib` option does not apply to the bindings.

An option to fix both of these issues would be to disable the bindings altogether. It seems that upstream is moving away from pybindgen to a new solution which no longer creates shared libraries in the python package: https://gitlab.com/nsnam/ns-3-dev/-/merge_requests/1032