### PR TITLE
mpfi: add livecheck

### DIFF
--- a/Formula/mpfi.rb
+++ b/Formula/mpfi.rb
@@ -5,6 +5,11 @@ class Mpfi < Formula
   sha256 "2383d457b208c6cd3cf2e66b69c4ce47477b2a0db31fbec0cd4b1ebaa247192f"
   license all_of: ["GPL-3.0-or-later", "LGPL-2.1-or-later"]
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?mpfi[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_big_sur: "294ebea233e52a6a0153e535a031e3bbea8bd4b36c4323c9d715512d77defc41"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check `mpfi` for new versions. This PR adds a `livecheck` block that checks the homepage, as it now links directly to tarballs (before it simply pointed to https://gforge.inria.fr/frs/?group_id=157, which now gives a 403 (Forbidden) response).

A newer 1.5.4 version is available (albeit, from 2018-09-03) but it failed to build when I tried it. However, there's something to be said for adding this `livecheck` block, so we know when another new version is available to try. There are new commits in the [related repository](https://gitlab.inria.fr/mpfi/mpfi/-/commits/master) from earlier this year, so there's at least some development activity happening (beyond what the existing comment in the formula references).