### PR TITLE
influxdb: add livecheck blocks for resources

### DIFF
--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -34,6 +34,11 @@ class Influxdb < Formula
   resource "pkg-config-wrapper" do
     url "https://github.com/influxdata/pkg-config/archive/refs/tags/v0.2.11.tar.gz"
     sha256 "52b22c151163dfb051fd44e7d103fc4cde6ae8ff852ffc13adeef19d21c36682"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/influxdata/influxdb/v#{LATEST_VERSION}/go.mod"
+      regex(/pkg-config\s+v?(\d+(?:\.\d+)+)/i)
+    end
   end
 
   # NOTE: The version/URL here is specified in scripts/fetch-ui-assets.sh in influxdb.
@@ -41,6 +46,11 @@ class Influxdb < Formula
   resource "ui-assets" do
     url "https://github.com/influxdata/ui/releases/download/OSS-v2.6.0/build.tar.gz"
     sha256 "e3a492886f7d22b88f6c0c852c6ff6dc6993a18b0dbde41dab6f66309072ba85"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/influxdata/influxdb/v#{LATEST_VERSION}/scripts/fetch-ui-assets.sh"
+      regex(/UI_RELEASE=["']?OSS[._-]v?(\d+(?:\.\d+)+)["']?$/i)
+    end
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As stated in https://github.com/Homebrew/homebrew-core/pull/111257, after https://github.com/Homebrew/brew/pull/13613, it would be possible to use `brew livecheck` command for resources as well. 

While augmenting `brew livecheck` command, I tested the functionality on multiple different resources and formulae. `pkg-config-wrapper` was one of the resource which could benefit from such behaviour.

#

> Note: you can only test this functionality properly once https://github.com/Homebrew/brew/pull/13613 is merged successfully. Simply, run `brew livecheck influxdb -r` and you'd see the livecheck output for resources as well.

# 

As pointed out by @SMillerDev and @nandahkrishna, my earlier implementation was wrong as it was looking at the latest version. However, now it will fetch `pkg-config-wrapper` livecheck info from upstream repo version in `go.mod` of `influxdb` (as intended).

