### PR TITLE
readline: remove unnecessary `inreplace`.

### DIFF
--- a/Formula/readline.rb
+++ b/Formula/readline.rb
@@ -68,17 +68,11 @@ class Readline < Formula
   uses_from_macos "ncurses"
 
   def install
-    args = ["--prefix=#{prefix}"]
-    args << "--with-curses" if OS.linux?
-    system "./configure", *args
-
-    args = []
-    args << "SHLIB_LIBS=-lcurses" if OS.linux?
-    # There is no termcap.pc in the base system, so we have to comment out
-    # the corresponding Requires.private line.
-    # Otherwise, pkg-config will consider the readline module unusable.
-    inreplace "readline.pc", /^(Requires.private: .*)$/, "# \\1"
-    system "make", "install", *args
+    system "./configure", "--prefix=#{prefix}", "--with-curses"
+    # TODO: Work out why we need to set `SHLIB_LIBS` at all.
+    #       This is needed only on Linux, and is a no-op on macOS.
+    #       Arch does something similar, but Debian doesn't.
+    system "make", "install", "SHLIB_LIBS=-lncurses"
   end
 
   test do


### PR DESCRIPTION
Let's also simplify the `install` method a bit.

The `inreplace` was needed so that `readline.pc` did not declare

    Requires.private: termcap

However, the correct way to avoid that is to pass `--with-curses` so
that it instead does

    Requires.private: ncurses

which allows `readline.pc` to be usable without modification.

Passing `--with-curses` does not change the configuration on macOS. The
existing bottles already have linkage with the system `ncurses` library,
because linking with `ncurses` is the default on macOS:

    http://git.savannah.gnu.org/cgit/readline.git/tree/support/shobj-conf?id=5263c0d88064fda96292335d12eec1733f91cdc9#n174

We can use this fact to avoid having to condition passing `SHLIB_LIBS`
on Linux, because this flag has no effect on macOS. Arguably, we should
not be setting `SHLIB_LIBS` at all, the documentation and source both
suggest that readline shouldn't be linking with `ncurses` on Linux.
However, removing this flag is a more substantial change that I'd like
to leave for another patch.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
