### PR TITLE
audacious: depends on `curl`

### DIFF
--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -60,6 +60,8 @@ class Audacious < Formula
   depends_on "sdl2"
   depends_on "wavpack"
 
+  uses_from_macos "curl"
+
   fails_with gcc: "5"
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in #111354. Probably okay to keep bottle since `curl` it is linked on Linux
```
Full linkage --test audacious output
  Unwanted system libraries:
    /lib/x86_64-linux-gnu/libcurl.so.4
```
