### PR TITLE
sysbench: enable postgres support

### DIFF
--- a/Formula/sysbench.rb
+++ b/Formula/sysbench.rb
@@ -4,7 +4,7 @@ class Sysbench < Formula
   url "https://github.com/akopytov/sysbench/archive/1.0.20.tar.gz"
   sha256 "e8ee79b1f399b2d167e6a90de52ccc90e52408f7ade1b9b7135727efe181347f"
   license "GPL-2.0-or-later"
-  revision 2
+  revision 3
   head "https://github.com/akopytov/sysbench.git", branch: "master"
 
   bottle do
@@ -20,7 +20,8 @@ class Sysbench < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "luajit-openresty"
+  depends_on "libpq"
+  depends_on "luajit"
   depends_on "mysql-client"
   depends_on "openssl@1.1"
 
@@ -28,7 +29,7 @@ class Sysbench < Formula
 
   def install
     system "./autogen.sh"
-    system "./configure", *std_configure_args, "--with-mysql", "--with-system-luajit"
+    system "./configure", *std_configure_args, "--with-mysql", "--with-pgsql", "--with-system-luajit"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Add Postgresql support to `sysbench`, and once we're here, switch dependency to `luajit`.