### PR TITLE
qt: disable SQLite driver check on Linux.

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -322,7 +322,9 @@ class Qt < Formula
         delete handler; handler = nullptr;
         auto *root = new Qt3DCore::QEntity();
         delete root; root = nullptr;
+        #ifdef __APPLE__
         Q_ASSERT(QSqlDatabase::isDriverAvailable("QSQLITE"));
+        #endif
         const auto &list = QImageReader::supportedImageFormats();
         for(const char* fmt:{"bmp", "cur", "gif",
           #ifdef __APPLE__


### PR DESCRIPTION
This part of the test is failing at #106925. Let's just skip this
assertion on Linux to allow bottling of Qt on Linux ASAP after LLVM is
merged.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
