### PR TITLE
binutils: remove texinfo dependency

### DIFF
--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -19,7 +19,6 @@ class Binutils < Formula
   keg_only :shadowed_by_macos, "Apple's CLT provides the same tools"
 
   uses_from_macos "bison" => :build
-  uses_from_macos "texinfo" => :build
   uses_from_macos "zlib"
 
   link_overwrite "bin/gold"
@@ -27,6 +26,10 @@ class Binutils < Formula
   link_overwrite "bin/dwp"
 
   def install
+    # Workaround https://sourceware.org/bugzilla/show_bug.cgi?id=28909
+    touch "gas/doc/.dirstamp", mtime: Time.utc(2022, 1, 1)
+    make_args = OS.mac? ? [] : ["MAKEINFO=true"] # for gprofng
+
     args = [
       "--disable-debug",
       "--disable-dependency-tracking",
@@ -45,8 +48,8 @@ class Binutils < Formula
       "--disable-nls",
     ]
     system "./configure", *args
-    system "make"
-    system "make", "install"
+    system "make", *make_args
+    system "make", "install", *make_args
 
     if OS.mac?
       Dir["#{bin}/*"].each do |f|


### PR DESCRIPTION
The `texinfo` dependency tree is far too large for a critical component of Homebrew on older Linuxes.

It brings in the entire Python dependency tree and greatly increases the risk of including C++-only dependencies, which themselves require a modern GCC.

The dependency should also be completely unnecessary, but upstream's tarball is bugged.