### PR TITLE
ipmiutil: remove openssl since LANPLUS is disabled

### DIFF
--- a/Formula/ipmiutil.rb
+++ b/Formula/ipmiutil.rb
@@ -13,19 +13,23 @@ class Ipmiutil < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "97654675eb07ff4c52dfc12434302e4c57a50be29e18839d063e9f2acf4955b1"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
-  depends_on "openssl@1.1"
+  on_macos do
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
 
   conflicts_with "renameutils", because: "both install `icmd` binaries"
 
   def install
     # Darwin does not exist only on PowerPC
-    inreplace "configure.ac", "test \"$archp\" = \"powerpc\"", "true"
-    system "autoreconf", "-fiv"
+    if OS.mac?
+      inreplace "configure.ac", "test \"$archp\" = \"powerpc\"", "true"
+      system "autoreconf", "--force", "--install", "--verbose"
+    end
 
     system "./configure", *std_configure_args,
+                          "--disable-silent-rules",
                           "--disable-lanplus",
                           "--enable-sha256",
                           "--enable-gpl"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

No linkage to `openssl`:
```
% brew linkage ipmiutil
System libraries:
  /usr/lib/libSystem.B.dylib
```

Looks like dependency went away once we disabled LANPLUS:
> If ipmiutil is compiled with LANPLUS enabled, then it does depend upon
libcrypto.so, which is provided by the openssl package.
