### PR TITLE
hdf5: revision bump to build on Ubuntu 22.04

### DIFF
--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -4,7 +4,7 @@ class Hdf5 < Formula
   url "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.2/src/hdf5-1.12.2.tar.bz2"
   sha256 "1a88bbe36213a2cea0c8397201a459643e7155c9dc91e062675b3fb07ee38afe"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   version_scheme 1
 
   # This regex isn't matching filenames within href attributes (as we normally


### PR DESCRIPTION
On Linux, `hdf5` caches the `libdl.so` soname and passes it to `netcdf` and possibly other dependents at compile time.  Because `libdl.so` no longer exists on Ubuntu 22.04, this causes a build failure.  To resolve this `hdf5` must be revision bumped so it is built on Ubuntu 22.04.