### PR TITLE
hledger: update livecheck

### DIFF
--- a/Formula/hledger.rb
+++ b/Formula/hledger.rb
@@ -10,7 +10,7 @@ class Hledger < Formula
   # page instead.
   livecheck do
     url "https://hledger.org/install.html"
-    regex(%r{href=.*?/tag/(?:hledger[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+    regex(%r{href=.*?/tag/(?:hledger[._-])?v?(\d+(?:\.\d+)+)(?:#[^"' >]+?)?["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `hledger` isn't matching the current latest release on the [first-party install page](https://hledger.org/install.html) because the GitHub release link we want to match has been modified to including a trailing URL fragment (e.g., `1.26.1#mac-x64` instead of `1.26.1`). This is causing the check to give an older version as newest, 1.22.1, instead of 1.26.1.

This PR updates the existing regex to account for an optional fragment, so this check will return the correct latest version again.