### PR TITLE
echidna: build with `ghc@8.10`

### DIFF
--- a/Formula/echidna.rb
+++ b/Formula/echidna.rb
@@ -17,7 +17,7 @@ class Echidna < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "ghc" => :build
+  depends_on "ghc@8.10" => :build
   depends_on "haskell-stack" => :build
   depends_on "libtool" => :build
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
In the dependencies for indexed-traversable-instances-0.1:
    base-4.16.3.0 from stack configuration does not match >=4.5 && <4.16  (latest matching version
                  is 4.15.1.0)
needed due to echidna-2.0.3 -> indexed-traversable-instances-0.1

Some different approaches to resolving this:

  * Set 'allow-newer: true'
    in /private/tmp/echidna-20220912-22253-dw7qe8/echidna-2.0.3/.brew_home/.stack/config.yaml to ignore all version constraints and build anyway.

  * Build requires unattainable version of base. Since base is a part of GHC, you most likely need
    to use a different GHC version with the matching base.
```