### PR TITLE
liboqs: use `ENV.runtime_cpu_detection`

### DIFF
--- a/style_exceptions/runtime_cpu_detection_allowlist.json
+++ b/style_exceptions/runtime_cpu_detection_allowlist.json
@@ -3,6 +3,7 @@
   "apache-arrow",
   "blis",
   "fftw",
+  "liboqs",
   "libvpx",
   "luajit",
   "openblas",


### PR DESCRIPTION
Also:

1. Remove `doxygen` dependency, since we don't build the documentation.
   Attempting to build the documentation results in a build failure.
2. Install test executables into `libexec`. They're already built by
   CMake, so let's put them somewhere re-usable and re-use one of them
   for the test. The test executable is the same as the one built and
   run previously.
3. Add `head`.

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
