### PR TITLE
Unthrottle `balena-cli` version bumps

### DIFF
--- a/Formula/balena-cli.rb
+++ b/Formula/balena-cli.rb
@@ -3,7 +3,6 @@ require "language/node"
 class BalenaCli < Formula
   desc "Command-line tool for interacting with the balenaCloud and balena API"
   homepage "https://www.balena.io/docs/reference/cli/"
-  # balena-cli should only be updated every 10 releases on multiples of 10
   url "https://registry.npmjs.org/balena-cli/-/balena-cli-14.3.0.tgz"
   sha256 "6b9ce0c55fa56d68c3aa41ceff1a0de41779ff5fa7794a34bb010c5166f69e82"
   license "Apache-2.0"

--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -1,7 +1,6 @@
 {
   "aws-sdk-cpp": 10,
   "awscli@1": 10,
-  "balena-cli": 10,
   "checkov": 15,
   "contentful-cli": 5,
   "gatsby-cli": 10,


### PR DESCRIPTION
Since the pace of `balena-cli` development has stabilized I propose to unthrottle its version bumps.

The latest (v14.3.1) was released on September 6th and hasn't been able to make its way into Homebrew. The second-latest (v14.3.0) was released on August 17th.
For reference, there have been 23 releases in the past 6 months, which is less than 1 release per week on average.

Cheers.

