### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -166,6 +166,8 @@ jobs:
   upload:
     permissions:
       issues: write # for Homebrew/actions/post-comment
+      contents: write # for Homebrew/actions/git-try-push
+      packages: write # for brew pr-upload
     runs-on: ubuntu-latest
     needs: bottle
     if: github.event.inputs.upload

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -20,6 +20,9 @@ on:
         description: "Whether to fail immediately on a single OS version failure (default: true)"
         default: "true"
         required: false
+        
+permissions:
+  contents: read
 
 env:
   HOMEBREW_DEVELOPER: 1
@@ -161,6 +164,8 @@ jobs:
           bot: BrewTestBot
 
   upload:
+    permissions:
+      issues: write # for Homebrew/actions/post-comment
     runs-on: ubuntu-latest
     needs: bottle
     if: github.event.inputs.upload


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.