### PR TITLE
gromacs: add GPU acceleration

### DIFF
--- a/Formula/gromacs.rb
+++ b/Formula/gromacs.rb
@@ -53,6 +53,7 @@ class Gromacs < Formula
     args = %W[
       -DGROMACS_CXX_COMPILER=#{cxx}
       -DGMX_VERSION_STRING_OF_FORK=#{tap.user}
+      -DGMX_GPU=OpenCL
     ]
     # Force SSE2/SSE4.1 for compatibility when building Intel bottles
     args << "-DGMX_SIMD=#{MacOS.version.requires_sse41? ? "SSE4.1" : "SSE2"}" if Hardware::CPU.intel? && build.bottle?


### PR DESCRIPTION
Enables OpenCL acceleration which is possible in custom builds, but not through the easily installable Homebrew distribution. Users can now harness their GPUs by setting the environment variable `GMX_GPU_DISABLE_COMPATIBILITY_CHECK`. Performance is poor, but almost 2x that of CPU alone for super-massive molecular simulations. More information [here](https://gromacs.bioexcel.eu/t/gpu-acceleration-on-mac-m1-mini/2938/25).

In the future, there may be another pull request that adds SYCL acceleration on M1/M2 Macs, and retains OpenCL acceleration on Intel Macs.

---

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?