### PR TITLE
vapoursynth: fix python3 references

### DIFF
--- a/Formula/vapoursynth.rb
+++ b/Formula/vapoursynth.rb
@@ -67,7 +67,7 @@ class Vapoursynth < Formula
   end
 
   test do
-    system Formula["python@3.10"].opt_bin/"python3", "-c", "import vapoursynth"
+    system Formula["python@3.10"].opt_bin/"python3.10", "-c", "import vapoursynth"
     system bin/"vspipe", "--version"
   end
 end


### PR DESCRIPTION
See #108008

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
