### PR TITLE
jj: remove Linux-only `gcc` dependency

### DIFF
--- a/Formula/jj.rb
+++ b/Formula/jj.rb
@@ -21,7 +21,6 @@ class Jj < Formula
 
   on_linux do
     depends_on "pkg-config" => :build
-    depends_on "gcc"
   end
 
   def install


### PR DESCRIPTION
This should be the last one. Completes #110010.
