### PR TITLE
graphicsmagick: disable jpeg-xl support, which seems to require unreleased version of libjxl

### DIFF
--- a/Formula/graphicsmagick.rb
+++ b/Formula/graphicsmagick.rb
@@ -50,6 +50,7 @@ class Graphicsmagick < Formula
       --without-gslib
       --with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts
       --without-wmf
+      --without-jxl
     ]
 
     # versioned stuff in main tree is pointless for us


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Building graphicsmagick 1.38 locally fails in `coders/jxl.c`.

The failure in the build log starts with the following error:

```
coders/jxl.c:811:3: error: use of undeclared identifier 'JxlEncoderFrameSettings'
  JxlEncoderFrameSettings
  ^
```

It seems version 0.6.1 of jpeg-xl doesn't really support this JxlEncoderFrameSettings symbol, it was introduced in order to deprecate JxlEncoderOptions, but that will only be available in version 0.7 of jpeg-xl, which is not yet released. In particular, the release notes for the [release candidate for 0.7](https://github.com/libjxl/libjxl/releases/tag/v0.7rc) mentions this specific change, among others.

So it turns out the code in graphicsmagick 1.38 depends on jpeg-xl 0.7, which is not available yet.

Furthermore, the `--with-jxl` flag was [turned on by default just recently](https://sourceforge.net/p/graphicsmagick/code/ci/b2a4fb7af59b74ddb3bc745b0d1db3022d7437c8/), as version 1.38 of graphicsmagick was released.

Therefore, disabling it explicitly here doesn't look like a bad idea.

When jpeg-xl 0.7 is released and the formula for it is updated, we can go back to re-enabling jpeg-xl support here again.

Tested: `brew reinstall -s graphicsmagick`

---

One thing I don't understand is how this wasn't detected in upgrade to 1.38 in PR #98985, since from my tracking the source of the issue, it seems it has always been there. Also, I imagine there are successfully built bottles for this package (I use a non-standard prefix, so end up rebuilding from scratch more often, I guess that's why it's been tripping me, not sure.) I imagine the original upgrade and bottles were built against a checkout from trunk of jpeg-xl perhaps?

cc @chenrui333 @SMillerDev involved in PR #98985 which originally upgraded this package.
