### PR TITLE
udis86: fix `python3` reference.

### DIFF
--- a/Formula/udis86.rb
+++ b/Formula/udis86.rb
@@ -3,6 +3,7 @@ class Udis86 < Formula
   homepage "https://udis86.sourceforge.io"
   url "https://downloads.sourceforge.net/project/udis86/udis86/1.7/udis86-1.7.2.tar.gz"
   sha256 "9c52ac626ac6f531e1d6828feaad7e797d0f3cce1e9f34ad4e84627022b3c2f4"
+  license "BSD-2-Clause"
   revision 1
 
   livecheck do

--- a/Formula/udis86.rb
+++ b/Formula/udis86.rb
@@ -30,7 +30,7 @@ class Udis86 < Formula
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--enable-shared",
-                          "--with-python=#{which("python3")}"
+                          "--with-python=#{which("python3.10")}"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
See #108008, and also include the license.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
