### PR TITLE
lcrack: deprecate because the upstream is gone

### DIFF
--- a/Formula/lcrack.rb
+++ b/Formula/lcrack.rb
@@ -20,6 +20,8 @@ class Lcrack < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "90d22ccc708ed4d14fd35364f07ee9cc7342dbeba5a8da0f051d39b699e84125"
   end
 
+  deprecate! date: "2022-08-28", because: :repo_removed
+
   def install
     system "./configure"
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
