### PR TITLE
workflows/tests: collapse some output in the summary

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
 
   setup_tests:
     permissions:
-      pull-requests: read  
+      pull-requests: read
     if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
     needs: tap_syntax
@@ -244,6 +244,7 @@ jobs:
           workdir: ${{matrix.workdir || github.workspace}}
           result_path: bottles/linkage_output.txt
           step_name: '`brew linkage` output on ${{ matrix.runner }}'
+          collapse: 'true'
 
       - name: Output brew bottle result
         if: always()
@@ -252,6 +253,7 @@ jobs:
           workdir: ${{matrix.workdir || github.workspace}}
           result_path: bottles/bottle_output.txt
           step_name: '`brew bottle` output on ${{ matrix.runner }}'
+          collapse: 'true'
 
       - name: Run brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
         if: ${{(success() || failure()) && fromJson(needs.setup_tests.outputs.test-dependents)}}
@@ -266,6 +268,7 @@ jobs:
           workdir: ${{matrix.workdir || github.workspace}}
           result_path: bottles/steps_output.txt
           step_name: 'Dependent summary on ${{ matrix.runner }}'
+          collapse: 'true'
 
       - name: Upload logs
         if: always()


### PR DESCRIPTION
Some of this output can be rather long, so let's hide them behind a
dropdown.

Needs Homebrew/actions#299.
