### PR TITLE
govendor: re-deprecate and disable on 2023-01-02

### DIFF
--- a/Formula/govendor.rb
+++ b/Formula/govendor.rb
@@ -17,8 +17,9 @@ class Govendor < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "24497503629e520a1fe718029ab520b05c012677df065c9fd104afe4d898b8b8"
   end
 
-  # Commented out while this formula still has dependents.
-  # deprecate! date: "2020-03-02", because: :repo_archived
+  # Original deprecation date: 2020-03-02
+  # Temporarily undeprecated from 2022-07-29 to 2022-10-02
+  disable! date: "2023-01-02", because: :repo_archived
 
   depends_on "go"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
