### PR TITLE
rgbds 0.6.0

### DIFF
--- a/Formula/rgbds.rb
+++ b/Formula/rgbds.rb
@@ -32,7 +32,7 @@ class Rgbds < Formula
   end
 
   def install
-    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_BUILD_TYPE=Release"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build", "-j"
     system "cmake", "--install", "build", "--prefix", prefix.to_s, "--strip"
     resource("rgbobj").stage do

--- a/Formula/rgbds.rb
+++ b/Formula/rgbds.rb
@@ -33,8 +33,8 @@ class Rgbds < Formula
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
-    system "cmake", "--build", "build", "-j"
-    system "cmake", "--install", "build", "--prefix", prefix.to_s, "--strip"
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
     resource("rgbobj").stage do
       system "cargo", "install", *std_cargo_args
       man1.install "rgbobj.1"

--- a/Formula/rgbds.rb
+++ b/Formula/rgbds.rb
@@ -1,8 +1,8 @@
 class Rgbds < Formula
   desc "Rednex GameBoy Development System"
   homepage "https://rgbds.gbdev.io"
-  url "https://github.com/gbdev/rgbds/archive/v0.5.2.tar.gz"
-  sha256 "29172a43c7a4f41e5809d8c40cb76b798a0d01dfc9f5340b160a405b89b3b182"
+  url "https://github.com/gbdev/rgbds/archive/v0.6.0.tar.gz"
+  sha256 "dcf26588b52a8ccfa28aa47c14f6b222f096f1109c658b3fe57dd6ff150cd0ab"
   license "MIT"
   head "https://github.com/gbdev/rgbds.git", branch: "master"
 
@@ -21,24 +21,20 @@ class Rgbds < Formula
   end
 
   depends_on "bison" => :build
+  depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "libpng"
 
   resource "rgbobj" do
-    url "https://github.com/gbdev/rgbobj/archive/refs/tags/v0.1.0.tar.gz"
-    sha256 "359a3504dc5a5f7812dfee602a23aec80163d1d9ec13f713645b5495aeef2a9b"
-
-    # Fix support for clap 3.2+. Remove in the next release.
-    # Issue ref: https://github.com/gbdev/rgbobj/issues/4
-    patch do
-      url "https://github.com/gbdev/rgbobj/commit/b4e1fe42dbc297d67d67ed17004a3f6956de199f.patch?full_index=1"
-      sha256 "27aceed0020c7561e8259308df0868d19e0b7f21ad5e0f2a389d591e8b60027d"
-    end
+    url "https://github.com/gbdev/rgbobj/archive/refs/tags/v0.2.1.tar.gz"
+    sha256 "3d91fb91c79974700e8b0379dcf5c92334f44928ed2fde88df281f46e3f6d7d1"
   end
 
   def install
-    system "make", "install", "PREFIX=#{prefix}", "mandir=#{man}"
+    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_BUILD_TYPE=Release"
+    system "cmake", "--build", "build", "-j"
+    system "cmake", "--install", "build", "--prefix", prefix.to_s, "--strip"
     resource("rgbobj").stage do
       system "cargo", "install", *std_cargo_args
       man1.install "rgbobj.1"
@@ -57,5 +53,7 @@ class Rgbds < Formula
     EOS
     system bin/"rgbasm", "-o", "output.o", "source.asm"
     system bin/"rgbobj", "-A", "-s", "data", "-p", "data", "output.o"
+    system bin/"rgbgfx", test_fixtures("test.png"), "-o", testpath/"test.2bpp"
+    assert_predicate testpath/"test.2bpp", :exist?
   end
 end


### PR DESCRIPTION
Update RGBDS to v0.6.0, and rgbobj to v0.2.1.
This also fixes the clap dependency issue, therefore the patch is no longer necessary.

The build system was switched to CMake for better cross-system compatibility. The Makefile currently passes `-flto=auto`, which is not supported by Clang before 13, and thus fails to build on macOS before Monterey.

Additionally, add a test to check that RGBGFX correctly runs.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? (#112184 was closed as stale.)
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? (I don't have Brew, I'm upstream working to help bump downsteam ;)
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
