### PR TITLE
node@12: fix `python@3.9` reference

### DIFF
--- a/Formula/node@12.rb
+++ b/Formula/node@12.rb
@@ -37,7 +37,7 @@ class NodeAT12 < Formula
 
   def install
     # make sure subprocesses spawned by make are using our Python 3
-    ENV["PYTHON"] = python = Formula["python@3.9"].opt_bin/"python3"
+    ENV["PYTHON"] = python = Formula["python@3.9"].opt_bin/"python3.9"
 
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
Needed for #98809.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
