### PR TITLE
fonts-encodings 1.0.6 (new formula)

### DIFF
--- a/Formula/fonts-encodings.rb
+++ b/Formula/fonts-encodings.rb
@@ -1,0 +1,25 @@
+class FontsEncodings < Formula
+  desc "Font encoding tables for libfontenc"
+  homepage "https://gitlab.freedesktop.org/xorg/font/encodings"
+  url "https://www.x.org/archive/individual/font/encodings-1.0.6.tar.xz"
+  sha256 "77e301de661f35a622b18f60b555a7e7d8c4d5f43ed41410e830d5ac9084fc26"
+  license :public_domain
+
+  depends_on "font-util"   => :build
+  depends_on "mkfontscale" => :build
+  depends_on "util-macros" => :build
+
+  def install
+    configure_args = std_configure_args + %W[
+      --with-fontrootdir=#{share}/fonts/X11
+    ]
+
+    system "./configure", *configure_args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    assert_predicate share/"fonts/X11/encodings/encodings.dir", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Formula `libfontenc` has following issue:
```
$ cat main.c
#include <X11/fonts/fontenc.h>
#include <stdio.h>
int main(void) {
  puts(FontEncDirectory());
}
$ cc main.c -lfontenc && ./a.out
/usr/local/Cellar/font-util/1.3.3/share/fonts/X11/encodings/encodings.dir
$ [ -f $(./a.out) ]
$ echo $?
1
```
This formula provides this fonts data file.