### PR TITLE
hashpump: fix `python3` references.

### DIFF
--- a/Formula/hashpump.rb
+++ b/Formula/hashpump.rb
@@ -36,7 +36,8 @@ class Hashpump < Formula
                    "CXX=#{ENV.cxx}",
                    "install"
 
-    system "python3", *Language::Python.setup_install_args(prefix)
+    python3 = "python3.10"
+    system python3, *Language::Python.setup_install_args(prefix, python3)
   end
 
   test do


### PR DESCRIPTION
See #108008.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
