### PR TITLE
frege: update livecheck

### DIFF
--- a/Formula/frege.rb
+++ b/Formula/frege.rb
@@ -6,10 +6,26 @@ class Frege < Formula
   license "BSD-3-Clause"
   revision 3
 
+  # The jar file versions in the GitHub release assets are often different
+  # than the tag version, so we can't identify the latest version from the tag
+  # alone. This `strategy` block fetches the separate asset list HTML for the
+  # "latest" release and matches versions in the jar filenames.
   livecheck do
-    url :stable
-    strategy :github_latest
+    url "https://github.com/Frege/frege/releases/latest"
     regex(/href=.*?frege[._-]?(\d+(?:\.\d+)+)\.jar/i)
+    strategy :header_match do |headers, regex|
+      next if headers["location"].blank?
+
+      # Identify the latest tag from the response's `location` header
+      latest_tag = File.basename(headers["location"])
+      next if latest_tag.blank?
+
+      # Fetch the assets list HTML for the latest tag and match within it
+      assets_page = Homebrew::Livecheck::Strategy.page_content(
+        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
+      )
+      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `frege` identified the version from jar files in the "latest" GitHub release's assets list. However, GitHub now omits the asset list HTML from release pages and it's fetched separately when the assets list is expanded (see https://github.com/Homebrew/brew/issues/13853), so this check is currently broken.

In this case, unfortunately the upstream repository doesn't always include the full version in the tag and, when it does, there are sometimes multiple jar files with different versions in the assets list. With this in mind, it's necessary to match versions from jar files in the "latest" release on GitHub.

This PR updates the `livecheck` block to find the tag for the latest release (using the `HeaderMatch` strategy to identify it in the `location` header), fetch the asset list HTML for that release, and match versions in the jar file links. This works for now but I intend to come up with a better approach (e.g., creating a strategy for this instead of needing a hefty `strategy` block for each of these) after the broken checks are working again.