### PR TITLE
pandoc-crossref: revision for pandoc 2.19.2 update

### DIFF
--- a/Formula/pandoc-crossref.rb
+++ b/Formula/pandoc-crossref.rb
@@ -4,6 +4,7 @@ class PandocCrossref < Formula
   url "https://hackage.haskell.org/package/pandoc-crossref-0.3.13.0/pandoc-crossref-0.3.13.0.tar.gz"
   sha256 "3d001c7e656fba84b3053ce4531766512505c9db1e8cb6c99939f40075eec53a"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "77964231643f46a4635a0795e9d2816ac69a1f1309349964288104b0e119a749"

--- a/Formula/pandoc-crossref.rb
+++ b/Formula/pandoc-crossref.rb
@@ -35,7 +35,8 @@ class PandocCrossref < Formula
 
       $$ P_i(x) = \\sum_i a_i x^i $$ {#eq:eqn1}
     EOS
-    system Formula["pandoc"].bin/"pandoc", "-F", bin/"pandoc-crossref", "-o", "out.html", "hello.md"
+    output = shell_output("#{Formula["pandoc"].bin/"pandoc"} -F #{bin/"pandoc-crossref"} -o out.html hello.md 2>&1")
     assert_match "∑", (testpath/"out.html").read
+    refute_includes output, "WARNING: pandoc-crossref was compiled"
   end
 end


### PR DESCRIPTION
`pandoc-crossref` warns when it was compiled against an older version of `pandoc` than its current invoker is. This avoids that warning and any weirdness resulting from the version mismatch. E.g.

```
WARNING: pandoc-crossref was compiled with pandoc 2.18 but is being run through 2.19.2. This is not supported. Strange things may (and likely will) happen silently.
```

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

_Edits made in GitHub editor_
