### PR TITLE
unshield: fix build with encoding support

### DIFF
--- a/Formula/unshield.rb
+++ b/Formula/unshield.rb
@@ -4,6 +4,7 @@ class Unshield < Formula
   url "https://github.com/twogood/unshield/archive/1.5.1.tar.gz"
   sha256 "34cd97ff1e6f764436d71676e3d6842dc7bd8e2dd5014068da5c560fe4661f60"
   license "MIT"
+  revision 1
   head "https://github.com/twogood/unshield.git", branch: "master"
 
   bottle do
@@ -21,11 +22,13 @@ class Unshield < Formula
   uses_from_macos "zlib"
 
   def install
+    # cmake check for libiconv will miss the OS library without this hint
+    ENV.append "LDFLAGS", "-liconv" if OS.mac?
     system "cmake", ".", *std_cmake_args
     system "make", "install"
   end
 
   test do
-    system bin/"unshield", "-V"
+    system bin/"unshield", "-e", "sjis", "-V"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This fixes encoding support, which is missing without this patch.

Unshield supports translating earlier non-Unicode encodings to Unicode, but this optional feature requires building with `libiconv`. While macOS ships the appropriate library, the cmake check fails to pick it up without a hint that it needs to link to the `-liconv` library. I've tested and confirms it works; without this fix, attempting to use the `-e` flag exits immediately with the error "This version of Unshield is not built with encoding support.", while with this fix the encoding flag works.