### PR TITLE
remove conflicts_with between coreutils and gegl

### DIFF
--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -38,7 +38,6 @@ class Coreutils < Formula
   conflicts_with "b2sum", because: "both install `b2sum` binaries"
   conflicts_with "ganglia", because: "both install `gstat` binaries"
   conflicts_with "gdu", because: "both install `gdu` binaries"
-  conflicts_with "gegl", because: "both install `gcut` binaries"
   conflicts_with "idutils", because: "both install `gid` and `gid.1`"
   conflicts_with "md5sha1sum", because: "both install `md5sum` and `sha1sum` binaries"
   conflicts_with "truncate", because: "both install `truncate` binaries"

--- a/Formula/gegl.rb
+++ b/Formula/gegl.rb
@@ -37,8 +37,6 @@ class Gegl < Formula
     depends_on "cairo"
   end
 
-  conflicts_with "coreutils", because: "both install `gcut` binaries"
-
   def install
     ### Temporary Fix ###
     # Temporary fix for a meson bug


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

gcut in gegl has been removed since GEGL-0.4.18 2019-10-27 [^1].
So gegl is no longer conflicts with coreutils.

[^1]: https://gegl.org/NEWS.html#_gegl_ui

