### PR TITLE
mtools: remove unneeded patch

### DIFF
--- a/Formula/mtools.rb
+++ b/Formula/mtools.rb
@@ -16,9 +16,6 @@ class Mtools < Formula
 
   conflicts_with "multimarkdown", because: "both install `mmd` binaries"
 
-  # 4.0.25 doesn't include the proper osx locale headers.
-  patch :DATA
-
   def install
     args = %W[
       --disable-debug
@@ -42,18 +39,3 @@ class Mtools < Formula
     assert_match version.to_s, shell_output("#{bin}/mtools --version")
   end
 end
-
-__END__
-diff --git a/sysincludes.h b/sysincludes.h
-index 056218e..ba3677b 100644
---- a/sysincludes.h
-+++ b/sysincludes.h
-@@ -279,6 +279,8 @@ extern int errno;
- #include <pwd.h>
- #endif
- 
-+#include <xlocale.h>
-+#include <strings.h>
- 
- #ifdef HAVE_STRING_H
- # include <string.h>


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The patch here was breaking the build on Linux and isn't even needed on macOS any more, so we can drop it.