### PR TITLE
tesseract: drop GCC dependency

### DIFF
--- a/Formula/tesseract.rb
+++ b/Formula/tesseract.rb
@@ -27,10 +27,6 @@ class Tesseract < Formula
   depends_on "leptonica"
   depends_on "libarchive"
 
-  on_linux do
-    depends_on "gcc"
-  end
-
   fails_with gcc: "5"
 
   resource "eng" do


### PR DESCRIPTION
How do we feel about skipping dependent testing altogether for these PRs to drop GCC to avoid needing `long build`?  It's clear by now that this change alone causes no breakage of dependents on Linux.  I think we've also also already built enough bottles with Xcode 14 to know that if merely rebuilding with it broke dependents, we would probably have seen something unless it was very formula-specific.