### PR TITLE
darcs: build with `ghc@8.10`

### DIFF
--- a/Formula/darcs.rb
+++ b/Formula/darcs.rb
@@ -15,7 +15,7 @@ class Darcs < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc" => :build
+  depends_on "ghc@8.10" => :build
   depends_on "gmp"
 
   uses_from_macos "ncurses"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

GHC 9.2 has too new of a `base`.

Current `darcs` has upper bound of `<4.16` (https://hackage.haskell.org/package/darcs) and causes build to fail

```
==> cabal v2-install --jobs=8 --max-backjumps=100000 --install-method=copy --installdir=/opt/homebrew/Cellar/darcs/2.16.5/bin
Error: cabal: Could not resolve dependencies:
[__0] trying: darcs-2.16.5 (user goal)
[__1] next goal: base (dependency of darcs)
[__1] rejecting: base-4.16.3.0/installed-4.16.3.0 (conflict: darcs =>
base>=4.10 && <4.16)
[__1] skipping: base-4.17.0.0, base-4.16.3.0, base-4.16.2.0, base-4.16.1.0,
base-4.16.0.0 (has the same characteristics that caused the previous version
to fail: excluded by constraint '>=4.10 && <4.16' from 'darcs')
[__1] rejecting: base-4.15.1.0, base-4.15.0.0, base-4.14.3.0, base-4.14.2.0,
base-4.14.1.0, base-4.14.0.0, base-4.13.0.0, base-4.12.0.0, base-4.11.1.0,
base-4.11.0.0, base-4.10.1.0, base-4.10.0.0, base-4.9.1.0, base-4.9.0.0,
base-4.8.2.0, base-4.8.1.0, base-4.8.0.0, base-4.7.0.2, base-4.7.0.1,
base-4.7.0.0, base-4.6.0.1, base-4.6.0.0, base-4.5.1.0, base-4.5.0.0,
base-4.4.1.0, base-4.4.0.0, base-4.3.1.0, base-4.3.0.0, base-4.2.0.2,
base-4.2.0.1, base-4.2.0.0, base-4.1.0.0, base-4.0.0.0, base-3.0.3.2,
base-3.0.3.1 (constraint from non-upgradeable package requires installed
instance)
[__1] fail (backjumping, conflict set: base, darcs)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: base, darcs
```