### PR TITLE
Tomcat@10.0

### DIFF
--- a/Aliases/tomcat@10.1
+++ b/Aliases/tomcat@10.1
@@ -1,0 +1,1 @@
+../Formula/tomcat.rb

--- a/Formula/tomcat@10.0.rb
+++ b/Formula/tomcat@10.0.rb
@@ -1,0 +1,60 @@
+class TomcatAT100 < Formula
+  desc "Implementation of Java Servlet and JavaServer Pages"
+  homepage "https://tomcat.apache.org/"
+  url "https://www.apache.org/dyn/closer.lua?path=tomcat/tomcat-10/v10.0.23/bin/apache-tomcat-10.0.23.tar.gz"
+  mirror "https://archive.apache.org/dist/tomcat/tomcat-10/v10.0.23/bin/apache-tomcat-10.0.23.tar.gz"
+  sha256 "575c99a2aeed61e26b2f379bd0f8c9e44a4ecc9509760aa81c20bb7126b7fd3d"
+  license "Apache-2.0"
+
+  livecheck do
+    url :stable
+    regex(%r{href=["']?v?(10\.0(?:\.\d+)+)/}i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "openjdk"
+
+  def install
+    # Remove Windows scripts
+    rm_rf Dir["bin/*.bat"]
+
+    # Install files
+    prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]
+
+    pkgetc.install Dir["conf/*"]
+    (buildpath/"conf").rmdir
+    libexec.install_symlink pkgetc => "conf"
+
+    libexec.install Dir["*"]
+    (bin/"catalina").write_env_script "#{libexec}/bin/catalina.sh", JAVA_HOME: Formula["openjdk"].opt_prefix
+  end
+
+  def caveats
+    <<~EOS
+      Configuration files: #{pkgetc}
+    EOS
+  end
+
+  service do
+    run [opt_bin/"catalina", "run"]
+    keep_alive true
+  end
+
+  test do
+    ENV["CATALINA_BASE"] = testpath
+    cp_r Dir["#{libexec}/*"], testpath
+    rm Dir["#{libexec}/logs/*"]
+
+    pid = fork do
+      exec bin/"catalina", "start"
+    end
+    sleep 3
+    begin
+      system bin/"catalina", "stop"
+    ensure
+      Process.wait pid
+    end
+    assert_predicate testpath/"logs/catalina.out", :exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

According to [Apache Tomcat Versions](https://tomcat.apache.org/whichversion.html), tomcat 10.1 and 10.0 support different Java Versions, different Specs. And both tomcat 10.1 and 10.0 will be support by Apache Tomcat Team.
I think that since we already have `tomcat@8`, `tomcat@9` and `tomcat@10`, we should add `tomcat@10.0` and `tomcat@10.1`.