### PR TITLE
libtorch: bump revision to test rebuild

### DIFF
--- a/Formula/libtorch.rb
+++ b/Formula/libtorch.rb
@@ -7,6 +7,7 @@ class Libtorch < Formula
       tag:      "v1.12.1",
       revision: "664058fa83f1d8eede5d66418abff6e20bd76ca8"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
Based on the failures I'm seeing in #110199, I believe that the `libtorch` formula will fail to build on Intel Mac architectures. The failures in that PR seem to coincide with the release of LLVM 14 (Command Line Tools version 2395). This pull request is a way that I can test that hypothesis.

If the Intel Mac builds do indeed fail, what is the best way forward? Mark this formula as `depends_on arch: :arm64` for Mac?

If all the builds succeed, then I will just close this pull request.