### PR TITLE
publish-commit-bottles: install `skopeo` on self-hosted runner

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -43,6 +43,12 @@ jobs:
         with:
           test-bot: false
 
+      - name: Install `skopeo` for bottle upload
+        if: github.event.inputs.self_hosted
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y skopeo
+
       # Workaround until the `cache` action uses the changes from
       # https://github.com/actions/toolkit/pull/580.
       - name: Unlink workspace


### PR DESCRIPTION
We typically only use the self-hosted runner when publishing an `icu4c`
PR. However, this currently does not work since `icu4c` is in `skopeo`'s
dependency tree.

Let's avoid trying to install our version of `skopeo` and failing by
using the system package manager instead.

I chose this route instead of installing into our Docker container since
skopeo installs a bunch of dependencies that I'd like to avoid
opportunistic linkage with. Moreover, we rarely ever use the self-hosted
runner to publish PRs, so it does not seem worth it to carry around a
skopeo installation in every Docker container for something that's done
only a few times a year.
