### PR TITLE
terragrunt: remove `terraform` dependency.

### DIFF
--- a/Formula/terragrunt.rb
+++ b/Formula/terragrunt.rb
@@ -15,7 +15,6 @@ class Terragrunt < Formula
   end
 
   depends_on "go" => :build
-  depends_on "terraform"
 
   conflicts_with "tgenv", because: "tgenv symlinks terragrunt binaries"
 


### PR DESCRIPTION
We get lots of complaints about this dependency. See: #106362, #73326,
etc. The build doesn't need it, and our test doesn't make use of it.

Let's try removing it. If we get more complaints about its removal than
we did about it being there in the first place, then we can revert this.

See discussion at Homebrew/brew#13732.
