### PR TITLE
perl: fix installation style

### DIFF
--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -57,6 +57,7 @@ class Perl < Formula
 
     args << "-Dusedevel" if build.head?
 
+    inreplace "./Configure", "installstyle=$dflt", "installstyle='lib/perl5'"
     system "./Configure", *args
 
     system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `installstyle` is not consistent with the macOS system perl, which would let formula use `uses_from_macos "perl"` install perl lib into a different location. See #110496.

# arm64 (macOS Monterey)

```bash
$ /usr/bin/perl -MConfig -e 'print $Config{installstyle}'
lib/perl5
```

# amd64 (homebrew/ubuntu22.04:master)

```bash
$ /home/linuxbrew/.linuxbrew/bin/perl -MConfig -e 'print $Config{installstyle}'
lib
```
