### PR TITLE
taskell: use brick<1 to fix build

### DIFF
--- a/Formula/taskell.rb
+++ b/Formula/taskell.rb
@@ -23,9 +23,16 @@ class Taskell < Formula
   uses_from_macos "zlib"
 
   def install
+    # Work around build failure from Brick v1 API.
+    # src/Taskell.hs:64:13: error:
+    #     Not in scope: 'Brick.continue'
+    #     Module 'Brick' does not export 'continue'.
+    # Issue ref: https://github.com/smallhadroncollider/taskell/issues/125
+    cabal_install_constraints = ["--constraint=brick<1"]
+
     system "hpack"
     system "cabal", "v2-update"
-    system "cabal", "v2-install", *std_cabal_v2_args
+    system "cabal", "v2-install", *std_cabal_v2_args, *cabal_install_constraints
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Reported upstream at https://github.com/smallhadroncollider/taskell/issues/125