### PR TITLE
libfaketime: Fix tests for ARM macOS

### DIFF
--- a/Formula/libfaketime.rb
+++ b/Formula/libfaketime.rb
@@ -26,8 +26,17 @@ class Libfaketime < Formula
   end
 
   test do
-    cp "/bin/date", testpath/"date" # Work around SIP.
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include <time.h>
+
+      int main(void) {
+        printf("%d\\n",(int)time(NULL));
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-o", "test"
     assert_match "1230106542",
-      shell_output(%Q(TZ=UTC #{bin}/faketime -f "2008-12-24 08:15:42" #{testpath}/date +%s)).strip
+      shell_output(%Q(#{bin}/faketime -f "2008-12-24 08:15:42" ./test)).strip
   end
 end

--- a/Formula/libfaketime.rb
+++ b/Formula/libfaketime.rb
@@ -36,6 +36,6 @@ class Libfaketime < Formula
       }
     EOS
     system ENV.cc, "test.c", "-o", "test"
-    assert_match "1230106542", shell_output("#{bin}/faketime -f '2008-12-24 08:15:42' ./test").strip
+    assert_match "1230106542", shell_output("TZ=UTC #{bin}/faketime -f '2008-12-24 08:15:42' ./test").strip
   end
 end

--- a/Formula/libfaketime.rb
+++ b/Formula/libfaketime.rb
@@ -36,7 +36,6 @@ class Libfaketime < Formula
       }
     EOS
     system ENV.cc, "test.c", "-o", "test"
-    assert_match "1230106542",
-      shell_output(%Q(#{bin}/faketime -f "2008-12-24 08:15:42" ./test)).strip
+    assert_match "1230106542", shell_output("#{bin}/faketime -f '2008-12-24 08:15:42' ./test").strip
   end
 end


### PR DESCRIPTION
The workaround previously made of copying `/bin/date` to a different location doesn't work anymore since macOS Monterey (12).

This fixes that by instead compiling a small C program that emits the current time as a Unix timestamp, making it easy to compare against the expected output.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?