### PR TITLE
fbi-servefiles: remove method definition from `test` block

### DIFF
--- a/Formula/fbi-servefiles.rb
+++ b/Formula/fbi-servefiles.rb
@@ -25,18 +25,18 @@ class FbiServefiles < Formula
     venv.pip_install_and_link buildpath/"servefiles"
   end
 
+  def test_socket
+    server = TCPServer.new(5000)
+    client = server.accept
+    client.puts "\n"
+    client_response = client.gets
+    client.close
+    server.close
+    client_response
+  end
+
   test do
     require "socket"
-
-    def test_socket
-      server = TCPServer.new(5000)
-      client = server.accept
-      client.puts "\n"
-      client_response = client.gets
-      client.close
-      server.close
-      client_response
-    end
 
     begin
       pid = fork do


### PR DESCRIPTION
This is no longer supported as of Homebrew/brew#13753.

See #109599.
