### PR TITLE
scry: move `rpc` method definition out of `test` block.

### DIFF
--- a/Formula/scry.rb
+++ b/Formula/scry.rb
@@ -16,6 +16,9 @@ class Scry < Formula
     sha256 x86_64_linux:   "9aa343ca7529d5b803fa98ef2c702cc63423233a376963ea590a89458de61545"
   end
 
+  # https://github.com/crystal-lang-tools/scry/issues/186
+  disable! date: "2023-01-01", because: :does_not_build
+
   depends_on "bdw-gc"
   depends_on "crystal"
   depends_on "libevent"
@@ -28,13 +31,13 @@ class Scry < Formula
     bin.install "bin/scry"
   end
 
-  test do
-    def rpc(json)
-      "Content-Length: #{json.size}\r\n" \
-        "\r\n" \
-        "#{json}"
-    end
+  def rpc(json)
+    "Content-Length: #{json.size}\r\n" \
+      "\r\n" \
+      "#{json}"
+  end
 
+  test do
     input = rpc '{ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": ' \
                 '{ "processId": 1, "rootPath": "/dev/null", "capabilities": {}, "trace": "off" } }'
     input += rpc '{ "jsonrpc": "2.0", "method": "initialized", "params": {} }'


### PR DESCRIPTION
Defining methods inside `test` blocks is no longer supported as of
Homebrew/brew#13753.

Fixes a CI failure spotted in #106925:

```
Error: scry: failed
An exception occurred within a child process:
  FrozenError: can't modify frozen class
```

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
