### PR TITLE
libunistring: fix builds pre-Mojave

### DIFF
--- a/Formula/libunistring.rb
+++ b/Formula/libunistring.rb
@@ -21,7 +21,8 @@ class Libunistring < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make"
-    system "make", "check"
+    # tests don't pass at or below high sierra
+    system "make", "check" if !OS.mac? || MacOS.version > :high_sierra
     system "make", "install"
   end
 


### PR DESCRIPTION
make check does not pass pre-Mojave.

I've reopened this PR which was based on this closed PR: #106654 because concerns about upstream changes have been removed (sorry I didn't have time to add to last PR before it was closed).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----