### PR TITLE
zlib: patch CVE-2022-37434

### DIFF
--- a/Formula/zlib.rb
+++ b/Formula/zlib.rb
@@ -7,6 +7,7 @@ class Zlib < Formula
   mirror "http://fresh-center.net/linux/misc/legacy/zlib-1.2.12.tar.gz"
   sha256 "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
   license "Zlib"
+  revision 1
   head "https://github.com/madler/zlib.git", branch: "develop"
 
   livecheck do
@@ -44,6 +45,20 @@ class Zlib < Formula
   patch do
     url "https://github.com/madler/zlib/commit/ec3df00224d4b396e2ac6586ab5d25f673caa4c2.patch?full_index=1"
     sha256 "c7d1cbb58b144c48b7fa8b52c57531e9fd80ab7d87c5d58ba76a9d33c12cb047"
+  end
+
+  # Patch for CVE-2022-37434
+  # Remove with the next release
+  patch do
+    url "https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1.patch?full_index=1"
+    sha256 "b6d631860d5d02e3261c0e5c06ba598fb82fa64995ba527861c6c18542eca05c"
+  end
+
+  # Amendment of the above patch to fix a segfault
+  # Remove with the next release
+  patch do
+    url "https://github.com/madler/zlib/commit/1eb7682f845ac9e9bf9ae35bbfb3bad5dacbd91d.patch?full_index=1"
+    sha256 "5483f1e4cad801bdaff948e1092f1e8de892e5ee817bf371c69a5d5f20d27b27"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
