### PR TITLE
neovim: point system directories inside `HOMEBREW_PREFIX`

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -104,8 +104,18 @@ class Neovim < Formula
       end
     end
 
+    # Point system locations inside `HOMEBREW_PREFIX`.
+    inreplace "src/nvim/os/stdpaths.c" do |s|
+      s.gsub! "/etc/xdg/", "#{etc}/xdg/:\\0"
+
+      unless HOMEBREW_PREFIX.to_s == HOMEBREW_DEFAULT_PREFIX
+        s.gsub! "/usr/local/share/:/usr/share/", "#{HOMEBREW_PREFIX}/share/:\\0"
+      end
+    end
+
     system "cmake", "-S", ".", "-B", "build",
                     "-DLIBLUV_LIBRARY=#{Formula["luv"].opt_lib/shared_library("libluv")}",
+                    "-DLIBUV_LIBRARY=#{Formula["libuv"].opt_lib/shared_library("libuv")}",
                     *std_cmake_args
 
     # Patch out references to Homebrew shims


### PR DESCRIPTION
Neovim follows the XDG Base Directory Specification, but this includes
directories users may need `sudo` to write to, nor does it always makes
sense for the user to own these directories.

Let's fix that by prepending paths inside `HOMEBREW_PREFIX` so that
Neovim looks there first. This allows users to install plugins into
`HOMEBREW_PREFIX` without additional configuration.

We achieve a similar effect in the Vim formula by configuring it as if
we were installing directly into `HOMEBREW_PREFIX`.

While we're here, let's make sure Neovim links with `libuv` as a shared
library. Upstream recently changed this to prioritise the static library
over the shared one. See https://github.com/neovim/neovim/commit/e23c5fda0a3fe385af615372c474d4dad3b74464.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
