### PR TITLE
protobuf: added PIC compilation flags

### DIFF
--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -58,7 +58,7 @@ class Protobuf < Formula
     ENV.cxx11
 
     system "./autogen.sh" if build.head?
-    system "./configure", *std_configure_args, "--with-zlib"
+    system "./configure", *std_configure_args, "--with-zlib", "--with-pic"
     system "make"
     system "make", "check"
     system "make", "install"


### PR DESCRIPTION
Added compilation of protobuf with -fPIC, otherwise usage of `libprotobuf.a` as a part of another dynamic library fails.
See similar issues https://github.com/protocolbuffers/protobuf/issues/1919