### PR TITLE
loki: add an explicit livecheck

### DIFF
--- a/Formula/loki.rb
+++ b/Formula/loki.rb
@@ -6,6 +6,11 @@ class Loki < Formula
   license "AGPL-3.0-only"
   head "https://github.com/grafana/loki.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "721a009f4330a15efe56180635ecb04fe9efc196cf31257db8eb8aed004b2486"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "2a64e295b739fb8ea34a90e160123ff4f12212f04f1858af01550b89b7acf987"


### PR DESCRIPTION
Use GitHub stable releases as an explicit livecheck strategy so that livecheck doesn't detect tags of the helm charts.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Livecheck currently grabs tags corresponding to helm charts for which versions are completely different.

The livecheck block aims to force it to the use of GitHub releases. However, is it normal that the default behavior of livecheck is to match tags with a very different form than the current one (ie. it have an helm prefix that current releases doesn't have), or should this be considered a bug in livecheck?