### PR TITLE
netcdf 4.9.0, netcdf-cxx 4.3.1, netcdf-fortran 4.6.0

### DIFF
--- a/Formula/netcdf-cxx.rb
+++ b/Formula/netcdf-cxx.rb
@@ -1,0 +1,56 @@
+class NetcdfCxx < Formula
+  desc "C++ libraries and utilities for NetCDF"
+  homepage "https://www.unidata.ucar.edu/software/netcdf/"
+  url "https://github.com/Unidata/netcdf-cxx4/archive/refs/tags/v4.3.1.tar.gz"
+  sha256 "e3fe3d2ec06c1c2772555bf1208d220aab5fee186d04bd265219b0bc7a978edc"
+  license "NetCDF"
+
+  depends_on "cmake" => :build
+  depends_on "hdf5"
+  depends_on "netcdf"
+
+  def install
+    args = std_cmake_args + %w[-DBUILD_TESTING=OFF -DNCXX_ENABLE_TESTS=OFF -DENABLE_TESTS=OFF -DENABLE_NETCDF_4=ON
+                               -DENABLE_DOXYGEN=OFF]
+
+    system "cmake", "-S", ".", "-B", "build_shared", *args, "-DBUILD_SHARED_LIBS=ON"
+    system "cmake", "--build", "build_shared"
+    system "cmake", "--install", "build_shared"
+
+    system "cmake", "-S", ".", "-B", "build_static", *args, "-DBUILD_SHARED_LIBS=OFF"
+    system "cmake", "--build", "build_static"
+    lib.install "build_static/cxx4/libnetcdf-cxx4.a"
+
+    # Remove shim paths
+    inreplace [bin/"ncxx4-config", lib/"libnetcdf-cxx.settings"] do |s|
+      s.gsub!(Superenv.shims_path/ENV.cc, ENV.cc, false)
+      s.gsub!(Superenv.shims_path/ENV.cxx, ENV.cxx, false)
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <iostream>
+      #include <netcdf>
+
+      constexpr int nx = 6;
+      constexpr int ny = 12;
+
+      int main() {
+          int dataOut[nx][ny];
+          for (int i = 0; i < nx; i++) {
+            for (int j = 0; j < ny; j++) {
+              dataOut[i][j] = i * ny + j;
+            }
+          }
+          netCDF::NcFile dataFile("simple_xy.nc", netCDF::NcFile::replace);
+          auto xDim = dataFile.addDim("x", nx);
+          auto yDim = dataFile.addDim("y", ny);
+          auto data = dataFile.addVar("data", netCDF::ncInt, {xDim, yDim});
+          data.putVar(dataOut);
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-std=c++11", "-L#{lib}", "-I#{include}", "-lnetcdf-cxx4", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/netcdf-fortran.rb
+++ b/Formula/netcdf-fortran.rb
@@ -1,0 +1,53 @@
+class NetcdfFortran < Formula
+  desc "Fortran libraries and utilities for NetCDF"
+  homepage "https://www.unidata.ucar.edu/software/netcdf/"
+  url "https://github.com/Unidata/netcdf-fortran/archive/refs/tags/v4.6.0.tar.gz"
+  sha256 "8194aa70e400c0adfc456127c1d97af2c6489207171d13b10cd754a16da8b0ca"
+  license "NetCDF"
+
+  depends_on "cmake" => :build
+  depends_on "gcc" # for gfortran
+  depends_on "hdf5"
+  depends_on "netcdf"
+
+  def install
+    args = std_cmake_args + %w[-DBUILD_TESTING=OFF -DENABLE_TESTS=OFF -DENABLE_NETCDF_4=ON -DENABLE_DOXYGEN=OFF]
+
+    system "cmake", "-S", ".", "-B", "build_shared", *args, "-DBUILD_SHARED_LIBS=ON"
+    system "cmake", "--build", "build_shared"
+    system "cmake", "--install", "build_shared"
+
+    system "cmake", "-S", ".", "-B", "build_static", *args, "-DBUILD_SHARED_LIBS=OFF"
+    system "cmake", "--build", "build_static"
+    lib.install "build_static/fortran/libnetcdff.a"
+
+    # Remove shim paths
+    inreplace [bin/"nf-config", lib/"libnetcdff.settings", lib/"pkgconfig/netcdf-fortran.pc"],
+      Superenv.shims_path/ENV.cc, ENV.cc
+  end
+
+  test do
+    (testpath/"test.f90").write <<~EOS
+      program test
+        use netcdf
+        integer :: ncid, varid, dimids(2)
+        integer :: dat(2,2) = reshape([1, 2, 3, 4], [2, 2])
+        call check( nf90_create("test.nc", NF90_CLOBBER, ncid) )
+        call check( nf90_def_dim(ncid, "x", 2, dimids(2)) )
+        call check( nf90_def_dim(ncid, "y", 2, dimids(1)) )
+        call check( nf90_def_var(ncid, "data", NF90_INT, dimids, varid) )
+        call check( nf90_enddef(ncid) )
+        call check( nf90_put_var(ncid, varid, dat) )
+        call check( nf90_close(ncid) )
+      contains
+        subroutine check(status)
+          integer, intent(in) :: status
+          if (status /= nf90_noerr) call abort
+        end subroutine check
+      end program test
+    EOS
+    system "gfortran", "test.f90", "-L#{lib}", "-I#{include}", "-lnetcdff",
+                       "-o", "testf"
+    system "./testf"
+  end
+end

--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -1,10 +1,9 @@
 class Netcdf < Formula
   desc "Libraries and data formats for array-oriented scientific data"
   homepage "https://www.unidata.ucar.edu/software/netcdf/"
-  url "https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.8.1.tar.gz"
-  sha256 "bc018cc30d5da402622bf76462480664c6668b55eb16ba205a0dfb8647161dd0"
+  url "https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.9.0.tar.gz"
+  sha256 "9f4cb864f3ab54adb75409984c6202323d2fc66c003e5308f3cdf224ed41c0a6"
   license "BSD-3-Clause"
-  revision 3
   head "https://github.com/Unidata/netcdf-c.git", branch: "main"
 
   livecheck do
@@ -23,89 +22,34 @@ class Netcdf < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "gcc" # for gfortran
   depends_on "hdf5"
 
   uses_from_macos "curl"
 
-  resource "cxx" do
-    url "https://downloads.unidata.ucar.edu/netcdf-cxx/4.3.1/netcdf-cxx4-4.3.1.tar.gz"
-    mirror "https://www.gfd-dennou.org/arch/netcdf/unidata-mirror/netcdf-cxx4-4.3.1.tar.gz"
-    sha256 "6a1189a181eed043b5859e15d5c080c30d0e107406fbb212c8fb9814e90f3445"
-  end
-
-  resource "fortran" do
-    # Source tarball at official domains are missing some configuration files
-    # Switch back at version bump
-    url "https://github.com/Unidata/netcdf-fortran/archive/refs/tags/v4.5.3.tar.gz"
-    sha256 "c6da30c2fe7e4e614c1dff4124e857afbd45355c6798353eccfa60c0702b495a"
+  # Patch for JSON collision. Remove in 4.9.1
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/1383fd8c15feb09c942665601d58fba3d6d5348f/netcdf/netcdf-json.diff"
+    sha256 "6a5183dc734509986713a00451d7f98c5ab2e00ab0df749027067b0880fa9e92"
   end
 
   def install
-    ENV.deparallelize
+    # Remove when this is resolved: https://github.com/Unidata/netcdf-c/issues/2390
+    inreplace "CMakeLists.txt", "SET(netCDF_LIB_VERSION 19})", "SET(netCDF_LIB_VERSION 19)"
 
-    common_args = std_cmake_args << "-DBUILD_TESTING=OFF"
+    args = std_cmake_args + %w[-DBUILD_TESTING=OFF -DENABLE_TESTS=OFF -DENABLE_NETCDF_4=ON -DENABLE_DOXYGEN=OFF]
+    # Fixes "relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used" on Linux
+    args << "-DCMAKE_POSITION_INDEPENDENT_CODE=ON" if OS.linux?
 
-    mkdir "build" do
-      args = common_args.dup
-      args << "-DENABLE_TESTS=OFF" << "-DENABLE_NETCDF_4=ON" << "-DENABLE_DOXYGEN=OFF"
+    system "cmake", "-S", ".", "-B", "build_shared", *args, "-DBUILD_SHARED_LIBS=ON"
+    system "cmake", "--build", "build_shared"
+    system "cmake", "--install", "build_shared"
+    system "cmake", "-S", ".", "-B", "build_static", *args, "-DBUILD_SHARED_LIBS=OFF"
+    system "cmake", "--build", "build_static"
+    lib.install "build_static/liblib/libnetcdf.a"
 
-      # Extra CMake flags for compatibility with hdf5 1.12
-      # Remove with the following PR lands in a release:
-      # https://github.com/Unidata/netcdf-c/pull/1973
-      args << "-DCMAKE_C_FLAGS='-I#{Formula["hdf5"].include} -DH5_USE_110_API'"
-
-      system "cmake", "..", "-DBUILD_SHARED_LIBS=ON", *args
-      system "make", "install"
-      system "make", "clean"
-      system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", *args
-      system "make"
-      lib.install "liblib/libnetcdf.a"
-    end
-
-    # Add newly created installation to paths so that binding libraries can
-    # find the core libs.
-    args = common_args.dup << "-DNETCDF_C_LIBRARY=#{lib}/#{shared_library("libnetcdf")}"
-
-    cxx_args = args.dup
-    cxx_args << "-DNCXX_ENABLE_TESTS=OFF"
-    resource("cxx").stage do
-      mkdir "build-cxx" do
-        system "cmake", "..", "-DBUILD_SHARED_LIBS=ON", *cxx_args
-        system "make", "install"
-        system "make", "clean"
-        system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", *cxx_args
-        system "make"
-        lib.install "cxx4/libnetcdf-cxx4.a"
-      end
-    end
-
-    fortran_args = args.dup
-    fortran_args << "-DENABLE_TESTS=OFF"
-
-    # Fix for netcdf-fortran with GCC 10, remove with next version
-    ENV.prepend "FFLAGS", "-fallow-argument-mismatch"
-
-    resource("fortran").stage do
-      mkdir "build-fortran" do
-        system "cmake", "..", "-DBUILD_SHARED_LIBS=ON", *fortran_args
-        system "make", "install"
-        system "make", "clean"
-        system "cmake", "..", "-DBUILD_SHARED_LIBS=OFF", *fortran_args
-        system "make"
-        lib.install "fortran/libnetcdff.a"
-      end
-    end
-
-    # Remove some shims path
-    inreplace [
-      bin/"nf-config", bin/"ncxx4-config", bin/"nc-config",
-      lib/"pkgconfig/netcdf.pc", lib/"pkgconfig/netcdf-fortran.pc",
-      lib/"cmake/netCDF/netCDFConfig.cmake",
-      lib/"libnetcdf.settings", lib/"libnetcdf-cxx.settings"
-    ], Superenv.shims_path/ENV.cc, ENV.cc
-
-    inreplace bin/"ncxx4-config", Superenv.shims_path/ENV.cxx, ENV.cxx if OS.linux?
+    # Remove shim paths
+    inreplace [bin/"nc-config", lib/"pkgconfig/netcdf.pc", lib/"cmake/netCDF/netCDFConfig.cmake",
+               lib/"libnetcdf.settings"], Superenv.shims_path/ENV.cc, ENV.cc
   end
 
   test do
@@ -125,28 +69,5 @@ class Netcdf < Formula
     else
       assert_equal version.to_s, `./test`
     end
-
-    (testpath/"test.f90").write <<~EOS
-      program test
-        use netcdf
-        integer :: ncid, varid, dimids(2)
-        integer :: dat(2,2) = reshape([1, 2, 3, 4], [2, 2])
-        call check( nf90_create("test.nc", NF90_CLOBBER, ncid) )
-        call check( nf90_def_dim(ncid, "x", 2, dimids(2)) )
-        call check( nf90_def_dim(ncid, "y", 2, dimids(1)) )
-        call check( nf90_def_var(ncid, "data", NF90_INT, dimids, varid) )
-        call check( nf90_enddef(ncid) )
-        call check( nf90_put_var(ncid, varid, dat) )
-        call check( nf90_close(ncid) )
-      contains
-        subroutine check(status)
-          integer, intent(in) :: status
-          if (status /= nf90_noerr) call abort
-        end subroutine check
-      end program test
-    EOS
-    system "gfortran", "test.f90", "-L#{lib}", "-I#{include}", "-lnetcdff",
-                       "-o", "testf"
-    system "./testf"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Closes https://github.com/Homebrew/homebrew-core/pull/106520.

Splits the netcdf formula into its C++ and Fortran versions. This ensures that livecheck will be able to detect updates, as otherwise they would have been hidden behind resource blocks. This also adds a test for the C++ version of the netcdf bindings. Finally, modernize and enable parallel building with the CMake --build method.

There will be audit failures (pre-existing from netcdf) for non-libraries installed to lib/.