### PR TITLE
ctail: autoreconf to fix build on Apple Silicon

### DIFF
--- a/Formula/ctail.rb
+++ b/Formula/ctail.rb
@@ -26,11 +26,12 @@ class Ctail < Formula
   conflicts_with "byobu", because: "both install `ctail` binaries"
 
   def install
-    system "./configure",
-        "--prefix=#{prefix}",
-        "--disable-debug",
-        "--with-apr=#{Formula["apr"].opt_bin}",
-        "--with-apr-util=#{Formula["apr-util"].opt_bin}"
+    # Workaround for ancient config files not recognizing aarch64 macos.
+    system "autoreconf", "--force", "--install", "--verbose" if Hardware::CPU.arm?
+
+    system "./configure", *std_configure_args,
+                          "--with-apr=#{Formula["apr"].opt_bin}",
+                          "--with-apr-util=#{Formula["apr-util"].opt_bin}"
     system "make", "LIBTOOL=glibtool --tag=CC"
     system "make", "install"
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
