### PR TITLE
clog: update URL

### DIFF
--- a/Formula/clog.rb
+++ b/Formula/clog.rb
@@ -1,7 +1,7 @@
 class Clog < Formula
   desc "Colorized pattern-matching log tail utility"
   homepage "https://taskwarrior.org/docs/clog/"
-  url "https://gothenburgbitfactory.org/download/clog-1.3.0.tar.gz"
+  url "https://github.com/GothenburgBitFactory/clog/releases/download/v1.3.0/clog-1.3.0.tar.gz"
   sha256 "fed44a8d398790ab0cf426c1b006e7246e20f3fcd56c0ec4132d24b05d5d2018"
   license "MIT"
   head "https://github.com/GothenburgBitFactory/clog.git", branch: "1.4.0"


### PR DESCRIPTION
Original URL now 404, new URL featured on [upstream's download page](https://taskwarrior.org/docs/clog/download/).

No change in source tarball, so `CI-syntax-only`?

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
