### PR TITLE
gcc: do not strip binaries on macOS

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -112,10 +112,14 @@ class Gcc < Formula
       system "../configure", *args
       system "make"
 
+      # Do not strip the binaries on macOS, it makes them unsuitable
+      # for loading plugins
+      install_target = OS.mac? ? "install" : "install-strip"
+
       # To make sure GCC does not record cellar paths, we configure it with
       # opt_prefix as the prefix. Then we use DESTDIR to install into a
       # temporary location, then move into the cellar path.
-      system "make", "install-strip", "DESTDIR=#{Pathname.pwd}/../instdir"
+      system "make", install_target, "DESTDIR=#{Pathname.pwd}/../instdir"
       mv Dir[Pathname.pwd/"../instdir/#{opt_prefix}/*"], prefix
     end
 


### PR DESCRIPTION
Fixes #106394

The use of `make install-strip` on macOS was introduced by me in b12aee882d375f32294c2c91c95a60500a9660f6 to make the binaries slightly smaller. It seems `install-strip` is not recommended on macOS, where `strip` has several issues. So let's roll back that part.

It only affects the loading of plugins, which is not a very commonly used feature, so I don't think it warrants a revision bump.