### PR TITLE
cpansearch: depend on `pcre` on macOS.

### DIFF
--- a/Formula/cpansearch.rb
+++ b/Formula/cpansearch.rb
@@ -24,6 +24,10 @@ class Cpansearch < Formula
 
   uses_from_macos "curl"
 
+  on_macos do
+    depends_on "pcre"
+  end
+
   def install
     unless OS.mac?
       # Help find some ncursesw headers


### PR DESCRIPTION
The existing macOS bottles have linkage with `pcre`, which is in this
formula's dependency tree through `glib`.

The `pcre` dependency will be removed from `glib` in #111019, so that will result in
broken linkage for new installs. Let's avoid that by adding the
appropriate dependency.

This fixes a test failure in #111019.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
