### PR TITLE
Update boost to use fPIC

### DIFF
--- a/Formula/boost-mpi.rb
+++ b/Formula/boost-mpi.rb
@@ -4,6 +4,7 @@ class BoostMpi < Formula
   url "https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2"
   sha256 "475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39"
   license "BSL-1.0"
+  revision 1
   head "https://github.com/boostorg/boost.git", branch: "master"
 
   livecheck do
@@ -35,6 +36,7 @@ class BoostMpi < Formula
       install
       threading=multi,single
       link=shared,static
+      cxxflags=-fPIC
     ]
 
     # Trunk starts using "clang++ -x c" to select C compiler which breaks C++11

--- a/Formula/boost-python3.rb
+++ b/Formula/boost-python3.rb
@@ -4,7 +4,7 @@ class BoostPython3 < Formula
   url "https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2"
   sha256 "475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39"
   license "BSL-1.0"
-  revision 1
+  revision 2
   head "https://github.com/boostorg/boost.git", branch: "master"
 
   livecheck do
@@ -39,6 +39,7 @@ class BoostPython3 < Formula
       install
       threading=multi,single
       link=shared,static
+      cxxflags=-fPIC
     ]
 
     # Boost is using "clang++ -x c" to select C compiler which breaks C++14

--- a/Formula/boost.rb
+++ b/Formula/boost.rb
@@ -4,7 +4,7 @@ class Boost < Formula
   url "https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2"
   sha256 "475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39"
   license "BSL-1.0"
-  revision 2
+  revision 3
   head "https://github.com/boostorg/boost.git", branch: "master"
 
   livecheck do
@@ -70,6 +70,7 @@ class Boost < Formula
       install
       threading=multi,single
       link=shared,static
+      cxxflags=-fPIC
     ]
 
     # Boost is using "clang++ -x c" to select C compiler which breaks C++14


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Boost does not turn on `-fPIC` option for static libraries. Might be related to https://github.com/boostorg/build/issues/366.