### PR TITLE
pypi_formula_mappings: add enex2notion

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -145,6 +145,9 @@
   "dxpy": {
     "exclude_packages": ["six"]
   },
+  "enex2notion": {
+    "exclude_packages": ["PyMuPDF", "six"]
+  },
   "esphome": {
     "exclude_packages": ["protobuf", "six", "tabulate"]
   },


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
[enex2notion formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/enex2notion.rb) has `pymupdf` and `six` as Homebrew dependencies. Need to exclude `PyMuPDF` and `six` packages to avoid adding them to formula on bump.