### PR TITLE
yosys: use `libffi` from macOS.

### DIFF
--- a/Formula/yosys.rb
+++ b/Formula/yosys.rb
@@ -17,11 +17,11 @@ class Yosys < Formula
 
   depends_on "bison" => :build
   depends_on "pkg-config" => :build
-  depends_on "libffi"
   depends_on "python@3.10"
   depends_on "readline"
 
   uses_from_macos "flex"
+  uses_from_macos "libffi", since: :catalina
   uses_from_macos "tcl-tk"
 
   def install
@@ -29,6 +29,6 @@ class Yosys < Formula
   end
 
   test do
-    system "#{bin}/yosys", "-p", "hierarchy; proc; opt; techmap; opt;", "-o", "synth.v", "#{pkgshare}/adff2dff.v"
+    system bin/"yosys", "-p", "hierarchy; proc; opt; techmap; opt;", "-o", "synth.v", pkgshare/"adff2dff.v"
   end
 end


### PR DESCRIPTION
macOS ships a recent version of `libffi`, so let's use that.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
