### PR TITLE
ruby-install: add `xz` as a dependency.

### DIFF
--- a/Formula/ruby-install.rb
+++ b/Formula/ruby-install.rb
@@ -10,6 +10,8 @@ class RubyInstall < Formula
     sha256 cellar: :any_skip_relocation, all: "e0fe47d5a5ca9f84ffe59b40d48981341a0ab937342069d7f79c51dd4b95af0e"
   end
 
+  depends_on "xz"
+
   def install
     system "make", "install", "PREFIX=#{prefix}"
 


### PR DESCRIPTION
`ruby-install` now requires `xzcat` as a workaround to the fact that OpenBSD's `tar` does not support extracting `.xz` archives. `xzcat` does not come preinstalled on macOS, thus an explicit dependency on `xz` is required for macOS users.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?