### PR TITLE
fourstore: depend on `avahi` on Linux.

### DIFF
--- a/Formula/fourstore.rb
+++ b/Formula/fourstore.rb
@@ -1,6 +1,7 @@
 class Fourstore < Formula
   desc "Efficient, stable RDF database"
   homepage "https://github.com/4store/4store"
+  # NOTE: Try building without `avahi` at version bump.
   url "https://github.com/4store/4store/archive/v1.1.6.tar.gz"
   sha256 "a0c8143fcceeb2f1c7f266425bb6b0581279129b86fdd10383bf1c1e1cab8e00"
   license "GPL-3.0"
@@ -28,6 +29,11 @@ class Fourstore < Formula
   depends_on "raptor"
   depends_on "rasqal"
   depends_on "readline"
+
+  # TODO: Check if this dependency can be removed at version bump.
+  on_linux do
+    depends_on "avahi"
+  end
 
   def install
     # Upstream issue garlik/4store#138

--- a/Formula/fourstore.rb
+++ b/Formula/fourstore.rb
@@ -35,10 +35,23 @@ class Fourstore < Formula
     depends_on "avahi"
   end
 
+  # Fix build on Linux. Remove on the next release
+  # sigval_t.h:13:3: error: #error "sigval_t defined for standard not including union sigval"
+  patch do
+    on_linux do
+      url "https://github.com/4store/4store/commit/c5a56d7c7504551a1f2fff6c16c4d9a440e4a317.patch?full_index=1"
+      sha256 "f476aa38098aaaebf970603a5003aae40fa43f3243890e404f799be8bdbf0aad"
+    end
+  end
+
   def install
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # /usr/bin/ld: query.o:(.bss+0x0): multiple definition of `rasqal_mutex'
+    ENV.append_to_cflags "-fcommon" if OS.linux?
     # Upstream issue garlik/4store#138
     # Otherwise .git directory is needed
     (buildpath/".version").write("v1.1.6")
+
     system "./autogen.sh"
     (var/"fourstore").mkpath
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
Fixes a linkage failure spotted at #109781.

This looks like opportunistic linkage picked up at #103916.
