### PR TITLE
dsda-doom: fix formatting of `caveats`.

### DIFF
--- a/Formula/dsda-doom.rb
+++ b/Formula/dsda-doom.rb
@@ -69,7 +69,7 @@ class DsdaDoom < Formula
   def caveats
     <<~EOS
       For DSDA-Doom to find your WAD files, place them in:
-      #{doomwaddir(HOMEBREW_PREFIX)}
+        #{doomwaddir(HOMEBREW_PREFIX)}
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
