### PR TITLE
sophus: reintroduce fmt dependency after upstream fix

### DIFF
--- a/Formula/sophus.rb
+++ b/Formula/sophus.rb
@@ -4,6 +4,7 @@ class Sophus < Formula
   url "https://github.com/strasdat/Sophus/archive/refs/tags/v22.10.tar.gz"
   sha256 "270709b83696da179447cf743357e36a8b9bc8eed5ff4b9d66d33fe691010bad"
   license "MIT"
+  revision 1
   head "https://github.com/strasdat/Sophus.git", branch: "master"
 
   bottle do
@@ -13,13 +14,13 @@ class Sophus < Formula
   depends_on "cmake" => [:build, :test]
   depends_on "ceres-solver"
   depends_on "eigen"
+  depends_on "fmt"
 
   fails_with gcc: "5" # C++17 (ceres-solver dependency)
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args,
-                    "-DBUILD_SOPHUS_EXAMPLES=OFF",
-                    "-DSOPHUS_USE_BASIC_LOGGING=ON"
+                    "-DBUILD_SOPHUS_EXAMPLES=OFF"
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
     (pkgshare/"examples").install "examples/HelloSO3.cpp"
@@ -30,7 +31,6 @@ class Sophus < Formula
     (testpath/"CMakeLists.txt").write <<~EOS
       cmake_minimum_required(VERSION 3.5)
       project(HelloSO3)
-      add_compile_definitions(SOPHUS_USE_BASIC_LOGGING)
       find_package(Sophus REQUIRED)
       add_executable(HelloSO3 HelloSO3.cpp)
       target_link_libraries(HelloSO3 Sophus::Sophus)


### PR DESCRIPTION
Sophus compilation was broken with libfmt version >= 9.0. As a workaround the dependency was removed and "basic logging" enabled:
- https://github.com/Homebrew/homebrew-core/pull/108156
- https://github.com/Homebrew/homebrew-core/pull/110137

The sophus formula was recently updated to version 22.10, which fixed the compatibility with libfmt version >= 9.0:
- https://github.com/strasdat/Sophus/pull/376
- https://github.com/Homebrew/homebrew-core/pull/11286

This PR removes the workaround.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
