### PR TITLE
verovio 3.12.1 (new formula)

### DIFF
--- a/Formula/atlantis.rb
+++ b/Formula/atlantis.rb
@@ -1,8 +1,8 @@
 class Atlantis < Formula
   desc "Terraform Pull Request Automation tool"
   homepage "https://www.runatlantis.io/"
-  url "https://github.com/runatlantis/atlantis/archive/v0.19.9.tar.gz"
-  sha256 "98e1f0f6b721fd3744eb4213673e842388956fad36cab5d91906b9ec2464d8d7"
+  url "https://github.com/runatlantis/atlantis/archive/v0.19.8.tar.gz"
+  sha256 "12f2e3d74264b4457d0a7766f8b4f580984a025fcdb3d443b8aad85f036994d4"
   license "Apache-2.0"
   head "https://github.com/runatlantis/atlantis.git", branch: "master"
 
@@ -12,12 +12,12 @@ class Atlantis < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "5d5e27d20856a3bde41231a9a8d7275b28e52a94980a870985ef90003a151f00"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "5cf65246a23c47b4d13fae770932f52014468d4a05c0be894bbb2e3c6edce27b"
-    sha256 cellar: :any_skip_relocation, monterey:       "b023d62b5d92cb0c18729915d871c46cffb325fce6eadd2ae487d56a77b27072"
-    sha256 cellar: :any_skip_relocation, big_sur:        "65c3b11a5edd5b37b6a069929b32c80073363aff02cd09eeec881a5855a87b0a"
-    sha256 cellar: :any_skip_relocation, catalina:       "754760700ca85da0e8e8bb6db060d5311a27147b7ed09e3c50fac1e5d7da9bde"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d1f8da1b30dbb0bb193a55ababd05b63c49987ec44caf84370aa6bee1f606a4a"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "43dd16991f6bac05a0bb05db52c27f64a36a2aed987f9a7826a663921a5fb822"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "fc50a0eb348c43ff20b5617481107f5039367207849254dac139a80ffdb98acd"
+    sha256 cellar: :any_skip_relocation, monterey:       "feaef126eb624f4a14bf3512d29880c2239346bbe752f0ec2087824042182715"
+    sha256 cellar: :any_skip_relocation, big_sur:        "123f85370b232a626dec386b642d793e446a94a01cb5935191e05af0fcf8aece"
+    sha256 cellar: :any_skip_relocation, catalina:       "f8e169662b04a87beba6db56b667f475aa75e32a6dea1d7fb439a07ae3cc358a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "024d68349c5631a01f076ad6f2eb2d258b1ef32686ef795029b8458decc6acbb"
   end
 
   depends_on "go" => :build

--- a/Formula/bash.rb
+++ b/Formula/bash.rb
@@ -1,30 +1,13 @@
 class Bash < Formula
   desc "Bourne-Again SHell, a UNIX command interpreter"
   homepage "https://www.gnu.org/software/bash/"
+  url "https://ftp.gnu.org/gnu/bash/bash-5.2.tar.gz"
+  mirror "https://ftpmirror.gnu.org/bash/bash-5.2.tar.gz"
+  mirror "https://mirrors.kernel.org/gnu/bash/bash-5.2.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/gnu/bash/bash-5.2.tar.gz"
+  sha256 "a139c166df7ff4471c5e0733051642ee5556c1cc8a4a78f145583c5c81ab32fb"
   license "GPL-3.0-or-later"
   head "https://git.savannah.gnu.org/git/bash.git", branch: "master"
-
-  stable do
-    url "https://ftp.gnu.org/gnu/bash/bash-5.2.tar.gz"
-    mirror "https://ftpmirror.gnu.org/bash/bash-5.2.tar.gz"
-    mirror "https://mirrors.kernel.org/gnu/bash/bash-5.2.tar.gz"
-    mirror "https://mirrors.ocf.berkeley.edu/gnu/bash/bash-5.2.tar.gz"
-    sha256 "a139c166df7ff4471c5e0733051642ee5556c1cc8a4a78f145583c5c81ab32fb"
-    version "5.2.2"
-
-    %w[
-      001 f42f2fee923bc2209f406a1892772121c467f44533bedfe00a176139da5d310a
-      002 45cc5e1b876550eee96f95bffb36c41b6cb7c07d33f671db5634405cd00fd7b8
-    ].each_slice(2) do |p, checksum|
-      patch :p0 do
-        url "https://ftp.gnu.org/gnu/bash/bash-5.2-patches/bash52-#{p}"
-        mirror "https://ftpmirror.gnu.org/bash/bash-5.2-patches/bash52-#{p}"
-        mirror "https://mirrors.kernel.org/gnu/bash/bash-5.2-patches/bash52-#{p}"
-        mirror "https://mirrors.ocf.berkeley.edu/gnu/bash/bash-5.2-patches/bash52-#{p}"
-        sha256 checksum
-      end
-    end
-  end
 
   # We're not using `url :stable` here because we need `url` to be a string
   # when we use it in the `strategy` block.
@@ -63,12 +46,12 @@ class Bash < Formula
   end
 
   bottle do
-    sha256 arm64_monterey: "f144e86255c7b8537e965e1e38622aa89f20bbfbd240dfaaa552406d5c8d5030"
-    sha256 arm64_big_sur:  "bcbaef0dbb3758d1d364efe8d166453971166e4f7cb7b5192155a13a780695eb"
-    sha256 monterey:       "a844d150df53490c40bd3135dee39490494442e58301233770439849a44731e0"
-    sha256 big_sur:        "e86a690fcabda57cebe0d1935b29eb4aff4c60889ee79b6fa821589075f77ff3"
-    sha256 catalina:       "29598d781c44882c5bf8d19a1b91b9da747f8e5b5bc89c57626864fb23c602a5"
-    sha256 x86_64_linux:   "1d58b8ad0482f5c9ab1211d63693f058279420a119ffba0e8ab0ede795edd219"
+    sha256 arm64_monterey: "824f87ed8e25d40bb7b1abbcb74e2a9cb7da1b6f4e484acecdb288f076201c85"
+    sha256 arm64_big_sur:  "c978d7c40c84d2c11435a2d7e804f714d0afa62421bac61cf212be7a34503227"
+    sha256 monterey:       "1ec2f5fd0b9635ff892e5ebc8def03ce55232abc3731bd6ae33528dccb3d9371"
+    sha256 big_sur:        "b3d95c6bc517d73397cad77ce6184b43184fa856d3c1abce638916bba70801b0"
+    sha256 catalina:       "55c6c14ff3b10f55069986ef6dc6dd43fffd8cb083b71a639e6ebd5378bc403f"
+    sha256 x86_64_linux:   "b6a8ea41858e0c60f113865c96ed3f82eff69d077465874f5567da047d2f4e90"
   end
 
   def install

--- a/Formula/bbtools.rb
+++ b/Formula/bbtools.rb
@@ -1,17 +1,17 @@
 class Bbtools < Formula
   desc "Brian Bushnell's tools for manipulating reads"
   homepage "https://jgi.doe.gov/data-and-tools/bbtools/"
-  url "https://downloads.sourceforge.net/bbmap/BBMap_39.01.tar.gz"
-  sha256 "98608da50130c47f3abd095b889cc87f60beeb8b96169b664bc9d849abe093e6"
+  url "https://downloads.sourceforge.net/bbmap/BBMap_39.00.tar.gz"
+  sha256 "fa5be8f54a5f4c6b7031847538701479426bdbffc86b7ed7f419308a0d21a28f"
   license "BSD-3-Clause"
 
   bottle do
-    sha256 cellar: :any,                 arm64_monterey: "4f724b3391445cb3801dd8add9f385111f5d0ce8df1fde3956b71c7778df1a31"
-    sha256 cellar: :any,                 arm64_big_sur:  "8f5328602a99242b650931945bd1ad3b3fbd4da8c8ebb76a615148835fcbeb27"
-    sha256 cellar: :any,                 monterey:       "fa2231392ff7a5cc23c618d3ede17dabf7c39fcab96af981f34a44d255d56986"
-    sha256 cellar: :any,                 big_sur:        "91b2d7d2cda27ae13fd9aa955874f5a3be3af97b481ee5d23ac10e09c54da33f"
-    sha256 cellar: :any,                 catalina:       "2edf1f85161f3a245b29fb55b117f074d04c0859cc1abbb9406ac98c038c7730"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "177acf4ad3c84029f0f067afc3c4838e8cc91ec4f693a02554eedcbd86a3f379"
+    sha256 cellar: :any,                 arm64_monterey: "ecfe1eb5f582a17a456113bd53c5e108010dfe9947c21f1605bf2fd79ded4773"
+    sha256 cellar: :any,                 arm64_big_sur:  "1fdb10930a4c94435dc59462da5fab40d0779c3abd85cfea1062607bd7666884"
+    sha256 cellar: :any,                 monterey:       "3f06aef40eb9cbc16b7926ff2ce990dbe9812bb54ffaccbb9b5ec1e75daea328"
+    sha256 cellar: :any,                 big_sur:        "5fa81f12dc0a25916691be24e003d976ffec1932d09e66e1216ccec0a2f31c51"
+    sha256 cellar: :any,                 catalina:       "10b49c531cdcb3677c03c0531720703ac8c33df18bde071136134311c4ac77ad"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4b59a699fd6b491382ec2b7afbc78c761180a423e14e9ac9be5217b58250a636"
   end
 
   depends_on "openjdk"

--- a/Formula/c7n.rb
+++ b/Formula/c7n.rb
@@ -3,8 +3,8 @@ class C7n < Formula
 
   desc "Rules engine for cloud security, cost optimization, and governance"
   homepage "https://github.com/cloud-custodian/cloud-custodian"
-  url "https://github.com/cloud-custodian/cloud-custodian/archive/0.9.19.0.tar.gz"
-  sha256 "3b6273b5e01a34b6a3b75cdae9a72f38754000e6a1fb5de6f99c991ec1581ed3"
+  url "https://github.com/cloud-custodian/cloud-custodian/archive/0.9.18.0.tar.gz"
+  sha256 "7b88f4b8935455b6f14c17d848574ac9488e65632034ccbf1fd616c6a6e3c2c8"
   license "Apache-2.0"
 
   livecheck do
@@ -13,12 +13,13 @@ class C7n < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "808d9e70cca73de9cc2d5c9e110467faa7d60f080bf1821dc3cc2749ca863227"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "2b60184289cd0b9627820c16f39db744a862351b76519a20f26e70597cf17bdc"
-    sha256 cellar: :any_skip_relocation, monterey:       "bd763c3db01a6db1353d9396bc5081361ef8927d0f5c2c14d0c2dda68c61a66d"
-    sha256 cellar: :any_skip_relocation, big_sur:        "f33b9a209ce5a3a0c3b17dc8ada01daaefdd635021305a7bc06a407e29cd65cb"
-    sha256 cellar: :any_skip_relocation, catalina:       "b1fbe139445d158afab4b4e773b6eb3ace620f0463c15509a4a2bd195fc93845"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2105ef9ab5d09a46d9a997ff86b4057782b0d33c6ccccd9ca33dece645aaedc3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f9485276743b1cadf6cbd9a5d0f47e234f6d03028744d557a985585cf4518e2b"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "2cca1f09c4aa1958430e08d1cc0b0fca53f9feed3d22ccda552139dcff4a345d"
+    sha256 cellar: :any_skip_relocation, monterey:       "1b98fca2b3f91ce46b891c11626a93db3b0dcf92fc8ac094cd7db90924639413"
+    sha256 cellar: :any_skip_relocation, big_sur:        "989907a6191958f74f0bd876684c8a60d1731019fce3b56041ff23db8e9a835d"
+    sha256 cellar: :any_skip_relocation, catalina:       "5556595cb12a55be6c82568845d4e8c757b582b6a9d79d139e4396633d2190b5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "31278cf584af6ec8c6fde6b1d96a15f74b276fd1199e9d5a8d0fc59a92714562"
   end
 
   depends_on "jsonschema"

--- a/Formula/cargo-nextest.rb
+++ b/Formula/cargo-nextest.rb
@@ -1,8 +1,8 @@
 class CargoNextest < Formula
   desc "Next-generation test runner for Rust"
   homepage "https://nexte.st"
-  url "https://github.com/nextest-rs/nextest/archive/refs/tags/cargo-nextest-0.9.38.tar.gz"
-  sha256 "2a57298eb484dd153e50e46f8c8961efaed23f489fdca522d462a1dd0ee6324f"
+  url "https://github.com/nextest-rs/nextest/archive/refs/tags/cargo-nextest-0.9.37.tar.gz"
+  sha256 "3f50929b8fe098cf2ed8e2b0993983aac28a5eaf52e480ab5cba5939b0e38ab1"
   license "Apache-2.0"
 
   livecheck do
@@ -11,12 +11,12 @@ class CargoNextest < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "08d454a32dac7e7897fb6ffd699342e6501d6a4e3f733cab32d21147cf76c775"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "b3854724b2250b1252bae4f3d1c025a57744ba4c94532d9bd46517022d03d011"
-    sha256 cellar: :any_skip_relocation, monterey:       "f2e2dff812b8dae671aaa00b999cbe20a87db524579b9ce02c84b3ce074da20e"
-    sha256 cellar: :any_skip_relocation, big_sur:        "9b8ef3b7a2f435d8bf50aa1f20f7a242f56aded5ee2eed3eeea2f3e314536807"
-    sha256 cellar: :any_skip_relocation, catalina:       "cd78a8e8e82f05428269aab2542e46d37e061e94c748188d0701e3a72b9184ed"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7289effc4a987e3efbcec93b44b479ccce9c010ba4f3a797c14e1b457afab2f7"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "93aa920c9c46d5187a24ee1234635dc1ee1e12232c3312250dfc59396a721e52"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "62da3e8ab49dd294408289828f12172bc6c03ee7f4a728a6224280d74ce802d4"
+    sha256 cellar: :any_skip_relocation, monterey:       "a809e2bbb507385c3134633b7a10198ab878fb5820ce5ff6a84f0fa061f099b9"
+    sha256 cellar: :any_skip_relocation, big_sur:        "6dc584c01334876e12481d1e5f5fa26c9b9c55fe48cc84533b7151101dc675aa"
+    sha256 cellar: :any_skip_relocation, catalina:       "546e3c6a7b02448352bb842e29567f5bf828a84f918c71f1ff8d34add775b4fd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "37075df415d33256e0a0f6ce73c93597ff635b6691eee7a10aa623c773e28fd1"
   end
 
   depends_on "rust" # uses `cargo` at runtime

--- a/Formula/cdk8s.rb
+++ b/Formula/cdk8s.rb
@@ -3,12 +3,12 @@ require "language/node"
 class Cdk8s < Formula
   desc "Define k8s native apps and abstractions using object-oriented programming"
   homepage "https://cdk8s.io/"
-  url "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.6.tgz"
-  sha256 "b96eb4cedc2fb71d14e408df88f9ff70a109ba73dee6a10357a16c53eb881495"
+  url "https://registry.npmjs.org/cdk8s-cli/-/cdk8s-cli-2.1.5.tgz"
+  sha256 "e7888030705eed1986ae9b270e591b371112e972b3fc0b379034a7b4d7245a18"
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "19af4f4e72ef78aa39fc846645c31ccb900d69909f80297471545d67e86f1a22"
+    sha256 cellar: :any_skip_relocation, all: "588383eb3532e3893c88fee349dd8c32448e5c1a25c05ca0ce8d768e5ca976e9"
   end
 
   depends_on "node"

--- a/Formula/dmenu.rb
+++ b/Formula/dmenu.rb
@@ -1,8 +1,8 @@
 class Dmenu < Formula
   desc "Dynamic menu for X11"
   homepage "https://tools.suckless.org/dmenu/"
-  url "https://dl.suckless.org/tools/dmenu-5.2.tar.gz"
-  sha256 "d4d4ca77b59140f272272db537e05bb91a5914f56802652dc57e61a773d43792"
+  url "https://dl.suckless.org/tools/dmenu-5.1.tar.gz"
+  sha256 "1f4d709ebba37eb7326eba0e665e0f13be4fa24ee35c95b0d79c30f14a348fd5"
   license "MIT"
   head "https://git.suckless.org/dmenu/", using: :git, branch: "master"
 
@@ -12,12 +12,12 @@ class Dmenu < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_monterey: "a38c53bfcb397d64e0d2711133111952681107e90c312fce10e2c05e00453910"
-    sha256 cellar: :any,                 arm64_big_sur:  "e0780e17a41fb6825390ab8ea583335cb5be93450bbf5feba9f2bfb3ba62d743"
-    sha256 cellar: :any,                 monterey:       "d1ee5fd7bddff131aa64cb50985001d002b127c84253348a789186e9d7b67ec8"
-    sha256 cellar: :any,                 big_sur:        "ae03a3e95ded418ebd8a249ccbf0a026efd64a41cccb53090075519a72670fc7"
-    sha256 cellar: :any,                 catalina:       "30477f6f373029ad6e4629c28e45d579770b3f89c2c8027d5245ae4b41ed18bb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8b0e7be290b1206f50abe98659c2594d1d4ef4983cd7e63932108cb0b19d892e"
+    sha256 cellar: :any,                 arm64_monterey: "1e24f7e58c83a9d5e7b8aa03d6f585e126238f4eaf4e9a0cdfb5fc6a066b7430"
+    sha256 cellar: :any,                 arm64_big_sur:  "4e7b1c05be6aec0421ce1a0504047b80ca4f6acef5cebf25fbd0ff51e83e4c9c"
+    sha256 cellar: :any,                 monterey:       "4ea5c73d6392527698e9e82db9c541c0e1eb3944e7103363163f59c3573fcabd"
+    sha256 cellar: :any,                 big_sur:        "c84d2df11a31969f91e8d03aae0b6e21220835f8e0c12d81808ed9126aa0283b"
+    sha256 cellar: :any,                 catalina:       "d28486b555358a932c8d4f93aa7d2c2384f867426fa060812ae3fce7204a9013"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "eab4d7dc460c98e3c4f7e8f418f2d3d5fe13c040a6dc05b23c27772717b62169"
   end
 
   depends_on "fontconfig"

--- a/Formula/dpp.rb
+++ b/Formula/dpp.rb
@@ -2,17 +2,18 @@ class Dpp < Formula
   desc "Directly include C headers in D source code"
   homepage "https://github.com/atilaneves/dpp"
   url "https://github.com/atilaneves/dpp.git",
-      tag:      "v0.4.12",
-      revision: "06a340250792eac4bb3c7ff2661cc76e1e75b5c7"
+      tag:      "v0.4.11",
+      revision: "4c66d7959917f8440970ac447129b7b9f691dbc0"
   license "BSL-1.0"
+  revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "da4b8359d7e016ec880089a9b28800b363553af2a9c54de34b6887df092b08b8"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "28f05c69e09240046206dc0a28743f7ab060bfe833290f6a2a67a41712aa601a"
-    sha256 cellar: :any_skip_relocation, monterey:       "428a66c01b7940ed0d32541fd016d9d8ff17e3cf0f2c309c7ff65bc001df9e12"
-    sha256 cellar: :any_skip_relocation, big_sur:        "43cc9c9c63f3a07dfb756dab9c387e6b64b3a59d8c6f64ff6f36a38ab22cc02c"
-    sha256 cellar: :any_skip_relocation, catalina:       "0fa0e83c5e676237d16bcaa80251f000bb0df19ce768fb7c7db2b6cc3500f8e9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4cf56aabe53afae0178dafc765d4e99dbe8668ac24d8347868ddc2a7f916c57e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "d0658eee6e138e9930ae0054affcea76cb33f2edccd0c226520eddef3f06bdb4"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "6ae3e6950689244e4f8a8af145253c5239579a311d75916d2f9ab0563cfb0a73"
+    sha256 cellar: :any_skip_relocation, monterey:       "1b712e76dbe96b358290d5b20723ba782dac9a0d7a96563d6ea9df08f5f7a31d"
+    sha256 cellar: :any_skip_relocation, big_sur:        "0f8679bce1298ac64c819afe9206dd4bf96db147c9a386e1df1433f25b95bd9a"
+    sha256 cellar: :any_skip_relocation, catalina:       "f5db719e6d8e3c89f84057ec6b20a055bbeabad778c44f156f7b1d6c5d114b63"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ff41dddefb361e9525f2aab7498711e21048420fb017cd537347fd8bdb8d59c6"
   end
 
   depends_on "dub" => :build

--- a/Formula/dvc.rb
+++ b/Formula/dvc.rb
@@ -3,17 +3,17 @@ class Dvc < Formula
 
   desc "Git for data science projects"
   homepage "https://dvc.org"
-  url "https://files.pythonhosted.org/packages/8f/f3/654f242dc7d1ee6db9730b999ca255168a8f252ff402a52396f12ccff502/dvc-2.29.0.tar.gz"
-  sha256 "68cea0444d6df0cebdf10c33a34b145b18093ce697264858ca9e499fbba6bd2c"
+  url "https://files.pythonhosted.org/packages/9a/0e/003bf08b5831755f1162602f8cadfd4b27856721788a67a868d1d41b455e/dvc-2.28.0.tar.gz"
+  sha256 "f14b6ee5f6a61b992c5c549747f1688272a5f95a1ec04d432bf87b0b22e28181"
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_monterey: "1277a7def9ca5716490ca735c70c23d000ce1d4774a645bb6b7a5d73b82d4e61"
-    sha256 cellar: :any,                 arm64_big_sur:  "b1a7704a322be166cf25f582f0473dccc43c730f005259f4caa6187ac60d320e"
-    sha256 cellar: :any,                 monterey:       "1a0d4bfce9a7978b821eca63a80ae8fa99ffb0d841f7c0ce89845c74ff8617ba"
-    sha256 cellar: :any,                 big_sur:        "d7746fe633b1eeefe59ed3a11b4cdf822e81203b66527e8fce4bd1714ad30e62"
-    sha256 cellar: :any,                 catalina:       "401db519b0bb26a86deb27fb69539b720be52335701a87bc06c1dd75f3040af2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c18bcdabd9b69cd6ef4c64b88b9a8496d2d8c540ed040d85b7baa27817bf671e"
+    sha256 cellar: :any,                 arm64_monterey: "68197c2b80303934972be486ea687d9486c71c6d645cb8257eacac720a165d28"
+    sha256 cellar: :any,                 arm64_big_sur:  "f5c08e9091ae79c8b4854ac032e8419daffca25636f649cf8593fd511ef46d20"
+    sha256 cellar: :any,                 monterey:       "61c9d2cdacded9b87dfd41a8d1b3f1725b8bc290e68f801e51490d9548e8c21c"
+    sha256 cellar: :any,                 big_sur:        "5004404cc98dd74db7c5b3a80cc7c8b3b41ae2f7344f86a33c9433ed9d05aadd"
+    sha256 cellar: :any,                 catalina:       "aa45ec5be384e2632adc127a08754776f880a0e2c6537dc467be69ab8f7dfcf1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "22db22b0bdea6d636bdadbb7fe9484ae60fbe22948010f476bdd61847be099c5"
   end
 
   depends_on "openjdk" => :build # for hydra-core
@@ -39,8 +39,8 @@ class Dvc < Formula
   end
 
   resource "adlfs" do
-    url "https://files.pythonhosted.org/packages/67/13/7b57e13f06393caeec97fb9930a1c59a9e2015d8d2afe7e0be50854737a1/adlfs-2022.10.0.tar.gz"
-    sha256 "8542f9e6799aeb77adb5cb9854f76b7dce874610dc0f2ff006cce960526ffad6"
+    url "https://files.pythonhosted.org/packages/47/1d/39ea6d87273da2c6fcae4c2502310929901987bc01fe45abcb01346f95c4/adlfs-2022.9.1.tar.gz"
+    sha256 "b74fdff5e8ea1d28c7906488791aa9ee564c586eddd4d03d213ab20ae96c6b08"
   end
 
   resource "aiobotocore" do
@@ -269,8 +269,8 @@ class Dvc < Formula
   end
 
   resource "dvc-data" do
-    url "https://files.pythonhosted.org/packages/0c/1c/0b64e2f082e7a2010fd70927a113133156cf7298a328340db1e2945af42d/dvc-data-0.14.0.tar.gz"
-    sha256 "f767622d061076597416f893c40011db74af86eeac4b09b89bbbc8e33cffebba"
+    url "https://files.pythonhosted.org/packages/28/28/178432434d5b628a8fb28b6234e9e54a1bfffc278b8c32697de76cf26912/dvc-data-0.13.0.tar.gz"
+    sha256 "2274efb490dd7451aaf5d2d2e8968fabc7360c75f70da36d7e71a5cfddee352a"
   end
 
   resource "dvc-gdrive" do
@@ -319,8 +319,8 @@ class Dvc < Formula
   end
 
   resource "dvc-task" do
-    url "https://files.pythonhosted.org/packages/f5/90/cc03445113ce60e78b244d857125fb3bb5eba3a8ba3901050f68f4776e9e/dvc-task-0.1.3.tar.gz"
-    sha256 "1670cf7dedfe4ff80a19b0b1768bfa8ef708374f50278575c6be99047a1dda43"
+    url "https://files.pythonhosted.org/packages/d6/b7/85258f0aa462c68d82e02a52fce2564c06ca5ef4795fd9a67762f608cd89/dvc-task-0.1.2.tar.gz"
+    sha256 "7dece92338232ad81f21a9c5fa1b4765cb2713ca06f85ea3c407480471fdeab7"
   end
 
   resource "dvc-webdav" do
@@ -394,8 +394,8 @@ class Dvc < Formula
   end
 
   resource "google-api-python-client" do
-    url "https://files.pythonhosted.org/packages/a7/ff/a8bc30fdbc62ce1b504a878c586c72c9d3308508fca0aa7a7d694ec080da/google-api-python-client-2.64.0.tar.gz"
-    sha256 "0dc4c967a5c795e981af01340f1bd22173a986534de968b5456cb208ed6775a6"
+    url "https://files.pythonhosted.org/packages/0d/a5/ecbcb0e6340c960f6077a92c806603caaeefc2b827a53a3c1d994b126e76/google-api-python-client-2.63.0.tar.gz"
+    sha256 "5cc828499a2cfec5845e095d32f68265c344eb32969f07a8e3774564153178bd"
   end
 
   resource "google-auth" do
@@ -429,8 +429,8 @@ class Dvc < Formula
   end
 
   resource "google-resumable-media" do
-    url "https://files.pythonhosted.org/packages/71/d2/d681d0c192d2948b692f155bc20ee03727ab3a70d541b0c39a327c9689a9/google-resumable-media-2.4.0.tar.gz"
-    sha256 "8d5518502f92b9ecc84ac46779bd4f09694ecb3ba38a3e7ca737a86d15cbca1f"
+    url "https://files.pythonhosted.org/packages/17/d1/74872a664d168c5d38774112d205502847b03f297f3af3199b5e1b126fe9/google-resumable-media-2.3.3.tar.gz"
+    sha256 "27c52620bd364d1c8116eaac4ea2afcbfb81ae9139fb3199652fcac1724bfb6c"
   end
 
   resource "googleapis-common-protos" do
@@ -525,8 +525,8 @@ class Dvc < Formula
   end
 
   resource "networkx" do
-    url "https://files.pythonhosted.org/packages/9e/89/90846e0da5c412cbffb66d1f976b056cd46c6f2aa7f2f1eb271573b5fefb/networkx-2.8.7.tar.gz"
-    sha256 "815383fd52ece0a7024b5fd8408cc13a389ea350cd912178b82eed8b96f82cd3"
+    url "https://files.pythonhosted.org/packages/d9/c6/ad9dc9195c0e5d8879d2a28667aa45e087631576b40f9c954a086693a36d/networkx-2.8.6.tar.gz"
+    sha256 "bd2b7730300860cbd2dafe8e5af89ff5c9a65c3975b352799d87a6238b4301a6"
   end
 
   resource "oauth2client" do
@@ -645,8 +645,8 @@ class Dvc < Formula
   end
 
   resource "pytz" do
-    url "https://files.pythonhosted.org/packages/31/da/2d48d3499b59c7f3c5d5e1c79fcee5537c320c8ab7b7a0cd2db578bc34b3/pytz-2022.4.tar.gz"
-    sha256 "48ce799d83b6f8aab2020e369b627446696619e79645419610b9facd909b3174"
+    url "https://files.pythonhosted.org/packages/24/0c/401283bb1499768e33ddd2e1a35817c775405c1f047a9dc088a29ce2ea5d/pytz-2022.2.1.tar.gz"
+    sha256 "cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"
   end
 
   resource "requests" do
@@ -665,8 +665,8 @@ class Dvc < Formula
   end
 
   resource "rich" do
-    url "https://files.pythonhosted.org/packages/11/23/814edf09ec6470d52022b9e95c23c1bef77f0bc451761e1504ebd09606d3/rich-12.6.0.tar.gz"
-    sha256 "ba3a3775974105c221d31141f2c116f4fd65c5ceb0698657a11e9f295ec93fd0"
+    url "https://files.pythonhosted.org/packages/bb/2d/c902484141330ded63c6c40d66a9725f8da5e818770f67241cf429eef825/rich-12.5.1.tar.gz"
+    sha256 "63a5c5ce3673d3d5fbbf23cd87e11ab84b6b451436f1b7f19ec54b6bc36ed7ca"
   end
 
   resource "rsa" do

--- a/Formula/dwm.rb
+++ b/Formula/dwm.rb
@@ -1,8 +1,8 @@
 class Dwm < Formula
   desc "Dynamic window manager"
   homepage "https://dwm.suckless.org/"
-  url "https://dl.suckless.org/dwm/dwm-6.4.tar.gz"
-  sha256 "fa9c0d69a584485076cfc18809fd705e5c2080dafb13d5e729a3646ca7703a6e"
+  url "https://dl.suckless.org/dwm/dwm-6.3.tar.gz"
+  sha256 "badaa028529b1fba1fd7f9a84f3b64f31190466c858011b53e2f7b70c6a3078d"
   license "MIT"
   head "https://git.suckless.org/dwm", using: :git, branch: "master"
 
@@ -12,12 +12,12 @@ class Dwm < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_monterey: "10e4acc8a0acf14b00397ddca12a3324e5cbf2ac881974472e473fe4a555b783"
-    sha256 cellar: :any,                 arm64_big_sur:  "45a4e170d418e0c7caeace0c4ddea6e8986b53e59906f056b95f42aa2d4201fe"
-    sha256 cellar: :any,                 monterey:       "9774dc44a72ebf8831d07261e49d5607036b03895af484091828452fed9e09b2"
-    sha256 cellar: :any,                 big_sur:        "1620a1e55c9bbce30c5c0247bd02425120fb317e39c5a97ff34ea163641b388d"
-    sha256 cellar: :any,                 catalina:       "0632b1fa0115e7f403e2cd6e05ad4df2554dabc1018825eb16976798b1a84e61"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "24c0fe1f422ba854396d792b3fe28225f5658edca9e0fd98cadff55eeb8b0f13"
+    sha256 cellar: :any,                 arm64_monterey: "2229c9fa0e2b34b02d6ceb6529b655e5100e6c96f3684fe9ba106908a1e59d81"
+    sha256 cellar: :any,                 arm64_big_sur:  "9544c01783dbd47a049adc2f1ae4269f79aa0a1ca0272e94414589d4acb9ca39"
+    sha256 cellar: :any,                 monterey:       "fed2ddf1b8509e7ecb5f236432ac23a5b2c843fc7ec84b16c7f0aa220a5cd59f"
+    sha256 cellar: :any,                 big_sur:        "96c4b987f4d8173368692428bd362c76ece48d34b267bb3040cb1fbac4406dab"
+    sha256 cellar: :any,                 catalina:       "513bb01c5c1276e7606edb577504b101240c1245558ab30fe724be6b9d7c2dbe"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0c3458070c89d4f324a82eb95651c456a1ccdc51bcac7df5bbe5ba305f02d72c"
   end
 
   depends_on "dmenu"

--- a/Formula/faust.rb
+++ b/Formula/faust.rb
@@ -1,17 +1,18 @@
 class Faust < Formula
   desc "Functional programming language for real time signal processing"
   homepage "https://faust.grame.fr"
-  url "https://github.com/grame-cncm/faust/releases/download/2.50.6/faust-2.50.6.tar.gz"
-  sha256 "d8b7a89d82ee5d3259c8194c363296bc13353160f847661ab84b2dbefdee7173"
+  url "https://github.com/grame-cncm/faust/releases/download/2.41.1/faust-2.41.1.tar.gz"
+  sha256 "72145e1d4ffcdd8e687ed7960d1d0717fa2c1dd2566e0bbc3a78fa95bb8b683e"
   license "GPL-2.0-or-later"
+  revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_monterey: "bbe2449e22fc66eaf4dbf90b7ccd220a9d65954c64ad51e8b178e0a7f3d3b471"
-    sha256 cellar: :any,                 arm64_big_sur:  "79f18d935e081f08cfb64d708a4d72222c240e050c83d022ca8fcbcdf783f803"
-    sha256 cellar: :any,                 monterey:       "0524e9894187380c7e47599fe47fd7e8e7d43372953f50c7dd022adf20e654c1"
-    sha256 cellar: :any,                 big_sur:        "3daa5ef4021cd4af1fcfb4678ca906abe0e2d8412ea8dda1478ef6b63829cfd3"
-    sha256 cellar: :any,                 catalina:       "8ee8b5cbbd4c775ab37940545b67db3d8665753330b29eb26d60b8e9ec928ecf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f5dc2b1de59bb4ed621bc2af343e3a7ad782781dbb5003fa7c60b10041ad7674"
+    sha256 cellar: :any,                 arm64_monterey: "82960a34b3d086c771fb8fc5a81d76c8320fe8d8c3dcd2b71abb3febd885feba"
+    sha256 cellar: :any,                 arm64_big_sur:  "ada2aa5feeff5e6cce7a130c359a94f0475210f4362471c69ee8a69d4254e40b"
+    sha256 cellar: :any,                 monterey:       "4039148223dd9d051b73b0734f49b67cae1013080bd938f3891b1f2e4741b457"
+    sha256 cellar: :any,                 big_sur:        "73964cdae017ca1cdeba8850cb055f16535186c02b79d346d2a54356fdf5e9b5"
+    sha256 cellar: :any,                 catalina:       "b80ba177994f548499ddfb496a619bd4054d7c3f2af23cb3bafc26ed42f5a47f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "806029859938cc14f50b735e75d01afc836eeab167b83893580a6385c63a8408"
   end
 
   depends_on "cmake" => :build

--- a/Formula/flow.rb
+++ b/Formula/flow.rb
@@ -1,18 +1,18 @@
 class Flow < Formula
   desc "Static type checker for JavaScript"
   homepage "https://flowtype.org/"
-  url "https://github.com/facebook/flow/archive/v0.188.2.tar.gz"
-  sha256 "e91f2941f97f87e418320e26478a839d166d78f76199e50455abfa2154f6b2b5"
+  url "https://github.com/facebook/flow/archive/v0.188.1.tar.gz"
+  sha256 "e569e5d2f0c818738166546494ff68ab3c0cabbd638eead1a70221cdc0d067e3"
   license "MIT"
   head "https://github.com/facebook/flow.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c50b253501730dc0c4f2f7563797b9a8a3bab20e4e4a17d8f8d2611580bf2bcf"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "007370c2769cb9364962c5f1d531f4c8781c8b451446229231dec899ddda0d31"
-    sha256 cellar: :any_skip_relocation, monterey:       "4b18e1364d9826cd2b1a8939cad2baec39d0b775ed86bf0cfafd58501f173754"
-    sha256 cellar: :any_skip_relocation, big_sur:        "c6a288bdea994d68f50ad143d2578fd10e6ec3acf8e15674254ef14c7bb83add"
-    sha256 cellar: :any_skip_relocation, catalina:       "d7f16203873892b35761d48c33d67e030a81fcb0fd27a4ce0891e803624b3680"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c97ae54396a5dd37e35f94ddef344aaf32a031178513394cfdb4a61c73feff1a"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "83da69cf3a622afa8f3644c3cee993ac018a0a9195781d1abe6899f2b8e60e27"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "03b8275972c9a71287f825c5fdf3237ef9af34104cc0e82716fafb4197727acd"
+    sha256 cellar: :any_skip_relocation, monterey:       "caada95c9452c3a90da1711f143e25edf6e04e493d8e5ab615b866e8a0a3e77b"
+    sha256 cellar: :any_skip_relocation, big_sur:        "b26a4b6df2a2f6fb4b059efe4603c73b3256ce47ccaeb42b6901a7f89f1cadc2"
+    sha256 cellar: :any_skip_relocation, catalina:       "877f8221c94ef1d77ec53d96cec8e0512c0852ac13423a31811624e54585d9c3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d67ffa770be84fc1a83fd7fb23997a9817f3b16cd8efedee1e2e55d79862efc9"
   end
 
   depends_on "ocaml" => :build

--- a/Formula/glooctl.rb
+++ b/Formula/glooctl.rb
@@ -4,8 +4,8 @@ class Glooctl < Formula
   # NOTE: Please wait until the newest stable release is finished building and
   # no longer marked as "Pre-release" before creating a PR for a new version.
   url "https://github.com/solo-io/gloo.git",
-      tag:      "v1.12.29",
-      revision: "4755de01751fc76bad75c4336c2f2a9fb74e8a20"
+      tag:      "v1.12.28",
+      revision: "802f24b56ebd2a88741a58b13dbc1033301c5c36"
   license "Apache-2.0"
   head "https://github.com/solo-io/gloo.git", branch: "master"
 
@@ -15,12 +15,12 @@ class Glooctl < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "01131bd7e33d4f9ce22aa5c0d3c54d02e375cb73b6bb42496bfbb3c07b8c3f70"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "3f009d628f41debb357c237cb64ea88997ad64b3bb67404494a1267d79781ea8"
-    sha256 cellar: :any_skip_relocation, monterey:       "b64ae74e96e7e55540db654161ae35689a325016fd48c78c5a6f97419ab5513b"
-    sha256 cellar: :any_skip_relocation, big_sur:        "a86cc6ab24b0291752fbc474003a1a7ac2b6e8ef7ed399d803b58b127d633429"
-    sha256 cellar: :any_skip_relocation, catalina:       "f4d59f9c0bbcdb467623fc83a88d85bc79841ffaf3a4e81786cf952561d594ad"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6463284daf1d6ca317e7976c7748893937341fc5b71dd0f85d40ab22c975e16c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "951f5b7f10c2968b5ed44dcc172223cb3188f3192676635449a3a37875415b22"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "4c43007dd6637d67b204bcd9f1c6c0058a0953bc22b5f61e648b9339e8479182"
+    sha256 cellar: :any_skip_relocation, monterey:       "c331740553a56013ea23f314af1cde9f40669dcef8f095308fc565442ec7e79b"
+    sha256 cellar: :any_skip_relocation, big_sur:        "1d4ce75f05467dfa8706818fd281a7b23d87fac2e5c76b2ae8b34fd688595145"
+    sha256 cellar: :any_skip_relocation, catalina:       "3b775c4ac67264a97a8117a1cfbd3f907f4f368c82877be4696d9e2ee612fcc7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0684a4a59da86cfbc1edf87fc1e7ffc10f8c8dcfc0011df3b8b42b1c7cb994ac"
   end
 
   depends_on "go" => :build

--- a/Formula/minio.rb
+++ b/Formula/minio.rb
@@ -2,9 +2,9 @@ class Minio < Formula
   desc "High Performance, Kubernetes Native Object Storage"
   homepage "https://min.io"
   url "https://github.com/minio/minio.git",
-      tag:      "RELEASE.2022-10-05T14-58-27Z",
-      revision: "4bdf41a6c70ff5809c3db5c427f3cbee1a725b79"
-  version "20221005145827"
+      tag:      "RELEASE.2022-10-02T19-29-29Z",
+      revision: "f696a221af84fcff27266fd934a427d346547b93"
+  version "20221002192929"
   license "AGPL-3.0-or-later"
   head "https://github.com/minio/minio.git", branch: "master"
 
@@ -17,12 +17,12 @@ class Minio < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "82aacb1481b4326162788dfc1b2cbc611f65b3976f559267ec744661e8d1fc18"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "c1273d8c408562f999fc2aaacd49879065fd9fed2c4e739879740d6b31332b0e"
-    sha256 cellar: :any_skip_relocation, monterey:       "41fbf9cb222aad02cf9b8fc50c0da9bc95accf2ac7b32d794b7c3470b17a6814"
-    sha256 cellar: :any_skip_relocation, big_sur:        "72ef5128a75a331efdd52eee2ec82a600aa9c4b588901cce68b3fc501bc65992"
-    sha256 cellar: :any_skip_relocation, catalina:       "ffcd971483a12b4c3790d70c324478c62afcc93d60089c0ea83607cc17f03d15"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d0d229d3c58188b843bae0fcf3fa22e3b3e9b2bbbc88ee56bf9ef7023cf85036"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "6003d82a6d8a1305200a67a8ae4293029d7910eff2e9155555944d07e89812bc"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "d65c4e887e0254aa686953202e482d9ce92df444e9e0b9bb598e92e42a2c56a9"
+    sha256 cellar: :any_skip_relocation, monterey:       "90d25a2d4f63d3b410f0bd2fce7463696ed9a50027763643dd3299b9b159e049"
+    sha256 cellar: :any_skip_relocation, big_sur:        "b96e7395a2dfa663c5998f7bb9403335017ebbfe1aad7daebf2133ab59f7373e"
+    sha256 cellar: :any_skip_relocation, catalina:       "86870b4fd826c9e57ea1d6e8bb290fb5ea97db82a96a6172f743a5bd723df5c7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b882fa1e79104524f6f0cb85fe7f67f21185438666170868161a8148c3b19a1d"
   end
 
   depends_on "go" => :build

--- a/Formula/murex.rb
+++ b/Formula/murex.rb
@@ -1,18 +1,18 @@
 class Murex < Formula
   desc "Bash-like shell designed for greater command-line productivity and safer scripts"
   homepage "https://murex.rocks"
-  url "https://github.com/lmorg/murex/archive/v2.11.2200.tar.gz"
-  sha256 "31930f6ddc1b44a08352e79b8b6afdca2b47ce6e30057e839ccfe06f68a45fe9"
+  url "https://github.com/lmorg/murex/archive/v2.11.2030.tar.gz"
+  sha256 "5d7dadc2d48bde20fe2239d8087612eccaa310b0f88863bdae2288b30388dff7"
   license "GPL-2.0-only"
   head "https://github.com/lmorg/murex.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "362f47131a27ea71ada1661efd4cec2921fab17d9ac595174f60b044ac073eaa"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "a996b11b0960be6f41f4aafcb5cc628cce2d40ca7c9a8207200e87e37adce557"
-    sha256 cellar: :any_skip_relocation, monterey:       "bf029d3bb3fae5747d377e347c6d76c494b5029000cf5c49fca03ca0e1caa987"
-    sha256 cellar: :any_skip_relocation, big_sur:        "c28182d5c15f27bc98626aed744496670e4be9ffe11582ce026f75985cf98f01"
-    sha256 cellar: :any_skip_relocation, catalina:       "a3a7ee87b5ce052f04c45df32a0023f68ed45b44a6a4b99fe329db7d44a77d3a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a2a5dc86edc34c3877665d2e8ebaa3882a69ebb92e8fd6840071359a2ab37136"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "d08fcf50769e9cdac901df8d32cdc4f359bb0a3c5bbbe748a722577c27314585"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "b6794ce337fad1a0ed3688c6ad10a48ca04b0355fd1c0a02c3a9ed0ed0811254"
+    sha256 cellar: :any_skip_relocation, monterey:       "50a535a88c0ceb2577007ab98e72c156e5ffa96d524b122ff189065af4d2df48"
+    sha256 cellar: :any_skip_relocation, big_sur:        "0ef896f7943bbddf7a0253549d6248c9bfc100978d4b2d519f55f969703041fc"
+    sha256 cellar: :any_skip_relocation, catalina:       "e19d73d4980d8228df554a63fce716afb8c4a85741744f8c943fe9d48f4ecdf8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "59774d034513288a89d2ebc53c95bb060be80acfc6419dcc84ff290303cce196"
   end
 
   depends_on "go" => :build

--- a/Formula/nomad.rb
+++ b/Formula/nomad.rb
@@ -1,8 +1,8 @@
 class Nomad < Formula
   desc "Distributed, Highly Available, Datacenter-Aware Scheduler"
   homepage "https://www.nomadproject.io"
-  url "https://github.com/hashicorp/nomad/archive/v1.4.0.tar.gz"
-  sha256 "e79fe16c8fa94231bc9e1a1ae93926343e16f0892112fc84e95e014ac56dcb6b"
+  url "https://github.com/hashicorp/nomad/archive/v1.3.5.tar.gz"
+  sha256 "79217b094831b0901dfe5ae9c03ff45ddde15ea02078a0fd07fabe2ff8867c83"
   license "MPL-2.0"
   head "https://github.com/hashicorp/nomad.git", branch: "main"
 
@@ -12,12 +12,12 @@ class Nomad < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8f22c207c370634b164716fa446905e63ef5e91af5b14a3905a7e8ca668d9860"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "30166147cd9e30a03b321658c36f9b3ac494ec8b496fcc051a39a1016678c8ab"
-    sha256 cellar: :any_skip_relocation, monterey:       "bb96021806f098773d950c0aeb8677fd313723d54d59e64a2a672c78697127a1"
-    sha256 cellar: :any_skip_relocation, big_sur:        "7f73ea0af78eaa823b334dbefd09f33a805169e9811ea6af42811997e77af75c"
-    sha256 cellar: :any_skip_relocation, catalina:       "6b0e605ec1e6a5dba4d3b58a2663e5bd81b681b0e61e7c45cbbaacedba06b192"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "21dd66ddd628ff095aaf567ff897a89d133fdd65e91b82bcd71d7dd688497eb0"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "38923f5a6d3cef22718346dc526dfeaeba92f2a8821983b70e91430e0c98cc0a"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "3019ed3511c2d6cbe472bb0d61b29c61021f138badf079c7238630968247d9b9"
+    sha256 cellar: :any_skip_relocation, monterey:       "98078a662bf5fd597b34ed3d770b29c57fff0a1f36836176f5d711c1f8679779"
+    sha256 cellar: :any_skip_relocation, big_sur:        "939493db69ade43e0a95e8db3a53c3c4791f674769e08f471d5f1bc32b447d47"
+    sha256 cellar: :any_skip_relocation, catalina:       "9974be6c403878ce0d59da6898f73e4c4568683aa20598c50d2a98a4fe971c88"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ffaf72937fa46c1c6ed4c9a09180ec1a10ccaa8f6325739a84e728f296a78346"
   end
 
   depends_on "go" => :build

--- a/Formula/oh-my-posh.rb
+++ b/Formula/oh-my-posh.rb
@@ -1,18 +1,18 @@
 class OhMyPosh < Formula
   desc "Prompt theme engine for any shell"
   homepage "https://ohmyposh.dev"
-  url "https://github.com/JanDeDobbeleer/oh-my-posh/archive/v12.0.0.tar.gz"
-  sha256 "d207cc8937e8bd0c567f01f2e7f4c4ca7acef66a608f4657ed38df2a8bba8185"
+  url "https://github.com/JanDeDobbeleer/oh-my-posh/archive/v11.4.0.tar.gz"
+  sha256 "2be5396be0f7e804ff36715b1d6a6019014ee066359c28e620d7b61790a130ae"
   license "MIT"
   head "https://github.com/JanDeDobbeleer/oh-my-posh.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f766ce454a92dc0bac453c1d1a234ff07fe5e5ed10035c489575e7ba6744500d"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ef63a8c7231a85283cbb833036f7d066ec33c1616c74117b231a5c6dd81a1c1e"
-    sha256 cellar: :any_skip_relocation, monterey:       "861aff70643a474c56431b16379b5f5385570ac865b95a26f0708f2b6910c5f1"
-    sha256 cellar: :any_skip_relocation, big_sur:        "8c2f7adc0146694c9634afb23fca8b972a29b5915c2ecad27f67204f7352200d"
-    sha256 cellar: :any_skip_relocation, catalina:       "5f77a37727f051719d6a71f6aecbf7cf942205acfd0d5e746da52847995c2d3a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "69b56ef8db4c52188520c3cd4235047a08fb39b3fb0e2feb2718b38fed15d0fd"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "1f98bd90017e2ba074badf63265eb9f305a700b166dc02089740d3fe00244e48"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "871817442d1b2fccc0bc0c1d21e532aaca21e17ed506586be1a77e2817d6b5f1"
+    sha256 cellar: :any_skip_relocation, monterey:       "f3b883298054f7afff60e1a101f16a28e1e2857e88a82b130a169425fa7052a0"
+    sha256 cellar: :any_skip_relocation, big_sur:        "ab012b7a985351f6ed67ca4736ba3d5fbe381d752c3f3906f325cb89faba16c8"
+    sha256 cellar: :any_skip_relocation, catalina:       "f2d924245291c514402081ecec4bfcd3e9931dc0b8ee3f9ea255afd61b2823d3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5c35f79ef976eacea1fd6b07255b60b0c2b169166244cda6c84590068e4e4aeb"
   end
 
   depends_on "go" => :build

--- a/Formula/pnpm.rb
+++ b/Formula/pnpm.rb
@@ -3,8 +3,8 @@ class Pnpm < Formula
 
   desc "📦🚀 Fast, disk space efficient package manager"
   homepage "https://pnpm.io/"
-  url "https://registry.npmjs.org/pnpm/-/pnpm-7.13.2.tgz"
-  sha256 "a3e4d1917c9ec75a100388f955efb70ace7cabf9268dcf5b8e67e979211a9df2"
+  url "https://registry.npmjs.org/pnpm/-/pnpm-7.13.1.tgz"
+  sha256 "e641f4de1b30ffff2d6c235f9bfe7db3ccd07584b446482c9578b51a99231668"
   license "MIT"
 
   livecheck do
@@ -13,12 +13,12 @@ class Pnpm < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "24508a55bacbcee62f5f078422a68912a4a44f7715cdd330cb488422ff4def5c"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "24508a55bacbcee62f5f078422a68912a4a44f7715cdd330cb488422ff4def5c"
-    sha256 cellar: :any_skip_relocation, monterey:       "5998df4dd43e7e0dec48fdd6978456001c8104f7be7589770e5babc4e9bda3cb"
-    sha256 cellar: :any_skip_relocation, big_sur:        "f85bd0f8f5c3170f77f9f70517c29edbec005282ce0520cb605cbe9a04077ef3"
-    sha256 cellar: :any_skip_relocation, catalina:       "f85bd0f8f5c3170f77f9f70517c29edbec005282ce0520cb605cbe9a04077ef3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "24508a55bacbcee62f5f078422a68912a4a44f7715cdd330cb488422ff4def5c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "17a8003e332d4d4b01278022c6c0e4d3886c9cb21e58d8b5c585db1e0886166c"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "17a8003e332d4d4b01278022c6c0e4d3886c9cb21e58d8b5c585db1e0886166c"
+    sha256 cellar: :any_skip_relocation, monterey:       "3accb27ad2934d42a5561bbd2ccb37c0629ddd36f21812cd08f6fc3cd8184ac6"
+    sha256 cellar: :any_skip_relocation, big_sur:        "ac539a43c3238d1c8021474f69e372a6b16bb2c600608afb84573c8d20d07ca9"
+    sha256 cellar: :any_skip_relocation, catalina:       "ac539a43c3238d1c8021474f69e372a6b16bb2c600608afb84573c8d20d07ca9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "17a8003e332d4d4b01278022c6c0e4d3886c9cb21e58d8b5c585db1e0886166c"
   end
 
   depends_on "node" => :test

--- a/Formula/vercel-cli.rb
+++ b/Formula/vercel-cli.rb
@@ -3,17 +3,17 @@ require "language/node"
 class VercelCli < Formula
   desc "Command-line interface for Vercel"
   homepage "https://vercel.com/home"
-  url "https://registry.npmjs.org/vercel/-/vercel-28.4.7.tgz"
-  sha256 "08ac92b2dc20ebe8a113a47d4a46493bd3111dffed18225e5043d7177780c656"
+  url "https://registry.npmjs.org/vercel/-/vercel-28.4.6.tgz"
+  sha256 "dd4be3a093ec4e70afab5509792e2337fbe76031f16ade633e50bf32a5ad2d4a"
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "febc7c4267db532a0fc04bb09af5c57f5d2108215c5e9e048998ac37b0ffcdac"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "febc7c4267db532a0fc04bb09af5c57f5d2108215c5e9e048998ac37b0ffcdac"
-    sha256 cellar: :any_skip_relocation, monterey:       "51cf4e6dad70ccabda67ff11d61404068ac5a65a332a88e42f66159f1db7a077"
-    sha256 cellar: :any_skip_relocation, big_sur:        "11766c0d495917692fb83f01343e038e60b271776b0e48eb8300f02cb2b1d3ab"
-    sha256 cellar: :any_skip_relocation, catalina:       "11766c0d495917692fb83f01343e038e60b271776b0e48eb8300f02cb2b1d3ab"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8f43bcf97842f820b8c609984e71856bc3cd7e05496cc599e01e542d53fc9d49"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "0a131f18fc45c007ad7fe46d577bf450df6f3d03c90e2ea007525c183e475f8c"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "0a131f18fc45c007ad7fe46d577bf450df6f3d03c90e2ea007525c183e475f8c"
+    sha256 cellar: :any_skip_relocation, monterey:       "7f3664986451e18281fdb40c7ae97b8c28df0cf67a95a8c74371afc295634e8e"
+    sha256 cellar: :any_skip_relocation, big_sur:        "52e11f4aeb4d1e8d82e7488496759070453c01e63ca7e54d31664d67404fdb8b"
+    sha256 cellar: :any_skip_relocation, catalina:       "52e11f4aeb4d1e8d82e7488496759070453c01e63ca7e54d31664d67404fdb8b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8031ccd40aaf69e8bc7745ce44d2126f97298fceefe53c822ecfade2fba01f98"
   end
 
   depends_on "node"

--- a/Formula/verovio.rb
+++ b/Formula/verovio.rb
@@ -9,14 +9,20 @@ class Verovio < Formula
   depends_on "cmake" => :build
 
   def install
-    cd "tools" do
-      system "cmake", "../cmake", *std_cmake_args
-      system "make"
-      system "make", "install"
-    end
+    system "cmake", "-S", "./cmake", "-B", "tools", *std_cmake_args
+    system "cmake", "--build", "tools"
+    system "cmake", "--install", "tools"
+  end
+
+  resource("testdata") do
+    url "https://www.verovio.org/examples/downloads/Ahle_Jesu_meines_Herzens_Freud.mei"
+    sha256 "d08735930f5591b6d86250ed93795af156b8d0297ed38256fed84dc9739ed381"
   end
 
   test do
     system bin/"verovio", "--version"
+    resource("testdata").stage do
+      shell_output("#{bin}/verovio Ahle_Jesu_meines_Herzens_Freud.mei")
+    end
   end
 end

--- a/Formula/verovio.rb
+++ b/Formula/verovio.rb
@@ -1,0 +1,22 @@
+class Verovio < Formula
+  desc "Command-line MEI music notation engraver"
+  homepage "https://www.verovio.org"
+  url "https://github.com/rism-digital/verovio/archive/refs/tags/version-3.12.1.tar.gz"
+  sha256 "7f69b39e25f9662185906c9da495437e09539a520b9dda80f1bef818e905881b"
+  license "LGPL-3.0-only"
+  head "https://github.com/rism-digital/verovio.git", branch: "develop"
+
+  depends_on "cmake" => :build
+
+  def install
+    cd "tools" do
+      system "cmake", "../cmake", *std_cmake_args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    system bin/"verovio", "--version"
+  end
+end

--- a/Formula/verovio.rb
+++ b/Formula/verovio.rb
@@ -22,7 +22,8 @@ class Verovio < Formula
   test do
     system bin/"verovio", "--version"
     resource("testdata").stage do
-      shell_output("#{bin}/verovio Ahle_Jesu_meines_Herzens_Freud.mei")
+      shell_output("#{bin}/verovio Ahle_Jesu_meines_Herzens_Freud.mei -o #{testpath}/output.svg")
+      assert_predicate testpath/"output.svg", :exist?
     end
   end
 end

--- a/Formula/verovio.rb
+++ b/Formula/verovio.rb
@@ -8,15 +8,15 @@ class Verovio < Formula
 
   depends_on "cmake" => :build
 
+  resource("testdata") do
+    url "https://www.verovio.org/examples/downloads/Ahle_Jesu_meines_Herzens_Freud.mei"
+    sha256 "d08735930f5591b6d86250ed93795af156b8d0297ed38256fed84dc9739ed381"
+  end
+
   def install
     system "cmake", "-S", "./cmake", "-B", "tools", *std_cmake_args
     system "cmake", "--build", "tools"
     system "cmake", "--install", "tools"
-  end
-
-  resource("testdata") do
-    url "https://www.verovio.org/examples/downloads/Ahle_Jesu_meines_Herzens_Freud.mei"
-    sha256 "d08735930f5591b6d86250ed93795af156b8d0297ed38256fed84dc9739ed381"
   end
 
   test do


### PR DESCRIPTION
Adds the Verovio music notation engraver to homebrew.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
