### PR TITLE
icu4c: update homepage url

### DIFF
--- a/Formula/icu4c.rb
+++ b/Formula/icu4c.rb
@@ -1,6 +1,6 @@
 class Icu4c < Formula
   desc "C/C++ and Java libraries for Unicode and globalization"
-  homepage "https://site.icu-project.org/home"
+  homepage "https://icu.unicode.org/home"
   url "https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-src.tgz"
   version "71.1"
   sha256 "67a7e6e51f61faf1306b6935333e13b2c48abd8da6d2f46ce6adca24b1e21ebf"


### PR DESCRIPTION
It looks like commit 9010e85a7cba0ebd7ec26fe8661e95eb76f4a8ff inadvertently reversed fe6a2fe. This commit restores the homepage url from the previous commit.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
