### PR TITLE
Set run-name for dispatch workflows

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -1,5 +1,7 @@
 name: Dispatch build bottle (for chosen OS versions)
 
+run-name: ${{ inputs.formula }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -1,5 +1,7 @@
 name: Dispatch rebottle (for all currently bottled OS versions)
 
+run-name: ${{ inputs.formula }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -1,5 +1,7 @@
 name: Publish and commit bottles
 
+run-name: ${{ inputs.pull_request }}
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name

This will help us to get a better grip on which workflow run did what.