### PR TITLE
highway 1.0.1 (new formula), jpeg-xl: depend on `highway`

### DIFF
--- a/Formula/highway.rb
+++ b/Formula/highway.rb
@@ -1,0 +1,32 @@
+class Highway < Formula
+  desc "Performance-portable, length-agnostic SIMD with runtime dispatch"
+  homepage "https://github.com/google/highway"
+  url "https://github.com/google/highway/archive/refs/tags/1.0.1.tar.gz"
+  sha256 "7ca6af7dc2e3e054de9e17b9dfd88609a7fd202812b1c216f43cc41647c97311"
+  license "Apache-2.0"
+  head "https://github.com/google/highway.git", branch: "master"
+
+  depends_on "cmake" => :build
+
+  # These used to be bundled with `jpeg-xl`.
+  link_overwrite "include/hwy/*", "lib/pkgconfig/libhwy*"
+
+  def install
+    ENV.runtime_cpu_detection
+    system "cmake", "-S", ".", "-B", "builddir",
+                    "-DBUILD_SHARED_LIBS=ON",
+                    "-DHWY_ENABLE_TESTS=OFF",
+                    "-DHWY_ENABLE_EXAMPLES=OFF",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    *std_cmake_args
+    system "cmake", "--build", "builddir"
+    system "cmake", "--install", "builddir"
+    (share/"hwy").install "hwy/examples"
+  end
+
+  test do
+    system ENV.cxx, "-std=c++11", "-I#{share}", "-I#{include}",
+                    share/"hwy/examples/benchmark.cc", "-L#{lib}", "-lhwy"
+    system "./a.out"
+  end
+end

--- a/Formula/jpeg-xl.rb
+++ b/Formula/jpeg-xl.rb
@@ -4,6 +4,7 @@ class JpegXl < Formula
   url "https://github.com/libjxl/libjxl/archive/v0.7.0.tar.gz"
   sha256 "3114bba1fabb36f6f4adc2632717209aa6f84077bc4e93b420e0d63fa0455c5e"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -23,6 +24,7 @@ class JpegXl < Formula
   depends_on "pkg-config" => :build
   depends_on "brotli"
   depends_on "giflib"
+  depends_on "highway"
   depends_on "imath"
   depends_on "jpeg-turbo"
   depends_on "libpng"
@@ -37,11 +39,6 @@ class JpegXl < Formula
 
   # These resources are versioned according to the script supplied with jpeg-xl to download the dependencies:
   # https://github.com/libjxl/libjxl/tree/v#{version}/third_party
-  resource "highway" do
-    url "https://github.com/google/highway.git",
-        revision: "22e3d7276f4157d4a47586ba9fd91dd6303f441a"
-  end
-
   resource "lodepng" do
     url "https://github.com/lvandeve/lodepng.git",
         revision: "48e5364ef48ec2408f44c727657ac1b6703185f8"
@@ -62,6 +59,7 @@ class JpegXl < Formula
     # disable manpages due to problems with asciidoc 10
     system "cmake", "-S", ".", "-B", "build",
                     "-DJPEGXL_FORCE_SYSTEM_BROTLI=ON",
+                    "-DJPEGXL_FORCE_SYSTEM_HWY=ON",
                     "-DJPEGXL_ENABLE_JNI=OFF",
                     "-DJPEGXL_VERSION=#{version}",
                     "-DJPEGXL_ENABLE_MANPAGES=OFF",

--- a/style_exceptions/runtime_cpu_detection_allowlist.json
+++ b/style_exceptions/runtime_cpu_detection_allowlist.json
@@ -3,6 +3,7 @@
   "apache-arrow",
   "blis",
   "fftw",
+  "highway",
   "libvpx",
   "luajit",
   "openblas",


### PR DESCRIPTION
- highway 1.0.1 (new formula)
- runtime_cpu_detection_allowlist: add `highway`.
- jpeg-xl: depend on `highway`.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

I did the above only for `highway` and not `jpeg-xl`.
