### PR TITLE
libgrapheme 2.0.2 (new formula)

### DIFF
--- a/Formula/libgrapheme.rb
+++ b/Formula/libgrapheme.rb
@@ -1,0 +1,43 @@
+class Libgrapheme < Formula
+  desc "Unicode string library"
+  homepage "https://libs.suckless.org/libgrapheme/"
+  url "https://dl.suckless.org/libgrapheme/libgrapheme-2.0.1.tar.gz"
+  sha256 "3db593a20fcbedcf4aa01c2ff973c430c40e19b961422ded95efe74a216cda2a"
+  license "ISC"
+  head "git://git.suckless.org/libgrapheme/", branch: "master"
+
+  def install
+    args = if OS.mac?
+      [
+        "PREFIX=#{prefix}",
+        "SOFLAGS=-dynamiclib -install_name 'libgrapheme.$(VERSION_MAJOR).dylib' " \
+        "-current_version '$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)' " \
+        "-compatibility_version '$(VERSION_MAJOR).$(VERSION_MINOR).0'",
+        "SONAME=libgrapheme.$(VERSION_MAJOR).dylib",
+        "SOSYMLINK=false",
+        "LDCONFIG=",
+      ]
+    else
+      [
+        "PREFIX=#{prefix}",
+        "LDCONFIG=",
+      ]
+    end
+
+    system "make", *args, "install"
+  end
+
+  test do
+    (testpath/"example.c").write <<~EOS
+      #include <grapheme.h>
+
+      int
+      main(void)
+      {
+        return (grapheme_next_word_break_utf8("Hello World!", SIZE_MAX) != 5);
+      }
+    EOS
+    system ENV.cc, "example.c", "-I#{include}", "-L#{lib}", "-lgrapheme", "-o", "example"
+    system "./example"
+  end
+end

--- a/Formula/libgrapheme.rb
+++ b/Formula/libgrapheme.rb
@@ -8,11 +8,16 @@ class Libgrapheme < Formula
 
   def install
     args = if OS.mac?
+      soflags = %w[
+        -dynamiclib
+        -installname 'libgrapheme.$(VERSION_MAJOR).dylib'
+        -current_version '$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)'
+        -compatibility_version '$(VERSION_MAJOR).$(VERSION_MINOR).0'
+      ]
+
       [
         "PREFIX=#{prefix}",
-        "SOFLAGS=-dynamiclib -install_name 'libgrapheme.$(VERSION_MAJOR).dylib' " \
-        "-current_version '$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)' " \
-        "-compatibility_version '$(VERSION_MAJOR).$(VERSION_MINOR).0'",
+        "SOFLAGS=#{soflags.join(" ")}",
         "SONAME=libgrapheme.$(VERSION_MAJOR).dylib",
         "SOSYMLINK=false",
         "LDCONFIG=",

--- a/Formula/libgrapheme.rb
+++ b/Formula/libgrapheme.rb
@@ -1,35 +1,14 @@
 class Libgrapheme < Formula
   desc "Unicode string library"
   homepage "https://libs.suckless.org/libgrapheme/"
-  url "https://dl.suckless.org/libgrapheme/libgrapheme-2.0.1.tar.gz"
-  sha256 "3db593a20fcbedcf4aa01c2ff973c430c40e19b961422ded95efe74a216cda2a"
+  url "https://dl.suckless.org/libgrapheme/libgrapheme-2.0.2.tar.gz"
+  sha256 "a68bbddde76bd55ba5d64116ce5e42a13df045c81c0852de9ab60896aa143125"
   license "ISC"
   head "git://git.suckless.org/libgrapheme/", branch: "master"
 
   def install
-    args = if OS.mac?
-      soflags = %w[
-        -dynamiclib
-        -installname 'libgrapheme.$(VERSION_MAJOR).dylib'
-        -current_version '$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)'
-        -compatibility_version '$(VERSION_MAJOR).$(VERSION_MINOR).0'
-      ]
-
-      [
-        "PREFIX=#{prefix}",
-        "SOFLAGS=#{soflags.join(" ")}",
-        "SONAME=libgrapheme.$(VERSION_MAJOR).dylib",
-        "SOSYMLINK=false",
-        "LDCONFIG=",
-      ]
-    else
-      [
-        "PREFIX=#{prefix}",
-        "LDCONFIG=",
-      ]
-    end
-
-    system "make", *args, "install"
+    system "./configure"
+    system "make", "PREFIX=#{prefix}", "LDCONFIG=", "install"
   end
 
   test do


### PR DESCRIPTION
Signed-off-by: Laslo Hunhold <dev@frign.de>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds a formula for the libgrapheme library that has already been packaged in multiple other Linux/BSD distributions.

libgrapheme is an extremely simple freestanding C99 library providing utilities for properly handling strings according to the latest Unicode standard 15.0.0. It offers fully Unicode compliant

 - grapheme cluster (i.e. user-perceived character) segmentation
 - word segmentation
 - sentence segmentation
 - detection of permissible line break opportunities
 - case detection (lower-, upper- and title-case)
 - case conversion (to lower-, upper- and title-case)

on UTF-8 strings and codepoint arrays, which both can also be null-terminated.