### PR TITLE
mlton: Add arm binary for bootstrapping on M1

### DIFF
--- a/Formula/mlton.rb
+++ b/Formula/mlton.rb
@@ -28,11 +28,19 @@ class Mlton < Formula
   # The corresponding upstream binary release used to bootstrap.
   resource "bootstrap" do
     on_macos do
+      # See https://projects.laas.fr/tina/howto-arm64-darwin.html and
+      # https://projects.laas.fr/tina/software.php
+      on_arm do
+        url "https://projects.laas.fr/tina/software/mlton-20210117-1.arm64-darwin-21.6-gmp-static.tgz"
+        sha256 "5d8cc4046f502ca7d98670d53915e3a1973ec0826e4c4c23e25d483fa657c1e8"
+      end
       # https://github.com/Homebrew/homebrew-core/pull/58438#issuecomment-665375929
       # new `mlton-20210117-1.amd64-darwin-17.7.gmp-static.tgz` artifact
       # used here for bootstrapping all homebrew versions
-      url "https://downloads.sourceforge.net/project/mlton/mlton/20210117/mlton-20210117-1.amd64-darwin-19.6.gmp-static.tgz"
-      sha256 "5bea9f60136ea6847890c5f4e45d7126a32ef14fd46a2303cab875ca95c8cd76"
+      on_intel do
+        url "https://downloads.sourceforge.net/project/mlton/mlton/20210117/mlton-20210117-1.amd64-darwin-19.6.gmp-static.tgz"
+        sha256 "5bea9f60136ea6847890c5f4e45d7126a32ef14fd46a2303cab875ca95c8cd76"
+      end
     end
 
     on_linux do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Before this change the steps for building from source in this formula are insufficient to produce an arm64 version of mlton. A recipe is available at https://projects.laas.fr/tina/howto-arm64-darwin.html, but it is perhaps easiest to use a pre-built amr64-specific binary to bootstrap. The binary provider is endorsed by mlton developer: http://www.mlton.org/Release20210117#_binary_packages_available_at_other_sites

cc: @MatthewFluet