### PR TITLE
pythran: update test

### DIFF
--- a/Formula/pythran.rb
+++ b/Formula/pythran.rb
@@ -66,7 +66,8 @@ class Pythran < Formula
     rm_f testpath/"dprod.py"
     assert_equal "11", shell_output("#{python} -c 'import dprod; print(dprod.dprod([1,2], [3,4]))'").chomp
 
-    return if OS.linux? # FIXME: This test case fails with Linux trying to execute `gcc-5`, which does not exist.
+    # FIXME: This test case fails with Linux trying to execute `gcc-5`, which does not exist.
+    return if OS.linux? && Formula["python@3.10"].version < "3.10.7"
 
     (testpath/"arc_distance.py").write <<~EOS
       #pythran export arc_distance(float[], float[], float[], float[])
@@ -94,5 +95,9 @@ class Pythran < Formula
       )
       assert ([1.927, 1., 1.975, 1.83, 1.032] == np.round(d, 3)).all()
     EOS
+
+    return if OS.mac?
+
+    odie "The python3.10 version check should be removed! See Homebrew/homebrew-core#111909."
   end
 end


### PR DESCRIPTION
The second test case is broken on Linux until we rebuild `pythran` using
the newer GCC. This should happen when `python@3.10` is version 3.10.7
or newer.

Let's stop skipping the test on Linux when `python@3.10` has been
rebuilt, but throw an error as a reminder to remove the hacks in the
test when the time comes.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
