### PR TITLE
mxcheck 1.3.0 (new formula)

### DIFF
--- a/Formula/mxcheck.rb
+++ b/Formula/mxcheck.rb
@@ -1,0 +1,17 @@
+class Mxcheck < Formula
+  desc "DNS records and open relay checker for e-mail servers"
+  homepage "https://github.com/steffenfritz/mxcheck"
+  url "https://github.com/steffenfritz/mxcheck/archive/refs/tags/v1.3.0.tar.gz"
+  sha256 "512e7fb7fcbcde0f006c35e61690b7bcb3a68b81ff909431cb2b6069793d3cb5"
+  license "GPL-3.0-only"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    system "#{bin}/mxcheck"
+  end
+end


### PR DESCRIPTION
This single file binary checks the DNS entries of e-mail servers and if
the checked e-mail servers are open relays.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The GitHub repository is not notable enough. However, there is no other
tool doing what mxcheck is doing. Possibly this circumstance justifies
the request.
