### PR TITLE
prometheus: update livecheck

### DIFF
--- a/Formula/prometheus.rb
+++ b/Formula/prometheus.rb
@@ -7,7 +7,7 @@ class Prometheus < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `prometheus` uses the `GithubLatest` strategy but currently the "latest" release is for 2.37.1 instead of 2.38.0 (because the former was released after the latter). Since this repository maintains more than one minor version, we can't rely on the `GithubLatest` strategy to give the newest version. However, the `GithubLatest` strategy wasn't necessary here anyway, as the `stable` URL simply uses a tag archive file (i.e., not a release asset).

This PR updates the `livecheck` block to remove `strategy :github_latest` (so this will default back to the `Git` strategy for the `stable` URL) and to add an appropriate regex to match release tags (i.e., there are a number of unstable and unusual tags we need to avoid in this repository). With this change, livecheck correctly reports 2.38.0 as the latest version.