### PR TITLE
ytarchive 0.3.1 (new formula)

### DIFF
--- a/Formula/ytarchive.rb
+++ b/Formula/ytarchive.rb
@@ -1,0 +1,21 @@
+class Ytarchive < Formula
+  desc "Archive live and upcoming Youtube.com live streams"
+  homepage "https://github.com/Kethsar/ytarchive"
+  url "https://github.com/Kethsar/ytarchive/archive/refs/tags/latest.tar.gz"
+  version "0.3.1"
+  sha256 "29931b22d8cb22ff6aefd2f4601816eb5c3664ec88518f9da432e3d460549923"
+  license "MIT"
+  head "https://github.com/Kethsar/ytarchive.git", branch: "master"
+
+  depends_on "go" => :build
+  depends_on "ffmpeg"
+
+  def install
+    ENV["CGO_ENABLED"] = "0"
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    system bin/"ytarchive", "--version"
+  end
+end


### PR DESCRIPTION
This adds a new Go-based formula for archiving live or upcoming YT livestreams.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
