### PR TITLE
x86_64-linux-gnu-binutils: make keg only on Linux

### DIFF
--- a/Formula/x86_64-linux-gnu-binutils.rb
+++ b/Formula/x86_64-linux-gnu-binutils.rb
@@ -21,6 +21,10 @@ class X8664LinuxGnuBinutils < Formula
 
   uses_from_macos "texinfo"
 
+  on_linux do
+    keg_only "it conflicts with `binutils`"
+  end
+
   def install
     ENV.cxx11
 


### PR DESCRIPTION
This conflicts with `binutils`. Seen at #108271.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
