### PR TITLE
versioned_dependencies_conflicts_allowlist: remove `emscripten`.

### DIFF
--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -1,6 +1,5 @@
 [
   "couchdb-lucene",
-  "emscripten",
   "hive",
   "libgaiagraphics",
   "librasterlite",


### PR DESCRIPTION
See

https://github.com/Homebrew/homebrew-core/blob/f723d4a398ce17f48d684dcbd5f5a582e89a19fa/Formula/emscripten.rb#L6-L7
