### PR TITLE
xpa: deprecate

### DIFF
--- a/Formula/xpa.rb
+++ b/Formula/xpa.rb
@@ -17,6 +17,8 @@ class Xpa < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b81c4534c71e50918a8be11796766e6b75b27c40560c08ae1e12071e96c0bfc3"
   end
 
+  deprecate! date: "2022-10-01", because: :unmaintained
+
   depends_on "libxt" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
The author retired and declared their products "unsupported".

Excerpt from <https://github.com/ericmandel>:
> After 40+ years, my software development career will come to a close on July 1, 2022. The repositories contained herein should therefore be considered static and unsupported. Do with them what you will!