### PR TITLE
libnsl: disable libtirpc

### DIFF
--- a/Formula/libnsl.rb
+++ b/Formula/libnsl.rb
@@ -4,7 +4,7 @@ class Libnsl < Formula
   url "https://github.com/thkukuk/libnsl/releases/download/v2.0.0/libnsl-2.0.0.tar.xz"
   sha256 "2da075ef1893ebdfc5f074f83ac811873dc06fd5c62bc9a4729fd2e27a40341a"
   license "LGPL-2.1-or-later"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "ed70b285939e2ab21ba53d122ce2d4beab4cd0f9c86925c3d3a2cfb1b0eeecb3"
@@ -12,7 +12,6 @@ class Libnsl < Formula
 
   depends_on "gettext" => :build
   depends_on "pkg-config" => :build
-  depends_on "libtirpc"
   depends_on :linux
 
   link_overwrite "include/rpcsvc"
@@ -21,7 +20,8 @@ class Libnsl < Formula
 
   def install
     system "./configure", *std_configure_args,
-                          "--disable-silent-rules"
+                          "--disable-silent-rules",
+                          "HAVE_TIRPC=0"
     system "make"
     system "make", "install"
   end

--- a/Formula/python@3.7.rb
+++ b/Formula/python@3.7.rb
@@ -4,7 +4,7 @@ class PythonAT37 < Formula
   url "https://www.python.org/ftp/python/3.7.13/Python-3.7.13.tar.xz"
   sha256 "99f106275df8899c3e8cb9d7c01ce686c202ef275953301427194693de5bef84"
   license "Python-2.0"
-  revision 4
+  revision 5
 
   livecheck do
     url "https://www.python.org/ftp/python/"
@@ -40,6 +40,7 @@ class PythonAT37 < Formula
 
   on_linux do
     depends_on "libnsl"
+    depends_on "libtirpc"
   end
 
   skip_clean "bin/pip3", "bin/pip-3.4", "bin/pip-3.5", "bin/pip-3.6", "bin/pip-3.7"

--- a/Formula/python@3.8.rb
+++ b/Formula/python@3.8.rb
@@ -4,7 +4,7 @@ class PythonAT38 < Formula
   url "https://www.python.org/ftp/python/3.8.13/Python-3.8.13.tar.xz"
   sha256 "6f309077012040aa39fe8f0c61db8c0fa1c45136763299d375c9e5756f09cf57"
   license "Python-2.0"
-  revision 3
+  revision 4
 
   livecheck do
     url "https://www.python.org/ftp/python/"
@@ -43,6 +43,7 @@ class PythonAT38 < Formula
 
   on_linux do
     depends_on "libnsl"
+    depends_on "libtirpc"
   end
 
   skip_clean "bin/pip3", "bin/pip-3.4", "bin/pip-3.5", "bin/pip-3.6", "bin/pip-3.7", "bin/pip-3.8"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`libtirpc` is optional for `libnsl` and introduces circular dependencies.  Let's disable it to avoid complicating our dependency trees further.