### PR TITLE
neovim: add `caveats` for tree-sitter parsers.

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -137,6 +137,15 @@ class Neovim < Formula
     system "cmake", "--install", "build"
   end
 
+  def caveats
+    return if latest_head_version.blank?
+
+    <<~EOS
+      HEAD installs of Neovim do not include any tree-sitter parsers.
+      You can use the `nvim-treesitter` plugin to install them.
+    EOS
+  end
+
   test do
     (testpath/"test.txt").write("Hello World from Vim!!")
     system bin/"nvim", "--headless", "-i", "NONE", "-u", "NONE",


### PR DESCRIPTION
See Homebrew/discussions#3611.

When 0.8 is released, we can bundle the parsers for `stable` builds, or
ship them as separate formulae and add them as dependencies. Given this,
it makes sense to restrict the `caveats` to `--HEAD` installs.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
