### PR TITLE
guichan: use http for fixedfont.bmp resource to make curl happy

### DIFF
--- a/Formula/guichan.rb
+++ b/Formula/guichan.rb
@@ -25,7 +25,7 @@ class Guichan < Formula
   end
 
   resource "fixedfont.bmp" do
-    url "https://guichan.sourceforge.io/oldsite/images/fixedfont.bmp"
+    url "http://guichan.sourceforge.io/oldsite/images/fixedfont.bmp"
     sha256 "fc6144c8fefa27c207560820450abb41378c705a0655f536ce33e44a5332c5cc"
   end
 


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I see a redirect to http in a browser and curl SSL error on the Linux runner.