### PR TITLE
sqlcmd 0.9.1 (new formula)

### DIFF
--- a/Formula/sqlcmd.rb
+++ b/Formula/sqlcmd.rb
@@ -15,7 +15,8 @@ class Sqlcmd < Formula
   end
 
   test do
-    out = shell_output("#{bin}/sqlcmd -?")
-    assert_match "Usage: sqlcmd", out
+    out = shell_output("#{bin}/sqlcmd -S 127.0.0.1 -E -Q 'SELECT @@version'", 1)
+    assert_match "unable to open tcp connection with host '127.0.0.1:1433': " \
+                 "dial tcp 127.0.0.1:1433: connect: connection refused", out
   end
 end

--- a/Formula/sqlcmd.rb
+++ b/Formula/sqlcmd.rb
@@ -9,7 +9,6 @@ class Sqlcmd < Formula
 
   def install
     ENV["CGO_ENABLED"] = "0"
-
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/sqlcmd"
   end
 

--- a/Formula/sqlcmd.rb
+++ b/Formula/sqlcmd.rb
@@ -8,38 +8,7 @@ class Sqlcmd < Formula
 
   depends_on "go" => :build
 
-  def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
-      puts "The license terms for this product can be downloaded from"
-      puts "https://github.com/microsoft/go-sqlcmd/blob/main/LICENSE."
-      puts "By entering 'YES', you indicate that you accept the license terms."
-      puts ""
-      loop do
-        puts "Do you accept the license terms? (Enter YES or NO)"
-        accept_eula = $stdin.gets.chomp
-        if accept_eula
-          break if accept_eula.casecmp("YES").zero?
-
-          if accept_eula.casecmp("NO").zero?
-            puts "Installation terminated: License terms not accepted."
-            return false
-          else
-            puts "Please enter YES or NO"
-          end
-        else
-          puts "Installation terminated: Could not prompt for license acceptance."
-          puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
-          return false
-        end
-      end
-    end
-    true
-  end
-
   def install
-    return false unless check_eula_acceptance?
-
     ENV["CGO_ENABLED"] = "0"
 
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/sqlcmd"

--- a/Formula/sqlcmd.rb
+++ b/Formula/sqlcmd.rb
@@ -15,7 +15,6 @@ class Sqlcmd < Formula
 
   test do
     out = shell_output("#{bin}/sqlcmd -S 127.0.0.1 -E -Q 'SELECT @@version'", 1)
-    assert_match "unable to open tcp connection with host '127.0.0.1:1433': " \
-                 "dial tcp 127.0.0.1:1433: connect: connection refused", out
+    assert_match "connection refused", out
   end
 end

--- a/Formula/sqlcmd.rb
+++ b/Formula/sqlcmd.rb
@@ -1,0 +1,52 @@
+class Sqlcmd < Formula
+  desc "Microsoft SQL Server command-line interface"
+  homepage "https://github.com/microsoft/go-sqlcmd"
+  url "https://github.com/microsoft/go-sqlcmd.git",
+  tag:      "v0.8.1",
+  revision: "4e0b95ce49b8164c6496ca1b7a85fa57734fef4c"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def check_eula_acceptance?
+    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+      puts "The license terms for this product can be downloaded from"
+      puts "https://github.com/microsoft/go-sqlcmd/blob/main/LICENSE."
+      puts "By entering 'YES', you indicate that you accept the license terms."
+      puts ""
+      loop do
+        puts "Do you accept the license terms? (Enter YES or NO)"
+        accept_eula = $stdin.gets.chomp
+        if accept_eula
+          break if accept_eula.casecmp("YES").zero?
+
+          if accept_eula.casecmp("NO").zero?
+            puts "Installation terminated: License terms not accepted."
+            return false
+          else
+            puts "Please enter YES or NO"
+          end
+        else
+          puts "Installation terminated: Could not prompt for license acceptance."
+          puts "If you are performing an unattended installation, you may set"
+          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          return false
+        end
+      end
+    end
+    true
+  end
+
+  def install
+    return false unless check_eula_acceptance?
+
+    ENV["CGO_ENABLED"] = "0"
+
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/sqlcmd"
+  end
+
+  test do
+    out = shell_output("#{bin}/sqlcmd -?")
+    assert_match "Usage: sqlcmd", out
+  end
+end

--- a/Formula/sqlcmd.rb
+++ b/Formula/sqlcmd.rb
@@ -1,9 +1,8 @@
 class Sqlcmd < Formula
   desc "Microsoft SQL Server command-line interface"
   homepage "https://github.com/microsoft/go-sqlcmd"
-  url "https://github.com/microsoft/go-sqlcmd.git",
-  tag:      "v0.8.1",
-  revision: "4e0b95ce49b8164c6496ca1b7a85fa57734fef4c"
+  url "https://github.com/microsoft/go-sqlcmd/archive/refs/tags/v0.9.1.tar.gz"
+  sha256 "35a2d165ae6e1f39033ef7ab9ef3b0b205dc1b6b5583912a082297e93ad1c8ab"
   license "MIT"
 
   depends_on "go" => :build


### PR DESCRIPTION
The Microsoft SQL Server engineering team have re-written (and made OSS) the CLI for SQL Server (`sqlcmd`) in golang to enable it to be cross platform (and require no dependencies).  The `sqlcmd` utlity has been installed 100s of millions of times. We would like to make `sqlcmd` available for all package managers on all platforms.  This PR makes it available in `brew`.

https://github.com/microsoft/go-sqlcmd
https://docs.microsoft.com/en-us/sql/tools/sqlcmd-utility
https://docs.microsoft.com/en-us/sql/tools/go-sqlcmd-utility

- [Y] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [Y] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [Y] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [Y] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Y] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Y] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Updated: brew audit --strict now passes
