### PR TITLE
trezor-bridge 2.0.31 (new formula)

### DIFF
--- a/Formula/trezor-bridge.rb
+++ b/Formula/trezor-bridge.rb
@@ -1,0 +1,34 @@
+class TrezorBridge < Formula
+  desc "Trezor Communication Daemon"
+  homepage "https://github.com/trezor/trezord-go"
+  url "https://github.com/trezor/trezord-go/archive/refs/tags/v2.0.31.tar.gz"
+  sha256 "fd834a5bf04417cc50ed4a418d40de4c257cbc86edca01b07aa01a9cf818e60e"
+  license "LGPL-3.0-only"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(output: bin/"trezord-go", ldflags: "-s -w")
+  end
+
+  plist_options startup: true
+
+  service do
+    run opt_bin/"trezord-go"
+    keep_alive true
+    working_dir HOMEBREW_PREFIX
+  end
+
+  test do
+    # start the server with the USB disabled and enable UDP interface instead
+    server = IO.popen("#{bin}/trezord-go -u=false -e 21324")
+    sleep 1
+    assert_match '{"version":"2.0.31","githash":"unknown"}',
+        shell_output("curl -s -X POST -H 'Origin: https://test.trezor.io' http://localhost:21325/")
+    assert_match "[]",
+        shell_output("curl -s -X POST -H 'Origin: https://test.trezor.io' http://localhost:21325/enumerate")
+  ensure
+    Process.kill("SIGINT", server.pid)
+    Process.wait(server.pid)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Replacement for the [trezor-bridge cask](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/trezor-bridge.rb), since it can be built from the source. This also adds ARM64 build.