### PR TITLE
parallel: fix `:all` bottle

### DIFF
--- a/Formula/parallel.rb
+++ b/Formula/parallel.rb
@@ -32,9 +32,12 @@ class Parallel < Formula
 
     inreplace_files = [
       bin/"parallel",
+      doc/"parallel.texi",
       doc/"parallel_design.texi",
+      doc/"parallel_examples.texi",
       man1/"parallel.1",
       man7/"parallel_design.7",
+      man7/"parallel_examples.7",
     ]
 
     # Ignore `inreplace` failures when building from HEAD or not building a bottle.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
