### PR TITLE
sqlfluff: depend on python-typing-extensions

### DIFF
--- a/Formula/sqlfluff.rb
+++ b/Formula/sqlfluff.rb
@@ -16,6 +16,7 @@ class Sqlfluff < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "47aa88f0907e8ec639794484b57daa32c914f55e26a9f19798c8cfe90db27fc2"
   end
 
+  depends_on "python-typing-extensions"
   depends_on "python@3.10"
   depends_on "pyyaml"
 
@@ -122,11 +123,6 @@ class Sqlfluff < Formula
   resource "tqdm" do
     url "https://files.pythonhosted.org/packages/c1/c2/d8a40e5363fb01806870e444fc1d066282743292ff32a9da54af51ce36a2/tqdm-4.64.1.tar.gz"
     sha256 "5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4"
-  end
-
-  resource "typing-extensions" do
-    url "https://files.pythonhosted.org/packages/9e/1d/d128169ff58c501059330f1ad96ed62b79114a2eb30b8238af63a2e27f70/typing_extensions-4.3.0.tar.gz"
-    sha256 "e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
   end
 
   def install

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -474,7 +474,7 @@
     "extra_packages": ["numpydoc"]
   },
   "sqlfluff": {
-    "exclude_packages": ["PyYAML"]
+    "exclude_packages": ["PyYAML", "typing-extensions"]
   },
   "sqlite-utils": {
     "exclude_packages": ["tabulate", "six"]


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
