### PR TITLE
suil: drop gtk+

### DIFF
--- a/Formula/suil.rb
+++ b/Formula/suil.rb
@@ -32,7 +32,6 @@ class Suil < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "python@3.10" => :build
-  depends_on "gtk+"
   depends_on "gtk+3"
   depends_on "lv2"
   depends_on "qt@5"


### PR DESCRIPTION
This is a leftover from #73442.

Removing as gtk+ is now deprecated, see #111069

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
