### PR TITLE
maturin: fix python3 references

### DIFF
--- a/Formula/maturin.rb
+++ b/Formula/maturin.rb
@@ -25,10 +25,10 @@ class Maturin < Formula
   end
 
   test do
-    ENV.prepend_path "PATH", Formula["python@3.10"].opt_bin
+    python = Formula["python@3.10"].opt_bin/"python3.10"
     system "cargo", "new", "hello_world", "--bin"
     system bin/"maturin", "build", "-m", "hello_world/Cargo.toml", "-b", "bin", "-o", "dist", "--compatibility", "off"
-    system "python3", "-m", "pip", "install", "hello_world", "--no-index", "--find-links", testpath/"dist"
-    system "python3", "-m", "pip", "uninstall", "-y", "hello_world"
+    system python, "-m", "pip", "install", "hello_world", "--no-index", "--find-links", testpath/"dist"
+    system python, "-m", "pip", "uninstall", "-y", "hello_world"
   end
 end


### PR DESCRIPTION
See #108008

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
