### PR TITLE
mimirtool 2.3.1 (new formula)

### DIFF
--- a/Formula/mimirtool.rb
+++ b/Formula/mimirtool.rb
@@ -1,51 +1,51 @@
 class Mimirtool < Formula
-    desc "Mimirtool is a command-line tool that operators and tenants can use to execute a number of common tasks that involve Grafana Mimir or Grafana Cloud Metrics."
-    homepage "https://grafana.com/docs/mimir/latest/operators-guide/tools/mimirtool/"
-    url "https://github.com/grafana/mimir/releases/"
-    version "2.3.1"
-    sha256 "6ce99ef47d98bf240ada2acfe0b8e91641c326baf6f280e1c3db57f1cae6e0b6"
-    license "AGPL-3.0-only"
-  
-    on_macos do
-      if Hardware::CPU.arm?
-        url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-darwin-arm64"
-        sha256 "e6ec1a30d062e775265e94a685fdad090817a038db8168fea65a3064bd533be5"
-  
-        def install
-          bin.install "mimirtool-darwin-arm64" => "mimirtool"
-        end
-      end
-      if Hardware::CPU.intel?
-        url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-darwin-amd64"
-        sha256 "bcaf732700c1ce631a3137a935239cc52d2e5dfcf1b1c581d96bc9951c57d509"
-  
-        def install
-          bin.install "mimir-darwin-amd64" => "mimirtool"
-        end
+  desc "CLI tool for operating/managing Grafana Mimir or GrafanaCloud Metrics"
+  homepage "https://grafana.com/docs/mimir/latest/operators-guide/tools/mimirtool/"
+  url "https://github.com/grafana/mimir/releases/"
+  version "2.3.1"
+  sha256 "6ce99ef47d98bf240ada2acfe0b8e91641c326baf6f280e1c3db57f1cae6e0b6"
+  license "AGPL-3.0-only"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-darwin-arm64"
+      sha256 "e6ec1a30d062e775265e94a685fdad090817a038db8168fea65a3064bd533be5"
+
+      def install
+        bin.install "mimirtool-darwin-arm64" => "mimirtool"
       end
     end
-  
-    on_linux do
-      if Hardware::CPU.arm?
-        url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-linux-arm64"
-        sha256 "4c5b09385ed8bb4f141450fe511ba1671b40eb9b543e43de2ca0823e87e1f594"
-  
-        def install
-          bin.install "mimirtool-linux-arm64" => "mimirtool"
-        end
+    on_intel do
+      url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-darwin-amd64"
+      sha256 "bcaf732700c1ce631a3137a935239cc52d2e5dfcf1b1c581d96bc9951c57d509"
+
+      def install
+        bin.install "mimir-darwin-amd64" => "mimirtool"
       end
-      if Hardware::CPU.intel?
-        url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-linux-amd64"
-        sha256 "1d1de1948963e05f6f3706613fc2bac235c4b8f0205cfd200b6588790bfe1511"
-  
-        def install
-          bin.install "mimirtool-linux-amd64" => "mimirtool"
-        end
-      end
-    end
-  
-    test do
-      assert_match "Mimirtool, version 2.3.1 (branch: release-2.3, revision: 64a71a566)",
-        shell_output("#{bin}/mimirtool version", 0)
     end
   end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-linux-arm64"
+      sha256 "4c5b09385ed8bb4f141450fe511ba1671b40eb9b543e43de2ca0823e87e1f594"
+
+      def install
+        bin.install "mimirtool-linux-arm64" => "mimirtool"
+      end
+    end
+    on_intel do
+      url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-linux-amd64"
+      sha256 "1d1de1948963e05f6f3706613fc2bac235c4b8f0205cfd200b6588790bfe1511"
+
+      def install
+        bin.install "mimirtool-linux-amd64" => "mimirtool"
+      end
+    end
+  end
+
+  test do
+    assert_match "Mimirtool, version 2.3.1 (branch: release-2.3, revision: 64a71a566)",
+      shell_output("#{bin}/mimirtool version")
+  end
+end

--- a/Formula/mimirtool.rb
+++ b/Formula/mimirtool.rb
@@ -4,7 +4,7 @@ class Mimirtool < Formula
     url "https://github.com/grafana/mimir/releases/"
     version "2.3.1"
     sha256 "6ce99ef47d98bf240ada2acfe0b8e91641c326baf6f280e1c3db57f1cae6e0b6"
-    license "AGPL-3.0"
+    license "AGPL-3.0-only"
   
     on_macos do
       if Hardware::CPU.arm?
@@ -45,7 +45,7 @@ class Mimirtool < Formula
     end
   
     test do
-      assert_match "mimirtool: error: required flag --id not provided, try --help",
-        shell_output("#{bin}/mimirtool alertmanager get", 1)
+      assert_match "Mimirtool, version 2.3.1 (branch: release-2.3, revision: 64a71a566)",
+        shell_output("#{bin}/mimirtool version", 0)
     end
   end

--- a/Formula/mimirtool.rb
+++ b/Formula/mimirtool.rb
@@ -1,0 +1,51 @@
+class Mimirtool < Formula
+    desc "Mimirtool is a command-line tool that operators and tenants can use to execute a number of common tasks that involve Grafana Mimir or Grafana Cloud Metrics."
+    homepage "https://grafana.com/docs/mimir/latest/operators-guide/tools/mimirtool/"
+    url "https://github.com/grafana/mimir/releases/"
+    version "2.3.1"
+    sha256 "6ce99ef47d98bf240ada2acfe0b8e91641c326baf6f280e1c3db57f1cae6e0b6"
+    license "AGPL-3.0"
+  
+    on_macos do
+      if Hardware::CPU.arm?
+        url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-darwin-arm64"
+        sha256 "e6ec1a30d062e775265e94a685fdad090817a038db8168fea65a3064bd533be5"
+  
+        def install
+          bin.install "mimirtool-darwin-arm64" => "mimirtool"
+        end
+      end
+      if Hardware::CPU.intel?
+        url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-darwin-amd64"
+        sha256 "bcaf732700c1ce631a3137a935239cc52d2e5dfcf1b1c581d96bc9951c57d509"
+  
+        def install
+          bin.install "mimir-darwin-amd64" => "mimirtool"
+        end
+      end
+    end
+  
+    on_linux do
+      if Hardware::CPU.arm?
+        url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-linux-arm64"
+        sha256 "4c5b09385ed8bb4f141450fe511ba1671b40eb9b543e43de2ca0823e87e1f594"
+  
+        def install
+          bin.install "mimirtool-linux-arm64" => "mimirtool"
+        end
+      end
+      if Hardware::CPU.intel?
+        url "https://github.com/grafana/mimir/releases/download/mimir-2.3.1/mimirtool-linux-amd64"
+        sha256 "1d1de1948963e05f6f3706613fc2bac235c4b8f0205cfd200b6588790bfe1511"
+  
+        def install
+          bin.install "mimirtool-linux-amd64" => "mimirtool"
+        end
+      end
+    end
+  
+    test do
+      assert_match "mimirtool: error: required flag --id not provided, try --help",
+        shell_output("#{bin}/mimirtool alertmanager get", 1)
+    end
+  end


### PR DESCRIPTION
Adding mimirtool (a component of mimir) to homebrew-core to allow users of mimir to install mimirtool via brew.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
