### PR TITLE
magic_enum: drop GCC dependency

### DIFF
--- a/Formula/magic_enum.rb
+++ b/Formula/magic_enum.rb
@@ -11,11 +11,7 @@ class MagicEnum < Formula
 
   depends_on "cmake" => :build
 
-  on_linux do
-    depends_on "gcc" # C++17
-  end
-
-  fails_with gcc: "5"
+  fails_with gcc: "5" # C++17
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
