### PR TITLE
spidermonkey: fix build with new setuptools

### DIFF
--- a/Formula/spidermonkey.rb
+++ b/Formula/spidermonkey.rb
@@ -48,6 +48,10 @@ class Spidermonkey < Formula
   end
 
   def install
+    # Avoid installing into HOMEBREW_PREFIX.
+    # https://github.com/Homebrew/homebrew-core/pull/98809
+    ENV["SETUPTOOLS_USE_DISTUTILS"] = "stdlib"
+
     # Remove the broken *(for anyone but FF) install_name
     # _LOADER_PATH := @executable_path
     inreplace "config/rules.mk",


### PR DESCRIPTION
Needed for #98809.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
