### PR TITLE
workerd 1.20220926.2 (new formula)

### DIFF
--- a/Formula/workerd.rb
+++ b/Formula/workerd.rb
@@ -1,0 +1,20 @@
+require "language/node"
+
+class Workerd < Formula
+  desc "👷 workerd, Cloudflare's JavaScript/Wasm Runtime"
+  homepage "https://github.com/cloudflare/workerd"
+  url "https://registry.npmjs.org/workerd/-/workerd-1.20220926.2.tgz"
+  sha256 "9deae9872f969914138949501379e6f610db8e45fa8c484e6cea2a7d502d278b"
+  license "Apache-2.0"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_equal "workerd 2022-09-26\n", shell_output("PWD=$(pwd) #{bin}/workerd --version")
+  end
+end

--- a/Formula/workerd.rb
+++ b/Formula/workerd.rb
@@ -2,7 +2,7 @@ require "language/node"
 
 class Workerd < Formula
   desc "👷 workerd, Cloudflare's JavaScript/Wasm Runtime"
-  homepage "https://github.com/cloudflare/workerd"
+  homepage "https://workers.cloudflare.com/"
   url "https://registry.npmjs.org/workerd/-/workerd-1.20220926.2.tgz"
   sha256 "9deae9872f969914138949501379e6f610db8e45fa8c484e6cea2a7d502d278b"
   license "Apache-2.0"


### PR DESCRIPTION
This adds support for `workerd`, the recently open-sourced Cloudflare Workers runtime

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew audit --strict <formula>` doesn't pass, since the GitHub rep was only made public today—is there any way to bypass that?