### PR TITLE
Add livecheck block for resource `pkg-config-wrapper` for Formulae `influxdb` and `flux`

### DIFF
--- a/Formula/flux.rb
+++ b/Formula/flux.rb
@@ -33,6 +33,12 @@ class Flux < Formula
   resource "pkg-config-wrapper" do
     url "https://github.com/influxdata/pkg-config/archive/v0.2.12.tar.gz"
     sha256 "23b2ed6a2f04d42906f5a8c28c8d681d03d47a1c32435b5df008adac5b935f1a"
+
+    livecheck do
+      url "https://github.com/influxdata/pkg-config/tags"
+      regex(%r{href="/influxdata/pkg-config/archive/refs/tags/v(.*).tar.gz"}i)
+      strategy :page_match
+    end
   end
 
   def install

--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -9,6 +9,9 @@ class Influxdb < Formula
 
   # The regex below omits a rogue `v9.9.9` tag that breaks version comparison.
   livecheck do
+
+    # skip "No version information available to check"
+
     url :stable
     regex(/^v?((?!9\.9\.9)\d+(?:\.\d+)+)$/i)
   end
@@ -35,9 +38,29 @@ class Influxdb < Formula
     sha256 "52b22c151163dfb051fd44e7d103fc4cde6ae8ff852ffc13adeef19d21c36682"
 
     livecheck do
-      url "https://github.com/influxdata/pkg-config/tags"
-      regex(%r{href="/influxdata/pkg-config/archive/refs/tags/v(.*).tar.gz"}i)
-      strategy :page_match
+
+      # skip "Not maintained by upstream, so skipping"
+
+      # url "https://github.com/influxdata/pkg-config/tags"
+      # regex(%r{href="/influxdata/pkg-config/archive/refs/tags/v(.*).tar.gz"}i)
+      # strategy :page_match
+
+      url "https://raw.githubusercontent.com/influxdata/influxdb/master/go.mod"
+      # regex(/(pkg-config\s)+(v?((?!9\.9\.9)\d+(?:\.\d+)+))/i)
+      # regex(/(pkg-config\s)+(v?((?!9\.9\.9)\d+))/i)
+      # regex(/(pkg-config )+(v?((?!9\.9\.9)\d+(?:\.\d+)+))/)
+      regex(/(pkg-config\sv)+(\d+(?:\.\d+)+)/i)
+      
+      # regex(/(pkg-config)/)
+
+      strategy :page_match do |page, regex|
+
+        # p "page: #{page}"
+        p "page.scan(regex): #{page.scan(regex)}"
+        page.scan(regex).map { |match| match[1] }
+
+      end
+
     end
   end
 

--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -33,6 +33,12 @@ class Influxdb < Formula
   resource "pkg-config-wrapper" do
     url "https://github.com/influxdata/pkg-config/archive/refs/tags/v0.2.11.tar.gz"
     sha256 "52b22c151163dfb051fd44e7d103fc4cde6ae8ff852ffc13adeef19d21c36682"
+    
+    livecheck do
+      url "https://github.com/influxdata/pkg-config/tags"
+      regex(%r{href="/influxdata/pkg-config/archive/refs/tags/v(.*).tar.gz"}i)
+      strategy :page_match
+    end
   end
 
   # NOTE: The version/URL here is specified in scripts/fetch-ui-assets.sh in influxdb.

--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -33,7 +33,7 @@ class Influxdb < Formula
   resource "pkg-config-wrapper" do
     url "https://github.com/influxdata/pkg-config/archive/refs/tags/v0.2.11.tar.gz"
     sha256 "52b22c151163dfb051fd44e7d103fc4cde6ae8ff852ffc13adeef19d21c36682"
-    
+
     livecheck do
       url "https://github.com/influxdata/pkg-config/tags"
       regex(%r{href="/influxdata/pkg-config/archive/refs/tags/v(.*).tar.gz"}i)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

After merging https://github.com/Homebrew/brew/pull/13613, it would be possible to use `brew livecheck` command for resources as well. 

While augmenting `brew livecheck` command, I tested the functionality on multiple different resources and formulae. `pkg-config-wrapper` was one of the resource which could benefit from such behaviour.

---

> Note: you can only test this functionality properly once https://github.com/Homebrew/brew/pull/13613 is merged successfully. Simply, run `brew livecheck influxdb -r` and you'd see the livecheck output for resources as well.