### PR TITLE
apr: remove `libxcrypt` dependency.

### DIFF
--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -20,8 +20,6 @@ class Apr < Formula
 
   depends_on "autoconf@2.69" => :build
 
-  uses_from_macos "libxcrypt"
-
   on_linux do
     depends_on "util-linux"
   end


### PR DESCRIPTION
This is not a dependency. See #108662.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
