### PR TITLE
fail2ban: fix `python3` references.

### DIFF
--- a/Formula/fail2ban.rb
+++ b/Formula/fail2ban.rb
@@ -45,8 +45,9 @@ class Fail2ban < Formula
   end
 
   def install
-    ENV.prepend_create_path "PYTHONPATH", libexec/Language::Python.site_packages("python3")
-    ENV["PYTHON"] = which("python3")
+    python3 = "python3.10"
+    ENV.prepend_create_path "PYTHONPATH", libexec/Language::Python.site_packages(python3)
+    ENV["PYTHON"] = which(python3)
 
     rm "setup.cfg"
     Dir["config/paths-*.conf"].each do |r|
@@ -98,9 +99,7 @@ class Fail2ban < Formula
     inreplace "setup.py", "platform_system in ('linux',", "platform_system in ('linux', 'darwin',"
 
     system "./fail2ban-2to3"
-    system "python3", *Language::Python.setup_install_args(libexec),
-                      "--install-lib=#{libexec/Language::Python.site_packages("python3")}",
-                      "--without-tests"
+    system python3, *Language::Python.setup_install_args(libexec, python3), "--without-tests"
 
     cd "doc" do
       system "make", "dirhtml", "SPHINXBUILD=sphinx-build"


### PR DESCRIPTION
See #108008.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
