### PR TITLE
glib: disable use of close_range by spawn

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -42,6 +42,10 @@ class Glib < Formula
     sha256 "d81c9e8296ec5b53b4ead6917f174b06026eeb0c671dfffc4965b2271fb6a82c"
   end
 
+  # Temporary fix to disable usage of close_range by gspawn since the syscall
+  # is blocked by a Docker bug in CI.  Remove when this has been fixed.
+  patch :DATA
+
   def install
     inreplace %w[gio/xdgmime/xdgmime.c glib/gutils.c], "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX
 
@@ -120,3 +124,19 @@ class Glib < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git a/glib/gspawn.c b/glib/gspawn.c
+index 4e029ee..d8dd71f 100644
+--- a/glib/gspawn.c
++++ b/glib/gspawn.c
+@@ -21,6 +21,9 @@
+  */
+
+ #include "config.h"
++#ifdef __linux__
++#undef HAVE_CLOSE_RANGE
++#endif
+
+ #include <sys/time.h>
+ #include <sys/types.h>


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I was looking more into the usage of `close_range` by `glib` and noticed that it is only used by gspawn, and its usage is gated by the `HAVE_CLOSE_RANGE` macro there.  This is done because `close_range` was only recently added to `glibc` so many systems still don't support it.  The code gracefully falls back to using older less elegant methods when `close_range` is unavailable (see https://gitlab.gnome.org/GNOME/glib/-/issues/2580). 

I've confirmed through local testing that `webkitgtk`, which reproducibly fails because the `close_range` syscall is blocked in Docker, builds with no issues once `glib` has been rebuilt with this patch.  To test this, I have added a temporary revision bump to `webkitgtk` so it is rebuilt.  This should tell us if the fix worked as it should fail if it didn't.