### PR TITLE
speedtest-cli: fix test

### DIFF
--- a/Formula/speedtest-cli.rb
+++ b/Formula/speedtest-cli.rb
@@ -29,6 +29,9 @@ class SpeedtestCli < Formula
   end
 
   test do
-    system bin/"speedtest"
+    assert_match "speedtest-cli",
+                 shell_output(bin/"speedtest --version")
+    assert_match "Command line interface for testing internet bandwidth using speedtest.net",
+                 shell_output(bin/"speedtest --help")
   end
 end


### PR DESCRIPTION
Test fails with: ERROR: Unable to connect to servers to test latency.
I can reproduce this locally too, maybe upstreams servers are down / something has changed.
Note that I am on tethered connection on a phone right now, so this might explain the issue on my side.

Testing the version and help commands is probably enough here as we just make sure the python code
can be executed (there is only a single python file in this project), and avoids any fragile
connection to speedtest's servers

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
