### PR TITLE
arrayfire: use `rpath` DSL

### DIFF
--- a/Formula/arrayfire.rb
+++ b/Formula/arrayfire.rb
@@ -29,15 +29,19 @@ class Arrayfire < Formula
 
   def install
     # Fix for: `ArrayFire couldn't locate any backends.`
-    if OS.mac?
-      ENV.append "LDFLAGS", "-Wl,-rpath,@loader_path/#{Formula["fftw"].opt_lib.relative_path_from(lib)}"
-      ENV.append "LDFLAGS", "-Wl,-rpath,@loader_path/#{Formula["openblas"].opt_lib.relative_path_from(lib)}"
-      ENV.append "LDFLAGS", "-Wl,-rpath,@loader_path/#{(HOMEBREW_PREFIX/"lib").relative_path_from(lib)}"
-    end
+    # We cannot use `CMAKE_INSTALL_RPATH` since upstream override this:
+    #   https://github.com/arrayfire/arrayfire/blob/590267d2/CMakeModules/InternalUtils.cmake#L181
+    linker_flags = [
+      rpath(source: lib, target: Formula["fftw"].opt_lib),
+      rpath(source: lib, target: Formula["openblas"].opt_lib),
+      rpath(source: lib, target: HOMEBREW_PREFIX/"lib"),
+    ]
+    linker_flags.map! { |path| "-Wl,-rpath,#{path}" }
 
     system "cmake", "-S", ".", "-B", "build",
                     "-DAF_BUILD_CUDA=OFF",
                     "-DAF_COMPUTE_LIBRARY=FFTW/LAPACK/BLAS",
+                    "-DCMAKE_SHARED_LINKER_FLAGS=#{linker_flags.join(" ")}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
`rpath` can now passed arguments to compute the correct `RPATH` entry on
both macOS and Linux.

See Homebrew/brew#13722.
