### PR TITLE
pce: fix build with GCC 11 and use `sdl2` on HEAD

### DIFF
--- a/Formula/pce.rb
+++ b/Formula/pce.rb
@@ -1,10 +1,14 @@
 class Pce < Formula
   desc "PC emulator"
   homepage "http://www.hampa.ch/pce/"
-  url "http://www.hampa.ch/pub/pce/pce-0.2.2.tar.gz"
-  sha256 "a8c0560fcbf0cc154c8f5012186f3d3952afdbd144b419124c09a56f9baab999"
   revision 3
-  head "git://git.hampa.ch/pce.git", branch: "master"
+
+  # TODO: Remove `-fcommon` workaround and switch to `sdl2` on next release
+  stable do
+    url "http://www.hampa.ch/pub/pce/pce-0.2.2.tar.gz"
+    sha256 "a8c0560fcbf0cc154c8f5012186f3d3952afdbd144b419124c09a56f9baab999"
+    depends_on "sdl12-compat"
+  end
 
   bottle do
     sha256 cellar: :any, arm64_monterey: "e91060cfda85a63fee4413b7eb726714f8775e0cd452edd0957eba43c578fdd4"
@@ -14,16 +18,24 @@ class Pce < Formula
     sha256 cellar: :any, catalina:       "2d003611fb1b523196faccd42360b38a5ef955ba9a5accf213270381499c00d7"
   end
 
+  head do
+    url "git://git.hampa.ch/pce.git", branch: "master"
+    depends_on "sdl2"
+  end
+
   depends_on "readline"
-  depends_on "sdl12-compat"
 
   on_high_sierra :or_newer do
     depends_on "nasm" => :build
   end
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # src/cpu/e68000/e68000.a(e68000.o):(.bss+0x0): multiple definition of `e68_ea_tab'
+    # TODO: Remove in the next release.
+    ENV.append_to_cflags "-fcommon" if OS.linux? && build.stable?
+
+    system "./configure", *std_configure_args,
                           "--without-x",
                           "--enable-readline"
     system "make"
@@ -36,6 +48,6 @@ class Pce < Formula
   end
 
   test do
-    system "#{bin}/pce-ibmpc", "-V"
+    system bin/"pce-ibmpc", "-V"
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Failure from #111081