### PR TITLE
rfcstrip 1.3

### DIFF
--- a/Formula/rfcstrip.rb
+++ b/Formula/rfcstrip.rb
@@ -1,13 +1,8 @@
 class Rfcstrip < Formula
   desc "Strips headers and footers from RFCs and Internet-Drafts"
-  homepage "https://trac.tools.ietf.org/tools/rfcstrip/"
-  url "https://trac.tools.ietf.org/tools/rfcstrip/rfcstrip-1.03.tgz"
-  sha256 "db5cccb14b2dfdb5e0e3b4ac98d5af29d1f2f647787bcd470a866e02173d4e5b"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?rfcstrip[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  homepage "https://github.com/mbj4668/rfcstrip"
+  url "https://github.com/mbj4668/rfcstrip/archive/1.3.tar.gz"
+  sha256 "bba42a64535f55bfd1eae0cf0b85f781dacf5f3ce323b16515f32cefff920c6b"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "4756e7bca511bbeaeea367e84a845854cd86079ec2d66c6a505b91e7431313a0"
@@ -20,7 +15,6 @@ class Rfcstrip < Formula
 
   def install
     bin.install "rfcstrip"
-    doc.install %w[about todo]
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `rfcstrip` stopped working because the homepage redirects to https://trac.ietf.org, which doesn't reference `rfcstrip` anywhere. I searched around for `rfcstrip` and found https://authors.ietf.org/en/tools-catalog, which links to https://github.com/mbj4668/rfcstrip.

This PR updates the `rfcstrip` formula to use a tag archive from this GitHub repository, as the existing `stable` URL no longer resolves (it also redirects to https://trac.ietf.org). The new archive does not contain `about` or `todo`, so I've removed that part of the install steps. Additionally, this removes the existing `livecheck` block, as it's no longer necessary in this case with the switch to the GitHub repository (i.e., livecheck will successfully check the Git tags by default).

Regarding the change in version format, the [`rfcstrip` file](https://github.com/mbj4668/rfcstrip/blob/master/rfcstrip) lists this version as `1.3` and the tag is `1.3` as well.

Edit: Not entirely sure what the license is but you can find it in the [`COPYING` file](https://github.com/mbj4668/rfcstrip/blob/master/COPYING). It's most similar to the [TCL/TK License](https://spdx.org/licenses/TCL.html) but omits the "GOVERNMENT USE" paragraph at the end.