### PR TITLE
podman: use HELPER_BINARIES_DIR env instead of inreplace to set location of libexec

### DIFF
--- a/Formula/podman.rb
+++ b/Formula/podman.rb
@@ -22,6 +22,11 @@ class Podman < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "291babc343bc2976a95d55ab2c81735f3cd48b3932a098d156d3dc9395679cf9"
   end
 
+  # The path to libexec where `gvproxy` can be found is hardcoded into the Go binary.
+  # Therefore, only use pre-built bottle if installing in default prefix.
+  # Otherwise, rebuild from source.
+  pour_bottle? only_if: :default_prefix
+
   head do
     url "https://github.com/containers/podman.git", branch: "main"
 

--- a/Formula/podman.rb
+++ b/Formula/podman.rb
@@ -40,10 +40,7 @@ class Podman < Formula
     ENV["CGO_ENABLED"] = "1"
     os = OS.kernel_name.downcase
 
-    inreplace "vendor/github.com/containers/common/pkg/config/config_#{os}.go",
-              "/usr/local/libexec/podman",
-              libexec
-
+    ENV["HELPER_BINARIES_DIR"] = libexec
     system "make", "podman-remote"
     if OS.mac?
       bin.install "bin/#{os}/podman" => "podman-remote"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

PR containers/podman#13372 started recognizing a new environment variable `$HELPER_BINARIES_DIR` that can be used to set location of helper binaries such as `gvproxy`. We can set this variable during the build instead of using an `inreplace` to update the location inside the Go source code.

This is a follow up to PR #93794 which added the `inreplace`. (cc @gibfahn, @carlocab and @afbjorklund who worked on that PR and that patch.)

Tested: `brew reinstall -s podman` and confirmed that `podman machine start` works as expected. If I only remove the `inreplace` without setting the environment variable, then `podman machine start` fails with:

> `Error: unable to start host networking: "could not find \"gvproxy\" in one of [...]"`

Where the list of paths doesn't include the libexec of this keg.

Additionally, added a commit to only pour bottle if using the default prefix. The location of the keg libexec gets hardcoded into the binary, and `podman` fails to find `gvproxy` during `podman machine start` if the location of the keg libexec is not correct.

Therefore, rebuild from source whenever installing into a non-standard prefix.
