### PR TITLE
poetry: disable keyring in tests

### DIFF
--- a/Formula/poetry.rb
+++ b/Formula/poetry.rb
@@ -208,6 +208,8 @@ class Poetry < Formula
 
   test do
     ENV["LC_ALL"] = "en_US.UTF-8"
+    # The poetry add command would fail in CI when keyring is enabled
+    ENV["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
 
     assert_match version.to_s, shell_output("#{bin}/poetry --version")
     assert_match "Created package", shell_output("#{bin}/poetry new homebrew")


### PR DESCRIPTION
The tests would fail in CI when keyring is enabled

The `Failed to unlock the item!` error message in this pr https://github.com/Homebrew/homebrew-core/pull/109777#issuecomment-1241157933 is from https://github.com/jaraco/keyring/blob/977ed03677bb0602b91f005461ef3dddf01a49f6/keyring/backends/SecretService.py#L70-L74 or https://github.com/jaraco/keyring/blob/977ed03677bb0602b91f005461ef3dddf01a49f6/keyring/backends/libsecret.py#L59-L78

The tests probably don't need keyring, so disable it should be fine. 

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
