### PR TITLE
librtlsdr 0.6.0_1: apply Debian stable patches

### DIFF
--- a/Formula/librtlsdr.rb
+++ b/Formula/librtlsdr.rb
@@ -1,10 +1,31 @@
 class Librtlsdr < Formula
   desc "Use Realtek DVB-T dongles as a cheap SDR"
   homepage "https://osmocom.org/projects/rtl-sdr/wiki"
-  url "https://github.com/steve-m/librtlsdr/archive/0.6.0.tar.gz"
-  sha256 "80a5155f3505bca8f1b808f8414d7dcd7c459b662a1cde84d3a2629a6e72ae55"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
+  revision 1
   head "https://git.osmocom.org/rtl-sdr", using: :git, branch: "master"
+
+  stable do
+    url "https://github.com/steve-m/librtlsdr/archive/0.6.0.tar.gz"
+    sha256 "80a5155f3505bca8f1b808f8414d7dcd7c459b662a1cde84d3a2629a6e72ae55"
+    # These patches are applied upstream after 0.6.0, but have not been released yet
+    patch do # lib: Add workaround for Linux usbfs mmap() bug
+      url "https://gitea.osmocom.org/sdr/rtl-sdr/commit/f68bb2fa772ad94f58c59babd78353667570630b.patch"
+      sha256 "6467a2378793290573124b31dad7180e207ab8895651e2a53a5e5dbb30cecee0"
+    end
+    patch do # lib: fix memory leak in rtlsdr_open()
+      url "https://gitea.osmocom.org/sdr/rtl-sdr/commit/be1d1206bfb6e6c41f7d91b20b77e20f929fa6a7.patch"
+      sha256 "2778eb2e4b1ace7386ea5b96a9fb5baa2f407b73fb5ce1060cbd6e92ef7c4e43"
+    end
+    patch do # lib: disable usbfs zero-copy support by default
+      url "https://gitea.osmocom.org/sdr/rtl-sdr/commit/81833a1cf6288fee93a9157c0f60cafb5ec340b9.patch"
+      sha256 "17de7e509ff25e1fd3f2251a69574b756b931572bda6a3ea14e84fba7f28e360"
+    end
+    patch do # Improve librtlsdr.pc file
+      url "https://gitea.osmocom.org/sdr/rtl-sdr/commit/222517b506278178ab93182d79ccf7eb04d107ce.patch"
+      sha256 "da4fa0da5d3298a5a9f978eb11fad890d7e658999f6c06ae6c80e9aa344288d0"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "f61808ab70f1d625cbc411d4f5e5e68a26b14f93eb926352353523cc54e188a6"
@@ -25,7 +46,7 @@ class Librtlsdr < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
       system "make", "install"
     end
   end


### PR DESCRIPTION
The Debian patchset brings several improvements to librtlsdr.
Update `license` to GPL-2.0-or-later:
https://metadata.ftp-master.debian.org/changelogs//main/r/rtl-sdr/rtl-sdr_0.6.0-3_copyright
Build command is updated to match modernized cmake.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
