### PR TITLE
helix: remove tree-sitter grammar sources

### DIFF
--- a/Formula/helix.rb
+++ b/Formula/helix.rb
@@ -25,6 +25,7 @@ class Helix < Formula
 
   def install
     system "cargo", "install", "-vv", *std_cargo_args(root: libexec, path: "helix-term")
+    rm_r "runtime/grammars/sources/"
     libexec.install "runtime"
 
     (bin/"hx").write_env_script(libexec/"bin/hx", HELIX_RUNTIME: libexec/"runtime")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The tree-sitter grammar sources in `runtime/grammars/sources` are used
to create compiled tree-sitter parsers. Once the build of helix is
complete, there isn't any reason to keep the grammar sources around:
they are only used to create the compiled parsers during installation.
They can collectively take quite a lot of disk space so it's wise to
remove them.

See https://github.com/Homebrew/homebrew-core/pull/105833#issuecomment-1189398814