### PR TITLE
mimalloc 2.0.6

### DIFF
--- a/Formula/mimalloc.rb
+++ b/Formula/mimalloc.rb
@@ -1,9 +1,8 @@
 class Mimalloc < Formula
   desc "Compact general purpose allocator"
   homepage "https://github.com/microsoft/mimalloc"
-  # 2.x series is in beta and shouldn't be upgraded to until it's stable
-  url "https://github.com/microsoft/mimalloc/archive/refs/tags/v1.7.6.tar.gz"
-  sha256 "d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da"
+  url "https://github.com/microsoft/mimalloc/archive/refs/tags/v2.0.6.tar.gz"
+  sha256 "9f05c94cc2b017ed13698834ac2a3567b6339a8bde27640df5a1581d49d05ce5"
   license "MIT"
 
   livecheck do
@@ -23,11 +22,9 @@ class Mimalloc < Formula
   depends_on "cmake" => :build
 
   def install
-    mkdir "build" do
-      system "cmake", "..", *std_cmake_args, "-DMI_INSTALL_TOPLEVEL=ON"
-      system "make"
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build", "-DMI_INSTALL_TOPLEVEL=ON", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
     pkgshare.install "test"
   end
 

--- a/Formula/mold.rb
+++ b/Formula/mold.rb
@@ -4,6 +4,7 @@ class Mold < Formula
   url "https://github.com/rui314/mold/archive/v1.4.2.tar.gz"
   sha256 "47e6c48d20f49e5b47dfb8197dd9ffcb11a8833d614f7a03bd29741c658a69cd"
   license "AGPL-3.0-only"
+  revision 1
   head "https://github.com/rui314/mold.git", branch: "main"
 
   bottle do
@@ -24,7 +25,6 @@ class Mold < Formula
   end
 
   on_linux do
-    depends_on "gcc"
     depends_on "mimalloc"
     depends_on "openssl@1.1" # Uses CommonCrypto on macOS
   end


### PR DESCRIPTION
In https://github.com/Homebrew/homebrew-core/pull/110343, `mold` failed to build because it was searching for the unversioned sonames `libpthread.so` and `librt.so`.  These were removed in Ubuntu 22.04 because in newer versions of `glibc`, binaries should either link to unversioned static libraries `libpthread.a` and `librt.a`, or the versioned dynamic libraries `libpthread.so.0` and `librt.so.1`.  

Because `mimalloc` was built in Ubuntu 16.04 which still had the unversioned sonames, it references these now nonexistent files and passes them on to `mold`.  Simply revision bumping `mimalloc` so that it is built on Ubuntu 22.04 is sufficient to fix the problem - no changes are needed to the formula.