### PR TITLE
tarsnap-gui: remove unneeded fails_with

### DIFF
--- a/Formula/tarsnap-gui.rb
+++ b/Formula/tarsnap-gui.rb
@@ -20,8 +20,6 @@ class TarsnapGui < Formula
   depends_on "qt@5"
   depends_on "tarsnap"
 
-  fails_with gcc: "5" # qt@5 is built with GCC
-
   # Work around build error: Set: Entry, ":CFBundleGetInfoString", Does Not Exist
   # Issue ref: https://github.com/Tarsnap/tarsnap-gui/issues/557
   patch :DATA


### PR DESCRIPTION
As noted in https://github.com/Homebrew/homebrew-core/pull/110085, the `fails_with` statement here seems to indicate that the GCC dependency was only added due the the dependency explosion problem we've now resolved rather than because `tarsnap-gui` itself actually requires a newer C++ compiler.