### PR TITLE
cmd/determine-rebottle-runners: use Ubuntu 22.04

### DIFF
--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -34,7 +34,7 @@ module Homebrew
     linux_runner_spec = {
       runner:    linux_runner,
       container: {
-        image:   "ghcr.io/homebrew/ubuntu16.04:master",
+        image:   "ghcr.io/homebrew/ubuntu22.04:master",
         options: "--user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED",
       },
       workdir:   "/github/home",


### PR DESCRIPTION
We missed updating the image used for this command from Ubuntu 16.04 to Ubuntu 22.04 so it's currently broken.