### PR TITLE
task: make Linux headers dep build-only

### DIFF
--- a/Formula/task.rb
+++ b/Formula/task.rb
@@ -25,7 +25,7 @@ class Task < Formula
   depends_on "gnutls"
 
   on_linux do
-    depends_on "linux-headers@5.15"
+    depends_on "linux-headers@5.15" => :build
     depends_on "readline"
     depends_on "util-linux"
   end


### PR DESCRIPTION
It was noted in https://github.com/Homebrew/homebrew-core/pull/110084 that `linux-headers@5.15` was being declared as a run time dependency for `task` when it is almost certainly a build-only dependency, given that `linux-headers@5.15` doesn't provide any run time binaries.