### PR TITLE
austin: fix `python3` reference.

### DIFF
--- a/Formula/austin.rb
+++ b/Formula/austin.rb
@@ -28,6 +28,7 @@ class Austin < Formula
   end
 
   test do
-    shell_output(bin/"austin #{Formula["python@3.10"].opt_bin}/python3 -c \"from time import sleep; sleep(1)\"", 37)
+    python = Formula["python@3.10"].opt_bin/"python3.10"
+    shell_output(bin/"austin #{python} -c \"from time import sleep; sleep(1)\"", 37)
   end
 end


### PR DESCRIPTION
See #108008.
