### PR TITLE
linux-headers@5.15: avoid rsync dependency

### DIFF
--- a/Formula/linux-headers@5.15.rb
+++ b/Formula/linux-headers@5.15.rb
@@ -11,12 +11,16 @@ class LinuxHeadersAT515 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "rsync" => :build
   depends_on :linux
 
   def install
-    system "make", "headers_install", "INSTALL_HDR_PATH=#{prefix}"
-    rm prefix.glob("**/{.install,..install.cmd}")
+    system "make", "headers"
+
+    cd "usr/include" do
+      Pathname.glob("**/*.h").each do |header|
+        (include/header.dirname).install header
+      end
+    end
   end
 
   test do


### PR DESCRIPTION
This avoids rsync being seen as a dependency of glibc.

Install tree is the same as it is in the bottle, except it now has some additional files with the same name as another but with different casing - but those being missing in the bottle might be an issue in the bottling process.