### PR TITLE
flatbuffers: remove method definitions from `test` block

### DIFF
--- a/Formula/flatbuffers.rb
+++ b/Formula/flatbuffers.rb
@@ -35,51 +35,47 @@ class Flatbuffers < Formula
   end
 
   test do
-    def testfbs
-      <<~EOS
-        // example IDL file
+    testfbs = <<~EOS
+      // example IDL file
 
-        namespace MyGame.Sample;
+      namespace MyGame.Sample;
 
-        enum Color:byte { Red = 0, Green, Blue = 2 }
+      enum Color:byte { Red = 0, Green, Blue = 2 }
 
-        union Any { Monster }  // add more elements..
+      union Any { Monster }  // add more elements..
 
-          struct Vec3 {
-            x:float;
-            y:float;
-            z:float;
-          }
+        struct Vec3 {
+          x:float;
+          y:float;
+          z:float;
+        }
 
-          table Monster {
-            pos:Vec3;
-            mana:short = 150;
-            hp:short = 100;
-            name:string;
-            friendly:bool = false (deprecated);
-            inventory:[ubyte];
-            color:Color = Blue;
-          }
+        table Monster {
+          pos:Vec3;
+          mana:short = 150;
+          hp:short = 100;
+          name:string;
+          friendly:bool = false (deprecated);
+          inventory:[ubyte];
+          color:Color = Blue;
+        }
 
-        root_type Monster;
+      root_type Monster;
 
-      EOS
-    end
+    EOS
     (testpath/"test.fbs").write(testfbs)
 
-    def testjson
-      <<~EOS
-        {
-          pos: {
-            x: 1,
-            y: 2,
-            z: 3
-          },
-          hp: 80,
-          name: "MyMonster"
-        }
-      EOS
-    end
+    testjson = <<~EOS
+      {
+        pos: {
+          x: 1,
+          y: 2,
+          z: 3
+        },
+        hp: 80,
+        name: "MyMonster"
+      }
+    EOS
     (testpath/"test.json").write(testjson)
 
     system bin/"flatc", "-c", "-b", "test.fbs", "test.json"


### PR DESCRIPTION
This is no longer supported as of Homebrew/brew#13753.

See #109599.
