### PR TITLE
git-machete 3.12.0 (new formula)

### DIFF
--- a/Formula/git-machete.rb
+++ b/Formula/git-machete.rb
@@ -1,0 +1,37 @@
+class GitMachete < Formula
+  include Language::Python::Virtualenv
+
+  desc "Git repository organizer & rebase workflow automation tool"
+  homepage "https://github.com/VirtusLab/git-machete"
+  url "https://pypi.org/packages/source/g/git-machete/git-machete-3.12.0.tar.gz"
+  sha256 "b999ff0ead4b856436ee74aae394ae3c68941fab8286256488304382d0fc8452"
+  license "MIT"
+
+  depends_on "python@3.10"
+
+  def install
+    virtualenv_install_with_resources
+
+    bash_completion.install "completion/git-machete.completion.bash"
+    zsh_completion.install "completion/git-machete.completion.zsh"
+    fish_completion.install "completion/git-machete.fish"
+  end
+
+  test do
+    system "git", "init"
+    system "git", "config", "user.email", "you@example.com"
+    system "git", "config", "user.name", "Your Name"
+    (testpath/"test").write "foo"
+    system "git", "add", "test"
+    system "git", "commit", "--message", "Initial commit"
+    system "git", "branch", "-m", "main"
+    system "git", "checkout", "-b", "develop"
+    (testpath/"test2").write "bar"
+    system "git", "add", "test2"
+    system "git", "commit", "--message", "Other commit"
+
+    (testpath/".git/machete").write "main\n  develop"
+    expected_output = "  main\n  |\n  | Other commit\n  o-develop *\n"
+    assert_equal expected_output, shell_output("git machete status --list-commits")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hi Homebrew team,

This is the second approach to adding our software tool to Homebrew, our first try was 3 years ago: [#48238](https://github.com/Homebrew/homebrew-core/pull/48238). Since then, we grew a lot in both download stats, visibility (we recently got mentioned in an independently-written blog post https://benjamincongdon.me/blog/2022/07/17/In-Praise-of-Stacked-PRs/ ) and we also have got 500+ stars on [GitHub](https://github.com/VirtusLab/git-machete).