### PR TITLE
pyyaml 6.0 (new formula)

### DIFF
--- a/Formula/pyyaml.rb
+++ b/Formula/pyyaml.rb
@@ -1,0 +1,49 @@
+class Pyyaml < Formula
+  desc "YAML framework for Python"
+  homepage "https://pyyaml.org"
+  url "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz"
+  sha256 "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"
+  license "MIT"
+
+  depends_on "cython" => :build
+  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.8" => [:build, :test]
+  depends_on "python@3.9" => [:build, :test]
+  depends_on "libyaml"
+
+  def pythons
+    deps.select { |dep| dep.name.start_with?("python") }
+        .map(&:to_formula)
+        .sort_by(&:version)
+  end
+
+  def install
+    cythonize = Formula["cython"].bin/"cythonize"
+    system cythonize, "yaml/_yaml.pyx"
+    pythons.each do |python|
+      python_exe = python.opt_libexec/"bin/python"
+      system python_exe, *Language::Python.setup_install_args(prefix, python_exe)
+    end
+  end
+
+  def caveats
+    python_versions = pythons.map { |p| p.version.major_minor }
+                             .map(&:to_s)
+                             .join(", ")
+
+    <<~EOS
+      This formula provides the `yaml` module for Python #{python_versions}.
+      If you need `yaml` for a different version of Python, use pip.
+    EOS
+  end
+
+  test do
+    pythons.each do |python|
+      system python.opt_libexec/"bin/python", "-c", <<~EOS
+        import yaml
+        assert yaml.__with_libyaml__
+        assert yaml.dump({"foo": "bar"}) == "foo: bar\\n"
+      EOS
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We have almost 100 Python formulae that depend on [PyYAML](https://pyyaml.org). Although PyYAML does not provide an executable file, which appears to be the normal standard for inclusion, I would argue that it is widely used enough to merit its own formula, similar to `six`. ~~This pull request also modifies a handful of other formulae that were depending on their own PyYAML resource, changing them to depend on this formula instead. I'm happy to change which other formulae are included in this pull request, if requested; or to undo those changes so that this pull request only adds the new formula, instead of changing existing formulae.~~

This was discussed and rejected a few years ago in #19719, but I believe that the situation has changed enough that it's worth re-discussing this.