### PR TITLE
charmcraft: exclude typing-extensions in pypi_formula_mappings

### DIFF
--- a/Formula/charmcraft.rb
+++ b/Formula/charmcraft.rb
@@ -225,11 +225,6 @@ class Charmcraft < Formula
     sha256 "e04ce58929509865359e91dcc38720123262b4cd68fa2a8a90312d50390bb6fa"
   end
 
-  resource "typing-extensions" do
-    url "https://files.pythonhosted.org/packages/9e/1d/d128169ff58c501059330f1ad96ed62b79114a2eb30b8238af63a2e27f70/typing_extensions-4.3.0.tar.gz"
-    sha256 "e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
-  end
-
   resource "urllib3" do
     url "https://files.pythonhosted.org/packages/b2/56/d87d6d3c4121c0bcec116919350ca05dc3afd2eeb7dc88d07e8083f8ea94/urllib3-1.26.12.tar.gz"
     sha256 "3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -77,7 +77,7 @@
   },
   "charmcraft": {
     "extra_packages": ["appdirs", "pydantic"],
-    "exclude_packages": ["six", "tabulate", "PyYAML", "jsonschema", "attrs", "pyrsistent"]
+    "exclude_packages": ["six", "tabulate", "PyYAML", "jsonschema", "attrs", "pyrsistent", "typing-extensions"]
   },
   "ciphey": {
     "exclude_packages": ["six"]


### PR DESCRIPTION
`charmcraft` already depends on `python-typing-extensions`, but apparently this resource crept back in anyway. We should exclude it in the `pypi_formula_mappings.json` file.