### PR TITLE
vim: depend on libsodium

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -5,7 +5,7 @@ class Vim < Formula
   url "https://github.com/vim/vim/archive/v9.0.0350.tar.gz"
   sha256 "36c211d34beb734fa322975daa170868d7172b1a5f9605257d532cebf956f708"
   license "Vim"
-  revision 1
+  revision 2
   head "https://github.com/vim/vim.git", branch: "master"
 
   # The Vim repository contains thousands of tags and the `Git` strategy isn't
@@ -27,6 +27,7 @@ class Vim < Formula
   end
 
   depends_on "gettext"
+  depends_on "libsodium"
   depends_on "lua"
   depends_on "ncurses"
   depends_on "perl"


### PR DESCRIPTION
I've tested this and it includes libsodium and successfully enables the sodium feature.  It can successfully read and write xchacha20 encrypted text files.  I tested the formula and it does bring in libsodium before compiling.

This will enable encryption with the optional xchacha20 cryptmethod.

Bumped revision number for vim formula

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
