### PR TITLE
pianobar: add livecheck

### DIFF
--- a/Formula/pianobar.rb
+++ b/Formula/pianobar.rb
@@ -1,11 +1,16 @@
 class Pianobar < Formula
   desc "Command-line player for https://pandora.com"
-  homepage "https://github.com/PromyLOPh/pianobar/"
+  homepage "https://6xq.net/pianobar/"
   url "https://6xq.net/pianobar/pianobar-2022.04.01.tar.bz2"
   sha256 "1670b28865a8b82a57bb6dfea7f16e2fa4145d2f354910bb17380b32c9b94763"
   license "MIT"
   revision 1
   head "https://github.com/PromyLOPh/pianobar.git", branch: "master"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?pianobar[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "7c33a6f2e9b9ae1d701f14a520292c89caa7ea330e8211c9987ee391f20618d4"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git repository for `pianobar` but the most recent tag is `2020.11.28`, whereas the formula is using version `2022.04.01`. This PR updates the homepage to point to the site where the `stable` archive is found and adds a `livecheck` block to match versions from the tarball links on the page.