### PR TITLE
awscli@1, remarshal: depend on pyyaml

### DIFF
--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -24,8 +24,8 @@ class AwscliAT1 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "libyaml" # for faster PyYAML
   depends_on "python@3.10"
+  depends_on "pyyaml"
   depends_on "six"
 
   uses_from_macos "groff"
@@ -58,11 +58,6 @@ class AwscliAT1 < Formula
   resource "python-dateutil" do
     url "https://files.pythonhosted.org/packages/4c/c4/13b4776ea2d76c115c1d1b84579f3764ee6d57204f6be27119f13a61d0a9/python-dateutil-2.8.2.tar.gz"
     sha256 "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
-  end
-
-  resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz"
-    sha256 "607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"
   end
 
   resource "rsa" do

--- a/Formula/remarshal.rb
+++ b/Formula/remarshal.rb
@@ -19,8 +19,8 @@ class Remarshal < Formula
   end
 
   depends_on "poetry" => :build
-  depends_on "libyaml" # for faster PyYAML
   depends_on "python@3.10"
+  depends_on "pyyaml"
   depends_on "six"
 
   conflicts_with "msgpack-tools", because: "both install 'json2msgpack' binary"
@@ -33,11 +33,6 @@ class Remarshal < Formula
   resource "python-dateutil" do
     url "https://files.pythonhosted.org/packages/4c/c4/13b4776ea2d76c115c1d1b84579f3764ee6d57204f6be27119f13a61d0a9/python-dateutil-2.8.2.tar.gz"
     sha256 "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
-  end
-
-  resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz"
-    sha256 "607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"
   end
 
   resource "tomlkit" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -32,7 +32,7 @@
     "exclude_packages": ["six"]
   },
   "awscli@1": {
-    "exclude_packages": ["six"]
+    "exclude_packages": ["six", "PyYAML"]
   },
   "awsume": {
     "exclude_packages": ["six"]

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -362,7 +362,7 @@
     "exclude_packages": ["tabulate"]
   },
   "remarshal": {
-    "exclude_packages": ["six"]
+    "exclude_packages": ["six", "PyYAML"]
   },
   "restview": {
     "exclude_packages": ["six"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Follow-up from #110106. These two formulae have comments specifically indicating that the only reason they depend on `libyaml` is to make PyYAML faster. These formulae should depend on the `pyyaml` formula instead.