### PR TITLE
man-db: fix test on Linux

### DIFF
--- a/Formula/man-db.rb
+++ b/Formula/man-db.rb
@@ -88,13 +88,13 @@ class ManDb < Formula
 
   test do
     ENV["PAGER"] = "cat"
-    output = shell_output("#{bin}/gman true")
     if OS.mac?
+      output = shell_output("#{bin}/gman true")
       assert_match "BSD General Commands Manual", output
       assert_match(/The true utility always returns with (an )?exit code (of )?zero/, output)
-    else
-      assert_match "true - do nothing, successfully", output
-      assert_match "GNU coreutils online help: <http://www.gnu.org/software/coreutils/", output
     end
+    output = shell_output("#{bin}/gman gman")
+    assert_match "gman - an interface to the system reference manuals", output
+    assert_match "https://savannah.nongnu.org/bugs/?group=man-db", output
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in Perl PR #112161.
```
==> /home/linuxbrew/.linuxbrew/Cellar/man-db/2.10.2/bin/gman true
  No manual entry for true
```