### PR TITLE
libfontenc: fix `fontrootdir` reference

### DIFF
--- a/Formula/libfontenc.rb
+++ b/Formula/libfontenc.rb
@@ -4,6 +4,7 @@ class Libfontenc < Formula
   url "https://xorg.freedesktop.org/archive/individual/lib/libfontenc-1.1.6.tar.gz"
   sha256 "c103543a47ce5c0200fb1867f32df5e754a7c3ef575bf1fe72187117eac22a53"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "1702ab755edeefdc9cf36a96083102cad9f031db459d5d520013ba5e3d3a7d57"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
See #110677, `fontrootdir` is already fixed in #109228, just rebuild it with the new `fontrootdir`.