### PR TITLE
tmuxp: remove PyYAML resource

### DIFF
--- a/Formula/tmuxp.rb
+++ b/Formula/tmuxp.rb
@@ -30,11 +30,6 @@ class Tmuxp < Formula
     sha256 "cf352a645ebeaa5046ad0593cc01d691d77f8b3af1660327a6433cc6276ab796"
   end
 
-  resource "PyYAML" do
-    url "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz"
-    sha256 "68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"
-  end
-
   def install
     virtualenv_install_with_resources
   end

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -501,6 +501,9 @@
   "theharvester": {
     "exclude_packages": ["six", "PyYAML", "typing-extensions"]
   },
+  "tmuxp": {
+    "exclude_packages": ["PyYAML"]
+  },
   "todoman": {
     "exclude_packages": ["six", "tabulate"]
   },


### PR DESCRIPTION
`tmuxp` already depends on `pyyaml`, so it doesn't need to _also_ install PyYAML from PyPI.