### PR TITLE
hadolint: build with `ghc@8.10`

### DIFF
--- a/Formula/hadolint.rb
+++ b/Formula/hadolint.rb
@@ -14,7 +14,7 @@ class Hadolint < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "80adffee09ee9cf1121b7d286871c6751806a8ce2b81115e77a106c4e27d3866"
   end
 
-  depends_on "ghc" => :build
+  depends_on "ghc@8.10" => :build
   depends_on "haskell-stack" => :build
 
   uses_from_macos "xz"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for colourista-0.1.0.1:
    base-4.16.3.0 from stack configuration does not match >=4.10.1.0 && <4.16  (latest matching
                  version is 4.15.1.0)
    ghc-prim-0.8.0 from stack configuration does not match >=0.5 && <0.8  (latest matching version
                   is 0.7.0)
needed due to hadolint-2.10.0 -> colourista-0.1.0.1

In the dependencies for spdx-1.0.0.2:
    Cabal-3.6.3.0 from stack configuration does not match ^>=2.4.0.1 || ^>=3.0.0.0 || ^>=3.2.0.0
                  (latest matching version is 3.2.1.0)
    base-4.16.3.0 from stack configuration does not match >=4.3.0.0 && <4.15  (latest matching
                  version is 4.14.3.0)
needed due to hadolint-2.10.0 -> spdx-1.0.0.2

Some different approaches to resolving this:

  * Set 'allow-newer: true'
    in /private/tmp/hadolint-20220912-35043-dtgcii/hadolint-2.10.0/.brew_home/.stack/config.yaml to ignore all version constraints and build anyway.

  * Build requires unattainable version of base. Since base is a part of GHC, you most likely need
    to use a different GHC version with the matching base.
```