### PR TITLE
verovio 3.12.1 (new formula)

### DIFF
--- a/Formula/verovio.rb
+++ b/Formula/verovio.rb
@@ -1,0 +1,29 @@
+class Verovio < Formula
+  desc "Command-line MEI music notation engraver"
+  homepage "https://www.verovio.org"
+  url "https://github.com/rism-digital/verovio/archive/refs/tags/version-3.12.1.tar.gz"
+  sha256 "7f69b39e25f9662185906c9da495437e09539a520b9dda80f1bef818e905881b"
+  license "LGPL-3.0-only"
+  head "https://github.com/rism-digital/verovio.git", branch: "develop"
+
+  depends_on "cmake" => :build
+
+  resource("testdata") do
+    url "https://www.verovio.org/examples/downloads/Ahle_Jesu_meines_Herzens_Freud.mei"
+    sha256 "d08735930f5591b6d86250ed93795af156b8d0297ed38256fed84dc9739ed381"
+  end
+
+  def install
+    system "cmake", "-S", "./cmake", "-B", "tools", *std_cmake_args
+    system "cmake", "--build", "tools"
+    system "cmake", "--install", "tools"
+  end
+
+  test do
+    system bin/"verovio", "--version"
+    resource("testdata").stage do
+      shell_output("#{bin}/verovio Ahle_Jesu_meines_Herzens_Freud.mei -o #{testpath}/output.svg")
+      assert_predicate testpath/"output.svg", :exist?
+    end
+  end
+end

--- a/Formula/verovio.rb
+++ b/Formula/verovio.rb
@@ -21,7 +21,7 @@ class Verovio < Formula
 
   test do
     system bin/"verovio", "--version"
-    resource("testdata").stage do
+    resource("homebrew-testdata").stage do
       shell_output("#{bin}/verovio Ahle_Jesu_meines_Herzens_Freud.mei -o #{testpath}/output.svg")
       assert_predicate testpath/"output.svg", :exist?
     end

--- a/Formula/verovio.rb
+++ b/Formula/verovio.rb
@@ -8,7 +8,7 @@ class Verovio < Formula
 
   depends_on "cmake" => :build
 
-  resource("testdata") do
+  resource "homebrew-testdata" do
     url "https://www.verovio.org/examples/downloads/Ahle_Jesu_meines_Herzens_Freud.mei"
     sha256 "d08735930f5591b6d86250ed93795af156b8d0297ed38256fed84dc9739ed381"
   end

--- a/Formula/verovio.rb
+++ b/Formula/verovio.rb
@@ -10,7 +10,7 @@ class Verovio < Formula
 
   resource "homebrew-testdata" do
     url "https://www.verovio.org/examples/downloads/Ahle_Jesu_meines_Herzens_Freud.mei"
-    sha256 "d08735930f5591b6d86250ed93795af156b8d0297ed38256fed84dc9739ed381"
+    sha256 "79e6e062f7f0300e8f0f4364c4661835a0baffc3c1468504a555a5b3f9777cc9"
   end
 
   def install

--- a/Formula/verovio.rb
+++ b/Formula/verovio.rb
@@ -23,7 +23,7 @@ class Verovio < Formula
     system bin/"verovio", "--version"
     resource("homebrew-testdata").stage do
       shell_output("#{bin}/verovio Ahle_Jesu_meines_Herzens_Freud.mei -o #{testpath}/output.svg")
-      assert_predicate testpath/"output.svg", :exist?
     end
+    assert_predicate testpath/"output.svg", :exist?
   end
 end


### PR DESCRIPTION
Attempt number 2 at adding the Verovio command-line notation engraver.

Initial attempt in PR #112475

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
