### PR TITLE
pyqt, pyqt@5: unify resource names with PyPI packages

### DIFF
--- a/Formula/pyqt.rb
+++ b/Formula/pyqt.rb
@@ -29,27 +29,27 @@ class Pyqt < Formula
     sha256 "6d87a3ee5872d7511b76957d68a32109352caf3b7a42a01d9ee20032b350d979"
   end
 
-  resource "3d" do
+  resource "PyQt6-3D" do
     url "https://files.pythonhosted.org/packages/79/bc/5e2c0919b787eb59346a13b0938ec00ea2223c4b7b882af44f31b8242e55/PyQt6_3D-6.3.0.tar.gz"
     sha256 "fab024b7fb3245d9b463029e0000f46cff95f0bdab603b875fabcaa53d9fe63f"
   end
 
-  resource "charts" do
+  resource "PyQt6-Charts" do
     url "https://files.pythonhosted.org/packages/b9/f7/669fdd84d0bbd18f1a3c01dff3bcdd12f866d01fa212cf05f2ffc06f5efb/PyQt6_Charts-6.3.1.tar.gz"
     sha256 "e6bbb17a3d5503508cb28a7b8f44dfedd659c43ff62adb64182a004fbd968f2f"
   end
 
-  resource "datavis" do
+  resource "PyQt6-DataVisualization" do
     url "https://files.pythonhosted.org/packages/6e/4d/281a11a6b2147167014285142d8dbfba8f8ac8d4de3dc8c8e7c66d152dbb/PyQt6_DataVisualization-6.3.1.tar.gz"
     sha256 "7509f24a84f92d127e17129ec18cb208f96bd3d12a0e4b6f57d57e955527ec34"
   end
 
-  resource "networkauth" do
+  resource "PyQt6-NetworkAuth" do
     url "https://files.pythonhosted.org/packages/3c/75/64bd1f9c9ff50f28e3b5e6938d10b82ee10f9669c1e140ad08b9aec8e7a9/PyQt6_NetworkAuth-6.3.0.tar.gz"
     sha256 "b1434b349e0820649341accf78689e9efd2c73543ed7d5474f660aaea2708454"
   end
 
-  resource "webengine" do
+  resource "PyQt6-WebEngine" do
     url "https://files.pythonhosted.org/packages/90/99/59acbe75fb0ad284945d27e40f68c642850c7a186bfc9cc338c3f638d0dc/PyQt6_WebEngine-6.3.1.tar.gz"
     sha256 "c3d1f5527b4b15f44102d617c59b1d74d9af50f821629e9335f13df47de8f007"
   end
@@ -77,7 +77,7 @@ class Pyqt < Formula
     resources.each do |r|
       next if r.name == "PyQt6-sip"
       # Don't build WebEngineCore bindings on macOS if the SDK is too old to have built qtwebengine in qt.
-      next if r.name == "webengine" && OS.mac? && DevelopmentTools.clang_build_version <= 1200
+      next if r.name == "PyQt6-WebEngine" && OS.mac? && DevelopmentTools.clang_build_version <= 1200
 
       r.stage do
         inreplace "pyproject.toml", "[tool.sip.project]",

--- a/Formula/pyqt@5.rb
+++ b/Formula/pyqt@5.rb
@@ -21,10 +21,6 @@ class PyqtAT5 < Formula
   depends_on "sip"          => :build
   depends_on "qt@5"
 
-  on_linux do
-    depends_on "gcc"
-  end
-
   fails_with gcc: "5"
 
   # extra components
@@ -33,32 +29,32 @@ class PyqtAT5 < Formula
     sha256 "b4710fd85b57edef716cc55fae45bfd5bfac6fc7ba91036f1dcc3f331ca0eb39"
   end
 
-  resource "3d" do
+  resource "PyQt3D" do
     url "https://files.pythonhosted.org/packages/44/af/58684ce08013c0e16839662844b29cd73259a909982c4d6517ce5ffda05f/PyQt3D-5.15.5.tar.gz"
     sha256 "c025e8a2de12a27e3bd34671d01cac39f78305128cc6cea3f0ba99e4ca3ec41b"
   end
 
-  resource "chart" do
+  resource "PyQtChart" do
     url "https://files.pythonhosted.org/packages/eb/17/1d9bb859b3e09a06633264ad91249ede0abd68c1e3f2f948ae7df94702d3/PyQtChart-5.15.6.tar.gz"
     sha256 "2691796fe92a294a617592a5c5c35e785dc91f7759def9eb22da79df63762339"
   end
 
-  resource "datavis" do
+  resource "PyQtDataVisualization" do
     url "https://files.pythonhosted.org/packages/9c/ff/6ba767b4e1dbc32c7ffb93cd5d657048f6a4edf318c5b8810c8931a1733b/PyQtDataVisualization-5.15.5.tar.gz"
     sha256 "8927f8f7aa70857ef00c51e3dfbf6f83dd9f3855f416e0d531592761cbb9dc7f"
   end
 
-  resource "networkauth" do
+  resource "PyQtNetworkAuth" do
     url "https://files.pythonhosted.org/packages/85/b6/6b8f30ebd7c15ded3d91ed8d6082dee8aebaf79c4e8d5af77b1172c805c2/PyQtNetworkAuth-5.15.5.tar.gz"
     sha256 "2230b6f56f4c9ad2e88bf5ac648e2f3bee9cd757550de0fb98fe0bcb31217b16"
   end
 
-  resource "webengine" do
+  resource "PyQtWebEngine" do
     url "https://files.pythonhosted.org/packages/cf/4b/ca01d875eff114ba5221ce9311912fbbc142b7bb4cbc4435e04f4f1f73cb/PyQtWebEngine-5.15.6.tar.gz"
     sha256 "ae241ef2a61c782939c58b52c2aea53ad99b30f3934c8358d5e0a6ebb3fd0721"
   end
 
-  resource "purchasing" do
+  resource "PyQtPurchasing" do
     url "https://files.pythonhosted.org/packages/41/2a/354f0ae3fa02708719e2ed6a8c310da4283bf9a589e2a7fcf7dadb9638af/PyQtPurchasing-5.15.5.tar.gz"
     sha256 "8bb1df553ba6a615f8ec3d9b9c5270db3e15e831a6161773dabfdc1a7afe4834"
   end
@@ -70,7 +66,7 @@ class PyqtAT5 < Formula
   end
 
   def install
-    components = %w[3d chart datavis networkauth purchasing webengine]
+    components = %w[PyQt3D PyQtChart PyQtDataVisualization PyQtNetworkAuth PyQtWebEngine PyQtPurchasing]
 
     pythons.each do |python|
       site_packages = prefix/Language::Python.site_packages(python)


### PR DESCRIPTION
This makes it easier to do vulnerability scanning on these dependencies, and is consistent with how all other PyPI resources in Python formulae are named.

I haven't run the build or tests locally yet, since they're pretty heavy.

Signed-off-by: William Woodruff <william@yossarian.net>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
