### PR TITLE
cproto: remove licenses for build scripts

### DIFF
--- a/Formula/cproto.rb
+++ b/Formula/cproto.rb
@@ -4,11 +4,7 @@ class Cproto < Formula
   url "https://invisible-mirror.net/archives/cproto/cproto-4.7t.tgz"
   mirror "https://deb.debian.org/debian/pool/main/c/cproto/cproto_4.7t.orig.tar.gz"
   sha256 "3cce82a71687b69e0a3e23489fe825ba72e693e559ccf193395208ac0eb96fe5"
-  license all_of: [
-    :public_domain,
-    "MIT",
-    "GPL-3.0-or-later" => { with: "Autoconf-exception-3.0" },
-  ]
+  license :public_domain
 
   livecheck do
     url "https://invisible-mirror.net/archives/cproto/"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
