### PR TITLE
wxwidgets: update license as SPDX deprecated wxWindows

### DIFF
--- a/Formula/wxwidgets.rb
+++ b/Formula/wxwidgets.rb
@@ -3,7 +3,7 @@ class Wxwidgets < Formula
   homepage "https://www.wxwidgets.org"
   url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.1/wxWidgets-3.2.1.tar.bz2"
   sha256 "c229976bb413eb88e45cb5dfb68b27890d450149c09b331abd751e7ae0f5fa66"
-  license "wxWindows"
+  license "LGPL-2.0-or-later" => { with: "WxWindows-exception-3.1" }
   head "https://github.com/wxWidgets/wxWidgets.git", branch: "master"
 
   livecheck do

--- a/Formula/wxwidgets@3.0.rb
+++ b/Formula/wxwidgets@3.0.rb
@@ -3,7 +3,7 @@ class WxwidgetsAT30 < Formula
   homepage "https://www.wxwidgets.org"
   url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5.1/wxWidgets-3.0.5.1.tar.bz2"
   sha256 "440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807"
-  license "wxWindows"
+  license "LGPL-2.0-or-later" => { with: "WxWindows-exception-3.1" }
   revision 1
 
   livecheck do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Prior to PR:
```console
❯ brew audit --strict wxwidgets
wxwidgets:
  * Formula wxwidgets contains deprecated SPDX licenses: ["wxWindows"].
    You may need to add `-only` or `-or-later` for GNU licenses (e.g. `GPL`, `LGPL`, `AGPL`, `GFDL`).
    For a list of valid licenses check: https://spdx.org/licenses/
Error: 1 problem in 1 formula detected
```

https://spdx.org/licenses/wxWindows.html
> Deprecated
> This license identifier has been deprecated since license list version 2.0rc2.
