### PR TITLE
libb64: revision bump to build with Ubuntu 22.04

### DIFF
--- a/Formula/libb64.rb
+++ b/Formula/libb64.rb
@@ -3,6 +3,7 @@ class Libb64 < Formula
   homepage "https://libb64.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/libb64/libb64/libb64/libb64-1.2.1.zip"
   sha256 "20106f0ba95cfd9c35a13c71206643e3fb3e46512df3e2efb2fdbf87116314b2"
+  revision 1
 
   bottle do
     rebuild 1


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
