### PR TITLE
vapoursynth-ocr: fix `python3` reference.

### DIFF
--- a/Formula/vapoursynth-ocr.rb
+++ b/Formula/vapoursynth-ocr.rb
@@ -47,7 +47,7 @@ class VapoursynthOcr < Formula
     python = Formula["vapoursynth"].deps
                                    .find { |d| d.name.match?(/^python@\d\.\d+$/) }
                                    .to_formula
-                                   .opt_bin/"python3"
+                                   .opt_libexec/"bin/python"
     system python, "-c", "from vapoursynth import core; core.ocr"
   end
 end


### PR DESCRIPTION
See #108008.
