### PR TITLE
matplotplusplus: drop GCC dependency

### DIFF
--- a/Formula/matplotplusplus.rb
+++ b/Formula/matplotplusplus.rb
@@ -24,9 +24,7 @@ class Matplotplusplus < Formula
   depends_on "libtiff"
   depends_on "openexr"
 
-  on_linux do
-    depends_on "gcc"
-  end
+  uses_from_macos "zlib"
 
   fails_with :clang do
     build 1100


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
