### PR TITLE
caf: drop GCC dependency

### DIFF
--- a/Formula/caf.rb
+++ b/Formula/caf.rb
@@ -20,10 +20,6 @@ class Caf < Formula
   depends_on "cmake" => :build
   depends_on "openssl@1.1"
 
-  on_linux do
-    depends_on "gcc" # For C++17
-  end
-
   fails_with gcc: "5"
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The latest version of `caf` is having build failures unrelated to GCC: https://github.com/Homebrew/homebrew-core/pull/110230.  For now we should drop the GCC dependency on the current version and rebase or close https://github.com/Homebrew/homebrew-core/pull/110230.