### PR TITLE
nagios: fix postinstall to replace only nagios_user directive

### DIFF
--- a/Formula/nagios.rb
+++ b/Formula/nagios.rb
@@ -82,10 +82,10 @@ class Nagios < Formula
     (var/"lib/nagios/rw").mkpath
 
     config = etc/"nagios/nagios.cfg"
-    return unless File.exist?(config)
-    return if File.read(config).include?(ENV["USER"])
+    return unless config.exist?
+    return if config.read.include?("nagios_user=#{ENV["USER"]}")
 
-    inreplace config, "brew", ENV["USER"]
+    inreplace config, /^nagios_user=.*/, "nagios_user=#{ENV["USER"]}"
   end
 
   def caveats


### PR DESCRIPTION
Fixes: #111110

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
