### PR TITLE
mupen64plus: fix build with GCC 11

### DIFF
--- a/Formula/mupen64plus.rb
+++ b/Formula/mupen64plus.rb
@@ -4,7 +4,7 @@ class Mupen64plus < Formula
   url "https://github.com/mupen64plus/mupen64plus-core/releases/download/2.5/mupen64plus-bundle-src-2.5.tar.gz"
   sha256 "9c75b9d826f2d24666175f723a97369b3a6ee159b307f7cc876bbb4facdbba66"
   license "GPL-2.0"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -46,6 +46,11 @@ class Mupen64plus < Formula
     inreplace "source/mupen64plus-video-glide64mk2/src/Glide64/3dmath.cpp",
               "__builtin_ia32_storeups", "_mm_storeu_ps"
 
+    if OS.linux?
+      ENV.append "CFLAGS", "-fcommon"
+      ENV.append "CFLAGS", "-fpie"
+    end
+
     args = ["install", "PREFIX=#{prefix}"]
     args << if OS.mac?
       "INSTALL_STRIP_FLAG=-S"
@@ -78,7 +83,7 @@ class Mupen64plus < Formula
     end
 
     cd "source/mupen64plus-ui-console/projects/unix" do
-      system "make", *args
+      system "make", *args, "PIE=1"
     end
   end
 

--- a/Formula/mupen64plus.rb
+++ b/Formula/mupen64plus.rb
@@ -3,7 +3,7 @@ class Mupen64plus < Formula
   homepage "https://www.mupen64plus.org/"
   url "https://github.com/mupen64plus/mupen64plus-core/releases/download/2.5/mupen64plus-bundle-src-2.5.tar.gz"
   sha256 "9c75b9d826f2d24666175f723a97369b3a6ee159b307f7cc876bbb4facdbba66"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 3
 
   livecheck do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We need to revision bump this for `boost`: https://github.com/Homebrew/homebrew-core/pull/111800.