### PR TITLE
stockfish: add comment about C++17

### DIFF
--- a/Formula/stockfish.rb
+++ b/Formula/stockfish.rb
@@ -21,7 +21,7 @@ class Stockfish < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a9f92ead9b38a5ffcac5fc72b052a6c63953c0cd057a142ffa7f8215cb7146c6"
   end
 
-  fails_with gcc: "5"
+  fails_with gcc: "5" # For C++17
 
   def install
     arch = Hardware::CPU.arm? ? "apple-silicon" : "x86-64-modern"


### PR DESCRIPTION
In https://github.com/Homebrew/homebrew-core/pull/110129 we removed the GCC dependency but also removed a comment indicating that it was specifically needed for C++17 support.  We should keep this comment in case we want to use  a block-style `fails_with` in the future explaining why a certain version of GCC is needed.