### PR TITLE
mold: build a relocatable bottle.

### DIFF
--- a/Formula/mold.rb
+++ b/Formula/mold.rb
@@ -42,6 +42,9 @@ class Mold < Formula
   def install
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1200)
 
+    # Undefine the `LIBDIR` macro to avoid embedding it in the binary.
+    # This helps make the bottle relocatable.
+    ENV.append_to_cflags "-ULIBDIR"
     # Ensure we're using Homebrew-provided versions of these dependencies.
     %w[mimalloc tbb zlib zstd].map { |dir| (buildpath/"third-party"/dir).rmtree }
     args = %w[


### PR DESCRIPTION
The build defines a `LIBDIR` macro which embeds the `lib` directory in
the `mold` binary.

If we undefine this macro, `mold` will fall back to looking for the
`lib` directory relative to itself, so it should continue to function
correctly even without this. This has the benefit of making the bottle
relocatable.

Our test should exercise this code path, so any breakage will be
detected in CI.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
