### PR TITLE
lasso: depend on `libxml2`

### DIFF
--- a/Formula/lasso.rb
+++ b/Formula/lasso.rb
@@ -21,17 +21,19 @@ class Lasso < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
-  depends_on "six" => :build
   depends_on "glib"
+  depends_on "libxml2"
   depends_on "libxmlsec1"
   depends_on "openssl@1.1"
 
-  uses_from_macos "libxml2"
+  uses_from_macos "python" => :build
+
+  on_linux do
+    depends_on "six" => :build # macOS Python has `six` installed.
+  end
 
   def install
-    xy = Language::Python.major_minor_version "python3"
-    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{xy}/site-packages"
+    ENV["PYTHON"] = "python3"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--disable-java",
@@ -52,11 +54,10 @@ class Lasso < Formula
         return lasso_init();
       }
     EOS
-    libxml = OS.mac? ? MacOS.sdk_path/"usr/include/libxml2" : Formula["libxml2"].include/"libxml2"
     system ENV.cc, "test.c",
                    "-I#{Formula["glib"].include}/glib-2.0",
                    "-I#{Formula["glib"].lib}/glib-2.0/include",
-                   "-I#{libxml}",
+                   "-I#{Formula["libxml2"].include}/libxml2",
                    "-I#{Formula["libxmlsec1"].include}/xmlsec1",
                    "-L#{lib}", "-llasso", "-o", "test"
     system "./test"


### PR DESCRIPTION
This already links with our `libxml2` indirectly through `libxmlsec1`.
This means, in particular, that we should not be mixing the system
`libxml2` headers with the library that we ship.

I've also removed the call to `ENV.prepend_create_path` as this just
creates an empty directory in `libexec`.

I've also speculatively removed all Python dependencies, since this may
not be needed. (Or it might be, for Python scripts from `glib` that
are now in `glib-utils`.)

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
