### PR TITLE
graphicsmagick: add dependency on jpeg-xl 0.7.0

### DIFF
--- a/Formula/graphicsmagick.rb
+++ b/Formula/graphicsmagick.rb
@@ -24,6 +24,7 @@ class Graphicsmagick < Formula
   depends_on "freetype"
   depends_on "jasper"
   depends_on "jpeg-turbo"
+  depends_on "jpeg-xl"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "libtool"
@@ -50,7 +51,7 @@ class Graphicsmagick < Formula
       --without-gslib
       --with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts
       --without-wmf
-      --without-jxl
+      --with-jxl
     ]
 
     # versioned stuff in main tree is pointless for us


### PR DESCRIPTION
This compile feature was previously disabled (in PR #108635), since graphicsmagick depended on the then unreleased 0.7, which was now released and incorporated into Homebrew.

Tested: `brew reinstall -s graphicsmagick`

-----

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
