### PR TITLE
gitg: remove `libsoup@2` dependency

### DIFF
--- a/Formula/gitg.rb
+++ b/Formula/gitg.rb
@@ -37,7 +37,6 @@ class Gitg < Formula
   depends_on "libgit2-glib"
   depends_on "libpeas"
   depends_on "libsecret"
-  depends_on "libsoup@2"
 
   # Apply upstream commit to fix build.  Remove with next release.
   patch do
@@ -47,12 +46,9 @@ class Gitg < Formula
 
   def install
     ENV["DESTDIR"] = "/"
-
-    mkdir "build" do
-      system "meson", *std_meson_args, "-Dpython=false", ".."
-      system "ninja"
-      system "ninja", "install"
-    end
+    system "meson", *std_meson_args, "build", "-Dpython=false"
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
   end
 
   def post_install
@@ -89,7 +85,6 @@ class Gitg < Formula
     libgit2 = Formula["libgit2"]
     libgit2_glib = Formula["libgit2-glib"]
     libpng = Formula["libpng"]
-    libsoup = Formula["libsoup@2"]
     pango = Formula["pango"]
     pixman = Formula["pixman"]
     flags = %W[
@@ -112,7 +107,6 @@ class Gitg < Formula
       -I#{libgit2}/include
       -I#{libgit2_glib.opt_include}/libgit2-glib-1.0
       -I#{libpng.opt_include}/libpng16
-      -I#{libsoup.opt_include}/libsoup-2.4
       -I#{pango.opt_include}/pango-1.0
       -I#{pixman.opt_include}/pixman-1
       -DGIT_SSH=1
@@ -127,7 +121,6 @@ class Gitg < Formula
       -L#{libgee.opt_lib}
       -L#{libgit2.opt_lib}
       -L#{libgit2_glib.opt_lib}
-      -L#{libsoup.opt_lib}
       -L#{lib}
       -L#{pango.opt_lib}
       -latk-1.0


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://gitlab.gnome.org/GNOME/gitg/-/commit/3fff7926332e0f2ba2aff24407d1fe0fd547c375