### PR TITLE
terraform-ls: set version & release ldflags

### DIFF
--- a/Formula/terraform-ls.rb
+++ b/Formula/terraform-ls.rb
@@ -23,7 +23,12 @@ class TerraformLs < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w")
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.versionPrerelease=#{tap.user}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags.join(" "))
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently `terraform-ls version` installed via Homebrew reports the following:

```
0.0.0-dev
platform: darwin/arm64
go: go1.19
compiler: gc
```
After the patch, it reports

```
0.29.0-homebrew
platform: darwin/arm64
go: go1.19
compiler: gc
```

I am intentionally adding the `homebrew` release tag such that when we (maintainers of LS at HashiCorp) end up debugging issues from users, we can more easily tell the different builds apart.
