### PR TITLE
jbig2dec: update livecheck

### DIFF
--- a/Formula/jbig2dec.rb
+++ b/Formula/jbig2dec.rb
@@ -5,14 +5,14 @@ class Jbig2dec < Formula
   sha256 "279476695b38f04939aa59d041be56f6bade3422003a406a85e9792c27118a37"
   license "AGPL-3.0-or-later"
 
-  # Not every GhostPDL release contains a jbig2dec archive, so we have to check
-  # the GitHub releases page (which we otherwise avoid) instead of the tags.
-  # We avoid checking the jbig2dec homepage because it has been very slow to
-  # update in the past when new versions were released.
+  # Not every GhostPDL release on GitHub provides a jbig2dec archive, so it's
+  # necessary to check releases until we find one. Since the assets list HTML
+  # is no longer part of release pages, it would take several requests to do
+  # this. As it stands, this checks the homepage, even though it has typically
+  # been slow to update the tarball link when a new version is released.
   livecheck do
-    url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases?q=prerelease%3Afalse"
+    url :homepage
     regex(%r{href=.*?/jbig2dec[._-]v?(\d+(?:\.\d+)+)\.t}i)
-    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `jbig2dec` identifies versions from the tarball in some release assets lists. However, GitHub recently updated release pages to omit the assets list from the HTML and it's now fetched separately when the list is expanded (see https://github.com/Homebrew/brew/issues/13853), so this check is currently broken.

Unfortunately, not all GhostPDL releases provide a `jbig2dec` tarball, so it's necessary to go through release assets until we find the newest release providing the tarball we use. Cycling through the GitHub release assets lists currently involves seven requests and this would continue to grow with each subsequent release until the next `jbig2dec` release (at which point it would reset to two requests and grow again from there). Due to the unpredictable and comparatively large number of requests involved, I'm against that approach. The newest `jbig2dec` release was two years ago, so this isn't an unfounded concern.

With that in mind, I've updated the `livecheck` block to simply check the homepage as an alternative. The homepage has historically been slow to update the tarball link when a new version is available but it's better than nothing. [For what it's worth, `jbig2dec` is carried by other package managers, so `brew bump` will make it apparent if one of them updates to a new version before the version is surfaced by livecheck.]