### PR TITLE
poetry: disable keyring in test

### DIFF
--- a/Formula/poetry.rb
+++ b/Formula/poetry.rb
@@ -205,6 +205,10 @@ class Poetry < Formula
   test do
     ENV["LC_ALL"] = "en_US.UTF-8"
 
+    # The poetry add command would fail in CI when keyring is enabled
+    # https://github.com/Homebrew/homebrew-core/pull/109777#issuecomment-1248353918
+    ENV["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+
     assert_match version.to_s, shell_output("#{bin}/poetry --version")
     assert_match "Created package", shell_output("#{bin}/poetry new homebrew")
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
