### PR TITLE
osrm-backend: use `tbb` for HEAD build

### DIFF
--- a/Formula/osrm-backend.rb
+++ b/Formula/osrm-backend.rb
@@ -1,11 +1,14 @@
 class OsrmBackend < Formula
   desc "High performance routing engine"
   homepage "http://project-osrm.org/"
-  url "https://github.com/Project-OSRM/osrm-backend/archive/v5.26.0.tar.gz"
-  sha256 "45e986db540324bd0fc881b746e96477b054186698e8d14610ff7c095e906dcd"
   license "BSD-2-Clause"
   revision 2
-  head "https://github.com/Project-OSRM/osrm-backend.git", branch: "master"
+
+  stable do
+    url "https://github.com/Project-OSRM/osrm-backend/archive/v5.26.0.tar.gz"
+    sha256 "45e986db540324bd0fc881b746e96477b054186698e8d14610ff7c095e906dcd"
+    depends_on "tbb@2020"
+  end
 
   livecheck do
     url :stable
@@ -21,27 +24,30 @@ class OsrmBackend < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1e78299d0601d9aefce6ba8d0597e256ae57dfc7890b88a9f03701e10155d08a"
   end
 
+  head do
+    url "https://github.com/Project-OSRM/osrm-backend.git", branch: "master"
+    depends_on "tbb"
+  end
+
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "libstxxl"
   depends_on "libxml2"
   depends_on "libzip"
   depends_on "lua"
-  depends_on "tbb@2020"
 
   conflicts_with "flatbuffers", because: "both install flatbuffers headers"
 
   def install
     lua = Formula["lua"]
     luaversion = lua.version.major_minor
-    mkdir "build" do
-      system "cmake", "..", "-DENABLE_CCACHE:BOOL=OFF",
-                            "-DLUA_INCLUDE_DIR=#{lua.opt_include}/lua#{luaversion}",
-                            "-DLUA_LIBRARY=#{lua.opt_lib}/#{shared_library("liblua", luaversion)}",
-                            *std_cmake_args
-      system "make"
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DENABLE_CCACHE:BOOL=OFF",
+                    "-DLUA_INCLUDE_DIR=#{lua.opt_include}/lua#{luaversion}",
+                    "-DLUA_LIBRARY=#{lua.opt_lib/shared_library("liblua", luaversion)}",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
     pkgshare.install "profiles"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream PR for `tbb` support: https://github.com/Project-OSRM/osrm-backend/pull/6300

Didn't try, but seemed unlikely to easily backport patch given last release was 1 year ago.