### PR TITLE
z3: build with CMake.

### DIFF
--- a/Formula/z3.rb
+++ b/Formula/z3.rb
@@ -22,24 +22,38 @@ class Z3 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "19fea9a2eade95898190d751a651886b973591ec9f2e0e8ad327cd8abf75a607"
   end
 
+  depends_on "cmake" => :build
   # Has Python bindings but are supplementary to the main library
   # which does not need Python.
-  depends_on "python@3.10" => :build
+  depends_on "python@3.10" => [:build, :test]
 
   fails_with gcc: "5"
 
-  def install
-    python3 = Formula["python@3.10"].opt_bin/"python3.10"
-    system python3, "scripts/mk_make.py",
-                     "--prefix=#{prefix}",
-                     "--python",
-                     "--pypkgdir=#{prefix/Language::Python.site_packages(python3)}",
-                     "--staticlib"
+  def python3
+    which("python3.10")
+  end
 
-    cd "build" do
-      system "make"
-      system "make", "install"
-    end
+  def install
+    # LTO on Intel Monterey produces segfaults.
+    do_lto = MacOS.version != :monterey || Hardware::CPU.arm?
+    args = %W[
+      -DZ3_LINK_TIME_OPTIMIZATION=#{do_lto ? "ON" : "OFF"}
+      -DZ3_INCLUDE_GIT_DESCRIBE=OFF
+      -DZ3_INCLUDE_GIT_HASH=OFF
+      -DZ3_INSTALL_PYTHON_BINDINGS=ON
+      -DZ3_BUILD_EXECUTABLE=ON
+      -DZ3_BUILD_TEST_EXECUTABLES=OFF
+      -DZ3_BUILD_PYTHON_BINDINGS=ON
+      -DZ3_BUILD_DOTNET_BINDINGS=OFF
+      -DZ3_BUILD_JAVA_BINDINGS=OFF
+      -DZ3_USE_LIB_GMP=OFF
+      -DPYTHON_EXECUTABLE=#{python3}
+      -DCMAKE_INSTALL_PYTHON_PKG_DIR=#{Language::Python.site_packages(python3)}
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
 
     system "make", "-C", "contrib/qprofdiff"
     bin.install "contrib/qprofdiff/qprofdiff"
@@ -48,8 +62,9 @@ class Z3 < Formula
   end
 
   test do
-    system ENV.cc, pkgshare/"examples/c/test_capi.c",
-           "-I#{include}", "-L#{lib}", "-lz3", "-o", testpath/"test"
+    system ENV.cc, pkgshare/"examples/c/test_capi.c", "-I#{include}",
+                   "-L#{lib}", "-lz3", "-o", testpath/"test"
     system "./test"
+    assert_equal version.to_s, shell_output("#{python3} -c 'import z3; print(z3.get_version_string())'").strip
   end
 end


### PR DESCRIPTION
Upstream recommends [using CMake](https://github.com/Z3Prover/z3#building-z3-using-cmake) to build Z3. This is also the way
other distros (e.g. Arch, Debian, Fedora, Gentoo) build their respective
Z3 packages.

Finally, building with only Python creates only an unversioned
`libz3.dylib`, whereas building with CMake creates a versioned one (e.g.
`libz3.4.11.dylib`), which we need for `brew linkage --test` to work.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
