### PR TITLE
pytorch: renamed from libtorch

### DIFF
--- a/Formula/pytorch.rb
+++ b/Formula/pytorch.rb
@@ -1,4 +1,4 @@
-class Libtorch < Formula
+class Pytorch < Formula
   desc "Tensors and dynamic neural networks"
   homepage "https://pytorch.org/"
   url "https://github.com/pytorch/pytorch.git",
@@ -11,20 +11,12 @@ class Libtorch < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_monterey: "5e16e47a6006e86190a245820fafbefef2829478818d61b0d6dc9b851f729d78"
-    sha256 cellar: :any,                 arm64_big_sur:  "4d49131eeb1e403521fcf04833b004a0af997381a54d018047776fe9b3f7dfc7"
-    sha256 cellar: :any,                 monterey:       "30fca833944f65f0d7c1df6170bbcbdda67623054acc6b99714a38766c9bf975"
-    sha256 cellar: :any,                 big_sur:        "a86aeb431832568ebcf214fbf7d08e96cec8a11eabb07c1e125db1ad48089a95"
-    sha256 cellar: :any,                 catalina:       "ec36245f5f4274950e000d6a998af57ce93e3357a797ea143d50d5a399e2f270"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bbcffba1dbf409906cc77a2d1889e9ee656a46065dbdb1896f7ff12ca8749a93"
-  end
-
   depends_on "cmake" => :build
-  depends_on "python@3.10" => :build
+  depends_on "ninja" => :build
+  depends_on "python@3.10" => [:build, :test]
   depends_on "eigen"
   depends_on "libuv"
+  depends_on "numpy"
   depends_on "openblas"
   depends_on "openssl@1.1"
   depends_on "protobuf"
@@ -48,14 +40,22 @@ class Libtorch < Formula
 
     resource("fbgemm").stage(buildpath/"third_party/fbgemm")
 
+    # Remove with next release
+    inreplace "cmake/Dependencies.cmake",
+      'if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13.0.0)',
+      "if(FALSE)"
+
     openssl_root = Formula["openssl@1.1"].opt_prefix
+    python_exe = Formula["python@3.10"].opt_libexec/"bin/python"
     args = %W[
+      -GNinja
       -DBLAS=OpenBLAS
       -DBUILD_CUSTOM_PROTOBUF=OFF
-      -DBUILD_PYTHON=OFF
+      -DBUILD_PYTHON=ON
       -DCMAKE_CXX_COMPILER=#{ENV.cxx}
       -DCMAKE_C_COMPILER=#{ENV.cc}
       -DOPENSSL_ROOT_DIR=#{openssl_root}
+      -DPYTHON_EXECUTABLE=#{python_exe}
       -DUSE_CUDA=OFF
       -DUSE_DISTRIBUTED=ON
       -DUSE_METAL=OFF
@@ -68,16 +68,27 @@ class Libtorch < Formula
     # Remove when https://github.com/pytorch/pytorch/issues/67974 is addressed
     args << "-DUSE_SYSTEM_BIND11=ON"
 
+    ENV["LDFLAGS"] = "-L#{buildpath}/build/lib"
+
+    # Update references to shared libraries
+    inreplace "torch/__init__.py" do |s|
+      s.sub!(/here = os.path.abspath\(__file__\)/, "here = \"#{lib}\"")
+      s.sub!(/get_file_path\('torch', 'bin', 'torch_shm_manager'\)/, "\"#{bin}/torch_shm_manager\"")
+    end
+
+    inreplace "torch/utils/cpp_extension.py", "_TORCH_PATH = os.path.dirname(os.path.dirname(_HERE))",
+                                              "_TORCH_PATH = \"#{opt_prefix}\""
+
     system "cmake", "-B", "build", "-S", ".", *std_cmake_args, *args
 
     # Avoid references to Homebrew shims
     inreplace "build/caffe2/core/macros.h", Superenv.shims_path/ENV.cxx, ENV.cxx
 
-    system "cmake", "--build", "build"
-    system "cmake", "--install", "build"
+    system python_exe, *Language::Python.setup_install_args(prefix, python_exe)
   end
 
   test do
+    # test that C++ libraries are available
     (testpath/"test.cpp").write <<~EOS
       #include <torch/torch.h>
       #include <iostream>
@@ -91,5 +102,12 @@ class Libtorch < Formula
                     "-I#{include}/torch/csrc/api/include",
                     "-L#{lib}", "-ltorch", "-ltorch_cpu", "-lc10"
     system "./test"
+
+    # test that `torch` Python module is available
+    python = Formula["python@3.10"]
+    system python.opt_libexec/"bin/python", "-c", <<~EOS
+      import torch
+      torch.rand(5, 3)
+    EOS
   end
 end

--- a/Formula/torchvision.rb
+++ b/Formula/torchvision.rb
@@ -22,7 +22,7 @@ class Torchvision < Formula
   depends_on "cmake" => :build
   depends_on "jpeg-turbo"
   depends_on "libpng"
-  depends_on "libtorch"
+  depends_on "pytorch"
 
   on_macos do
     depends_on "libomp"
@@ -47,7 +47,7 @@ class Torchvision < Formula
         assert(ops.size() == 1);
       }
     EOS
-    libtorch = Formula["libtorch"]
+    pytorch = Formula["pytorch"]
     openmp_flags = if OS.mac?
       libomp = Formula["libomp"]
       %W[
@@ -59,9 +59,9 @@ class Torchvision < Formula
       %w[-fopenmp]
     end
     system ENV.cxx, "-std=c++14", "test.cpp", "-o", "test", *openmp_flags,
-                    "-I#{libtorch.opt_include}",
-                    "-I#{libtorch.opt_include}/torch/csrc/api/include",
-                    "-L#{libtorch.opt_lib}", "-ltorch", "-ltorch_cpu", "-lc10",
+                    "-I#{pytorch.opt_include}",
+                    "-I#{pytorch.opt_include}/torch/csrc/api/include",
+                    "-L#{pytorch.opt_lib}", "-ltorch", "-ltorch_cpu", "-lc10",
                     "-L#{lib}", "-ltorchvision"
 
     system "./test"

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -91,6 +91,7 @@
   "libcppa": "caf",
   "libmongoclient": "mongo-cxx-driver",
   "libsasl2": "cyrus-sasl",
+  "libtorch": "pytorch",
   "linux-headers": "linux-headers@4.4",
   "lua51": "lua@5.1",
   "mat": "mat2",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This renames `libtorch` to `pytorch`, and installs the Python module as well as the C++ libraries. This was originally #110199, but I opened a new pull request to get more attention on this change.