### PR TITLE
onnxruntime: drop GCC dependency

### DIFF
--- a/Formula/onnxruntime.rb
+++ b/Formula/onnxruntime.rb
@@ -23,10 +23,6 @@ class Onnxruntime < Formula
   depends_on "cmake" => :build
   depends_on "python@3.10" => :build
 
-  on_linux do
-    depends_on "gcc"
-  end
-
   fails_with gcc: "5" # GCC version < 7 is no longer supported
 
   def install

--- a/Formula/onnxruntime.rb
+++ b/Formula/onnxruntime.rb
@@ -29,15 +29,14 @@ class Onnxruntime < Formula
     cmake_args = %W[
       -Donnxruntime_RUN_ONNX_TESTS=OFF
       -Donnxruntime_GENERATE_TEST_REPORTS=OFF
-      -DPYTHON_EXECUTABLE=#{Formula["python@3.10"].opt_bin}/python3
+      -DPYTHON_EXECUTABLE=#{which("python3.10")}
       -Donnxruntime_BUILD_SHARED_LIB=ON
       -Donnxruntime_BUILD_UNIT_TESTS=OFF
     ]
 
-    mkdir "build" do
-      system "cmake", "../cmake", *std_cmake_args, *cmake_args
-      system "make", "install"
-    end
+    system "cmake", "-S", "cmake", "-B", "build", *cmake_args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
