### PR TITLE
Drop Linux-only GCC dependencies in deprecated formulae

### DIFF
--- a/Formula/mariadb@10.2.rb
+++ b/Formula/mariadb@10.2.rb
@@ -33,7 +33,6 @@ class MariadbAT102 < Formula
   # This upstream commit was added for MariaDB 10.3+, but not 10.2. If it is not
   # added in the next release, we should open an upstream PR to do so.
   on_linux do
-    depends_on "gcc"
     depends_on "linux-pam"
   end
 

--- a/Formula/pprint.rb
+++ b/Formula/pprint.rb
@@ -14,10 +14,6 @@ class Pprint < Formula
 
   depends_on macos: :high_sierra # needs C++17
 
-  on_linux do
-    depends_on "gcc"
-  end
-
   fails_with gcc: "5"
 
   def install

--- a/Formula/spidermonkey@78.rb
+++ b/Formula/spidermonkey@78.rb
@@ -27,10 +27,6 @@ class SpidermonkeyAT78 < Formula
   uses_from_macos "llvm" => :build # for llvm-objdump
   uses_from_macos "zlib"
 
-  on_linux do
-    depends_on "gcc"
-  end
-
   # From python/mozbuild/mozbuild/test/configure/test_toolchain_configure.py
   fails_with :gcc do
     version "6"

--- a/Formula/vtk@8.2.rb
+++ b/Formula/vtk@8.2.rb
@@ -43,7 +43,6 @@ class VtkAT82 < Formula
   end
 
   on_linux do
-    depends_on "gcc"
     depends_on "icu4c"
     depends_on "libaec"
     depends_on "libxt"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These formulae are deprecated so there is no point in rebuilding them.