### PR TITLE
gcc: Add glibc.opt_lib to the library search path

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -204,8 +204,8 @@ class Gcc < Formula
       #   * `-idirafter <dir>` instructs gcc to search system header
       #     files after gcc internal header files.
       # For libraries:
-      #   * `-nostdlib -L#{libgcc}` instructs gcc to use brewed glibc
-      #     if applied.
+      #   * `-nostdlib -L#{libgcc} -L#{glibc.opt_lib}` instructs gcc to use
+      #     brewed glibc if applied.
       #   * `-L#{libdir}` instructs gcc to find the corresponding gcc
       #     libraries. It is essential if there are multiple brewed gcc
       #     with different versions installed.
@@ -219,7 +219,7 @@ class Gcc < Formula
         + -isysroot #{HOMEBREW_PREFIX}/nonexistent #{system_header_dirs.map { |p| "-idirafter #{p}" }.join(" ")}
 
         *link_libgcc:
-        #{glibc_installed ? "-nostdlib -L#{libgcc}" : "+"} -L#{libdir} -L#{HOMEBREW_PREFIX}/lib
+        #{glibc_installed ? "-nostdlib -L#{libgcc} -L#{glibc.opt_lib}" : "+"} -L#{libdir} -L#{HOMEBREW_PREFIX}/lib
 
         *link:
         + --dynamic-linker #{HOMEBREW_PREFIX}/lib/ld.so -rpath #{libdir}


### PR DESCRIPTION
When brewed `glibc` is installed, add `glibc.opt_lib` to the library search path in `specs`.
It's not necessary to rebuild bottles, because this PR affects only `post_install`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

# Before this PR
```console
$ docker run -it --rm homebrew/ubuntu20.04
$ brew install gcc
…
$ brew test gcc
==> Testing gcc
==> /home/linuxbrew/.linuxbrew/Cellar/gcc/12.2.0/bin/gcc-12 -o hello-c hello-c.c
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/gcc/test.01.gcc-12:
2022-09-27 22:13:31 +0000

/home/linuxbrew/.linuxbrew/Cellar/gcc/12.2.0/bin/gcc-12
-o
hello-c
hello-c.c

/usr/bin/ld: cannot find -lc
collect2: error: ld returned 1 exit status
Error: gcc: failed
```

# After this PR
```console
$ docker run -it --rm homebrew/ubuntu20.04
$ brew install gcc
…
$ brew test gcc
==> Testing gcc
==> /home/linuxbrew/.linuxbrew/Cellar/gcc/12.2.0/bin/gcc-12 -o hello-c hello-c.c
==> ./hello-c
==> /home/linuxbrew/.linuxbrew/Cellar/gcc/12.2.0/bin/g++-12 -o hello-cc hello-cc
==> ./hello-cc
==> /home/linuxbrew/.linuxbrew/Cellar/gcc/12.2.0/bin/gfortran -o test test.f90
==> ./test
```
