### PR TITLE
inko: use `libffi` from macOS

### DIFF
--- a/Formula/inko.rb
+++ b/Formula/inko.rb
@@ -19,14 +19,13 @@ class Inko < Formula
 
   depends_on "coreutils" => :build
   depends_on "rust" => :build
-  depends_on "libffi"
 
+  uses_from_macos "libffi", since: :catalina
   uses_from_macos "ruby", since: :sierra
 
   def install
-    system "make", "build", "PREFIX=#{libexec}", "FEATURES=libinko/libffi-system"
-    system "make", "install", "PREFIX=#{libexec}"
-    bin.install Dir[libexec/"bin/*"]
+    system "make", "build", "PREFIX=#{prefix}", "FEATURES=libinko/libffi-system"
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do


### PR DESCRIPTION
Recent versions of macOS ship a new enough `libffi`, so let's use that.

Also, I don't see why this should install everything into `libexec`, so
let's try installing into `prefix` instead.

`revision` bump omitted since this should cause no issues for users
still on an older version of the formula.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
