### PR TITLE
llvm@13: backport fixes

### DIFF
--- a/Formula/klee.rb
+++ b/Formula/klee.rb
@@ -4,7 +4,7 @@ class Klee < Formula
   desc "Symbolic Execution Engine"
   homepage "https://klee.github.io/"
   license "NCSA"
-  revision 1
+  revision 2
   head "https://github.com/klee/klee.git", branch: "master"
 
   stable do

--- a/Formula/oclgrind.rb
+++ b/Formula/oclgrind.rb
@@ -4,7 +4,7 @@ class Oclgrind < Formula
   url "https://github.com/jrprice/Oclgrind/archive/v21.10.tar.gz"
   sha256 "b40ea81fcf64e9012d63c3128640fde9785ef4f304f9f876f53496595b8e62cc"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
 
   livecheck do
     url :homepage

--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -2,12 +2,12 @@ class Zig < Formula
   desc "Programming language designed for robustness, optimality, and clarity"
   homepage "https://ziglang.org/"
   license "MIT"
-  revision 1
+  revision 2
 
   stable do
     url "https://ziglang.org/download/0.9.1/zig-0.9.1.tar.xz"
     sha256 "38cf4e84481f5facc766ba72783e7462e08d6d29a5d47e3b75c8ee3142485210"
-    depends_on "llvm@13"
+    depends_on "llvm@13" => :build
   end
 
   bottle do
@@ -21,7 +21,7 @@ class Zig < Formula
 
   head do
     url "https://github.com/ziglang/zig.git", branch: "master"
-    depends_on "llvm"
+    depends_on "llvm" => :build
   end
 
   depends_on "cmake" => :build
@@ -29,8 +29,10 @@ class Zig < Formula
   fails_with gcc: "5" # LLVM is built with GCC
 
   def install
-    system "cmake", ".", *std_cmake_args, "-DZIG_STATIC_LLVM=ON"
-    system "make", "install"
+    odie "HEAD installs of `zig` are broken until ziglang/zig#12923 is resolved!" if build.head?
+    system "cmake", "-S", ".", "-B", "build", "-DZIG_STATIC_LLVM=ON", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

1. Disable `libxml2` on Linux. This doesn't seem useful.
2. Remove `glibc` dependency. This is managed by `brew`.
3. Make sure `clang` Python bindings can find `libclang`.
4. Install `libc++` into `lib/"c++"`.
5. Make sure CMake does not try to set `CMAKE_LINKER` to `ld.lld`.
6. Fix Compiler-RT multi-arch build.
7. Remove unused `swig` dependency.
8. Use idiomatic `scan-build` test.
