### PR TITLE
pdal: update livecheck

### DIFF
--- a/Formula/pdal.rb
+++ b/Formula/pdal.rb
@@ -7,15 +7,14 @@ class Pdal < Formula
   revision 1
   head "https://github.com/PDAL/PDAL.git", branch: "master"
 
-  # The upstream GitHub repository sometimes tags a commit with only a
-  # major/minor version (`1.2`) and then uses major/minor/patch (`1.2.3`) for
-  # the release (with downloadable assets). This inconsistency can be a problem
-  # if we need to substitute the version from livecheck in the `stable` URL, so
-  # we use the `GithubLatest` strategy here.
+  # The upstream GitHub repository sometimes creates tags that only include a
+  # major/minor version (`1.2`) and then uses major/minor/patch (`1.2.0`) for
+  # the release tarball. This inconsistency can be a problem if we need to
+  # substitute the version from livecheck in the `stable` URL, so we check the
+  # first-party download page, which links to the tarballs on GitHub.
   livecheck do
-    url :stable
+    url "https://pdal.io/en/stable/download.html"
     regex(/href=.*?PDAL[._-]v?(\d+(?:\.\d+)+)[._-]src\.t/i)
-    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `pdal` matches the version from the tarball in a GitHub release assets list but the HTML of these pages was recently changed to omit the assets list so this check is broken (see Homebrew/brew#13853). In this instance, it's not sufficient to match the version from the release tag because sometimes the tag version only includes a major/minor version (e.g., `1.2`) whereas the tarball version uses major/minor/patch (e.g., `1.2.0`) and this could create problems in the future if we do automated version bumping using the livecheck version.

This PR resolves the issue by updating the `livecheck` block to check the [first-party download page](https://pdal.io/en/stable/download.html), which links to release tarballs on GitHub.