### PR TITLE
libav sdl_rtf (disabled): migrate `sdl` to `sdl12-compat`

### DIFF
--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -32,7 +32,7 @@ class Libav < Formula
   depends_on "libvorbis"
   depends_on "libvpx"
   depends_on "opus"
-  depends_on "sdl"
+  depends_on "sdl12-compat"
   depends_on "theora"
   depends_on "x264"
   depends_on "xvid"

--- a/Formula/sdl_rtf.rb
+++ b/Formula/sdl_rtf.rb
@@ -28,7 +28,7 @@ class SdlRtf < Formula
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
   disable! date: "2022-07-31", because: :deprecated_upstream
 
-  depends_on "sdl"
+  depends_on "sdl12-compat"
 
   def install
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Needed to rename `sdl` to `sdl12-compat` in #111081

Can't rebuild bottles as formulae are disabled.