### PR TITLE
rust-analyzer: remove method definition from `test` block

### DIFF
--- a/Formula/rust-analyzer.rb
+++ b/Formula/rust-analyzer.rb
@@ -24,13 +24,13 @@ class RustAnalyzer < Formula
     end
   end
 
-  test do
-    def rpc(json)
-      "Content-Length: #{json.size}\r\n" \
-        "\r\n" \
-        "#{json}"
-    end
+  def rpc(json)
+    "Content-Length: #{json.size}\r\n" \
+      "\r\n" \
+      "#{json}"
+  end
 
+  test do
     input = rpc <<-EOF
     {
       "jsonrpc":"2.0",


### PR DESCRIPTION
This is no longer supported as of Homebrew/brew#13753.

See #109599.
