### PR TITLE
libtiff: enable zstd

### DIFF
--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -23,16 +23,17 @@ class Libtiff < Formula
   end
 
   depends_on "jpeg-turbo"
+  depends_on "zstd"
 
   uses_from_macos "zlib"
 
   def install
     args = %W[
       --prefix=#{prefix}
+      --enable-zstd
       --disable-dependency-tracking
       --disable-lzma
       --disable-webp
-      --disable-zstd
       --with-jpeg-include-dir=#{Formula["jpeg-turbo"].opt_include}
       --with-jpeg-lib-dir=#{Formula["jpeg-turbo"].opt_lib}
       --without-x


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Enabled ZSTD support in libtiff to allow usage downstream e.g.: gdal

Fixes: #106450