### PR TITLE
workflows/tests: split summary and bottle result again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,17 +229,29 @@ jobs:
           cd bottles
           brew test-bot ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
 
-      - name: Failures Summary and Bottle Result
+      - name: Failures summary for brew test-bot --only-formula
         if: always()
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
           workdir: ${{matrix.workdir || github.workspace}}
+          result_path: bottles/steps_output.txt
+          step_name: 'Build summary on ${{ matrix.runner }}'
 
       - name: Output brew linkage result
         if: always()
-        run: |
-          cat bottles/linkage_output.txt
-          rm bottles/linkage_output.txt
+        uses: Homebrew/actions/failures-summary-and-bottle-result@master
+        with:
+          workdir: ${{matrix.workdir || github.workspace}}
+          result_path: bottles/linkage_output.txt
+          step_name: '`brew linkage` output on ${{ matrix.runner }}'
+
+      - name: Output brew bottle result
+        if: always()
+        uses: Homebrew/actions/failures-summary-and-bottle-result@master
+        with:
+          workdir: ${{matrix.workdir || github.workspace}}
+          result_path: bottles/bottle_output.txt
+          step_name: '`brew bottle` output on ${{ matrix.runner }}'
 
       - name: Run brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
         if: ${{(success() || failure()) && fromJson(needs.setup_tests.outputs.test-dependents)}}


### PR DESCRIPTION
Also, produce a step summary on the workflow summary page (see #105786).

Needed as soon as Homebrew/actions#295 is merged.

This may need a quick revert, since I'm not 100% certain that my changes to the action is working. I'll monitor this closely right after merging to revert and pin the summary output action to a known-good commit if things break.
