### PR TITLE
binutils: make keg-only on Linux too.

### DIFF
--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -16,7 +16,7 @@ class Binutils < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "efa7497e2ea56d9b68ce41363cdc1a41cad032b3ae2fa2cbe819459011651809"
   end
 
-  keg_only :shadowed_by_macos, "Apple's CLT provides the same tools"
+  keg_only "it shadows the host toolchain"
 
   uses_from_macos "bison" => :build
   uses_from_macos "zlib"


### PR DESCRIPTION
See discussion at #110877.

Note that the removal of `:shadowed_by_macos` now means that `brew link --force binutils` will work in `/usr/local` prefixes now too, when it previously did not.

If that is not desired, we can make two `keg_only` declarations in `on_macos` and `on_linux` blocks.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
