### PR TITLE
make: link gnumake to make

### DIFF
--- a/Formula/make.rb
+++ b/Formula/make.rb
@@ -32,6 +32,7 @@ class Make < Formula
 
     if OS.mac?
       (libexec/"gnubin").install_symlink bin/"gmake" =>"make"
+      (libexec/"gnubin").install_symlink bin/"gnumake" =>"make"
       (libexec/"gnuman/man1").install_symlink man1/"gmake.1" => "make.1"
     end
 


### PR DESCRIPTION
Some tools use `gnumake` instead of `gmake`, specifically, `glibc`.

To allow compilation on MacOS link `gnumake` to `make`.

Signed-off-by: Paul Spooren <paul.spooren@rhebo.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
