### PR TITLE
open-mpi: use `etc` for system-wide config directory

### DIFF
--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -54,25 +54,24 @@ class OpenMpi < Formula
     ENV.runtime_cpu_detection
 
     args = %W[
-      --prefix=#{prefix}
-      --disable-dependency-tracking
       --disable-silent-rules
       --enable-ipv6
       --enable-mca-no-build=reachable-netlink
+      --sysconfdir=#{etc}
       --with-libevent=#{Formula["libevent"].opt_prefix}
       --with-sge
     ]
     args << "--with-platform-optimized" if build.head?
 
     system "./autogen.pl", "--force" if build.head?
-    system "./configure", *args
+    system "./configure", *std_configure_args, *args
     system "make", "all"
     system "make", "check"
     system "make", "install"
 
     # Fortran bindings install stray `.mod` files (Fortran modules) in `lib`
     # that need to be moved to `include`.
-    include.install Dir["#{lib}/*.mod"]
+    include.install lib.glob("*.mod")
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Existing bottle:
```console
% ls -l /usr/local/opt/open-mpi/etc
total 32
-rw-r--r--  1 cho-m  admin  1661 May 26 07:38 openmpi-default-hostfile
-rw-r--r--  1 cho-m  admin  2886 Aug 16 19:57 openmpi-mca-params.conf
-rw-r--r--  1 cho-m  admin  1441 May 26 07:38 openmpi-totalview.tcl
-rw-r--r--  1 cho-m  admin  2902 Aug 16 19:57 pmix-mca-params.conf
```

Snippet from `/usr/local/etc/openmpi-mca-params.conf`
```
# This is the default system-wide MCA parameters defaults file.
# Specifically, the MCA parameter "mca_param_files" defaults to a
# value of
# "$HOME/.openmpi/mca-params.conf:$sysconf/openmpi-mca-params.conf"
# (this file is the latter of the two).  So if the default value of
# mca_param_files is not changed, this file is used to set system-wide
# MCA parameters.  This file can therefore be used to set system-wide
# default MCA parameters for all users.  Of course, users can override
```