### PR TITLE
pandoc 2.19.1

### DIFF
--- a/Formula/pandoc.rb
+++ b/Formula/pandoc.rb
@@ -1,8 +1,8 @@
 class Pandoc < Formula
   desc "Swiss-army knife of markup format conversion"
   homepage "https://pandoc.org/"
-  url "https://hackage.haskell.org/package/pandoc-2.19/pandoc-2.19.tar.gz"
-  sha256 "425c13728b4e158deb54996b6bd57bc71120af39f6d01a12b9c0ec21e8121cbf"
+  url "https://hackage.haskell.org/package/pandoc-2.19.1/pandoc-2.19.1.tar.gz"
+  sha256 "6c686cd3df13a81573e12147c40f9df59dfd4cf818a5c007282c4a493114f980"
   license "GPL-2.0-or-later"
   head "https://github.com/jgm/pandoc.git", branch: "master"
 


### PR DESCRIPTION
---

Debug Info:
- homebrew updater version: 1.0.6
- formula new file size: 7,245,677 bytes
- formula fetch time: 1.7 seconds

Pull request opened by [homebrew-updater](https://github.com/bepsvpt/homebrew-updater) project.

Open a new [issue](https://github.com/bepsvpt/homebrew-updater/issues) to monitor new formula.