### PR TITLE
qdae: fix build with glibc 2.35 and deprecate

### DIFF
--- a/Formula/qdae.rb
+++ b/Formula/qdae.rb
@@ -19,16 +19,22 @@ class Qdae < Formula
     sha256 catalina:       "9b52e69dfcbeed51cacae5189cd2833da3bafda73ebb155b7d6a3c57eb8152fd"
   end
 
+  deprecate! date: "2022-09-23", because: :unmaintained
+
   depends_on "sdl12-compat"
 
   uses_from_macos "libxml2"
 
   def install
+    # Fix build failure with newer glibc:
+    # /usr/bin/ld: ../lib/.libs/libdsk.a(drvlinux.o): in function `linux_open':
+    # drvlinux.c:(.text+0x168): undefined reference to `major'
+    # /usr/bin/ld: ../lib/.libs/libdsk.a(compress.o): in function `comp_open':
+    # compress.c:(.text+0x268): undefined reference to `major'
+    ENV.append_to_cflags "-include sys/sysmacros.h" if OS.linux?
+
     ENV.cxx11
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
