### PR TITLE
angle-grinder: remove `openssl@1.1` dependency

### DIFF
--- a/Formula/angle-grinder.rb
+++ b/Formula/angle-grinder.rb
@@ -17,11 +17,6 @@ class AngleGrinder < Formula
 
   depends_on "rust" => :build
 
-  on_linux do
-    depends_on "pkg-config" => :build
-    depends_on "openssl@1.1"
-  end
-
   def install
     system "cargo", "install", *std_cargo_args
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

No openssl* in Cargo.lock and https://github.com/rcoh/angle-grinder/commit/b9e46b9ad3dea5c32017319a92541c17757e058f mentions dropping openssl dependency.