### PR TITLE
ghostscript: update livecheck

### DIFF
--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -5,11 +5,13 @@ class Ghostscript < Formula
   sha256 "8f2b7941f60df694b4f5c029b739007f7c4e0d43858471ae481e319a967d5d8b"
   license "AGPL-3.0-or-later"
 
-  # We check the tags from the `head` repository because the GitHub tags are
-  # formatted ambiguously, like `gs9533` (corresponding to version 9.53.3).
+  # The GitHub tags omit delimiters (e.g. `gs9533` for version 9.53.3). The
+  # `head` repository tags are formatted fine (e.g. `ghostpdl-9.53.3`) but a
+  # version may be tagged before the release is available on GitHub, so we
+  # check the version from the first-party website instead.
   livecheck do
-    url :head
-    regex(/^ghostpdl[._-]v?(\d+(?:\.\d+)+)$/i)
+    url "https://www.ghostscript.com/json/settings.json"
+    regex(/["']GS_VER["']:\s*?["']v?(\d+(?:\.\d+)+)["']/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #111494, where [I suggested a different `livecheck` block](https://github.com/Homebrew/homebrew-core/pull/111494#discussion_r979266270) to fix the broken check but it wasn't committed before merging. Checking the Git tags from the `head` repository technically works but the `stable` URL is a release asset and the corresponding release may not be available yet when the tag is created (this why we were using the `GithubLatest` strategy before the recent release page HTML changes broke the check).

The approach in this PR checks the JSON file that's used on the first-party website to produce the links on the [GhostPDL releases page](https://www.ghostscript.com/releases/gpdldnld.html). The `GS_VER` value in this file is used as the version in the GitHub tarball URL on the page.

[For what it's worth, I'll update this in the future to use a `Json` strategy (which will properly parse the JSON and extract the value for the `GS_VER` field) but I still have to work my way to creating that PR (i.e., the work's done but I have some other brew PRs to tackle first).]