### PR TITLE
pyqt-builder: fix `python3` references.

### DIFF
--- a/Formula/pyqt-builder.rb
+++ b/Formula/pyqt-builder.rb
@@ -16,13 +16,16 @@ class PyqtBuilder < Formula
   depends_on "python@3.10"
   depends_on "sip"
 
+  def python3
+    "python3.10"
+  end
+
   def install
-    system Formula["python@3.10"].opt_bin/"python3", *Language::Python.setup_install_args(prefix),
-           "--install-lib=#{prefix/Language::Python.site_packages("python3")}"
+    system Formula["python@3.10"].opt_bin/python3, *Language::Python.setup_install_args(prefix, python3)
   end
 
   test do
     system bin/"pyqt-bundle", "-V"
-    system Formula["python@3.10"].opt_bin/"python3", "-c", "import pyqtbuild"
+    system Formula["python@3.10"].opt_bin/python3, "-c", "import pyqtbuild"
   end
 end


### PR DESCRIPTION
See #108008.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
