### PR TITLE
x86_64-linux-gnu-binutils: improve test.

### DIFF
--- a/Formula/x86_64-linux-gnu-binutils.rb
+++ b/Formula/x86_64-linux-gnu-binutils.rb
@@ -25,6 +25,11 @@ class X8664LinuxGnuBinutils < Formula
     keg_only "it conflicts with `binutils`"
   end
 
+  resource "homebrew-sysroot" do
+    url "https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain/2028cdaf24259d23adcff95393b8cc4f0eef714b/debian_bullseye_amd64_sysroot.tar.xz"
+    sha256 "1be60e7c456abc590a613c64fab4eac7632c81ec6f22734a61b53669a4407346"
+  end
+
   def install
     ENV.cxx11
 
@@ -54,10 +59,20 @@ class X8664LinuxGnuBinutils < Formula
     assert_match "f()", shell_output("#{bin}/x86_64-linux-gnu-c++filt _Z1fv")
     return if OS.linux?
 
+    (testpath/"sysroot").install resource("homebrew-sysroot")
     (testpath/"hello.c").write <<~EOS
-      void hello() {}
+      #include <stdio.h>
+      int main() { printf("hello!\\n"); }
     EOS
-    system ENV.cc, "--target=x86_64-pc-linux-gnu", "-c", "hello.c"
-    assert_match "hello", shell_output("#{bin}/x86_64-linux-gnu-nm hello.o")
+
+    ENV.remove_macosxsdk
+    system ENV.cc, "-v", "--target=x86_64-pc-linux-gnu", "--sysroot=#{testpath}/sysroot", "-c", "hello.c"
+    assert_match "main", shell_output("#{bin}/x86_64-linux-gnu-nm hello.o")
+
+    system ENV.cc, "-v", "--target=x86_64-pc-linux-gnu", "--sysroot=#{testpath}/sysroot",
+                   "-fuse-ld=#{bin}/x86_64-linux-gnu-ld", "hello.o", "-o", "hello"
+    assert_match "ELF", shell_output("file ./hello")
+    assert_match "libc.so", shell_output("#{bin}/x86_64-linux-gnu-readelf -d ./hello")
+    system bin/"x86_64-linux-gnu-strip", "./hello"
   end
 end


### PR DESCRIPTION
Let's improve the test by actually trying to link something. This is
based on feedback from #108421.

The binary produced using this test (with, e.g. `brew test --keep-tmp`)
can be copied into a Docker container and successfully executed.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
