### PR TITLE
gcc@5 gcc@6 isl@0.18: deprecate

### DIFF
--- a/Formula/gcc@5.rb
+++ b/Formula/gcc@5.rb
@@ -6,11 +6,6 @@ class GccAT5 < Formula
   sha256 "530cea139d82fe542b358961130c69cfde8b3d14556370b65823d2f91f0ced87"
   revision 8
 
-  livecheck do
-    url :stable
-    regex(%r{href=.*?gcc[._-]v?(5(?:\.\d+)+)(?:/?["' >]|\.t)}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "a3e52eeea5f2dc3fa99e021ee2e06034efd5ad27ccc331e751cf7f92110c7434"
   end
@@ -18,6 +13,9 @@ class GccAT5 < Formula
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? only_if: :clt_installed
+
+  # https://gcc.gnu.org/gcc-5/
+  deprecate! date: "2022-09-09", because: :deprecated_upstream
 
   depends_on maximum_macos: [:high_sierra, :build]
 

--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -10,11 +10,6 @@ class GccAT6 < Formula
   ]
   revision 7
 
-  livecheck do
-    url :stable
-    regex(%r{href=.*?gcc[._-]v?(6(?:\.\d+)+)(?:/?["' >]|\.t)}i)
-  end
-
   bottle do
     rebuild 1
     sha256                               monterey:     "6c06fbf374a3d102b63992b16c4d4af3e1631db7a6b7a73663de40abdbee276f"
@@ -26,6 +21,9 @@ class GccAT6 < Formula
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? only_if: :clt_installed
+
+  # https://gcc.gnu.org/gcc-6/
+  deprecate! date: "2022-09-09", because: :deprecated_upstream
 
   depends_on arch: :x86_64
   depends_on "gmp"

--- a/Formula/isl@0.18.rb
+++ b/Formula/isl@0.18.rb
@@ -25,8 +25,7 @@ class IslAT018 < Formula
 
   keg_only :versioned_formula
 
-  # Commented out while this formula still has dependents.
-  # deprecate! date: "2020-11-05", because: :versioned_formula
+  deprecate! date: "2020-11-05", because: :versioned_formula
 
   depends_on "gmp"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Need confirmation if safe to deprecate `gcc@5` now, which is needed to re-deprecate `isl@0.18` (related to #106902).

Also considering deprecating `gcc@6` to reduce number of GCC formulae to get closer to our versioning requirement. GCC 6 seems to be least used of not-yet-deprecated but officially unsupported/unmaintained GCC versions (GCC 9 and older are no longer supported -- https://gcc.gnu.org/gcc-9/)

GCC formulae does still exceed our max of 5 versions by 1 (i.e. 7, 8, 9, 10, 11, unversioned/12).