### PR TITLE
kahip: `fails_with :clang`

### DIFF
--- a/Formula/kahip.rb
+++ b/Formula/kahip.rb
@@ -23,17 +23,14 @@ class Kahip < Formula
     depends_on "gcc"
   end
 
-  def install
-    if OS.mac?
-      gcc_major_ver = Formula["gcc"].any_installed_version.major
-      ENV["CC"] = Formula["gcc"].opt_bin/"gcc-#{gcc_major_ver}"
-      ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{gcc_major_ver}"
-    end
+  fails_with :clang do
+    cause "needs OpenMP support"
+  end
 
-    mkdir "build" do
-      system "cmake", *std_cmake_args, ".."
-      system "make", "install"
-    end
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

If I understand from original PR #38401, `gcc` was used for OpenMP support. So, let's try using `libomp` instead and avoid bypassing shims.

Need to check for linkage.