### PR TITLE
gst-plugins-bad: Add fdk-aac as a dependency

### DIFF
--- a/Formula/gst-plugins-bad.rb
+++ b/Formula/gst-plugins-bad.rb
@@ -27,6 +27,7 @@ class GstPluginsBad < Formula
   depends_on "pkg-config" => :build
   depends_on "faac"
   depends_on "faad2"
+  depends_on "fdk-aac"
   depends_on "gettext"
   depends_on "gst-plugins-base"
   depends_on "jpeg-turbo"
@@ -64,6 +65,8 @@ class GstPluginsBad < Formula
   test do
     gst = Formula["gstreamer"].opt_bin/"gst-inspect-1.0"
     output = shell_output("#{gst} --plugin dvbsuboverlay")
+    assert_match version.to_s, output
+    output = shell_output("#{gst} --plugin fdkaac")
     assert_match version.to_s, output
   end
 end


### PR DESCRIPTION
This should get us the `fdkaacenc` element.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
