### PR TITLE
faudio: Remove caveats

### DIFF
--- a/Formula/faudio.rb
+++ b/Formula/faudio.rb
@@ -25,12 +25,6 @@ class Faudio < Formula
     end
   end
 
-  def caveats
-    <<~EOS
-      FAudio is built without FFmpeg support for decoding xWMA resources.
-    EOS
-  end
-
   test do
     (testpath/"test.c").write <<~EOS
       #include <FAudio.h>


### PR DESCRIPTION
faudio hasn’t used ffmpeg since 20.08, gst-libav backend was removed since 22.02

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
