### PR TITLE
glib: remove `.gitignore` from completions

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -89,6 +89,7 @@ class Glib < Formula
       end
     end
 
+    rm "gio/completion/.gitignore"
     bash_completion.install (buildpath/"gio/completion").children
     rewrite_shebang detected_python_shebang(use_python_from_path: true), *bin.children
   end


### PR DESCRIPTION
Fixes #108936.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
