### PR TITLE
krb5: disable gettext

### DIFF
--- a/Formula/krb5.rb
+++ b/Formula/krb5.rb
@@ -25,14 +25,11 @@ class Krb5 < Formula
 
   uses_from_macos "bison"
 
-  on_linux do
-    depends_on "gettext"
-  end
-
   def install
     cd "src" do
       system "./configure", "--disable-debug",
                             "--disable-dependency-tracking",
+                            "--disable-nls",
                             "--disable-silent-rules",
                             "--prefix=#{prefix}",
                             "--without-system-verto",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
