### PR TITLE
aws-vault: install fish completions

### DIFF
--- a/Formula/aws-vault.rb
+++ b/Formula/aws-vault.rb
@@ -4,6 +4,7 @@ class AwsVault < Formula
   url "https://github.com/99designs/aws-vault/archive/v6.6.0.tar.gz"
   sha256 "c9973d25047dc2487f413b86f91ccc4272b385fea3132e397c3a921baa01c885"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable
@@ -33,6 +34,7 @@ class AwsVault < Formula
 
     zsh_completion.install "contrib/completions/zsh/aws-vault.zsh"
     bash_completion.install "contrib/completions/bash/aws-vault.bash"
+    fish_completion.install "contrib/completions/fish/aws-vault.fish"
   end
 
   test do

--- a/Formula/aws-vault.rb
+++ b/Formula/aws-vault.rb
@@ -4,7 +4,6 @@ class AwsVault < Formula
   url "https://github.com/99designs/aws-vault/archive/v6.6.0.tar.gz"
   sha256 "c9973d25047dc2487f413b86f91ccc4272b385fea3132e397c3a921baa01c885"
   license "MIT"
-  revision 1
 
   livecheck do
     url :stable


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

[Fish completions](https://github.com/99designs/aws-vault/blob/master/contrib/completions/fish/aws-vault.fish) have been added to upstream but were not installed by the formula. This PR should fix that.