### PR TITLE
Disable old deprecated formula

### DIFF
--- a/Formula/bsponmpi.rb
+++ b/Formula/bsponmpi.rb
@@ -15,7 +15,7 @@ class Bsponmpi < Formula
   end
 
   # SConstruct is written in Python 2 but Homebrew `scons` is built for Python 3
-  deprecate! date: "2021-08-08", because: :does_not_build
+  disable! date: "2022-09-14", because: :does_not_build
 
   depends_on "scons" => :build
   depends_on :macos

--- a/Formula/docker-machine-driver-hyperkit.rb
+++ b/Formula/docker-machine-driver-hyperkit.rb
@@ -18,7 +18,7 @@ class DockerMachineDriverHyperkit < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:     "92bef33ec9ad5fbdfb887fcabe550603c886065c8ec3c677732a55f84a4c7520"
   end
 
-  deprecate! date: "2021-07-29", because: :unmaintained
+  disable! date: "2022-09-14", because: :unmaintained
 
   depends_on "go" => :build
   depends_on "docker-machine"

--- a/Formula/hardlink.rb
+++ b/Formula/hardlink.rb
@@ -18,7 +18,7 @@ class Hardlink < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b849b6cdc2d96380221c9dddc48a4c6485db0f4257ea7c48ade59b50e29f7bfd"
   end
 
-  deprecate! date: "2021-02-17", because: "has been merged into `util-linux`"
+  disable! date: "2022-09-14", because: "has been merged into `util-linux`"
 
   depends_on "pkg-config" => :build
   depends_on "gnu-getopt"

--- a/Formula/ironcli.rb
+++ b/Formula/ironcli.rb
@@ -17,7 +17,7 @@ class Ironcli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "65022e0f3c0a56a87bceb8bd8dd8d6a786b77d70c00c9170e5fc30e473a79264"
   end
 
-  deprecate! date: "2021-07-29", because: :unmaintained
+  disable! date: "2022-09-14", because: :unmaintained
 
   depends_on "dep" => :build
   depends_on "go" => :build

--- a/Formula/kestrel.rb
+++ b/Formula/kestrel.rb
@@ -16,7 +16,7 @@ class Kestrel < Formula
   end
 
   # See: https://github.com/twitter-archive/kestrel#status
-  deprecate! date: "2016-01-22", because: :deprecated_upstream
+  disable! date: "2022-09-14", because: :deprecated_upstream
 
   def install
     inreplace "scripts/kestrel.sh" do |s|

--- a/Formula/libgraphqlparser.rb
+++ b/Formula/libgraphqlparser.rb
@@ -16,7 +16,7 @@ class Libgraphqlparser < Formula
     sha256 cellar: :any, high_sierra:    "64779ec3108d9eef789d279abfafa90437c6a76b2ed3973d45979cd1051dc170"
   end
 
-  deprecate! date: "2020-04-20", because: "requires Python 2 to build"
+  disable! date: "2022-09-14", because: "requires Python 2 to build"
 
   depends_on "cmake" => :build
   depends_on :macos # Due to Python 2

--- a/Formula/modd.rb
+++ b/Formula/modd.rb
@@ -16,7 +16,7 @@ class Modd < Formula
   end
 
   # https://github.com/cortesi/modd/issues/96
-  deprecate! date: "2021-08-27", because: :unmaintained
+  disable! date: "2022-09-14", because: :unmaintained
 
   depends_on "go@1.16" => :build
 

--- a/Formula/opentsdb.rb
+++ b/Formula/opentsdb.rb
@@ -16,7 +16,7 @@ class Opentsdb < Formula
     sha256 cellar: :any_skip_relocation, high_sierra: "5bcdc828069e124c16e1e6c8b2eb6732d0ef88533c27f60fcbb0bec369aca375"
   end
 
-  deprecate! date: "2020-11-13", because: :does_not_build
+  disable! date: "2022-09-14", because: :does_not_build
 
   depends_on "gnuplot"
   depends_on "hbase"

--- a/Formula/vert.rb
+++ b/Formula/vert.rb
@@ -17,7 +17,7 @@ class Vert < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ed8cfcf0ce2cb0fcf0ad6bccea62e3726009131681e68c85e60d88b9135d10b6"
   end
 
-  deprecate! date: "2021-07-29", because: :unmaintained
+  disable! date: "2022-09-14", because: :unmaintained
 
   depends_on "dep" => :build
   depends_on "go" => :build


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I've re-used @SMillerDev's script for that. This takes into account the 3 month deprecation period.
