### PR TITLE
pypi_formula_mappings: fix semgrep resource updates

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -449,6 +449,7 @@
     "exclude_packages": ["six"]
   },
   "semgrep": {
+    "package_name": "semgrep",
     "exclude_packages": ["jsonschema", "attrs", "pyrsistent", "typing-extensions"]
   },
   "sgr": {


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Resource updates were broken after https://github.com/Homebrew/homebrew-core/commit/e24d779ff96b66d8185a12de95d6bb6e36910f1a as seen in #112504