### PR TITLE
libsigc++: drop GCC dependency

### DIFF
--- a/Formula/libsigc++.rb
+++ b/Formula/libsigc++.rb
@@ -18,10 +18,7 @@ class Libsigcxx < Formula
   depends_on "ninja" => :build
   depends_on macos: :high_sierra # needs C++17
 
-  on_linux do
-    depends_on "m4" => :build
-    depends_on "gcc"
-  end
+  uses_from_macos "m4" => :build
 
   fails_with gcc: "5"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
