### PR TITLE
umple: update livecheck, version scheme

### DIFF
--- a/Formula/umple.rb
+++ b/Formula/umple.rb
@@ -2,13 +2,13 @@ class Umple < Formula
   desc "Modeling tool/programming language that enables Model-Oriented Programming"
   homepage "https://www.umple.org"
   url "https://github.com/umple/umple/releases/download/v1.31.1/umple-1.31.1.5860.78bb27cc6.jar"
-  version "1.31.1.5860.78bb27cc6"
+  version "1.31.1"
   sha256 "686beb3c8aa3c0546f4a218dad353f4efce05aed056c59ccf3d5394747c0e13d"
   license "MIT"
+  version_scheme 1
 
   livecheck do
     url :stable
-    regex(/href=.*?umple[._-]v?(\d+(?:\.\d+)+(?:\.[\da-f]+)?)\.jar/i)
     strategy :github_latest
   end
 
@@ -24,8 +24,10 @@ class Umple < Formula
   depends_on "openjdk"
 
   def install
-    libexec.install "umple-#{version}.jar"
-    bin.write_jar_script libexec/"umple-#{version}.jar", "umple"
+    filename = File.basename(stable.url)
+
+    libexec.install filename
+    bin.write_jar_script libexec/filename, "umple"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `umple` identifies versions from the jar file in the "latest" release assets list. However, GitHub recently updated release pages to omit the assets list from the HTML and it's now fetched separately when the assets list is expanded (see https://github.com/Homebrew/brew/issues/13853), so this check is currently broken.

In this case, it's only necessary to identify the version from the jar file because the formula is using the full version from the filename (e.g., `1.31.1.5860.78bb27cc6`), whereas upstream simply refers to a given version by the leading major/minor/patch (e.g., `1.31.1`) in the tag, release title, etc. We can fix the `livecheck` block by simply removing the regex (continuing to use the `GithubLatest` strategy with the default strategy regex) if the formula is updated to use `version "1.31.1"` instead.

If past releases are any indicator, it may be several months before we see a new version, so this PR includes the `version` change and bumps `version_scheme` as a result. [The install count is low (30 days: 12, 90 days: 29, 365 days: 116), so this arguably wouldn't be a huge burden for users.] Modifying the version requires some small changes to the install steps (in relation to the filename) but nothing major.