### PR TITLE
Use Ubuntu 22.04 to build bottles

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -845,7 +845,7 @@ permissions:
 jobs:
   autobump:
     if: github.repository == 'Homebrew/homebrew-core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     steps:

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -8,7 +8,7 @@ on:
         required: false
   schedule:
     # Every day at 5am
-    - cron: '0 5 * * *'
+    - cron: "0 5 * * *"
 
 env:
   HOMEBREW_FORCE_HOMEBREW_ON_LINUX: 1
@@ -847,7 +847,7 @@ jobs:
     if: github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/homebrew/ubuntu16.04:master
+      image: ghcr.io/homebrew/ubuntu22.04:master
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   autopublish:
     if: github.repository == 'Homebrew/homebrew-core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -92,7 +92,7 @@ jobs:
             --env-file <(env | egrep 'HOMEBREW|GITHUB') \
             --workdir /tmp/bottles \
             --pull always \
-            ghcr.io/homebrew/ubuntu16.04:master \
+            ghcr.io/homebrew/ubuntu22.04:master \
             sleep inf
           # Fix working directory permissions
           docker exec --user root ${{github.sha}} chmod 777 /tmp/bottles

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       runners: ${{steps.runner-matrix.outputs.result}}
     steps:
@@ -221,7 +221,7 @@ jobs:
           bot_body: ":x: Bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
           bot: BrewTestBot
   upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: bottle
     if: github.event.inputs.upload
     env:

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:
@@ -168,7 +168,7 @@ jobs:
       issues: write # for Homebrew/actions/post-comment
       contents: write # for Homebrew/actions/git-try-push
       packages: write # for brew pr-upload
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: bottle
     if: github.event.inputs.upload
     env:

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -34,7 +34,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/homebrew/ubuntu16.04:master
+      image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:
       runners: ${{steps.determine-runners.outputs.runners}}
     steps:

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   upload:
     runs-on: ${{github.event.inputs.self_hosted == 'true' && 'linux-self-hosted-1' || 'ubuntu-latest'}}
-    container: ${{github.event.inputs.self_hosted == 'true' && fromJson('{"image":"ghcr.io/homebrew/ubuntu16.04:master","options":"--user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"}') || ''}}
+    container: ${{github.event.inputs.self_hosted == 'true' && fromJson('{"image":"ghcr.io/homebrew/ubuntu22.04:master","options":"--user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"}') || ''}}
     steps:
       - name: Post comment once started
         uses: Homebrew/actions/post-comment@master

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   upload:
-    runs-on: ${{github.event.inputs.self_hosted == 'true' && 'linux-self-hosted-1' || 'ubuntu-latest'}}
+    runs-on: ${{github.event.inputs.self_hosted == 'true' && 'linux-self-hosted-1' || 'ubuntu-22.04'}}
     container: ${{github.event.inputs.self_hosted == 'true' && fromJson('{"image":"ghcr.io/homebrew/ubuntu22.04:master","options":"--user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"}') || ''}}
     steps:
       - name: Post comment once started

--- a/.github/workflows/recreate-linux-runners.yml
+++ b/.github/workflows/recreate-linux-runners.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   recreate:
     if: github.repository == 'Homebrew/homebrew-core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       # TODO agree on one label for all runners
       RUNNER_LABEL: TODO

--- a/.github/workflows/remove-disabled-formulae.yml
+++ b/.github/workflows/remove-disabled-formulae.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   remove-disabled-formulae:
     if: startsWith(github.repository, 'Homebrew/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   tap_syntax:
     if: github.repository == 'Homebrew/homebrew-core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     env:
@@ -46,7 +46,7 @@ jobs:
     permissions:
       pull-requests: read
     if: github.event_name == 'pull_request' && github.repository == 'Homebrew/homebrew-core'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: tap_syntax
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
@@ -85,7 +85,7 @@ jobs:
             if (label_names.includes('CI-linux-self-hosted')) {
               core.setOutput('linux-runner', 'linux-self-hosted-1')
             } else {
-              core.setOutput('linux-runner', 'ubuntu-latest')
+              core.setOutput('linux-runner', 'ubuntu-22.04')
             }
 
             if (label_names.includes('CI-no-fail-fast')) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/homebrew/ubuntu16.04:master
+      image: ghcr.io/homebrew/ubuntu22.04:master
     env:
       HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
     outputs:
@@ -186,14 +186,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: '12-arm64'
-          - runner: '12-${{github.run_id}}-${{github.run_attempt}}'
-          - runner: '11-arm64'
-          - runner: '11-${{github.run_id}}-${{github.run_attempt}}'
-          - runner: '10.15-${{github.run_id}}-${{github.run_attempt}}'
+          - runner: "12-arm64"
+          - runner: "12-${{github.run_id}}-${{github.run_attempt}}"
+          - runner: "11-arm64"
+          - runner: "11-${{github.run_id}}-${{github.run_attempt}}"
+          - runner: "10.15-${{github.run_id}}-${{github.run_attempt}}"
           - runner: ${{needs.setup_tests.outputs.linux-runner}}
             container:
-              image: ghcr.io/homebrew/ubuntu16.04:master
+              image: ghcr.io/homebrew/ubuntu22.04:master
               options: --user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED
             workdir: /github/home
             timeout: 4320

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -29,7 +29,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'stale')
         )
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Mark/Close Stale Issues and Pull Requests
         uses: actions/stale@v5
@@ -55,7 +55,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'stale')
         )
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Mark/Close Stale `bump-formula-pr` and `bump-cask-pr` Pull Requests
         uses: actions/stale@v5
@@ -72,7 +72,7 @@ jobs:
 
   lock-threads:
     if: startsWith(github.repository, 'Homebrew/') && github.event_name != 'issue_comment'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Lock Outdated Threads
         uses: dessant/lock-threads@e460dfeb36e731f3aeb214be6b0c9a9d9a67eda6

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check commit format
         uses: Homebrew/actions/check-commit-format@master

--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -29,7 +29,7 @@ module Homebrew
     linux_runner = if timeout > 360
       "linux-self-hosted-1"
     else
-      "ubuntu-latest"
+      "ubuntu-22.04"
     end
     linux_runner_spec = {
       runner:    linux_runner,


### PR DESCRIPTION
Use Ubuntu 22.04 rather than Ubuntu 16.04 to build bottles. This PR needs to be merged after merging PR https://github.com/Homebrew/brew/pull/13733 and tagging Homebrew 3.6.0.

- https://github.com/Homebrew/brew/pull/13733
- https://github.com/Homebrew/brew/issues/13619

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
