### PR TITLE
xkb*: avoid Cellar in *.pc variables

### DIFF
--- a/Formula/font-util.rb
+++ b/Formula/font-util.rb
@@ -4,6 +4,7 @@ class FontUtil < Formula
   url "https://www.x.org/archive/individual/font/font-util-1.3.3.tar.xz"
   sha256 "e791c890779c40056ab63aaed5e031bb6e2890a98418ca09c534e6261a2eebd2"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "1e2205892be19c7afd594a119f156c34be0bbb2ff558e27f607a1abfd4aa39e4"
@@ -18,17 +19,15 @@ class FontUtil < Formula
   depends_on "util-macros" => :build
 
   def install
-    args = %W[
-      --prefix=#{prefix}
+    args = std_configure_args + %W[
       --sysconfdir=#{etc}
       --localstatedir=#{var}
-      --disable-dependency-tracking
-      --disable-silent-rules
+      --with-fontrootdir=#{HOMEBREW_PREFIX}/share/fonts/X11
     ]
 
     system "./configure", *args
     system "make"
-    system "make", "install"
+    system "make", "fontrootdir=#{share}/fonts/X11", "install"
   end
 
   def post_install

--- a/Formula/xkbcomp.rb
+++ b/Formula/xkbcomp.rb
@@ -4,6 +4,7 @@ class Xkbcomp < Formula
   url "https://www.x.org/releases/individual/app/xkbcomp-1.4.5.tar.bz2"
   sha256 "6851086c4244b6fd0cc562880d8ff193fb2bbf1e141c73632e10731b31d4b05e"
   license all_of: ["HPND", "MIT-open-group"]
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "da94cb771debb09217e45550470e2299982cd7a01ecb648d3ea0ddd940c80f04"
@@ -20,9 +21,11 @@ class Xkbcomp < Formula
   depends_on "libxkbfile"
 
   def install
-    system "./configure", *std_configure_args
+    system "./configure", *std_configure_args, "--with-xkb-config-root=#{HOMEBREW_PREFIX}/share/X11/xkb"
     system "make"
     system "make", "install"
+    # avoid cellar in bindir
+    inreplace lib/"pkgconfig/xkbcomp.pc", prefix, opt_prefix
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----
Ensure variables in `xkbcomp.pc` and default data dir in program `xkbcomp` points to the `HOMEBREW_PREFIX/share` rather than cellar, see #109215. Using `DESTDIR` here because the default directory is controlled by macro [`DFLT_XKB_CONFIG_ROOT`](https://gitlab.freedesktop.org/xorg/app/xkbcomp/-/blob/master/Makefile.am#L25) in [`xkbpath.c`](https://gitlab.freedesktop.org/xorg/app/xkbcomp/-/blob/master/xkbpath.c#L172).
Formula `font-util` also need to change.

-----
`xkbcomp.pc`:
```
prefix=/usr/local
exec_prefix=${prefix}
bindir=${exec_prefix}/bin
datarootdir=${prefix}/share
datadir=${datarootdir}
xkbconfigdir=${datadir}/X11/xkb

Name: xkbcomp
Description: XKB keymap compiler
Version: 1.4.5
```

`fontutil.pc`:
```
prefix=/usr/local
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
datarootdir=${prefix}/share
datadir=${datarootdir}
fontrootdir=${datadir}/fonts/X11
mapdir=${fontrootdir}/util
 
Name: FontUtil
Description: Font utilities dirs
Version: 1.3.3
```