### PR TITLE
gator 3.9.0 (new formula)

### DIFF
--- a/Formula/gator.rb
+++ b/Formula/gator.rb
@@ -1,0 +1,95 @@
+class Gator < Formula
+  desc "CLI Utility for Open Policy Agent Gatekeeper"
+  homepage "https://open-policy-agent.github.io/gatekeeper/website/docs/gator"
+  url "https://github.com/open-policy-agent/gatekeeper/archive/refs/tags/v3.9.0.tar.gz"
+  sha256 "af77ac7eedbe429e2b7df2f8470bc98d0af41a99f0829d95fc7883d34e23ba4d"
+  license "Apache-2.0"
+  head "https://github.com/open-policy-agent/gatekeeper.git", branch: "master"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/open-policy-agent/gatekeeper/pkg/version.Version=#{version}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/gator"
+  end
+
+  test do
+    assert_match "gator is a suite of authorship tools for Gatekeeper", shell_output("#{bin}/gator -h")
+
+    # Create a test manifest file
+    (testpath/"gator-manifest.yaml").write <<~EOS
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: ingress-demo-disallowed
+        annotations:
+          kubernetes.io/ingress.allow-http: "false"
+      spec:
+        tls: [{}]
+        rules:
+          - host: example-host.example.com
+            http:
+              paths:
+              - pathType: Prefix
+                path: "/"
+                backend:
+                  service:
+                    name: nginx
+                    port:
+                      number: 80
+    EOS
+    # Create a test constraint tempalte
+    (testpath/"template-and-constraints/gator-constraint-template.yaml").write <<~EOS
+      apiVersion: templates.gatekeeper.sh/v1
+      kind: ConstraintTemplate
+      metadata:
+        name: k8shttpsonly
+        annotations:
+          description: >-
+            Requires Ingress resources to be HTTPS only.
+            Ingress resources must:
+            - include a valid TLS configuration
+            - include the `kubernetes.io/ingress.allow-http` annotation, set to
+              `false`.
+            https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+      spec:
+        crd:
+          spec:
+            names:
+              kind: K8sHttpsOnly
+        targets:
+          - target: admission.k8s.gatekeeper.sh
+            rego: |
+              package k8shttpsonly
+              violation[{"msg": msg}] {
+                input.review.object.kind == "Ingress"
+                re_match("^(extensions|networking.k8s.io)/", input.review.object.apiVersion)
+                ingress := input.review.object
+                not https_complete(ingress)
+                msg := sprintf("Ingress should be https. tls configuration and allow-http=false annotation are required for %v", [ingress.metadata.name])
+              }
+              https_complete(ingress) = true {
+                ingress.spec["tls"]
+                count(ingress.spec.tls) > 0
+                ingress.metadata.annotations["kubernetes.io/ingress.allow-http"] == "false"
+              }
+    EOS
+    # Create a test constraint file
+    (testpath/"template-and-constraints/gator-constraint.yaml").write <<~EOS
+      apiVersion: constraints.gatekeeper.sh/v1beta1
+      kind: K8sHttpsOnly
+      metadata:
+        name: ingress-https-only
+      spec:
+        match:
+          kinds:
+            - apiGroups: ["extensions", "networking.k8s.io"]
+              kinds: ["Ingress"]
+    EOS
+
+    assert_empty shell_output("#{bin}/gator test -f gator-manifest.yaml -f template-and-constraints/")
+  end
+end


### PR DESCRIPTION
gator is the cli tool for Open Policy Agent Gatekeeper. This PR adds the cli to be available via brew.

Apologies for the previous incomplete PR. This is now a source package rather than a binary as requested, and I've properly run all audit commands locally prior to opening.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
