### PR TITLE
gauche: update livecheck

### DIFF
--- a/Formula/gauche.rb
+++ b/Formula/gauche.rb
@@ -8,8 +8,10 @@ class Gauche < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
-    regex(/href=.*?Gauche[._-]v?(\d+(?:\.\d+)+(?:[._-]p\d+)?)\.t/i)
+    regex(%r{href=["']?[^"' >]*?/tag/\D*?(\d+(?:[._]\d+)+(?:[._-]?p\d+)?)["' >]}i)
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `gauche` matches the version from the tarball in a GitHub release assets list but the HTML of these pages was recently changed to omit the assets list so this check is broken (see Homebrew/brew#13853). Releases in this repository consistently provide the tarball that we use in the formula, so we're fine matching the version from the release tag.

We have to override the default `GithubLatest` regex to handle the specific tag format used here. Releases use a tag format like `release0_9_9`, though there have also been a couple others one-offs like `rel0-2-4`, `relase0_4_6`, `v0.9.12`,  so I've made the regex loose enough to handle all of those formats. The strategy block simply replaces underscores with dots, to convert the tag version format to the formula version format (though `Version` comparison doesn't care about delimiters, so this is mostly aesthetic at this point).