### PR TITLE
singular 4.3.1p2

### DIFF
--- a/Formula/singular.rb
+++ b/Formula/singular.rb
@@ -1,10 +1,39 @@
 class Singular < Formula
   desc "Computer algebra system for polynomial computations"
   homepage "https://www.singular.uni-kl.de/"
-  url "https://www.singular.uni-kl.de/ftp/pub/Math/Singular/SOURCES/4-3-1/singular-4.3.1p1.tar.gz"
-  version "4.3.1p1"
-  sha256 "1f1cba3ffd612b26d056859ca7f4cbeef5ce95cabd5782b035acd1c58ff01d30"
+  url "https://www.singular.uni-kl.de/ftp/pub/Math/Singular/SOURCES/4-3-1/singular-4.3.1p2.tar.gz"
+  version "4.3.1p2"
+  sha256 "95814bba0f0bd0290cd9799ec1d2ecc6f4c8a4e6429d9a02eb7f9c4e5649682a"
   license "GPL-2.0-or-later"
+
+  livecheck do
+    url "https://www.singular.uni-kl.de/ftp/pub/Math/Singular/SOURCES/"
+    regex(%r{href=["']?v?(\d+(?:[.-]\d+)+)/?["' >]}i)
+    strategy :page_match do |page, regex|
+      # Match versions from directories
+      versions = page.scan(regex)
+                     .flatten
+                     .uniq
+                     .map { |v| Version.new(v.tr("-", ".")) }
+                     .reject { |v| v.patch >= 90 }
+                     .sort
+      next versions if versions.blank?
+
+      # Assume the last-sorted version is newest
+      newest_version = versions.last
+
+      # Fetch the page for the newest version directory
+      dir_page = Homebrew::Livecheck::Strategy.page_content(
+        URI.join(@url, "#{newest_version.to_s.tr(".", "-")}/"),
+      )
+      next versions if dir_page[:content].blank?
+
+      # Identify versions from files in the version directory
+      dir_versions = dir_page[:content].scan(/href=.*?singular[._-]v?(\d+(?:\.\d+)+(?:p\d+)?)\.t/i).flatten
+
+      dir_versions || versions
+    end
+  end
 
   bottle do
     sha256 arm64_monterey: "318d66e582a30a56b3174e2d951440ab97fa9258b3f45eb8a4ca2a15a6ae7a1e"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `singular` to the latest version, 4.3.1p2.

This PR also adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. Related tarball files are kept in versioned subdirectories, so we have to borrow some of the approach used in other `livecheck` blocks like `bash` (where we identify the newest version directory and then check that directory page for versions).

By default, livecheck checks the Git repository for versions but the previously-mentioned approach is necessary because upstream doesn't tag all versions (e.g., the newest tag is `Release-4-3-1` and there aren't tags for 4.3.1p1 or 4.3.1p2). The repository does contain some tags like `4-2-1p3` but they're not exhaustive with respect to what's available as a source tarball, so the Git tags are unfortunately an unreliable source of version information at the moment.