### PR TITLE
ksh: Fix deprecation message

### DIFF
--- a/Formula/ksh.rb
+++ b/Formula/ksh.rb
@@ -16,7 +16,7 @@ class Ksh < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8a6f8d5a96eaf9d91da32c58e453d7aacc4f47acea57f6a2b3db7cc108bbcd1f"
   end
 
-  deprecate! date: "2020-05-01", because: "abandoned, unmaintained, no releases since 2019; consider ksh93 instead"
+  deprecate! date: "2020-05-01", because: "is abandoned, unmaintained, no releases since 2019; consider ksh93 instead"
 
   depends_on "meson" => :build
   depends_on "ninja" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
At the moment `brew info ksh` says:

> Deprecated because it abandoned, unmaintained, no releases since 2019; consider ksh93 instead!

This fixes the grammar slightly by adding "is" before the word "abandoned".

This deprecation message was originally added in #107154.