### PR TITLE
grep: depend on pcre2

### DIFF
--- a/Formula/grep.rb
+++ b/Formula/grep.rb
@@ -5,6 +5,7 @@ class Grep < Formula
   mirror "https://ftpmirror.gnu.org/grep/grep-3.8.tar.xz"
   sha256 "498d7cc1b4fb081904d87343febb73475cf771e424fb7e6141aff66013abc382"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "19f74ff07a70ef50f90ce31a4f02967146469a94c2a3a4136221fc770a4a2e68"
@@ -16,7 +17,7 @@ class Grep < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "pcre"
+  depends_on "pcre2"
 
   def install
     args = %W[
@@ -59,12 +60,12 @@ class Grep < Formula
     text_file.write "This line should be matched"
 
     if OS.mac?
-      grepped = shell_output("#{bin}/ggrep match #{text_file}")
+      grepped = shell_output("#{bin}/ggrep -P match #{text_file}")
       assert_match "should be matched", grepped
 
-      grepped = shell_output("#{opt_libexec}/gnubin/grep match #{text_file}")
+      grepped = shell_output("#{opt_libexec}/gnubin/grep -P match #{text_file}")
     else
-      grepped = shell_output("#{bin}/grep match #{text_file}")
+      grepped = shell_output("#{bin}/grep -P match #{text_file}")
     end
     assert_match "should be matched", grepped
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As mentioned on [this commit](https://github.com/Homebrew/homebrew-core/commit/3b90d39eb563e9790bb6a5b4a173625da6b5267e), `grep -P` stopped working after the update to grep 3.8 because upstream moved to pcre2 but (a) the formula wasn't updated and (b) grep doesn't fail to build in the absence of a usable pcre library--it just disables Perl matching.

Rebuilding with `pcre2` resolves the `ggrep: Perl matching not supported in a --disable-perl-regexp build` error returned by the bottled `grep -P`.