### PR TITLE
qt: add Vulkan/molten-vk support

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -30,7 +30,9 @@ class Qt < Formula
   depends_on "pkg-config" => :build
   depends_on "python@3.10" => :build
   depends_on "six" => :build
+  depends_on "vulkan-headers" => [:build, :test]
   depends_on xcode: :build
+  depends_on "vulkan-loader" => :test
 
   depends_on "assimp"
   depends_on "brotli"
@@ -63,6 +65,10 @@ class Qt < Formula
   uses_from_macos "krb5"
   uses_from_macos "libxslt"
   uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "molten-vk" => [:build, :test]
+  end
 
   on_linux do
     depends_on "alsa-lib"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Hi, I'm hoping to resurrect https://github.com/Homebrew/homebrew-core/pull/50038, I'm not sure why it wasn't merged. See also https://www.qt.io/blog/2018/05/30/vulkan-for-qt-on-macos

I am the developer of simple64 (https://simple64.github.io), an N64 emulator. I'd like to add Mac OS support, and this is blocking me