### PR TITLE
ghc: minimum Catalina

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -26,6 +26,7 @@ class Ghc < Formula
 
   depends_on "python@3.10" => :build
   depends_on "sphinx-doc" => :build
+  depends_on macos: :catalina
 
   uses_from_macos "m4" => :build
   uses_from_macos "ncurses"


### PR DESCRIPTION
Building on Mojave yields errors like:
```
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ffi/ffi.h:285:1: error: expected ','
FFI_AVAILABLE_APPLE_2019 FFI_API void ffi_raw_to_ptrarray (ffi_cif *cif, ffi_raw *raw, void **args);
^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ffi/ffi.h:56:73: note: expanded from macro 'FFI_AVAILABLE_APPLE_2019'
#define FFI_AVAILABLE_APPLE_2019 API_AVAILABLE(macos(10.15), macCatalyst(13.0)) API_UNAVAILABLE(ios, tvos, watchos)
                                                                        ^
```

`CI-syntax-only`, no rebuilds needed.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
