### PR TITLE
cln: add head

### DIFF
--- a/Formula/cln.rb
+++ b/Formula/cln.rb
@@ -1,9 +1,18 @@
 class Cln < Formula
   desc "Class Library for Numbers"
   homepage "https://www.ginac.de/CLN/"
-  url "https://www.ginac.de/CLN/cln-1.3.6.tar.bz2"
-  sha256 "f492530e8879bda529009b6033e1923c8f4aae843149fc28c667c20b094d984a"
   license "GPL-2.0"
+
+  stable do
+    url "https://www.ginac.de/CLN/cln-1.3.6.tar.bz2"
+    sha256 "f492530e8879bda529009b6033e1923c8f4aae843149fc28c667c20b094d984a"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
 
   livecheck do
     url :homepage
@@ -19,17 +28,19 @@ class Cln < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "899b98749201e57feef2d339c5a63ec88a19c241fa37a1480c020cca4d8363a8"
   end
 
-  depends_on "gmp"
+  head do
+    url "git://www.ginac.de/cln.git", branch: "master"
 
-  # Fix -flat_namespace being used on Big Sur and later.
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
-    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "wget" => :build
   end
 
+  depends_on "gmp"
+
   def install
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-dependency-tracking"
+    system "./autogen.sh" if build.head?
+    system "./configure", *std_configure_args
     system "make"
     system "make", "check"
     system "make", "install"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

HEAD has support for building on ARM64 / Apple Silicon.
```console
❯ brew info cln
==> cln: stable 1.3.6, HEAD
Class Library for Numbers
https://www.ginac.de/CLN/
/opt/homebrew/Cellar/cln/HEAD-b4d4489 (92 files, 6.6MB) *
  Built from source on 2022-09-30 at 00:11:44
```

Note that there are too many commits to cleanly apply upstream patches and some poor UTF-8 encoding of gitweb breaks some patches. Would need to manually backport fixes, which doesn't seem worth it.

Also tried building stable with `-DNO_ASM` but it fails on tests.