### PR TITLE
oras: fix sha256 of v0.15.0.tar.gz

### DIFF
--- a/Formula/oras.rb
+++ b/Formula/oras.rb
@@ -2,8 +2,9 @@ class Oras < Formula
   desc "OCI Registry As Storage"
   homepage "https://github.com/oras-project/oras"
   url "https://github.com/oras-project/oras/archive/v0.15.0.tar.gz"
-  sha256 "1b1f72d12b2c9c9b869ac73ddc1bf9fee43b1a435e418a6f6168f339fb622279"
+  sha256 "0d75af9e7d95b8c6b61328cd7587e1a49c64f1a6f2f5af34f40a0e576562857f"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "2a7b233c3a29b6a396f2efe1a5f74d63825f52e5d6fd60927a9965bca682c3d2"


### PR DESCRIPTION
update the sha256 sum to the v0.15.0.tar.gz on the release page

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
