### PR TITLE
questdb: create var/questdb directory

### DIFF
--- a/Formula/questdb.rb
+++ b/Formula/questdb.rb
@@ -18,6 +18,11 @@ class Questdb < Formula
     inreplace libexec/"questdb.sh", "/usr/local/var/questdb", var/"questdb"
   end
 
+  def post_install
+    # Make sure the var/questdb directory exists
+    (var/"questdb").mkpath
+  end
+
   service do
     run [opt_bin/"questdb", "start", "-d", var/"questdb", "-n", "-f"]
     keep_alive successful_exit: false


### PR DESCRIPTION
the directory is used as `working_dir` for questdb service and the service fails to start when the directory does not exist