### PR TITLE
texlab: move method definition out of `test` block.

### DIFF
--- a/Formula/texlab.rb
+++ b/Formula/texlab.rb
@@ -21,13 +21,11 @@ class Texlab < Formula
     system "cargo", "install", *std_cargo_args
   end
 
-  test do
-    def rpc(json)
-      "Content-Length: #{json.size}\r\n" \
-        "\r\n" \
-        "#{json}"
-    end
+  def rpc(json)
+    "Content-Length: #{json.size}\r\n\r\n#{json}"
+  end
 
+  test do
     input = rpc <<-EOF
     {
       "jsonrpc":"2.0",


### PR DESCRIPTION
Defining methods inside `test` blocks is no longer supported in `brew`.
Needed for #111434.
