### PR TITLE
dynare: use smaller test

### DIFF
--- a/Formula/dynare.rb
+++ b/Formula/dynare.rb
@@ -127,13 +127,13 @@ class Dynare < Formula
     io = resource("io")
     testpath.install statistics, io
 
-    cp lib/"dynare/examples/bkk.mod", testpath
+    cp lib/"dynare/examples/example1.mod", testpath
 
     (testpath/"dyn_test.m").write <<~EOS
       pkg prefix #{testpath}/octave
       pkg install io-#{io.version}.tar.gz
       pkg install statistics-#{statistics.version}.tar.gz
-      dynare bkk.mod console
+      dynare example1.mod console
     EOS
 
     system Formula["octave"].opt_bin/"octave", "--no-gui",


### PR DESCRIPTION
This is an attempt to fix the dynare test that has been failing since years now. The failures have been flacky, mostly due to numerical errors (nothing related to homebrew as far as I know).

The bkk.mod example has been in use since dynare has been added to homebrew-core in 2018. I think I have seen this test fail hundreds of times since then.

The latest failues have been:
error: The generalized Schur (QZ) decomposition failed. For more information, see the documentation for Lapack function dgges: info=38, n=36. You can also run model_diagnostics to get more information on what may cause this problem.

Some other errors popped up in the past.

Using example1 (which is described in the quick-start page of the dynare documentation) is probably enought to test dynare. I hope this test case is less prone to numerical errors.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
