### PR TITLE
ecasound: update homepage

### DIFF
--- a/Formula/ecasound.rb
+++ b/Formula/ecasound.rb
@@ -1,11 +1,11 @@
 class Ecasound < Formula
   desc "Multitrack-capable audio recorder and effect processor"
-  homepage "https://www.eca.cx/ecasound/"
+  homepage "https://nosignal.fi/ecasound/"
   url "https://ecasound.seul.org/download/ecasound-2.9.3.tar.gz"
   sha256 "468bec44566571043c655c808ddeb49ae4f660e49ab0072970589fd5a493f6d4"
 
   livecheck do
-    url "https://www.eca.cx/ecasound/download.php"
+    url "https://nosignal.fi/ecasound/download.php"
     regex(/href=.*?ecasound[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently, the livecheck failed, but also the homepage is not accessible. 
While searching online I found this new site (`https://nosignal.fi/ecasound/`), it looks like is the new site for the project, with mirrors matching with the artifact that we use. Thus, updating the homepage and livecheck to point to the new one.