### PR TITLE
llvm: add `BOLT` related tools

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -59,6 +59,7 @@ class Llvm < Formula
       lldb
       mlir
       polly
+      bolt
     ]
     runtimes = %w[
       compiler-rt


### PR DESCRIPTION
This PR adds [`BOLT`](https://github.com/llvm/llvm-project/tree/main/bolt) related binaries like `llvm-bolt` and `merge-fdata` in `LLVM` toolchain.