### PR TITLE
opencolorio: fix `python3` references.

### DIFF
--- a/Formula/opencolorio.rb
+++ b/Formula/opencolorio.rb
@@ -22,10 +22,11 @@ class Opencolorio < Formula
   depends_on "python@3.10"
 
   def install
+    python3 = "python3.10"
     args = %W[
       -DCMAKE_INSTALL_RPATH=#{rpath}
-      -DPYTHON=python3
-      -DPYTHON_EXECUTABLE=#{Formula["python@3.10"].opt_bin}/"python3"
+      -DPYTHON=#{python3}
+      -DPYTHON_EXECUTABLE=#{which(python3)}
     ]
 
     system "cmake", "-S", ".", "-B", "macbuild", *args, *std_cmake_args


### PR DESCRIPTION
See #110462.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
