### PR TITLE
mp3fs: revision bump for flac 1.4.0

### DIFF
--- a/Formula/mp3fs.rb
+++ b/Formula/mp3fs.rb
@@ -4,7 +4,7 @@ class Mp3fs < Formula
   url "https://github.com/khenriks/mp3fs/releases/download/v1.1.1/mp3fs-1.1.1.tar.gz"
   sha256 "942b588fb623ea58ce8cac8844e6ff2829ad4bc9b4c163bba58e3fa9ebc15608"
   license "GPL-3.0-or-later"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "b47a2250f894f7a92d828e26cdc0cb9f67e8ee9720c6af30e47cd03e8512f062"


### PR DESCRIPTION
This will need a revision bump after https://github.com/Homebrew/homebrew-core/pull/110113 is merged.