### PR TITLE
xcb-proto: fix python3 references

### DIFF
--- a/Formula/xcb-proto.rb
+++ b/Formula/xcb-proto.rb
@@ -13,12 +13,14 @@ class XcbProto < Formula
   depends_on "python@3.10" => :build
 
   def install
+    python = "python3.10"
+
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
       --disable-silent-rules
-      PYTHON=python3
+      PYTHON=#{python}
     ]
 
     system "./configure", *args


### PR DESCRIPTION
See #108008

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
