### PR TITLE
igraph: suite-sparse is not a dependency any more

### DIFF
--- a/Formula/igraph.rb
+++ b/Formula/igraph.rb
@@ -19,7 +19,6 @@ class Igraph < Formula
   depends_on "glpk"
   depends_on "gmp"
   depends_on "openblas"
-  depends_on "suite-sparse"
 
   uses_from_macos "libxml2"
 
@@ -42,7 +41,6 @@ class Igraph < Formula
                       "-DIGRAPH_GRAPHML_SUPPORT=ON",
                       "-DIGRAPH_USE_INTERNAL_ARPACK=OFF",
                       "-DIGRAPH_USE_INTERNAL_BLAS=OFF",
-                      "-DIGRAPH_USE_INTERNAL_CXSPARSE=OFF",
                       "-DIGRAPH_USE_INTERNAL_GLPK=OFF",
                       "-DIGRAPH_USE_INTERNAL_GMP=OFF",
                       "-DIGRAPH_USE_INTERNAL_LAPACK=OFF",


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

igraph 0.9.11 and earlier versions required suite-sparse as a dependency. From igraph 0.10, suite-sparse is not a dependency any more, but the Homebrew formula still declares it as a dependency incorrectly. This PR fixes the issue by removing suite-sparse from the list of dependencies.

Note that igraph 0.10.0 includes a vendored copy of CXSparse, a sparse matrix library that is part of suite-sparse, but it is patched to ensure that the size of integers in CXSparse matches the size of integers in igraph, even if igraph is forcibly compiled with 32-bit integers on 64-bit platforms. Therefore, a stock suite-sparse would not be suitable for linking to igraph even if there was an option to use an external CXSparse instance (which is now gone with version 0.10.0).
