### PR TITLE
fontforge: add dependency on woff2

### DIFF
--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -33,8 +33,14 @@ class Fontforge < Formula
   depends_on "pango"
   depends_on "python@3.10"
   depends_on "readline"
+  depends_on "woff2"
 
   uses_from_macos "libxml2"
+
+  resource "homebrew-testdata" do
+    url "https://raw.githubusercontent.com/fontforge/fontforge/1346ce6e4c004c312589fdb67e31d4b2c32a1656/tests/fonts/Ambrosia.sfd"
+    sha256 "6a22acf6be4ab9e5c5a3373dc878030b4b8dc4652323395388abe43679ceba81"
+  end
 
   # Fix for rpath on ARM
   # https://github.com/fontforge/fontforge/issues/4658
@@ -67,6 +73,15 @@ class Fontforge < Formula
     system bin/"fontforge", "-version"
     system bin/"fontforge", "-lang=py", "-c", "import fontforge; fontforge.font()"
     system "python3.10", "-c", "import fontforge; fontforge.font()"
+
+    resource("homebrew-testdata").stage do
+      ffscript = "fontforge.open('Ambrosia.sfd').generate('#{testpath}/Ambrosia.woff2')"
+      system bin/"fontforge", "-c", ffscript
+    end
+    assert_predicate testpath/"Ambrosia.woff2", :exist?
+
+    fileres = shell_output("/usr/bin/file #{testpath}/Ambrosia.woff2")
+    assert_match "Web Open Font Format (Version 2)", fileres
   end
 end
 


### PR DESCRIPTION
Generating WOFF2 fonts with the current fontforge installation does not work. Adding the woff2 library dependency allows it to work correctly.

Refs #111516

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The tests fail on my machine, but I think they are failing anyway; this change does not affect anything to do with the tests, and the package works fine.