### PR TITLE
botan: fix `python3` reference.

### DIFF
--- a/Formula/botan.rb
+++ b/Formula/botan.rb
@@ -44,7 +44,7 @@ class Botan < Formula
       --with-sqlite3
     ]
 
-    system "python3", "configure.py", *args
+    system "python3.10", "configure.py", *args
     system "make", "install"
   end
 


### PR DESCRIPTION
See #108008.
