### PR TITLE
pypy3: migrate to Python 3.8

### DIFF
--- a/Formula/pypy3.rb
+++ b/Formula/pypy3.rb
@@ -128,7 +128,7 @@ class Pypy3 < Formula
     # so that user-installed Python software survives minor updates, such
     # as going from 1.7.0 to 1.7.1.
 
-    # Create a site-packages in the prefix.
+    # Create a site-packages in HOMEBREW_PREFIX/lib/pypy3/site-packages
     prefix_site_packages.mkpath
 
     # Symlink the prefix site-packages into the cellar.
@@ -143,7 +143,11 @@ class Pypy3 < Formula
 
     %w[setuptools pip].each do |pkg|
       resource(pkg).stage do
-        system bin/"pypy3", "-s", "setup.py", "--no-user-cfg", "install", "--force", "--verbose"
+        system bin/"pypy3", "-s", "setup.py", "--no-user-cfg", "install",
+                            "--force", "--verbose", "--install-scripts=#{bin}",
+                            "--install-lib=#{site_packages}",
+                            "--single-version-externally-managed",
+                            "--record=installed.txt"
       end
     end
 

--- a/Formula/pypy3.rb
+++ b/Formula/pypy3.rb
@@ -1,10 +1,17 @@
 class Pypy3 < Formula
   desc "Implementation of Python 3 in Python"
   homepage "https://pypy.org/"
-  url "https://downloads.python.org/pypy/pypy3.7-v7.3.9-src.tar.bz2"
-  sha256 "70426163b194ee46009986eea6d9426098a3ffb552d9cdbd3dfaa64a47373f49"
   license "MIT"
-  head "https://foss.heptapod.net/pypy/pypy", using: :hg, branch: "py3.7"
+  head "https://foss.heptapod.net/pypy/pypy", using: :hg, branch: "py3.8"
+
+  stable do
+    # M1 support is planned to be included in the next release
+    # See https://www.pypy.org/posts/2022/07/m1-support-for-pypy.html
+    depends_on arch: :x86_64
+
+    url "https://downloads.python.org/pypy/pypy3.8-v7.3.9-src.tar.bz2"
+    sha256 "5b5d9d9256f12a129af8384e2f581bdfab3bc0fbbe3a0a480d9c1d2e95490eb1"
+  end
 
   livecheck do
     url "https://downloads.python.org/pypy/"
@@ -20,7 +27,6 @@ class Pypy3 < Formula
 
   depends_on "pkg-config" => :build
   depends_on "pypy" => :build
-  depends_on arch: :x86_64
   depends_on "gdbm"
   depends_on "openssl@1.1"
   depends_on "sqlite"
@@ -100,7 +106,7 @@ class Pypy3 < Formula
     # we want to avoid putting PyPy's Python.h somewhere that configure
     # scripts will find it.
     bin.install_symlink libexec/"bin/pypy3"
-    bin.install_symlink libexec/"bin/pypy" => "pypy3.7"
+    bin.install_symlink libexec/"bin/pypy" => "pypy3.8"
     lib.install_symlink libexec/"lib/#{shared_library("libpypy3-c")}"
 
     # Delete two files shipped which we do not want to deliver

--- a/Formula/pypy3.rb
+++ b/Formula/pypy3.rb
@@ -144,8 +144,8 @@ class Pypy3 < Formula
     %w[setuptools pip].each do |pkg|
       resource(pkg).stage do
         system bin/"pypy3", "-s", "setup.py", "--no-user-cfg", "install",
-                            "--force", "--verbose", "--install-scripts=#{bin}",
-                            "--install-lib=#{site_packages}",
+                            "--force", "--verbose", "--install-scripts=#{scripts_folder}",
+                            "--install-lib=#{prefix_site_packages}",
                             "--single-version-externally-managed",
                             "--record=installed.txt"
       end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

From PyPy 7.3.8, the Python 3.8 implementation by PyPy is considered as stable.
https://www.pypy.org/posts/2022/02/pypy-v738-release.html