### PR TITLE
meson: build an `:all` bottle (again)

### DIFF
--- a/Formula/meson.rb
+++ b/Formula/meson.rb
@@ -1,6 +1,4 @@
 class Meson < Formula
-  include Language::Python::Virtualenv
-
   desc "Fast and user friendly build system"
   homepage "https://mesonbuild.com/"
   url "https://github.com/mesonbuild/meson/releases/download/0.63.1/meson-0.63.1.tar.gz"
@@ -21,9 +19,29 @@ class Meson < Formula
   depends_on "python@3.10"
 
   def install
-    virtualenv_install_with_resources
+    python = "python3.10"
+    system python, *Language::Python.setup_install_args(prefix, python), "--install-data=#{prefix}"
+
     bash_completion.install "data/shell-completions/bash/meson"
     zsh_completion.install "data/shell-completions/zsh/_meson"
+    vim_plugin_dir = buildpath/"data/syntax-highlighting/vim"
+    (share/"vim/vimfiles").install %w[ftdetect ftplugin indent syntax].map { |dir| vim_plugin_dir/dir }
+
+    # Make the bottles uniform. This also ensures meson checks `HOMEBREW_PREFIX`
+    # for fulfilling dependencies rather than just `/usr/local`.
+    mesonbuild = prefix/Language::Python.site_packages(python)/"mesonbuild"
+    inreplace_files = %w[
+      coredata.py
+      dependencies/boost.py
+      dependencies/cuda.py
+      dependencies/qt.py
+      mesonlib/universal.py
+      modules/python.py
+    ].map { |f| mesonbuild/f }
+    inreplace_files << (bash_completion/"meson")
+
+    # Passing `build.stable?` ensures a failed `inreplace` won't fail HEAD installs.
+    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX, build.stable?
   end
 
   test do
@@ -38,9 +56,10 @@ class Meson < Formula
       executable('hello', 'helloworld.c')
     EOS
 
-    mkdir testpath/"build" do
-      system bin/"meson", ".."
-      assert_predicate testpath/"build/build.ninja", :exist?
-    end
+    system bin/"meson", "setup", "build"
+    assert_predicate testpath/"build/build.ninja", :exist?
+
+    system "meson", "compile", "-C", "build", "--verbose"
+    assert_equal "hi", shell_output("build/hello").chomp
   end
 end


### PR DESCRIPTION
Also:

- make sure `meson` generates a well-formed `build.ninja` file
  by actually trying to build the test project.
- install vim plugins

This partially reverts commit 3c72d615f25bf9b410daa6078ea253b800721e96.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
