### PR TITLE
xxhash: update license as `xxhsum` is GPLv2+

### DIFF
--- a/Formula/xxhash.rb
+++ b/Formula/xxhash.rb
@@ -3,7 +3,10 @@ class Xxhash < Formula
   homepage "https://github.com/Cyan4973/xxHash"
   url "https://github.com/Cyan4973/xxHash/archive/v0.8.1.tar.gz"
   sha256 "3bb6b7d6f30c591dd65aaaff1c8b7a5b94d81687998ca9400082c739a690436c"
-  license "BSD-2-Clause"
+  license all_of: [
+    "BSD-2-Clause", # library
+    "GPL-2.0-or-later", # `xxhsum` command line utility
+  ]
 
   livecheck do
     url :stable
@@ -22,6 +25,7 @@ class Xxhash < Formula
   def install
     system "make"
     system "make", "install", "PREFIX=#{prefix}"
+    prefix.install "cli/COPYING"
   end
 
   test do


### PR DESCRIPTION
Also install a copy of xxhsum license (cli/COPYING) into prefix.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
