### PR TITLE
docbook-xsl: Make dbtoepub executable

### DIFF
--- a/Formula/docbook-xsl.rb
+++ b/Formula/docbook-xsl.rb
@@ -60,6 +60,7 @@ class DocbookXsl < Formula
       doc.install "doc" => "reference"
     end
 
+    chmod 0755, "#{prefix}/docbook-xsl/epub/bin/dbtoepub"
     bin.write_exec_script "#{prefix}/docbook-xsl/epub/bin/dbtoepub"
   end
 
@@ -103,5 +104,6 @@ class DocbookXsl < Formula
     system "xmlcatalog", "#{etc}/xml/catalog", "http://docbook.sourceforge.net/release/xsl/#{version}/"
     system "xmlcatalog", "#{etc}/xml/catalog", "http://docbook.sourceforge.net/release/xsl-ns/current/"
     system "xmlcatalog", "#{etc}/xml/catalog", "http://docbook.sourceforge.net/release/xsl-ns/#{version}/"
+    system bin/"dbtoepub", "--help"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This used to work, but somehow at the moment the `.../docbook-xsl/epub/bin/dbtoepub` file ends up without executable permissions, and the wrapper script fails when you try to call it.