### PR TITLE
r: depend on `pcre`.

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -27,7 +27,7 @@ class R < Formula
   depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "openblas"
-  depends_on "pcre2"
+  depends_on "pcre"
   depends_on "readline"
   depends_on "tcl-tk"
   depends_on "xz"


### PR DESCRIPTION
This links with `pcre` and not `pcre2`. It currently has `pcre` in its
dependency tree through `glib`, but that will be removed in #111019.

Fixes a test failure in #111019.
