### PR TITLE
gtk+: deprecate

### DIFF
--- a/Formula/gtk+.rb
+++ b/Formula/gtk+.rb
@@ -38,6 +38,9 @@ class Gtkx < Formula
     depends_on "libtool" => :build
   end
 
+  # https://blog.gtk.org/2020/12/16/gtk-4-0/
+  deprecate! date: "2022-09-18", because: :unmaintained
+
   depends_on "gobject-introspection" => :build
   depends_on "pkg-config" => :build
   depends_on "atk"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

> It does mean, however, that GTK 2 has reached the end of its life. We will do one final 2.x release in the coming days, and we encourage everybody to port their GTK 2 applications to GTK 3 or 4.

https://blog.gtk.org/2020/12/16/gtk-4-0/