### PR TITLE
throttled_formulae: add `testkube` again.

### DIFF
--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -7,5 +7,6 @@
   "gatsby-cli": 10,
   "netlify-cli": 5,
   "quicktype": 10,
+  "testkube": 5,
   "vim": 50
 }


### PR DESCRIPTION
This reverts commit 11beee598078dd441bcae943d98216634fb22168.

Needs to wait until the version of `testkube` is a multiple of 5.
