### PR TITLE
expat 2.4.9

### DIFF
--- a/Formula/expat.rb
+++ b/Formula/expat.rb
@@ -1,14 +1,16 @@
 class Expat < Formula
   desc "XML 1.0 parser"
   homepage "https://libexpat.github.io/"
-  url "https://github.com/libexpat/libexpat/releases/download/R_2_4_8/expat-2.4.8.tar.xz"
-  sha256 "f79b8f904b749e3e0d20afeadecf8249c55b2e32d4ebb089ae378df479dcaf25"
+  url "https://github.com/libexpat/libexpat/releases/download/R_2_4_9/expat-2.4.9.tar.xz"
+  sha256 "6e8c0728fe5c7cd3f93a6acce43046c5e4736c7b4b68e032e9350daa0efc0354"
   license "MIT"
 
   livecheck do
     url :stable
-    strategy :github_latest
-    regex(/href=.*?expat[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=["']?[^"' >]*?/tag/\D*?(\d+(?:[._]\d+)*)["' >]}i)
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
+    end
   end
 
   bottle do
@@ -21,7 +23,7 @@ class Expat < Formula
   end
 
   head do
-    url "https://github.com/libexpat/libexpat.git"
+    url "https://github.com/libexpat/libexpat.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "docbook2x" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `expat` matches the version from the tarball in a GitHub release assets list but the HTML of these pages was recently changed to omit the assets list so this check is broken (see Homebrew/brew#13853). Releases in this repository consistently provide the tarball that we use in the formula, so we're fine matching the version from the release tag.

We have to override the default `GithubLatest` regex to handle the specific tag format used here. Releases use a tag format like `R_2_4_9` but there are other non-release tags in the repository like `V19991013`, `V1_0_2`, etc., so I've made the regex loose enough to handle all of those formats. The `strategy` block simply replaces underscores with dots, to convert the tag version format to the formula version format (though `Version` comparison doesn't care about delimiters, so this is mostly aesthetic at this point).

Besides that, this PR updates `expat` to the latest version, 2.4.9. This also adds `branch: "master"` to the `head` URL to resolve the related audit.