### PR TITLE
luvit: added livecheck block for resource `luvi`

### DIFF
--- a/Formula/luvit.rb
+++ b/Formula/luvit.rb
@@ -39,6 +39,16 @@ class Luvit < Formula
         tag:      "v2.12.0",
         revision: "5d1052f11e813ff9edc3ec75b5282b3e6cb0f3bf"
 
+    livecheck do
+      url "https://raw.githubusercontent.com/luvit/luvit/master/Makefile"
+      regex(/(LIT_VERSION=)+(\d+(?:\.\d+)+)/i)
+      strategy :page_match do |page, regex|
+        lit_version = page[regex, 2]
+        luvi_page = Homebrew::Livecheck::Strategy.page_content("https://raw.githubusercontent.com/luvit/lit/#{lit_version}/get-lit.sh")
+        luvi_page[:content].scan(/(LUVI_VERSION:-)+(\d+(?:\.\d+)+)/i).map { |match| match[1] }
+      end
+    end
+
     # Remove outdated linker flags that break the ARM build.
     # https://github.com/luvit/luvi/pull/261
     patch do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

To update this resource, we needed to check `LUVI_VERSION` in `https://github.com/luvit/lit/raw/$(LIT_VERSION)/get-lit.sh`, that's why I reused the logic implemented in https://github.com/Homebrew/homebrew-core/pull/112157 to first fetch the correct `LIT_VERSION`, and then fetch the content of  `https://raw.githubusercontent.com/luvit/lit/#{LIT_VERSION}/get-lit.sh"` file to extract `LUVI_VERSION` information.

#

@nandahkrishna please have a look at this PR too. I have tested it locally, and it works as we intended.