### PR TITLE
httpd: rebuild to fix config vars

### DIFF
--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -5,6 +5,7 @@ class Httpd < Formula
   mirror "https://downloads.apache.org/httpd/httpd-2.4.54.tar.bz2"
   sha256 "eb397feeefccaf254f8d45de3768d9d68e8e73851c49afd5b7176d1ecf80c340"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 arm64_monterey: "629e972fa257879e1fa9c7ada3c77d074f695a4a17d703b6237b8ff08cef4ea5"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

After #108662, `apxs` is not giving the correct path for the config variable `APU_CONFIG`.
```sh
$ apxs -q APU_CONFIG       
/opt/homebrew/opt/apr-util/libexec/bin/apu-1-config
apxs:Error: /opt/homebrew/opt/apr-util/libexec/bin/apu-1-config not found!.
```
This breaks building PHP
https://github.com/shivammathur/homebrew-php/runs/7985886068?check_suite_focus=true#step:8:237

Reinstalling httpd from the source fixes the issue.
```
$ brew reinstall -s httpd
...
$ apxs -q APU_CONFIG
/opt/homebrew/opt/apr-util/bin/apu-1-config
```