### PR TITLE
openjdk: Ensure rpath for libraries includes server/lib

### DIFF
--- a/Formula/openjdk@11.rb
+++ b/Formula/openjdk@11.rb
@@ -4,6 +4,7 @@ class OpenjdkAT11 < Formula
   url "https://github.com/openjdk/jdk11u/archive/refs/tags/jdk-11.0.16.1-ga.tar.gz"
   sha256 "3008e50e258a5e9a488a814df2998b9823b6c2959d6a5a85221d333534d2f24c"
   license "GPL-2.0-only"
+  revision 1
 
   livecheck do
     url :stable
@@ -37,6 +38,9 @@ class OpenjdkAT11 < Formula
     depends_on "unzip"
     depends_on "zip"
 
+    # FIXME: This should not be needed because of the `-rpath` flag
+    #        we set in `--with-extra-ldflags`, but this configuration
+    #        does not appear to have made it to the linker.
     ignore_missing_libraries "libjvm.so"
   end
 
@@ -82,11 +86,13 @@ class OpenjdkAT11 < Formula
       --without-version-pre
     ]
 
+    ldflags = ["-Wl,-rpath,#{loader_path}/server"]
     args += if OS.mac?
+      ldflags << "-headerpad_max_install_names"
+
       %W[
+        --enable-dtrace
         --with-sysroot=#{MacOS.sdk_path}
-        --enable-dtrace=auto
-        --with-extra-ldflags=-headerpad_max_install_names
       ]
     else
       %W[
@@ -95,6 +101,7 @@ class OpenjdkAT11 < Formula
         --with-fontconfig=#{HOMEBREW_PREFIX}
       ]
     end
+    args << "--with-extra-ldflags=#{ldflags.join(" ")}"
 
     chmod 0755, "configure"
     system "./configure", *args

--- a/Formula/openjdk@17.rb
+++ b/Formula/openjdk@17.rb
@@ -4,6 +4,7 @@ class OpenjdkAT17 < Formula
   url "https://github.com/openjdk/jdk17u/archive/jdk-17.0.4.1-ga.tar.gz"
   sha256 "9b3e2558590fbb06ae4c02355919b1f75af9c696b786b113088ab6630e425824"
   license "GPL-2.0-only" => { with: "Classpath-exception-2.0" }
+  revision 1
 
   livecheck do
     url :stable
@@ -39,6 +40,9 @@ class OpenjdkAT17 < Formula
     depends_on "unzip"
     depends_on "zip"
 
+    # FIXME: This should not be needed because of the `-rpath` flag
+    #        we set in `--with-extra-ldflags`, but this configuration
+    #        does not appear to have made it to the linker.
     ignore_missing_libraries "libjvm.so"
   end
 
@@ -85,10 +89,12 @@ class OpenjdkAT17 < Formula
       --without-version-pre
     ]
 
+    ldflags = ["-Wl,-rpath,#{loader_path}/server"]
     args += if OS.mac?
+      ldflags << "-headerpad_max_install_names"
+
       %W[
         --enable-dtrace
-        --with-extra-ldflags=-headerpad_max_install_names
         --with-sysroot=#{MacOS.sdk_path}
       ]
     else
@@ -98,6 +104,7 @@ class OpenjdkAT17 < Formula
         --with-fontconfig=#{HOMEBREW_PREFIX}
       ]
     end
+    args << "--with-extra-ldflags=#{ldflags.join(" ")}"
 
     chmod 0755, "configure"
     system "./configure", *args


### PR DESCRIPTION
Also:
openjdk@11: Ensure rpath for libraries includes server/lib
openjdk@17: Ensure rpath for libraries includes server/lib

I couldn't build openjdk@8 because I have too new of a version of Xcode installed, so I did not include a change for that formula.

Closes: #111068

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
