### PR TITLE
elm: build with `ghc@8.10`

### DIFF
--- a/Formula/elm.rb
+++ b/Formula/elm.rb
@@ -17,7 +17,7 @@ class Elm < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc" => :build
+  depends_on "ghc@8.10" => :build
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently failing on `snap-server`, which has an open issue https://github.com/snapframework/snap-server/issues/148

```
==> cabal v2-install --jobs=8 --max-backjumps=100000 --install-method=copy --installdir=/opt/homebrew/Cellar/elm/0.19.1/bin
Error: cabal: Could not resolve dependencies:
[__0] trying: elm-0.19.1 (user goal)
[__1] trying: snap-server-1.1.2.0 (dependency of elm)
[__2] next goal: transformers (dependency of snap-server)
[__2] rejecting: transformers-0.5.6.2/installed-0.5.6.2 (conflict: snap-server
=> base>=4.6 && <4.16, transformers => base==4.16.3.0/installed-4.16.3.0)
[__2] rejecting: transformers-0.6.0.4 (conflict: snap-server =>
transformers>=0.3 && <0.6)
[__2] skipping: transformers-0.6.0.3, transformers-0.6.0.2 (has the same
characteristics that caused the previous version to fail: excluded by
constraint '>=0.3 && <0.6' from 'snap-server')
[__2] trying: transformers-0.5.6.2
[__3] trying: io-streams-1.5.2.2 (dependency of snap-server)
[__4] trying: primitive-0.7.4.0 (dependency of io-streams)
[__5] next goal: base (dependency of elm)
[__5] rejecting: base-4.16.3.0/installed-4.16.3.0 (conflict: snap-server =>
base>=4.6 && <4.16)
[__5] skipping: base-4.17.0.0, base-4.16.3.0, base-4.16.2.0, base-4.16.1.0,
base-4.16.0.0 (has the same characteristics that caused the previous version
to fail: excluded by constraint '>=4.6 && <4.16' from 'snap-server')
[__5] rejecting: base-4.15.1.0, base-4.15.0.0, base-4.14.3.0, base-4.14.2.0,
base-4.14.1.0, base-4.14.0.0, base-4.13.0.0, base-4.12.0.0, base-4.11.1.0,
base-4.11.0.0, base-4.10.1.0, base-4.10.0.0, base-4.9.1.0, base-4.9.0.0,
base-4.8.2.0, base-4.8.1.0, base-4.8.0.0, base-4.7.0.2, base-4.7.0.1,
base-4.7.0.0, base-4.6.0.1, base-4.6.0.0, base-4.5.1.0, base-4.5.0.0,
base-4.4.1.0, base-4.4.0.0, base-4.3.1.0, base-4.3.0.0, base-4.2.0.2,
base-4.2.0.1, base-4.2.0.0, base-4.1.0.0, base-4.0.0.0, base-3.0.3.2,
base-3.0.3.1 (constraint from non-upgradeable package requires installed
instance)
[__5] fail (backjumping, conflict set: base, elm, snap-server)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: snap-server, base, transformers,
monads-fd, primitive, vector-algorithms, enumerator, io-streams, elm
Try running with --minimize-conflict-set to improve the error message.
```