### PR TITLE
lightgbm 3.3.3

### DIFF
--- a/Formula/lightgbm.rb
+++ b/Formula/lightgbm.rb
@@ -2,8 +2,8 @@ class Lightgbm < Formula
   desc "Fast, distributed, high performance gradient boosting framework"
   homepage "https://github.com/microsoft/LightGBM"
   url "https://github.com/microsoft/LightGBM.git",
-      tag:      "v3.3.2",
-      revision: "dce7e58b020bc14b69eefc31546c366971ecb2d9"
+      tag:      "v3.3.3",
+      revision: "a0a617dfff2e2e1637b72b7a2adbe5453e7f97e0"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
Following https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md#to-submit-a-version-upgrade-for-the-foo-formula, I ran the following.

```shell
HOMEBREW_GITHUB_API_TOKEN='MY-TOKEN-HERE' \
brew bump-formula-pr \
    --strict lightgbm \
    --tag=v3.3.3
```

Bumps `lightgbm` to v3.3.3, based on its new release: https://github.com/microsoft/LightGBM/releases/tag/v3.3.3
