### PR TITLE
ocrmypdf: use `libffi` from macOS.

### DIFF
--- a/Formula/ocrmypdf.rb
+++ b/Formula/ocrmypdf.rb
@@ -21,7 +21,6 @@ class Ocrmypdf < Formula
   depends_on "freetype"
   depends_on "ghostscript"
   depends_on "jbig2enc"
-  depends_on "libffi"
   depends_on "libpng"
   depends_on "pillow"
   depends_on "pngquant"
@@ -31,6 +30,7 @@ class Ocrmypdf < Formula
   depends_on "tesseract"
   depends_on "unpaper"
 
+  uses_from_macos "libffi", since: :catalina
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
 


### PR DESCRIPTION
macOS ships a recent version of `libffi`, so let's use that.

The `libffi` dependency was added in #68565. However, since then, its
dependencies have had their dependencies switched to `libffi` from
macOS, so let's now do the same here.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
