### PR TITLE
mycli: use `uses_from_macos "libffi"`.

### DIFF
--- a/Formula/mycli.rb
+++ b/Formula/mycli.rb
@@ -22,9 +22,10 @@ class Mycli < Formula
   depends_on "openssl@1.1"
   depends_on "python@3.10"
 
+  uses_from_macos "libffi"
+
   on_linux do
     depends_on "pkg-config" => :build
-    depends_on "libffi"
   end
 
   resource "cffi" do


### PR DESCRIPTION
This has linkage with `libffi` on macOS, so let's use the appropriate
DSL.
