### PR TITLE
urh: fix finding `libcython`

### DIFF
--- a/Formula/urh.rb
+++ b/Formula/urh.rb
@@ -6,7 +6,7 @@ class Urh < Formula
   url "https://files.pythonhosted.org/packages/c2/3d/9cbaac6d7101f50c408ac428d9e37668916a4a3e22292f38748b230239e0/urh-2.9.3.tar.gz"
   sha256 "037b91bb87a113ac03d0695e0c2b5cce35d0886469b3ef46ba52d2342c8cfd8c"
   license "GPL-3.0-only"
-  revision 2
+  revision 3
   head "https://github.com/jopohl/urh.git", branch: "master"
 
   bottle do
@@ -31,8 +31,15 @@ class Urh < Formula
   end
 
   def install
-    site_packages = Language::Python.site_packages("python3")
-    ENV.prepend_create_path "PYTHONPATH", Formula["libcython"].opt_libexec/site_packages
+    python3 = "python3.10"
+
+    # Enable finding cython, which is keg-only
+    site_packages = Language::Python.site_packages(python3)
+    pth_contents = <<~EOS
+      import site; site.addsitedir('#{Formula["libcython"].opt_libexec/site_packages}')
+    EOS
+    (libexec/site_packages/"homebrew-libcython.pth").write pth_contents
+
     virtualenv_install_with_resources
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Fixes #108986
