### PR TITLE
various formulae: add reminder to remove outdated workaround.

### DIFF
--- a/Formula/deno.rb
+++ b/Formula/deno.rb
@@ -1,6 +1,7 @@
 class Deno < Formula
   desc "Secure runtime for JavaScript and TypeScript"
   homepage "https://deno.land/"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://github.com/denoland/deno/releases/download/v1.25.3/deno_src.tar.gz"
   sha256 "b20a5a223aae4c654e9a1f5e1c5efd7aed2162d4863e2d3fb7ac271ef3f7d2d8"
   license "MIT"

--- a/Formula/grokj2k.rb
+++ b/Formula/grokj2k.rb
@@ -1,6 +1,7 @@
 class Grokj2k < Formula
   desc "JPEG 2000 Library"
   homepage "https://github.com/GrokImageCompression/grok"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://github.com/GrokImageCompression/grok/archive/v9.7.1.tar.gz"
   sha256 "a7d433dca92b035349ef8203eb44cb6d0b2c9b41aecd2d12872a9ca2761e0606"
   license "AGPL-3.0-or-later"

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -1,6 +1,7 @@
 class Grpc < Formula
   desc "Next generation open source RPC library and framework"
   homepage "https://grpc.io/"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://github.com/grpc/grpc.git",
       tag:      "v1.49.0",
       revision: "8f8edfd04b46ee67f90454b3f6a70aa58ff82c2d"

--- a/Formula/mold.rb
+++ b/Formula/mold.rb
@@ -1,6 +1,7 @@
 class Mold < Formula
   desc "Modern Linker"
   homepage "https://github.com/rui314/mold"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://github.com/rui314/mold/archive/v1.4.2.tar.gz"
   sha256 "47e6c48d20f49e5b47dfb8197dd9ffcb11a8833d614f7a03bd29741c658a69cd"
   license "AGPL-3.0-only"

--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -1,6 +1,7 @@
 class Node < Formula
   desc "Platform built on V8 to build network applications"
   homepage "https://nodejs.org/"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://nodejs.org/dist/v18.9.0/node-v18.9.0.tar.xz"
   sha256 "c75cc89afead976791900accde02a7b1e7e762702f0f6fa68eaacb01984d9654"
   license "MIT"

--- a/Formula/pdnsrec.rb
+++ b/Formula/pdnsrec.rb
@@ -1,6 +1,7 @@
 class Pdnsrec < Formula
   desc "Non-authoritative/recursing DNS server"
   homepage "https://www.powerdns.com/recursor.html"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://downloads.powerdns.com/releases/pdns-recursor-4.7.2.tar.bz2"
   sha256 "bdb4190790fe759778d6f0515afbbcc0a28b3e7e1b83c570caaf38419d57820d"
   license "GPL-2.0-only"

--- a/Formula/poac.rb
+++ b/Formula/poac.rb
@@ -1,6 +1,7 @@
 class Poac < Formula
   desc "Package manager for C++"
   homepage "https://github.com/poacpm/poac"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://github.com/poacpm/poac/archive/refs/tags/0.4.1.tar.gz"
   sha256 "3717a873120a7125fcdcc99227f5c7d42c4e170f7572feee19ab458d657f9451"
   license "Apache-2.0"

--- a/Formula/snappy.rb
+++ b/Formula/snappy.rb
@@ -1,6 +1,7 @@
 class Snappy < Formula
   desc "Compression/decompression library aiming for high speed"
   homepage "https://google.github.io/snappy/"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://github.com/google/snappy/archive/1.1.9.tar.gz"
   sha256 "75c1fbb3d618dd3a0483bff0e26d0a92b495bbe5059c8b4f1c962b478b6e06e7"
   license "BSD-3-Clause"

--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -2,6 +2,7 @@ class V8 < Formula
   desc "Google's JavaScript engine"
   homepage "https://github.com/v8/v8/wiki"
   # Track V8 version from Chrome stable: https://omahaproxy.appspot.com
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://github.com/v8/v8/archive/10.2.154.4.tar.gz"
   sha256 "6f4865ffe499f51da3e422cf7e4d85d3dab1b0a99b2d5bf204910ce423505597"
   license "BSD-3-Clause"

--- a/Formula/vte3.rb
+++ b/Formula/vte3.rb
@@ -1,6 +1,7 @@
 class Vte3 < Formula
   desc "Terminal emulator widget used by GNOME terminal"
   homepage "https://wiki.gnome.org/Apps/Terminal/VTE"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://download.gnome.org/sources/vte/0.68/vte-0.68.0.tar.xz"
   sha256 "13e7d4789ca216a33780030d246c9b13ddbfd04094c6316eea7ff92284dd1749"
   license "LGPL-2.0-or-later"

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -1,6 +1,7 @@
 class Vtk < Formula
   desc "Toolkit for 3D computer graphics, image processing, and visualization"
   homepage "https://www.vtk.org/"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   license "BSD-3-Clause"
   revision 6
   head "https://gitlab.kitware.com/vtk/vtk.git", branch: "master"

--- a/Formula/vtk@8.2.rb
+++ b/Formula/vtk@8.2.rb
@@ -1,6 +1,7 @@
 class VtkAT82 < Formula
   desc "Toolkit for 3D computer graphics, image processing, and visualization"
   homepage "https://www.vtk.org/"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://www.vtk.org/files/release/8.2/VTK-8.2.0.tar.gz"
   sha256 "34c3dc775261be5e45a8049155f7228b6bd668106c72a3c435d95730d17d57bb"
   license "BSD-3-Clause"

--- a/Formula/xgboost.rb
+++ b/Formula/xgboost.rb
@@ -1,6 +1,7 @@
 class Xgboost < Formula
   desc "Scalable, Portable and Distributed Gradient Boosting Library"
   homepage "https://xgboost.ai/"
+  # TODO: Remove `ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib` at rebuild.
   url "https://github.com/dmlc/xgboost.git",
       tag:      "v1.6.2",
       revision: "b9934246faa9a25e10a12339685dfbe56d56f70b"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The
```ruby
ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_bin
```
workaround is no longer needed after #106925.

Some of these formulae are expensive to run in CI, so let's delay removing it until we actually have to run them. I've left a reminder in a comment to remove the workaround the next time these formulae are rebuilt.
