### PR TITLE
virtualenvwrapper: fix `python3` references.

### DIFF
--- a/Formula/virtualenvwrapper.rb
+++ b/Formula/virtualenvwrapper.rb
@@ -62,14 +62,15 @@ class Virtualenvwrapper < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3")
+    python3 = "python3.10"
+    venv = virtualenv_create(libexec, python3)
     venv.pip_install resources
     venv.pip_install buildpath
 
     bin.install_symlink libexec/"bin/virtualenvwrapper_lazy.sh"
     (bin/"virtualenvwrapper.sh").write <<~SH
       #!/bin/sh
-      export VIRTUALENVWRAPPER_PYTHON="#{libexec}/bin/python"
+      export VIRTUALENVWRAPPER_PYTHON="#{libexec}/bin/#{python3}"
       source "#{libexec}/bin/virtualenvwrapper.sh"
     SH
   end


### PR DESCRIPTION
See #108008.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
