### PR TITLE
Handle CI-skip-livecheck label

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,6 +177,13 @@ jobs:
               console.log('No CI-skip-recursive-dependents label found. Not passing --skip-recursive-dependents to brew test-bot.')
             }
 
+            if (label_names.includes('CI-skip-livecheck')) {
+              console.log('CI-skip-livecheck label found. Passing --skip-livecheck to brew test-bot.')
+              test_bot_formulae_args.push('--skip-livecheck')
+            } else {
+              console.log('No CI-skip-livecheck label found. Not passing --skip-livecheck to brew test-bot.')
+            }
+
             core.setOutput('test-bot-formulae-args', test_bot_formulae_args.join(" "))
             core.setOutput('test-bot-dependents-args', test_bot_dependents_args.join(" "))
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to Homebrew/homebrew-test-bot#839, where I introduced a `--skip-livecheck` option in test-bot. This PR modifies `workflows/tests.yml` to set this option when a PR has the `CI-skip-livecheck` label applied.