### PR TITLE
nut: update livecheck, stable

### DIFF
--- a/Formula/nut.rb
+++ b/Formula/nut.rb
@@ -4,7 +4,7 @@ class Nut < Formula
   license "GPL-2.0-or-later"
 
   stable do
-    url "https://networkupstools.org/source/2.8/nut-2.8.0.tar.gz"
+    url "https://github.com/networkupstools/nut/releases/download/v2.8.0/nut-2.8.0.tar.gz"
     sha256 "c3e5a708da797b7c70b653d37b1206a000fcb503b85519fe4cdf6353f792bfe5"
 
     # fix build failure
@@ -16,8 +16,8 @@ class Nut < Formula
   end
 
   livecheck do
-    url "https://networkupstools.org/download.html"
-    regex(/href=.*?nut[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #101035 to fix the broken `livecheck` block. As mentioned in that PR, identifying stable versions from the first-party website requires digging through the [source directories](https://networkupstools.org/source/). However, the tarball from the stable releases on GitHub are the same as the one from the first-party website (i.e., same SHA256) and switching to that tarball would allow us to simply use the `GithubLatest` strategy here (this is appropriate since we would be using a release asset).

With that in mind, this PR updates the `stable` URL to use the tarball from the 2.8.0 GitHub release and updates the `livecheck` block to use the `GithubLatest` strategy.