### PR TITLE
httpie: add completion

### DIFF
--- a/Formula/httpie.rb
+++ b/Formula/httpie.rb
@@ -3,8 +3,8 @@ class Httpie < Formula
 
   desc "User-friendly cURL replacement (command-line HTTP client)"
   homepage "https://httpie.io/"
-  url "https://files.pythonhosted.org/packages/e9/38/e94dac67b61f4dab49c1d26dd47e0b13be8c69c8c1c4fad5a4a87de1d647/httpie-3.2.1.tar.gz"
-  sha256 "c9c0032ca3a8d62492b7231b2dd83d94becf3b71baf8a4bbcd9ed1038537e3ec"
+  url "https://github.com/httpie/httpie/archive/refs/tags/3.2.1.tar.gz"
+  sha256 "803e1624e005c2f7002802a77ebc687b05375aca76af42639f844405328633eb"
   license "BSD-3-Clause"
   head "https://github.com/httpie/httpie.git", branch: "master"
 
@@ -92,6 +92,9 @@ class Httpie < Formula
     man1.install_symlink libexec/"share/man/man1/http.1"
     man1.install_symlink libexec/"share/man/man1/https.1"
     man1.install_symlink libexec/"share/man/man1/httpie.1"
+
+    bash_completion.install "extras/httpie-completion.bash" => "httpie"
+    fish_completion.install "extras/httpie-completion.fish" => "httpie.fish"
   end
 
   test do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -193,6 +193,7 @@
   "howdoi": {
     "exclude_packages": ["six"]
   },
+  "httpie": "httpie",
   "http-prompt": {
     "exclude_packages": ["six"]
   },


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Only the GitHub source includes the completion scripts, so I switched to that.