### PR TITLE
linux-headers: Change the default version to 5.15

### DIFF
--- a/Aliases/linux-headers
+++ b/Aliases/linux-headers
@@ -1,1 +1,1 @@
-../Formula/linux-headers@4.4.rb
+../Formula/linux-headers@5.15.rb

--- a/Formula/linux-headers@4.4.rb
+++ b/Formula/linux-headers@4.4.rb
@@ -9,6 +9,8 @@ class LinuxHeadersAT44 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "b3821c05a871c143c38d75b7494380f8f7a5725090528d849d2c066956a93344"
   end
 
+  keg_only :versioned_formula
+
   depends_on :linux
 
   def install

--- a/Formula/linux-headers@5.15.rb
+++ b/Formula/linux-headers@5.15.rb
@@ -9,8 +9,6 @@ class LinuxHeadersAT515 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "adb558844cfbf7fb8af6bd8134bc61120218246bd40b4746250fba1ae0a7933a"
   end
 
-  keg_only :versioned_formula
-
   depends_on :linux
 
   def install

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -18,7 +18,7 @@
   "libsigc++@2",
   "libxml++@4",
   "libxml++@5",
-  "linux-headers@4.4",
+  "linux-headers@5.15",
   "lua@5.1",
   "numpy@1.16",
   "openssl@1.1",


### PR DESCRIPTION
Ubuntu 22.04 provides Linux kernel headers version 5.15. This PR can be merged any time, since we've already upgraded `glibc` to version 2.35.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/Homebrew/brew/issues/13619