### PR TITLE
ormolu 0.5.0.1

### DIFF
--- a/Formula/ormolu.rb
+++ b/Formula/ormolu.rb
@@ -1,8 +1,8 @@
 class Ormolu < Formula
   desc "Formatter for Haskell source code"
   homepage "https://github.com/tweag/ormolu"
-  url "https://github.com/tweag/ormolu/archive/0.4.0.0.tar.gz"
-  sha256 "c87b2e09cef54aa7568b9bc990bb6ffd7b8dae3d8b950557fbe60ec286039353"
+  url "https://github.com/tweag/ormolu/archive/0.5.0.1.tar.gz"
+  sha256 "589e7e93eb71ba12cdffed9c439025bfa8524d33d66ffd300c195af57720503a"
   license "BSD-3-Clause"
   head "https://github.com/tweag/ormolu.git", branch: "master"
 
@@ -20,7 +20,7 @@ class Ormolu < Formula
 
   def install
     system "cabal", "v2-update"
-    system "cabal", "v2-install", *std_cabal_v2_args
+    system "cabal", "v2-install", "-f-fixity-th", *std_cabal_v2_args
   end
 
   test do


### PR DESCRIPTION
Disables the `fixity-th` flag as this seems to cause linker errors on aarch64 with clang.

See https://github.com/tweag/ormolu/issues/927.

Can't test this as I don't actually have a working Mac on aarch64 handy, but I'm hoping the automated checks will do the work for me.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
