### PR TITLE
antidote 1.6.4 (new formula)

### DIFF
--- a/Formula/antidote.rb
+++ b/Formula/antidote.rb
@@ -1,0 +1,33 @@
+class Antidote < Formula
+  desc "Plugin manager for zsh, inspired by antigen and antibody"
+  homepage "https://getantidote.github.io/"
+  url "https://github.com/mattmc3/antidote/archive/refs/tags/v1.6.4.tar.gz"
+  sha256 "336ea89aab33d07d5d2eaa14af2f015d7da657837f64d3e76fa5c54645210950"
+  license "MIT"
+
+  uses_from_macos "zsh"
+
+  def install
+    pkgshare.install "antidote.zsh"
+    pkgshare.install "functions"
+    man.install "man/man1"
+  end
+
+  def caveats
+    <<~EOS
+      To activate antidote, add the following to your ~/.zshrc:
+        source #{opt_pkgshare}/antidote.zsh
+    EOS
+  end
+
+  test do
+    (testpath/".zshrc").write <<~EOS
+      export GIT_TERMINAL_PROMPT=0
+      export ANTIDOTE_HOME=~/.zplugins
+      source #{pkgshare}/antidote.zsh
+    EOS
+    system "zsh", "--login", "-i", "-c", "antidote install rupa/z"
+    assert_equal (testpath/".zsh_plugins.txt").read, "rupa/z\n"
+    assert_predicate testpath/".zplugins/https-COLON--SLASH--SLASH-github.com-SLASH-rupa-SLASH-z/z.sh", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add antidote, a Zsh plugin manager successor to antigen/antibody. https://getantidote.github.io