### PR TITLE
nqc 3.2r1 (new formula)

### DIFF
--- a/Formula/nqc.rb
+++ b/Formula/nqc.rb
@@ -1,0 +1,16 @@
+class Nqc < Formula
+  desc "Programming language for LEGO MINDSTORMS RCX, CyberMaster and Scout"
+  homepage "https://bricxcc.sourceforge.net/nqc/"
+  url "https://github.com/jverne/nqc/archive/refs/tags/v3.2r1.tar.gz"
+  sha256 "057ca37e92d4eb7b0418e4c503ed9df2e1d057dc30e9426ce3072ee6eb75271a"
+  license "MPL-2.0"
+
+  def install
+    ENV.deparallelize
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    system "#{bin}/nqc"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)?
- [ ] If this is a new formula, does it pass `brew audit --new <formula>`?

---

The [nqc](https://github.com/jverne/nqc) repository does not have many stars but it is the only version that compiles on modern architectures and is still maintained. NQC has existed for more than 20 years and is used with legacy LEGO MINDSTORMS products so it should be very stable.