### PR TITLE
fish: fix broken bottle install for non-default prefix

### DIFF
--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -10,6 +10,8 @@ class Fish < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
+  pour_bottle? only_if: :default_prefix
+
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "13e8e8cbb8dff7100071fa3c6b6ac1c8020391bebb6ee6bc09a30f6596b745b6"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? _(no additional errors from my change)_

-----

Marks bottle as default prefix only as current bottle installs a broken version on non-default prefixes (verified on multiple fresh Macs). There may be a better way of handling it for non-default prefixes, but this is likely the fastest/easiest for now to make sure it's not broken for them.

Current experience installing with the bottle on a non-default prefix (broken):

![fish-bottle](https://user-images.githubusercontent.com/1835431/187989663-368f0c9a-62e5-4301-b66d-4a4b7ae1f6d8.png)


When manually specifying `--build-from-source` (working):

![fish-compile-from-source](https://user-images.githubusercontent.com/1835431/187989676-923544a5-7651-4e0c-95fe-eaa85cd84bb5.png)
