### PR TITLE
fairymax: fix install location of shared files

### DIFF
--- a/Formula/fairymax.rb
+++ b/Formula/fairymax.rb
@@ -5,6 +5,7 @@ class Fairymax < Formula
       tag:      "5.0b",
       revision: "f7a7847ea2d4764d9a0a211ba6559fa98e8dbee6"
   version "5.0b"
+  license :public_domain
   head "http://hgm.nubati.net/git/fairymax.git", branch: "master"
 
   bottle do
@@ -19,12 +20,7 @@ class Fairymax < Formula
   end
 
   def install
-    system "make", "all",
-                   "INI_F=#{pkgshare}/fmax.ini",
-                   "INI_Q=#{pkgshare}/qmax.ini"
-    bin.install "fairymax", "shamax", "maxqi"
-    pkgshare.install Dir["data/*.ini"]
-    man6.install "fairymax.6.gz"
+    system "make", "install", "prefix=#{prefix}"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
As written, the formula for fairymax installs shared files to an
incorrect location. One other Homebrew formula uses fairymax as a
dependency: xboard. That formula is unable to locate ini files installed
by fairymax because they have been installed in a non-standard location.

To replicate this issue, install the xboard formula and run it using the
`xboard` command. You should notice an error message about being unable
to locate `fmax.ini`.

The standard location for the shared files installed by fairymax:

"$(brew --prefix)/share/games/fairymax/"

The current location where these shared files are installed:

"$(brew --prefix)/share/fairymax/"

The change in this commit simply passes the correct prefix to the
Makefile to ensure that all resources are placed in the correct
locations.