### PR TITLE
qt-*: drop GCC dependency

### DIFF
--- a/Formula/qt-libiodbc.rb
+++ b/Formula/qt-libiodbc.rb
@@ -23,10 +23,6 @@ class QtLibiodbc < Formula
   depends_on "libiodbc"
   depends_on "qt"
 
-  on_linux do
-    depends_on "gcc"
-  end
-
   conflicts_with "qt-unixodbc",
     because: "qt-unixodbc and qt-libiodbc install the same binaries"
 

--- a/Formula/qt-mariadb.rb
+++ b/Formula/qt-mariadb.rb
@@ -23,10 +23,6 @@ class QtMariadb < Formula
   depends_on "mariadb"
   depends_on "qt"
 
-  on_linux do
-    depends_on "gcc"
-  end
-
   conflicts_with "qt-mysql", "qt-percona-server",
     because: "qt-mysql, qt-mariadb, and qt-percona-server install the same binaries"
 

--- a/Formula/qt-mysql.rb
+++ b/Formula/qt-mysql.rb
@@ -23,10 +23,6 @@ class QtMysql < Formula
   depends_on "mysql"
   depends_on "qt"
 
-  on_linux do
-    depends_on "gcc"
-  end
-
   conflicts_with "qt-mariadb", "qt-percona-server",
     because: "qt-mysql, qt-mariadb, and qt-percona-server install the same binaries"
 

--- a/Formula/qt-percona-server.rb
+++ b/Formula/qt-percona-server.rb
@@ -24,10 +24,6 @@ class QtPerconaServer < Formula
   depends_on "percona-server"
   depends_on "qt"
 
-  on_linux do
-    depends_on "gcc"
-  end
-
   conflicts_with "qt-mysql", "qt-mariadb",
     because: "qt-mysql, qt-mariadb, and qt-percona-server install the same binaries"
 

--- a/Formula/qt-postgresql.rb
+++ b/Formula/qt-postgresql.rb
@@ -23,10 +23,6 @@ class QtPostgresql < Formula
   depends_on "libpq"
   depends_on "qt"
 
-  on_linux do
-    depends_on "gcc"
-  end
-
   fails_with gcc: "5"
 
   def install

--- a/Formula/qt-unixodbc.rb
+++ b/Formula/qt-unixodbc.rb
@@ -23,10 +23,6 @@ class QtUnixodbc < Formula
   depends_on "qt"
   depends_on "unixodbc"
 
-  on_linux do
-    depends_on "gcc"
-  end
-
   conflicts_with "qt-libiodbc",
     because: "qt-unixodbc and qt-libiodbc install the same binaries"
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These formulae don't currently install on Linux because we don't have Qt, so there is no point in running CI on them. 