### PR TITLE
gdal: disable OpenCL on Apple silicon

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -4,6 +4,7 @@ class Gdal < Formula
   url "http://download.osgeo.org/gdal/3.5.2/gdal-3.5.2.tar.xz"
   sha256 "0874dfdeb9ac42e53c37be4184b19350be76f0530e1f4fa8004361635b9030c2"
   license "MIT"
+  revision 1
 
   livecheck do
     url "https://download.osgeo.org/gdal/CURRENT/"
@@ -150,7 +151,7 @@ class Gdal < Formula
 
     if OS.mac?
       args << "--with-curl=/usr/bin/curl-config"
-      args << "--with-opencl"
+      args << (Hardware::CPU.arm? ? "--without-opencl" : "--with-opencl")
     else
       args << "--with-curl=#{Formula["curl"].opt_bin}/curl-config"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

GDAL's resampling methods produce incorrect results when OpenCL is used on Apple silicon - see OSGeo/gdal#4754. Until that's fixed I suggest we should disable OpenCL on MacOS/ARM.