### PR TITLE
mesa: set `dridriverdir` correctly

### DIFF
--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -4,6 +4,7 @@ class Mesa < Formula
   desc "Graphics Library"
   homepage "https://www.mesa3d.org/"
   license "MIT"
+  revision 1
   head "https://gitlab.freedesktop.org/mesa/mesa.git", branch: "main"
 
   stable do
@@ -124,6 +125,9 @@ class Mesa < Formula
     system "meson", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build"
     system "meson", "install", "-C", "build"
+    inreplace lib/"pkgconfig/dri.pc" do |s|
+      s.change_make_var! "dridriverdir", HOMEBREW_PREFIX/"lib/dri"
+    end
 
     if OS.linux?
       # Strip executables/libraries/object files to reduce their size


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`dridriverdir` in `dri.pc` is used by `xorg-server` to detect dri drivers, some formulae may provide dridrivers e.g `libva`, if use the origin value of `dridriverdir`, i.e. `Formula["mesa"].prefix/lib/dri`, `xorg-server` may need revision bump.
`meson` provides option `dri-drivers-path`, but it also effect the installation process.