### PR TITLE
vapoursynth-sub: fix `python3` reference.

### DIFF
--- a/Formula/vapoursynth-sub.rb
+++ b/Formula/vapoursynth-sub.rb
@@ -38,7 +38,7 @@ class VapoursynthSub < Formula
     python = Formula["vapoursynth"].deps
                                    .find { |d| d.name.match?(/^python@\d\.\d+$/) }
                                    .to_formula
-                                   .opt_bin/"python3"
+                                   .opt_libexec/"bin/python"
     system python, "-c", "from vapoursynth import core; core.sub"
   end
 end


### PR DESCRIPTION
See #108008.
