### PR TITLE
synced_versions_formulae: remove `glib-utils`.

### DIFF
--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -26,7 +26,6 @@
   ["gdb", "i386-elf-gdb", "x86_64-elf-gdb"],
   ["ghz", "ghz-web"],
   ["git", "git-credential-libsecret", "git-gui", "git-svn"],
-  ["glib", "glib-utils"],
   ["hdf5", "hdf5-mpi"],
   ["ilmbase", "openexr@2"],
   ["libexosip", "libosip"],


### PR DESCRIPTION
`glib-utils` was removed in #108307.
