### PR TITLE
sfml, csfml: revision bump to build with Ubuntu 22.04

### DIFF
--- a/Formula/csfml.rb
+++ b/Formula/csfml.rb
@@ -5,6 +5,7 @@ class Csfml < Formula
   url "https://github.com/SFML/CSFML/archive/2.5.1.tar.gz"
   sha256 "0c6693805b700c53552565149405a041a00dbe898c2efb828e91999ab8b6b1d4"
   license "Zlib"
+  revision 1
   head "https://github.com/SFML/CSFML.git", branch: "master"
 
   bottle do

--- a/Formula/sfml.rb
+++ b/Formula/sfml.rb
@@ -5,7 +5,7 @@ class Sfml < Formula
   url "https://www.sfml-dev.org/files/SFML-2.5.1-sources.zip"
   sha256 "bf1e0643acb92369b24572b703473af60bac82caf5af61e77c063b779471bb7f"
   license "Zlib"
-  revision 1
+  revision 2
   head "https://github.com/SFML/SFML.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
These formulae need to be rebuilt with GCC 11 now that the `csfml` test is run with GCC 11.  No other changes are needed to the formulae.