### PR TITLE
opencoarrays: add a test case to check the open-mpi version

### DIFF
--- a/Formula/opencoarrays.rb
+++ b/Formula/opencoarrays.rb
@@ -4,7 +4,7 @@ class Opencoarrays < Formula
   url "https://github.com/sourceryinstitute/OpenCoarrays/releases/download/2.10.0/OpenCoarrays-2.10.0.tar.gz"
   sha256 "c08717aea6ed5c68057f80957188a621b9862ad0e1460470e7ec82cdd84ae798"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://github.com/sourceryinstitute/opencoarrays.git", branch: "main"
 
   bottle do
@@ -51,5 +51,6 @@ class Opencoarrays < Formula
     EOS
     system "#{bin}/caf", "tally.f90", "-o", "tally"
     system "#{bin}/cafrun", "-np", "3", "--oversubscribe", "./tally"
+    assert_match Formula["open-mpi"].lib.realpath.to_s, shell_output("#{bin}/caf --show")
   end
 end


### PR DESCRIPTION
Closes #110650.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
