### PR TITLE
testkube: add helm and kubectl dependencies

### DIFF
--- a/Formula/testkube.rb
+++ b/Formula/testkube.rb
@@ -21,6 +21,8 @@ class Testkube < Formula
   end
 
   depends_on "go" => :build
+  depends_on "helm"
+  depends_on "kubernetes-cli"
 
   def install
     ENV["CGO_ENABLED"] = "0"


### PR DESCRIPTION
As of now, the Testkube CLI can be installed without helm and kubectl, but it is unusable. To make setup easier and simpler for the users, we are adding these dependencies.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? **- there is one other commit on the same formulae but it is addressing a different issue, adding symlinks**
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
